### PR TITLE
chore(ux): random change to trigger tests

### DIFF
--- a/frontend/src/scenes/insights/Funnels.stories.tsx
+++ b/frontend/src/scenes/insights/Funnels.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta = {
         testOptions: {
             snapshotBrowsers: ['chromium'],
             viewport: {
-                // needs a slightly larger width to push the rendered scene away from breakpoint boundary
+                // needs a slightly larger width to push the rendered scene away from the breakpoint boundary
                 width: 1300,
                 height: 720,
             },

--- a/playwright/e2e/surveys/settings.spec.ts
+++ b/playwright/e2e/surveys/settings.spec.ts
@@ -20,6 +20,7 @@ test.describe('Survey Settings', () => {
         await expect(page).toHaveTitle('Surveys • PostHog')
         await page.getByRole('tab', { name: 'Settings' }).locator('div').click()
         await expect(page.getByTestId('opt-in-surveys-switch')).not.toBeDisabled()
+        await expect(page.getByText('Surveys opt in updated')).not.toBeVisible()
         await toggleSurveysSettingsAndWaitResponse(page)
         await toggleSurveysSettingsAndWaitResponse(page)
     })
@@ -31,7 +32,7 @@ test.describe('Survey Settings', () => {
         await page.goToMenuItem('settings')
         await page.locator('#main-content').getByRole('link', { name: 'Surveys', exact: true }).click()
         await expect(page.getByTestId('opt-in-surveys-switch')).not.toBeDisabled()
-
+        await expect(page.getByText('Surveys opt in updated')).not.toBeVisible()
         await toggleSurveysSettingsAndWaitResponse(page)
         await toggleSurveysSettingsAndWaitResponse(page)
     })


### PR DESCRIPTION
## Problem

This is always [failing](https://github.com/PostHog/posthog/pull/37537) for me:

<img width="962" height="210" alt="image" src="https://github.com/user-attachments/assets/1ee030b9-e57d-4231-84c9-70b5c3dd5f2d" />

Let's see if it's like that in `master`

## Changes

- Potentially fixes an issue with one survey E2E test

## How did you test this code?

👀 