### PR TITLE
feat(web-analytics): Switch pre-aggregation to hourly tables

### DIFF
--- a/ee/hogai/graph/session_summaries/test/__snapshots__/test_nodes.ambr
+++ b/ee/hogai/graph/session_summaries/test/__snapshots__/test_nodes.ambr
@@ -16,10 +16,10 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2025-09-03 11:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-24 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-24 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-09-03 23:59:59.000000', 6, 'UTC')))
   GROUP BY s.session_id
   HAVING ifNull(greater(active_seconds, 8.0), 0)
   ORDER BY start_time DESC
@@ -53,7 +53,7 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2025-09-03 11:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-27 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-31 23:59:59.000000', 6, 'UTC')))
@@ -90,7 +90,7 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2025-09-03 11:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-27 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-31 23:59:59.000000', 6, 'UTC')))
@@ -127,7 +127,7 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), and(globalIn(s.session_id,

--- a/posthog/hogql/helpers/timestamp_visitor.py
+++ b/posthog/hogql/helpers/timestamp_visitor.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Optional
 
@@ -216,7 +217,7 @@ class IsTimeOrIntervalConstantVisitor(Visitor[bool]):
         return all(self.visit(arg) for arg in node.exprs)
 
 
-class IsStartOfPeriodConstantVisitor(Visitor[bool]):
+class IsStartOfPeriodConstantVisitor(Visitor[bool], ABC):
     constant_fns: list[str]
     constant_if_first_arg_constant_fns: list[str]
     interval_fns: list[str]
@@ -224,6 +225,7 @@ class IsStartOfPeriodConstantVisitor(Visitor[bool]):
     def __init__(self, tombstone_string: Optional[str]):
         self.tombstone_string = tombstone_string
 
+    @abstractmethod
     def check_parsed(self, parsed: datetime) -> bool:
         raise NotImplementedError("check_parsed must be implemented in subclasses")
 
@@ -355,7 +357,8 @@ def is_start_of_hour_constant(expr: ast.Expr, tombstone_string: Optional[str] = 
     return IsStartOfHourConstantVisitor(tombstone_string).visit(expr)
 
 
-class IsEndOfPeriodConstantVisitor(Visitor[bool]):
+class IsEndOfPeriodConstantVisitor(Visitor[bool], ABC):
+    @abstractmethod
     def check_parsed(self, parsed: datetime) -> bool:
         raise NotImplementedError("check_parsed must be implemented in subclasses")
 

--- a/posthog/hogql/helpers/timestamp_visitor.py
+++ b/posthog/hogql/helpers/timestamp_visitor.py
@@ -216,13 +216,16 @@ class IsTimeOrIntervalConstantVisitor(Visitor[bool]):
         return all(self.visit(arg) for arg in node.exprs)
 
 
-def is_start_of_day_constant(expr: ast.Expr, tombstone_string: Optional[str] = None) -> bool:
-    return IsStartOfDayConstantVisitor(tombstone_string).visit(expr)
+class IsStartOfPeriodConstantVisitor(Visitor[bool]):
+    constant_fns: list[str]
+    constant_if_first_arg_constant_fns: list[str]
+    interval_fns: list[str]
 
-
-class IsStartOfDayConstantVisitor(Visitor[bool]):
     def __init__(self, tombstone_string: Optional[str]):
         self.tombstone_string = tombstone_string
+
+    def check_parsed(self, parsed: datetime) -> bool:
+        raise NotImplementedError("check_parsed must be implemented in subclasses")
 
     def visit_constant(self, node: ast.Constant) -> bool:
         if self.tombstone_string is not None and node.value == self.tombstone_string:
@@ -233,10 +236,7 @@ class IsStartOfDayConstantVisitor(Visitor[bool]):
             parsed = datetime.fromisoformat(node.value)
         except ValueError:
             return False
-        # Check if the constant is a date without time (i.e., start of the day)
-        if parsed.hour == 0 and parsed.minute == 0 and parsed.second == 0:
-            return True
-        return False
+        return self.check_parsed(parsed)
 
     def visit_select_query(self, node: ast.SelectQuery) -> bool:
         return False
@@ -249,9 +249,9 @@ class IsStartOfDayConstantVisitor(Visitor[bool]):
 
     def visit_call(self, node: ast.Call) -> bool:
         # some functions just return a constant
-        if node.name in ["today", "yesterday"]:
+        if node.name in self.constant_fns:
             return True
-        elif node.name in ["toStartOfDay", "toStartOfWeek", "toStartOfMonth", "toStartOfQuarter", "toStartOfYear"]:
+        elif node.name in self.constant_if_first_arg_constant_fns:
             # these functions return the start of the day/week/month/quarter/year
             # note that we no longer care that it's a constant representing the start of the period, just that it's a constant now
             return is_time_or_interval_constant(node.args[0])
@@ -259,13 +259,7 @@ class IsStartOfDayConstantVisitor(Visitor[bool]):
         elif node.name.startswith("toStartOfInterval") and len(node.args) == 2:
             if is_time_or_interval_constant(node.args[0]):
                 interval = node.args[1]
-                if isinstance(interval, ast.Call) and interval.name in [
-                    "toIntervalDay",
-                    "toIntervalWeek",
-                    "toIntervalMonth",
-                    "toIntervalQuarter",
-                    "toIntervalYear",
-                ]:
+                if isinstance(interval, ast.Call) and interval.name in self.interval_fns:
                     # these intervals are valid for start of day/week/month/quarter/year
                     num_intervals = interval.args[0]
                     if (
@@ -315,11 +309,56 @@ class IsStartOfDayConstantVisitor(Visitor[bool]):
         return False
 
 
-def is_end_of_day_constant(expr: ast.Expr, tombstone_string: Optional[str] = None) -> bool:
-    return IsEndOfDayConstantVisitor(tombstone_string).visit(expr)
+class IsStartOfDayConstantVisitor(IsStartOfPeriodConstantVisitor):
+    constant_fns = ["today", "yesterday"]
+    constant_if_first_arg_constant_fns = [
+        "toStartOfDay",
+        "toStartOfWeek",
+        "toStartOfMonth",
+        "toStartOfQuarter",
+        "toStartOfYear",
+    ]
+    interval_fns = ["toIntervalDay", "toIntervalWeek", "toIntervalMonth", "toIntervalQuarter", "toIntervalYear"]
+
+    def check_parsed(self, parsed: datetime) -> bool:
+        return parsed.hour == 0 and parsed.minute == 0 and parsed.second == 0 and parsed.microsecond == 0
 
 
-class IsEndOfDayConstantVisitor(Visitor[bool]):
+def is_start_of_day_constant(expr: ast.Expr, tombstone_string: Optional[str] = None) -> bool:
+    return IsStartOfDayConstantVisitor(tombstone_string).visit(expr)
+
+
+class IsStartOfHourConstantVisitor(IsStartOfPeriodConstantVisitor):
+    constant_fns = ["today", "yesterday"]
+    constant_if_first_arg_constant_fns = [
+        "toStartOfHour",
+        "toStartOfDay",
+        "toStartOfWeek",
+        "toStartOfMonth",
+        "toStartOfQuarter",
+        "toStartOfYear",
+    ]
+    interval_fns = [
+        "toIntervalHour",
+        "toIntervalDay",
+        "toIntervalWeek",
+        "toIntervalMonth",
+        "toIntervalQuarter",
+        "toIntervalYear",
+    ]
+
+    def check_parsed(self, parsed: datetime) -> bool:
+        return parsed.minute == 0 and parsed.second == 0 and parsed.microsecond == 0
+
+
+def is_start_of_hour_constant(expr: ast.Expr, tombstone_string: Optional[str] = None) -> bool:
+    return IsStartOfHourConstantVisitor(tombstone_string).visit(expr)
+
+
+class IsEndOfPeriodConstantVisitor(Visitor[bool]):
+    def check_parsed(self, parsed: datetime) -> bool:
+        raise NotImplementedError("check_parsed must be implemented in subclasses")
+
     def __init__(self, tombstone_string: Optional[str]):
         self.tombstone_string = tombstone_string
 
@@ -334,9 +373,7 @@ class IsEndOfDayConstantVisitor(Visitor[bool]):
             return False
         # Check if the constant is 23:59:59 of any day. This is not exact, but this is how
         # our QueryDateRange class works, and we need to be compatible with that.
-        if parsed.hour == 23 and parsed.minute == 59 and parsed.second == 59:
-            return True
-        return False
+        return self.check_parsed(parsed)
 
     def visit_select_query(self, node: ast.SelectQuery) -> bool:
         return False
@@ -387,3 +424,21 @@ class IsEndOfDayConstantVisitor(Visitor[bool]):
 
     def visit_array(self, node: ast.Array) -> bool:
         return False
+
+
+class IsEndOfDayConstantVisitor(IsEndOfPeriodConstantVisitor):
+    def check_parsed(self, parsed: datetime) -> bool:
+        return parsed.hour == 23 and parsed.minute == 59 and parsed.second == 59
+
+
+def is_end_of_day_constant(expr: ast.Expr, tombstone_string: Optional[str] = None) -> bool:
+    return IsEndOfDayConstantVisitor(tombstone_string).visit(expr)
+
+
+class IsEndOfHourConstantVisitor(IsEndOfPeriodConstantVisitor):
+    def check_parsed(self, parsed: datetime) -> bool:
+        return parsed.minute == 59 and parsed.second == 59
+
+
+def is_end_of_hour_constant(expr: ast.Expr, tombstone_string: Optional[str] = None) -> bool:
+    return IsEndOfHourConstantVisitor(tombstone_string).visit(expr)

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -121,6 +121,8 @@ class HogQLQueryExecutor:
     def _apply_optimizers(self):
         if self.query_modifiers.useWebAnalyticsPreAggregatedTables:
             with self.timings.measure("preaggregated_table_transforms"):
+                assert self.hogql_context is not None
+                assert self.hogql_context.team is not None
                 transformed_node = do_preaggregated_table_transforms(self.select_query, self.hogql_context)
                 if isinstance(transformed_node, ast.SelectQuery) or isinstance(transformed_node, ast.SelectSetQuery):
                     self.select_query = transformed_node

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -121,7 +121,7 @@ class HogQLQueryExecutor:
     def _apply_optimizers(self):
         if self.query_modifiers.useWebAnalyticsPreAggregatedTables:
             with self.timings.measure("preaggregated_table_transforms"):
-                transformed_node = do_preaggregated_table_transforms(self.select_query, self.context)
+                transformed_node = do_preaggregated_table_transforms(self.select_query, self.hogql_context)
                 if isinstance(transformed_node, ast.SelectQuery) or isinstance(transformed_node, ast.SelectSetQuery):
                     self.select_query = transformed_node
 
@@ -136,6 +136,8 @@ class HogQLQueryExecutor:
             modifiers=self.query_modifiers,
             limit_context=self.limit_context,
         )
+
+        self._apply_optimizers()
 
         with self.timings.measure("clone"):
             cloned_query = clone_expr(self.select_query, True)
@@ -275,7 +277,6 @@ class HogQLQueryExecutor:
         self._process_variables()
         self._process_placeholders()
         self._apply_limit()
-        self._apply_optimizers()
         with self.timings.measure("_generate_hogql"):
             self._generate_hogql()
         with self.timings.measure("_generate_clickhouse_sql"):

--- a/posthog/hogql/transforms/preaggregated_table_transformation.py
+++ b/posthog/hogql/transforms/preaggregated_table_transformation.py
@@ -128,7 +128,7 @@ def is_to_start_of_hour_timestamp_field(expr: ast.Call, context: HogQLContext) -
         and is_simple_timestamp_field_expression(expr.args[0], context)
     ):
         return True
-    # also accept toStartOfInterval(timestamp, toIntervalDay(1))
+    # also accept toStartOfInterval(timestamp, toIntervalHour(1))
     if (
         expr.name == "toStartOfInterval"
         and len(expr.args) == 2

--- a/posthog/hogql/transforms/preaggregated_table_transformation.py
+++ b/posthog/hogql/transforms/preaggregated_table_transformation.py
@@ -25,8 +25,10 @@ from posthog.hogql.base import AST
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.helpers.timestamp_visitor import (
     is_end_of_day_constant,
+    is_end_of_hour_constant,
     is_simple_timestamp_field_expression,
     is_start_of_day_constant,
+    is_start_of_hour_constant,
 )
 from posthog.hogql.visitor import CloningVisitor
 
@@ -36,6 +38,8 @@ from posthog.hogql_queries.web_analytics.pre_aggregated.properties import (
 )
 
 _T_AST = TypeVar("_T_AST", bound=AST)
+
+PREAGGREGATED_TABLE_NAME = "web_pre_aggregated_stats"
 
 
 def flatten_and(node: Optional[ast.Expr]) -> list[ast.Expr]:
@@ -113,7 +117,30 @@ def is_to_start_of_day_timestamp_field(expr: ast.Call, context: HogQLContext) ->
     return False
 
 
-def _try_transform_timestamp_comparsion_with_start_of_day_time_constant(
+def is_to_start_of_hour_timestamp_field(expr: ast.Call, context: HogQLContext) -> bool:
+    """Check if a call represents a toStartOfHour timestamp operation, or toStartOfX where X is a whole number of hours."""
+    if (
+        expr.name == "toStartOfHour"
+        and len(expr.args) == 1
+        and is_simple_timestamp_field_expression(expr.args[0], context)
+    ):
+        return True
+    # also accept toStartOfInterval(timestamp, toIntervalDay(1))
+    if (
+        expr.name == "toStartOfInterval"
+        and len(expr.args) == 2
+        and is_simple_timestamp_field_expression(expr.args[0], context)
+        and isinstance(expr.args[1], ast.Call)
+        and expr.args[1].name == "toIntervalHour"
+        and len(expr.args[1].args) == 1
+        and isinstance(expr.args[1].args[0], ast.Constant)
+        and expr.args[1].args[0].value == 1
+    ):
+        return True
+    return False
+
+
+def _try_transform_timestamp_comparison_with_start_of_day_time_constant(
     expr: ast.Call, context: HogQLContext
 ) -> Optional[ast.Call]:
     """
@@ -125,8 +152,6 @@ def _try_transform_timestamp_comparsion_with_start_of_day_time_constant(
     timestamp <  toStartOfDay(date) is equivalent to toStartOfDay(timestamp) <  toStartOfDay(date)
     toStartOfDay(date) <= timestamp is equivalent to toStartOfDay(date) <= toStartOfDay(timestamp)
     toStartOfDay(date) >  timestamp is equivalent to toStartOfDay(date) >  toStartOfDay(timestamp)
-
-    We don't have a toEndOfDay function but we can approximate it, if we did then the following variants would also be valid:
     """
     if expr.name not in ["greaterOrEquals", "lessOrEquals", "greater", "less"] or len(expr.args) != 2:
         return None
@@ -140,6 +165,25 @@ def _try_transform_timestamp_comparsion_with_start_of_day_time_constant(
             return ast.Call(name=name, args=[ast.Field(chain=["period_bucket"]), arg1])
     if is_simple_timestamp_field_expression(arg1, context):
         if name in ["lessOrEquals", "greater"] and is_start_of_day_constant(arg0):
+            return ast.Call(name=expr.name, args=[arg0, ast.Field(chain=["period_bucket"])])
+    return None
+
+
+def _try_transform_timestamp_comparison_with_start_of_hour_time_constant(
+    expr: ast.Call, context: HogQLContext
+) -> Optional[ast.Call]:
+    if expr.name not in ["greaterOrEquals", "lessOrEquals", "greater", "less"] or len(expr.args) != 2:
+        return None
+    arg0 = expr.args[0]
+    arg1 = expr.args[1]
+    name = expr.name
+    if is_simple_timestamp_field_expression(arg0, context):
+        if name in ["greaterOrEquals", "less"] and is_start_of_hour_constant(arg1):
+            return ast.Call(name=name, args=[ast.Field(chain=["period_bucket"]), arg1])
+        if name in ["lessOrEquals"] and is_end_of_hour_constant(arg1):
+            return ast.Call(name=name, args=[ast.Field(chain=["period_bucket"]), arg1])
+    if is_simple_timestamp_field_expression(arg1, context):
+        if name in ["lessOrEquals", "greater"] and is_start_of_hour_constant(arg0):
             return ast.Call(name=expr.name, args=[arg0, ast.Field(chain=["period_bucket"])])
     return None
 
@@ -297,7 +341,15 @@ class ExprTransformer(CloningVisitor):
             self.has_transformed_aggregation = True
             # toStartOfDay(timestamp) becomes toStartOfDay(period_bucket)
             return ast.Call(name="toStartOfDay", args=[ast.Field(chain=["period_bucket"])])
-        elif transformed_call := _try_transform_timestamp_comparsion_with_start_of_day_time_constant(
+        elif is_to_start_of_hour_timestamp_field(node, self.context):
+            self.has_transformed_aggregation = True
+            # toStartOfHour(timestamp) becomes toStartOfHour(period_bucket)
+            return ast.Call(name="toStartOfHour", args=[ast.Field(chain=["period_bucket"])])
+        elif transformed_call := _try_transform_timestamp_comparison_with_start_of_day_time_constant(
+            node, self.context
+        ):
+            return transformed_call
+        elif transformed_call := _try_transform_timestamp_comparison_with_start_of_hour_time_constant(
             node, self.context
         ):
             return transformed_call
@@ -364,7 +416,7 @@ def _shallow_transform_select(node: ast.SelectQuery, context: HogQLContext) -> a
 
     # TODO right now we only have the one preaggregated table that is supported, but in the future could support more.
     # We could even make them unique per team (depending on what the team queries) or allow them to be user-defined.
-    table_name = "web_stats_daily"
+    table_name = "web_pre_aggregated_stats"
 
     # Bail if any unsupported part of the SELECT query exist
     # Some of these could be supported in the future, if you add them, make sure you add some tests!

--- a/posthog/hogql/transforms/test/__snapshots__/test_preaggregated_table_transformation.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_preaggregated_table_transformation.ambr
@@ -3,7 +3,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state) AS c, uniqMerge(persons_uniq_state) AS p, uniqMerge(sessions_uniq_state) AS s, utm_medium AS m
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY m)
   '''
 # ---
@@ -11,7 +11,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY browser)
   '''
 # ---
@@ -19,7 +19,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY os)
   '''
 # ---
@@ -27,7 +27,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY viewport_width)
   '''
 # ---
@@ -35,7 +35,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY viewport_height)
   '''
 # ---
@@ -43,7 +43,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY country_code)
   '''
 # ---
@@ -51,7 +51,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY city_name)
   '''
 # ---
@@ -59,7 +59,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY region_code)
   '''
 # ---
@@ -67,7 +67,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY region_name)
   '''
 # ---
@@ -75,7 +75,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_source)
   '''
 # ---
