### PR TITLE
chore(data-warehouse): use the size of the queryable files for table size

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/calculate_table_size.py
+++ b/posthog/temporal/data_imports/workflow_activities/calculate_table_size.py
@@ -41,7 +41,10 @@ def calculate_table_size_activity(inputs: CalculateTableSizeActivityInputs) -> N
         return
 
     folder_name = schema.folder_path()
-    s3_folder = f"{settings.BUCKET_URL}/{folder_name}/{schema.normalized_name}"
+    if table.format == DataWarehouseTable.TableFormat.DeltaS3Wrapper:
+        s3_folder = f"{settings.BUCKET_URL}/{folder_name}/{schema.normalized_name}__query"
+    else:
+        s3_folder = f"{settings.BUCKET_URL}/{folder_name}/{schema.normalized_name}"
 
     total_mib = get_size_of_folder(s3_folder)
 

--- a/posthog/warehouse/data_load/create_table.py
+++ b/posthog/warehouse/data_load/create_table.py
@@ -31,7 +31,7 @@ async def calculate_table_size(saved_query: DataWarehouseSavedQuery, team_id: in
     await logger.adebug("Calculating table size in S3")
 
     folder_name = saved_query.folder_path
-    s3_folder = f"{settings.BUCKET_URL}/{folder_name}/{saved_query.name}"
+    s3_folder = f"{settings.BUCKET_URL}/{folder_name}/{saved_query.name}__query"
 
     total_mib = get_size_of_folder(s3_folder)
 


### PR DESCRIPTION
## Problem
- We're reporting table size in usage reports, but we're calculating the whole delta table instead of just the query files
- the delta table will have un-compacted files, so we're likely overestimating the table size

## Changes
- Only use the size of the actual queryable files 
