### PR TITLE
fix(ux): hide scene header for existing sql editor scene

### DIFF
--- a/frontend/src/layout/scenes/SceneHeader.tsx
+++ b/frontend/src/layout/scenes/SceneHeader.tsx
@@ -11,6 +11,7 @@ import { Link } from 'lib/lemon-ui/Link'
 import { IconMenu, IconSlash } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { cn } from 'lib/utils/css-classes'
+import { SceneConfig } from 'scenes/sceneTypes'
 import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
@@ -26,7 +27,12 @@ import { ProjectDropdownMenu } from '../panel-layout/ProjectDropdownMenu'
 import { SceneTabs } from './SceneTabs'
 import { sceneLayoutLogic } from './sceneLayoutLogic'
 
-export function SceneHeader({ className }: { className?: string }): JSX.Element | null {
+export interface SceneHeaderProps {
+    className?: string
+    layout?: SceneConfig['layout']
+}
+
+export function SceneHeader({ className, layout }: SceneHeaderProps): JSX.Element | null {
     const { mobileLayout } = useValues(navigationLogic)
     const { breadcrumbs } = useValues(breadcrumbsLogic)
     const { setActionsContainer } = useActions(breadcrumbsLogic)
@@ -44,120 +50,126 @@ export function SceneHeader({ className }: { className?: string }): JSX.Element 
     const { currentTeam } = useValues(teamLogic)
     const effectiveBreadcrumbs = useSceneTabs ? breadcrumbs.slice(1) : breadcrumbs
     const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
+    const useSceneHeader = layout !== 'app-raw-no-header' && layout !== 'app-raw'
     return effectiveBreadcrumbs.length || projectTreeRefEntry ? (
         <>
             <div className="flex flex-col items-center z-[var(--z-top-navigation)]">
                 {useSceneTabs ? <SceneTabs /> : null}
-                <div
-                    className={cn(
-                        'flex items-center gap-1 w-full py-1 px-4 h-[var(--scene-layout-header-height)]',
-                        className
-                    )}
-                >
-                    {mobileLayout && (
-                        <LemonButton
-                            size="small"
-                            onClick={() => showLayoutNavBar(!isLayoutNavbarVisibleForMobile)}
-                            icon={isLayoutNavbarVisibleForMobile ? <IconX /> : <IconMenu />}
-                            className="-ml-2"
-                        />
-                    )}
-                    <div className="flex gap-1 justify-between w-full items-center overflow-hidden">
-                        <ScrollableShadows
-                            direction="horizontal"
-                            styledScrollbars
-                            className="h-[var(--scene-layout-header-height)] pr-2 flex-1"
-                            innerClassName="flex gap-0 flex-1 items-center overflow-x-auto show-scrollbar-on-hover h-full"
-                        >
-                            {!newSceneLayout && effectiveBreadcrumbs.length > 0 ? (
-                                <>
-                                    {effectiveBreadcrumbs.map((breadcrumb, index) => (
-                                        <React.Fragment key={joinBreadcrumbKey(breadcrumb.key)}>
-                                            <Breadcrumb
-                                                breadcrumb={breadcrumb}
-                                                here={index === effectiveBreadcrumbs.length - 1}
-                                            />
-                                            {index < effectiveBreadcrumbs.length - 1 && (
+                {useSceneHeader ? (
+                    <div
+                        className={cn(
+                            'flex items-center gap-1 w-full py-1 px-4 h-[var(--scene-layout-header-height)]',
+                            className
+                        )}
+                    >
+                        {mobileLayout && (
+                            <LemonButton
+                                size="small"
+                                onClick={() => showLayoutNavBar(!isLayoutNavbarVisibleForMobile)}
+                                icon={isLayoutNavbarVisibleForMobile ? <IconX /> : <IconMenu />}
+                                className="-ml-2"
+                            />
+                        )}
+                        <div className="flex gap-1 justify-between w-full items-center overflow-hidden">
+                            <ScrollableShadows
+                                direction="horizontal"
+                                styledScrollbars
+                                className="h-[var(--scene-layout-header-height)] pr-2 flex-1"
+                                innerClassName="flex gap-0 flex-1 items-center overflow-x-auto show-scrollbar-on-hover h-full"
+                            >
+                                {!newSceneLayout && effectiveBreadcrumbs.length > 0 ? (
+                                    <>
+                                        {effectiveBreadcrumbs.map((breadcrumb, index) => (
+                                            <React.Fragment key={joinBreadcrumbKey(breadcrumb.key)}>
+                                                <Breadcrumb
+                                                    breadcrumb={breadcrumb}
+                                                    here={index === effectiveBreadcrumbs.length - 1}
+                                                />
+                                                {index < effectiveBreadcrumbs.length - 1 && (
+                                                    <span className="flex items-center shrink-0 opacity-50">
+                                                        <IconSlash fontSize="1rem" />
+                                                    </span>
+                                                )}
+                                            </React.Fragment>
+                                        ))}
+                                    </>
+                                ) : (
+                                    <>
+                                        {isAuthenticatedTeam(currentTeam) && (
+                                            <>
+                                                <ProjectDropdownMenu
+                                                    buttonProps={{
+                                                        size: 'xxs',
+                                                        className:
+                                                            'text-primary font-normal p-0 hover:text-primary gap-1',
+                                                    }}
+                                                />
                                                 <span className="flex items-center shrink-0 opacity-50">
                                                     <IconSlash fontSize="1rem" />
                                                 </span>
-                                            )}
-                                        </React.Fragment>
-                                    ))}
-                                </>
-                            ) : (
-                                <>
-                                    {isAuthenticatedTeam(currentTeam) && (
-                                        <>
-                                            <ProjectDropdownMenu
-                                                buttonProps={{
-                                                    size: 'xxs',
-                                                    className: 'text-primary font-normal p-0 hover:text-primary gap-1',
-                                                }}
-                                            />
-                                            <span className="flex items-center shrink-0 opacity-50">
-                                                <IconSlash fontSize="1rem" />
-                                            </span>
-                                        </>
-                                    )}
-                                    {effectiveBreadcrumbs.length > 0 && (
-                                        <>
-                                            {effectiveBreadcrumbs.map((breadcrumb, index) => {
-                                                const isLast = index === effectiveBreadcrumbs.length - 1
-                                                const isOnlyBreadcrumb = effectiveBreadcrumbs.length === 1
-                                                const shouldShowBreadcrumb = !isLast && !isOnlyBreadcrumb
+                                            </>
+                                        )}
+                                        {effectiveBreadcrumbs.length > 0 && (
+                                            <>
+                                                {effectiveBreadcrumbs.map((breadcrumb, index) => {
+                                                    const isLast = index === effectiveBreadcrumbs.length - 1
+                                                    const isOnlyBreadcrumb = effectiveBreadcrumbs.length === 1
+                                                    const shouldShowBreadcrumb = !isLast && !isOnlyBreadcrumb
 
-                                                return (
-                                                    <React.Fragment key={joinBreadcrumbKey(breadcrumb.key)}>
-                                                        {shouldShowBreadcrumb && (
-                                                            <Breadcrumb breadcrumb={breadcrumb} here={isLast} />
-                                                        )}
-                                                        {index < effectiveBreadcrumbs.length - 1 && (
-                                                            <span className="flex items-center shrink-0 opacity-50">
-                                                                <IconSlash fontSize="1rem" />
-                                                            </span>
-                                                        )}
-                                                    </React.Fragment>
-                                                )
-                                            })}
-                                        </>
-                                    )}
-                                </>
-                            )}
-                        </ScrollableShadows>
+                                                    return (
+                                                        <React.Fragment key={joinBreadcrumbKey(breadcrumb.key)}>
+                                                            {shouldShowBreadcrumb && (
+                                                                <Breadcrumb breadcrumb={breadcrumb} here={isLast} />
+                                                            )}
+                                                            {index < effectiveBreadcrumbs.length - 1 && (
+                                                                <span className="flex items-center shrink-0 opacity-50">
+                                                                    <IconSlash fontSize="1rem" />
+                                                                </span>
+                                                            )}
+                                                        </React.Fragment>
+                                                    )
+                                                })}
+                                            </>
+                                        )}
+                                    </>
+                                )}
+                            </ScrollableShadows>
 
-                        <div className="flex gap-1 items-center shrink-0 pr-px">
-                            <div className="contents" ref={setActionsContainer} />
+                            <div className="flex gap-1 items-center shrink-0 pr-px">
+                                <div className="contents" ref={setActionsContainer} />
 
-                            {scenePanelIsPresent && (
-                                <LemonButton
-                                    onClick={() =>
-                                        scenePanelIsRelative
-                                            ? setForceScenePanelClosedWhenRelative(!forceScenePanelClosedWhenRelative)
-                                            : setScenePanelOpen(!scenePanelOpen)
-                                    }
-                                    icon={<IconEllipsis className="text-primary" />}
-                                    tooltip={
-                                        !scenePanelOpen
-                                            ? 'Open Info & actions panel'
-                                            : scenePanelIsRelative
-                                              ? 'Force close Info & actions panel'
-                                              : 'Close Info & actions panel'
-                                    }
-                                    aria-label={
-                                        !scenePanelOpen
-                                            ? 'Open Info & actions panel'
-                                            : scenePanelIsRelative
-                                              ? 'Force close Info & actions panel'
-                                              : 'Close Info & actions panel'
-                                    }
-                                    active={scenePanelOpen}
-                                    size="small"
-                                />
-                            )}
+                                {scenePanelIsPresent && (
+                                    <LemonButton
+                                        onClick={() =>
+                                            scenePanelIsRelative
+                                                ? setForceScenePanelClosedWhenRelative(
+                                                      !forceScenePanelClosedWhenRelative
+                                                  )
+                                                : setScenePanelOpen(!scenePanelOpen)
+                                        }
+                                        icon={<IconEllipsis className="text-primary" />}
+                                        tooltip={
+                                            !scenePanelOpen
+                                                ? 'Open Info & actions panel'
+                                                : scenePanelIsRelative
+                                                  ? 'Force close Info & actions panel'
+                                                  : 'Close Info & actions panel'
+                                        }
+                                        aria-label={
+                                            !scenePanelOpen
+                                                ? 'Open Info & actions panel'
+                                                : scenePanelIsRelative
+                                                  ? 'Force close Info & actions panel'
+                                                  : 'Close Info & actions panel'
+                                        }
+                                        active={scenePanelOpen}
+                                        size="small"
+                                    />
+                                )}
+                            </div>
                         </div>
                     </div>
-                </div>
+                ) : null}
             </div>
         </>
     ) : null

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -90,7 +90,6 @@ export function ScenePanelLabel({ children, title, ...props }: PropsWithChildren
         </div>
     )
 }
-8
 
 export function SceneLayout({ children, className, layoutConfig }: SceneLayoutProps): JSX.Element {
     const {
@@ -146,9 +145,7 @@ export function SceneLayout({ children, className, layoutConfig }: SceneLayoutPr
                         }
                     )}
                 >
-                    {layoutConfig?.layout !== 'app-raw-no-header' && (
-                        <SceneHeader className="row-span-1 col-span-1 min-w-0" />
-                    )}
+                    <SceneHeader layout={layoutConfig?.layout} className="row-span-1 col-span-1 min-w-0" />
                     <ScrollableShadows
                         direction="vertical"
                         className={cn(

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -16,8 +16,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
-import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
-import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind } from '~/queries/schema/schema-general'
 
@@ -79,7 +77,6 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
     const { sidebarWidth } = useValues(editorSizingLogic)
     const { resetDefaultSidebarWidth } = useActions(editorSizingLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
 
     const [editingViewDisabledReason, EditingViewButtonIcon] = useMemo(() => {
         if (updatingDataWarehouseSavedQuery) {
@@ -129,19 +126,6 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
 
     return (
         <div className="flex flex-1 flex-col h-full overflow-hidden">
-            {newSceneLayout && (
-                <div className="flex flex-col gap-2 pt-2 px-4">
-                    <SceneTitleSection
-                        name="SQL Editor"
-                        description={null}
-                        resourceType={{
-                            type: 'sql',
-                            typePlural: 'sql',
-                        }}
-                    />
-                    <SceneDivider />
-                </div>
-            )}
             <div className="flex flex-row overflow-x-auto">
                 {renderSidebarButton()}
                 <QueryTabs

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -8,7 +8,6 @@ import { IconBook, IconDownload, IconInfo, IconPlayFilled, IconSidebarClose } fr
 import { LemonDivider, Spinner } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { IconCancel } from 'lib/lemon-ui/icons'

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -390,13 +390,9 @@ export const sceneLogic = kea<sceneLogicType>([
         sceneId: [(s) => [s.activeTab], (activeTab) => activeTab?.sceneId],
         sceneKey: [(s) => [s.activeTab], (activeTab) => activeTab?.sceneKey],
         sceneConfig: [
-            (s) => [s.sceneId, s.featureFlags],
-            (sceneId: Scene, featureFlags): SceneConfig | null => {
-                const config = sceneConfigurations[sceneId] || null
-                if (sceneId === Scene.SQLEditor && featureFlags[FEATURE_FLAGS.SCENE_TABS]) {
-                    return { ...config, layout: 'app' }
-                }
-                return config
+            (s) => [s.sceneId],
+            (sceneId: Scene): SceneConfig | null => {
+                return sceneConfigurations[sceneId] || null
             },
         ],
         sceneParams: [


### PR DESCRIPTION
## Problem

The current SQL editor works better as a full screen scene. There's a lot of wasted space on top, and less space to see results as result.

<img width="824" height="355" alt="Screenshot 2025-09-04 at 23 02 07" src="https://github.com/user-attachments/assets/888dbfb7-6b32-44dd-ac14-9bb147cadc8b" />

## Changes

Let's keep the scene as is.

<img width="1047" height="366" alt="image" src="https://github.com/user-attachments/assets/bb303950-7cbc-4e58-ab5c-2a84b2bbb433" />

We'll revisit the header question tomorrow when I'll try doing this.

<img width="533" height="313" alt="Screenshot 2025-09-04 at 23 17 28" src="https://github.com/user-attachments/assets/6801270f-403c-4932-b205-386dd829d43c" />

## How did you test this code?

👀 
