### PR TITLE
chore: add write scopes for experiment + survey to mcp server

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -108,7 +108,9 @@ export const API_KEY_SCOPE_PRESETS: {
         value: 'mcp_server',
         label: 'MCP Server',
         scopes: API_SCOPES.map(({ key }) =>
-            ['feature_flag', 'insight', 'dashboard'].includes(key) ? `${key}:write` : `${key}:read`
+            ['feature_flag', 'insight', 'dashboard', 'survey', 'experiment'].includes(key)
+                ? `${key}:write`
+                : `${key}:read`
         ),
         access_type: 'all',
     },


### PR DESCRIPTION
## Problem

We're adding more products to the MCP - so API keys will need more scopes.

## Changes

Add write scopes for surveys and experiments