### PR TITLE
feat: Build authentication HyperCache for `local_evaluation`

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -296,6 +296,15 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.17
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."api_token"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.18
+  '''
   SELECT "posthog_hogflow"."id",
          "posthog_hogflow"."name",
          "posthog_hogflow"."description",
@@ -400,7 +409,7 @@
          AND "posthog_hogflow"."trigger" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.18
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.19
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -513,7 +522,16 @@
          AND "posthog_hogfunction"."filters" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.19
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.2
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."organization_id",
+         "posthog_team"."access_control"
+  FROM "posthog_team"
+  WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.20
   '''
   SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
          "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
@@ -526,16 +544,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.2
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."organization_id",
-         "posthog_team"."access_control"
-  FROM "posthog_team"
-  WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.20
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.21
   '''
   SELECT "posthog_teammarketinganalyticsconfig"."team_id",
          "posthog_teammarketinganalyticsconfig"."sources_map",
@@ -545,7 +554,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.21
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.22
   '''
   SELECT 1 AS "a"
   FROM "posthog_grouptypemapping"
@@ -553,7 +562,7 @@
   LIMIT 1
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.22
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.23
   '''
   SELECT "posthog_grouptypemapping"."group_type",
          "posthog_grouptypemapping"."group_type_index",
@@ -567,7 +576,7 @@
   ORDER BY "posthog_grouptypemapping"."group_type_index" ASC
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.23
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.24
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -648,7 +657,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.24
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.25
   '''
   SELECT "posthog_productintent"."id",
          "posthog_productintent"."team_id",
@@ -663,7 +672,7 @@
   WHERE "posthog_productintent"."team_id" = 99999
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.25
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.26
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -697,7 +706,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.26
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.27
   '''
   SELECT "posthog_datacolortheme"."id"
   FROM "posthog_datacolortheme"
@@ -706,7 +715,7 @@
   LIMIT 1
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.27
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.28
   '''
   SELECT "posthog_productintent"."product_type",
          "posthog_productintent"."created_at",
@@ -716,7 +725,7 @@
   WHERE "posthog_productintent"."team_id" = 99999
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.28
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.29
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -747,35 +756,6 @@
   FROM "posthog_user"
   WHERE "posthog_user"."id" = 99999
   LIMIT 21
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.29
-  '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."rollout_percentage",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."version",
-         "posthog_featureflag"."last_modified_by_id",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics",
-         "posthog_featureflag"."is_remote_configuration",
-         "posthog_featureflag"."has_encrypted_payloads",
-         "posthog_featureflag"."evaluation_runtime"
-  FROM "posthog_featureflag"
-  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_team"."project_id" = 99999)
   '''
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
@@ -868,6 +848,35 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.30
   '''
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."version",
+         "posthog_featureflag"."last_modified_by_id",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics",
+         "posthog_featureflag"."is_remote_configuration",
+         "posthog_featureflag"."has_encrypted_payloads",
+         "posthog_featureflag"."evaluation_runtime"
+  FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.31
+  '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_survey"
   INNER JOIN "posthog_team" ON ("posthog_survey"."team_id" = "posthog_team"."id")
@@ -875,14 +884,14 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.31
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.32
   '''
   SELECT "posthog_errortrackingsuppressionrule"."filters"
   FROM "posthog_errortrackingsuppressionrule"
   WHERE "posthog_errortrackingsuppressionrule"."team_id" = 99999
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.32
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.33
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -1122,6 +1131,15 @@
 # ---
 # name: TestDecide.test_flag_with_behavioural_cohorts
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."api_token"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecide.test_flag_with_behavioural_cohorts.1
+  '''
   SELECT "posthog_hogflow"."id",
          "posthog_hogflow"."name",
          "posthog_hogflow"."description",
@@ -1226,7 +1244,34 @@
          AND "posthog_hogflow"."trigger" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.1
+# name: TestDecide.test_flag_with_behavioural_cohorts.10
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."cohort_type",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestDecide.test_flag_with_behavioural_cohorts.2
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -1339,7 +1384,7 @@
          AND "posthog_hogfunction"."filters" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.2
+# name: TestDecide.test_flag_with_behavioural_cohorts.3
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -1372,7 +1417,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.3
+# name: TestDecide.test_flag_with_behavioural_cohorts.4
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1460,7 +1505,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.4
+# name: TestDecide.test_flag_with_behavioural_cohorts.5
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -1482,7 +1527,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.5
+# name: TestDecide.test_flag_with_behavioural_cohorts.6
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -1504,7 +1549,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.6
+# name: TestDecide.test_flag_with_behavioural_cohorts.7
   '''
   SELECT "posthog_integration"."id",
          "posthog_integration"."team_id",
@@ -1521,7 +1566,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.7
+# name: TestDecide.test_flag_with_behavioural_cohorts.8
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -1547,33 +1592,6 @@
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestDecide.test_flag_with_behavioural_cohorts.8
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."cohort_type",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_cohort"."deleted"
          AND "posthog_team"."project_id" = 99999)
   '''
 # ---
@@ -1606,6 +1624,15 @@
 # ---
 # name: TestDecide.test_flag_with_regular_cohorts
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."api_token"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecide.test_flag_with_regular_cohorts.1
+  '''
   SELECT "posthog_hogflow"."id",
          "posthog_hogflow"."name",
          "posthog_hogflow"."description",
@@ -1710,7 +1737,58 @@
          AND "posthog_hogflow"."trigger" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.1
+# name: TestDecide.test_flag_with_regular_cohorts.10
+  '''
+  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'::jsonb
+          AND "posthog_person"."properties" ? '$some_prop_1'
+          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null'::jsonb)) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id_1'
+         AND "posthog_persondistinctid"."team_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecide.test_flag_with_regular_cohorts.11
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."cohort_type",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestDecide.test_flag_with_regular_cohorts.12
+  '''
+  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'::jsonb
+          AND "posthog_person"."properties" ? '$some_prop_1'
+          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null'::jsonb)) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'another_id'
+         AND "posthog_persondistinctid"."team_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecide.test_flag_with_regular_cohorts.2
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -1823,46 +1901,7 @@
          AND "posthog_hogfunction"."filters" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.10
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."cohort_type",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestDecide.test_flag_with_regular_cohorts.11
-  '''
-  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'::jsonb
-          AND "posthog_person"."properties" ? '$some_prop_1'
-          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null'::jsonb)) AS "flag_X_condition_0"
-  FROM "posthog_person"
-  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
-  WHERE ("posthog_persondistinctid"."distinct_id" = 'another_id'
-         AND "posthog_persondistinctid"."team_id" = 99999
-         AND "posthog_person"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecide.test_flag_with_regular_cohorts.2
+# name: TestDecide.test_flag_with_regular_cohorts.3
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -1895,7 +1934,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.3
+# name: TestDecide.test_flag_with_regular_cohorts.4
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1983,7 +2022,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.4
+# name: TestDecide.test_flag_with_regular_cohorts.5
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -2005,7 +2044,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.5
+# name: TestDecide.test_flag_with_regular_cohorts.6
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -2027,7 +2066,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.6
+# name: TestDecide.test_flag_with_regular_cohorts.7
   '''
   SELECT "posthog_integration"."id",
          "posthog_integration"."team_id",
@@ -2044,7 +2083,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.7
+# name: TestDecide.test_flag_with_regular_cohorts.8
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -2073,7 +2112,7 @@
          AND "posthog_team"."project_id" = 99999)
   '''
 # ---
-# name: TestDecide.test_flag_with_regular_cohorts.8
+# name: TestDecide.test_flag_with_regular_cohorts.9
   '''
   SELECT "posthog_cohort"."id",
          "posthog_cohort"."name",
@@ -2098,18 +2137,6 @@
   INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
   WHERE (NOT "posthog_cohort"."deleted"
          AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestDecide.test_flag_with_regular_cohorts.9
-  '''
-  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'::jsonb
-          AND "posthog_person"."properties" ? '$some_prop_1'
-          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null'::jsonb)) AS "flag_X_condition_0"
-  FROM "posthog_person"
-  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
-  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id_1'
-         AND "posthog_persondistinctid"."team_id" = 99999
-         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestDecide.test_web_app_queries
@@ -2240,6 +2267,15 @@
 # ---
 # name: TestDecide.test_web_app_queries.3
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."api_token"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecide.test_web_app_queries.4
+  '''
   SELECT "posthog_hogflow"."id",
          "posthog_hogflow"."name",
          "posthog_hogflow"."description",
@@ -2344,7 +2380,7 @@
          AND "posthog_hogflow"."trigger" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_web_app_queries.4
+# name: TestDecide.test_web_app_queries.5
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -2457,7 +2493,7 @@
          AND "posthog_hogfunction"."filters" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecide.test_web_app_queries.5
+# name: TestDecide.test_web_app_queries.6
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -2473,7 +2509,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecide.test_web_app_queries.6
+# name: TestDecide.test_web_app_queries.7
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -2786,6 +2822,15 @@
 # ---
 # name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.17
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."api_token"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.18
+  '''
   SELECT "posthog_hogflow"."id",
          "posthog_hogflow"."name",
          "posthog_hogflow"."description",
@@ -2890,7 +2935,7 @@
          AND "posthog_hogflow"."trigger" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.18
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.19
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -3003,7 +3048,16 @@
          AND "posthog_hogfunction"."filters" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.19
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.2
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."organization_id",
+         "posthog_team"."access_control"
+  FROM "posthog_team"
+  WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.20
   '''
   SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
          "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
@@ -3016,16 +3070,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.2
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."organization_id",
-         "posthog_team"."access_control"
-  FROM "posthog_team"
-  WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.20
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.21
   '''
   SELECT "posthog_teammarketinganalyticsconfig"."team_id",
          "posthog_teammarketinganalyticsconfig"."sources_map",
@@ -3035,7 +3080,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.21
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.22
   '''
   SELECT 1 AS "a"
   FROM "posthog_grouptypemapping"
@@ -3043,7 +3088,7 @@
   LIMIT 1
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.22
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.23
   '''
   SELECT "posthog_grouptypemapping"."group_type",
          "posthog_grouptypemapping"."group_type_index",
@@ -3057,7 +3102,7 @@
   ORDER BY "posthog_grouptypemapping"."group_type_index" ASC
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.23
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.24
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -3138,7 +3183,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.24
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.25
   '''
   SELECT "posthog_productintent"."id",
          "posthog_productintent"."team_id",
@@ -3153,7 +3198,7 @@
   WHERE "posthog_productintent"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.25
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.26
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -3187,7 +3232,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.26
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.27
   '''
   SELECT "posthog_datacolortheme"."id"
   FROM "posthog_datacolortheme"
@@ -3196,7 +3241,7 @@
   LIMIT 1
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.27
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.28
   '''
   SELECT "posthog_productintent"."product_type",
          "posthog_productintent"."created_at",
@@ -3206,7 +3251,7 @@
   WHERE "posthog_productintent"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.28
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.29
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -3236,18 +3281,6 @@
          "posthog_user"."email_opt_in"
   FROM "posthog_user"
   WHERE "posthog_user"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.29
-  '''
-  SELECT "posthog_remoteconfig"."id",
-         "posthog_remoteconfig"."team_id",
-         "posthog_remoteconfig"."config",
-         "posthog_remoteconfig"."updated_at",
-         "posthog_remoteconfig"."synced_at"
-  FROM "posthog_remoteconfig"
-  WHERE "posthog_remoteconfig"."team_id" = 99999
   LIMIT 21
   '''
 # ---
@@ -3341,6 +3374,18 @@
 # ---
 # name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.30
   '''
+  SELECT "posthog_remoteconfig"."id",
+         "posthog_remoteconfig"."team_id",
+         "posthog_remoteconfig"."config",
+         "posthog_remoteconfig"."updated_at",
+         "posthog_remoteconfig"."synced_at"
+  FROM "posthog_remoteconfig"
+  WHERE "posthog_remoteconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.31
+  '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
          "posthog_team"."organization_id",
@@ -3420,7 +3465,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.31
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.32
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -3432,7 +3477,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.32
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.33
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -3441,14 +3486,14 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.33
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.34
   '''
   SELECT "posthog_errortrackingsuppressionrule"."filters"
   FROM "posthog_errortrackingsuppressionrule"
   WHERE "posthog_errortrackingsuppressionrule"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.34
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.35
   '''
   SELECT "posthog_survey"."id",
          "posthog_survey"."team_id",
@@ -3550,7 +3595,7 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.35
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.36
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -3566,7 +3611,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.36
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.37
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -3582,7 +3627,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.37
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.38
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -3698,7 +3743,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.38
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.39
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -3790,15 +3835,6 @@
   INNER JOIN "posthog_team" ON ("posthog_remoteconfig"."team_id" = "posthog_team"."id")
   WHERE "posthog_team"."api_token" = 'token123'
   LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.39
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_featureflag"
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
 # name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.4
@@ -3845,12 +3881,21 @@
 # ---
 # name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.40
   '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.41
+  '''
   SELECT "posthog_errortrackingsuppressionrule"."filters"
   FROM "posthog_errortrackingsuppressionrule"
   WHERE "posthog_errortrackingsuppressionrule"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.41
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.42
   '''
   SELECT "posthog_survey"."id",
          "posthog_survey"."team_id",
@@ -3952,7 +3997,7 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.42
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.43
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -3968,7 +4013,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.43
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.44
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -3984,7 +4029,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.44
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.45
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -4100,7 +4145,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.45
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.46
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -4112,7 +4157,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.46
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.47
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -4200,7 +4245,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.47
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.48
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -4209,14 +4254,54 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.48
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.49
   '''
   SELECT "posthog_errortrackingsuppressionrule"."filters"
   FROM "posthog_errortrackingsuppressionrule"
   WHERE "posthog_errortrackingsuppressionrule"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.49
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.5
+  '''
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 99999
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.50
   '''
   SELECT "posthog_survey"."id",
          "posthog_survey"."team_id",
@@ -4318,47 +4403,7 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.5
-  '''
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."logo_media_id",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."session_cookie_age",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."is_ai_data_processing_approved",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."members_can_invite",
-         "posthog_organization"."members_can_use_personal_api_keys",
-         "posthog_organization"."allow_publicly_shared_resources",
-         "posthog_organization"."default_role_id",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."default_experiment_stats_method",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."is_platform"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE "posthog_organizationmembership"."user_id" = 99999
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.50
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.51
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -4374,7 +4419,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.51
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.52
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -4390,7 +4435,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.52
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.53
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -4506,7 +4551,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.53
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.54
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -4600,7 +4645,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.54
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.55
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -4609,14 +4654,14 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.55
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.56
   '''
   SELECT "posthog_errortrackingsuppressionrule"."filters"
   FROM "posthog_errortrackingsuppressionrule"
   WHERE "posthog_errortrackingsuppressionrule"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.56
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.57
   '''
   SELECT "posthog_survey"."id",
          "posthog_survey"."team_id",
@@ -4718,7 +4763,7 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.57
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.58
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -4734,7 +4779,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.58
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.59
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -4750,7 +4795,16 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.59
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.6
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."organization_id",
+         "posthog_team"."access_control"
+  FROM "posthog_team"
+  WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.60
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -4866,16 +4920,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.6
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."organization_id",
-         "posthog_team"."access_control"
-  FROM "posthog_team"
-  WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.60
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.61
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -4904,7 +4949,7 @@
          AND "posthog_team"."project_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.61
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.62
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_survey"
@@ -4913,7 +4958,7 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.62
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.63
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -4925,7 +4970,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.63
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.64
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -5013,7 +5058,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.64
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.65
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -5022,14 +5067,14 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.65
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.66
   '''
   SELECT "posthog_errortrackingsuppressionrule"."filters"
   FROM "posthog_errortrackingsuppressionrule"
   WHERE "posthog_errortrackingsuppressionrule"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.66
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.67
   '''
   SELECT "posthog_survey"."id",
          "posthog_survey"."team_id",
@@ -5131,7 +5176,7 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.67
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.68
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -5147,7 +5192,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.68
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.69
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -5161,122 +5206,6 @@
          AND "posthog_pluginsourcefile"."filename" = 'site.ts'
          AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
          AND "posthog_pluginconfig"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.69
-  '''
-  SELECT "posthog_hogfunction"."id",
-         "posthog_hogfunction"."team_id",
-         "posthog_hogfunction"."name",
-         "posthog_hogfunction"."description",
-         "posthog_hogfunction"."created_at",
-         "posthog_hogfunction"."created_by_id",
-         "posthog_hogfunction"."deleted",
-         "posthog_hogfunction"."updated_at",
-         "posthog_hogfunction"."enabled",
-         "posthog_hogfunction"."type",
-         "posthog_hogfunction"."kind",
-         "posthog_hogfunction"."icon_url",
-         "posthog_hogfunction"."hog",
-         "posthog_hogfunction"."bytecode",
-         "posthog_hogfunction"."transpiled",
-         "posthog_hogfunction"."inputs_schema",
-         "posthog_hogfunction"."inputs",
-         "posthog_hogfunction"."encrypted_inputs",
-         "posthog_hogfunction"."filters",
-         "posthog_hogfunction"."mappings",
-         "posthog_hogfunction"."masking",
-         "posthog_hogfunction"."template_id",
-         "posthog_hogfunction"."hog_function_template_id",
-         "posthog_hogfunction"."execution_order",
-         "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_hogfunction"
-  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_hogfunction"."deleted"
-         AND "posthog_hogfunction"."enabled"
-         AND "posthog_hogfunction"."team_id" = 99999
-         AND "posthog_hogfunction"."type" IN ('site_destination',
-                                              'site_app'))
   '''
 # ---
 # name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.7
@@ -5323,6 +5252,122 @@
 # ---
 # name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.70
   '''
+  SELECT "posthog_hogfunction"."id",
+         "posthog_hogfunction"."team_id",
+         "posthog_hogfunction"."name",
+         "posthog_hogfunction"."description",
+         "posthog_hogfunction"."created_at",
+         "posthog_hogfunction"."created_by_id",
+         "posthog_hogfunction"."deleted",
+         "posthog_hogfunction"."updated_at",
+         "posthog_hogfunction"."enabled",
+         "posthog_hogfunction"."type",
+         "posthog_hogfunction"."kind",
+         "posthog_hogfunction"."icon_url",
+         "posthog_hogfunction"."hog",
+         "posthog_hogfunction"."bytecode",
+         "posthog_hogfunction"."transpiled",
+         "posthog_hogfunction"."inputs_schema",
+         "posthog_hogfunction"."inputs",
+         "posthog_hogfunction"."encrypted_inputs",
+         "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
+         "posthog_hogfunction"."masking",
+         "posthog_hogfunction"."template_id",
+         "posthog_hogfunction"."hog_function_template_id",
+         "posthog_hogfunction"."execution_order",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_hogfunction"
+  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_hogfunction"."deleted"
+         AND "posthog_hogfunction"."enabled"
+         AND "posthog_hogfunction"."team_id" = 99999
+         AND "posthog_hogfunction"."type" IN ('site_destination',
+                                              'site_app'))
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.71
+  '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
          "posthog_remoteconfig"."config",
@@ -5415,7 +5460,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.71
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.72
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -5424,14 +5469,14 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.72
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.73
   '''
   SELECT "posthog_errortrackingsuppressionrule"."filters"
   FROM "posthog_errortrackingsuppressionrule"
   WHERE "posthog_errortrackingsuppressionrule"."team_id" = 99999
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.73
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.74
   '''
   SELECT "posthog_survey"."id",
          "posthog_survey"."team_id",
@@ -5533,7 +5578,7 @@
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.74
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.75
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -5549,7 +5594,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.75
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.76
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -5565,7 +5610,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.76
+# name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.77
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -5772,6 +5817,15 @@
 # ---
 # name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."api_token"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.1
+  '''
   SELECT "posthog_hogflow"."id",
          "posthog_hogflow"."name",
          "posthog_hogflow"."description",
@@ -5876,7 +5930,495 @@
          AND "posthog_hogflow"."trigger" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.1
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.10
+  '''
+  SELECT "posthog_remoteconfig"."id",
+         "posthog_remoteconfig"."team_id",
+         "posthog_remoteconfig"."config",
+         "posthog_remoteconfig"."updated_at",
+         "posthog_remoteconfig"."synced_at"
+  FROM "posthog_remoteconfig"
+  WHERE "posthog_remoteconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.11
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.12
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginsourcefile"."transpiled",
+         "posthog_pluginconfig"."web_token",
+         "posthog_plugin"."config_schema",
+         "posthog_pluginconfig"."config"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.13
+  '''
+  SELECT "posthog_hogfunction"."id",
+         "posthog_hogfunction"."team_id",
+         "posthog_hogfunction"."name",
+         "posthog_hogfunction"."description",
+         "posthog_hogfunction"."created_at",
+         "posthog_hogfunction"."created_by_id",
+         "posthog_hogfunction"."deleted",
+         "posthog_hogfunction"."updated_at",
+         "posthog_hogfunction"."enabled",
+         "posthog_hogfunction"."type",
+         "posthog_hogfunction"."kind",
+         "posthog_hogfunction"."icon_url",
+         "posthog_hogfunction"."hog",
+         "posthog_hogfunction"."bytecode",
+         "posthog_hogfunction"."transpiled",
+         "posthog_hogfunction"."inputs_schema",
+         "posthog_hogfunction"."inputs",
+         "posthog_hogfunction"."encrypted_inputs",
+         "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
+         "posthog_hogfunction"."masking",
+         "posthog_hogfunction"."template_id",
+         "posthog_hogfunction"."hog_function_template_id",
+         "posthog_hogfunction"."execution_order",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_hogfunction"
+  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_hogfunction"."deleted"
+         AND "posthog_hogfunction"."enabled"
+         AND "posthog_hogfunction"."team_id" = 99999
+         AND "posthog_hogfunction"."type" IN ('site_destination',
+                                              'site_app'))
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.14
+  '''
+  SELECT "posthog_remoteconfig"."id",
+         "posthog_remoteconfig"."team_id",
+         "posthog_remoteconfig"."config",
+         "posthog_remoteconfig"."updated_at",
+         "posthog_remoteconfig"."synced_at",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_remoteconfig"
+  INNER JOIN "posthog_team" ON ("posthog_remoteconfig"."team_id" = "posthog_team"."id")
+  WHERE "posthog_team"."api_token" = 'token123'
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.15
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.16
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginsourcefile"."transpiled",
+         "posthog_pluginconfig"."web_token",
+         "posthog_plugin"."config_schema",
+         "posthog_pluginconfig"."config"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.17
+  '''
+  SELECT "posthog_hogfunction"."id",
+         "posthog_hogfunction"."team_id",
+         "posthog_hogfunction"."name",
+         "posthog_hogfunction"."description",
+         "posthog_hogfunction"."created_at",
+         "posthog_hogfunction"."created_by_id",
+         "posthog_hogfunction"."deleted",
+         "posthog_hogfunction"."updated_at",
+         "posthog_hogfunction"."enabled",
+         "posthog_hogfunction"."type",
+         "posthog_hogfunction"."kind",
+         "posthog_hogfunction"."icon_url",
+         "posthog_hogfunction"."hog",
+         "posthog_hogfunction"."bytecode",
+         "posthog_hogfunction"."transpiled",
+         "posthog_hogfunction"."inputs_schema",
+         "posthog_hogfunction"."inputs",
+         "posthog_hogfunction"."encrypted_inputs",
+         "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
+         "posthog_hogfunction"."masking",
+         "posthog_hogfunction"."template_id",
+         "posthog_hogfunction"."hog_function_template_id",
+         "posthog_hogfunction"."execution_order",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_hogfunction"
+  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_hogfunction"."deleted"
+         AND "posthog_hogfunction"."enabled"
+         AND "posthog_hogfunction"."team_id" = 99999
+         AND "posthog_hogfunction"."type" IN ('site_destination',
+                                              'site_app'))
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.18
+  '''
+  SELECT "posthog_remoteconfig"."id",
+         "posthog_remoteconfig"."team_id",
+         "posthog_remoteconfig"."config",
+         "posthog_remoteconfig"."updated_at",
+         "posthog_remoteconfig"."synced_at"
+  FROM "posthog_remoteconfig"
+  WHERE "posthog_remoteconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.19
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.2
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -5989,7 +6531,7 @@
          AND "posthog_hogfunction"."filters" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.10
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.20
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -5998,7 +6540,7 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.11
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.21
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -6014,7 +6556,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.12
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.22
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -6130,7 +6672,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.13
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.23
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -6224,7 +6766,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.14
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.24
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -6233,7 +6775,7 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.15
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.25
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -6249,7 +6791,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.16
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.26
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -6365,7 +6907,63 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.17
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.27
+  '''
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."version",
+         "posthog_featureflag"."last_modified_by_id",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics",
+         "posthog_featureflag"."is_remote_configuration",
+         "posthog_featureflag"."has_encrypted_payloads",
+         "posthog_featureflag"."evaluation_runtime"
+  FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.28
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."cohort_type",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.29
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -6377,104 +6975,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.18
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.19
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_featureflag"
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.2
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.3
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -6507,628 +7008,105 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.20
-  '''
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginsourcefile"."transpiled",
-         "posthog_pluginconfig"."web_token",
-         "posthog_plugin"."config_schema",
-         "posthog_pluginconfig"."config"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.21
-  '''
-  SELECT "posthog_hogfunction"."id",
-         "posthog_hogfunction"."team_id",
-         "posthog_hogfunction"."name",
-         "posthog_hogfunction"."description",
-         "posthog_hogfunction"."created_at",
-         "posthog_hogfunction"."created_by_id",
-         "posthog_hogfunction"."deleted",
-         "posthog_hogfunction"."updated_at",
-         "posthog_hogfunction"."enabled",
-         "posthog_hogfunction"."type",
-         "posthog_hogfunction"."kind",
-         "posthog_hogfunction"."icon_url",
-         "posthog_hogfunction"."hog",
-         "posthog_hogfunction"."bytecode",
-         "posthog_hogfunction"."transpiled",
-         "posthog_hogfunction"."inputs_schema",
-         "posthog_hogfunction"."inputs",
-         "posthog_hogfunction"."encrypted_inputs",
-         "posthog_hogfunction"."filters",
-         "posthog_hogfunction"."mappings",
-         "posthog_hogfunction"."masking",
-         "posthog_hogfunction"."template_id",
-         "posthog_hogfunction"."hog_function_template_id",
-         "posthog_hogfunction"."execution_order",
-         "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_hogfunction"
-  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_hogfunction"."deleted"
-         AND "posthog_hogfunction"."enabled"
-         AND "posthog_hogfunction"."team_id" = 99999
-         AND "posthog_hogfunction"."type" IN ('site_destination',
-                                              'site_app'))
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.22
-  '''
-  SELECT "posthog_remoteconfig"."id",
-         "posthog_remoteconfig"."team_id",
-         "posthog_remoteconfig"."config",
-         "posthog_remoteconfig"."updated_at",
-         "posthog_remoteconfig"."synced_at",
-         "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_remoteconfig"
-  INNER JOIN "posthog_team" ON ("posthog_remoteconfig"."team_id" = "posthog_team"."id")
-  WHERE "posthog_team"."api_token" = 'token123'
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.23
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_featureflag"
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.24
-  '''
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginsourcefile"."transpiled",
-         "posthog_pluginconfig"."web_token",
-         "posthog_plugin"."config_schema",
-         "posthog_pluginconfig"."config"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.25
-  '''
-  SELECT "posthog_hogfunction"."id",
-         "posthog_hogfunction"."team_id",
-         "posthog_hogfunction"."name",
-         "posthog_hogfunction"."description",
-         "posthog_hogfunction"."created_at",
-         "posthog_hogfunction"."created_by_id",
-         "posthog_hogfunction"."deleted",
-         "posthog_hogfunction"."updated_at",
-         "posthog_hogfunction"."enabled",
-         "posthog_hogfunction"."type",
-         "posthog_hogfunction"."kind",
-         "posthog_hogfunction"."icon_url",
-         "posthog_hogfunction"."hog",
-         "posthog_hogfunction"."bytecode",
-         "posthog_hogfunction"."transpiled",
-         "posthog_hogfunction"."inputs_schema",
-         "posthog_hogfunction"."inputs",
-         "posthog_hogfunction"."encrypted_inputs",
-         "posthog_hogfunction"."filters",
-         "posthog_hogfunction"."mappings",
-         "posthog_hogfunction"."masking",
-         "posthog_hogfunction"."template_id",
-         "posthog_hogfunction"."hog_function_template_id",
-         "posthog_hogfunction"."execution_order",
-         "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_hogfunction"
-  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_hogfunction"."deleted"
-         AND "posthog_hogfunction"."enabled"
-         AND "posthog_hogfunction"."team_id" = 99999
-         AND "posthog_hogfunction"."type" IN ('site_destination',
-                                              'site_app'))
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.26
-  '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."rollout_percentage",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."version",
-         "posthog_featureflag"."last_modified_by_id",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics",
-         "posthog_featureflag"."is_remote_configuration",
-         "posthog_featureflag"."has_encrypted_payloads",
-         "posthog_featureflag"."evaluation_runtime"
-  FROM "posthog_featureflag"
-  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.27
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."cohort_type",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.28
-  '''
-  SELECT "posthog_remoteconfig"."id",
-         "posthog_remoteconfig"."team_id",
-         "posthog_remoteconfig"."config",
-         "posthog_remoteconfig"."updated_at",
-         "posthog_remoteconfig"."synced_at"
-  FROM "posthog_remoteconfig"
-  WHERE "posthog_remoteconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.29
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.3
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
 # name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.30
   '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_featureflag"
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id" = 99999)
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
   '''
 # ---
 # name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.31
   '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.32
+  '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
          "posthog_pluginconfig"."web_token",
@@ -7143,7 +7121,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.32
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.33
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -7259,7 +7237,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.33
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.34
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -7353,7 +7331,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.34
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.35
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -7362,7 +7340,7 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.35
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.36
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -7378,7 +7356,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.36
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.37
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -7494,7 +7472,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.37
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.38
   '''
   SELECT "posthog_cohort"."id",
          "posthog_cohort"."name",
