### PR TITLE
fix(err): fix notebook editor width css

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -7,7 +7,7 @@
     .NotebookEditor {
         position: relative;
         flex: 1;
-        width: 100%;
+        min-width: 0; // So trends and other insight elements resize properly
         margin: 0 auto;
 
         .ProseMirror {


### PR DESCRIPTION
Fixes https://posthoghelp.zendesk.com/agent/tickets/37264 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38700)

Before:
<img width="1706" height="798" alt="image" src="https://github.com/user-attachments/assets/8f9f81ce-2ae3-4461-827a-4adfcd917981" />


After:
<img width="1722" height="848" alt="image" src="https://github.com/user-attachments/assets/8ff60db4-6b85-48b8-8521-ebd19a34042a" />
