### PR TITLE
fix(batch-exports): Snowflake: Improve warehouse suspended error handling during `COPY INTO`

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -67,6 +67,7 @@ from products.batch_exports.backend.temporal.temporary_file import BatchExportTe
 from products.batch_exports.backend.temporal.utils import (
     JsonType,
     handle_non_retryable_errors,
+    make_retryable_with_exponential_backoff,
     set_status_to_running_task,
 )
 
@@ -101,6 +102,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "InvalidPrivateKeyError",
     # Raised when a valid authentication method is not provided.
     "SnowflakeAuthenticationError",
+    # Raised when a Warehouse is suspended.
+    "SnowflakeWarehouseSuspendedError",
 )
 
 
@@ -130,6 +133,12 @@ class SnowflakeConnectionError(Exception):
 
 class SnowflakeRetryableConnectionError(Exception):
     """Raised when a connection to Snowflake is not established."""
+
+    pass
+
+
+class SnowflakeWarehouseSuspendedError(Exception):
+    """Raised when a Warehouse is suspended."""
 
     pass
 
@@ -611,10 +620,34 @@ class SnowflakeClient:
             PURGE = TRUE
             """
 
+        # Handle cases where the Warehouse is suspended (sometimes we can recover from this)
+        max_attempts = 3
+
+        def _is_exception_retryable(e: Exception) -> bool:
+            if isinstance(e, snowflake.connector.errors.ProgrammingError):
+                # Warehouse suspended error
+                return e.errno == 608
+            return False
+
+        execute_copy_into = make_retryable_with_exponential_backoff(
+            self.execute_async_query,
+            max_attempts=max_attempts,
+            retryable_exceptions=(snowflake.connector.errors.ProgrammingError,),
+            is_exception_retryable=_is_exception_retryable,
+        )
+
         # We need to explicitly catch the exception here because otherwise it seems to be swallowed
         try:
-            result = await self.execute_async_query(query, poll_interval=1.0)
+            result = await execute_copy_into(query, poll_interval=1.0)
         except snowflake.connector.errors.ProgrammingError as e:
+            if e.errno == 608:
+                err_msg = (
+                    f"Failed to execute COPY INTO query after {max_attempts} attempts due to warehouse being suspended"
+                )
+                if e.msg is not None:
+                    err_msg += f": {e.msg}"
+                raise SnowflakeWarehouseSuspendedError(err_msg)
+
             self.logger.exception(f"Error executing COPY INTO query: {e}")
             raise SnowflakeFileNotLoadedError(
                 table_name,

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -635,6 +635,8 @@ class SnowflakeClient:
         try:
             result = await execute_copy_into(query, poll_interval=1.0)
         except snowflake.connector.errors.ProgrammingError as e:
+            self.logger.exception(f"Error executing COPY INTO query: {e}")
+
             if e.errno == 608:
                 err_msg = (
                     f"Failed to execute COPY INTO query after {max_attempts} attempts due to warehouse being suspended"
@@ -643,7 +645,6 @@ class SnowflakeClient:
                     err_msg += f": {e.msg}"
                 raise SnowflakeWarehouseSuspendedError(err_msg)
 
-            self.logger.exception(f"Error executing COPY INTO query: {e}")
             raise SnowflakeFileNotLoadedError(
                 table_name,
                 "NO STATUS",


### PR DESCRIPTION
## Problem

When executing the `COPY INTO` query we can sometimes get a 'warehouse suspended' error, which we continually retry on (at a Temporal level).

## Changes

- Retry a few times when we get a warehouse suspended error (since we have seen instances where a retry can work)
- If retries fail, raise a new `SnowflakeWarehouseSuspendedError` which is marked as non-retryable.

## How did you test this code?

### Manual testing

To reproduce the issue I took the following steps:

- In our test Snowflake account I set our warehouse to auto-suspend after 1 min and disabled auto-resume.
- Then I added a sleep into our batch export and asserted we retry continually

To test the fix, I retried with the new code and saw that we raised the new error and failed the run: `SnowflakeWarehouseSuspendedError: Failed to execute COPY INTO query after 3 attempts due to warehouse being suspended: 000608: 608: Warehouse 'BATCH_EXPORTS_TESTING' is suspended.  Use 'alter warehouse BATCH_EXPORTS_TESTING resume;' command if you need to use it again.`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