@@ -7523,6 +7501,94 @@
 # ---
 # name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.4
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.5
+  '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
          "posthog_filesystem"."path",
@@ -7543,7 +7609,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.5
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.6
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -7565,7 +7631,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.6
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.7
   '''
   SELECT "posthog_integration"."id",
          "posthog_integration"."team_id",
@@ -7582,7 +7648,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.7
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.8
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -7594,7 +7660,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.8
+# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.9
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -7675,19 +7741,16 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_behavioural_cohorts.9
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts
   '''
-  SELECT "posthog_remoteconfig"."id",
-         "posthog_remoteconfig"."team_id",
-         "posthog_remoteconfig"."config",
-         "posthog_remoteconfig"."updated_at",
-         "posthog_remoteconfig"."synced_at"
-  FROM "posthog_remoteconfig"
-  WHERE "posthog_remoteconfig"."team_id" = 99999
+  SELECT "posthog_team"."id",
+         "posthog_team"."api_token"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.1
   '''
   SELECT "posthog_hogflow"."id",
          "posthog_hogflow"."name",
@@ -7793,7 +7856,495 @@
          AND "posthog_hogflow"."trigger" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.1
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.10
+  '''
+  SELECT "posthog_remoteconfig"."id",
+         "posthog_remoteconfig"."team_id",
+         "posthog_remoteconfig"."config",
+         "posthog_remoteconfig"."updated_at",
+         "posthog_remoteconfig"."synced_at"
+  FROM "posthog_remoteconfig"
+  WHERE "posthog_remoteconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.11
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.12
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginsourcefile"."transpiled",
+         "posthog_pluginconfig"."web_token",
+         "posthog_plugin"."config_schema",
+         "posthog_pluginconfig"."config"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.13
+  '''
+  SELECT "posthog_hogfunction"."id",
+         "posthog_hogfunction"."team_id",
+         "posthog_hogfunction"."name",
+         "posthog_hogfunction"."description",
+         "posthog_hogfunction"."created_at",
+         "posthog_hogfunction"."created_by_id",
+         "posthog_hogfunction"."deleted",
+         "posthog_hogfunction"."updated_at",
+         "posthog_hogfunction"."enabled",
+         "posthog_hogfunction"."type",
+         "posthog_hogfunction"."kind",
+         "posthog_hogfunction"."icon_url",
+         "posthog_hogfunction"."hog",
+         "posthog_hogfunction"."bytecode",
+         "posthog_hogfunction"."transpiled",
+         "posthog_hogfunction"."inputs_schema",
+         "posthog_hogfunction"."inputs",
+         "posthog_hogfunction"."encrypted_inputs",
+         "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
+         "posthog_hogfunction"."masking",
+         "posthog_hogfunction"."template_id",
+         "posthog_hogfunction"."hog_function_template_id",
+         "posthog_hogfunction"."execution_order",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_hogfunction"
+  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_hogfunction"."deleted"
+         AND "posthog_hogfunction"."enabled"
+         AND "posthog_hogfunction"."team_id" = 99999
+         AND "posthog_hogfunction"."type" IN ('site_destination',
+                                              'site_app'))
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.14
+  '''
+  SELECT "posthog_remoteconfig"."id",
+         "posthog_remoteconfig"."team_id",
+         "posthog_remoteconfig"."config",
+         "posthog_remoteconfig"."updated_at",
+         "posthog_remoteconfig"."synced_at",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_remoteconfig"
+  INNER JOIN "posthog_team" ON ("posthog_remoteconfig"."team_id" = "posthog_team"."id")
+  WHERE "posthog_team"."api_token" = 'token123'
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.15
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.16
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginsourcefile"."transpiled",
+         "posthog_pluginconfig"."web_token",
+         "posthog_plugin"."config_schema",
+         "posthog_pluginconfig"."config"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.17
+  '''
+  SELECT "posthog_hogfunction"."id",
+         "posthog_hogfunction"."team_id",
+         "posthog_hogfunction"."name",
+         "posthog_hogfunction"."description",
+         "posthog_hogfunction"."created_at",
+         "posthog_hogfunction"."created_by_id",
+         "posthog_hogfunction"."deleted",
+         "posthog_hogfunction"."updated_at",
+         "posthog_hogfunction"."enabled",
+         "posthog_hogfunction"."type",
+         "posthog_hogfunction"."kind",
+         "posthog_hogfunction"."icon_url",
+         "posthog_hogfunction"."hog",
+         "posthog_hogfunction"."bytecode",
+         "posthog_hogfunction"."transpiled",
+         "posthog_hogfunction"."inputs_schema",
+         "posthog_hogfunction"."inputs",
+         "posthog_hogfunction"."encrypted_inputs",
+         "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
+         "posthog_hogfunction"."masking",
+         "posthog_hogfunction"."template_id",
+         "posthog_hogfunction"."hog_function_template_id",
+         "posthog_hogfunction"."execution_order",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_hogfunction"
+  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_hogfunction"."deleted"
+         AND "posthog_hogfunction"."enabled"
+         AND "posthog_hogfunction"."team_id" = 99999
+         AND "posthog_hogfunction"."type" IN ('site_destination',
+                                              'site_app'))
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.18
+  '''
+  SELECT "posthog_remoteconfig"."id",
+         "posthog_remoteconfig"."team_id",
+         "posthog_remoteconfig"."config",
+         "posthog_remoteconfig"."updated_at",
+         "posthog_remoteconfig"."synced_at"
+  FROM "posthog_remoteconfig"
+  WHERE "posthog_remoteconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.19
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.2
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -7906,7 +8457,7 @@
          AND "posthog_hogfunction"."filters" @> '{"filter_test_accounts": true}'::jsonb)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.10
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.20
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -7915,7 +8466,7 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.11
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.21
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -7931,7 +8482,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.12
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.22
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -8047,7 +8598,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.13
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.23
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -8141,7 +8692,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.14
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.24
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -8150,7 +8701,7 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.15
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.25
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -8166,7 +8717,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.16
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.26
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -8282,116 +8833,75 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.17
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.27
   '''
-  SELECT "posthog_remoteconfig"."id",
-         "posthog_remoteconfig"."team_id",
-         "posthog_remoteconfig"."config",
-         "posthog_remoteconfig"."updated_at",
-         "posthog_remoteconfig"."synced_at"
-  FROM "posthog_remoteconfig"
-  WHERE "posthog_remoteconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.18
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.19
-  '''
-  SELECT COUNT(*) AS "__count"
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."version",
+         "posthog_featureflag"."last_modified_by_id",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics",
+         "posthog_featureflag"."is_remote_configuration",
+         "posthog_featureflag"."has_encrypted_payloads",
+         "posthog_featureflag"."evaluation_runtime"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.2
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.28
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."cohort_type",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.29
+  '''
+  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'::jsonb
+          AND "posthog_person"."properties" ? '$some_prop_1'
+          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null'::jsonb)) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id_1'
+         AND "posthog_persondistinctid"."team_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.3
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -8424,442 +8934,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.20
-  '''
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginsourcefile"."transpiled",
-         "posthog_pluginconfig"."web_token",
-         "posthog_plugin"."config_schema",
-         "posthog_pluginconfig"."config"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.21
-  '''
-  SELECT "posthog_hogfunction"."id",
-         "posthog_hogfunction"."team_id",
-         "posthog_hogfunction"."name",
-         "posthog_hogfunction"."description",
-         "posthog_hogfunction"."created_at",
-         "posthog_hogfunction"."created_by_id",
-         "posthog_hogfunction"."deleted",
-         "posthog_hogfunction"."updated_at",
-         "posthog_hogfunction"."enabled",
-         "posthog_hogfunction"."type",
-         "posthog_hogfunction"."kind",
-         "posthog_hogfunction"."icon_url",
-         "posthog_hogfunction"."hog",
-         "posthog_hogfunction"."bytecode",
-         "posthog_hogfunction"."transpiled",
-         "posthog_hogfunction"."inputs_schema",
-         "posthog_hogfunction"."inputs",
-         "posthog_hogfunction"."encrypted_inputs",
-         "posthog_hogfunction"."filters",
-         "posthog_hogfunction"."mappings",
-         "posthog_hogfunction"."masking",
-         "posthog_hogfunction"."template_id",
-         "posthog_hogfunction"."hog_function_template_id",
-         "posthog_hogfunction"."execution_order",
-         "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_hogfunction"
-  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_hogfunction"."deleted"
-         AND "posthog_hogfunction"."enabled"
-         AND "posthog_hogfunction"."team_id" = 99999
-         AND "posthog_hogfunction"."type" IN ('site_destination',
-                                              'site_app'))
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.22
-  '''
-  SELECT "posthog_remoteconfig"."id",
-         "posthog_remoteconfig"."team_id",
-         "posthog_remoteconfig"."config",
-         "posthog_remoteconfig"."updated_at",
-         "posthog_remoteconfig"."synced_at",
-         "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_remoteconfig"
-  INNER JOIN "posthog_team" ON ("posthog_remoteconfig"."team_id" = "posthog_team"."id")
-  WHERE "posthog_team"."api_token" = 'token123'
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.23
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_featureflag"
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_featureflag"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.24
-  '''
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginsourcefile"."transpiled",
-         "posthog_pluginconfig"."web_token",
-         "posthog_plugin"."config_schema",
-         "posthog_pluginconfig"."config"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.25
-  '''
-  SELECT "posthog_hogfunction"."id",
-         "posthog_hogfunction"."team_id",
-         "posthog_hogfunction"."name",
-         "posthog_hogfunction"."description",
-         "posthog_hogfunction"."created_at",
-         "posthog_hogfunction"."created_by_id",
-         "posthog_hogfunction"."deleted",
-         "posthog_hogfunction"."updated_at",
-         "posthog_hogfunction"."enabled",
-         "posthog_hogfunction"."type",
-         "posthog_hogfunction"."kind",
-         "posthog_hogfunction"."icon_url",
-         "posthog_hogfunction"."hog",
-         "posthog_hogfunction"."bytecode",
-         "posthog_hogfunction"."transpiled",
-         "posthog_hogfunction"."inputs_schema",
-         "posthog_hogfunction"."inputs",
-         "posthog_hogfunction"."encrypted_inputs",
-         "posthog_hogfunction"."filters",
-         "posthog_hogfunction"."mappings",
-         "posthog_hogfunction"."masking",
-         "posthog_hogfunction"."template_id",
-         "posthog_hogfunction"."hog_function_template_id",
-         "posthog_hogfunction"."execution_order",
-         "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_hogfunction"
-  INNER JOIN "posthog_team" ON ("posthog_hogfunction"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_hogfunction"."deleted"
-         AND "posthog_hogfunction"."enabled"
-         AND "posthog_hogfunction"."team_id" = 99999
-         AND "posthog_hogfunction"."type" IN ('site_destination',
-                                              'site_app'))
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.26
-  '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."rollout_percentage",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."version",
-         "posthog_featureflag"."last_modified_by_id",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics",
-         "posthog_featureflag"."is_remote_configuration",
-         "posthog_featureflag"."has_encrypted_payloads",
-         "posthog_featureflag"."evaluation_runtime"
-  FROM "posthog_featureflag"
-  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."active"
-         AND NOT "posthog_featureflag"."deleted"
-         AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.27
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."cohort_type",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.28
-  '''
-  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'::jsonb
-          AND "posthog_person"."properties" ? '$some_prop_1'
-          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null'::jsonb)) AS "flag_X_condition_0"
-  FROM "posthog_person"
-  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
-  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id_1'
-         AND "posthog_persondistinctid"."team_id" = 99999
-         AND "posthog_person"."team_id" = 99999)
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.29
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.30
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -8871,183 +8946,95 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.3
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.30
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
 # name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.31
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.32
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -9056,7 +9043,7 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.32
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.33
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -9072,7 +9059,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.33
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.34
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -9188,7 +9175,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.34
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.35
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -9282,7 +9269,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.35
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.36
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
@@ -9291,7 +9278,7 @@
          AND "posthog_featureflag"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.36
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.37
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginsourcefile"."transpiled",
@@ -9307,7 +9294,7 @@
          AND "posthog_pluginconfig"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.37
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.38
   '''
   SELECT "posthog_hogfunction"."id",
          "posthog_hogfunction"."team_id",
@@ -9423,7 +9410,7 @@
                                               'site_app'))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.38
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.39
   '''
   SELECT "posthog_cohort"."id",
          "posthog_cohort"."name",
@@ -9450,7 +9437,95 @@
          AND "posthog_team"."project_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.39
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.4
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.40
   '''
   SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'::jsonb
           AND "posthog_person"."properties" ? '$some_prop_1'
@@ -9462,7 +9537,7 @@
          AND "posthog_person"."team_id" = 99999)
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.4
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.5
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -9484,7 +9559,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.5
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.6
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -9506,7 +9581,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.6
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.7
   '''
   SELECT "posthog_integration"."id",
          "posthog_integration"."team_id",
@@ -9523,7 +9598,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.7
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.8
   '''
   SELECT "posthog_remoteconfig"."id",
          "posthog_remoteconfig"."team_id",
@@ -9535,7 +9610,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.8
+# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.9
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -9613,18 +9688,6 @@
          "posthog_team"."base_currency"
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestDecideRemoteConfig.test_flag_with_regular_cohorts.9
-  '''
-  SELECT "posthog_remoteconfig"."id",
-         "posthog_remoteconfig"."team_id",
-         "posthog_remoteconfig"."config",
-         "posthog_remoteconfig"."updated_at",
-         "posthog_remoteconfig"."synced_at"
-  FROM "posthog_remoteconfig"
-  WHERE "posthog_remoteconfig"."team_id" = 99999
   LIMIT 21
   '''
 # ---

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -309,6 +309,7 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "id",
         "secret_api_token",
         "secret_api_token_backup",
+        "_old_api_token",
     ],
     "Project": ["id", "created_at"],
     "DataWarehouseSavedQuery": [

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models, transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch.dispatcher import receiver
 from django.http import HttpRequest
 from django.utils import timezone
@@ -19,9 +19,12 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.error_tracking.error_tracking import ErrorTrackingSuppressionRule
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.hog_functions.hog_function import HogFunction
+from posthog.models.organization import OrganizationMembership
+from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.plugin import PluginConfig
 from posthog.models.surveys.survey import Survey
 from posthog.models.team.team import Team
+from posthog.models.user import User
 from posthog.models.utils import UUIDTModel, execute_with_timeout
 from posthog.storage.hypercache import HyperCache, HyperCacheStoreMissing
 
@@ -467,9 +470,29 @@ def _update_team_remote_config(team_id: int):
     update_team_remote_config.delay(team_id)
 
 
+@receiver(pre_save, sender=Team)
+def team_pre_save(sender, instance: "Team", **kwargs):
+    """Capture old api_token value before save for cache cleanup."""
+    from posthog.storage.team_access_cache_signal_handlers import capture_old_api_token
+
+    capture_old_api_token(instance, **kwargs)
+
+
 @receiver(post_save, sender=Team)
 def team_saved(sender, instance: "Team", created, **kwargs):
     transaction.on_commit(lambda: _update_team_remote_config(instance.id))
+
+    from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache
+
+    transaction.on_commit(lambda: update_team_authentication_cache(instance, created, **kwargs))
+
+
+@receiver(post_delete, sender=Team)
+def team_deleted(sender, instance: "Team", **kwargs):
+    """Handle team deletion for access cache."""
+    from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache_on_delete
+
+    transaction.on_commit(lambda: update_team_authentication_cache_on_delete(instance, **kwargs))
 
 
 @receiver(post_save, sender=FeatureFlag)
@@ -500,3 +523,85 @@ def survey_saved(sender, instance: "Survey", created, **kwargs):
 @receiver(post_save, sender=ErrorTrackingSuppressionRule)
 def error_tracking_suppression_rule_saved(sender, instance: "ErrorTrackingSuppressionRule", created, **kwargs):
     transaction.on_commit(lambda: _update_team_remote_config(instance.team_id))
+
+
+@receiver(post_save, sender=PersonalAPIKey)
+def personal_api_key_saved(sender, instance: "PersonalAPIKey", created, **kwargs):
+    """
+    Handle PersonalAPIKey save for team access cache invalidation.
+
+    Skip cache updates for last_used_at field updates to avoid unnecessary cache warming
+    during authentication requests.
+    """
+    from posthog.storage.team_access_cache_signal_handlers import update_personal_api_key_authentication_cache
+
+    # Skip cache updates if only last_used_at is being updated
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and set(update_fields) == {"last_used_at"}:
+        return
+
+    transaction.on_commit(lambda: update_personal_api_key_authentication_cache(instance))
+
+
+@receiver(post_delete, sender=PersonalAPIKey)
+def personal_api_key_deleted(sender, instance: "PersonalAPIKey", **kwargs):
+    """
+    Handle PersonalAPIKey delete for team access cache invalidation.
+    """
+    from posthog.storage.team_access_cache_signal_handlers import update_personal_api_key_deleted_cache
+
+    transaction.on_commit(lambda: update_personal_api_key_deleted_cache(instance))
+
+
+@receiver(post_save, sender=User)
+def user_saved(sender, instance: "User", created, **kwargs):
+    """
+    Handle User save for team access cache updates when is_active changes.
+
+    When a user's is_active status changes, their Personal API Keys need to be
+    added or removed from team authentication caches.
+    """
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and "is_active" not in update_fields:
+        logger.debug(f"User {instance.id} updated but is_active unchanged, skipping cache update")
+        return
+
+    # If update_fields is None, we need to update cache since all fields (including is_active) might have changed
+
+    from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+    transaction.on_commit(lambda: update_user_authentication_cache(instance, **kwargs))
+
+
+@receiver(post_save, sender=OrganizationMembership)
+def organization_membership_saved(sender, instance: "OrganizationMembership", created, **kwargs):
+    """
+    Handle OrganizationMembership creation for team access cache updates.
+
+    When a user is added to an organization, their unscoped personal API keys
+    should gain access to teams within that organization. This ensures
+    that the authentication cache is updated to reflect the new access rights.
+
+    Note: We intentionally only handle creation (created=True), not updates.
+    Changes to membership level (e.g., MEMBER → ADMIN) don't affect API key
+    access - Personal API keys grant access based on organization membership
+    existence, not role level.
+    """
+    if created:
+        from posthog.storage.team_access_cache_signal_handlers import update_organization_membership_created_cache
+
+        transaction.on_commit(lambda: update_organization_membership_created_cache(instance))
+
+
+@receiver(post_delete, sender=OrganizationMembership)
+def organization_membership_deleted(sender, instance: "OrganizationMembership", **kwargs):
+    """
+    Handle OrganizationMembership deletion for team access cache invalidation.
+
+    When a user is removed from an organization, their unscoped personal API keys
+    should no longer have access to teams within that organization. This ensures
+    that the authentication cache is updated to reflect the change in access rights.
+    """
+    from posthog.storage.team_access_cache_signal_handlers import update_organization_membership_deleted_cache
+
+    transaction.on_commit(lambda: update_organization_membership_deleted_cache(instance))

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -258,9 +258,9 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
             {"key": "$host", "operator": "regex", "value": "^(localhost|127\\.0\\.0\\.1)($|:)"},
             {"key": "$pageview", "operator": "regex", "value": "test"},
         ]
