### PR TITLE
chore: reduce postgres source count call

### DIFF
--- a/posthog/temporal/data_imports/sources/README.md
+++ b/posthog/temporal/data_imports/sources/README.md
@@ -43,7 +43,7 @@ class TemplateSource(BaseSource[Config]): # Replace this after config generation
     def validate_credentials(self, config: Config, team_id: int) -> tuple[bool, str | None]: # Replace `Config` with your config class
       return True, None # Implement logic to validate the credentials of your source, e.g. check the validity of API keys. Return a tuple of whether the credentials are valid, and if not, return an error message to return to the user
 
-    def get_schemas(self, config: Config, team_id: int) -> list[SourceSchema]: # Replace `Config` with your config class
+    def get_schemas(self, config: Config, team_id: int, with_counts: bool = False) -> list[SourceSchema]: # Replace `Config` with your config class
       return [] # Implement your source schema logic here
 
     def source_for_pipeline(self, config: Config, inputs: SourceInputs) -> SourceResponse: # Replace `Config` with your config class

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -37,7 +37,7 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.BIGQUERY
 
-    def get_schemas(self, config: BigQuerySourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: BigQuerySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         bq_schemas = get_bigquery_schemas(
             config,
             logger=None,

--- a/posthog/temporal/data_imports/sources/chargebee/source.py
+++ b/posthog/temporal/data_imports/sources/chargebee/source.py
@@ -28,7 +28,7 @@ class ChargebeeSource(BaseSource[ChargebeeSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CHARGEBEE
 
-    def get_schemas(self, config: ChargebeeSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: ChargebeeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/common/base.py
+++ b/posthog/temporal/data_imports/sources/common/base.py
@@ -48,7 +48,7 @@ class BaseSource(ABC, Generic[ConfigType]):
     def source_for_pipeline(self, config: ConfigType, inputs: SourceInputs) -> SourceResponse:
         raise NotImplementedError()
 
-    def get_schemas(self, config: ConfigType, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: ConfigType, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         raise NotImplementedError()
 
     @property

--- a/posthog/temporal/data_imports/sources/doit/source.py
+++ b/posthog/temporal/data_imports/sources/doit/source.py
@@ -22,7 +22,7 @@ class DoItSource(BaseSource[DoItSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.DOIT
 
-    def get_schemas(self, config: DoItSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: DoItSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         reports = doit_list_reports(config)
 
         return [

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -37,7 +37,10 @@ class GoogleAdsSource(BaseSource[GoogleAdsSourceConfig | GoogleAdsServiceAccount
         return GoogleAdsServiceAccountSourceConfig.from_dict(job_inputs)
 
     def get_schemas(
-        self, config: GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig, team_id: int
+        self,
+        config: GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
     ) -> list[SourceSchema]:
         google_ads_schemas = get_google_ads_schemas(
             config,

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -29,7 +29,9 @@ class GoogleSheetsSource(BaseSource[GoogleSheetsSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.GOOGLESHEETS
 
-    def get_schemas(self, config: GoogleSheetsSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: GoogleSheetsSourceConfig, team_id: int, with_counts: bool = False
+    ) -> list[SourceSchema]:
         sheets = get_google_sheets_schemas(config)
 
         schemas: list[SourceSchema] = []

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -54,7 +54,9 @@ class HubspotSource(BaseSource[HubspotSourceConfig | HubspotSourceOldConfig], OA
 
         return HubspotSourceOldConfig.from_dict(job_inputs)
 
-    def get_schemas(self, config: HubspotSourceConfig | HubspotSourceOldConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: HubspotSourceConfig | HubspotSourceOldConfig, team_id: int, with_counts: bool = False
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -24,7 +24,7 @@ class MetaAdsSource(BaseSource[MetaAdsSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.METAADS
 
-    def get_schemas(self, config: MetaAdsSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: MetaAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -29,7 +29,7 @@ class MongoDBSource(BaseSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.MONGODB
 
-    def get_schemas(self, config: MongoDBSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: MongoDBSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         mongo_schemas = get_mongo_schemas(config)
 
         filtered_results = [

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -89,7 +89,7 @@ class MSSQLSource(BaseSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabas
             ),
         )
 
-    def get_schemas(self, config: MSSQLSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: MSSQLSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -97,7 +97,7 @@ class MySQLSource(BaseSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabas
             ),
         )
 
-    def get_schemas(self, config: MySQLSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: MySQLSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -103,7 +103,7 @@ class PostgresSource(BaseSource[PostgresSourceConfig], SSHTunnelMixin, ValidateD
             ),
         )
 
-    def get_schemas(self, config: PostgresSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: PostgresSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):
@@ -116,14 +116,17 @@ class PostgresSource(BaseSource[PostgresSourceConfig], SSHTunnelMixin, ValidateD
                 schema=config.schema,
             )
 
-            row_counts = get_postgres_row_count(
-                host=host,
-                port=port,
-                user=config.user,
-                password=config.password,
-                database=config.database,
-                schema=config.schema,
-            )
+            if with_counts:
+                row_counts = get_postgres_row_count(
+                    host=host,
+                    port=port,
+                    user=config.user,
+                    password=config.password,
+                    database=config.database,
+                    schema=config.schema,
+                )
+            else:
+                row_counts = {}
 
         for table_name, columns in db_schemas.items():
             column_info = [(col_name, col_type) for col_name, col_type in columns]

--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -25,7 +25,9 @@ class SalesforceSource(BaseSource[SalesforceSourceConfig], OAuthMixin):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SALESFORCE
 
-    def get_schemas(self, config: SalesforceSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: SalesforceSourceConfig, team_id: int, with_counts: bool = False
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -147,7 +147,7 @@ class SnowflakeSource(BaseSource[SnowflakeSourceConfig]):
             ),
         )
 
-    def get_schemas(self, config: SnowflakeSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: SnowflakeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         schemas = []
 
         db_schemas = get_snowflake_schemas(config)

--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -64,7 +64,7 @@ Currently, **read permissions are required** for the following resources:
             ),
         )
 
-    def get_schemas(self, config: StripeSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: StripeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -27,7 +27,9 @@ class TemporalIOSource(BaseSource[TemporalIOSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.TEMPORALIO
 
-    def get_schemas(self, config: TemporalIOSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: TemporalIOSourceConfig, team_id: int, with_counts: bool = False
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -33,7 +33,7 @@ class VitallySource(BaseSource[VitallySourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.VITALLY
 
-    def get_schemas(self, config: VitallySourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: VitallySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/zendesk/source.py
+++ b/posthog/temporal/data_imports/sources/zendesk/source.py
@@ -29,7 +29,7 @@ class ZendeskSource(BaseSource[ZendeskSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.ZENDESK
 
-    def get_schemas(self, config: ZendeskSourceConfig, team_id: int) -> list[SourceSchema]:
+    def get_schemas(self, config: ZendeskSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -548,7 +548,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
 
         try:
-            schemas = source.get_schemas(source_config, self.team_id)
+            schemas = source.get_schemas(source_config, self.team_id, True)
         except Exception as e:
             capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
             return Response(


### PR DESCRIPTION
## Problem

- postgres count call being made on every sync run when it's unnecessary (called in sync_new_schemas activity)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add a param to source schema and only retrieve counts during API call not on syncs

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
