### PR TITLE
feat(max): Generate Session summaries names for clarity

### DIFF
--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -128,11 +128,16 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 max_timestamp=max_timestamp,
                 extra_summary_context=extra_summary_context,
             )
+            summary_name = "API generated"
             summary_content = generate_notebook_content_from_summary(
-                summary=summary, session_ids=session_ids, project_name=self.team.name, team_id=self.team.id
+                summary=summary,
+                session_ids=session_ids,
+                project_name=self.team.name,
+                team_id=self.team.id,
+                summary_name=summary_name,
             )
             async_to_sync(create_notebook_from_summary_content)(
-                user=user, team=self.team, summary_content=summary_content
+                user=user, team=self.team, summary_content=summary_content, summary_name=summary_name
             )
             return Response(summary.model_dump(exclude_none=True, mode="json"), status=status.HTTP_200_OK)
         except Exception as err:

--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -128,16 +128,16 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 max_timestamp=max_timestamp,
                 extra_summary_context=extra_summary_context,
             )
-            summary_name = "API generated"
+            summary_title = "API generated"
             summary_content = generate_notebook_content_from_summary(
                 summary=summary,
                 session_ids=session_ids,
                 project_name=self.team.name,
                 team_id=self.team.id,
-                summary_name=summary_name,
+                summary_title=summary_title,
             )
             async_to_sync(create_notebook_from_summary_content)(
-                user=user, team=self.team, summary_content=summary_content, summary_name=summary_name
+                user=user, team=self.team, summary_content=summary_content, summary_title=summary_title
             )
             return Response(summary.model_dump(exclude_none=True, mode="json"), status=status.HTTP_200_OK)
         except Exception as err:

--- a/ee/api/test/test_session_summaries.py
+++ b/ee/api/test/test_session_summaries.py
@@ -143,12 +143,14 @@ class TestSessionSummariesAPI(APIBaseTest):
             session_ids=["session1", "session2"],
             project_name=self.team.name,
             team_id=self.team.id,
+            summary_name="API generated",
         )
         # Verify create_notebook_from_summary_content was called
         mock_create_notebook.assert_called_once_with(
             user=self.user,
             team=self.team,
             summary_content=mock_generate_content.return_value,
+            summary_name="API generated",
         )
 
     @patch("ee.api.session_summaries.posthoganalytics.feature_enabled")
@@ -197,12 +199,14 @@ class TestSessionSummariesAPI(APIBaseTest):
             session_ids=["session1", "session2"],
             project_name=self.team.name,
             team_id=self.team.id,
+            summary_name="API generated",
         )
         # Verify create_notebook_from_summary_content was called
         mock_create_notebook.assert_called_once_with(
             user=self.user,
             team=self.team,
             summary_content=mock_generate_content.return_value,
+            summary_name="API generated",
         )
 
     @patch("ee.api.session_summaries.posthoganalytics.feature_enabled")
@@ -432,10 +436,12 @@ class TestSessionSummariesAPI(APIBaseTest):
             session_ids=["single_session"],
             project_name=self.team.name,
             team_id=self.team.id,
+            summary_name="API generated",
         )
         # Verify create_notebook_from_summary_content was called
         mock_create_notebook.assert_called_once_with(
             user=self.user,
             team=self.team,
             summary_content=mock_generate_content.return_value,
+            summary_name="API generated",
         )

--- a/ee/api/test/test_session_summaries.py
+++ b/ee/api/test/test_session_summaries.py
@@ -143,14 +143,14 @@ class TestSessionSummariesAPI(APIBaseTest):
             session_ids=["session1", "session2"],
             project_name=self.team.name,
             team_id=self.team.id,
-            summary_name="API generated",
+            summary_title="API generated",
         )
         # Verify create_notebook_from_summary_content was called
         mock_create_notebook.assert_called_once_with(
             user=self.user,
             team=self.team,
             summary_content=mock_generate_content.return_value,
-            summary_name="API generated",
+            summary_title="API generated",
         )
 
     @patch("ee.api.session_summaries.posthoganalytics.feature_enabled")
@@ -199,14 +199,14 @@ class TestSessionSummariesAPI(APIBaseTest):
             session_ids=["session1", "session2"],
             project_name=self.team.name,
             team_id=self.team.id,
-            summary_name="API generated",
+            summary_title="API generated",
         )
         # Verify create_notebook_from_summary_content was called
         mock_create_notebook.assert_called_once_with(
             user=self.user,
             team=self.team,
             summary_content=mock_generate_content.return_value,
-            summary_name="API generated",
+            summary_title="API generated",
         )
 
     @patch("ee.api.session_summaries.posthoganalytics.feature_enabled")
@@ -436,12 +436,12 @@ class TestSessionSummariesAPI(APIBaseTest):
             session_ids=["single_session"],
             project_name=self.team.name,
             team_id=self.team.id,
-            summary_name="API generated",
+            summary_title="API generated",
         )
         # Verify create_notebook_from_summary_content was called
         mock_create_notebook.assert_called_once_with(
             user=self.user,
             team=self.team,
             summary_content=mock_generate_content.return_value,
-            summary_name="API generated",
+            summary_title="API generated",
         )

--- a/ee/hogai/eval/ci/eval_session_summarization.py
+++ b/ee/hogai/eval/ci/eval_session_summarization.py
@@ -184,7 +184,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "summarize sessions from the last 7 days with test accounts filtered out",
                         "should_use_current_filters": True,  # Matches current filters exactly