@@ -83,7 +83,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_medium)
   '''
 # ---
@@ -91,7 +91,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_campaign)
   '''
 # ---
@@ -99,7 +99,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_term)
   '''
 # ---
@@ -107,7 +107,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_content)
   '''
 # ---
@@ -115,7 +115,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY referring_domain)
   '''
 # ---
@@ -123,7 +123,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY mat_metadata_loggedIn)
   '''
 # ---
@@ -131,7 +131,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY mat_metadata_backend)
   '''
 # ---
@@ -139,7 +139,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY entry_pathname)
   '''
 # ---
@@ -147,7 +147,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY end_pathname)
   '''
 # ---
@@ -155,14 +155,14 @@
   '''
   sql
     (SELECT multiply(sumMerge(pageviews_count_state), 2) AS double_count
-     FROM web_stats_daily)
+     FROM web_pre_aggregated_stats)
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_case_when_expressions
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), if(equals(utm_source, 'google'), 'search', 'other') AS source_type
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY source_type)
   '''
 # ---
@@ -170,14 +170,14 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily)
+     FROM web_pre_aggregated_stats)
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_equals_function
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily)
+     FROM web_pre_aggregated_stats)
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_full_trends_line_query
@@ -188,7 +188,7 @@
        (SELECT sum(total) AS count, day_start
         FROM
           (SELECT sumMerge(pageviews_count_state) AS total, toStartOfDay(period_bucket) AS day_start
-           FROM web_stats_daily AS e
+           FROM web_pre_aggregated_stats AS e
            WHERE and(greaterOrEquals(period_bucket, toStartOfInterval(assumeNotNull(toDateTime('2025-07-10 14:04:24')), toIntervalDay(1))), lessOrEquals(period_bucket, assumeNotNull(toDateTime('2025-07-17 23:59:59'))))
            GROUP BY day_start)
         GROUP BY day_start
@@ -205,7 +205,7 @@
        (SELECT sum(total) AS count, day_start
         FROM
           (SELECT sumMerge(pageviews_count_state) AS total, toStartOfDay(period_bucket) AS day_start
-           FROM web_stats_daily AS e
+           FROM web_pre_aggregated_stats AS e
            WHERE and(greaterOrEquals(period_bucket, toStartOfInterval(assumeNotNull(toDateTime('2025-07-10 20:59:19')), toIntervalDay(1))), lessOrEquals(period_bucket, assumeNotNull(toDateTime('2025-07-17 23:59:59'))))
            GROUP BY day_start)
         GROUP BY day_start
@@ -218,7 +218,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state), utm_source AS u
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY u)
   '''
 # ---
