### PR TITLE
fix(messaging): block branch deletes if they contain child actions

### DIFF
--- a/products/messaging/frontend/Campaigns/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -66,7 +66,7 @@ export const LOGIC_NODES_TO_SHOW: CreateActionType[] = [
     {
         type: 'conditional_branch',
         name: 'Conditional branch',
-        description: 'Branch based on a condition such as the event trigger or a person property.',
+        description: 'Branch using conditions on event or person properties.',
         branchEdges: 1,
         config: {
             conditions: [

--- a/products/messaging/frontend/Campaigns/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/steps/StepConditionalBranch.tsx
@@ -19,7 +19,7 @@ export function StepConditionalBranchConfiguration({
     const action = node.data
     const { conditions } = action.config
 
-    const { edgesByActionId } = useValues(hogFlowEditorLogic)
+    const { edgesByActionId, selectedNodeCanBeDeleted } = useValues(hogFlowEditorLogic)
     const { setCampaignAction, setCampaignActionEdges } = useActions(hogFlowEditorLogic)
 
     const nodeEdges = edgesByActionId[action.id]
@@ -89,7 +89,12 @@ export function StepConditionalBranchConfiguration({
                 <div key={index} className="flex flex-col gap-2 p-2 rounded border">
                     <div className="flex justify-between items-center">
                         <LemonLabel>Condition {index + 1}</LemonLabel>
-                        <LemonButton size="xsmall" icon={<IconX />} onClick={() => removeCondition(index)} />
+                        <LemonButton
+                            size="xsmall"
+                            icon={<IconX />}
+                            onClick={() => removeCondition(index)}
+                            disabledReason={selectedNodeCanBeDeleted ? undefined : 'Clean up branching steps first'}
+                        />
                     </div>
 
                     <HogFlowFilters


### PR DESCRIPTION
## Problem

Just like when deleting the entire branching node, we should block deletes when they contain child nodes, as this can result in orphaned nodes and/or deleting more than the user intended.



## Changes
<img width="1181" height="567" alt="Screenshot 2025-09-04 at 11 17 34 AM" src="https://github.com/user-attachments/assets/0c107d1e-0b24-4a42-897b-836b655b27c7" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

See above