### PR TITLE
fix(experiments): copy ordering fields on exp duplication

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -548,6 +548,8 @@ class EnterpriseExperimentsViewSet(ForbidDestroyModel, TeamAndOrgViewSetMixin, v
             "exposure_criteria": source_experiment.exposure_criteria,
             "saved_metrics_ids": saved_metrics_data,
             "feature_flag_key": feature_flag_key,  # Use provided key or fall back to existing
+            "primary_metrics_ordered_uuids": source_experiment.primary_metrics_ordered_uuids,
+            "secondary_metrics_ordered_uuids": source_experiment.secondary_metrics_ordered_uuids,
             # Reset fields for new experiment
             "start_date": None,
             "end_date": None,


### PR DESCRIPTION
## Changes
When duplicating an experiment, copy the ordering fields too.

## How did you test this code?
👀 