@@ -226,7 +226,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state) AS total, toStartOfDay(period_bucket) AS day_start, utm_source AS u
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      WHERE ifNull(u, 'null')
      GROUP BY day_start, u)
   '''
@@ -235,7 +235,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_source, utm_campaign, entry_pathname, end_pathname)
   '''
 # ---
@@ -243,7 +243,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state) AS total, toStartOfDay(period_bucket) AS day_start
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY day_start)
   '''
 # ---
@@ -251,7 +251,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state) AS c, uniqMerge(persons_uniq_state) AS u
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_source
      HAVING greater(c, 100))
   '''
@@ -260,7 +260,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      LIMIT 10
      OFFSET 5)
   '''
@@ -271,7 +271,7 @@
     (SELECT *
      FROM
        (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-        FROM web_stats_daily))
+        FROM web_pre_aggregated_stats))
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_nested_select_queries
@@ -279,7 +279,7 @@
   sql
     (SELECT count() AS total,
        (SELECT sumMerge(pageviews_count_state)
-        FROM web_stats_daily) AS pageviews
+        FROM web_pre_aggregated_stats) AS pageviews
      FROM events
      WHERE equals(event, '$pageview'))
   '''
@@ -288,7 +288,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state) AS c, uniqMerge(persons_uniq_state) AS u
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_source
      ORDER BY c DESC)
   '''
@@ -297,14 +297,14 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(persons_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state), uniqMerge(sessions_uniq_state)
-     FROM web_stats_daily)
+     FROM web_pre_aggregated_stats)
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_preaggregation_tables_group_by_session_property
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY entry_pathname)
   '''
 # ---
