### PR TITLE
fix: Remove config key after parsing

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -858,8 +858,10 @@ export const batchExportConfigurationLogic = kea<batchExportConfigurationLogicTy
                         filereader.readAsText(value[0])
                     })
                     const jsonConfig = JSON.parse(loadedFile)
+                    const { json_config_file, ...remainingConfig } = values.configuration
+
                     actions.setConfigurationValues({
-                        ...values.configuration,
+                        ...remainingConfig,
                         project_id: jsonConfig.project_id,
                         private_key: jsonConfig.private_key,
                         private_key_id: jsonConfig.private_key_id,


### PR DESCRIPTION
## Problem

Our configuration validation is tripping up with BigQuery as it includes an extra `json_config_file`. This should be removed when the config file is parsed.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Remove `json_config_file` from configuration after parsing file.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