-                        "summary_name": "All sessions (last 7 days)",
+                        "summary_name": "All sessions, no test accounts (last 7 days)",
                     },
                 ),
             ),

--- a/ee/hogai/eval/ci/eval_session_summarization.py
+++ b/ee/hogai/eval/ci/eval_session_summarization.py
@@ -68,7 +68,6 @@ def call_root_for_replay_sessions(demo_org_team_user):
 async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_replay_sessions, pytestconfig):
     """Test routing between search_session_recordings (contextual) and session_summarization (root) with context."""
 
-    # Create a wrapper that passes True for include_search_session_recordings_context
     async def task_with_context(messages):
         return await call_root_for_replay_sessions(messages, include_search_session_recordings_context=True)
 
@@ -220,7 +219,6 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
 async def eval_session_summarization_no_context(patch_feature_enabled, call_root_for_replay_sessions, pytestconfig):
     """Test session summarization without search_session_recordings context - should_use_current_filters should always be false."""
 
-    # Create a wrapper that passes False for include_search_session_recordings_context
     async def task_without_context(messages):
         return await call_root_for_replay_sessions(messages, include_search_session_recordings_context=False)
 

--- a/ee/hogai/eval/ci/eval_session_summarization.py
+++ b/ee/hogai/eval/ci/eval_session_summarization.py
@@ -74,7 +74,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
     await MaxPublicEval(
         experiment_name="tool_routing_session_replay",
         task=task_with_context,
-        scores=[ToolRelevance(semantic_similarity_args={"change", "session_summarization_query", "summary_name"})],
+        scores=[ToolRelevance(semantic_similarity_args={"change", "session_summarization_query", "summary_title"})],
         data=[
             # Cases where search_session_recordings should be used (filtering/searching)
             EvalCase(
@@ -111,7 +111,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "summarize sessions from yesterday",
                         "should_use_current_filters": False,  # Specific time frame differs from current filters
-                        "summary_name": "Sessions from yesterday",
+                        "summary_title": "Sessions from yesterday",
                     },
                 ),
             ),
@@ -123,7 +123,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "watch sessions of the user 09081 in the last 30 days",
                         "should_use_current_filters": False,  # Specific user and timeframe
-                        "summary_name": "User 09081 sessions (last 30 days)",
+                        "summary_title": "User 09081 sessions (last 30 days)",
                     },
                 ),
             ),
@@ -135,7 +135,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "analyze mobile user sessions from last week",
                         "should_use_current_filters": False,  # Specific device type and timeframe
-                        "summary_name": "Mobile user sessions (last week)",
+                        "summary_title": "Mobile user sessions (last week)",
                     },
                 ),
             ),
@@ -147,7 +147,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "summarize sessions from the last 30 days with test accounts included",
                         "should_use_current_filters": False,  # Different time frame/conditions
-                        "summary_name": "All sessions with test accounts (last 30 days)",
+                        "summary_title": "All sessions with test accounts (last 30 days)",
                     },
                 ),
             ),
@@ -160,7 +160,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "summarize these sessions",
                         "should_use_current_filters": True,  # "these" refers to current filters
-                        "summary_name": "All sessions (last 7 days)",
+                        "summary_title": "All sessions (last 7 days)",
                     },
                 ),
             ),
@@ -172,7 +172,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "summarize all sessions",
                         "should_use_current_filters": True,  # "all" in context of filtered view
-                        "summary_name": "All sessions (last 7 days)",
+                        "summary_title": "All sessions (last 7 days)",
                     },
                 ),
             ),
@@ -184,7 +184,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "summarize sessions from the last 7 days with test accounts filtered out",
                         "should_use_current_filters": True,  # Matches current filters exactly
-                        "summary_name": "All sessions, no test accounts (last 7 days)",
+                        "summary_title": "All sessions, no test accounts (last 7 days)",
                     },
                 ),
             ),
@@ -197,7 +197,7 @@ async def eval_tool_routing_session_replay(patch_feature_enabled, call_root_for_
                     args={
                         "session_summarization_query": "show me what users did with our app",
                         "should_use_current_filters": True,  # Analyzing user behavior, use current context
-                        "summary_name": "All sessions (last 7 days)",
+                        "summary_title": "All sessions (last 7 days)",
                     },
                 ),
             ),
@@ -225,7 +225,7 @@ async def eval_session_summarization_no_context(patch_feature_enabled, call_root
     await MaxPublicEval(
         experiment_name="session_summarization_no_context",
         task=task_without_context,
-        scores=[ToolRelevance(semantic_similarity_args={"session_summarization_query", "summary_name"})],
+        scores=[ToolRelevance(semantic_similarity_args={"session_summarization_query", "summary_title"})],
         data=[
             # All cases should have should_use_current_filters=false when no context
             EvalCase(
@@ -236,7 +236,7 @@ async def eval_session_summarization_no_context(patch_feature_enabled, call_root
                     args={
                         "session_summarization_query": "summarize sessions from yesterday",
                         "should_use_current_filters": False,  # No context, always false
-                        "summary_name": "Sessions from yesterday",
+                        "summary_title": "Sessions from yesterday",
                     },
                 ),
             ),
@@ -248,7 +248,7 @@ async def eval_session_summarization_no_context(patch_feature_enabled, call_root
                     args={
                         "session_summarization_query": "analyze the current recordings from today",
                         "should_use_current_filters": False,  # Even with "current", no context means false
-                        "summary_name": "Sessions from today",
+                        "summary_title": "Sessions from today",
                     },
                 ),
             ),
@@ -260,7 +260,7 @@ async def eval_session_summarization_no_context(patch_feature_enabled, call_root
                     args={
                         "session_summarization_query": "watch all session recordings",
                         "should_use_current_filters": False,  # Even with "all", no context means false
-                        "summary_name": "All session recordings",
+                        "summary_title": "All session recordings",
                     },
                 ),
             ),

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -670,7 +670,7 @@ class RootNodeTools(AssistantNode):
                 session_summarization_query=tool_call.args["session_summarization_query"],
                 # Safety net in case the argument is missing to avoid raising exceptions internally
                 should_use_current_filters=tool_call.args.get("should_use_current_filters", False),
-                summary_name=tool_call.args.get("summary_name"),
+                summary_title=tool_call.args.get("summary_title"),
                 root_tool_calls_count=tool_call_count + 1,
             )
         elif ToolClass := get_contextual_tool_class(tool_call.name):

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -670,6 +670,7 @@ class RootNodeTools(AssistantNode):
                 session_summarization_query=tool_call.args["session_summarization_query"],
                 # Safety net in case the argument is missing to avoid raising exceptions internally
                 should_use_current_filters=tool_call.args.get("should_use_current_filters", False),