-        # 1 update team, 1 load hog flows, 1 load hog functions, 1 update hog functions
+        # 1 select team (for field comparison), 1 update team, 1 load hog flows, 1 load hog functions, 1 update hog functions
         # Note: RemoteConfig refresh queries are now deferred via async signals
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             self.team.save()
         hog_function_1.refresh_from_db()
         hog_function_2.refresh_from_db()

--- a/posthog/models/test/test_remote_config_signals.py
+++ b/posthog/models/test/test_remote_config_signals.py
@@ -1,0 +1,208 @@
+"""
+Tests for signal handlers in posthog/models/remote_config.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from posthog.models.organization import OrganizationMembership
+from posthog.models.remote_config import organization_membership_deleted, user_saved
+from posthog.models.user import User
+
+
+class TestUserSavedSignalHandler(TestCase):
+    """Test the user_saved signal handler in remote_config.py."""
+
+    @parameterized.expand(
+        [
+            # (update_fields, should_schedule_update, description)
+            (["is_active", "email"], True, "is_active in update_fields"),
+            (None, True, "update_fields is None (bulk operation)"),
+            (["email", "name"], False, "is_active not in update_fields"),
+            ([], False, "empty update_fields list"),
+            (["is_active"], True, "only is_active in update_fields"),
+        ]
+    )
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_update_fields_scenarios(
+        self, update_fields, should_schedule_update, description, mock_on_commit
+    ):
+        """Test user_saved signal handler for various update_fields scenarios."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with specified update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=update_fields)
+
+        # Verify transaction.on_commit behavior
+        if should_schedule_update:
+            mock_on_commit.assert_called_once()
+        else:
+            mock_on_commit.assert_not_called()
+
+    @patch("posthog.models.remote_config.logger")
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_logs_debug_when_skipping_update(self, mock_on_commit, mock_logger):
+        """Test that user_saved logs debug message when skipping cache update."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with is_active NOT in update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=["email", "name"])
+
+        # Verify debug message was logged
+        mock_logger.debug.assert_called_once_with("User 42 updated but is_active unchanged, skipping cache update")
+
+        # Verify transaction.on_commit was not called
+        mock_on_commit.assert_not_called()
+
+    @patch("posthog.storage.team_access_cache_signal_handlers.update_user_authentication_cache")
+    @patch("django.db.transaction.on_commit")
+    def test_user_saved_uses_transaction_on_commit(self, mock_on_commit, mock_update_cache):
+        """Test that user_saved uses transaction.on_commit to defer cache updates."""
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_user.is_active = True
+
+        # Call user_saved with is_active in update_fields
+        user_saved(sender=User, instance=mock_user, created=False, update_fields=["is_active"])
+
+        # Verify transaction.on_commit was called
+        mock_on_commit.assert_called_once()
+
+        # Get the lambda function that was passed to on_commit and call it
+        on_commit_lambda = mock_on_commit.call_args[0][0]
+        on_commit_lambda()
+
+        # Verify that the update function would be called after transaction commits
+        # The lambda passes instance and **kwargs (which doesn't include created)
+        mock_update_cache.assert_called_once_with(mock_user, update_fields=["is_active"])
+
+
+class TestOrganizationMembershipDeletedSignalHandler(TestCase):
+    """Test the organization_membership_deleted signal handler in remote_config.py."""
+
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_calls_update_when_user_removed(self, mock_on_commit):
+        """Test that organization_membership_deleted schedules cache update when a user is removed from org."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+
+        # Call organization_membership_deleted
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+
+        # Verify transaction.on_commit was called (update was scheduled)
+        mock_on_commit.assert_called_once()
+
+    @patch("posthog.storage.team_access_cache_signal_handlers.update_organization_membership_deleted_cache")
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_uses_transaction_on_commit(self, mock_on_commit, mock_update_cache):
+        """Test that organization_membership_deleted uses transaction.on_commit to defer cache updates."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+        mock_membership.organization_id = "test-org-uuid"
+        mock_membership.user_id = 42
+
+        # Call organization_membership_deleted
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+
+        # Verify transaction.on_commit was called
+        mock_on_commit.assert_called_once()
+
+        # Get the lambda function that was passed to on_commit and call it
+        on_commit_lambda = mock_on_commit.call_args[0][0]
+        on_commit_lambda()
+
+        # Verify that the update function would be called after transaction commits
+        # The lambda passes the membership instance
+        mock_update_cache.assert_called_once_with(mock_membership)
+
+    @patch("posthog.models.remote_config.logger")
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_logs_when_scheduled(self, mock_on_commit, mock_logger):
+        """Test that organization_membership_deleted properly schedules cache updates."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+
+        # Call organization_membership_deleted
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+
+        # Verify transaction.on_commit was called (update was scheduled)
+        mock_on_commit.assert_called_once()
+
+    def test_organization_membership_deleted_handles_none_user(self):
+        """Test that organization_membership_deleted handles membership with None user gracefully."""
+
+        # Create mock OrganizationMembership with None user
+        mock_membership = MagicMock()
+        mock_membership.user = None
+
+        # Should not raise an exception
+        try:
+            organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership)
+        except Exception as e:
+            self.fail(f"organization_membership_deleted raised an exception with None user: {e}")
+
+    @patch("django.db.transaction.on_commit")
+    def test_organization_membership_deleted_with_different_kwargs(self, mock_on_commit):
+        """Test that organization_membership_deleted properly forwards kwargs to the cache update."""
+
+        # Create mock user and organization
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        mock_org = MagicMock()
+        mock_org.id = "test-org-uuid"
+
+        # Create mock OrganizationMembership
+        mock_membership = MagicMock()
+        mock_membership.user = mock_user
+        mock_membership.organization = mock_org
+
+        # Call organization_membership_deleted with additional kwargs
+        test_kwargs = {"raw": False, "using": "default"}
+        organization_membership_deleted(sender=OrganizationMembership, instance=mock_membership, **test_kwargs)
+
+        # Verify transaction.on_commit was called
+        mock_on_commit.assert_called_once()

--- a/posthog/storage/team_access_cache.py
+++ b/posthog/storage/team_access_cache.py
@@ -1,0 +1,383 @@
+"""
+Per-team access token cache layer for cache-based authentication.
+
+This module provides Redis-based caching of hashed access tokens per team,
+enabling zero-database-call authentication for the local_evaluation endpoint.
+"""
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from django.db import transaction
+from django.db.models import Q
+
+from posthog.models.organization import OrganizationMembership
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.team.team import Team
+from posthog.storage.hypercache import HyperCache, HyperCacheStoreMissing, KeyType
+
+logger = logging.getLogger(__name__)
+
+# Cache configuration
+DEFAULT_TTL = 300  # 5 minutes
+CACHE_KEY_PREFIX = "cache/teams"
+
+
+class TeamAccessTokenCache:
+    """
+    HyperCache-based cache for per-team access token lists.
+
+    This class manages hashed token lists per team to enable fast authentication
+    lookups without database queries. Each team has its own cache entry with
+    JSON data containing hashed authorized tokens and metadata. Uses HyperCache
+    for automatic Redis + S3 backup and improved reliability.
+    """
+
+    def __init__(self, ttl: int = DEFAULT_TTL):
+        """
+        Initialize the team access token cache.
+
+        Args:
+            ttl: Time-to-live for cache entries in seconds
+        """
+        self.ttl = ttl
+
+    def update_team_tokens(self, project_api_key: str, team_id: int, hashed_tokens: list[str]) -> None:
+        """
+        Update a team's complete token list in cache.
+
+        Args:
+            project_api_key: The team's project API key
+            team_id: The team's ID
+            hashed_tokens: List of hashed tokens (already in sha256$ format)
+        """
+        try:
+            token_data = {
+                "hashed_tokens": hashed_tokens,
+                "last_updated": datetime.now(UTC).isoformat(),
+                "team_id": team_id,
+            }
+            team_access_tokens_hypercache.set_cache_value(project_api_key, token_data)
+
+            logger.info(
+                f"Updated token cache for team {project_api_key} with {len(hashed_tokens)} tokens",
+                extra={"team_project_api_key": project_api_key, "token_count": len(hashed_tokens)},
+            )
+
+        except Exception as e:
+            logger.exception(f"Error updating tokens for team {project_api_key}: {e}")
+            raise
+
+    def invalidate_team(self, project_api_key: str) -> None:
+        """
+        Invalidate (delete) a team's token cache.
+
+        Args:
+            project_api_key: The team's project API key
+        """
+        try:
+            team_access_tokens_hypercache.clear_cache(project_api_key)
+
+            logger.info(f"Invalidated token cache for team {project_api_key}")
+
+        except Exception as e:
+            logger.exception(f"Error invalidating cache for team {project_api_key}: {e}")
+            raise
+
+
+def _load_team_access_tokens(team_token: KeyType) -> dict[str, Any] | HyperCacheStoreMissing:
+    """
+    Load team access tokens from the database.
+
+    Args:
+        team_token: Team identifier (can be Team object, API token string, or team ID)
+
+    Returns:
+        Dictionary containing hashed tokens and metadata, or HyperCacheStoreMissing if team not found
+    """
+    try:
+        # Use transaction isolation to ensure consistent reads across all queries
+        with transaction.atomic():
+            if isinstance(team_token, str):
+                team = Team.objects.select_related("organization").get(api_token=team_token)
+            elif isinstance(team_token, int):
+                team = Team.objects.select_related("organization").get(id=team_token)
+            else:
+                # team_token is already a Team object, but ensure organization is loaded
+                team = team_token
+                if not hasattr(team, "organization") or team.organization is None:
+                    team = Team.objects.select_related("organization").get(id=team.id)
+
+            hashed_tokens: list[str] = []
+
+            # Get all relevant personal API keys in one optimized query
+            # Combines scoped and unscoped keys with proper filtering
+            personal_keys = (
+                PersonalAPIKey.objects.select_related("user")
+                .filter(
+                    user__organization_membership__organization_id=team.organization_id,
+                    user__is_active=True,
+                )
+                .filter(
+                    # Organization scoping: key must either have no org restriction OR include this org
+                    Q(scoped_organizations__isnull=True)
+                    | Q(scoped_organizations=[])
+                    | Q(scoped_organizations__contains=[str(team.organization_id)])
+                )
+                .filter(
+                    (
+                        # Scoped keys: explicitly include this team AND have feature flag read or write access
+                        Q(scoped_teams__contains=[team.id])
+                        & (
+                            # Keys with write permission implicitly have read permission
+                            Q(scopes__contains=["feature_flag:read"]) | Q(scopes__contains=["feature_flag:write"])
+                        )
+                    )
+                    | (
+                        # Unscoped keys: no team restriction (null or empty array)
+                        (Q(scoped_teams__isnull=True) | Q(scoped_teams=[]))
+                        & (
+                            # AND either no scope restriction OR has feature flag read or write access
+                            Q(scopes__isnull=True)
+                            | Q(scopes=[])
+                            | Q(scopes__contains=["feature_flag:read"])
+                            | Q(scopes__contains=["feature_flag:write"])
+                        )
+                    )
+                )
+                .distinct()
+                .values_list("secure_value", flat=True)
+            )
+
+            # Collect personal API key tokens
+            hashed_tokens.extend(secure_value for secure_value in personal_keys if secure_value)
+
+            # Add team secret tokens
+            if team.secret_api_token:
+                hashed_secret = hash_key_value(team.secret_api_token, mode="sha256")
+                hashed_tokens.append(hashed_secret)
+
+            if team.secret_api_token_backup:
+                hashed_secret_backup = hash_key_value(team.secret_api_token_backup, mode="sha256")
+                hashed_tokens.append(hashed_secret_backup)
+
+            return {
+                "hashed_tokens": hashed_tokens,
+                "last_updated": datetime.now(UTC).isoformat(),
+                "team_id": team.id,  # Include team_id for zero-DB-call authentication
+            }
+
+    except Team.DoesNotExist:
+        logger.warning(f"Team not found for project API key: {team_token}")
+        return HyperCacheStoreMissing()
+
+    except Exception as e:
+        logger.exception(f"Error loading team access tokens for {team_token}: {e}")
+        return HyperCacheStoreMissing()
+
+
+# HyperCache instance for team access tokens
+team_access_tokens_hypercache = HyperCache(
+    namespace="team_access_tokens",
+    value="access_tokens.json",
+    token_based=True,  # Use team API token as key
+    load_fn=_load_team_access_tokens,
+)
+
+# Global instance for convenience
+team_access_cache = TeamAccessTokenCache()
+
+
+def warm_team_token_cache(project_api_key: str) -> bool:
+    """
+    Warm the token cache for a specific team by loading from database.
+
+    This function now uses the HyperCache to update the cache, which handles
+    both Redis and S3 storage automatically.
+
+    Args:
+        project_api_key: The team's project API key
+
+    Returns:
+        True if cache warming succeeded, False otherwise
+    """
+    # Use HyperCache to update the cache - this will call _load_team_access_tokens
+    # It does not raise an exception if the cache is not updated, so we don't need to try/except
+    success = team_access_tokens_hypercache.update_cache(project_api_key)
+
+    if success:
+        logger.info(
+            f"Warmed token cache for team {project_api_key} using HyperCache",
+            extra={"project_api_key": project_api_key},
+        )
+    else:
+        logger.warning(f"Failed to warm token cache for team {project_api_key}")
+
+    return success
+
+
+def get_teams_needing_cache_refresh(limit: int | None = None, offset: int = 0) -> list[str]:
+    """
+    Get a list of project API keys for teams that need cache refresh.
+
+    This function now supports pagination to handle large datasets efficiently.
+    For installations with many teams, use limit/offset to process in batches.
+
+    Args:
+        limit: Maximum number of teams to check. None means no limit (all teams).
+        offset: Number of teams to skip before starting to check.
+
+    Returns:
+        List of project API keys that need cache refresh
+
+    Raises:
+        Exception: Database connectivity or other systemic issues that should trigger retries
+    """
+    # Build queryset with pagination support
+    # Note: Filtering by project__isnull=False may be needed in production
+    # but is removed for testing since test teams often don't have projects
+    queryset = Team.objects.values_list("api_token", flat=True).order_by("id")  # Consistent ordering for pagination
+
+    # Apply pagination if specified
+    if offset > 0:
+        queryset = queryset[offset:]
+    if limit is not None:
+        queryset = queryset[:limit]
+
+    # Check which teams have missing caches in HyperCache
+    teams_needing_refresh = []
+
+    for project_api_key in queryset:
+        try:
+            token_data = team_access_tokens_hypercache.get_from_cache(project_api_key)
+            if token_data is None:
+                teams_needing_refresh.append(project_api_key)
+        except Exception as e:
+            # Log individual team cache check failure but continue with others
+            logger.warning(
+                f"Failed to check cache for team {project_api_key}: {e}",
+                extra={"project_api_key": project_api_key, "error": str(e)},
+            )
+            # Assume this team needs refresh if we can't check its cache
+            teams_needing_refresh.append(project_api_key)
+
+    return teams_needing_refresh
+
+
+def get_teams_needing_cache_refresh_paginated(batch_size: int = 1000):
+    """
+    Generator that yields batches of teams needing cache refresh.
+
+    This is the recommended approach for processing large numbers of teams
+    to avoid memory issues. It processes teams in chunks and yields each
+    batch as it's completed.
+
+    Args:
+        batch_size: Number of teams to process per batch
+
+    Yields:
+        List[str]: Batches of project API keys that need cache refresh
+    """
+    offset = 0
+
+    while True:
+        batch = get_teams_needing_cache_refresh(limit=batch_size, offset=offset)
+
+        if not batch:
+            # No more teams to process
+            break
+
+        yield batch
+        offset += batch_size
+
+        # If we got fewer teams than requested, we've reached the end
+        if len(batch) < batch_size:
+            break
+
+
+def get_teams_for_user_personal_api_keys(user_id: int) -> set[str]:
+    """
+    Get all project API keys for teams that a user's PersonalAPIKeys have access to.
+
+    This function eliminates N+1 queries by determining all affected teams for
+    a user's personal API keys in minimal database queries (1-3 queries maximum).
+
+    Args:
+        user_id: The user ID whose personal API keys to analyze
+
+    Returns:
+        Set of project API keys (strings) for all teams the user's keys have access to
+    """
+    # Get all personal API keys for the user
+    personal_keys = list(PersonalAPIKey.objects.filter(user_id=user_id).values("id", "scoped_teams"))
+
+    if not personal_keys:
+        return set()
+
+    affected_teams = set()
+    scoped_team_ids: set[int] = set()
+    has_unscoped_keys = False
+
+    # Analyze all keys to determine which teams they affect
+    for key_data in personal_keys:
+        scoped_teams = key_data["scoped_teams"] or []
+        if scoped_teams:
+            # Scoped key - add specific team IDs
+            scoped_team_ids.update(scoped_teams)
+        else:
+            # Unscoped key - will need all teams in user's organizations
+            has_unscoped_keys = True
+
+    # Get project API keys for scoped teams (if any) in one query
+    if scoped_team_ids:
+        scoped_team_tokens = Team.objects.filter(id__in=scoped_team_ids).values_list("api_token", flat=True)
+        affected_teams.update(scoped_team_tokens)
+
+    # Get project API keys for unscoped keys (if any) in two queries maximum
+    if has_unscoped_keys:
+        # Get user's organizations
+        user_organizations = OrganizationMembership.objects.filter(user_id=user_id).values_list(
+            "organization_id", flat=True
+        )
+
+        if user_organizations:
+            # Get all teams in those organizations
+            org_team_tokens = Team.objects.filter(organization_id__in=user_organizations).values_list(
+                "api_token", flat=True
+            )
+            affected_teams.update(org_team_tokens)
+
+    return affected_teams
+
+
+def get_teams_for_single_personal_api_key(personal_api_key_instance: "PersonalAPIKey") -> list[str]:
+    """
+    Get project API keys for teams that a single PersonalAPIKey has access to.
+
+    This is a helper function that internally uses the optimized user-based function.
+    For better performance when processing multiple keys for the same user, use
+    get_teams_for_user_personal_api_keys() directly.
+
+    Args:
+        personal_api_key_instance: The PersonalAPIKey instance
+
+    Returns:
+        List of project API keys (strings) for teams the key has access to
+    """
+    user_id = personal_api_key_instance.user_id
+    all_user_teams = get_teams_for_user_personal_api_keys(user_id)
+
+    # Filter to only teams this specific key has access to
+    scoped_teams = personal_api_key_instance.scoped_teams or []
+
+    if scoped_teams:
+        # Scoped key - only return teams in the scoped list
+        scoped_team_tokens = set(Team.objects.filter(id__in=scoped_teams).values_list("api_token", flat=True))
+        # Return intersection of user teams and scoped teams
+        result = list(all_user_teams.intersection(scoped_team_tokens))
+    else:
+        # Unscoped key - return all teams the user has access to
+        result = list(all_user_teams)
+
+    return result

