### PR TITLE
fix(experiments): initialize ordering in updateExperiment too

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1377,10 +1377,10 @@ export const experimentLogic = kea<experimentLogicType>([
                             }
                         }
 
-                        initializeMetricOrdering(response)
+                        const responseWithMetricsOrdering = initializeMetricOrdering(response)
 
-                        actions.setUnmodifiedExperiment(structuredClone(response))
-                        return response
+                        actions.setUnmodifiedExperiment(structuredClone(responseWithMetricsOrdering))
+                        return responseWithMetricsOrdering
                     } catch (error: any) {
                         if (error.status === 404) {
                             actions.setExperimentMissing()
@@ -1396,10 +1396,10 @@ export const experimentLogic = kea<experimentLogicType>([
                     `api/projects/${values.currentProjectId}/experiments/${values.experimentId}`,
                     update
                 )
-                initializeMetricOrdering(response)
+                const responseWithMetricsOrdering = initializeMetricOrdering(response)
                 refreshTreeItem('experiment', String(values.experimentId))
-                actions.setUnmodifiedExperiment(structuredClone(response))
-                return response
+                actions.setUnmodifiedExperiment(structuredClone(responseWithMetricsOrdering))
+                return responseWithMetricsOrdering
             },
         },
         exposureCohort: [

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -89,6 +89,7 @@ import { addExposureToMetric, compose, getInsight, getQuery } from './metricQuer
 import { modalsLogic } from './modalsLogic'
 import {
     featureFlagEligibleForExperiment,
+    initializeMetricOrdering,
     isLegacyExperiment,
     percentageDistribution,
     transformFiltersForWinningVariant,
@@ -1376,31 +1377,7 @@ export const experimentLogic = kea<experimentLogicType>([
                             }
                         }
 
-                        // Initialize primary_metrics_ordered_uuids if it's null
-                        if (response.primary_metrics_ordered_uuids === null) {
-                            const primaryMetrics = response.metrics || []
-                            const sharedPrimaryMetrics = (response.saved_metrics || []).filter(
-                                (sharedMetric: any) => sharedMetric.metadata.type === 'primary'
-                            )
-
-                            const allMetrics = [...primaryMetrics, ...sharedPrimaryMetrics]
-                            response.primary_metrics_ordered_uuids = allMetrics
-                                .map((metric: any) => metric.uuid || metric.query?.uuid)
-                                .filter(Boolean)
-                        }
-
-                        // Initialize secondary_metrics_ordered_uuids if it's null
-                        if (response.secondary_metrics_ordered_uuids === null) {
-                            const secondaryMetrics = response.metrics_secondary || []
-                            const sharedSecondaryMetrics = (response.saved_metrics || []).filter(
-                                (sharedMetric: any) => sharedMetric.metadata.type === 'secondary'
-                            )
-
-                            const allMetrics = [...secondaryMetrics, ...sharedSecondaryMetrics]
-                            response.secondary_metrics_ordered_uuids = allMetrics
-                                .map((metric: any) => metric.uuid || metric.query?.uuid)
-                                .filter(Boolean)
-                        }
+                        initializeMetricOrdering(response)
 
                         actions.setUnmodifiedExperiment(structuredClone(response))
                         return response
@@ -1419,6 +1396,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     `api/projects/${values.currentProjectId}/experiments/${values.experimentId}`,
                     update
                 )
+                initializeMetricOrdering(response)
                 refreshTreeItem('experiment', String(values.experimentId))
                 actions.setUnmodifiedExperiment(structuredClone(response))
                 return response

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -771,3 +771,34 @@ export function insertMetricIntoOrderingArray(
     newArray.splice(afterIndex + 1, 0, newUuid)
     return newArray
 }
+
+/**
+ * Initialize ordering arrays for metrics if they're null
+ */
+export function initializeMetricOrdering(experiment: Experiment): void {
+    // Initialize primary_metrics_ordered_uuids if it's null
+    if (experiment.primary_metrics_ordered_uuids === null) {
+        const primaryMetrics = experiment.metrics || []
+        const sharedPrimaryMetrics = (experiment.saved_metrics || []).filter(
+            (sharedMetric: any) => sharedMetric.metadata.type === 'primary'
+        )
+
+        const allMetrics = [...primaryMetrics, ...sharedPrimaryMetrics]
+        experiment.primary_metrics_ordered_uuids = allMetrics
+            .map((metric: any) => metric.uuid || metric.query?.uuid)
+            .filter(Boolean)
+    }
+
+    // Initialize secondary_metrics_ordered_uuids if it's null
+    if (experiment.secondary_metrics_ordered_uuids === null) {
+        const secondaryMetrics = experiment.metrics_secondary || []
+        const sharedSecondaryMetrics = (experiment.saved_metrics || []).filter(
+            (sharedMetric: any) => sharedMetric.metadata.type === 'secondary'
+        )
+
+        const allMetrics = [...secondaryMetrics, ...sharedSecondaryMetrics]
+        experiment.secondary_metrics_ordered_uuids = allMetrics
+            .map((metric: any) => metric.uuid || metric.query?.uuid)
+            .filter(Boolean)
+    }
+}

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -774,31 +774,36 @@ export function insertMetricIntoOrderingArray(
 
 /**
  * Initialize ordering arrays for metrics if they're null
+ * Returns a new experiment object with initialized ordering arrays
  */
-export function initializeMetricOrdering(experiment: Experiment): void {
+export function initializeMetricOrdering(experiment: Experiment): Experiment {
+    const newExperiment = { ...experiment }
+
     // Initialize primary_metrics_ordered_uuids if it's null
-    if (experiment.primary_metrics_ordered_uuids === null) {
-        const primaryMetrics = experiment.metrics || []
-        const sharedPrimaryMetrics = (experiment.saved_metrics || []).filter(
+    if (newExperiment.primary_metrics_ordered_uuids === null) {
+        const primaryMetrics = newExperiment.metrics || []
+        const sharedPrimaryMetrics = (newExperiment.saved_metrics || []).filter(
             (sharedMetric: any) => sharedMetric.metadata.type === 'primary'
         )
 
         const allMetrics = [...primaryMetrics, ...sharedPrimaryMetrics]
-        experiment.primary_metrics_ordered_uuids = allMetrics
+        newExperiment.primary_metrics_ordered_uuids = allMetrics
             .map((metric: any) => metric.uuid || metric.query?.uuid)
             .filter(Boolean)
     }
 
     // Initialize secondary_metrics_ordered_uuids if it's null
-    if (experiment.secondary_metrics_ordered_uuids === null) {
-        const secondaryMetrics = experiment.metrics_secondary || []
-        const sharedSecondaryMetrics = (experiment.saved_metrics || []).filter(
+    if (newExperiment.secondary_metrics_ordered_uuids === null) {
+        const secondaryMetrics = newExperiment.metrics_secondary || []
+        const sharedSecondaryMetrics = (newExperiment.saved_metrics || []).filter(
             (sharedMetric: any) => sharedMetric.metadata.type === 'secondary'
         )
 
         const allMetrics = [...secondaryMetrics, ...sharedSecondaryMetrics]
-        experiment.secondary_metrics_ordered_uuids = allMetrics
+        newExperiment.secondary_metrics_ordered_uuids = allMetrics
             .map((metric: any) => metric.uuid || metric.query?.uuid)
             .filter(Boolean)
     }
+
+    return newExperiment
 }


### PR DESCRIPTION
## Problem
When changing the status of the experiment, the experiment reloads, after which all metrics disappear.

Currently, when ordering arrays are null (any experiments created before the feature was shipped), the ordering is initialized in `loadExperiment`.
However, we also have the `updateExperiment loader`, which reloads the experiment too. It needs to have the same initialization logic.

## Changes
Add initialization logic to `updateExperiment`.

## How did you test this code?
Tested locally that metrics load correctly on status changes.