+                summary_name=tool_call.args.get("summary_name"),
                 root_tool_calls_count=tool_call_count + 1,
             )
         elif ToolClass := get_contextual_tool_class(tool_call.name):

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -149,7 +149,7 @@ There are no current filters in the user's UI context. It means that you need to
 - Convert the user query into a `session_summarization_query`
 - The query should be used to search for relevant sessions and then summarize them
 - Assume the `should_use_current_filters` should be always `false`
-- Generate the `summary_name` based on the user's query
+- Generate the `summary_title` based on the user's query
 """
 
 SESSION_SUMMARIZATION_PROMPT_WITH_REPLAY_CONTEXT = """
@@ -157,7 +157,7 @@ There are current filters in the user's UI context. It means that you need to:
 - Convert the user query into a `session_summarization_query`
 - The query should be used to understand the user's intent
 - Decide if the query is relevant to the current filters and set `should_use_current_filters` accordingly
-- Generate the `summary_name` based on the user's query and the current filters
+- Generate the `summary_title` based on the user's query and the current filters
 
 ```json
 {{{current_filters}}}

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -149,6 +149,7 @@ There are no current filters in the user's UI context. It means that you need to
 - Convert the user query into a `session_summarization_query`
 - The query should be used to search for relevant sessions and then summarize them
 - Assume the `should_use_current_filters` should be always `false`
+- Generate the `summary_name` based on the user's query
 """
 
 SESSION_SUMMARIZATION_PROMPT_WITH_REPLAY_CONTEXT = """
@@ -156,6 +157,7 @@ There are current filters in the user's UI context. It means that you need to:
 - Convert the user query into a `session_summarization_query`
 - The query should be used to understand the user's intent
 - Decide if the query is relevant to the current filters and set `should_use_current_filters` accordingly
+- Generate the `summary_name` based on the user's query and the current filters
 
 ```json
 {{{current_filters}}}

--- a/ee/hogai/graph/session_summaries/nodes.py
+++ b/ee/hogai/graph/session_summaries/nodes.py
@@ -217,14 +217,14 @@ class SessionSummarizationNode(AssistantNode):
         state: AssistantState,
         writer: StreamWriter | None,
         notebook: Notebook | None,
-        summary_name: str | None,
+        summary_title: str | None,
     ) -> str:
         """Summarize sessions as a group (for larger sets)."""
         min_timestamp, max_timestamp = find_sessions_timestamps(session_ids=session_ids, team=self._team)
 
         # Initialize intermediate state with plan
         self._intermediate_state = SummaryNotebookIntermediateState(
-            team_name=self._team.name, summary_name=summary_name
+            team_name=self._team.name, summary_title=summary_title
         )
 
         # Stream initial plan
@@ -277,7 +277,7 @@ class SessionSummarizationNode(AssistantNode):
                     session_ids=session_ids,
                     project_name=self._team.name,
                     team_id=self._team.id,
-                    summary_name=summary_name,
+                    summary_title=summary_title,
                 )
                 self._stream_notebook_content(summary_content, state, writer, partial=False)
                 # Update the notebook through BE for cases where the chat was closed
@@ -317,7 +317,7 @@ class SessionSummarizationNode(AssistantNode):
             return self._create_error_response(self._base_error_instructions, state)
         # If the current filters were marked as relevant, but not present in the context
         current_filters = self._get_contextual_tools(config).get("search_session_recordings", {}).get("current_filters")
-        summary_name = state.summary_name
+        summary_title = state.summary_title
         try:
             # Use current filters, if provided
             if state.should_use_current_filters:
@@ -371,7 +371,7 @@ class SessionSummarizationNode(AssistantNode):
                 notebook = None
                 if not state.notebook_short_id:
                     notebook = await create_empty_notebook_for_summary(
-                        user=self._user, team=self._team, summary_name=summary_name
+                        user=self._user, team=self._team, summary_title=summary_title
                     )
                     # Could be moved to a separate "create notebook" node (or reuse the one from deep research)
                     state.notebook_short_id = notebook.short_id
