### PR TITLE
fix(ux): scene heights/padding + 1 thing

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -44,6 +44,7 @@ import { sidePanelLogic } from '../navigation-3000/sidepanel/sidePanelLogic'
 import { sidePanelStateLogic } from '../navigation-3000/sidepanel/sidePanelStateLogic'
 import { AccountPopoverOverlay } from '../navigation/TopBar/AccountPopover'
 import { navigationLogic } from '../navigation/navigationLogic'
+import { sceneLayoutLogic } from '../scenes/sceneLayoutLogic'
 import { OrganizationDropdownMenu } from './OrganizationDropdownMenu'
 import { ProjectDropdownMenu } from './ProjectDropdownMenu'
 
@@ -92,6 +93,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const { visibleTabs, sidePanelOpen, selectedTab } = useValues(sidePanelLogic)
     const { openSidePanel, closeSidePanel } = useActions(sidePanelStateLogic)
     const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
+    const { sceneLayoutConfig } = useValues(sceneLayoutLogic)
 
     function handlePanelTriggerClick(item: PanelLayoutNavIdentifier): void {
         if (activePanelIdentifier !== item) {
@@ -563,7 +565,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                             data-attr="tree-navbar-resizer"
                             className={cn({
                                 'top-[calc(var(--scene-layout-header-height)+4px)]': newSceneLayout,
-                                'top-0': newSceneLayout && isLayoutPanelVisible,
+                                'top-0':
+                                    (newSceneLayout && isLayoutPanelVisible) ||
+                                    sceneLayoutConfig?.layout === 'app-raw-no-header',
                             })}
                             offset={newSceneLayout ? -1 : 0}
                         />

--- a/frontend/src/layout/scenes/sceneLayoutLogic.tsx
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { SceneConfig } from 'scenes/sceneTypes'
 
 import type { sceneLayoutLogicType } from './sceneLayoutLogicType'
 
@@ -21,6 +22,7 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
         setForceScenePanelClosedWhenRelative: (closed: boolean) => ({ closed }),
         setSceneContainerRef: (ref: SceneLayoutContainerRef) => ({ ref }),
         setSceneContainerRect: (rect: DOMRect) => ({ rect }),
+        setSceneLayoutConfig: (config: SceneConfig) => ({ config }),
     }),
     reducers({
         scenePanelElement: [
@@ -59,6 +61,12 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
             null as DOMRect | null,
             {
                 setSceneContainerRect: (_, { rect }) => rect,
+            },
+        ],
+        sceneLayoutConfig: [
+            null as SceneConfig | null,
+            {
+                setSceneLayoutConfig: (_, { config }) => config,
             },
         ],
     }),

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -8,6 +8,7 @@ import { IconBook, IconDownload, IconInfo, IconPlayFilled, IconSidebarClose } fr
 import { LemonDivider, Spinner } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { IconCancel } from 'lib/lemon-ui/icons'
@@ -15,6 +16,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind } from '~/queries/schema/schema-general'
 
@@ -76,6 +79,7 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
     const { sidebarWidth } = useValues(editorSizingLogic)
     const { resetDefaultSidebarWidth } = useActions(editorSizingLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
 
     const [editingViewDisabledReason, EditingViewButtonIcon] = useMemo(() => {
         if (updatingDataWarehouseSavedQuery) {
@@ -125,6 +129,19 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
 
     return (
         <div className="flex flex-1 flex-col h-full overflow-hidden">
+            {newSceneLayout && (
+                <div className="flex flex-col gap-2 pt-2 px-4">
+                    <SceneTitleSection
+                        name="SQL Editor"
+                        description={null}
+                        resourceType={{
+                            type: 'sql',
+                            typePlural: 'sql',
+                        }}
+                    />
+                    <SceneDivider />
+                </div>
+            )}
             <div className="flex flex-row overflow-x-auto">
                 {renderSidebarButton()}
                 <QueryTabs

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -267,6 +267,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Session replay',
         activityScope: ActivityScope.REPLAY,
         defaultDocsPath: '/docs/session-replay',
+        hideProjectNotice: true,
     },
     [Scene.RevenueAnalytics]: {
         projectBased: true,

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -20,6 +20,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { cn } from 'lib/utils/css-classes'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { NotebookNodeType } from 'scenes/notebooks/types'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -253,7 +254,7 @@ function PageTabs(): JSX.Element {
     return (
         <LemonTabs
             activeKey={tab}
-            className="flex"
+            className={cn('flex', newSceneLayout && 'mt-0')}
             barClassName="mb-0"
             onChange={(t) => router.actions.push(urls.replay(t as ReplayTabs))}
             sceneInset={newSceneLayout}


### PR DESCRIPTION
## Problem
Scene config raw wasn't respected (SQL editor)
Replay header was overlapping with breadcrumbs
Pinned panel resizer wasn't full height

## Changes
Edit layout to respect scene config raw
Fix replay margin top on lemon tabs
Fix panel resizer line full height
Added scene title section to SQL editor
Added scene config into panel logic so i can reference it in other components (navbar for resizer)

![2025-09-04 16 33 21](https://github.com/user-attachments/assets/7d42b291-afee-47c9-9bfc-6abbd42d11d8)


## How did you test this code?
Clicking round