@@ -312,7 +312,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      GROUP BY utm_source)
   '''
 # ---
@@ -320,14 +320,14 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily)
+     FROM web_pre_aggregated_stats)
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_simple_and_condition_transforms
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      WHERE equals(plus(1, 2), 3))
   '''
 # ---
@@ -335,7 +335,23 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
+     WHERE greaterOrEquals(period_bucket, '2024-11-24'))
+  '''
+# ---
+# name: TestPreaggregatedTableTransformation.test_start_of_hour_timestamp_with_condition
+  '''
+  sql
+    (SELECT sumMerge(pageviews_count_state)
+     FROM web_pre_aggregated_stats
+     WHERE greaterOrEquals(toStartOfHour(period_bucket), '2024-11-24'))
+  '''
+# ---
+# name: TestPreaggregatedTableTransformation.test_start_of_week_timestamp_with_condition
+  '''
+  sql
+    (SELECT sumMerge(pageviews_count_state)
+     FROM web_pre_aggregated_stats
      WHERE greaterOrEquals(period_bucket, '2024-11-24'))
   '''
 # ---
@@ -343,23 +359,31 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      WHERE lessOrEquals(period_bucket, assumeNotNull(toDateTime('2024-11-24 23:59:59'))))
   '''
 # ---
-# name: TestPreaggregatedTableTransformation.test_timestamp_string_condition
+# name: TestPreaggregatedTableTransformation.test_timestamp_string_day_condition
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      WHERE greaterOrEquals(period_bucket, '2024-11-24'))
+  '''
+# ---
+# name: TestPreaggregatedTableTransformation.test_timestamp_string_hour_condition
+  '''
+  sql
+    (SELECT sumMerge(pageviews_count_state)
+     FROM web_pre_aggregated_stats
+     WHERE greaterOrEquals(period_bucket, '2024-11-24T13:00:00'))
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_timestamp_with_start_of_day_condition
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      WHERE greaterOrEquals(period_bucket, toStartOfDay('2024-11-24')))
   '''
 # ---
@@ -367,7 +391,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      WHERE lessOrEquals(toStartOfDay('2024-11-24'), period_bucket))
   '''
 # ---