@@ -382,7 +382,7 @@ class SessionSummarizationNode(AssistantNode):
                     writer=writer,
                 )
                 summaries_content = await self._summarize_sessions_as_group(
-                    session_ids=session_ids, state=state, writer=writer, notebook=notebook, summary_name=summary_name
+                    session_ids=session_ids, state=state, writer=writer, notebook=notebook, summary_title=summary_title
                 )
             return PartialAssistantState(
                 messages=[

--- a/ee/hogai/graph/session_summaries/nodes.py
+++ b/ee/hogai/graph/session_summaries/nodes.py
@@ -212,13 +212,20 @@ class SessionSummarizationNode(AssistantNode):
         return "\n".join(summaries)
 
     async def _summarize_sessions_as_group(
-        self, session_ids: list[str], state: AssistantState, writer: StreamWriter | None, notebook: Notebook | None
+        self,
+        session_ids: list[str],
+        state: AssistantState,
+        writer: StreamWriter | None,
+        notebook: Notebook | None,
+        summary_name: str | None,
     ) -> str:
         """Summarize sessions as a group (for larger sets)."""
         min_timestamp, max_timestamp = find_sessions_timestamps(session_ids=session_ids, team=self._team)
 
         # Initialize intermediate state with plan
-        self._intermediate_state = SummaryNotebookIntermediateState(team_name=self._team.name)
+        self._intermediate_state = SummaryNotebookIntermediateState(
+            team_name=self._team.name, summary_name=summary_name
+        )
 
         # Stream initial plan
         initial_state = self._intermediate_state.format_intermediate_state()
@@ -266,7 +273,11 @@ class SessionSummarizationNode(AssistantNode):
                 # Replace the intermediate state with final report
                 summary = data
                 summary_content = generate_notebook_content_from_summary(
-                    summary=summary, session_ids=session_ids, project_name=self._team.name, team_id=self._team.id
+                    summary=summary,
+                    session_ids=session_ids,
+                    project_name=self._team.name,
+                    team_id=self._team.id,
+                    summary_name=summary_name,
                 )
                 self._stream_notebook_content(summary_content, state, writer, partial=False)
                 # Update the notebook through BE for cases where the chat was closed
@@ -306,6 +317,7 @@ class SessionSummarizationNode(AssistantNode):
             return self._create_error_response(self._base_error_instructions, state)
         # If the current filters were marked as relevant, but not present in the context
         current_filters = self._get_contextual_tools(config).get("search_session_recordings", {}).get("current_filters")
+        summary_name = state.summary_name
         try:
             # Use current filters, if provided
             if state.should_use_current_filters:
@@ -358,7 +370,9 @@ class SessionSummarizationNode(AssistantNode):
                 # Check if the notebook is provided, create a notebook to fill if not
                 notebook = None
                 if not state.notebook_short_id:
-                    notebook = await create_empty_notebook_for_summary(user=self._user, team=self._team)
+                    notebook = await create_empty_notebook_for_summary(
+                        user=self._user, team=self._team, summary_name=summary_name
+                    )
                     # Could be moved to a separate "create notebook" node (or reuse the one from deep research)
                     state.notebook_short_id = notebook.short_id
                 # For large groups, process in detail, searching for patterns
@@ -368,7 +382,7 @@ class SessionSummarizationNode(AssistantNode):
                     writer=writer,
                 )
                 summaries_content = await self._summarize_sessions_as_group(
-                    session_ids=session_ids, state=state, writer=writer, notebook=notebook
+                    session_ids=session_ids, state=state, writer=writer, notebook=notebook, summary_name=summary_name
                 )
             return PartialAssistantState(
                 messages=[

--- a/ee/hogai/graph/session_summaries/test/test_nodes.py
+++ b/ee/hogai/graph/session_summaries/test/test_nodes.py
@@ -227,7 +227,7 @@ class TestSessionSummarizationNode(BaseTest):
 
         state = self._create_test_state()
         with self.assertRaises(ValueError) as context:
-            async_to_sync(self.node._summarize_sessions_as_group)(session_ids, state, None, None)
+            async_to_sync(self.node._summarize_sessions_as_group)(session_ids, state, None, None, "test summary")
 
         self.assertIn("No summary was generated", str(context.exception))
 

--- a/ee/hogai/session_summaries/session_group/summary_notebooks.py
+++ b/ee/hogai/session_summaries/session_group/summary_notebooks.py
@@ -197,7 +197,7 @@ class SummaryNotebookIntermediateState:
 
 def _create_notebook_title(team_name: str, summary_name: str | None) -> str:
     title = f"Session Summaries Report - {team_name}"
-    timestamp = {timezone.now().strftime("%Y-%m-%d")}
+    timestamp = timezone.now().strftime("%Y-%m-%d")
     if summary_name:
         title += f" - {summary_name}"
     title += f" ({timestamp})"

--- a/ee/hogai/session_summaries/session_group/summary_notebooks.py
+++ b/ee/hogai/session_summaries/session_group/summary_notebooks.py
@@ -196,7 +196,7 @@ class SummaryNotebookIntermediateState:
 
 
 def _create_notebook_title(team_name: str, summary_name: str | None) -> str:
-    title = f"Session Summaries Report - {team_name}"
+    title = f"Session summaries report - {team_name}"
     timestamp = timezone.now().strftime("%Y-%m-%d")
     if summary_name:
         title += f" - {summary_name}"

--- a/ee/hogai/session_summaries/session_group/summary_notebooks.py
+++ b/ee/hogai/session_summaries/session_group/summary_notebooks.py
@@ -87,9 +87,10 @@ def format_patterns_assignment_progress() -> TipTapNode:
 class SummaryNotebookIntermediateState:
     """Manages the intermediate state of a notebook during session group summarization."""
 
-    def __init__(self, team_name: str):
+    def __init__(self, team_name: str, summary_name: str | None):
         """Initialize the intermediate state with a plan."""
         self.team_name = team_name
+        self.summary_name = summary_name
         # Using dict to maintain order (Python 3.7+ guarantees order)
         self.plan_items: dict[SessionSummaryStep, tuple[str, bool]] = {
             SessionSummaryStep.WATCHING_SESSIONS: ("Watch sessions", False),
@@ -161,7 +162,11 @@ class SummaryNotebookIntermediateState:
         content = []
 
         # Add main title
-        content.append(create_heading_with_text(_create_notebook_title(team_name=self.team_name), 1))
+        content.append(
+            create_heading_with_text(
+                _create_notebook_title(team_name=self.team_name, summary_name=self.summary_name), 1
+            )
+        )
         content.append(create_empty_paragraph())
 
         # Add plan section
@@ -190,15 +195,20 @@ class SummaryNotebookIntermediateState:
         return {"type": "doc", "content": content}
 
 
-def _create_notebook_title(team_name: str) -> str:
-    return f"Session Summaries Report - {team_name} ({timezone.now().strftime('%Y-%m-%d')})"
+def _create_notebook_title(team_name: str, summary_name: str | None) -> str:
+    title = f"Session Summaries Report - {team_name}"
+    timestamp = {timezone.now().strftime("%Y-%m-%d")}
+    if summary_name:
+        title += f" - {summary_name}"
+    title += f" ({timestamp})"
+    return title
 
 
-async def create_empty_notebook_for_summary(user: User, team: Team) -> Notebook:
+async def create_empty_notebook_for_summary(user: User, team: Team, summary_name: str | None) -> Notebook:
     """Create an empty notebook for a summary."""
     notebook = await Notebook.objects.acreate(
         team=team,
-        title=_create_notebook_title(team_name=team.name),
+        title=_create_notebook_title(team_name=team.name, summary_name=summary_name),
         content="",
         created_by=user,
         last_modified_by=user,
@@ -206,11 +216,13 @@ async def create_empty_notebook_for_summary(user: User, team: Team) -> Notebook:
     return notebook
 
 
-async def create_notebook_from_summary_content(user: User, team: Team, summary_content: TipTapNode) -> Notebook:
+async def create_notebook_from_summary_content(
+    user: User, team: Team, summary_content: TipTapNode, summary_name: str | None
+) -> Notebook:
     """Create a notebook with session summary patterns."""
     notebook = await Notebook.objects.acreate(
         team=team,
-        title=_create_notebook_title(team_name=team.name),
+        title=_create_notebook_title(team_name=team.name, summary_name=summary_name),
         content=summary_content,
         created_by=user,
         last_modified_by=user,
@@ -232,7 +244,11 @@ async def update_notebook_from_summary_content(
 
 
 def generate_notebook_content_from_summary(
-    summary: EnrichedSessionGroupSummaryPatternsList, session_ids: list[str], project_name: str, team_id: int
+    summary: EnrichedSessionGroupSummaryPatternsList,
+    session_ids: list[str],
+    project_name: str,
+    team_id: int,
+    summary_name: str | None,
 ) -> TipTapNode:
     """Convert summary data to notebook structure."""
     patterns = summary.patterns
@@ -241,7 +257,7 @@ def generate_notebook_content_from_summary(
         return {
             "type": "doc",
             "content": [
-                create_heading_with_text(_create_notebook_title(team_name=project_name), 1),
+                create_heading_with_text(_create_notebook_title(team_name=project_name, summary_name=summary_name), 1),
                 create_paragraph_with_text("No patterns found."),
                 create_paragraph_with_text(f"Sessions covered: {', '.join(session_ids)}"),
             ],
@@ -250,7 +266,9 @@ def generate_notebook_content_from_summary(
     # Sort patterns by severity: critical, high, medium, low
     content = []
     # Title
-    content.append(create_heading_with_text(_create_notebook_title(team_name=project_name), 1))
+    content.append(
+        create_heading_with_text(_create_notebook_title(team_name=project_name, summary_name=summary_name), 1)
+    )
     # Issues to review summary
     session_text = "session" if total_sessions == 1 else "sessions"
     content.append(create_heading_with_text(f"Issues to review – based on {total_sessions} {session_text}", 2))

--- a/ee/hogai/session_summaries/tests/test_summary_notebooks.py
+++ b/ee/hogai/session_summaries/tests/test_summary_notebooks.py
@@ -792,7 +792,7 @@ class TestTaskListUtilities(APIBaseTest):
 
 class TestSummaryNotebookIntermediateState(APIBaseTest):
     def test_initialization(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         assert state.team_name == "Test Team"
         assert len(state.plan_items) == 3
@@ -806,7 +806,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
 
     def test_race_condition_late_arriving_updates(self) -> None:
         """Test that late-arriving updates for previous steps are handled correctly."""
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         # Simulate UI moving to FINDING_PATTERNS step
         ui_content: dict[str, Any] = {
@@ -840,7 +840,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
 
     def test_update_step_progress_same_step(self) -> None:
         """Test updating content for the current step."""
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         test_content: dict[str, Any] = {
             "type": "doc",
@@ -853,7 +853,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
 
     def test_step_transition(self) -> None:
         """Test that transitioning to a new step marks the previous step as completed."""
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         # Add content for the first step
         content_step_one: dict[str, Any] = {
@@ -890,7 +890,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert completed["Watch sessions"] == content_step_one
 
     def test_complete_multiple_steps(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         # Complete first step
         content_step_one: dict[str, Any] = {"type": "doc", "content": [{"type": "text", "text": "Sessions watched"}]}
@@ -914,7 +914,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert completed["Find initial patterns"] == content_step_two
 
     def test_format_initial_state(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         formatted: dict[str, Any] = state.format_intermediate_state()
 
@@ -940,7 +940,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
             assert text.startswith("[ ]")
 
     def test_format_state_with_current_progress(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         # Add progress to current step
         progress_content: dict[str, Any] = {
@@ -963,7 +963,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert "Step: Watch sessions (In progress)" in formatted_str
 
     def test_format_state_with_completed_steps(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_title="test summary")
 
         # Complete first step
         content_step_one: dict[str, Any] = {
@@ -1000,7 +1000,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert "Analyzing behaviors" in content_str
 
     def test_e2e_workflow(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="PostHog", summary_name="test summary")
+        state = SummaryNotebookIntermediateState(team_name="PostHog", summary_title="test summary")
 
         # Initial state - just the plan
         initial_formatted: dict[str, Any] = state.format_intermediate_state()

--- a/ee/hogai/session_summaries/tests/test_summary_notebooks.py
+++ b/ee/hogai/session_summaries/tests/test_summary_notebooks.py
@@ -113,8 +113,10 @@ class TestNotebookCreation(APIBaseTest):
         session_ids: list[str] = ["session_1", "session_2"]
 
         # Generate content first
-        content = generate_notebook_content_from_summary(summary_data, session_ids, self.team.name, self.team.id)
-        notebook = await create_notebook_from_summary_content(self.user, self.team, content)
+        content = generate_notebook_content_from_summary(
+            summary_data, session_ids, self.team.name, self.team.id, "test summary"
+        )
+        notebook = await create_notebook_from_summary_content(self.user, self.team, content, "test summary")
 
         # Verify the notebook was created
         assert notebook is not None
@@ -143,7 +145,7 @@ class TestNotebookCreation(APIBaseTest):
         session_ids: list[str] = ["session_1", "session_2"]
 
         content: dict[str, Any] = generate_notebook_content_from_summary(
-            summary_data, session_ids, self.team.name, self.team.id
+            summary_data, session_ids, self.team.name, self.team.id, "test summary"
         )
 
         # Check basic structure
@@ -165,7 +167,7 @@ class TestNotebookCreation(APIBaseTest):
         empty_summary = EnrichedSessionGroupSummaryPatternsList(patterns=[])
 
         content: dict[str, Any] = generate_notebook_content_from_summary(
-            empty_summary, session_ids, self.team.name, self.team.id
+            empty_summary, session_ids, self.team.name, self.team.id, "test summary"
         )
 
         # Should still create valid content
@@ -212,7 +214,7 @@ class TestNotebookCreation(APIBaseTest):
         summary_data.patterns[0].events.append(segment_context_2)
 
         content: dict[str, Any] = generate_notebook_content_from_summary(
-            summary_data, session_ids, self.team.name, self.team.id
+            summary_data, session_ids, self.team.name, self.team.id, "test summary"
         )
 
         # Should contain both examples
@@ -326,7 +328,7 @@ class TestNotebookCreation(APIBaseTest):
 
         summary_data = EnrichedSessionGroupSummaryPatternsList(patterns=[pattern])
         content: dict[str, Any] = generate_notebook_content_from_summary(
-            summary_data, ["test_session"], self.team.name, self.team.id
+            summary_data, ["test_session"], self.team.name, self.team.id, "test summary"
         )
 
         # Find the outcome section in the content
@@ -416,7 +418,7 @@ class TestNotebookCreation(APIBaseTest):
 
         summary_data = EnrichedSessionGroupSummaryPatternsList(patterns=[pattern])
         content: dict[str, Any] = generate_notebook_content_from_summary(
-            summary_data, ["test_session_id"], self.team.name, self.team.id
+            summary_data, ["test_session_id"], self.team.name, self.team.id, "test summary"
         )
 
         # Convert content to JSON string to search for the replay link
@@ -468,7 +470,7 @@ class TestNotebookCreation(APIBaseTest):
 
             pattern.events = [segment_context_case]
             content = generate_notebook_content_from_summary(
-                summary_data, ["test_session_id"], self.team.name, self.team.id
+                summary_data, ["test_session_id"], self.team.name, self.team.id, "test summary"
             )
             content_text = json.dumps(content)
 
@@ -687,7 +689,9 @@ class TestNotebookCreation(APIBaseTest):
         summary_data = self.create_summary_data()
         session_ids = ["session_1", "session_2"]
 
-        content = generate_notebook_content_from_summary(summary_data, session_ids, self.team.name, self.team.id)
+        content = generate_notebook_content_from_summary(
+            summary_data, session_ids, self.team.name, self.team.id, "test summary"
+        )
 
         content_text = json.dumps(content)
 
@@ -707,7 +711,9 @@ class TestNotebookCreation(APIBaseTest):
         summary_data = self.create_summary_data()
         session_ids = ["session_1"]
 
-        content = generate_notebook_content_from_summary(summary_data, session_ids, self.team.name, self.team.id)
+        content = generate_notebook_content_from_summary(
+            summary_data, session_ids, self.team.name, self.team.id, "test summary"
+        )
 
         content_text = json.dumps(content)
 
@@ -786,7 +792,7 @@ class TestTaskListUtilities(APIBaseTest):
 
 class TestSummaryNotebookIntermediateState(APIBaseTest):
     def test_initialization(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         assert state.team_name == "Test Team"
         assert len(state.plan_items) == 3
@@ -800,7 +806,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
 
     def test_race_condition_late_arriving_updates(self) -> None:
         """Test that late-arriving updates for previous steps are handled correctly."""
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         # Simulate UI moving to FINDING_PATTERNS step
         ui_content: dict[str, Any] = {
@@ -834,7 +840,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
 
     def test_update_step_progress_same_step(self) -> None:
         """Test updating content for the current step."""
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         test_content: dict[str, Any] = {
             "type": "doc",
@@ -847,7 +853,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
 
     def test_step_transition(self) -> None:
         """Test that transitioning to a new step marks the previous step as completed."""
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         # Add content for the first step
         content_step_one: dict[str, Any] = {
@@ -884,7 +890,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert completed["Watch sessions"] == content_step_one
 
     def test_complete_multiple_steps(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         # Complete first step
         content_step_one: dict[str, Any] = {"type": "doc", "content": [{"type": "text", "text": "Sessions watched"}]}
@@ -908,7 +914,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert completed["Find initial patterns"] == content_step_two
 
     def test_format_initial_state(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         formatted: dict[str, Any] = state.format_intermediate_state()
 
@@ -934,7 +940,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
             assert text.startswith("[ ]")
 
     def test_format_state_with_current_progress(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         # Add progress to current step
         progress_content: dict[str, Any] = {
@@ -957,7 +963,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert "Step: Watch sessions (In progress)" in formatted_str
 
     def test_format_state_with_completed_steps(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="Test Team")
+        state = SummaryNotebookIntermediateState(team_name="Test Team", summary_name="test summary")
 
         # Complete first step
         content_step_one: dict[str, Any] = {
@@ -994,7 +1000,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         assert "Analyzing behaviors" in content_str
 
     def test_e2e_workflow(self) -> None:
-        state = SummaryNotebookIntermediateState(team_name="PostHog")
+        state = SummaryNotebookIntermediateState(team_name="PostHog", summary_name="test summary")
 
         # Initial state - just the plan
         initial_formatted: dict[str, Any] = state.format_intermediate_state()

--- a/ee/hogai/session_summaries/tests/test_summary_notebooks.py
+++ b/ee/hogai/session_summaries/tests/test_summary_notebooks.py
@@ -124,7 +124,7 @@ class TestNotebookCreation(APIBaseTest):
         assert notebook.created_by == self.user
         assert notebook.last_modified_by == self.user
         assert notebook.title is not None
-        assert f"Session Summaries Report - {self.team.name}" in notebook.title
+        assert f"Session summaries report - {self.team.name}" in notebook.title
 
         # Check content structure
         assert content["type"] == "doc"
@@ -132,7 +132,7 @@ class TestNotebookCreation(APIBaseTest):
 
         # Check that it has the expected structure
         assert content["content"][0]["type"] == "heading"
-        assert f"Session Summaries Report - {self.team.name}" in content["content"][0]["content"][0]["text"]
+        assert f"Session summaries report - {self.team.name}" in content["content"][0]["content"][0]["text"]
 
         # Check that pattern content is included
         content_text: str = json.dumps(content)
@@ -923,7 +923,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
 
         # Check main title
         assert content[0]["type"] == "heading"
-        assert "Session Summaries Report - Test Team" in content[0]["content"][0]["text"]
+        assert "Session summaries report - Test Team" in content[0]["content"][0]["text"]
 
         # Check plan section
         assert content[2]["type"] == "heading"
@@ -1005,7 +1005,7 @@ class TestSummaryNotebookIntermediateState(APIBaseTest):
         # Initial state - just the plan
         initial_formatted: dict[str, Any] = state.format_intermediate_state()
         initial_str: str = json.dumps(initial_formatted)
-        assert "Session Summaries Report - PostHog" in initial_str
+        assert "Session summaries report - PostHog" in initial_str
         assert "[ ] Watch sessions" in initial_str
         assert "[ ] Find initial patterns" in initial_str
         assert "[ ] Generate final report" in initial_str

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -89,6 +89,23 @@ class session_summarization(BaseModel):
             - the user specifies conditions (user, device, id, URL, etc.) not present in the current filters
         """,
     )
+    summary_name: str = Field(
+        description="""
+        - The name of the summary that expected to be generated from the user's `session_summarization_query` and/or `current_filters` (if present).
+        - The name should cover in 3-7 words what sessions would be to be summarized in the summary
+        - This won't be used for any search of filtering, only to properly label the generated summary.
+        - Examples:
+          * If `should_use_current_filters` is `false`, then the `summary_name` should be generated based on the `session_summarization_query`:
+            - query: "I want to watch all the sessions of user `user@example.com` in the last 30 days no matter how long" -> name: "Sessions of the user example@gmail.com (last 30 days)"
+            - query: "summarize my last 100 session recordings" -> name: "Last 100 sessions"
+            - and similar
+          * If `should_use_current_filters` is `false`, then the `summary_name` should be generated based on the current filters in the context (if present):
+            - filters: "{"key":"$os","value":["Mac OS X"],"operator":"exact","type":"event"}" -> name: "MacOS users"
+            - filters: "{"date_from": "-7d", "filter_test_accounts": True}" -> name: "All sessions (last 7 days)"
+            - and similar
+          * If there's no enough context to generated the summary name - keep it an empty string ("")
+        """
+    )
 
 
 class search_documentation(BaseModel):

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -99,7 +99,7 @@ class session_summarization(BaseModel):
             - query: "I want to watch all the sessions of user `user@example.com` in the last 30 days no matter how long" -> name: "Sessions of the user user@example.com (last 30 days)"
             - query: "summarize my last 100 session recordings" -> name: "Last 100 sessions"
             - and similar
-          * If `should_use_current_filters` is `false`, then the `summary_name` should be generated based on the current filters in the context (if present):
+          * If `should_use_current_filters` is `true`, then the `summary_name` should be generated based on the current filters in the context (if present):
             - filters: "{"key":"$os","value":["Mac OS X"],"operator":"exact","type":"event"}" -> name: "MacOS users"
             - filters: "{"date_from": "-7d", "filter_test_accounts": True}" -> name: "All sessions (last 7 days)"
             - and similar

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -96,7 +96,7 @@ class session_summarization(BaseModel):
         - This won't be used for any search of filtering, only to properly label the generated summary.
         - Examples:
           * If `should_use_current_filters` is `false`, then the `summary_name` should be generated based on the `session_summarization_query`:
-            - query: "I want to watch all the sessions of user `user@example.com` in the last 30 days no matter how long" -> name: "Sessions of the user example@gmail.com (last 30 days)"
+            - query: "I want to watch all the sessions of user `user@example.com` in the last 30 days no matter how long" -> name: "Sessions of the user user@example.com (last 30 days)"
             - query: "summarize my last 100 session recordings" -> name: "Last 100 sessions"
             - and similar
           * If `should_use_current_filters` is `false`, then the `summary_name` should be generated based on the current filters in the context (if present):

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -89,17 +89,17 @@ class session_summarization(BaseModel):
             - the user specifies conditions (user, device, id, URL, etc.) not present in the current filters
         """,
     )
-    summary_name: str = Field(
+    summary_title: str = Field(
         description="""
-        - The name of the summary that expected to be generated from the user's `session_summarization_query` and/or `current_filters` (if present).
+        - The name of the summary that is expected to be generated from the user's `session_summarization_query` and/or `current_filters` (if present).
         - The name should cover in 3-7 words what sessions would be to be summarized in the summary
         - This won't be used for any search of filtering, only to properly label the generated summary.
         - Examples:
-          * If `should_use_current_filters` is `false`, then the `summary_name` should be generated based on the `session_summarization_query`:
+          * If `should_use_current_filters` is `false`, then the `summary_title` should be generated based on the `session_summarization_query`:
             - query: "I want to watch all the sessions of user `user@example.com` in the last 30 days no matter how long" -> name: "Sessions of the user user@example.com (last 30 days)"
             - query: "summarize my last 100 session recordings" -> name: "Last 100 sessions"
             - and similar
-          * If `should_use_current_filters` is `true`, then the `summary_name` should be generated based on the current filters in the context (if present):
+          * If `should_use_current_filters` is `true`, then the `summary_title` should be generated based on the current filters in the context (if present):
             - filters: "{"key":"$os","value":["Mac OS X"],"operator":"exact","type":"event"}" -> name: "MacOS users"
             - filters: "{"date_from": "-7d", "filter_test_accounts": True}" -> name: "All sessions (last 7 days)"
             - and similar

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -103,7 +103,7 @@ class session_summarization(BaseModel):
             - filters: "{"key":"$os","value":["Mac OS X"],"operator":"exact","type":"event"}" -> name: "MacOS users"
             - filters: "{"date_from": "-7d", "filter_test_accounts": True}" -> name: "All sessions (last 7 days)"
             - and similar
-          * If there's no enough context to generated the summary name - keep it an empty string ("")
+          * If there's not enough context to generated the summary name - keep it an empty string ("")
         """
     )
 

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -232,7 +232,7 @@ class _SharedAssistantState(BaseState):
     """
     Whether to use current filters from user's UI to find relevant sessions.
     """
-    summary_name: Optional[str] = Field(default=None)
+    summary_title: Optional[str] = Field(default=None)
     """
     The name of the summary to generate, based on the user's query and/or current filters.
     """

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -232,6 +232,10 @@ class _SharedAssistantState(BaseState):
     """
     Whether to use current filters from user's UI to find relevant sessions.
     """
+    summary_name: Optional[str] = Field(default=None)
+    """
+    The name of the summary to generate, based on the user's query and/or current filters.
+    """
     notebook_short_id: Optional[str] = Field(default=None)
     """
     The short ID of the notebook being used.


### PR DESCRIPTION
## Problem

- All the summaries are generated with the same name and stored as notebooks, so it's hard to understand which were the input conditions that led to generating this summary (or to differ one summary from another)
- Using Max conversation title was an idea, but:
  - it's generated without acknowledging the page context (like, current Replay filters)
  - a summary could be just part of the conversation, happening later, where the title is already generated
  - adjusting it for summary usage would make it non-generic and would probably cause future issues for other tools

<img width="453" height="287" alt="CleanShot 2025-09-04 at 16 46 36" src="https://github.com/user-attachments/assets/803e37f8-f1e3-417b-a441-fcb9ea14161b" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Generate a summary title within the tool call
- Use a summary title when storing summaries in the notebooks

<img width="1572" height="570" alt="CleanShot 2025-09-04 at 16 55 10" src="https://github.com/user-attachments/assets/26c5f20f-e1e2-4722-bd33-ecf750699035" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
