### PR TITLE
feat(funnels): support values on series for funnel trends

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -95,7 +95,7 @@ export function InsightDisplayConfig(): JSX.Element {
     )
 
     const advancedOptions: LemonMenuItems = [
-        ...(((isTrends || isRetention) && display !== ChartDisplayType.CalendarHeatmap) || isLifecycle
+        ...(((isTrends || isRetention || isTrendsFunnel) && display !== ChartDisplayType.CalendarHeatmap) || isLifecycle
             ? [
                   {
                       title: 'Display',
@@ -299,7 +299,11 @@ export function InsightDisplayConfig(): JSX.Element {
             </div>
             <div className="flex items-center gap-x-2 flex-wrap">
                 {advancedOptions.length > 0 && (
-                    <LemonMenu items={advancedOptions} closeOnClickInside={false}>
+                    <LemonMenu
+                        items={advancedOptions}
+                        closeOnClickInside={false}
+                        placement={isTrendsFunnel ? 'bottom-end' : undefined}
+                    >
                         <LemonButton size="small" disabledReason={editingDisabledReason}>
                             <span className="font-medium whitespace-nowrap">
                                 Options

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12916,6 +12916,10 @@
                     "description": "Customizations for the appearance of result datasets.",
                     "type": "object"
                 },
+                "showValuesOnSeries": {
+                    "default": false,
+                    "type": "boolean"
+                },
                 "useUdf": {
                     "type": "boolean"
                 }

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1272,6 +1272,8 @@ export type FunnelsFilter = {
     resultCustomizations?: Record<string, ResultCustomizationByValue>
     /** Goal Lines */
     goalLines?: GoalLine[]
+    /** @default false */
+    showValuesOnSeries?: boolean
 }
 
 export interface FunnelsQuery extends InsightsQueryBase<FunnelsQueryResponse> {

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -453,6 +453,8 @@ export const getShowValuesOnSeries = (query: InsightQueryNode): boolean | undefi
         return query.stickinessFilter?.showValuesOnSeries
     } else if (isTrendsQuery(query)) {
         return query.trendsFilter?.showValuesOnSeries
+    } else if (isFunnelsQuery(query)) {
+        return query.funnelsFilter?.showValuesOnSeries
     }
     return undefined
 }

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -38,6 +38,7 @@ export function FunnelLineGraph({
         querySource,
         interval,
         insightData,
+        showValuesOnSeries,
     } = useValues(funnelDataLogic(insightProps))
     const { weekStartDay, timezone } = useValues(teamLogic)
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
@@ -59,6 +60,7 @@ export function FunnelLineGraph({
                 isInProgress={incompletenessOffsetFromEnd < 0}
                 inSharedMode={!!inSharedMode}
                 showPersonsModal={showPersonsModal}
+                showValuesOnSeries={showValuesOnSeries}
                 goalLines={goalLines ?? []}
                 tooltip={{
                     showHeader: false,

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -67,6 +67,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                 'insightData',
                 'insightDataError',
                 'getTheme',
+                'showValuesOnSeries',
             ],
             groupsModel,
             ['aggregationLabel'],

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -303,7 +303,7 @@ describe('insightNavLogic', () => {
                         source: {
                             kind: 'FunnelsQuery',
                             series: [{ kind: 'EventsNode', name: '$pageview', event: '$pageview' }],
-                            funnelsFilter: { funnelVizType: 'steps' },
+                            funnelsFilter: { funnelVizType: 'steps', showValuesOnSeries: true },
                             filterTestAccounts: true,
                             interval: 'hour',
                             breakdownFilter: {
@@ -383,7 +383,7 @@ describe('insightNavLogic', () => {
                         source: {
                             kind: 'FunnelsQuery',
                             series: [{ kind: 'EventsNode', name: '$pageview', event: '$pageview' }],
-                            funnelsFilter: { funnelVizType: 'steps' },
+                            funnelsFilter: { funnelVizType: 'steps', showValuesOnSeries: true },
                             filterTestAccounts: true,
                             interval: 'hour',
                             breakdownFilter: {

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -170,11 +170,11 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         ],
         supportsPercentStackView: [(s) => [s.querySource], (q) => supportsPercentStackView(q)],
         supportsValueOnSeries: [
-            (s) => [s.isTrends, s.isStickiness, s.isLifecycle, s.display],
-            (isTrends, isStickiness, isLifecycle, display) => {
+            (s) => [s.isTrends, s.isFunnels, s.isStickiness, s.isLifecycle, s.display],
+            (isTrends, isFunnels, isStickiness, isLifecycle, display) => {
                 if (isTrends || isStickiness) {
                     return !NON_VALUES_ON_SERIES_DISPLAY_TYPES.includes(display || ChartDisplayType.ActionsLineGraph)
-                } else if (isLifecycle) {
+                } else if (isLifecycle || isFunnels) {
                     return true
                 }
                 return false

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -11511,6 +11511,7 @@ class FunnelsFilter(BaseModel):
     resultCustomizations: Optional[dict[str, ResultCustomizationByValue]] = Field(
         default=None, description="Customizations for the appearance of result datasets."
     )
+    showValuesOnSeries: Optional[bool] = False
     useUdf: Optional[bool] = None
 
 


### PR DESCRIPTION
## Problem

The funnel trends chart should be consistent with the other trend charts. Extending the options to support showing values on the series. Closes #20871

## Changes

<img width="1142" height="698" alt="Screenshot 2025-09-04 at 13 30 06" src="https://github.com/user-attachments/assets/a56c5e9d-2ffa-4f48-b729-038d05bd9982" />

## How did you test this code?

Manually tested

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