@@ -375,7 +399,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      WHERE greaterOrEquals(period_bucket, toStartOfInterval(assumeNotNull(toDateTime('2025-07-10 14:04:24')), toIntervalDay(1))))
   '''
 # ---
@@ -383,14 +407,14 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
-     FROM web_stats_daily AS e)
+     FROM web_pre_aggregated_stats AS e)
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_trends_line_inner_query
   '''
   sql
     (SELECT sumMerge(pageviews_count_state) AS total, toStartOfDay(period_bucket) AS day_start
-     FROM web_stats_daily AS e
+     FROM web_pre_aggregated_stats AS e
      WHERE and(greaterOrEquals(period_bucket, toStartOfInterval(assumeNotNull(toDateTime('2025-07-10 14:04:24')), toIntervalDay(1))), lessOrEquals(period_bucket, assumeNotNull(toDateTime('2025-07-17 23:59:59'))))
      GROUP BY day_start)
   '''
@@ -399,7 +423,7 @@
   '''
   sql
     (SELECT sumMerge(pageviews_count_state) AS total
-     FROM web_stats_daily AS e
+     FROM web_pre_aggregated_stats AS e
      WHERE and(equals(team_id, 99999), greaterOrEquals(period_bucket, toStartOfInterval(assumeNotNull(toDateTime('2025-07-11 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(period_bucket, assumeNotNull(toDateTime('2025-07-18 23:59:59', 'UTC'))))
      ORDER BY 1 DESC)
   '''
@@ -408,24 +432,24 @@
   '''
   sql
     (SELECT tuple(uniqMerge(persons_uniq_state), sumMerge(pageviews_count_state), uniqMerge(sessions_uniq_state)) AS daily_metrics
-     FROM web_stats_daily)
+     FROM web_pre_aggregated_stats)
   '''
 # ---
 # name: TestPreaggregatedTableTransformation.test_union_queries
   '''
   sql
     (SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily
+     FROM web_pre_aggregated_stats
      UNION ALL SELECT sumMerge(pageviews_count_state)
-     FROM web_stats_daily)
+     FROM web_pre_aggregated_stats)
   '''
 # ---
 # name: TestPreaggregatedTableTransformationIntegration.test_basic_hogql_query
   '''
-  SELECT sumMerge(web_stats_daily.pageviews_count_state) AS `sumMerge(pageviews_count_state)`,
-         uniqMerge(web_stats_daily.persons_uniq_state) AS `uniqMerge(persons_uniq_state)`
-  FROM web_stats_daily
-  WHERE equals(web_stats_daily.team_id, 99999)
+  SELECT sumMerge(web_pre_aggregated_stats.pageviews_count_state) AS `sumMerge(pageviews_count_state)`,
+         uniqMerge(web_pre_aggregated_stats.persons_uniq_state) AS `uniqMerge(persons_uniq_state)`
+  FROM web_pre_aggregated_stats
+  WHERE equals(web_pre_aggregated_stats.team_id, 99999)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -440,16 +464,16 @@
 # ---
 # name: TestPreaggregatedTableTransformationIntegration.test_complex_hogql_select
   '''
-  SELECT sumMerge(web_stats_daily.pageviews_count_state) AS c,
-         uniqMerge(web_stats_daily.persons_uniq_state) AS p,
-         uniqMerge(web_stats_daily.sessions_uniq_state) AS s,
-         toStartOfDay(toTimeZone(web_stats_daily.period_bucket, 'UTC')) AS t,
-         web_stats_daily.utm_source AS u
-  FROM web_stats_daily
-  WHERE and(equals(web_stats_daily.team_id, 99999), ifNull(equals(web_stats_daily.utm_campaign, ''), 0))
+  SELECT sumMerge(web_pre_aggregated_stats.pageviews_count_state) AS c,
+         uniqMerge(web_pre_aggregated_stats.persons_uniq_state) AS p,
+         uniqMerge(web_pre_aggregated_stats.sessions_uniq_state) AS s,
+         toStartOfDay(toTimeZone(web_pre_aggregated_stats.period_bucket, 'UTC')) AS t,
+         web_pre_aggregated_stats.utm_source AS u
+  FROM web_pre_aggregated_stats
+  WHERE and(equals(web_pre_aggregated_stats.team_id, 99999), ifNull(equals(web_pre_aggregated_stats.utm_campaign, ''), 0))
   GROUP BY t,
            u,
-           web_stats_daily.utm_medium
+           web_pre_aggregated_stats.utm_medium
   HAVING and(ifNull(greater(c, 0), 0), ifNull(equals(u, ''), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -467,7 +491,7 @@
   '''
   SELECT sumMerge(e.pageviews_count_state) AS total,
          toStartOfDay(toTimeZone(e.period_bucket, 'UTC')) AS day_start
-  FROM web_stats_daily AS e
+  FROM web_pre_aggregated_stats AS e
   WHERE and(equals(e.team_id, 99999), ifNull(greaterOrEquals(toTimeZone(e.period_bucket, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2024-11-22 00:00:00', 'UTC')), toIntervalDay(1))), 0), ifNull(lessOrEquals(toTimeZone(e.period_bucket, 'UTC'), assumeNotNull(toDateTime('2024-11-26 23:59:59', 'UTC'))), 0))
   GROUP BY day_start
   LIMIT 100 SETTINGS readonly=2,
@@ -493,7 +517,7 @@
      FROM
        (SELECT uniqMerge(e.persons_uniq_state) AS total,
                toStartOfDay(toTimeZone(e.period_bucket, 'UTC')) AS day_start
-        FROM web_stats_daily AS e
+        FROM web_pre_aggregated_stats AS e
         WHERE and(equals(e.team_id, 99999), ifNull(greaterOrEquals(toTimeZone(e.period_bucket, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2024-11-22 00:00:00', 'UTC')), toIntervalDay(1))), 0), ifNull(lessOrEquals(toTimeZone(e.period_bucket, 'UTC'), assumeNotNull(toDateTime('2024-11-26 23:59:59', 'UTC'))), 0))
         GROUP BY day_start)
      GROUP BY day_start
@@ -522,7 +546,7 @@
      FROM
        (SELECT sumMerge(e.pageviews_count_state) AS total,
                toStartOfDay(toTimeZone(e.period_bucket, 'UTC')) AS day_start
-        FROM web_stats_daily AS e
+        FROM web_pre_aggregated_stats AS e
         WHERE and(equals(e.team_id, 99999), ifNull(greaterOrEquals(toTimeZone(e.period_bucket, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2024-11-22 00:00:00', 'UTC')), toIntervalDay(1))), 0), ifNull(lessOrEquals(toTimeZone(e.period_bucket, 'UTC'), assumeNotNull(toDateTime('2024-11-26 23:59:59', 'UTC'))), 0))
         GROUP BY day_start)
      GROUP BY day_start

--- a/posthog/hogql/transforms/test/__snapshots__/test_preaggregated_table_transformation.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_preaggregated_table_transformation.ambr
@@ -173,6 +173,13 @@
      FROM web_pre_aggregated_stats)
   '''
 # ---
+# name: TestPreaggregatedTableTransformation.test_enable_for_integer_team_timezones
+  '''
+  sql
+    (SELECT sumMerge(pageviews_count_state), uniqMerge(persons_uniq_state)
+     FROM web_pre_aggregated_stats)
+  '''
+# ---
 # name: TestPreaggregatedTableTransformation.test_equals_function
   '''
   sql

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -313,13 +313,13 @@ class Command(BaseCommand):
             (end_date - dt.timedelta(days=backfill_days - i)).strftime("%Y-%m-%d") for i in range(backfill_days + 1)
         ]
 
-        daily_asset_names = ["web_analytics_stats_table_daily", "web_analytics_bounces_daily"]
+        asset_names = ["web_pre_aggregated_stats", "web_pre_aggregated_bounces"]
         result = client._execute(
             self.backfill_mutation_gql(),
             {
                 "backfillParams": {
                     "tags": [{"key": "generate_demo_data", "value": "true"}],
-                    "assetSelection": [{"path": [asset_name]} for asset_name in daily_asset_names],
+                    "assetSelection": [{"path": [asset_name]} for asset_name in asset_names],
                     "partitionNames": partition_list,
                     "fromFailure": False,
                 }


### PR DESCRIPTION
## Problem

The ast-to-ast preaggregation uses the daily tables, meaning that non-UTC queries may yield incorrect results, as the time bucket may not line up the date breakdowns

## Changes

Switch to using the hourly tables, so that we can get correct results for any team with a time zone of an integer number of hours. Disable the transformation for non-integer time zones.

## How did you test this code?

Updated the existing tests and added a couple of new ones for timezone logic

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
