### PR TITLE
fix(experiments): prevent duplicated UUID on shared metrics

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -157,7 +157,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
             if (id && didPathChange) {
                 const parsedId = id === 'new' ? 'new' : parseInt(id)
                 if (parsedId === 'new') {
-                    actions.setSharedMetric({ ...values.newSharedMetric })
+                    actions.setSharedMetric({ ...values.newSharedMetric, query: getDefaultFunnelMetric() })
                 }
 
                 if (parsedId !== 'new' && parsedId === values.sharedMetricId) {


### PR DESCRIPTION
## Problem

When creating multiple shared metrics, two metrics may get the same `uuid` for their query if the page is not refreshed or the metric type is changed. This is because the Kea logic is not unmounted.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We need to reset the `new` state for `sharedMetric`, and the easiest way is to call the default `getDefaultFunnelMetric` again.

| Before | 
| - |
| <img width="1463" height="76" alt="image" src="https://github.com/user-attachments/assets/f998486b-1102-4970-bfe1-cb7e1852c2d6" /> | 

| After |
| - |
| <img width="1461" height="76" alt="image" src="https://github.com/user-attachments/assets/be8403e9-072c-48e7-b6e2-0ec102154f4f" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/a8ebb067-510f-406c-a576-a969c2070d1d)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
