### PR TITLE
fix: prevent shared dashboards from refreshing fresh insights

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1257,6 +1257,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 if (props.dashboard) {
                     // If we already have dashboard data, use it. Should the data turn out to be stale,
                     // the loadDashboardSuccess listener will initiate a refresh
+                    // Ensure loading state is properly initialized for shared dashboards
+                    actions.loadingDashboardItemsStarted(DashboardLoadAction.InitialLoad)
                     actions.loadDashboardSuccess(props.dashboard)
                 } else {
                     if (!(SEARCH_PARAM_QUERY_VARIABLES_KEY in router.values.searchParams)) {


### PR DESCRIPTION
## Problem
Shared dashboards fire off calls to refresh all their insights even if the data is fresh

## Changes
We need to call "loadingDashboardItemsStarted" in the workaround for shared dashboards as well as "loadDashboardSuccess" to the initial_load state gets properly initialized.

## How did you test this code?
Loading the dashboard locally both shared and unshared. Looked at requests.