--- a/posthog/storage/team_access_cache_signal_handlers.py
+++ b/posthog/storage/team_access_cache_signal_handlers.py
@@ -1,0 +1,326 @@
+"""
+Signal handler functions for team access token cache invalidation.
+
+This module provides handler functions that automatically update
+the team access token cache when PersonalAPIKey or Team models change,
+ensuring cache consistency with the database.
+
+Note: Signal subscriptions are registered in posthog/models/remote_config.py
+"""
+
+import logging
+
+from posthog.models.organization import OrganizationMembership
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.team.team import Team
+from posthog.storage.team_access_cache import (
+    get_teams_for_user_personal_api_keys,
+    team_access_cache,
+    warm_team_token_cache,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def capture_old_api_token(instance: Team, **kwargs):
+    """
+    Capture the old api_token value before save for cleanup.
+
+    This pre_save handler stores the old api_token value so the post_save
+    handler can clean up the old cache entry when the token changes.
+    """
+    if instance.pk:  # Only for existing teams
+        try:
+            old_team = Team.objects.only("api_token").get(pk=instance.pk)
+            # Store the old api_token value for post_save cleanup
+            instance._old_api_token = old_team.api_token  # type: ignore[attr-defined]
+        except Team.DoesNotExist:
+            pass
+
+
+def update_team_authentication_cache(instance: Team, created: bool, **kwargs):
+    """
+    Rebuild team access cache when Team model is saved.
+
+    This handler only rebuilds the cache when authentication-related fields change
+    to avoid unnecessary cache operations for unrelated team updates.
+    """
+    try:
+        if not instance.api_token:
+            return
+
+        if created:
+            logger.debug(f"New team created: {instance.pk}")
+            return
+
+        # Check if this is a new team being created
+        if hasattr(instance, "_state") and instance._state.adding:
+            logger.debug(f"Team {instance.pk} is being created, skipping cache update")
+            return
+
+        # Check if api_token changed (project API key regeneration)
+        # We look for the old value stored before save
+        old_api_token = getattr(instance, "_old_api_token", None)
+
+        # If update_fields is specified, only rebuild cache if auth-related fields changed
+        update_fields = kwargs.get("update_fields")
+        auth_related_fields = {"api_token", "secret_api_token", "secret_api_token_backup"}
+
+        if update_fields is not None:
+            # Convert update_fields to set for efficient intersection
+            updated_fields = set(update_fields) if update_fields else set()
+
+            # Check if any auth-related fields were updated
+            if not updated_fields.intersection(auth_related_fields):
+                logger.debug(
+                    f"Team {instance.pk} updated but no auth fields changed, skipping cache update",
+                    extra={
+                        "team_id": instance.pk,
+                        "updated_fields": list(updated_fields),
+                        "auth_fields": list(auth_related_fields),
+                    },
+                )
+                return
+
+        try:
+            # Clean up old cache if api_token changed
+            if old_api_token and old_api_token != instance.api_token:
+                team_access_cache.invalidate_team(old_api_token)
+                logger.info(
+                    f"Invalidated old cache for team {instance.pk} after API token change",
+                    extra={"team_id": instance.pk, "old_api_token": old_api_token, "new_api_token": instance.api_token},
+                )
+
+            warm_team_token_cache(instance.api_token)
+            logger.info(
+                f"Rebuilt team access cache for team {instance.pk} after auth field change",
+                extra={"team_id": instance.pk, "project_api_key": instance.api_token},
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to rebuild cache for team {instance.pk}, falling back to invalidation: {e}",
+                extra={"team_id": instance.pk},
+            )
+            # Fall back to invalidation if rebuild fails
+            team_access_cache.invalidate_team(instance.api_token)
+
+    except Exception as e:
+        logger.exception(f"Error updating cache on team save for team {instance.pk}: {e}")
+
+
+def update_team_authentication_cache_on_delete(instance: Team, **kwargs):
+    """
+    Invalidate team access cache when Team is deleted.
+    """
+    try:
+        if instance.api_token:
+            team_access_cache.invalidate_team(instance.api_token)
+            logger.info(f"Invalidated cache for deleted team {instance.pk}")
+
+    except Exception as e:
+        logger.exception(f"Error invalidating cache on team delete for team {instance.pk}: {e}")
+
+
+def update_personal_api_key_authentication_cache(instance: PersonalAPIKey):
+    """
+    Update team access cache when PersonalAPIKey is saved.
+
+    This handler warms the cache for all teams that the user's personal API keys have
+    access to. For optimal performance, it uses the user-based function to warm all
+    affected teams at once. Since warming completely rebuilds the cache from the database,
+    no prior invalidation is needed.
+    """
+    # Get the list of affected teams using optimized user-based function
+    affected_teams = get_teams_for_user_personal_api_keys(instance.user_id)
+
+    # Warm the cache for each affected team
+    for project_api_key in affected_teams:
+        try:
+            warm_team_token_cache(project_api_key)
+            logger.debug(f"Warmed cache for team {project_api_key} after PersonalAPIKey change")
+        except Exception as e:
+            logger.warning(
+                f"Failed to warm cache for team {project_api_key} after PersonalAPIKey change: {e}",
+                extra={"project_api_key": project_api_key, "personal_api_key_id": instance.id},
+            )
+
+    logger.info(
+        f"Updated authentication cache for {len(affected_teams)} teams after PersonalAPIKey change",
+        extra={"personal_api_key_id": instance.id, "affected_teams_count": len(affected_teams)},
+    )
+
+
+def update_user_authentication_cache(instance, **kwargs):
+    """
+    Update team access caches when a User's status changes.
+
+    When a user is activated/deactivated, their Personal API Keys need to be
+    added/removed from the authentication caches of all teams they have access to.
+    This includes both scoped and unscoped keys.
+
+    Note: The update_fields filtering is now handled by the user_saved signal handler
+    in remote_config.py before calling this function.
+
+    Args:
+        sender: The model class (User)
+        instance: The User instance that changed
+        **kwargs: Additional signal arguments
+    """
+    try:
+        # Get all teams that the user's personal API keys have access to
+        affected_teams = get_teams_for_user_personal_api_keys(instance.id)
+
+        _warm_cache_for_teams(affected_teams, "user status change", str(instance.id), None)
+
+    except Exception as e:
+        logger.exception(f"Error updating authentication cache for user {instance.id} status change: {e}")
+
+
+def update_personal_api_key_deleted_cache(instance: PersonalAPIKey):
+    """
+    Update team access caches when a PersonalAPIKey is deleted.
+
+    When a PersonalAPIKey is deleted, it needs to be removed from all team caches
+    that it had access to. This includes both scoped and unscoped keys.
+
+    Args:
+        instance: The PersonalAPIKey instance that was deleted
+    """
+    try:
+        # Get all teams that this specific key had access to
+        # We need to determine this based on the key's scoping
+        scoped_teams = instance.scoped_teams or []
+
+        if scoped_teams:
+            # Scoped key - only affects specific teams
+            team_api_tokens = Team.objects.filter(id__in=scoped_teams).values_list("api_token", flat=True)
+        else:
+            # Unscoped key - affects all teams in user's organizations
+            user_organizations = OrganizationMembership.objects.filter(user_id=instance.user_id).values_list(
+                "organization_id", flat=True
+            )
+
+            if user_organizations:
+                team_api_tokens = Team.objects.filter(organization_id__in=user_organizations).values_list(
+                    "api_token", flat=True
+                )
+            else:
+                team_api_tokens = []
+
+        _warm_cache_for_teams(team_api_tokens, "PersonalAPIKey deletion", str(instance.user_id), None)
+
+    except Exception as e:
+        logger.exception(
+            f"Error updating team caches after PersonalAPIKey deletion: {e}",
+            extra={
+                "personal_api_key_id": getattr(instance, "id", None),
+                "user_id": getattr(instance, "user_id", None),
+            },
+        )
+
+
+def update_organization_membership_created_cache(membership_instance):
+    """
+    Update team access caches when an OrganizationMembership is created.
+
+    When a user is added to an organization, their unscoped Personal API Keys should
+    gain access to teams within that organization. This function updates the caches for
+    all teams in the organization that was joined.
+
+    Args:
+        membership_instance: The OrganizationMembership instance that was created
+    """
+    try:
+        # Get all teams in the organization the user joined
+        organization_id = membership_instance.organization_id
+        user_id = membership_instance.user_id
+
+        team_api_tokens = Team.objects.filter(organization_id=organization_id).values_list("api_token", flat=True)
+
+        _warm_cache_for_teams(team_api_tokens, "adding user to organization", user_id, organization_id)
+
+    except Exception as e:
+        logger.exception(
+            f"Error updating team caches after OrganizationMembership creation: {e}",
+            extra={
+                "user_id": getattr(membership_instance, "user_id", None),
+                "organization_id": getattr(membership_instance, "organization_id", None),
+            },
+        )
+
+
+def update_organization_membership_deleted_cache(membership_instance):
+    """
+    Update team access caches when an OrganizationMembership is deleted.
+
+    When a user is removed from an organization, their Personal API Keys should no longer
+    have access to teams within that organization. This function updates the caches for
+    all teams in the organization that was removed from.
+
+    This is different from update_user_authentication_cache because we need to update
+    the teams from the organization the user was REMOVED from, not their current teams
+    (which won't include the removed organization anymore).
+
+    Args:
+        membership_instance: The OrganizationMembership instance that was deleted
+    """
+    try:
+        # Get all teams in the organization the user was removed from
+        organization_id = membership_instance.organization_id
+        user_id = membership_instance.user_id
+
+        team_api_tokens = Team.objects.filter(organization_id=organization_id).values_list("api_token", flat=True)
+
+        _warm_cache_for_teams(team_api_tokens, "removing user from organization", user_id, organization_id)
+
+    except Exception as e:
+        logger.exception(
+            f"Error updating team caches after OrganizationMembership deletion: {e}",
+            extra={
+                "user_id": getattr(membership_instance, "user_id", None),
+                "organization_id": getattr(membership_instance, "organization_id", None),
+            },
+        )
+
+
+def _warm_cache_for_teams(
+    team_api_tokens: set[str] | list[str], action: str, user_id: str, organization_id: str | None
+):
+    """
+    Warm the cache for a set of teams.
+    """
+    if not team_api_tokens:
+        logger.debug(f"No teams found in organization {organization_id}, no cache updates needed")
+        return
+
+    # Warm the cache for each team in the organization
+    # This will rebuild the cache without the removed user's keys
+    for project_api_key in team_api_tokens:
+        try:
+            warm_team_token_cache(project_api_key)
+            logger.debug(
+                f"Warmed cache for team {project_api_key} after {action}",
+                extra={
+                    "project_api_key": project_api_key,
+                    "user_id": user_id,
+                    "organization_id": organization_id,
+                },
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to warm cache for team {project_api_key} after {action}: {e}",
+                extra={
+                    "project_api_key": project_api_key,
+                    "user_id": user_id,
+                    "organization_id": organization_id,
+                },
+            )
+
+    logger.info(
+        f"Updated {len(team_api_tokens)} team caches after {action}",
+        extra={
+            "user_id": user_id,
+            "organization_id": organization_id,
+            "teams_updated": len(team_api_tokens),
+        },
+    )

--- a/posthog/storage/test/test_team_access_cache.py
+++ b/posthog/storage/test/test_team_access_cache.py
@@ -1,0 +1,2609 @@
+"""
+Tests for team access token cache functionality.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from posthog.models.personal_api_key import hash_key_value
+from posthog.storage.team_access_cache import (
+    TeamAccessTokenCache,
+    get_teams_for_single_personal_api_key,
+    get_teams_for_user_personal_api_keys,
+    get_teams_needing_cache_refresh,
+    get_teams_needing_cache_refresh_paginated,
+    team_access_tokens_hypercache,
+    warm_team_token_cache,
+)
+
+
+class TestTeamAccessTokenCache(TestCase):
+    """Test the TeamAccessTokenCache class."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.cache = TeamAccessTokenCache(ttl=300)
+        self.project_api_key = "phs_test_project_key_123"
+        self.team_id = 42
+        self.access_token = "phx_test_access_token_456"
+        self.hashed_token = hash_key_value(self.access_token, mode="sha256")
+
+        # Clear cache before each test
+        cache.clear()
+        # Also clear HyperCache
+        team_access_tokens_hypercache.clear_cache(self.project_api_key)
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+        # Also clear HyperCache
+        team_access_tokens_hypercache.clear_cache(self.project_api_key)
+
+    def test_update_team_tokens(self):
+        """Test updating team token list using HyperCache."""
+        tokens = [
+            hash_key_value("phx_token_one_123", mode="sha256"),
+            hash_key_value("phx_token_two_456", mode="sha256"),
+        ]
+
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, tokens)
+
+        # Verify tokens are cached in JSON format
+        cached_data = team_access_tokens_hypercache.get_from_cache(self.project_api_key)
+
+        assert cached_data is not None
+        assert cached_data["hashed_tokens"] == tokens
+        assert cached_data["team_id"] == self.team_id
+        assert "last_updated" in cached_data
+
+    def test_invalidate_team(self):
+        """Test invalidating team cache."""
+        # Set up cache
+        self.cache.update_team_tokens(self.project_api_key, self.team_id, [self.hashed_token])
+
+        # Verify token is cached
+        cached_data = team_access_tokens_hypercache.get_from_cache(self.project_api_key)
+        assert cached_data is not None
+        assert self.hashed_token in cached_data.get("hashed_tokens", [])
+
+        # Invalidate cache
+        self.cache.invalidate_team(self.project_api_key)
+
+        # Verify token is no longer cached
+        cached_data = team_access_tokens_hypercache.get_from_cache(self.project_api_key)
+        assert cached_data is None
+
+
+class TestTeamAccessCacheIntegration(TestCase):
+    """Integration tests for team access cache with models."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @parameterized.expand(
+        [
+            ("feature_flag:read", "Test with read scope"),
+            ("feature_flag:write", "Test with write scope"),
+        ]
+    )
+    def test_warm_team_token_cache(self, scope, description):
+        """Test warming team token cache from database with real data."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data
+        scope_suffix = scope.split(":")[1]  # 'read' or 'write'
+        organization = Organization.objects.create(name=f"Test Organization {scope_suffix}")
+        team = Team.objects.create(
+            organization=organization,
+            name=f"Test Team {scope_suffix}",
+            api_token=f"phc_test_{scope_suffix}_123",
+            secret_api_token=f"phsk_secret_{scope_suffix}_123",
+            secret_api_token_backup=f"phsk_backup_{scope_suffix}_456",
+        )
+
+        # Create users and personal API keys
+        user1 = User.objects.create(email=f"user1_{scope_suffix}@test.com", is_active=True)
+        user2 = User.objects.create(email=f"user2_{scope_suffix}@test.com", is_active=True)
+
+        # Add users to organization
+        OrganizationMembership.objects.create(organization=organization, user=user1)
+        OrganizationMembership.objects.create(organization=organization, user=user2)
+
+        # Create personal API keys with the scope being tested
+        PersonalAPIKey.objects.create(
+            user=user1,
+            label=f"Test Key 1 {scope_suffix}",
+            secure_value=hash_key_value(f"test_key_1_{scope_suffix}"),
+            scopes=[scope],  # Use the scope being tested
+        )
+        PersonalAPIKey.objects.create(
+            user=user2,
+            label=f"Test Key 2 {scope_suffix}",
+            secure_value=hash_key_value(f"test_key_2_{scope_suffix}"),
+            scoped_teams=[team.id],
+            scopes=[scope],  # Use the scope being tested
+        )
+
+        # Warm the cache
+        result = warm_team_token_cache(team.api_token)
+
+        # Verify cache warming succeeded
+        assert result is True, f"Cache warming should succeed for {scope}"
+
+        # Verify cache was populated via HyperCache
+        cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+
+        assert cached_data is not None, f"Cache should be populated for {scope}"
+        hashed_tokens = cached_data["hashed_tokens"]
+
+        # Should contain personal API key hashes and secret tokens
+        expected_personal_key_1 = hash_key_value(f"test_key_1_{scope_suffix}", mode="sha256")
+        expected_personal_key_2 = hash_key_value(f"test_key_2_{scope_suffix}", mode="sha256")
+        expected_secret = hash_key_value(f"phsk_secret_{scope_suffix}_123", mode="sha256")
+        expected_secret_backup = hash_key_value(f"phsk_backup_{scope_suffix}_456", mode="sha256")
+
+        assert expected_personal_key_1 in hashed_tokens, f"Unscoped key with {scope} should be in cache"
+        assert expected_personal_key_2 in hashed_tokens, f"Scoped key with {scope} should be in cache"
+        assert expected_secret in hashed_tokens, f"Secret token should be in cache for {scope}"
+        assert expected_secret_backup in hashed_tokens, f"Backup secret token should be in cache for {scope}"
+
+        # Should have team_id for zero-DB-call authentication
+        assert cached_data["team_id"] == team.id
+        assert "last_updated" in cached_data
+
+    @patch("posthog.models.team.team.Team.objects.get")
+    def test_warm_team_token_cache_team_not_found(self, mock_team_get):
+        """Test warming cache when team doesn't exist."""
+        from posthog.models.team.team import Team
+
+        mock_team_get.side_effect = Team.DoesNotExist()
+
+        # Should not raise exception
+        warm_team_token_cache("nonexistent_project_key")
+
+        # Cache should remain empty
+        cached_data = team_access_tokens_hypercache.get_from_cache("nonexistent_project_key")
+        assert cached_data is None
+
+    @patch("posthog.storage.team_access_cache.team_access_tokens_hypercache.get_from_cache")
+    def test_get_teams_needing_cache_refresh_paginated_generator(self, mock_get_from_cache):
+        """Test the paginated generator function by mocking cache checks."""
+        from posthog.models import Organization, Team
+
+        # Create test data
+        organization = Organization.objects.create(name="Test Organization")
+        teams = []
+        for i in range(7):  # 7 teams total
+            team = Team.objects.create(organization=organization, name=f"Team {i}", api_token=f"phs_team_{i:03d}")
+            teams.append(team)
+
+        # Mock cache to return None for all teams (all need refresh)
+        mock_get_from_cache.return_value = None
+
+        # Test paginated generator with batch size 3
+        all_batches = list(get_teams_needing_cache_refresh_paginated(batch_size=3))
+
+        # Flatten all batches
+        all_teams_from_batches = []
+        for batch in all_batches:
+            all_teams_from_batches.extend(batch)
+
+        # Should match non-paginated result
+        expected_teams = get_teams_needing_cache_refresh()
+        assert set(all_teams_from_batches) == set(expected_teams)
+
+        # All our test teams should be included (since mock returns None for all)
+        expected_api_keys = {f"phs_team_{i:03d}" for i in range(7)}
+        # At least our test teams should be present
+        assert expected_api_keys.issubset(set(all_teams_from_batches))
+
+        # Should have gotten some batches
+        assert len(all_batches) >= 1
+
+        # Each batch should respect the batch size limit
+        for batch in all_batches:
+            assert len(batch) <= 3
+
+
+class TestCacheWarmingWithUnscopedKeys(TestCase):
+    """Test cache warming functionality with unscoped PersonalAPIKeys."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    def test_warm_team_cache_includes_unscoped_keys(self):
+        """Test that cache warming includes unscoped PersonalAPIKeys."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data
+        organization = Organization.objects.create(name="Test Organization")
+        team = Team.objects.create(
+            organization=organization,
+            name="Test Team",
+            api_token="phc_test_project_key",
+            secret_api_token="phsk_secret_token_123",
+        )
+
+        # Create users with both scoped and unscoped keys
+        user1 = User.objects.create(email="user1@test.com", is_active=True)
+        user2 = User.objects.create(email="user2@test.com", is_active=True)
+        user3 = User.objects.create(email="user3@test.com", is_active=True)
+
+        # Add users to organization
+        OrganizationMembership.objects.create(organization=organization, user=user1)
+        OrganizationMembership.objects.create(organization=organization, user=user2)
+        OrganizationMembership.objects.create(organization=organization, user=user3)
+
+        # Create scoped keys (for specific team)
+        PersonalAPIKey.objects.create(
+            user=user1,
+            label="Scoped Key 1",
+            secure_value=hash_key_value("scoped_key_1"),
+            scoped_teams=[team.id],
+            scopes=["feature_flag:read"],
+        )
+        PersonalAPIKey.objects.create(
+            user=user2,
+            label="Scoped Key 2",
+            secure_value=hash_key_value("scoped_key_2"),
+            scoped_teams=[team.id],
+            scopes=["feature_flag:read"],
+        )
+
+        # Create unscoped key (access to all teams in organization)
+        PersonalAPIKey.objects.create(
+            user=user3,
+            label="Unscoped Key",
+            secure_value=hash_key_value("unscoped_key_1"),
+            scopes=["feature_flag:read"],  # No scoped_teams means all teams
+        )
+
+        # Warm the cache
+        result = warm_team_token_cache(team.api_token)
+        assert result is True
+
+        # Verify cache contains all keys (scoped and unscoped)
+        cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+        assert cached_data is not None
+        hashed_tokens = cached_data["hashed_tokens"]
+
+        # Should contain hashed versions of all keys
+        expected_scoped_1 = hash_key_value("scoped_key_1", mode="sha256")
+        expected_scoped_2 = hash_key_value("scoped_key_2", mode="sha256")
+        expected_unscoped = hash_key_value("unscoped_key_1", mode="sha256")
+        expected_secret = hash_key_value("phsk_secret_token_123", mode="sha256")
+
+        assert expected_scoped_1 in hashed_tokens
+        assert expected_scoped_2 in hashed_tokens
+        assert expected_unscoped in hashed_tokens
+        assert expected_secret in hashed_tokens
+
+    def test_warm_team_cache_no_unscoped_keys(self):
+        """Test cache warming when there are no unscoped PersonalAPIKeys."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data with only scoped keys
+        organization = Organization.objects.create(name="Test Organization")
+        team = Team.objects.create(organization=organization, name="Test Team", api_token="phc_test_project_key")
+
+        # Create user with only scoped key (no unscoped key)
+        user1 = User.objects.create(email="user1@test.com", is_active=True)
+        OrganizationMembership.objects.create(organization=organization, user=user1)
+
+        # Create only scoped key
+        PersonalAPIKey.objects.create(
+            user=user1,
+            label="Scoped Key Only",
+            secure_value=hash_key_value("scoped_key_1"),
+            scoped_teams=[team.id],
+            scopes=["feature_flag:read"],
+        )
+
+        # Warm the cache
+        result = warm_team_token_cache(team.api_token)
+        assert result is True
+
+        # Verify cache was populated with only scoped keys
+        cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+        assert cached_data is not None
+        hashed_tokens = cached_data["hashed_tokens"]
+
+        # Should contain the scoped key
+        expected_scoped = hash_key_value("scoped_key_1", mode="sha256")
+        assert expected_scoped in hashed_tokens
+
+        # Should not contain any unscoped keys (since none were created)
+        assert len(hashed_tokens) == 1  # Only the one scoped key
+
+    def test_warm_team_cache_duplicate_key_handling(self):
+        """Test that duplicate keys between scoped and unscoped are handled correctly."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data - scenario where same user might have key that could match both scoped/unscoped
+        organization = Organization.objects.create(name="Test Organization")
+        team = Team.objects.create(organization=organization, name="Test Team", api_token="phc_test_project_key")
+
+        # Create user
+        user1 = User.objects.create(email="user1@test.com", is_active=True)
+        OrganizationMembership.objects.create(organization=organization, user=user1)
+
+        # Create unscoped key (has access to all teams in org)
+        PersonalAPIKey.objects.create(
+            user=user1,
+            label="Unscoped Key",
+            secure_value=hash_key_value("duplicate_key"),
+            scopes=["feature_flag:read"],  # No scoped_teams = all teams
+        )
+
+        # Warm the cache
+        result = warm_team_token_cache(team.api_token)
+        assert result is True
+
+        # Verify cache was populated
+        cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+        assert cached_data is not None
+        hashed_tokens = cached_data["hashed_tokens"]
+
+        # The key should appear in the cache
+        expected_key = hash_key_value("duplicate_key", mode="sha256")
+        assert expected_key in hashed_tokens
+
+        # Should only appear once (SQL DISTINCT handles duplicates)
+        duplicate_count = sum(1 for token in hashed_tokens if token == expected_key)
+        assert duplicate_count == 1
+
+
+class TestGetTeamsForPersonalAPIKey(TestCase):
+    """Test the get_teams_for_single_personal_api_key function."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    def test_get_teams_for_scoped_personal_api_key(self):
+        """Test getting teams for a PersonalAPIKey with scoped teams."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data
+        organization = Organization.objects.create(name="Test Organization")
+        team1 = Team.objects.create(organization=organization, name="Team 1", api_token="phs_team1_123")
+        team2 = Team.objects.create(organization=organization, name="Team 2", api_token="phs_team2_456")
+        team3 = Team.objects.create(organization=organization, name="Team 3", api_token="phs_team3_789")
+
+        # Create user and add to organization
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=organization, user=user)
+
+        # Create PersonalAPIKey with scoped teams (only team1 and team2)
+        personal_key = PersonalAPIKey.objects.create(
+            user=user,
+            label="Scoped Key",
+            secure_value=hash_key_value("scoped_key_1"),
+            scoped_teams=[team1.id, team2.id],
+            scopes=["feature_flag:read"],
+        )
+
+        # Call the function
+        result = get_teams_for_single_personal_api_key(personal_key)
+
+        # Verify correct teams were returned (should only include scoped teams)
+        expected_tokens = {team1.api_token, team2.api_token}
+        assert set(result) == expected_tokens
+        assert team3.api_token not in result
+
+    def test_get_teams_for_unscoped_personal_api_key(self):
+        """Test getting teams for an unscoped PersonalAPIKey (all user's org teams)."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data - multiple organizations
+        org1 = Organization.objects.create(name="Organization 1")
+        org2 = Organization.objects.create(name="Organization 2")
+        org3 = Organization.objects.create(name="Organization 3")
+
+        # Create teams in different organizations
+        team1 = Team.objects.create(organization=org1, name="Team 1", api_token="phs_team1_123")
+        team2 = Team.objects.create(organization=org1, name="Team 2", api_token="phs_team2_456")
+        team3 = Team.objects.create(organization=org2, name="Team 3", api_token="phs_team3_789")
+        team4 = Team.objects.create(organization=org3, name="Team 4", api_token="phs_team4_abc")  # User not in this org
+
+        # Create user and add to org1 and org2 only
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org1, user=user)
+        OrganizationMembership.objects.create(organization=org2, user=user)
+
+        # Create PersonalAPIKey without scoped teams (unscoped)
+        personal_key = PersonalAPIKey.objects.create(
+            user=user,
+            label="Unscoped Key",
+            secure_value=hash_key_value("unscoped_key_1"),
+            scopes=["feature_flag:read"],  # No scoped_teams means all teams
+        )
+
+        # Call the function
+        result = get_teams_for_single_personal_api_key(personal_key)
+
+        # Verify correct teams were returned (should include all teams from user's organizations)
+        expected_tokens = {team1.api_token, team2.api_token, team3.api_token}
+        assert set(result) == expected_tokens
+        assert team4.api_token not in result  # User not in org3
+
+    def test_get_teams_for_unscoped_personal_api_key_empty_scoped_teams(self):
+        """Test getting teams for PersonalAPIKey with empty scoped_teams list."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data
+        organization = Organization.objects.create(name="Test Organization")
+        team = Team.objects.create(organization=organization, name="Team 1", api_token="phs_team1_123")
+
+        # Create user and add to organization
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=organization, user=user)
+
+        # Create PersonalAPIKey with empty scoped teams list (unscoped)
+        personal_key = PersonalAPIKey.objects.create(
+            user=user,
+            label="Unscoped Key",
+            secure_value=hash_key_value("unscoped_key_1"),
+            scoped_teams=[],  # Empty list = unscoped
+            scopes=["feature_flag:read"],
+        )
+
+        # Call the function
+        result = get_teams_for_single_personal_api_key(personal_key)
+
+        # Verify correct team was returned
+        assert result == [team.api_token]
+
+    def test_get_teams_for_unscoped_personal_api_key_no_organizations(self):
+        """Test getting teams when user has no organization memberships."""
+        from posthog.models import PersonalAPIKey, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create user without any organization memberships
+        user = User.objects.create(email="test@example.com", is_active=True)
+
+        # Create PersonalAPIKey without scoped teams
+        personal_key = PersonalAPIKey.objects.create(
+            user=user,
+            label="Unscoped Key",
+            secure_value=hash_key_value("unscoped_key_1"),
+            scopes=["feature_flag:read"],
+        )
+
+        # Call the function
+        result = get_teams_for_single_personal_api_key(personal_key)
+
+        # Verify empty list was returned (no organizations = no teams)
+        assert result == []
+
+    def test_get_teams_for_scoped_personal_api_key_nonexistent_team_ids(self):
+        """Test getting teams for PersonalAPIKey with non-existent scoped team IDs."""
+        from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, User
+        from posthog.models.personal_api_key import hash_key_value
+
+        # Create real test data
+        organization = Organization.objects.create(name="Test Organization")
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=organization, user=user)
+
+        # Create PersonalAPIKey with non-existent scoped team IDs
+        personal_key = PersonalAPIKey.objects.create(
+            user=user,
+            label="Scoped Key",
+            secure_value=hash_key_value("scoped_key_1"),
+            scoped_teams=[999, 1000],  # Non-existent team IDs
+            scopes=["feature_flag:read"],
+        )
+
+        # Call the function
+        result = get_teams_for_single_personal_api_key(personal_key)
+
+        # Verify empty list was returned (no matching teams)
+        assert result == []
+
+
+class TestUpdateUserAuthenticationCache(TestCase):
+    """Test the update_user_authentication_cache function."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+        # Note: HyperCache doesn't support wildcard clearing, individual tests will clear as needed
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    def test_user_activated_warms_affected_team_caches(self):
+        """Test that when a user is activated, caches are warmed for all teams they have access to."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create real database objects
+        org = Organization.objects.create(name="Test Org")
+        team1 = Team.objects.create(organization=org, name="Team 1")
+        team2 = Team.objects.create(organization=org, name="Team 2")
+        team3 = Team.objects.create(organization=org, name="Team 3")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API keys with different scopes
+        token1_value = generate_random_token_personal()
+        token2_value = generate_random_token_personal()
+
+        # Scoped key for team1 and team2
+        PersonalAPIKey.objects.create(
+            label="Scoped Key",
+            user=user,
+            scoped_teams=[team1.id, team2.id],
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token1_value),
+            mask_value=mask_key_value(token1_value),
+        )
+
+        # Another scoped key for team2 and team3
+        PersonalAPIKey.objects.create(
+            label="Another Scoped Key",
+            user=user,
+            scoped_teams=[team2.id, team3.id],
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token2_value),
+            mask_value=mask_key_value(token2_value),
+        )
+
+        # Track cache warming calls
+        warmed_teams = []
+        original_warm_cache = warm_team_token_cache
+
+        def track_warm_cache(project_api_key):
+            warmed_teams.append(project_api_key)
+            return original_warm_cache(project_api_key)
+
+        with patch(
+            "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache", side_effect=track_warm_cache
+        ):
+            # Call function for user status change
+            update_user_authentication_cache(instance=user, update_fields=["is_active"])
+
+        # Verify cache warming was called for all unique teams (team1, team2, team3)
+        assert len(set(warmed_teams)) == 3
+        assert team1.api_token in warmed_teams
+        assert team2.api_token in warmed_teams
+        assert team3.api_token in warmed_teams
+
+    def test_user_deactivated_warms_affected_team_caches(self):
+        """Test that when a user is deactivated, caches are warmed for all affected teams to remove their tokens."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create real database objects
+        org = Organization.objects.create(name="Test Org")
+        team1 = Team.objects.create(organization=org, name="Team 1")
+        team2 = Team.objects.create(organization=org, name="Team 2")
+
+        user = User.objects.create(email="test@example.com", is_active=False)  # Deactivated
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key
+        token_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=user,
+            scoped_teams=[team1.id, team2.id],
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value),
+            mask_value=mask_key_value(token_value),
+        )
+
+        # Track cache warming calls
+        warmed_teams = []
+        original_warm_cache = warm_team_token_cache
+
+        def track_warm_cache(project_api_key):
+            warmed_teams.append(project_api_key)
+            return original_warm_cache(project_api_key)
+
+        with patch(
+            "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache", side_effect=track_warm_cache
+        ):
+            # Call function for user deactivation
+            update_user_authentication_cache(instance=user, update_fields=["is_active"])
+
+        # Verify cache warming was called for affected teams (to remove deactivated user's tokens)
+        assert len(warmed_teams) == 2
+        assert team1.api_token in warmed_teams
+        assert team2.api_token in warmed_teams
+
+    @parameterized.expand(
+        [
+            # (update_fields, num_teams, has_api_keys, expected_warm_calls, description)
+            (["email", "name"], 1, True, 1, "non-is_active fields with API keys"),
+            (None, 2, True, 2, "no update_fields (bulk operation) with multiple teams"),
+            (["is_active"], 0, False, 0, "user with no API keys"),
+        ]
+    )
+    def test_update_user_authentication_cache_scenarios(
+        self, update_fields, num_teams, has_api_keys, expected_warm_calls, description
+    ):
+        """Test update_user_authentication_cache function with various scenarios."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create org and teams
+        org = Organization.objects.create(name=f"Test Org {description}")
+        teams = []
+        for i in range(max(1, num_teams)):  # Create at least 1 team even if user has no keys
+            team = Team.objects.create(organization=org, name=f"Team {i+1}")
+            teams.append(team)
+
+        user = User.objects.create(email=f"test_{description}@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key if needed
+        if has_api_keys and teams:
+            token_value = generate_random_token_personal()
+            team_ids = [t.id for t in teams[:num_teams]] if num_teams > 0 else []
+            PersonalAPIKey.objects.create(
+                label="Test Key",
+                user=user,
+                scoped_teams=team_ids,
+                scopes=["feature_flag:read"],
+                secure_value=hash_key_value(token_value),
+                mask_value=mask_key_value(token_value),
+            )
+
+        # Track cache warming calls
+        warmed_teams = []
+        original_warm_cache = warm_team_token_cache
+
+        def track_warm_cache(project_api_key):
+            warmed_teams.append(project_api_key)
+            return original_warm_cache(project_api_key)
+
+        with patch(
+            "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache", side_effect=track_warm_cache
+        ):
+            # Call with specified update_fields
+            update_user_authentication_cache(instance=user, update_fields=update_fields)
+
+        # Verify expected cache warming calls
+        assert len(warmed_teams) == expected_warm_calls
+        if expected_warm_calls > 0:
+            for team in teams[:num_teams]:
+                assert team.api_token in warmed_teams
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_adding_user_to_organization_adds_keys_to_team_caches(self, mock_on_commit):
+        """Test that adding a user to an organization adds their unscoped keys to all team caches."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create first organization with teams
+        org1 = Organization.objects.create(name="Org 1")
+        team1 = Team.objects.create(organization=org1, name="Team 1")
+
+        # Create user and add to first org
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org1, user=user)
+
+        # Create an unscoped personal API key (has access to all user's orgs)
+        token = generate_random_token_personal()
+        unscoped_key = PersonalAPIKey.objects.create(
+            label="Unscoped Key",
+            user=user,
+            scoped_teams=None,  # Unscoped
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token),
+            mask_value=mask_key_value(token),
+        )
+
+        # Create a scoped key that only has access to team1
+        scoped_token = generate_random_token_personal()
+        scoped_key = PersonalAPIKey.objects.create(
+            label="Scoped Key",
+            user=user,
+            scoped_teams=[team1.id],
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(scoped_token),
+            mask_value=mask_key_value(scoped_token),
+        )
+
+        # Warm team1 cache
+        warm_team_token_cache(team1.api_token)
+        cache1 = team_access_tokens_hypercache.get_from_cache(team1.api_token)
+        assert cache1 is not None, "Cache should exist for team1"
+        assert unscoped_key.secure_value in cache1["hashed_tokens"], "Unscoped key should be in team1"
+        assert scoped_key.secure_value in cache1["hashed_tokens"], "Scoped key should be in team1"
+
+        # Create second organization with teams
+        org2 = Organization.objects.create(name="Org 2")
+        team2 = Team.objects.create(organization=org2, name="Team 2")
+        team3 = Team.objects.create(organization=org2, name="Team 3")
+
+        # Warm org2 team caches BEFORE adding user
+        warm_team_token_cache(team2.api_token)
+        warm_team_token_cache(team3.api_token)
+
+        # Verify keys are NOT in org2 teams yet
+        cache2_before = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+        cache3_before = team_access_tokens_hypercache.get_from_cache(team3.api_token)
+        assert cache2_before is not None, "Cache should exist for team2"
+        assert cache3_before is not None, "Cache should exist for team3"
+        assert (
+            unscoped_key.secure_value not in cache2_before["hashed_tokens"]
+        ), "Unscoped key should NOT be in team2 before joining"
+        assert (
+            unscoped_key.secure_value not in cache3_before["hashed_tokens"]
+        ), "Unscoped key should NOT be in team3 before joining"
+        assert scoped_key.secure_value not in cache2_before["hashed_tokens"], "Scoped key should NOT be in team2"
+        assert scoped_key.secure_value not in cache3_before["hashed_tokens"], "Scoped key should NOT be in team3"
+
+        # Add user to org2 - this should trigger cache updates
+        OrganizationMembership.objects.create(organization=org2, user=user)
+
+        # Verify unscoped key is now in org2 team caches, but scoped key is not
+        cache2_after = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+        cache3_after = team_access_tokens_hypercache.get_from_cache(team3.api_token)
+        assert cache2_after is not None, "Cache should exist for team2"
+        assert cache3_after is not None, "Cache should exist for team3"
+        assert (
+            unscoped_key.secure_value in cache2_after["hashed_tokens"]
+        ), "Unscoped key should be in team2 after joining"
+        assert (
+            unscoped_key.secure_value in cache3_after["hashed_tokens"]
+        ), "Unscoped key should be in team3 after joining"
+        assert scoped_key.secure_value not in cache2_after["hashed_tokens"], "Scoped key should still NOT be in team2"
+        assert scoped_key.secure_value not in cache3_after["hashed_tokens"], "Scoped key should still NOT be in team3"
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_removing_user_from_organization_removes_keys_from_team_caches(self, mock_on_commit):
+        """Test that removing a user from an organization removes their keys from all team caches."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create organization with multiple teams
+        org = Organization.objects.create(name="Test Org for Removal")
+        team1 = Team.objects.create(organization=org, name="Team 1", api_token="phc_removal_team1")
+        team2 = Team.objects.create(organization=org, name="Team 2", api_token="phc_removal_team2")
+        team3 = Team.objects.create(organization=org, name="Team 3", api_token="phc_removal_team3")
+
+        # Create users
+        user_to_remove = User.objects.create(email="remove_me@example.com", is_active=True)
+        user_to_keep = User.objects.create(email="keep_me@example.com", is_active=True)
+
+        # Add both users to organization
+        membership_to_remove = OrganizationMembership.objects.create(organization=org, user=user_to_remove)
+        OrganizationMembership.objects.create(organization=org, user=user_to_keep)
+
+        # Create personal API keys for both users
+        token_to_remove = generate_random_token_personal()
+        key_to_remove = PersonalAPIKey.objects.create(
+            label="Key to Remove",
+            user=user_to_remove,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_to_remove),
+            mask_value=mask_key_value(token_to_remove),
+        )
+
+        token_to_keep = generate_random_token_personal()
+        key_to_keep = PersonalAPIKey.objects.create(
+            label="Key to Keep",
+            user=user_to_keep,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_to_keep),
+            mask_value=mask_key_value(token_to_keep),
+        )
+
+        # Warm caches for all teams (simulate normal operation)
+        for team in [team1, team2, team3]:
+            warm_team_token_cache(team.api_token)
+
+        # Verify both users' keys are in all team caches
+        for team in [team1, team2, team3]:
+            cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+            assert cached_data is not None, f"Cache should exist for {team.api_token}"
+            hashed_tokens = cached_data["hashed_tokens"]
+
+            assert key_to_remove.secure_value in hashed_tokens, f"User to remove's key should be in {team.name} cache"
+            assert key_to_keep.secure_value in hashed_tokens, f"User to keep's key should be in {team.name} cache"
+
+        # Remove user from organization - signal will trigger cache update
+        membership_to_remove.delete()
+
+        # After removal, caches should be updated for all teams
+        # The removed user's keys should no longer be in any team cache
+        for team in [team1, team2, team3]:
+            cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+            assert cached_data is not None, f"Cache should still exist for {team.api_token}"
+            hashed_tokens = cached_data["hashed_tokens"]
+
+            assert (
+                key_to_remove.secure_value not in hashed_tokens
+            ), f"Removed user's key should NOT be in {team.name} cache"
+            assert key_to_keep.secure_value in hashed_tokens, f"Kept user's key should still be in {team.name} cache"
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_personal_api_key_deleted_updates_all_team_caches(self, mock_on_commit):
+        """Test that deleting a PersonalAPIKey removes it from all affected team caches."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create organization with multiple teams
+        org = Organization.objects.create(name="Test Org for Key Deletion")
+        team1 = Team.objects.create(organization=org, name="Team 1", api_token="phc_key_del_team1")
+        team2 = Team.objects.create(organization=org, name="Team 2", api_token="phc_key_del_team2")
+
+        # Create another org with a team to ensure we don't affect other orgs
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team", api_token="phc_key_del_other")
+
+        # Create users
+        user1 = User.objects.create(email="user1@example.com", is_active=True)
+        user2 = User.objects.create(email="user2@example.com", is_active=True)
+
+        # Add users to organizations
+        OrganizationMembership.objects.create(organization=org, user=user1)
+        OrganizationMembership.objects.create(organization=org, user=user2)
+        OrganizationMembership.objects.create(organization=other_org, user=user1)
+
+        # Create multiple personal API keys
+        # Key 1: User1's unscoped key (affects all teams in org)
+        token1 = generate_random_token_personal()
+        key1_to_delete = PersonalAPIKey.objects.create(
+            label="Key 1 to Delete",
+            user=user1,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token1),
+            mask_value=mask_key_value(token1),
+        )
+
+        # Key 2: User1's scoped key (only team1)
+        token2 = generate_random_token_personal()
+        key2_scoped = PersonalAPIKey.objects.create(
+            label="Key 2 Scoped",
+            user=user1,
+            scopes=["feature_flag:write"],
+            scoped_teams=[team1.id],
+            secure_value=hash_key_value(token2),
+            mask_value=mask_key_value(token2),
+        )
+
+        # Key 3: User2's key (to ensure it's not affected)
+        token3 = generate_random_token_personal()
+        key3_keep = PersonalAPIKey.objects.create(
+            label="Key 3 Keep",
+            user=user2,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token3),
+            mask_value=mask_key_value(token3),
+        )
+
+        # Warm all caches
+        for team in [team1, team2, other_team]:
+            warm_team_token_cache(team.api_token)
+
+        # Verify initial state - all keys are in appropriate caches
+        cached_data_team1 = team_access_tokens_hypercache.get_from_cache(team1.api_token)
+        cached_data_team2 = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+        cached_data_other = team_access_tokens_hypercache.get_from_cache(other_team.api_token)
+
+        assert cached_data_team1 is not None, "Cache should exist for team1"
+        assert cached_data_team2 is not None, "Cache should exist for team2"
+        assert cached_data_other is not None, "Cache should exist for other team"
+
+        assert key1_to_delete.secure_value in cached_data_team1["hashed_tokens"], "Key1 should be in team1"
+        assert key1_to_delete.secure_value in cached_data_team2["hashed_tokens"], "Key1 should be in team2"
+        assert key1_to_delete.secure_value in cached_data_other["hashed_tokens"], "Key1 should be in other team"
+        assert key2_scoped.secure_value in cached_data_team1["hashed_tokens"], "Key2 should be in team1"
+        assert key2_scoped.secure_value not in cached_data_team2["hashed_tokens"], "Key2 should NOT be in team2"
+        assert key3_keep.secure_value in cached_data_team1["hashed_tokens"], "Key3 should be in team1"
+        assert key3_keep.secure_value in cached_data_team2["hashed_tokens"], "Key3 should be in team2"
+
+        # Delete key1 (unscoped key) - signal will trigger cache update
+        key1_to_delete.delete()
+
+        # Verify key1 is removed from all caches but other keys remain
+        cached_data_team1 = team_access_tokens_hypercache.get_from_cache(team1.api_token)
+        cached_data_team2 = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+        cached_data_other = team_access_tokens_hypercache.get_from_cache(other_team.api_token)
+
+        assert cached_data_team1 is not None, "Cache should exist for team1"
+        assert cached_data_team2 is not None, "Cache should exist for team2"
+        assert cached_data_other is not None, "Cache should exist for other team"
+
+        assert (
+            key1_to_delete.secure_value not in cached_data_team1["hashed_tokens"]
+        ), "Deleted key1 should NOT be in team1"
+        assert (
+            key1_to_delete.secure_value not in cached_data_team2["hashed_tokens"]
+        ), "Deleted key1 should NOT be in team2"
+        assert (
+            key1_to_delete.secure_value not in cached_data_other["hashed_tokens"]
+        ), "Deleted key1 should NOT be in other team"
+        assert key2_scoped.secure_value in cached_data_team1["hashed_tokens"], "Key2 should still be in team1"
+        assert key3_keep.secure_value in cached_data_team1["hashed_tokens"], "Key3 should still be in team1"
+        assert key3_keep.secure_value in cached_data_team2["hashed_tokens"], "Key3 should still be in team2"
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_personal_api_key_rolled_updates_cache(self, mock_on_commit):
+        """Test that rolling a PersonalAPIKey updates cache with new token."""
+
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create two teams that the personal API key has access to
+        org = Organization.objects.create(name="Test Org")
+        team1 = Team.objects.create(organization=org, name="Team 1")
+        team2 = Team.objects.create(organization=org, name="Team 2")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key with unscoped access
+        original_token = generate_random_token_personal()
+        original_secure = hash_key_value(original_token)
+        personal_key = PersonalAPIKey.objects.create(
+            label="Test Key to Roll",
+            user=user,
+            scoped_teams=None,  # Unscoped - has access to all teams
+            scopes=["feature_flag:read"],
+            secure_value=original_secure,
+            mask_value=mask_key_value(original_token),
+        )
+
+        # Warm initial caches
+        warm_team_token_cache(team1.api_token)
+        warm_team_token_cache(team2.api_token)
+
+        # Verify original token is in cache
+        cached_data_team1 = team_access_tokens_hypercache.get_from_cache(team1.api_token)
+        cached_data_team2 = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+
+        assert cached_data_team1 is not None, "Team1 cache should exist"
+        assert cached_data_team2 is not None, "Team2 cache should exist"
+        assert original_secure in cached_data_team1["hashed_tokens"], "Original token should be in team1 cache"
+        assert original_secure in cached_data_team2["hashed_tokens"], "Original token should be in team2 cache"
+
+        # Roll the key using the serializer's roll method (same as API endpoint)
+        from unittest.mock import MagicMock
+
+        from posthog.api.personal_api_key import PersonalAPIKeySerializer
+
+        # Create a mock request context for the serializer
+        mock_request = MagicMock()
+        mock_request.user = user
+        serializer = PersonalAPIKeySerializer(instance=personal_key, context={"request": mock_request})
+        rolled_key = serializer.roll(personal_key)
+
+        # Get the new secure value from the rolled key
+        new_secure = rolled_key.secure_value
+
+        # Get updated cache data
+        cached_data_team1_after = team_access_tokens_hypercache.get_from_cache(team1.api_token)
+        cached_data_team2_after = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+
+        # Verify old token is NOT in cache and new token IS in cache
+        assert cached_data_team1_after is not None, "Team1 cache should still exist"
+        assert cached_data_team2_after is not None, "Team2 cache should still exist"
+        assert original_secure not in cached_data_team1_after["hashed_tokens"], "Old token should NOT be in team1 cache"
+        assert original_secure not in cached_data_team2_after["hashed_tokens"], "Old token should NOT be in team2 cache"
+        assert new_secure in cached_data_team1_after["hashed_tokens"], "New token should be in team1 cache"
+        assert new_secure in cached_data_team2_after["hashed_tokens"], "New token should be in team2 cache"
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_user_deleted_removes_all_personal_api_keys_from_caches(self, mock_on_commit):
+        """Test that deleting a user removes all their PersonalAPIKeys from team caches via CASCADE delete."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache import team_access_tokens_hypercache
+
+        # Create organization with teams
+        org = Organization.objects.create(name="Test Org for User Deletion")
+        team1 = Team.objects.create(organization=org, name="Team 1", api_token="phc_user_del_team1")
+        team2 = Team.objects.create(organization=org, name="Team 2", api_token="phc_user_del_team2")
+
+        # Create users
+        user_to_delete = User.objects.create(email="delete_me@example.com", is_active=True)
+        user_to_keep = User.objects.create(email="keep_me@example.com", is_active=True)
+
+        # Add users to organization
+        OrganizationMembership.objects.create(organization=org, user=user_to_delete)
+        OrganizationMembership.objects.create(organization=org, user=user_to_keep)
+
+        # Create personal API keys for both users
+        # User to delete: 2 keys
+        token1 = generate_random_token_personal()
+        key1 = PersonalAPIKey.objects.create(
+            label="Delete User Key 1",
+            user=user_to_delete,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token1),
+            mask_value=mask_key_value(token1),
+        )
+
+        token2 = generate_random_token_personal()
+        key2 = PersonalAPIKey.objects.create(
+            label="Delete User Key 2",
+            user=user_to_delete,
+            scopes=["feature_flag:write"],
+            secure_value=hash_key_value(token2),
+            mask_value=mask_key_value(token2),
+        )
+
+        # User to keep: 1 key
+        token3 = generate_random_token_personal()
+        key3 = PersonalAPIKey.objects.create(
+            label="Keep User Key",
+            user=user_to_keep,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token3),
+            mask_value=mask_key_value(token3),
+        )
+
+        # Warm caches - both users' keys should be present
+        from posthog.storage.team_access_cache import warm_team_token_cache
+
+        warm_team_token_cache(team1.api_token)
+        warm_team_token_cache(team2.api_token)
+
+        # Verify initial state - both users' keys are in caches
+        for team in [team1, team2]:
+            cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+            assert cached_data is not None, f"Cache should exist for {team.api_token}"
+            hashed_tokens = cached_data["hashed_tokens"]
+
+            assert key1.secure_value in hashed_tokens, f"Delete user key1 should be in {team.name} cache"
+            assert key2.secure_value in hashed_tokens, f"Delete user key2 should be in {team.name} cache"
+            assert key3.secure_value in hashed_tokens, f"Keep user key should be in {team.name} cache"
+
+        # Delete the user - this should CASCADE delete their PersonalAPIKeys
+        user_to_delete.delete()
+
+        # The CASCADE delete of PersonalAPIKeys should trigger personal_api_key_deleted signals
+        # which should update the caches
+
+        # Verify deleted user's keys are removed from all team caches
+        for team in [team1, team2]:
+            cached_data = team_access_tokens_hypercache.get_from_cache(team.api_token)
+            assert cached_data is not None, f"Cache should still exist for {team.api_token}"
+            hashed_tokens = cached_data["hashed_tokens"]
+
+            # Deleted user's keys should NOT be in cache
+            assert key1.secure_value not in hashed_tokens, f"Deleted user key1 should NOT be in {team.name} cache"
+            assert key2.secure_value not in hashed_tokens, f"Deleted user key2 should NOT be in {team.name} cache"
+
+            # Kept user's key should still be in cache
+            assert key3.secure_value in hashed_tokens, f"Kept user key should still be in {team.name} cache"
+
+        # Verify PersonalAPIKeys were actually deleted
+        assert not PersonalAPIKey.objects.filter(user_id=user_to_delete.id).exists(), "User's keys should be deleted"
+        assert PersonalAPIKey.objects.filter(user_id=user_to_keep.id).exists(), "Other user's keys should remain"
+
+    def test_update_user_authentication_cache_handles_warm_cache_failures(self):
+        """Test function handles individual cache warming failures gracefully."""
+        import logging
+
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_user_authentication_cache
+
+        # Create real database objects
+        org = Organization.objects.create(name="Test Org")
+        team1 = Team.objects.create(organization=org, name="Team 1")
+        team2 = Team.objects.create(organization=org, name="Team 2")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key
+        token_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=user,
+            scoped_teams=[team1.id, team2.id],
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value),
+            mask_value=mask_key_value(token_value),
+        )
+
+        # Track cache warming calls and make one fail
+        warmed_teams = []
+        original_warm_cache = warm_team_token_cache
+
+        def failing_warm_cache(project_api_key):
+            warmed_teams.append(project_api_key)
+            if project_api_key == team1.api_token:
+                raise Exception("Cache warming failed")
+            return original_warm_cache(project_api_key)
+
+        # Capture log messages
+        with self.assertLogs("posthog.storage.team_access_cache_signal_handlers", level=logging.WARNING) as log_context:
+            with patch(
+                "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache",
+                side_effect=failing_warm_cache,
+            ):
+                # Should not raise exception
+                update_user_authentication_cache(instance=user, update_fields=["is_active"])
+
+        # Verify both cache warming attempts were made
+        assert len(warmed_teams) == 2
+        assert team1.api_token in warmed_teams
+        assert team2.api_token in warmed_teams
+
+        # Verify warning was logged for the failure
+        assert any(f"Failed to warm cache for team {team1.api_token}" in record for record in log_context.output)
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    @patch("posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache")
+    def test_personal_api_key_last_used_at_update_skips_cache_warming(self, mock_warm_cache, mock_on_commit):
+        """Test that updating only last_used_at field doesn't trigger cache warming."""
+
+        from django.utils import timezone
+
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create test data
+        org = Organization.objects.create(name="Test Org")
+        Team.objects.create(organization=org, name="Team 1")  # Team is created to ensure proper org setup
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key
+        token = generate_random_token_personal()
+        personal_key = PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=user,
+            secure_value=hash_key_value(token),
+            mask_value=mask_key_value(token),
+        )
+
+        # Clear any calls from the initial creation
+        mock_warm_cache.reset_mock()
+
+        # Update only the last_used_at field (simulating authentication)
+        now = timezone.now()
+        personal_key.last_used_at = now
+        personal_key.save(update_fields=["last_used_at"])
+
+        # Verify that cache update was NOT called
+        mock_warm_cache.assert_not_called()
+
+        # Now update a different field
+        mock_warm_cache.reset_mock()
+        personal_key.label = "Updated Label"
+        personal_key.save(update_fields=["label"])
+
+        # Verify that cache update WAS called for non-last_used_at update
+        # It should be called once per team the user has access to
+        assert mock_warm_cache.call_count > 0, "Cache warming should be called for non-last_used_at updates"
+
+        # Reset and test updating without specifying update_fields
+        mock_warm_cache.reset_mock()
+        personal_key.label = "Another Label"
+        personal_key.save()
+
+        # Should trigger cache update when update_fields is not specified
+        assert mock_warm_cache.call_count > 0, "Cache warming should be called when update_fields is not specified"
+
+
+class TestSignalHandlerCacheWarming(TestCase):
+    """Test that signal handlers properly warm caches instead of just invalidating."""
+
+    def setUp(self):
+        """Set up test data."""
+        cache.clear()
+        # Note: HyperCache doesn't support wildcard clearing, individual tests will clear as needed
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    def test_personal_api_key_signal_handlers_warm_caches(self):
+        """Test that personal API key signal handlers warm caches efficiently."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_personal_api_key_authentication_cache
+
+        # Create real database objects
+        org = Organization.objects.create(name="Test Org")
+        team1 = Team.objects.create(organization=org, name="Team 1")
+        team2 = Team.objects.create(organization=org, name="Team 2")
+        team3 = Team.objects.create(organization=org, name="Team 3")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key
+        token_value = generate_random_token_personal()
+        key = PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=user,
+            scoped_teams=[team1.id, team2.id],
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value),
+            mask_value=mask_key_value(token_value),
+        )
+
+        # Track cache warming calls for save handler
+        warmed_teams_save = []
+        original_warm_cache = warm_team_token_cache
+
+        def track_warm_cache_save(project_api_key):
+            warmed_teams_save.append(project_api_key)
+            return original_warm_cache(project_api_key)
+
+        with patch(
+            "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache", side_effect=track_warm_cache_save
+        ):
+            # Test save handler
+            update_personal_api_key_authentication_cache(instance=key)
+
+        # Verify cache warming was called for each affected team
+        assert len(warmed_teams_save) == 2
+        assert team1.api_token in warmed_teams_save
+        assert team2.api_token in warmed_teams_save
+
+        # Test delete handler with different team scope
+        key.scoped_teams = [team3.id]
+        key.save()
+
+        warmed_teams_delete = []
+
+        def track_warm_cache_delete(project_api_key):
+            warmed_teams_delete.append(project_api_key)
+            return original_warm_cache(project_api_key)
+
+        with patch(
+            "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache",
+            side_effect=track_warm_cache_delete,
+        ):
+            update_personal_api_key_authentication_cache(instance=key)
+
+        # Verify cache warming was called for the new scope
+        assert len(warmed_teams_delete) == 1
+        assert team3.api_token in warmed_teams_delete
+
+    @patch("posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache")
+    def test_team_signal_handlers_warm_caches(self, mock_warm_cache):
+        """Test that team signal handlers warm caches instead of just invalidating."""
+        from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache
+
+        # Create mock Team
+        mock_team = MagicMock()
+        mock_team.pk = 123
+        mock_team.api_token = "phs_team_token_123"
+        mock_team._state = MagicMock()
+        mock_team._state.adding = False  # Not being created
+
+        # Test save handler (not created)
+        update_team_authentication_cache(instance=mock_team, created=False)
+
+        # Verify cache warming was called (not just invalidation)
+        mock_warm_cache.assert_called_once_with("phs_team_token_123")
+
+        # Test that it doesn't warm cache for new teams (created=True)
+        mock_warm_cache.reset_mock()
+        update_team_authentication_cache(instance=mock_team, created=True)
+
+        # Should not warm cache for new teams
+        mock_warm_cache.assert_not_called()
+
+    def test_team_deletion_invalidates_cache_and_removes_access(self):
+        """Test that team deletion properly invalidates cache and removes all access."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache_on_delete
+
+        # Create organization with multiple teams
+        org = Organization.objects.create(name="Test Org for Team Deletion")
+        team_to_delete = Team.objects.create(
+            organization=org,
+            name="Team to Delete",
+            api_token="phc_team_delete_1",
+            secret_api_token="phsk_team_secret_delete",
+        )
+        team_to_keep = Team.objects.create(organization=org, name="Team to Keep", api_token="phc_team_keep_1")
+
+        # Create users and add to organization
+        user1 = User.objects.create(email="user1@example.com", is_active=True)
+        user2 = User.objects.create(email="user2@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user1)
+        OrganizationMembership.objects.create(organization=org, user=user2)
+
+        # Create PersonalAPIKeys
+        # Key 1: Scoped to team_to_delete only
+        token1 = generate_random_token_personal()
+        key1_scoped_to_deleted = PersonalAPIKey.objects.create(
+            label="Key Scoped to Deleted Team",
+            user=user1,
+            scopes=["feature_flag:read"],
+            scoped_teams=[team_to_delete.id],
+            secure_value=hash_key_value(token1),
+            mask_value=mask_key_value(token1),
+        )
+
+        # Key 2: Scoped to both teams
+        token2 = generate_random_token_personal()
+        key2_scoped_to_both = PersonalAPIKey.objects.create(
+            label="Key Scoped to Both Teams",
+            user=user1,
+            scopes=["feature_flag:write"],
+            scoped_teams=[team_to_delete.id, team_to_keep.id],
+            secure_value=hash_key_value(token2),
+            mask_value=mask_key_value(token2),
+        )
+
+        # Key 3: Unscoped (all teams)
+        token3 = generate_random_token_personal()
+        key3_unscoped = PersonalAPIKey.objects.create(
+            label="Unscoped Key",
+            user=user2,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token3),
+            mask_value=mask_key_value(token3),
+        )
+
+        # Warm both caches
+        warm_team_token_cache(team_to_delete.api_token)
+        warm_team_token_cache(team_to_keep.api_token)
+
+        # Verify initial state
+        cache_delete = team_access_tokens_hypercache.get_from_cache(team_to_delete.api_token)
+        cache_keep = team_access_tokens_hypercache.get_from_cache(team_to_keep.api_token)
+
+        assert cache_delete is not None
+        assert cache_keep is not None
+
+        # Verify keys are in appropriate caches
+        assert key1_scoped_to_deleted.secure_value in cache_delete["hashed_tokens"]
+        assert key2_scoped_to_both.secure_value in cache_delete["hashed_tokens"]
+        assert key3_unscoped.secure_value in cache_delete["hashed_tokens"]
+        assert hash_key_value(team_to_delete.secret_api_token, mode="sha256") in cache_delete["hashed_tokens"]
+
+        assert key1_scoped_to_deleted.secure_value not in cache_keep["hashed_tokens"]  # Not scoped to this team
+        assert key2_scoped_to_both.secure_value in cache_keep["hashed_tokens"]
+        assert key3_unscoped.secure_value in cache_keep["hashed_tokens"]
+
+        # Store the team ID before deletion for later verification
+        deleted_team_id = team_to_delete.id
+        deleted_team_api_token = team_to_delete.api_token
+
+        # Delete the team
+        team_to_delete.delete()
+
+        # Since we're in a test transaction, manually trigger the cache update
+        # Create a mock instance with the necessary attributes for the handler
+        from unittest.mock import MagicMock
+
+        mock_deleted_team = MagicMock()
+        mock_deleted_team.api_token = deleted_team_api_token
+        mock_deleted_team.pk = deleted_team_id
+
+        update_team_authentication_cache_on_delete(instance=mock_deleted_team)
+
+        # Verify the deleted team's cache is invalidated
+        cache_delete_after = team_access_tokens_hypercache.get_from_cache(deleted_team_api_token)
+        assert cache_delete_after is None, "Deleted team's cache should be invalidated"
+
+        # Verify the kept team's cache is unaffected but properly updated
+        # We need to refresh it to simulate what would happen in production
+        warm_team_token_cache(team_to_keep.api_token)
+        cache_keep_after = team_access_tokens_hypercache.get_from_cache(team_to_keep.api_token)
+
+        assert cache_keep_after is not None
+        # Key1 was only for deleted team, still shouldn't be in kept team
+        assert key1_scoped_to_deleted.secure_value not in cache_keep_after["hashed_tokens"]
+        # Key2 is scoped to both teams, but after deletion it should still be in kept team
+        # (the key itself still exists and is still scoped to team_to_keep)
+        assert key2_scoped_to_both.secure_value in cache_keep_after["hashed_tokens"]
+        # Key3 is unscoped, should still be in kept team
+        assert key3_unscoped.secure_value in cache_keep_after["hashed_tokens"]
+
+    def test_organization_deletion_invalidates_all_team_caches(self):
+        """Test that organization deletion invalidates all team caches via cascade."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create two organizations
+        org_to_delete = Organization.objects.create(name="Org to Delete")
+        org_to_keep = Organization.objects.create(name="Org to Keep")
+
+        # Create teams in both orgs
+        teams_to_delete = []
+        for i in range(3):
+            team = Team.objects.create(
+                organization=org_to_delete,
+                name=f"Team {i} to Delete",
+                api_token=f"phc_org_del_team{i}",
+                secret_api_token=f"phsk_org_del_secret{i}",
+            )
+            teams_to_delete.append(team)
+
+        team_to_keep = Team.objects.create(organization=org_to_keep, name="Team to Keep", api_token="phc_org_keep_team")
+
+        # Create users
+        user1 = User.objects.create(email="user1@example.com", is_active=True)
+        user2 = User.objects.create(email="user2@example.com", is_active=True)
+
+        # Add users to both organizations
+        OrganizationMembership.objects.create(organization=org_to_delete, user=user1)
+        OrganizationMembership.objects.create(organization=org_to_delete, user=user2)
+        OrganizationMembership.objects.create(organization=org_to_keep, user=user1)
+
+        # Create PersonalAPIKeys
+        # Key 1: Scoped to a team in org_to_delete
+        token1 = generate_random_token_personal()
+        key1 = PersonalAPIKey.objects.create(
+            label="Key for Deleted Org Team",
+            user=user1,
+            scopes=["feature_flag:read"],
+            scoped_teams=[teams_to_delete[0].id],
+            secure_value=hash_key_value(token1),
+            mask_value=mask_key_value(token1),
+        )
+
+        # Key 2: Unscoped (affects all teams in both orgs)
+        token2 = generate_random_token_personal()
+        key2 = PersonalAPIKey.objects.create(
+            label="Unscoped Key",
+            user=user1,
+            scopes=["feature_flag:write"],
+            secure_value=hash_key_value(token2),
+            mask_value=mask_key_value(token2),
+        )
+
+        # Key 3: Scoped to team in org_to_keep
+        token3 = generate_random_token_personal()
+        key3 = PersonalAPIKey.objects.create(
+            label="Key for Kept Org Team",
+            user=user1,
+            scopes=["feature_flag:read"],
+            scoped_teams=[team_to_keep.id],
+            secure_value=hash_key_value(token3),
+            mask_value=mask_key_value(token3),
+        )
+
+        # Warm all caches
+        for team in [*teams_to_delete, team_to_keep]:
+            warm_team_token_cache(team.api_token)
+
+        # Verify initial state - all caches exist
+        for team in teams_to_delete:
+            cache = team_access_tokens_hypercache.get_from_cache(team.api_token)
+            assert cache is not None, f"Cache should exist for {team.api_token}"
+            # Verify keys are properly set up
+            if team == teams_to_delete[0]:
+                assert key1.secure_value in cache["hashed_tokens"]
+            assert key2.secure_value in cache["hashed_tokens"]  # Unscoped key in all teams
+
+        cache_keep = team_access_tokens_hypercache.get_from_cache(team_to_keep.api_token)
+        assert cache_keep is not None
+        assert key2.secure_value in cache_keep["hashed_tokens"]  # Unscoped key
+        assert key3.secure_value in cache_keep["hashed_tokens"]  # Scoped to this team
+
+        # Store API tokens before deletion
+        deleted_team_api_tokens = [team.api_token for team in teams_to_delete]
+
+        # Delete the organization
+        # This will CASCADE delete all teams, which will trigger team deletion handlers
+        org_to_delete.delete()
+
+        # Since we're in a test transaction, manually trigger cache invalidation for each team
+        from unittest.mock import MagicMock
+
+        from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache_on_delete
+
+        for i, api_token in enumerate(deleted_team_api_tokens):
+            mock_team = MagicMock()
+            mock_team.api_token = api_token
+            mock_team.pk = teams_to_delete[i].id if i < len(teams_to_delete) else i
+            update_team_authentication_cache_on_delete(instance=mock_team)
+
+        # Verify all caches for deleted org's teams are invalidated
+        for api_token in deleted_team_api_tokens:
+            cache = team_access_tokens_hypercache.get_from_cache(api_token)
+            assert cache is None, f"Cache should be invalidated for deleted team {api_token}"
+
+        # Verify the kept org's team cache is unaffected
+        # Refresh the cache to simulate production behavior
+        warm_team_token_cache(team_to_keep.api_token)
+        cache_keep_after = team_access_tokens_hypercache.get_from_cache(team_to_keep.api_token)
+        assert cache_keep_after is not None, "Kept team's cache should still exist"
+
+        # Key1 was scoped to deleted team, no longer relevant
+        assert key1.secure_value not in cache_keep_after["hashed_tokens"]
+        # Key2 is unscoped, still has access to kept team
+        assert key2.secure_value in cache_keep_after["hashed_tokens"]
+        # Key3 is scoped to kept team, still has access
+        assert key3.secure_value in cache_keep_after["hashed_tokens"]
+
+    def test_personal_api_key_with_deleted_team_references(self):
+        """Test that PersonalAPIKeys handle orphaned team references gracefully."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create organization and teams
+        org = Organization.objects.create(name="Test Org")
+        team1 = Team.objects.create(organization=org, name="Team 1", api_token="phc_orphan_team1")
+        team2 = Team.objects.create(organization=org, name="Team 2", api_token="phc_orphan_team2")
+        team3_to_delete = Team.objects.create(organization=org, name="Team 3 to Delete", api_token="phc_orphan_team3")
+
+        # Create user and add to organization
+        user = User.objects.create(email="user@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create PersonalAPIKey scoped to all three teams
+        token = generate_random_token_personal()
+        key = PersonalAPIKey.objects.create(
+            label="Key Scoped to Multiple Teams",
+            user=user,
+            scopes=["feature_flag:read"],
+            scoped_teams=[team1.id, team2.id, team3_to_delete.id],
+            secure_value=hash_key_value(token),
+            mask_value=mask_key_value(token),
+        )
+
+        # Warm caches for all teams
+        warm_team_token_cache(team1.api_token)
+        warm_team_token_cache(team2.api_token)
+        warm_team_token_cache(team3_to_delete.api_token)
+
+        # Verify initial state - key is in all three caches
+        cache1 = team_access_tokens_hypercache.get_from_cache(team1.api_token)
+        cache2 = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+        cache3 = team_access_tokens_hypercache.get_from_cache(team3_to_delete.api_token)
+
+        assert cache1 is not None, "Cache should exist for team1"
+        assert cache2 is not None, "Cache should exist for team2"
+        assert cache3 is not None, "Cache should exist for team3"
+
+        assert key.secure_value in cache1["hashed_tokens"]
+        assert key.secure_value in cache2["hashed_tokens"]
+        assert key.secure_value in cache3["hashed_tokens"]
+
+        # Store the deleted team ID and API token
+        deleted_team_id = team3_to_delete.id
+        deleted_team_api_token = team3_to_delete.api_token
+
+        # Delete team3
+        team3_to_delete.delete()
+
+        # Since we're in a test transaction, manually trigger the cache invalidation
+        from unittest.mock import MagicMock
+
+        from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache_on_delete
+
+        mock_deleted_team = MagicMock()
+        mock_deleted_team.api_token = deleted_team_api_token
+        mock_deleted_team.pk = deleted_team_id
+        update_team_authentication_cache_on_delete(instance=mock_deleted_team)
+
+        # The PersonalAPIKey still exists in the database with scoped_teams including the deleted team ID
+        key.refresh_from_db()
+        assert deleted_team_id in key.scoped_teams, "Deleted team ID should still be in scoped_teams"
+
+        # Warm the remaining team caches
+        # This should handle the orphaned reference gracefully
+        warm_team_token_cache(team1.api_token)
+        warm_team_token_cache(team2.api_token)
+
+        # Verify the key is still in the remaining teams' caches
+        cache1_after = team_access_tokens_hypercache.get_from_cache(team1.api_token)
+        cache2_after = team_access_tokens_hypercache.get_from_cache(team2.api_token)
+
+        assert cache1_after is not None, "Cache should exist for team1"
+        assert cache2_after is not None, "Cache should exist for team2"
+
+        assert key.secure_value in cache1_after["hashed_tokens"], "Key should still be in team1's cache"
+        assert key.secure_value in cache2_after["hashed_tokens"], "Key should still be in team2's cache"
+
+        # Verify the deleted team's cache is invalidated
+        cache3_after = team_access_tokens_hypercache.get_from_cache(deleted_team_api_token)
+        assert cache3_after is None, "Deleted team's cache should be invalidated"
+
+        # Test that the system doesn't break when loading tokens for a key with orphaned references
+        # This simulates what happens when the cache is being rebuilt
+        from posthog.storage.team_access_cache import get_teams_for_single_personal_api_key
+
+        # This should not raise an exception despite having an orphaned team reference
+        try:
+            affected_teams = get_teams_for_single_personal_api_key(key)
+            # Should only return the existing teams, not the deleted one
+            assert set(affected_teams) == {team1.api_token, team2.api_token}
+        except Exception as e:
+            raise AssertionError(f"Should handle orphaned team references gracefully, but raised: {e}")
+
+    def test_signal_handlers_handle_cache_warming_failures(self):
+        """Test that signal handlers handle cache warming failures gracefully."""
+        import logging
+
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_personal_api_key_authentication_cache
+
+        # Create real database objects
+        org = Organization.objects.create(name="Test Org")
+        team1 = Team.objects.create(organization=org, name="Team 1")
+        team2 = Team.objects.create(organization=org, name="Team 2")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key
+        token_value = generate_random_token_personal()
+        key = PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=user,
+            scoped_teams=[team1.id, team2.id],
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value),
+            mask_value=mask_key_value(token_value),
+        )
+
+        # Track cache warming calls and make one fail
+        warmed_teams = []
+        original_warm_cache = warm_team_token_cache
+
+        def failing_warm_cache(project_api_key):
+            warmed_teams.append(project_api_key)
+            if project_api_key == team1.api_token:
+                raise Exception("Cache warming failed")
+            return original_warm_cache(project_api_key)
+
+        # Capture log messages
+        with self.assertLogs("posthog.storage.team_access_cache_signal_handlers", level=logging.WARNING) as log_context:
+            with patch(
+                "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache",
+                side_effect=failing_warm_cache,
+            ):
+                # Should not raise exception
+                update_personal_api_key_authentication_cache(instance=key)
+
+        # Verify both cache warming attempts were made
+        assert len(warmed_teams) == 2
+        assert team1.api_token in warmed_teams
+        assert team2.api_token in warmed_teams
+
+        # Verify warning was logged for the failure
+        assert any(f"Failed to warm cache for team {team1.api_token}" in record for record in log_context.output)
+
+    def test_signal_handlers_handle_empty_affected_teams(self):
+        """Test signal handlers handle cases where no teams are affected."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+        from posthog.storage.team_access_cache_signal_handlers import update_personal_api_key_authentication_cache
+
+        # Create org and user but no teams
+        org = Organization.objects.create(name="Test Org")
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org, user=user)
+
+        # Create personal API key with no scoped teams (empty list means no teams)
+        token_value = generate_random_token_personal()
+        key = PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=user,
+            scoped_teams=[],  # Empty list - no teams
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value),
+            mask_value=mask_key_value(token_value),
+        )
+
+        # Track cache warming calls
+        warmed_teams = []
+        original_warm_cache = warm_team_token_cache
+
+        def track_warm_cache(project_api_key):
+            warmed_teams.append(project_api_key)
+            return original_warm_cache(project_api_key)
+
+        with patch(
+            "posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache", side_effect=track_warm_cache
+        ):
+            # Should not raise exception
+            update_personal_api_key_authentication_cache(instance=key)
+
+        # Verify no cache warming attempts (no teams affected)
+        assert len(warmed_teams) == 0
+
+    @parameterized.expand(
+        [
+            # (update_fields, created, adding_state, should_warm_cache, description)
+            (["name", "timezone", "capture_performance_opt_in"], False, False, False, "non-auth fields"),
+            (["name", "secret_api_token", "timezone"], False, False, True, "auth field secret_api_token"),
+            (["secret_api_token_backup"], False, False, True, "auth field secret_api_token_backup"),
+            (None, False, False, True, "no update_fields (full save)"),
+            (["secret_api_token"], False, True, False, "newly created team via state"),
+            ([], False, False, False, "empty update_fields list"),
+        ]
+    )
+    @patch("posthog.storage.team_access_cache_signal_handlers.warm_team_token_cache")
+    def test_team_signal_handler_update_fields_scenarios(
+        self, update_fields, created, adding_state, should_warm_cache, description, mock_warm_cache
+    ):
+        """Test team signal handler behavior for various update_fields scenarios."""
+        from posthog.storage.team_access_cache_signal_handlers import update_team_authentication_cache
+
+        # Create mock Team
+        mock_team = MagicMock()
+        mock_team.pk = 123
+        mock_team.api_token = "phs_team_token_123"
+        mock_team._state = MagicMock()
+        mock_team._state.adding = adding_state
+
+        # Call the signal handler
+        update_team_authentication_cache(instance=mock_team, created=created, update_fields=update_fields)
+
+        # Verify cache warming behavior
+        if should_warm_cache:
+            mock_warm_cache.assert_called_once_with("phs_team_token_123")
+        else:
+            mock_warm_cache.assert_not_called()
+
+
+class TestUserPersonalAPIKeyTeamLookup(TestCase):
+    """Test the optimized user-based function that eliminates N+1 queries."""
+
+    def test_user_function_matches_individual_results_scoped_keys(self):
+        """Test that user-based function produces same results as individual calls for scoped keys."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create test data
+        org1 = Organization.objects.create(name="Org 1")
+        org2 = Organization.objects.create(name="Org 2")
+
+        team1 = Team.objects.create(organization=org1, name="Team 1")
+        team2 = Team.objects.create(organization=org1, name="Team 2")
+        team3 = Team.objects.create(organization=org2, name="Team 3")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org1, user=user)
+        OrganizationMembership.objects.create(organization=org2, user=user)
+
+        # Create scoped personal API keys
+        token_value1 = generate_random_token_personal()
+        key1 = PersonalAPIKey.objects.create(
+            label="Scoped Key 1",
+            user=user,
+            scoped_teams=[team1.id, team2.id],  # Scoped to specific teams
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value1),
+            mask_value=mask_key_value(token_value1),
+        )
+
+        token_value2 = generate_random_token_personal()
+        key2 = PersonalAPIKey.objects.create(
+            label="Scoped Key 2",
+            user=user,
+            scoped_teams=[team3.id],  # Different scoped team
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value2),
+            mask_value=mask_key_value(token_value2),
+        )
+
+        # Get results using individual function calls (N+1 pattern)
+        individual_results = set()
+        for key in [key1, key2]:
+            individual_results.update(get_teams_for_single_personal_api_key(key))
+
+        # Get results using user-based function (optimized)
+        user_results = get_teams_for_user_personal_api_keys(user.id)
+
+        # Results should be identical
+        assert individual_results == user_results
+        assert len(user_results) == 3  # Should include all 3 teams
+        assert team1.api_token in user_results
+        assert team2.api_token in user_results
+        assert team3.api_token in user_results
+
+    def test_user_function_matches_individual_results_unscoped_keys(self):
+        """Test that user-based function produces same results as individual calls for unscoped keys."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create test data
+        org1 = Organization.objects.create(name="Org 1")
+        org2 = Organization.objects.create(name="Org 2")
+
+        team1 = Team.objects.create(organization=org1, name="Team 1")
+        team2 = Team.objects.create(organization=org1, name="Team 2")
+        team3 = Team.objects.create(organization=org2, name="Team 3")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org1, user=user)
+        OrganizationMembership.objects.create(organization=org2, user=user)
+
+        # Create unscoped personal API keys (access to all teams in user's orgs)
+        token_value1 = generate_random_token_personal()
+        key1 = PersonalAPIKey.objects.create(
+            label="Unscoped Key 1",
+            user=user,
+            scoped_teams=None,  # Unscoped
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value1),
+            mask_value=mask_key_value(token_value1),
+        )
+
+        token_value2 = generate_random_token_personal()
+        key2 = PersonalAPIKey.objects.create(
+            label="Unscoped Key 2",
+            user=user,
+            scoped_teams=[],  # Empty list = unscoped
+            scopes=None,  # No scopes = access to everything
+            secure_value=hash_key_value(token_value2),
+            mask_value=mask_key_value(token_value2),
+        )
+
+        # Get results using individual function calls (N+1 pattern)
+        individual_results = set()
+        for key in [key1, key2]:
+            individual_results.update(get_teams_for_single_personal_api_key(key))
+
+        # Get results using user-based function (optimized)
+        user_results = get_teams_for_user_personal_api_keys(user.id)
+
+        # Results should be identical
+        assert individual_results == user_results
+        assert len(user_results) == 3  # Should include all teams in both organizations
+        assert team1.api_token in user_results
+        assert team2.api_token in user_results
+        assert team3.api_token in user_results
+
+    def test_user_function_mixed_scoped_and_unscoped_keys(self):
+        """Test user-based function with mix of scoped and unscoped keys."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create test data
+        org1 = Organization.objects.create(name="Org 1")
+        org2 = Organization.objects.create(name="Org 2")
+
+        team1 = Team.objects.create(organization=org1, name="Team 1")
+        team2 = Team.objects.create(organization=org1, name="Team 2")
+        team3 = Team.objects.create(organization=org2, name="Team 3")
+        team4 = Team.objects.create(organization=org2, name="Team 4")
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        OrganizationMembership.objects.create(organization=org1, user=user)
+        OrganizationMembership.objects.create(organization=org2, user=user)
+
+        # Create mix of scoped and unscoped keys
+        token_value1 = generate_random_token_personal()
+        scoped_key = PersonalAPIKey.objects.create(
+            label="Scoped Key",
+            user=user,
+            scoped_teams=[team1.id],  # Only team1
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value1),
+            mask_value=mask_key_value(token_value1),
+        )
+
+        token_value2 = generate_random_token_personal()
+        unscoped_key = PersonalAPIKey.objects.create(
+            label="Unscoped Key",
+            user=user,
+            scoped_teams=None,  # All teams in user's orgs
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value2),
+            mask_value=mask_key_value(token_value2),
+        )
+
+        # Get results using individual function calls (N+1 pattern)
+        individual_results = set()
+        for key in [scoped_key, unscoped_key]:
+            individual_results.update(get_teams_for_single_personal_api_key(key))
+
+        # Get results using user-based function (optimized)
+        user_results = get_teams_for_user_personal_api_keys(user.id)
+
+        # Results should be identical
+        assert individual_results == user_results
+        # Should include all teams due to unscoped key (unscoped overrides scoped)
+        assert len(user_results) == 4
+        assert team1.api_token in user_results
+        assert team2.api_token in user_results
+        assert team3.api_token in user_results
+        assert team4.api_token in user_results
+
+    def test_user_function_no_personal_api_keys(self):
+        """Test user-based function with user who has no personal API keys."""
+        from posthog.models.user import User
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+
+        # Should return empty set
+        user_results = get_teams_for_user_personal_api_keys(user.id)
+        assert user_results == set()
+
+    def test_user_function_user_not_in_organizations(self):
+        """Test user-based function with user who has keys but no organization memberships."""
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        user = User.objects.create(email="test@example.com", is_active=True)
+        # Note: user has no OrganizationMembership records
+
+        # Create unscoped personal API key
+        token_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Unscoped Key",
+            user=user,
+            scoped_teams=None,  # Unscoped but user has no org memberships
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(token_value),
+            mask_value=mask_key_value(token_value),
+        )
+
+        # Should return empty set (user not in any organizations)
+        user_results = get_teams_for_user_personal_api_keys(user.id)
+        assert user_results == set()
+
+
+class TestOrganizationScopedAPIKeys(TestCase):
+    """Test that PersonalAPIKeys with scoped_organizations are correctly filtered in cache."""
+
+    def setUp(self):
+        """Set up test data with multiple organizations and teams."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Clear cache before tests
+        cache.clear()
+
+        # Create user
+        self.user = User.objects.create(email="test@example.com", is_active=True)
+
+        # Create two organizations
+        self.org1 = Organization.objects.create(name="Org 1")
+        self.org2 = Organization.objects.create(name="Org 2")
+
+        # Add user to both organizations
+        OrganizationMembership.objects.create(user=self.user, organization=self.org1)
+        OrganizationMembership.objects.create(user=self.user, organization=self.org2)
+
+        # Create teams in each organization
+        self.team1_org1 = Team.objects.create(
+            organization=self.org1, name="Team 1 Org 1", api_token="pht_team1_org1_token"
+        )
+        self.team2_org1 = Team.objects.create(
+            organization=self.org1, name="Team 2 Org 1", api_token="pht_team2_org1_token"
+        )
+        self.team1_org2 = Team.objects.create(
+            organization=self.org2, name="Team 1 Org 2", api_token="pht_team1_org2_token"
+        )
+
+        # Create various PersonalAPIKeys with different organization scoping
+
+        # Unscoped key - should appear in all teams
+        self.unscoped_token = generate_random_token_personal()
+        self.unscoped_key = PersonalAPIKey.objects.create(
+            label="Unscoped Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=None,  # No organization restriction
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(self.unscoped_token),
+            mask_value=mask_key_value(self.unscoped_token),
+        )
+
+        # Key scoped to org1 only
+        self.org1_scoped_token = generate_random_token_personal()
+        self.org1_scoped_key = PersonalAPIKey.objects.create(
+            label="Org1 Scoped Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=[str(self.org1.id)],  # Only org1
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(self.org1_scoped_token),
+            mask_value=mask_key_value(self.org1_scoped_token),
+        )
+
+        # Key scoped to org2 only
+        self.org2_scoped_token = generate_random_token_personal()
+        self.org2_scoped_key = PersonalAPIKey.objects.create(
+            label="Org2 Scoped Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=[str(self.org2.id)],  # Only org2
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(self.org2_scoped_token),
+            mask_value=mask_key_value(self.org2_scoped_token),
+        )
+
+        # Key scoped to both organizations
+        self.both_orgs_token = generate_random_token_personal()
+        self.both_orgs_key = PersonalAPIKey.objects.create(
+            label="Both Orgs Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=[str(self.org1.id), str(self.org2.id)],  # Both orgs
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(self.both_orgs_token),
+            mask_value=mask_key_value(self.both_orgs_token),
+        )
+
+        # Key scoped to specific team and organization
+        self.team_and_org_token = generate_random_token_personal()
+        self.team_and_org_key = PersonalAPIKey.objects.create(
+            label="Team and Org Scoped Key",
+            user=self.user,
+            scoped_teams=[self.team1_org1.id],  # Only team1 in org1
+            scoped_organizations=[str(self.org1.id)],  # Only org1
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(self.team_and_org_token),
+            mask_value=mask_key_value(self.team_and_org_token),
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    def test_unscoped_key_appears_in_all_team_caches(self):
+        """Test that unscoped keys appear in all teams the user has access to."""
+        # Warm caches for all teams
+        warm_team_token_cache(self.team1_org1.api_token)
+        warm_team_token_cache(self.team2_org1.api_token)
+        warm_team_token_cache(self.team1_org2.api_token)
+
+        # Check that unscoped key is in all caches
+        team1_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org1.api_token)
+        team2_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team2_org1.api_token)
+        team1_org2_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org2.api_token)
+
+        # Check that unscoped key is in all caches
+        assert team1_org1_cache is not None
+        assert team2_org1_cache is not None
+        assert team1_org2_cache is not None
+
+        assert hash_key_value(self.unscoped_token) in team1_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.unscoped_token) in team2_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.unscoped_token) in team1_org2_cache["hashed_tokens"]
+
+    def test_org_scoped_key_only_appears_in_correct_org_teams(self):
+        """Test that org-scoped keys only appear in teams within their allowed organizations."""
+        # Warm caches for all teams
+        warm_team_token_cache(self.team1_org1.api_token)
+        warm_team_token_cache(self.team2_org1.api_token)
+        warm_team_token_cache(self.team1_org2.api_token)
+
+        team1_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org1.api_token)
+        team2_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team2_org1.api_token)
+        team1_org2_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org2.api_token)
+
+        assert team1_org1_cache is not None, "Cache should exist for team1_org1"
+        assert team2_org1_cache is not None, "Cache should exist for team2_org1"
+        assert team1_org2_cache is not None, "Cache should exist for team1_org2"
+
+        # Org1-scoped key should only be in org1 teams
+        assert hash_key_value(self.org1_scoped_token) in team1_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.org1_scoped_token) in team2_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.org1_scoped_token) not in team1_org2_cache["hashed_tokens"]
+
+        # Org2-scoped key should only be in org2 teams
+        assert hash_key_value(self.org2_scoped_token) not in team1_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.org2_scoped_token) not in team2_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.org2_scoped_token) in team1_org2_cache["hashed_tokens"]
+
+    def test_multi_org_scoped_key_appears_in_all_specified_orgs(self):
+        """Test that keys scoped to multiple organizations appear in all specified orgs."""
+        # Warm caches for all teams
+        warm_team_token_cache(self.team1_org1.api_token)
+        warm_team_token_cache(self.team2_org1.api_token)
+        warm_team_token_cache(self.team1_org2.api_token)
+
+        team1_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org1.api_token)
+        team2_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team2_org1.api_token)
+        team1_org2_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org2.api_token)
+
+        assert team1_org1_cache is not None, "Cache should exist for team1_org1"
+        assert team2_org1_cache is not None, "Cache should exist for team2_org1"
+        assert team1_org2_cache is not None, "Cache should exist for team1_org2"
+
+        # Both-orgs key should be in all teams (both org1 and org2)
+        assert hash_key_value(self.both_orgs_token) in team1_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.both_orgs_token) in team2_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.both_orgs_token) in team1_org2_cache["hashed_tokens"]
+
+    def test_team_and_org_scoped_key_only_in_specific_team(self):
+        """Test that keys scoped to both team and organization only appear in the specific team."""
+        # Warm caches for all teams
+        warm_team_token_cache(self.team1_org1.api_token)
+        warm_team_token_cache(self.team2_org1.api_token)
+        warm_team_token_cache(self.team1_org2.api_token)
+
+        team1_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org1.api_token)
+        team2_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team2_org1.api_token)
+        team1_org2_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org2.api_token)
+
+        assert team1_org1_cache is not None, "Cache should exist for team1_org1"
+        assert team2_org1_cache is not None, "Cache should exist for team2_org1"
+        assert team1_org2_cache is not None, "Cache should exist for team1_org2"
+
+        # Team-and-org-scoped key should only be in team1 of org1
+        assert hash_key_value(self.team_and_org_token) in team1_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.team_and_org_token) not in team2_org1_cache["hashed_tokens"]
+        assert hash_key_value(self.team_and_org_token) not in team1_org2_cache["hashed_tokens"]
+
+    def test_org_scoped_key_outside_user_membership(self):
+        """Test that org-scoped keys don't appear in teams if user is not in that org."""
+        from posthog.models.organization import Organization
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create a third organization that user is NOT a member of
+        org3 = Organization.objects.create(name="Org 3")
+        team_org3 = Team.objects.create(organization=org3, name="Team Org 3", api_token="pht_team_org3_token")
+
+        # Create key scoped to org3 (user not a member)
+        org3_token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Org3 Scoped Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=[str(org3.id)],  # Org3 where user is not a member
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(org3_token),
+            mask_value=mask_key_value(org3_token),
+        )
+
+        # Warm cache for org3 team
+        warm_team_token_cache(team_org3.api_token)
+
+        # Key should NOT appear in org3 team cache (user not in org)
+        team_org3_cache = team_access_tokens_hypercache.get_from_cache(team_org3.api_token)
+        assert team_org3_cache is not None, "Cache should exist for team_org3"
+        assert hash_key_value(org3_token) not in team_org3_cache["hashed_tokens"]
+
+    def test_empty_scoped_organizations_behaves_as_unscoped(self):
+        """Test that empty scoped_organizations array behaves as unscoped."""
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create key with empty scoped_organizations array
+        empty_org_token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Empty Org Array Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=[],  # Empty array should behave as unscoped
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(empty_org_token),
+            mask_value=mask_key_value(empty_org_token),
+        )
+
+        # Warm caches
+        warm_team_token_cache(self.team1_org1.api_token)
+        warm_team_token_cache(self.team1_org2.api_token)
+
+        # Key should appear in all teams (unscoped behavior)
+        team1_org1_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org1.api_token)
+        team1_org2_cache = team_access_tokens_hypercache.get_from_cache(self.team1_org2.api_token)
+
+        assert team1_org1_cache is not None, "Cache should exist for team1_org1"
+        assert team1_org2_cache is not None, "Cache should exist for team1_org2"
+
+        assert hash_key_value(empty_org_token) in team1_org1_cache["hashed_tokens"]
+        assert hash_key_value(empty_org_token) in team1_org2_cache["hashed_tokens"]
+
+
+class TestOrganizationScopingSignalHandlers(TestCase):
+    """Test that signal handlers properly update caches when scoped_organizations changes."""
+
+    def setUp(self):
+        """Set up test data."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Clear cache before tests
+        cache.clear()
+
+        # Create user
+        self.user = User.objects.create(email="test@example.com", is_active=True)
+
+        # Create two organizations
+        self.org1 = Organization.objects.create(name="Org 1")
+        self.org2 = Organization.objects.create(name="Org 2")
+
+        # Add user to both organizations
+        OrganizationMembership.objects.create(user=self.user, organization=self.org1)
+        OrganizationMembership.objects.create(user=self.user, organization=self.org2)
+
+        # Create teams
+        self.team_org1 = Team.objects.create(
+            organization=self.org1, name="Team Org 1", api_token="pht_team_org1_signal_test"
+        )
+        self.team_org2 = Team.objects.create(
+            organization=self.org2, name="Team Org 2", api_token="pht_team_org2_signal_test"
+        )
+
+        # Create a personal API key initially unscoped
+        self.token = generate_random_token_personal()
+        self.personal_key = PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=None,  # Initially unscoped
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(self.token),
+            mask_value=mask_key_value(self.token),
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_updating_scoped_organizations_updates_caches(self, mock_on_commit):
+        """Test that changing scoped_organizations field triggers cache updates."""
+        # Initially warm caches - key should be in both
+        warm_team_token_cache(self.team_org1.api_token)
+        warm_team_token_cache(self.team_org2.api_token)
+
+        cache1 = team_access_tokens_hypercache.get_from_cache(self.team_org1.api_token)
+        cache2 = team_access_tokens_hypercache.get_from_cache(self.team_org2.api_token)
+
+        assert cache1 is not None, "Cache should exist for team_org1"
+        assert cache2 is not None, "Cache should exist for team_org2"
+
+        # Initially unscoped, so should be in both teams
+        assert hash_key_value(self.token) in cache1["hashed_tokens"]
+        assert hash_key_value(self.token) in cache2["hashed_tokens"]
+
+        # Update to be scoped to org1 only
+        self.personal_key.scoped_organizations = [str(self.org1.id)]
+        self.personal_key.save(update_fields=["scoped_organizations"])
+
+        # Check caches again - should only be in org1 teams now
+        cache1_after = team_access_tokens_hypercache.get_from_cache(self.team_org1.api_token)
+        cache2_after = team_access_tokens_hypercache.get_from_cache(self.team_org2.api_token)
+
+        assert cache1_after is not None, "Cache should exist for team_org1 after"
+        assert cache2_after is not None, "Cache should exist for team_org2 after"
+
+        assert hash_key_value(self.token) in cache1_after["hashed_tokens"]
+        assert hash_key_value(self.token) not in cache2_after["hashed_tokens"]
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_removing_organization_scoping_updates_caches(self, mock_on_commit):
+        """Test that removing organization scoping makes key available to all orgs again."""
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.utils import generate_random_token_personal, mask_key_value
+
+        # Create a key scoped to org1 only
+        scoped_token = generate_random_token_personal()
+        scoped_key = PersonalAPIKey.objects.create(
+            label="Scoped Key",
+            user=self.user,
+            scoped_teams=None,
+            scoped_organizations=[str(self.org1.id)],  # Initially scoped to org1
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(scoped_token),
+            mask_value=mask_key_value(scoped_token),
+        )
+
+        # Warm caches
+        warm_team_token_cache(self.team_org1.api_token)
+        warm_team_token_cache(self.team_org2.api_token)
+
+        # Check initial state - only in org1
+        cache1 = team_access_tokens_hypercache.get_from_cache(self.team_org1.api_token)
+        cache2 = team_access_tokens_hypercache.get_from_cache(self.team_org2.api_token)
+
+        assert cache1 is not None, "Cache should exist for team_org1"
+        assert cache2 is not None, "Cache should exist for team_org2"
+
+        assert hash_key_value(scoped_token) in cache1["hashed_tokens"]
+        assert hash_key_value(scoped_token) not in cache2["hashed_tokens"]
+
+        # Remove organization scoping
+        scoped_key.scoped_organizations = None
+        scoped_key.save(update_fields=["scoped_organizations"])
+
+        # Check caches again - should be in both orgs now
+        cache1_after = team_access_tokens_hypercache.get_from_cache(self.team_org1.api_token)
+        cache2_after = team_access_tokens_hypercache.get_from_cache(self.team_org2.api_token)
+
+        assert cache1_after is not None, "Cache should exist for team_org1 after"
+        assert cache2_after is not None, "Cache should exist for team_org2 after"
+
+        assert hash_key_value(scoped_token) in cache1_after["hashed_tokens"]
+        assert hash_key_value(scoped_token) in cache2_after["hashed_tokens"]
+
+
+class TestSecretTokenRotation(TestCase):
+    """Test that changes to secret_api_token and secret_api_token_backup update the cache."""
+
+    def setUp(self):
+        """Set up test data."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_secret
+
+        # Clear cache before tests
+        cache.clear()
+
+        # Create user and organization
+        self.user = User.objects.create(email="test@example.com", is_active=True)
+        self.org = Organization.objects.create(name="Test Org")
+        OrganizationMembership.objects.create(user=self.user, organization=self.org)
+
+        # Create team with initial secret token
+        self.initial_token = generate_random_token_secret()
+        self.team = Team.objects.create(
+            organization=self.org,
+            name="Test Team",
+            api_token="pht_test_rotation_token",
+            secret_api_token=self.initial_token,
+            secret_api_token_backup=None,
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_secret_api_token_changes_update_cache(self, mock_on_commit):
+        """Test that changing secret_api_token updates the cache correctly."""
+        from posthog.models.personal_api_key import hash_key_value
+        from posthog.models.utils import generate_random_token_secret
+
+        # Warm initial cache
+        warm_team_token_cache(self.team.api_token)
+
+        # Verify initial token is in cache
+        cache_data = team_access_tokens_hypercache.get_from_cache(self.team.api_token)
+        assert cache_data is not None
+        initial_token_hash = hash_key_value(self.initial_token, mode="sha256")
+        assert initial_token_hash in cache_data["hashed_tokens"]
+
+        # Change secret_api_token
+        new_token = generate_random_token_secret()
+        self.team.secret_api_token = new_token
+        self.team.save(update_fields=["secret_api_token"])
+
+        # Check cache was updated - new token in, old token out
+        cache_data = team_access_tokens_hypercache.get_from_cache(self.team.api_token)
+        assert cache_data is not None
+        assert hash_key_value(new_token, mode="sha256") in cache_data["hashed_tokens"]
+        assert hash_key_value(self.initial_token, mode="sha256") not in cache_data["hashed_tokens"]
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_secret_api_token_backup_changes_update_cache(self, mock_on_commit):
+        """Test that changing secret_api_token_backup updates the cache correctly."""
+        from posthog.models.personal_api_key import hash_key_value
+        from posthog.models.utils import generate_random_token_secret
+
+        # Warm initial cache
+        warm_team_token_cache(self.team.api_token)
+
+        # Start with backup=None, verify only primary token in cache
+        cache_data = team_access_tokens_hypercache.get_from_cache(self.team.api_token)
+        assert cache_data is not None
+        assert hash_key_value(self.team.secret_api_token, mode="sha256") in cache_data["hashed_tokens"]
+
+        # Set backup to a value
+        backup_token1 = generate_random_token_secret()
+        self.team.secret_api_token_backup = backup_token1
+        self.team.save(update_fields=["secret_api_token_backup"])
+
+        # Verify both tokens in cache
+        cache_data = team_access_tokens_hypercache.get_from_cache(self.team.api_token)
+        assert cache_data is not None, "Cache should exist after backup token set"
+        assert hash_key_value(self.team.secret_api_token, mode="sha256") in cache_data["hashed_tokens"]
+        assert hash_key_value(backup_token1, mode="sha256") in cache_data["hashed_tokens"]
+
+        # Change backup to different value
+        backup_token2 = generate_random_token_secret()
+        self.team.secret_api_token_backup = backup_token2
+        self.team.save(update_fields=["secret_api_token_backup"])
+
+        # Verify new backup in cache, old backup not in cache
+        cache_data = team_access_tokens_hypercache.get_from_cache(self.team.api_token)
+        assert cache_data is not None, "Cache should exist after backup token change"
+        assert hash_key_value(self.team.secret_api_token, mode="sha256") in cache_data["hashed_tokens"]
+        assert hash_key_value(backup_token2, mode="sha256") in cache_data["hashed_tokens"]
+        assert hash_key_value(backup_token1, mode="sha256") not in cache_data["hashed_tokens"]
+
+        # Set backup=None
+        self.team.secret_api_token_backup = None
+        self.team.save(update_fields=["secret_api_token_backup"])
+
+        # Verify only primary token remains
+        cache_data = team_access_tokens_hypercache.get_from_cache(self.team.api_token)
+        assert cache_data is not None
+        assert hash_key_value(self.team.secret_api_token, mode="sha256") in cache_data["hashed_tokens"]
+        assert hash_key_value(backup_token2, mode="sha256") not in cache_data["hashed_tokens"]
+
+
+class TestTeamAPITokenRegeneration(TestCase):
+    """Test that regenerating team API token properly cleans up old cache."""
+
+    def setUp(self):
+        """Set up test data."""
+        from posthog.models.organization import Organization, OrganizationMembership
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_personal, generate_random_token_project, mask_key_value
+
+        # Clear cache before tests
+        cache.clear()
+
+        # Create user and organization
+        self.user = User.objects.create(email="test@example.com", is_active=True)
+        self.org = Organization.objects.create(name="Test Org")
+        OrganizationMembership.objects.create(user=self.user, organization=self.org)
+
+        # Create team with initial API token
+        self.initial_api_token = generate_random_token_project()
+        self.team = Team.objects.create(organization=self.org, name="Test Team", api_token=self.initial_api_token)
+
+        # Create a personal API key to have some data in cache
+        self.personal_token = generate_random_token_personal()
+        self.personal_key = PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            scoped_teams=None,
+            scopes=["feature_flag:read"],
+            secure_value=hash_key_value(self.personal_token),
+            mask_value=mask_key_value(self.personal_token),
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_regenerating_api_token_cleans_up_old_cache(self, mock_on_commit):
+        """Test that regenerating team's API token removes old cache entry."""
+        from posthog.models.utils import generate_random_token_project
+
+        # Warm initial cache
+        warm_team_token_cache(self.initial_api_token)
+
+        # Verify initial cache exists
+        initial_cache = team_access_tokens_hypercache.get_from_cache(self.initial_api_token)
+        assert initial_cache is not None
+        assert "hashed_tokens" in initial_cache
+
+        # Store the old token for later verification
+        old_api_token = self.team.api_token
+
+        # Regenerate the API token
+        new_api_token = generate_random_token_project()
+        self.team.api_token = new_api_token
+        self.team.save(update_fields=["api_token"])
+
+        # Check that new cache exists
+        new_cache = team_access_tokens_hypercache.get_from_cache(new_api_token)
+        assert new_cache is not None
+        assert "hashed_tokens" in new_cache
+
+        # Check that old cache is cleaned up
+        old_cache = team_access_tokens_hypercache.get_from_cache(old_api_token)
+        assert old_cache is None, "Old cache should be cleaned up after API token regeneration"
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_api_token_change_preserves_data_in_new_cache(self, mock_on_commit):
+        """Test that changing API token preserves all token data in new cache."""
+        from posthog.models.personal_api_key import hash_key_value
+        from posthog.models.utils import generate_random_token_project
+
+        # Warm initial cache
+        warm_team_token_cache(self.initial_api_token)
+
+        # Verify personal key is in initial cache
+        initial_cache = team_access_tokens_hypercache.get_from_cache(self.initial_api_token)
+        assert initial_cache is not None, "Initial cache should exist"
+        assert hash_key_value(self.personal_token) in initial_cache["hashed_tokens"]
+
+        # Regenerate the API token
+        new_api_token = generate_random_token_project()
+        old_api_token = self.team.api_token
+        self.team.api_token = new_api_token
+        self.team.save(update_fields=["api_token"])
+
+        # Verify personal key is still in new cache
+        new_cache = team_access_tokens_hypercache.get_from_cache(new_api_token)
+        assert new_cache is not None, "New cache should exist after API token change"
+        assert hash_key_value(self.personal_token) in new_cache["hashed_tokens"]
+
+        # Verify old cache is gone
+        old_cache = team_access_tokens_hypercache.get_from_cache(old_api_token)
+        assert old_cache is None

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -54,6 +54,7 @@ from posthog.tasks.tasks import (
     update_survey_iteration,
     verify_persons_data_in_sync,
 )
+from posthog.tasks.team_access_cache_tasks import warm_all_team_access_caches_task
 from posthog.utils import get_crontab
 
 TWENTY_FOUR_HOURS = 24 * 60 * 60
@@ -93,6 +94,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="0"),
         schedule_warming_for_teams_task.s(),
         name="schedule warming for largest teams",
