### PR TITLE
fix: Small revert for external data source API endpoint

### DIFF
--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -543,10 +543,10 @@ class TestExternalDataSource(APIBaseTest):
                 "source_type",
                 "latest_error",
                 "prefix",
+                "revenue_analytics_enabled",
                 "last_run_at",
                 "schemas",
                 "job_inputs",
-                "revenue_analytics_config",
             ],
         )
         self.assertEqual(

--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -505,7 +505,7 @@ class TestExternalDataSource(APIBaseTest):
         self._create_external_data_source()
         self._create_external_data_source()
 
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(24):
             response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/")
         payload = response.json()
 


### PR DESCRIPTION
It's currently timing out in prod, let's try and revert it

Probably caused by https://github.com/PostHog/posthog/pull/37541