### PR TITLE
fix(batch-exports): Handle incompatible schema errors

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -104,6 +104,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "SnowflakeAuthenticationError",
     # Raised when a Warehouse is suspended.
     "SnowflakeWarehouseSuspendedError",
+    # Raised when the destination table schema is incompatible with the schema of the file we are trying to load.
+    "SnowflakeDestinationTableIncompatibleSchemaError",
 )
 
 
@@ -162,6 +164,12 @@ class InvalidPrivateKeyError(Exception):
 
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class SnowflakeDestinationTableIncompatibleSchemaError(Exception):
+    """Raised when the destination table schema is incompatible with the schema of the file we are trying to load."""
+
+    pass
 
 
 @dataclasses.dataclass
@@ -574,7 +582,7 @@ class SnowflakeClient:
                 raise TypeError(f"Expected tuple from Snowflake PUT query but got: '{result.__class__.__name__}'")
 
         status, message = result[6:8]
-        if status != "UPLOADED":
+        if status != "UPLOADED" and status != "SKIPPED":
             raise SnowflakeFileNotUploadedError(table_name, status, message)
 
     async def copy_loaded_files_to_snowflake_table(
@@ -631,7 +639,7 @@ class SnowflakeClient:
             and e.errno == 608,
         )
 
-        # We need to explicitly catch the exception here because otherwise it seems to be swallowed
+        # We need to explicitly catch exceptions here because otherwise they seem to be swallowed
         try:
             result = await execute_copy_into(query, poll_interval=1.0)
         except snowflake.connector.errors.ProgrammingError as e:
@@ -644,6 +652,11 @@ class SnowflakeClient:
                 if e.msg is not None:
                     err_msg += f": {e.msg}"
                 raise SnowflakeWarehouseSuspendedError(err_msg)