+    )
+
+    # Team access cache warming - every 10 minutes
+    add_periodic_task_with_expiry(
+        sender,
+        600,  # Every 10 minutes (no TTL, just fill missing entries)
+        warm_all_team_access_caches_task.s(),
+        name="warm team access caches",
     )
 
     # Update events table partitions twice a week

--- a/posthog/tasks/team_access_cache_tasks.py
+++ b/posthog/tasks/team_access_cache_tasks.py
@@ -1,0 +1,117 @@
+"""
+Background tasks for warming team access token caches.
+
+This module provides Celery tasks to periodically warm the team access token
+caches, ensuring that the cached authentication system has fresh data.
+"""
+
+import logging
+
+from django.conf import settings
+
+from celery import shared_task
+from celery.app.task import Task
+
+from posthog.storage.team_access_cache import get_teams_needing_cache_refresh_paginated, warm_team_token_cache
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+CACHE_WARMING_BATCH_SIZE = getattr(settings, "CACHE_WARMING_BATCH_SIZE", 50)
+CACHE_WARMING_PAGE_SIZE = getattr(settings, "CACHE_WARMING_PAGE_SIZE", 1000)  # Teams per database page
+
+
+@shared_task(bind=True, max_retries=3)
+def warm_team_cache_task(self: "Task", project_api_key: str) -> dict:
+    """
+    Warm the token cache for a specific team.
+
+    Args:
+        project_api_key: The team's project API key
+
+    Returns:
+        Dictionary with operation results
+    """
+    success = warm_team_token_cache(project_api_key)
+
+    if not success:
+        # Log a warning, but don't retry. We'll let the next scheduled task pick it up.
+        logger.warning(f"Failed to warm cache for team {project_api_key}")
+        return {"status": "failure", "project_api_key": project_api_key}
+
+    logger.info(
+        f"Successfully warmed cache for team {project_api_key}",
+        extra={"project_api_key": project_api_key},
+    )
+
+    return {"status": "success", "project_api_key": project_api_key}
+
+
+@shared_task(bind=True, max_retries=1)
+def warm_all_team_access_caches_task(self: "Task") -> dict:
+    """
+    Warm caches for all teams that need refreshing.
+
+    This task identifies teams with expired or missing caches and
+    schedules individual warming tasks for each team.
+
+    Returns:
+        Dictionary with operation results
+    """
+    try:
+        teams_scheduled = 0
+        failed_teams = 0
+        teams_pages_processed = 0
+        total_teams_found = 0
+
+        # Use paginated approach for memory efficiency
+        logger.info(f"Using paginated cache warming with page size {CACHE_WARMING_PAGE_SIZE}")
+
+        for teams_page in get_teams_needing_cache_refresh_paginated(batch_size=CACHE_WARMING_PAGE_SIZE):
+            teams_pages_processed += 1
+
+            if not teams_page:
+                continue
+
+            total_teams_found += len(teams_page)
+
+            logger.debug(
+                f"Processing page {teams_pages_processed} with {len(teams_page)} teams needing refresh",
+                extra={"page": teams_pages_processed, "teams_in_page": len(teams_page)},
+            )
+
+            # Process teams in batches to avoid overwhelming the system
+            for i in range(0, len(teams_page), CACHE_WARMING_BATCH_SIZE):
+                batch = teams_page[i : i + CACHE_WARMING_BATCH_SIZE]
+
+                # Schedule warming tasks for this batch
+                for project_api_key in batch:
+                    try:
+                        warm_team_cache_task.delay(project_api_key)
+                        teams_scheduled += 1
+                    except Exception as e:
+                        # Log individual team scheduling failure but continue with others
+                        failed_teams += 1
+                        logger.warning(
+                            f"Failed to schedule cache warming for team {project_api_key}: {e}",
+                            extra={"project_api_key": project_api_key, "error": str(e)},
+                        )
+
+                logger.debug(f"Scheduled cache warming for batch of {len(batch)} teams")
+
+        logger.info(
+            "Cache warming completed",
+            extra={"teams_found": total_teams_found, "teams_scheduled": teams_scheduled, "failed_teams": failed_teams},
+        )
+
+        return {
+            "status": "success",
+            "teams_found": total_teams_found,
+            "teams_scheduled": teams_scheduled,
+            "failed_teams": failed_teams,
+        }
+
+    except Exception as e:
+        # Retry for systemic failures (database connectivity, etc.)
+        logger.exception(f"Systemic failure in cache warming batch task: {e}")
+        raise self.retry(exc=e, countdown=300)  # 5 minutes

