### PR TITLE
fix: don't query for the whole persons object in surveys

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1772,10 +1772,10 @@ describe('processResultsForSurveyQuestions', () => {
                 },
             ]
             const results = [
-                ['Yes', '', 'user1', '2024-01-15T10:00:00Z'], // User 1: picked Yes for question 0
-                ['No', '', 'user2', '2024-01-15T10:15:00Z'], // User 2: picked No for question 0
-                ['Yes', '', 'user3', '2024-01-15T10:30:00Z'], // User 3: picked Yes for question 0
-                ['Custom answer', '', 'user4', '2024-01-15T10:45:00Z'], // User 4: picked custom answer for question 0
+                ['Yes', null, null, null, null, null, null, null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked Yes for question 0
+                ['No', null, null, null, null, null, null, null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked No for question 0
+                ['Yes', null, null, null, null, null, null, null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked Yes for question 0
+                ['Custom answer', null, null, null, null, null, null, null, 'user4', '2024-01-15T10:45:00Z'], // User 4: picked custom answer for question 0
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1826,9 +1826,9 @@ describe('processResultsForSurveyQuestions', () => {
             ]
             // For multiple choice questions, the response at questionIndex is an array of selected choices
             const results: SurveyRawResults = [
-                [['A', 'B'], '', 'user1', '2024-01-15T10:00:00Z'], // User 1: picked A and B for question 0
-                [['A'], '', 'user2', '2024-01-15T10:15:00Z'], // User 2: picked A only for question 0
-                [['C', 'Custom'], '', 'user3', '2024-01-15T10:30:00Z'], // User 3: picked C and a custom answer for question 0
+                [['A', 'B'], null, null, null, null, null, null, null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked A and B for question 0
+                [['A'], null, null, null, null, null, null, null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked A only for question 0
+                [['C', 'Custom'], null, null, null, null, null, null, null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked C and a custom answer for question 0
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1884,9 +1884,9 @@ describe('processResultsForSurveyQuestions', () => {
                 },
             ]
             const results = [
-                ['Great product!', '{"name": "John"}', 'user123', '2024-01-15T10:30:00Z'], // User 1: response, person props, distinct_id, timestamp
-                ['Could be better', null, 'user456', '2024-01-15T11:45:00Z'], // User 2: response, no person props, distinct_id, timestamp
-                ['', null, 'user789', '2024-01-15T12:00:00Z'], // User 3: empty response (should be ignored)
+                ['Great product!', null, null, null, null, 'John', null, null, 'user123', '2024-01-15T10:30:00Z'], // User 1: response, person props (name: John), distinct_id, timestamp
+                ['Could be better', null, null, null, null, null, null, null, 'user456', '2024-01-15T11:45:00Z'], // User 2: response, no person props, distinct_id, timestamp
+                ['', null, null, null, null, null, null, null, 'user789', '2024-01-15T12:00:00Z'], // User 3: empty response (should be ignored)
             ] as Array<Array<string | string[]>>
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1899,7 +1899,15 @@ describe('processResultsForSurveyQuestions', () => {
             expect(openData.data[0]).toEqual({
                 distinctId: 'user123',
                 response: 'Great product!',
-                personProperties: { name: 'John' },
+                personProperties: {
+                    email: null,
+                    Email: null,
+                    name: 'John',
+                    Name: null,
+                    username: null,
+                    Username: null,
+                    UserName: null,
+                },
                 timestamp: '2024-01-15T10:30:00Z',
             })
             expect(openData.data[1]).toEqual({
@@ -1923,10 +1931,10 @@ describe('processResultsForSurveyQuestions', () => {
             ]
             // Multiple people picking the same choice - should store the LATEST person's data
             const results = [
-                ['Yes', '{"name": "Alice"}', 'user1', '2024-01-15T10:00:00Z'], // Alice picks Yes at 10:00
-                ['Yes', '{"name": "Bob"}', 'user2', '2024-01-15T11:00:00Z'], // Bob picks Yes at 11:00 (later)
-                ['Yes', '{"name": "Carol"}', 'user3', '2024-01-15T12:00:00Z'], // Carol picks Yes at 12:00 (latest)
-                ['No', '{"name": "Dave"}', 'user4', '2024-01-15T13:00:00Z'], // Dave picks No
+                ['Yes', null, null, null, null, 'Alice', null, null, 'user1', '2024-01-15T10:00:00Z'], // Alice picks Yes at 10:00
+                ['Yes', null, null, null, null, 'Bob', null, null, 'user2', '2024-01-15T11:00:00Z'], // Bob picks Yes at 11:00 (later)
+                ['Yes', null, null, null, null, 'Carol', null, null, 'user3', '2024-01-15T12:00:00Z'], // Carol picks Yes at 12:00 (latest)
+                ['No', null, null, null, null, 'Dave', null, null, 'user4', '2024-01-15T13:00:00Z'], // Dave picks No
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1942,7 +1950,15 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 3,
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: { name: 'Carol' },
+                personProperties: {
+                    email: null,
+                    Email: null,
+                    name: 'Carol',
+                    Name: null,
+                    username: null,
+                    Username: null,
+                    UserName: null,
+                },
                 timestamp: '2024-01-15T12:00:00Z',
             })
 
@@ -1952,7 +1968,15 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: true,
                 distinctId: 'user4',
-                personProperties: { name: 'Dave' },
+                personProperties: {
+                    email: null,
+                    Email: null,
+                    name: 'Dave',
+                    Name: null,
+                    username: null,
+                    Username: null,
+                    UserName: null,
+                },
                 timestamp: '2024-01-15T13:00:00Z',
             })
         })
@@ -1968,9 +1992,9 @@ describe('processResultsForSurveyQuestions', () => {
             ]
             // Multiple people picking the same choices - should store the LATEST person's data for each choice
             const results: SurveyRawResults = [
-                [['A', 'B'], '{"name": "Alice"}', 'user1', '2024-01-15T10:00:00Z'], // Alice picks A,B at 10:00
-                [['A'], '{"name": "Bob"}', 'user2', '2024-01-15T11:00:00Z'], // Bob picks A at 11:00 (later for A)
-                [['B', 'C'], '{"name": "Carol"}', 'user3', '2024-01-15T12:00:00Z'], // Carol picks B,C at 12:00 (later for B)
+                [['A', 'B'], null, null, null, null, 'Alice', null, null, 'user1', '2024-01-15T10:00:00Z'], // Alice picks A,B at 10:00
+                [['A'], null, null, null, null, 'Bob', null, null, 'user2', '2024-01-15T11:00:00Z'], // Bob picks A at 11:00 (later for A)
+                [['B', 'C'], null, null, null, null, 'Carol', null, null, 'user3', '2024-01-15T12:00:00Z'], // Carol picks B,C at 12:00 (later for B)
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1986,7 +2010,15 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 2, // Alice and Bob both picked A
                 isPredefined: true,
                 distinctId: 'user2',
-                personProperties: { name: 'Bob' },
+                personProperties: {
+                    email: null,
+                    Email: null,
+                    name: 'Bob',
+                    Name: null,
+                    username: null,
+                    Username: null,
+                    UserName: null,
+                },
                 timestamp: '2024-01-15T11:00:00Z',
             })
 
@@ -1996,7 +2028,15 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 2, // Alice and Carol both picked B
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: { name: 'Carol' },
+                personProperties: {
+                    email: null,
+                    Email: null,
+                    name: 'Carol',
+                    Name: null,
+                    username: null,
+                    Username: null,
+                    UserName: null,
+                },
                 timestamp: '2024-01-15T12:00:00Z',
             })
 
@@ -2006,7 +2046,15 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: { name: 'Carol' },
+                personProperties: {
+                    email: null,
+                    Email: null,
+                    name: 'Carol',
+                    Name: null,
+                    username: null,
+                    Username: null,
+                    UserName: null,
+                },
                 timestamp: '2024-01-15T12:00:00Z',
             })
         })
@@ -2021,9 +2069,9 @@ describe('processResultsForSurveyQuestions', () => {
                 },
             ]
             const results = [
-                ['Option', 'invalid json', 'user1', '2024-01-15T10:00:00Z'], // Invalid JSON
-                ['Option', '{"name": "Bob"}', 'user2', '2024-01-15T11:00:00Z'], // Valid JSON (latest)
-                ['Option', '', 'user3', '2024-01-15T12:00:00Z'], // Empty props (most recent)
+                ['Option', 'invalid', null, null, null, null, null, null, 'user1', '2024-01-15T10:00:00Z'], // Invalid data
+                ['Option', null, null, null, null, 'Bob', null, null, 'user2', '2024-01-15T11:00:00Z'], // Valid name "Bob"
+                ['Option', null, null, null, null, null, null, null, 'user3', '2024-01-15T12:00:00Z'], // Empty props (most recent)
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1900,13 +1900,7 @@ describe('processResultsForSurveyQuestions', () => {
                 distinctId: 'user123',
                 response: 'Great product!',
                 personProperties: {
-                    email: null,
-                    Email: null,
                     name: 'John',
-                    Name: null,
-                    username: null,
-                    Username: null,
-                    UserName: null,
                 },
                 timestamp: '2024-01-15T10:30:00Z',
             })
@@ -1951,13 +1945,7 @@ describe('processResultsForSurveyQuestions', () => {
                 isPredefined: true,
                 distinctId: 'user3',
                 personProperties: {
-                    email: null,
-                    Email: null,
                     name: 'Carol',
-                    Name: null,
-                    username: null,
-                    Username: null,
-                    UserName: null,
                 },
                 timestamp: '2024-01-15T12:00:00Z',
             })
@@ -1969,13 +1957,7 @@ describe('processResultsForSurveyQuestions', () => {
                 isPredefined: true,
                 distinctId: 'user4',
                 personProperties: {
-                    email: null,
-                    Email: null,
                     name: 'Dave',
-                    Name: null,
-                    username: null,
-                    Username: null,
-                    UserName: null,
                 },
                 timestamp: '2024-01-15T13:00:00Z',
             })
@@ -2011,13 +1993,7 @@ describe('processResultsForSurveyQuestions', () => {
                 isPredefined: true,
                 distinctId: 'user2',
                 personProperties: {
-                    email: null,
-                    Email: null,
                     name: 'Bob',
-                    Name: null,
-                    username: null,
-                    Username: null,
-                    UserName: null,
                 },
                 timestamp: '2024-01-15T11:00:00Z',
             })
@@ -2029,13 +2005,7 @@ describe('processResultsForSurveyQuestions', () => {
                 isPredefined: true,
                 distinctId: 'user3',
                 personProperties: {
-                    email: null,
-                    Email: null,
                     name: 'Carol',
-                    Name: null,
-                    username: null,
-                    Username: null,
-                    UserName: null,
                 },
                 timestamp: '2024-01-15T12:00:00Z',
             })
@@ -2047,13 +2017,7 @@ describe('processResultsForSurveyQuestions', () => {
                 isPredefined: true,
                 distinctId: 'user3',
                 personProperties: {
-                    email: null,
-                    Email: null,
                     name: 'Carol',
-                    Name: null,
-                    username: null,
-                    Username: null,
-                    UserName: null,
                 },
                 timestamp: '2024-01-15T12:00:00Z',
             })

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -227,8 +227,8 @@ function extractPersonData(row: SurveyResponseRow): {
     let hasAnyProperties = false
     for (let i = 0; i < PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES.length; i++) {
         const value = row.at(-3 - i) as string
-        personProperties[PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES[i]] = value
         if (value && value !== null && value !== '') {
+            personProperties[PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES[i]] = value
             hasAnyProperties = true
         }
     }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -224,10 +224,15 @@ function extractPersonData(row: SurveyResponseRow): {
     // now, we're querying for all PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES, starting from the third last value, so build our person properties object
     // from those values. We use them to have a display name for the person
     const personProperties: Record<string, any> = {}
+    let hasAnyProperties = false
     for (let i = 0; i < PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES.length; i++) {
-        personProperties[PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES[i]] = row.at(-3 - i) as string
+        const value = row.at(-3 - i) as string
+        personProperties[PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES[i]] = value
+        if (value && value !== null && value !== '') {
+            hasAnyProperties = true
+        }
     }
-    return { distinctId, personProperties, timestamp }
+    return { distinctId, personProperties: hasAnyProperties ? personProperties : undefined, timestamp }
 }
 
 // Helper to count a choice and store person data for latest occurrence

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -7,7 +7,7 @@ import posthog from 'posthog-js'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
+import { FEATURE_FLAGS, PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
 import { allOperatorsMapping, debounce, hasFormErrors, isObject } from 'lib/utils'
@@ -221,17 +221,12 @@ function extractPersonData(row: SurveyResponseRow): {
 } {
     const distinctId = row.at(-2) as string
     const timestamp = row.at(-1) as string
-    const unparsedPersonProperties = row.at(-3)
-    let personProperties: Record<string, any> | undefined
-
-    if (unparsedPersonProperties && unparsedPersonProperties !== null) {
-        try {
-            personProperties = JSON.parse(unparsedPersonProperties as string)
-        } catch {
-            // Ignore parsing errors for person properties
-        }
+    // now, we're querying for all PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES, starting from the third last value, so build our person properties object
+    // from those values. We use them to have a display name for the person
+    const personProperties: Record<string, any> = {}
+    for (let i = 0; i < PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES.length; i++) {
+        personProperties[PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES[i]] = row.at(-3 - i) as string
     }
-
     return { distinctId, personProperties, timestamp }
 }
 
@@ -472,7 +467,16 @@ export const surveyLogic = kea<surveyLogicType>([
             teamLogic,
             ['addProductIntent'],
         ],
-        values: [enabledFlagLogic, ['featureFlags as enabledFlags'], surveysLogic, ['data'], userLogic, ['user']],
+        values: [
+            enabledFlagLogic,
+            ['featureFlags as enabledFlags'],
+            surveysLogic,
+            ['data'],
+            userLogic,
+            ['user'],
+            teamLogic,
+            ['currentTeam'],
+        ],
     })),
     actions({
         setSurveyMissing: true,
@@ -845,7 +849,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     -- QUERYING ALL SURVEY RESPONSES IN ONE GO
                     SELECT
                         ${questionFields.join(',\n')},
-                        person.properties,
+                        ${PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES.map((property) => `person.properties.${property}`).join(',\n')},
                         events.distinct_id,
                         events.timestamp
                     FROM events

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3158,7 +3158,7 @@ export interface ConsolidatedSurveyResults {
  *   ["7", ["Tutorials", "Other"], "Good but could improve", "user456"]
  * ]
  */
-export type SurveyResponseRow = Array<string | string[]>
+export type SurveyResponseRow = Array<null | string | string[]>
 export type SurveyRawResults = SurveyResponseRow[]
 
 export interface Survey {


### PR DESCRIPTION
## Problem

we currently query for the whole `person.properties` object in Surveys, but this is causing queries to timeout when there's a big volume of people in the project.

[ticket where I discovered the issue](https://posthoghelp.zendesk.com/agent/tickets/36687)

## Changes

this is only used for displaying the persons id/email/name/username in the response card, so it's not that crucial. So, now, I'm just querying for the default properties used for those names.

this makes the query much faster. I tested in prod, and the issue where the query runs out of memory no longer happens.

## How did you test this code?

tested locally