### PR TITLE
fix: support response times

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -65,7 +65,7 @@ const SupportResponseTimesTable = ({
     const expiredTrialDate = hasExpiredTrial ? dayjs(billing?.trial?.expires_at) : null
     const getResponseTimeFeature = (planName: string): BillingFeatureType | undefined => {
         // Find the plan in supportPlans
-        const plan = supportPlans?.find((p) => p.name === planName)
+        const plan = supportPlans?.find((p) => p.name?.includes(planName))
 
         // Return the support_response_time feature if found
         return plan?.features?.find((f) => f.key === AvailableFeature.SUPPORT_RESPONSE_TIME)
@@ -118,7 +118,7 @@ const SupportResponseTimesTable = ({
                   {
                       name: 'Teams',
                       current_plan: currentPlan === 'teams',
-                      features: [{ note: '1 business day' }],
+                      features: [getResponseTimeFeature('Teams') || { note: '1 business day' }],
                       plan_key: BillingPlan.Teams,
                       legacy_product: true,
                   },


### PR DESCRIPTION
Platform and support plan names can include `addon` suffix so this wasn't finding them and was therefore falling back to hard coded response times

Before
<img width="719" height="353" alt="image" src="https://github.com/user-attachments/assets/e593c2ab-d63e-4196-acf4-3d904bf06cd1" />

After
<img width="446" height="175" alt="SCR-20250904-pfdc" src="https://github.com/user-attachments/assets/a8a66f12-0ddb-4526-a178-237c2aabee41" />