--- a/posthog/tasks/test/test_team_access_cache_tasks.py
+++ b/posthog/tasks/test/test_team_access_cache_tasks.py
@@ -1,0 +1,167 @@
+"""
+Tests for team access cache Celery tasks.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from posthog.tasks.team_access_cache_tasks import warm_all_team_access_caches_task, warm_team_cache_task
+
+
+class TestWarmTeamCacheTask(TestCase):
+    """Test the individual team cache warming task."""
+
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_token_cache")
+    def test_warm_team_cache_task_success(self, mock_warm: MagicMock) -> None:
+        """Test successful cache warming for a team."""
+        mock_warm.return_value = True
+
+        project_api_key = "phs_test_team_123"
+
+        result = warm_team_cache_task(project_api_key)
+
+        mock_warm.assert_called_once_with(project_api_key)
+
+        assert result["status"] == "success"
+        assert result["project_api_key"] == project_api_key
+
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_token_cache")
+    def test_warm_team_cache_task_failure(self, mock_warm: MagicMock) -> None:
+        """Test that cache warming failure does not trigger retry."""
+        mock_warm.return_value = False
+
+        project_api_key = "phs_test_team_123"
+
+        result = warm_team_cache_task(project_api_key)
+
+        mock_warm.assert_called_once_with(project_api_key)
+
+        assert result["status"] == "failure"
+        assert result["project_api_key"] == project_api_key
+
+
+class TestWarmAllTeamsCachesTask(TestCase):
+    """Test the batch cache warming task."""
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh_paginated")
+    def test_warm_all_team_access_caches_task_no_teams(self, mock_get_teams_paginated: MagicMock) -> None:
+        """Test batch warming when no teams need refresh."""
+        mock_get_teams_paginated.return_value = iter([])
+
+        result = warm_all_team_access_caches_task()
+
+        assert result["status"] == "success"
+        assert result["teams_found"] == 0
+        assert result["teams_scheduled"] == 0
+        assert result["failed_teams"] == 0
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh_paginated")
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_cache_task.delay")
+    @patch("posthog.tasks.team_access_cache_tasks.CACHE_WARMING_BATCH_SIZE", 2)
+    def test_warm_all_team_access_caches_task_batching(
+        self, mock_delay: MagicMock, mock_get_teams_paginated: MagicMock
+    ) -> None:
+        """Test that teams are processed in configured batches."""
+        # Setup mock teams - more than batch size, split across pages
+        page1 = ["phs_team1_123", "phs_team2_456"]
+        page2 = ["phs_team3_789", "phs_team4_012"]
+        mock_get_teams_paginated.return_value = iter([page1, page2])
+
+        result = warm_all_team_access_caches_task()
+
+        # Verify all teams were scheduled despite batching
+        assert mock_delay.call_count == 4
+        all_teams = page1 + page2
+        for team in all_teams:
+            mock_delay.assert_any_call(team)
+
+        assert result["status"] == "success"
+        assert result["teams_scheduled"] == 4
+        assert result["teams_found"] == 4
+        assert result["failed_teams"] == 0
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh_paginated")
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_cache_task.delay")
+    def test_warm_all_team_access_caches_task_handles_individual_failures(
+        self, mock_delay: MagicMock, mock_get_teams_paginated: MagicMock
+    ) -> None:
+        """Test that batch warming handles individual team failures gracefully."""
+        # Setup mocks - single page of teams
+        mock_teams = ["phs_team1_123", "phs_team2_456", "phs_team3_789"]
+        mock_get_teams_paginated.return_value = iter([mock_teams])
+
+        # Make delay fail for the second team only
+        def delay_side_effect(project_api_key: str) -> None:
+            if project_api_key == "phs_team2_456":
+                raise Exception("Task scheduling failed for team 2")
+            return None
+
+        mock_delay.side_effect = delay_side_effect
+
+        # Execute task - should NOT raise exception, but should handle failure gracefully
+        result = warm_all_team_access_caches_task()
+
+        mock_get_teams_paginated.assert_called_once()
+
+        # Verify all teams were attempted
+        assert mock_delay.call_count == 3
+        mock_delay.assert_any_call("phs_team1_123")
+        mock_delay.assert_any_call("phs_team2_456")
+        mock_delay.assert_any_call("phs_team3_789")
+
+        # Verify result shows partial success
+        assert result["status"] == "success"
+        assert result["teams_scheduled"] == 2  # team2 failed to schedule
+        assert result["failed_teams"] == 1
+        assert result["teams_found"] == 3
+
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh_paginated")
+    def test_warm_all_team_access_caches_task_handles_systemic_failures(
+        self, mock_get_teams_paginated: MagicMock
+    ) -> None:
+        """Test that batch warming retries on systemic failures like database connectivity issues."""
+        # Make get_teams_needing_cache_refresh_paginated fail (systemic issue)
+        mock_get_teams_paginated.side_effect = Exception("Database connection failed")
+
+        # Execute task - should raise some exception that triggers retry
+        # The retry mechanism may raise the original exception or a Retry exception
+        with self.assertRaises(Exception) as cm:
+            warm_all_team_access_caches_task()
+
+        mock_get_teams_paginated.assert_called_once()
+
+        # Verify the exception is related to our test failure
+        self.assertIn("Database connection failed", str(cm.exception))
+
+
+class TestTaskIntegration(TestCase):
+    """Integration tests for the complete task flow."""
+
+    @patch("posthog.tasks.team_access_cache_tasks.warm_team_token_cache")
+    @patch("posthog.tasks.team_access_cache_tasks.get_teams_needing_cache_refresh_paginated")
+    def test_complete_cache_refresh_flow(self, mock_get_teams_paginated: MagicMock, mock_warm: MagicMock) -> None:
+        """Test the complete flow from batch task to individual warming."""
+        # Setup mocks - single page with one team
+        mock_teams = ["phs_team1_123"]
+        mock_get_teams_paginated.return_value = iter([mock_teams])
+        mock_warm.return_value = True
+
+        # Execute batch task (without actually scheduling async tasks)
+        with patch("posthog.tasks.team_access_cache_tasks.warm_team_cache_task.delay") as mock_delay:
+            batch_result = warm_all_team_access_caches_task()
+
+            # Verify batch task scheduled individual task
+            mock_delay.assert_called_once_with("phs_team1_123")
+
+        # Simulate individual task execution
+        individual_result = warm_team_cache_task("phs_team1_123")
+
+        # Verify both tasks succeeded
+        assert batch_result["status"] == "success"
+        assert batch_result["teams_scheduled"] == 1
+        assert batch_result["teams_found"] == 1
+        assert batch_result["failed_teams"] == 0
+
+        assert individual_result["status"] == "success"
+        assert individual_result["project_api_key"] == "phs_team1_123"


### PR DESCRIPTION
This is part 1 of building a HyperCache based authentication system for `local_evaluation` (and eventually other SDK endpoints such as remote config flags). Part 2 will be a Rust service to serve up the cached local_evaluation response using the HyperCache authentication.

## Problem

When the database is under load or having an outage, the `local_evaluation` endpoint responds with 503 errors. This is an important endpoint for customers that needs to be resilient to database issues.

The `local_evaluation` endpoint [already serves up cached flag definitions](https://github.com/PostHog/posthog/pull/36616). But it still requires database calls for authentication.

## Changes

This builds upon the HyperCache infrastructure to build a cache of tokens authorized to access the `local_evaluation` endpoint. This includes personal access tokens, `secret_api_token`, and `secret_api_token_backup`.

The cache is maintained by ensuring we rebuild the cache when changes that affect authorization occur. We also schedule cache updates regularly.

### Cache Format:

cache key: `team_tokens/{project_api_token}/team_access_tokens/access_tokens.json`
Example: `team_tokens/phc_wRUNeXnP631OZPGH73HMZyefkAlG6NeM4nsbelGtsIt/team_access_tokens/access_tokens.json`

Cache value is a JSON blob with these fields:

* `hashed_tokens`: Array of SHA256 hashed tokens (personal api keys that have access to local_evaluation, `secret_api_token`, and `secret_api_token_backup`)
* `last_updated`: When the token was last updated. We can use this for future etag support.
* `team_id`

Example:

```json
{
   "hashed_tokens":[
      "sha256$5bdc3e0a54c52287d88ce411e5d3aeb641f91ad5ea4a3b9f7db6d1b34648bd1f",
      "sha256$863803a3b54b515204e55c0c0f2263f0fa2256b2cff9066b44fc655d7dbb6e24",
      "sha256$c36058ae759e118f8b951125bba586d8fec9944f5fd3f369423219f42c368c28",
      "sha256$f6b20f2b61a201f1258c5f9612cb3106849435c2b492dde6013048f4919fc7d1"
   ],
   "last_updated":"2025-09-03T22:25:28.558863+00:00",
   "team_id":1
}
```

## How did you test this code?

Lots of unit tests.
Manually.

This checklist documents all the ways in which tokens can become valid or invalid for the local_evaluation authentication cache in PostHog.

### Personal API Keys

- [x] **User creates a personal API key** - Key becomes valid and is added to team caches ✅ (via `personal_api_key_saved` signal)
- [x] **User deletes a personal API key** - Key becomes invalid and is removed from team caches ✅ (via `personal_api_key_deleted` signal)
- [x] **User modifies personal API key scopes** - Cache updated if `feature_flag:read` or `feature_flag:write` scopes are added/removed ✅ (via `personal_api_key_saved` signal)
- [x] **User modifies personal API key team scoping** - Cache updated if `scoped_teams` array is modified ✅ (via `personal_api_key_saved` signal)
- [x] **User modifies personal API key team scoping** - Cache updated if `scoped_organizations` array is modified ✅ (via `personal_api_key_saved` signal)
- [x] **User rolls/regenerates a personal API key** - Old key becomes invalid, new key becomes valid ✅ 

### User Status Changes

- [x] **User is deactivated** (`is_active = False`) - All user's personal API keys become invalid ✅ (via `user_saved` signal)
- [x] **User is reactivated** (`is_active = True`) - All user's personal API keys become valid again ✅ (via `user_saved` signal)
- [x] **User is deleted** - All user's personal API keys are deleted and become invalid ✅ (CASCADE delete handles this automatically)

### Organization Membership

- [x] **User is added to an organization** - Unscoped keys gain access to new organization's teams ✅ (via `organization_membership_saved` signal)
- [x] **User is removed from an organization** - Unscoped keys lose access to that organization's teams ✅ (via `organization_membership_deleted` signal)
- [x] **Organization is deleted** - All tokens for teams in that organization become invalid ✅

### Team Secret Tokens

- [x] **Team's `secret_api_token` is set/changed** - New token becomes valid, old token becomes invalid ✅ (via `team_saved` signal)
- [x] **Team's `secret_api_token_backup` is set/changed** - Backup token becomes valid/invalid ✅ (via `team_saved` signal)
- [x] **Team rotates secret tokens** - Primary becomes backup, new primary is generated, old backup expires ✅
- [x] **Team clears backup token** - Backup token becomes invalid ✅

### Team Lifecycle

- [x] **Team is created** - New team's tokens can start being cached ✅ (via `team_saved` signal with `created=True`)
- [x] **Team is deleted** - All tokens for that team become invalid ✅ (via `team_deleted` signal)
- [x] **Team's API token is regenerated** - Cache needs to be rebuilt with new project API key ✅ (via `team_pre_save` and `team_saved` signals)

### Scope and Permission Changes

- [x] **Personal API key gains `feature_flag:read` scope** - Key becomes valid for local_evaluation ✅ (handled in `_load_team_access_tokens` filter logic)
- [x] **Personal API key loses `feature_flag:read` scope** - Key becomes invalid for local_evaluation ✅ (handled in `_load_team_access_tokens` filter logic)
- [x] **Personal API key gains `feature_flag:write` scope** - Key becomes valid (write implies read) ✅ (handled in `_load_team_access_tokens` filter logic)
- [x] **Personal API key loses `feature_flag:write` scope** - Key may become invalid if no read scope remains ✅ (handled in `_load_team_access_tokens` filter logic)
- [x] **Scoped key adds a team to `scoped_teams`** - Key gains access to that team ✅ (via `personal_api_key_saved` signal)
- [x] **Scoped key removes a team from `scoped_teams`** - Key loses access to that team ✅ (via `personal_api_key_saved` signal)
- [x] **Scoped key becomes unscoped** (`scoped_teams` set to null/empty) - Key gains access to all user's org teams ✅ 
- [x] **Unscoped key becomes scoped** - Key loses access to teams not in the scope list ✅
- [x] **Organization-scoped key adds/removes organization** (`scoped_organizations` field) - Key gains/loses access to teams in that organization ✅

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
