### PR TITLE
fix(ux): double tabs in sql editor

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -389,7 +389,16 @@ export const sceneLogic = kea<sceneLogicType>([
         ],
         sceneId: [(s) => [s.activeTab], (activeTab) => activeTab?.sceneId],
         sceneKey: [(s) => [s.activeTab], (activeTab) => activeTab?.sceneKey],
-        sceneConfig: [(s) => [s.sceneId], (sceneId: Scene): SceneConfig | null => sceneConfigurations[sceneId] || null],
+        sceneConfig: [
+            (s) => [s.sceneId, s.featureFlags],
+            (sceneId: Scene, featureFlags): SceneConfig | null => {
+                const config = sceneConfigurations[sceneId] || null
+                if (sceneId === Scene.SQLEditor && featureFlags[FEATURE_FLAGS.SCENE_TABS]) {
+                    return { ...config, layout: 'app' }
+                }
+                return config
+            },
+        ],
         sceneParams: [
             (s) => [s.activeTab],
             (activeTab): SceneParams => activeTab?.sceneParams || { params: {}, searchParams: {}, hashParams: {} },


### PR DESCRIPTION
## Problem

The global tabs vanish when you're on the SQL editor scene.

## Changes

When the global tabs feature flag is enabled, use the standard layout for the sql editor scene.

Everything else remains the same: we still have double tabs, and global state. Fixing all of that comes next.

<img width="1146" height="539" alt="image" src="https://github.com/user-attachments/assets/9093dcdb-7c40-4381-bc17-37c75301bd96" />


## How did you test this code?

👀 