### PR TITLE
feat: Add metric for postgres errors in plugin server

### DIFF
--- a/plugin-server/src/utils/db/metrics.ts
+++ b/plugin-server/src/utils/db/metrics.ts
@@ -28,3 +28,9 @@ export const personPropertiesSizeHistogram = new Histogram({
     labelNames: ['at'],
     buckets: [1024, 8192, 65536, 131072, 262144, 524288, 1048576, 2097152, 8388608],
 })
+
+export const postgresErrorCounter = new Counter({
+    name: 'plugin_server_postgres_errors',
+    help: 'Count of Postgres errors by type',
+    labelNames: ['error_type', 'database_use'],
+})

--- a/plugin-server/src/utils/db/postgres.ts
+++ b/plugin-server/src/utils/db/postgres.ts
@@ -1,5 +1,5 @@
 // Postgres
-import { Client, Pool, PoolClient, QueryConfig, QueryResult, QueryResultRow } from 'pg'
+import { Client, DatabaseError, Pool, PoolClient, QueryConfig, QueryResult, QueryResultRow } from 'pg'
 
 import { withSpan } from '~/common/tracing/tracing-utils'
 
@@ -8,6 +8,7 @@ import { logger } from '../logger'
 import { createPostgresPool } from '../utils'
 import { POSTGRES_UNAVAILABLE_ERROR_MESSAGES } from './db'
 import { DependencyUnavailableError } from './error'
+import { postgresErrorCounter } from './metrics'
 import { timeoutGuard } from './utils'
 
 export enum PostgresUse {
@@ -113,10 +114,10 @@ export class PostgresRouter {
     ): Promise<QueryResult<R>> {
         if (target instanceof TransactionClient) {
             const wrappedTag = `${PostgresUse[target.target]}:Tx<${tag}>`
-            return postgresQuery(target.client, queryString, values, wrappedTag, queryFailureLogLevel)
+            return postgresQuery(target.client, queryString, values, wrappedTag, queryFailureLogLevel, target.target)
         } else {
             const wrappedTag = `${PostgresUse[target]}<${tag}>`
-            return postgresQuery(this.pools.get(target)!, queryString, values, wrappedTag, queryFailureLogLevel)
+            return postgresQuery(this.pools.get(target)!, queryString, values, wrappedTag, queryFailureLogLevel, target)
         }
     }
 
@@ -140,7 +141,7 @@ export class PostgresRouter {
 
                 // if Postgres is down the ROLLBACK above won't work, but the transaction shouldn't be committed either
                 if (e.message && POSTGRES_UNAVAILABLE_ERROR_MESSAGES.some((message) => e.message.includes(message))) {
-                    throw new DependencyUnavailableError(e.message, 'Postgres', e)
+                    handlePostgresUnavailableError(e, usage)
                 }
 
                 throw e
@@ -170,7 +171,8 @@ function postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
     queryString: string | QueryConfig<I>,
     values: I | undefined,
     tag: string,
-    queryFailureLogLevel: 'error' | 'warn' = 'error'
+    queryFailureLogLevel: 'error' | 'warn' = 'error',
+    databaseUse: PostgresUse
 ): Promise<QueryResult<R>> {
     return withSpan('postgres', 'query.postgres', { tag: tag ?? 'unknown' }, async () => {
         const queryConfig =
@@ -189,7 +191,7 @@ function postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
                 error.message &&
                 POSTGRES_UNAVAILABLE_ERROR_MESSAGES.some((message) => error.message.includes(message))
             ) {
-                throw new DependencyUnavailableError(error.message, 'Postgres', error)
+                handlePostgresUnavailableError(error, databaseUse)
             }
 
             logger[queryFailureLogLevel]('🔴', 'Postgres query error', {
@@ -200,4 +202,19 @@ function postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
             throw error
         }
     })
+}
+
+function handlePostgresUnavailableError(error: DatabaseError, databaseUse: PostgresUse) {
+    const databaseUseLabel = PostgresUse[databaseUse]
+    let errorType = 'other'
+
+    const matchedError = POSTGRES_UNAVAILABLE_ERROR_MESSAGES.find((message) => error.message.includes(message))
+    if (matchedError) {
+        errorType = matchedError
+    } else if (error.code) {
+        errorType = error.code
+    }
+
+    postgresErrorCounter.inc({ error_type: errorType, database_use: databaseUseLabel })
+    throw new DependencyUnavailableError(error.message, 'Postgres', error)
 }


### PR DESCRIPTION
## Problem

Sometimes we get postgres errors in the plugin-server and get no notifications for it, mainly we see `query_wait_timeout` when `pg_bouncer` is overloaded. This PR creates a metric to report this, so that we can create an alarm based on it

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
