### PR TITLE
fix(ux): hide url from tab, add share button

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -3,7 +3,7 @@ import { SortableContext, horizontalListSortingStrategy, useSortable } from '@dn
 import { CSS } from '@dnd-kit/utilities'
 import { useActions, useValues } from 'kea'
 
-import { IconCopy, IconPlus, IconSearch, IconX } from '@posthog/icons'
+import { IconPlus, IconSearch, IconShare, IconX } from '@posthog/icons'
 
 import { commandBarLogic } from 'lib/components/CommandBar/commandBarLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
@@ -133,37 +133,29 @@ function SortableSceneTab({ tab }: { tab: SceneTab }): JSX.Element {
                     </SceneTabContextMenu>
                 </HoverCardTrigger>
                 <HoverCardContent
-                    className="break-all"
+                    className="break-words"
                     onPointerDown={(e) => e.stopPropagation()}
                     onMouseDown={(e) => e.stopPropagation()}
                 >
-                    <div className="flex flex-col gap-1">
-                        <span className="text-primary text-sm font-semibold">{tab.title}</span>
-                        <span className="text-secondary text-xs flex items-center gap-1">
-                            <span>
-                                {window.location.origin}
-                                {tab.pathname}
-                            </span>
-                            <ButtonPrimitive
-                                iconOnly
-                                size="xs"
-                                tooltip="Copy tab URL with pathname, search, and hash"
-                                className="text-primary"
-                                onClick={() => {
-                                    try {
-                                        navigator.clipboard.writeText(
-                                            `${window.location.origin}${tab.pathname}${tab.search}${tab.hash}`
-                                        )
-                                        lemonToast.success('URL copied to clipboard')
-                                    } catch (error) {
-                                        lemonToast.error(`Failed to copy URL to clipboard ${error}`)
-                                    }
-                                }}
-                            >
-                                <IconCopy />
-                            </ButtonPrimitive>
-                        </span>
-                    </div>
+                    <ButtonPrimitive
+                        iconOnly
+                        size="xs"
+                        tooltip="Copy tab URL for sharing"
+                        className="text-primary float-right"
+                        onClick={() => {
+                            try {
+                                navigator.clipboard.writeText(
+                                    `${window.location.origin}${tab.pathname}${tab.search}${tab.hash}`
+                                )
+                                lemonToast.success('URL copied to clipboard')
+                            } catch (error) {
+                                lemonToast.error(`Failed to copy URL to clipboard ${error}`)
+                            }
+                        }}
+                    >
+                        <IconShare />
+                    </ButtonPrimitive>
+                    <span className="text-primary text-sm font-semibold">{tab.title}</span>
                 </HoverCardContent>
             </HoverCard>
         </div>


### PR DESCRIPTION
## Problem

I think these big tooltips are beautiful, but there's an issue. The URL shown is not he URL we're copying:

<img width="788" height="343" alt="image" src="https://github.com/user-attachments/assets/0ecc7b7a-5d3d-43f1-a8e4-d051c4ecdfda" />

The real URL is way too long, yet I would still like to know what I'm copying (and as a technical person I know the difference of having or not having the hash makes, so it's misleading... making me stop and think). However I also don't think seeing the URL really matters.

## Changes

So let's remove the URL. I also swapped the copy button out with a share button at Raquel's earlier suggestion. I like the share button over the copy button myself because it kind of implies that you can share the entire tab, whereas the copy button is a bit ambiguous without the URL (am I copying the title? let's wait for the tooltip and find out!)

![2025-09-04 23 34 38](https://github.com/user-attachments/assets/86ab167c-bc69-4864-b3db-41a4a2a37639)

## How did you test this code?

See the gif above. Clicking the button does this:

![2025-09-04 23 35 05](https://github.com/user-attachments/assets/96aba8da-85d5-43cc-bbfa-a619206cf8d0)
