### PR TITLE
fix(ux): command bar 'all' to load progressively

### DIFF
--- a/frontend/src/lib/components/CommandBar/SearchResults.tsx
+++ b/frontend/src/lib/components/CommandBar/SearchResults.tsx
@@ -6,11 +6,12 @@ import { SearchResultPreview } from './SearchResultPreview'
 import { searchBarLogic } from './searchBarLogic'
 
 export const SearchResults = (): JSX.Element => {
-    const { combinedSearchResults, combinedSearchLoading, activeResultIndex } = useValues(searchBarLogic)
+    const { combinedSearchResults, combinedSearchLoading, anySearchLoading, activeResultIndex } =
+        useValues(searchBarLogic)
 
     return (
         <>
-            {!combinedSearchLoading && combinedSearchResults?.length === 0 ? (
+            {!combinedSearchLoading && !anySearchLoading && combinedSearchResults?.length === 0 ? (
                 <div className="w-full h-full flex flex-col items-center justify-center p-3 text-center">
                     <h3 className="mb-0 text-xl">No results</h3>
                     <p className="opacity-75 mb-0">This doesn't happen often, but we're stumped!</p>
@@ -19,22 +20,26 @@ export const SearchResults = (): JSX.Element => {
             ) : (
                 <div className="md:grid md:grid-cols-[320px_1fr] overflow-y-auto overflow-x-hidden">
                     <div className="border-r border-b md:border-b-0 bg-primary overscroll-contain overflow-y-auto overflow-x-hidden">
-                        {combinedSearchLoading && (
+                        {combinedSearchLoading && !combinedSearchResults?.length && (
                             <>
                                 <SearchResultSkeleton />
                                 <SearchResultSkeleton />
                                 <SearchResultSkeleton />
                             </>
                         )}
-                        {!combinedSearchLoading &&
-                            combinedSearchResults?.map((result, index) => (
-                                <SearchResult
-                                    key={`${result.type}_${result.result_id}`}
-                                    result={result}
-                                    resultIndex={index}
-                                    focused={index === activeResultIndex}
-                                />
-                            ))}
+                        {combinedSearchResults?.map((result, index) => (
+                            <SearchResult
+                                key={`${result.type}_${result.result_id}`}
+                                result={result}
+                                resultIndex={index}
+                                focused={index === activeResultIndex}
+                            />
+                        ))}
+                        {!combinedSearchLoading && anySearchLoading && (
+                            <div className="px-3 py-2 text-xs text-muted opacity-75 border-t">
+                                Loading more results...
+                            </div>
+                        )}
                     </div>
                     <div className="p-2 grow hidden md:block overflow-auto">
                         <SearchResultPreview />

--- a/frontend/src/lib/components/CommandBar/searchBarLogic.ts
+++ b/frontend/src/lib/components/CommandBar/searchBarLogic.ts
@@ -308,20 +308,6 @@ export const searchBarLogic = kea<searchBarLogicType>([
                 activeTab,
                 featureFlags
             ) => {
-                if (
-                    !searchResponse &&
-                    !personsResponse &&
-                    !group0Response &&
-                    !group1Response &&
-                    !group2Response &&
-                    !group3Response &&
-                    !group4Response &&
-                    activeTab !== Tab.Products &&
-                    activeTab !== Tab.All
-                ) {
-                    return null
-                }
-
                 const results = []
 
                 // Add regular search results (not for Products tab)
@@ -372,6 +358,55 @@ export const searchBarLogic = kea<searchBarLogicType>([
             },
         ],
         combinedSearchLoading: [
+            (s) => [
+                s.rawSearchResponseLoading,
+                s.rawPersonsResponseLoading,
+                s.rawGroup0ResponseLoading,
+                s.rawGroup1ResponseLoading,
+                s.rawGroup2ResponseLoading,
+                s.rawGroup3ResponseLoading,
+                s.rawGroup4ResponseLoading,
+                s.activeTab,
+            ],
+            (
+                searchLoading: boolean,
+                personsLoading: boolean,
+                group0Loading: boolean,
+                group1Loading: boolean,
+                group2Loading: boolean,
+                group3Loading: boolean,
+                group4Loading: boolean,
+                activeTab: Tab
+            ) => {
+                // For individual tabs, only check the relevant loading state
+                if (activeTab === Tab.Person) {
+                    return personsLoading
+                }
+                if (activeTab === Tab.Group0) {
+                    return group0Loading
+                }
+                if (activeTab === Tab.Group1) {
+                    return group1Loading
+                }
+                if (activeTab === Tab.Group2) {
+                    return group2Loading
+                }
+                if (activeTab === Tab.Group3) {
+                    return group3Loading
+                }
+                if (activeTab === Tab.Group4) {
+                    return group4Loading
+                }
+                if (activeTab !== Tab.All && activeTab !== Tab.Products) {
+                    return searchLoading
+                }
+
+                // For "All" tab, only show loading if the primary search is loading
+                // This allows other results to show while slow group searches are still running
+                return searchLoading
+            },
+        ],
+        anySearchLoading: [
             (s) => [
                 s.rawSearchResponseLoading,
                 s.rawPersonsResponseLoading,


### PR DESCRIPTION

## Problem
Command K search (aka command bar) "all" tab can be _really_ slow to load, blocking the results from showing up due to 1 or more resources taking a large amount of time, making the experience unusable.

## Changes
1. combinedSearchResults: Removed the blocking
  condition that prevented showing results when any search was incomplete. Results
  now appear as each individual search completes.
  2. combinedSearchLoading: Made loading state more
  granular - for the "All" tab, only shows loading for the primary search, allowing
  other results to appear immediately while slow group searches continue in
  background.
  3. anySearchLoading: New selector to track if any
  searches are still running, used to show a subtle "Loading more results..."
  indicator.
  4. SearchResults.tsx: Updated UI to show partial results immediately
  with a discrete loading indicator at the bottom when additional searches are still
  running.

## How did you test this code?
loading, typing the command bar, it's a bit jumpy but better experience than before