### PR TITLE
fix: only trigger Admin middleware for staff

### DIFF
--- a/ee/middleware.py
+++ b/ee/middleware.py
@@ -56,7 +56,7 @@ class AdminOAuth2Middleware:
         if request.path == "/admin/oauth2/callback":
             return self.get_response(request)
 
-        if not request.user.is_authenticated:
+        if not request.user.is_authenticated or not request.user.is_staff:
             return self.get_response(request)
 
         if not request.user.email:


### PR DESCRIPTION
## Problem

When impersonating a user, visiting Admin would redirect to a Google login page for the impersonated user.

## Changes

Only trigger the OAuth flow for staff. Non-staff users should hit the standard redirect back to a non-Admin page.

## How did you test this code?

Manually