+            elif e.errno == 904 and e.msg is not None and "invalid identifier" in e.msg:
+                err_msg = "The data being loaded into the destination table does not match the schema of the destination table"
+                if e.msg is not None:
+                    err_msg += f": {e.msg}"
+                raise SnowflakeDestinationTableIncompatibleSchemaError(err_msg)
 
             raise SnowflakeFileNotLoadedError(
                 table_name,

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -653,10 +653,9 @@ class SnowflakeClient:
                     err_msg += f": {e.msg}"
                 raise SnowflakeWarehouseSuspendedError(err_msg)
             elif e.errno == 904 and e.msg is not None and "invalid identifier" in e.msg:
-                err_msg = "The data being loaded into the destination table does not match the schema of the destination table"
-                if e.msg is not None:
-                    err_msg += f": {e.msg}"
-                raise SnowflakeDestinationTableIncompatibleSchemaError(err_msg)
+                raise SnowflakeDestinationTableIncompatibleSchemaError(
+                    f"The data being loaded into the destination table does not match the schema of the destination table: {e.msg}"
+                )
 
             raise SnowflakeFileNotLoadedError(
                 table_name,

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -34,6 +34,7 @@ from products.batch_exports.backend.temporal.pipeline.internal_stage import (
     BatchExportInsertIntoInternalStageInputs,
     insert_into_internal_stage_activity,
 )
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import RecordBatchTaskError
 from products.batch_exports.backend.tests.temporal.destinations.snowflake.utils import (
     EXPECTED_PERSONS_BATCH_EXPORT_FIELDS,
@@ -69,6 +70,7 @@ async def _run_activity(
     expect_duplicates: bool = False,
     primary_key=None,
     use_internal_stage: bool = False,
+    assert_clickhouse_records: bool = True,
 ):
     """Helper function to run insert_into_snowflake_activity and assert records in Snowflake"""
     insert_inputs = SnowflakeInsertInputs(
@@ -102,24 +104,26 @@ async def _run_activity(
                 destination_default_fields=snowflake_default_fields(),
             ),
         )
-        await activity_environment.run(insert_into_snowflake_activity_from_stage, insert_inputs)
+        result = await activity_environment.run(insert_into_snowflake_activity_from_stage, insert_inputs)
     else:
-        await activity_environment.run(insert_into_snowflake_activity, insert_inputs)
+        result = await activity_environment.run(insert_into_snowflake_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_snowflake(
-        snowflake_cursor=snowflake_cursor,
-        clickhouse_client=clickhouse_client,
-        table_name=table_name,
-        team_id=team.pk,
-        data_interval_start=data_interval_start,
-        data_interval_end=data_interval_end,
-        exclude_events=exclude_events,
-        batch_export_model=batch_export_model or batch_export_schema,
-        sort_key=sort_key,
-        expected_fields=expected_fields,
-        expect_duplicates=expect_duplicates,
-        primary_key=primary_key,
-    )
+    if assert_clickhouse_records:
+        await assert_clickhouse_records_in_snowflake(
+            snowflake_cursor=snowflake_cursor,
+            clickhouse_client=clickhouse_client,
+            table_name=table_name,
+            team_id=team.pk,
+            data_interval_start=data_interval_start,
+            data_interval_end=data_interval_end,
+            exclude_events=exclude_events,
+            batch_export_model=batch_export_model or batch_export_schema,
+            sort_key=sort_key,
+            expected_fields=expected_fields,
+            expect_duplicates=expect_duplicates,
+            primary_key=primary_key,
+        )
+    return result
 
 
 @pytest.mark.parametrize("exclude_events", [None, ["test-exclude"]], indirect=True)
@@ -594,6 +598,66 @@ async def test_insert_into_snowflake_activity_handles_person_schema_changes(
         expected_fields=expected_fields,
         use_internal_stage=use_internal_stage,
     )
+
+
+async def test_insert_into_snowflake_activity_raises_error_when_schema_is_incompatible(
+    use_internal_stage,
+    clickhouse_client,
+    activity_environment,
+    snowflake_cursor,
+    snowflake_config,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+):
+    """Test that the `insert_into_snowflake_activity` raises an error when the schema of the destination table is
+    incompatible with the schema of the data we are trying to load. This typically applies to the events table, which
+    has a fixed schema (for now).
+
+    To replicate this situation we first export the data with the original
+    schema, then delete a column in the destination and then rerun the export.
+    """
+    model = BatchExportModel(name="events", schema=None)
+    table_name = f"test_insert_activity_events_table_{ateam.pk}"
+    if not use_internal_stage:
+        pytest.skip("This test is only applicable to the internal stage activity")
+
+    await _run_activity(
+        activity_environment=activity_environment,
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        snowflake_config=snowflake_config,
+        team=ateam,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        table_name=table_name,
+        batch_export_model=model,
+        sort_key="uuid",
+        use_internal_stage=use_internal_stage,
+    )
+
+    # Drop the timestamp column from the Snowflake table
+    snowflake_cursor.execute(f'ALTER TABLE "{table_name}" DROP COLUMN "timestamp"')
+
+    result = await _run_activity(
+        activity_environment=activity_environment,
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        snowflake_config=snowflake_config,
+        team=ateam,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        table_name=table_name,
+        batch_export_model=model,
+        sort_key="uuid",
+        use_internal_stage=use_internal_stage,
+        assert_clickhouse_records=False,
+    )
+
+    assert isinstance(result, BatchExportResult)
+    assert result.error is not None
+    assert result.error.type == "SnowflakeDestinationTableIncompatibleSchemaError"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

With the new pipeline, we're explicitly listing column names in the destination table, so can run into issues if the destination schema is different from the file contents we're trying to load. This should only happen for the events model, which doesn't support evolving schemas changes like we do for persons and sessions ([see here](https://github.com/PostHog/posthog/blob/3b076cd1b85977f70352828e9de994b1dcca53d3/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py#L854-L867))

## Changes

- Catch any syntax errors that contain "invalid identifier" when calling `COPY INTO`
- I also noticed an error `Snowflake upload for table 'EVENTS' expected status 'UPLOADED' but got 'SKIPPED'`. It's hard to find some definitive docs on this but asking AI, it suggests that the skipped status can be returned if the file to be uploaded already exists and has identical contents (same checksum). Therefore, I believe we should treat `SKIPPED` as if the file was uploaded successfully.

## How did you test this code?

Added a new automated test
Ran existing tests against test Snowflake instance

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
