### PR TITLE
fix: handle admin oauth flow when impersonating from web

### DIFF
--- a/ee/admin/oauth_views.py
+++ b/ee/admin/oauth_views.py
@@ -1,0 +1,34 @@
+from django.http import HttpRequest, HttpResponse, JsonResponse
+
+
+def admin_auth_check(request: HttpRequest) -> JsonResponse:
+    """
+    Returns 200 if verified, otherwise the middleware will redirect to OAuth2.
+    """
+    return JsonResponse({"authenticated": True})
+
+
+def admin_oauth_success(request: HttpRequest) -> HttpResponse:
+    nonce = getattr(request, "admin_csp_nonce", "")
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>Authentication Complete</title>
+    </head>
+    <body>
+        <h1>Authentication Successful</h1>
+        <p>This window will close automatically.</p>
+        <script nonce="{nonce}">
+            // Notify the parent window that authentication is complete
+            if (window.opener && !window.opener.closed) {{
+                window.opener.postMessage({{ type: 'oauth2_complete' }}, '*');
+            }}
+
+            window.close();
+        </script>
+    </body>
+    </html>
+    """
+    return HttpResponse(html)

--- a/ee/hogai/graph/session_summaries/test/__snapshots__/test_nodes.ambr
+++ b/ee/hogai/graph/session_summaries/test/__snapshots__/test_nodes.ambr
@@ -16,10 +16,10 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2025-09-03 11:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-24 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-24 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-09-03 23:59:59.000000', 6, 'UTC')))
   GROUP BY s.session_id
   HAVING ifNull(greater(active_seconds, 8.0), 0)
   ORDER BY start_time DESC
@@ -53,7 +53,7 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2025-09-03 11:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-27 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-31 23:59:59.000000', 6, 'UTC')))
@@ -90,7 +90,7 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2025-09-03 11:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-13 12:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-27 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2025-08-31 23:59:59.000000', 6, 'UTC')))
@@ -127,7 +127,7 @@
          sum(s.console_log_count) AS console_log_count,
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
-         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('today', 6, 'UTC')) AS ongoing,
+         greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
   FROM session_replay_events AS s
   WHERE and(equals(s.team_id, 99999), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), and(globalIn(s.session_id,

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -13,6 +13,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from posthog.utils import opt_slash_path
 from posthog.views import api_key_search_view, redis_values_view
 
+from ee.admin.oauth_views import admin_auth_check, admin_oauth_success
 from ee.api import integration
 from ee.api.mcp.http import mcp_view
 from ee.middleware import admin_oauth2_callback
@@ -127,6 +128,8 @@ if settings.ADMIN_PORTAL_ENABLED:
 
     admin_urlpatterns = [
         re_path(r"^admin/oauth2/callback$", admin_oauth2_callback, name="admin_oauth2_callback"),
+        re_path(r"^admin/oauth2/success$", admin_oauth_success, name="admin_oauth_success"),
+        re_path(r"^admin/auth_check$", admin_auth_check, name="admin_auth_check"),
         re_path(r"^admin/redisvalues$", redis_values_view, name="redis_values"),
         re_path(r"^admin/apikeysearch$", api_key_search_view, name="api_key_search"),
         path("admin/", include("loginas.urls")),

--- a/frontend/src/lib/components/NotFound/index.tsx
+++ b/frontend/src/lib/components/NotFound/index.tsx
@@ -141,27 +141,74 @@ export function LogInAsSuggestions({ suggestedUsers }: { suggestedUsers: UserBas
                     label: `${user.first_name} ${user.last_name} (${user.email})`,
                     tooltip: `Log in as ${user.first_name}`,
                     sideIcon: user.id === successfulUserId ? <IconCheckCircle /> : <IconArrowRight />,
-                    onClick: () => {
+                    onClick: async () => {
                         setIsLoginInProgress(true)
-                        fetch(`/admin/login/user/${user.id}/`, {
-                            method: 'POST',
-                            credentials: 'same-origin',
-                            mode: 'cors',
-                            headers: {
-                                'X-CSRFToken': getCookie('posthog_csrftoken') as string,
-                            },
-                        })
-                            .then((response) => {
-                                if (response.status !== 200) {
-                                    throw new Error(`django-loginas request resulted in status ${response.status}`)
-                                }
-                                setSuccessfulUserId(user.id)
-                                window.location.reload()
+
+                        try {
+                            // check if admin OAuth2 verification is needed
+                            const authCheckResponse = await fetch('/admin/auth_check', {
+                                method: 'GET',
+                                credentials: 'same-origin',
+                                redirect: 'manual',
                             })
-                            .catch(() => {
-                                lemonToast.error(`Failed to log in as ${user.first_name}`)
-                                setIsLoginInProgress(false) // Only set to false if we aren't about to reload the page
+
+                            if (!authCheckResponse.ok) {
+                                // Need OAuth2 verification - open a popup
+                                const width = 600
+                                const height = 700
+                                const left = window.screen.width / 2 - width / 2
+                                const top = window.screen.height / 2 - height / 2
+
+                                const authWindow = window.open(
+                                    '/admin/oauth2/success', // This will redirect to OAuth2
+                                    'admin_oauth2',
+                                    `width=${width},height=${height},top=${top},left=${left},toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes`
+                                )
+
+                                // Wait for the OAuth2 completion message
+                                await new Promise<void>((resolve) => {
+                                    const handleMessage = (event: MessageEvent): void => {
+                                        if (event.origin !== window.location.origin) {
+                                            return
+                                        }
+                                        if (event.data?.type === 'oauth2_complete') {
+                                            window.removeEventListener('message', handleMessage)
+                                            resolve()
+                                        }
+                                    }
+                                    window.addEventListener('message', handleMessage)
+
+                                    // Also poll to check if the window was closed manually
+                                    const checkClosed = setInterval(() => {
+                                        if (authWindow?.closed) {
+                                            clearInterval(checkClosed)
+                                            window.removeEventListener('message', handleMessage)
+                                            resolve()
+                                        }
+                                    }, 500)
+                                })
+                            }
+
+                            // Now proceed with the login-as request
+                            const loginResponse = await fetch(`/admin/login/user/${user.id}/`, {
+                                method: 'POST',
+                                credentials: 'same-origin',
+                                mode: 'cors',
+                                headers: {
+                                    'X-CSRFToken': getCookie('posthog_csrftoken') as string,
+                                },
                             })
+
+                            if (!loginResponse.ok) {
+                                throw new Error(`django-loginas request resulted in status ${loginResponse.status}`)
+                            }
+
+                            setSuccessfulUserId(user.id)
+                            window.location.reload()
+                        } catch {
+                            lemonToast.error(`Failed to log in as ${user.first_name}`)
+                            setIsLoginInProgress(false) // Only set to false if we aren't about to reload the page
+                        }
                     },
                 }))}
                 tooltipPlacement="right"


### PR DESCRIPTION
## Problem

Staff are unable to initiate impersonation from web when they don't already have a valid `ph_admin_verified` cookie. The POST to `/admin/login/user/${user.id}/` returns a 302 to Google that fetch doesn't properly handle.

Related: #37538
## Changes

This PR adds a pre-check before impersonating to see if the user is authenticated to Admin. If not, it initiates the Admin OAuth flow in a pop up and then kills the popup. This sets the `ph_admin_verified` cookie that's needed for the subequent POST to `/admin/login/user/${user.id}/`.

## How did you test this code?

Manually
