### PR TITLE
fix: drop recording events in Blobby if they are too old

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.test.ts
@@ -13,9 +13,16 @@ jest.mock('./metrics')
 describe('KafkaMessageParser', () => {
     let parser: KafkaMessageParser
 
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
     beforeEach(() => {
         jest.clearAllMocks()
         parser = new KafkaMessageParser()
+
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2023-01-01T00:00:00.000Z'))
     })
 
     const createMessage = (data: any, overrides: Partial<Message> = {}): Message => ({
@@ -24,15 +31,15 @@ describe('KafkaMessageParser', () => {
         topic: 'test-topic',
         offset: 0,
         partition: 0,
-        timestamp: 1234567890,
+        timestamp: 1672527600000,
         ...overrides,
     })
 
     describe('parseBatch', () => {
         it('handles valid snapshot message including source and lib', async () => {
             const snapshotItems = [
-                { type: 1, timestamp: 1234567890 },
-                { type: 2, timestamp: 1234567891 },
+                { type: 1, timestamp: 1672527600000 },
+                { type: 2, timestamp: 1672527601000 },
             ]
             const messages = [
                 createMessage({
@@ -59,7 +66,7 @@ describe('KafkaMessageParser', () => {
                     topic: 'test-topic',
                     rawSize: 100,
                     offset: 0,
-                    timestamp: 1234567890,
+                    timestamp: 1672527600000,
                 },
                 headers: undefined,
                 distinct_id: 'user123',
@@ -68,8 +75,8 @@ describe('KafkaMessageParser', () => {
                     window1: snapshotItems,
                 },
                 eventsRange: {
-                    start: DateTime.fromMillis(1234567890),
-                    end: DateTime.fromMillis(1234567891),
+                    start: DateTime.fromMillis(1672527600000),
+                    end: DateTime.fromMillis(1672527601000),
                 },
                 snapshot_source: 'test-source',
                 snapshot_library: 'test-lib',
@@ -79,8 +86,8 @@ describe('KafkaMessageParser', () => {
 
         it('handles valid snapshot message missing source and lib', async () => {
             const snapshotItems = [
-                { type: 1, timestamp: 1234567890 },
-                { type: 2, timestamp: 1234567891 },
+                { type: 1, timestamp: 1672527600000 },
+                { type: 2, timestamp: 1672527601000 },
             ]
             const messages = [
                 createMessage({
@@ -113,8 +120,8 @@ describe('KafkaMessageParser', () => {
 
         it('handles gzipped message', async () => {
             const snapshotItems = [
-                { type: 1, timestamp: 1234567890 },
-                { type: 2, timestamp: 1234567891 },
+                { type: 1, timestamp: 1672527600000 },
+                { type: 2, timestamp: 1672527601000 },
             ]
             const data = {
                 data: JSON.stringify({
@@ -141,8 +148,8 @@ describe('KafkaMessageParser', () => {
                     window1: snapshotItems,
                 },
                 eventsRange: {
-                    start: DateTime.fromMillis(1234567890),
-                    end: DateTime.fromMillis(1234567891),
+                    start: DateTime.fromMillis(1672527600000),
+                    end: DateTime.fromMillis(1672527601000),
                 },
             })
             expect(KafkaMetrics.incrementMessageDropped).not.toHaveBeenCalled()
@@ -255,7 +262,7 @@ describe('KafkaMessageParser', () => {
                         properties: {
                             $session_id: 'session1',
                             $window_id: 'window1',
-                            $snapshot_items: [{ timestamp: 1, type: 2 }],
+                            $snapshot_items: [{ timestamp: 1672527601000, type: 2 }],
                         },
                     }),
                 }),
@@ -266,7 +273,7 @@ describe('KafkaMessageParser', () => {
                         properties: {
                             $session_id: 'session2',
                             $window_id: 'window2',
-                            $snapshot_items: [{ timestamp: 2, type: 2 }],
+                            $snapshot_items: [{ timestamp: 1672527601000, type: 2 }],
                         },
                     }),
                 }),
@@ -281,10 +288,10 @@ describe('KafkaMessageParser', () => {
 
         it('filters out events with zero or negative timestamps', async () => {
             const snapshotItems = [
-                { type: 1, timestamp: 1234567890 },
+                { type: 1, timestamp: 1672527600000 },
                 { type: 2, timestamp: 0 },
                 { type: 3, timestamp: -1000 },
-                { type: 4, timestamp: 1234567891 },
+                { type: 4, timestamp: 1672527601000 },
             ]
             const messages = [
                 createMessage({
@@ -305,22 +312,22 @@ describe('KafkaMessageParser', () => {
             expect(results).toHaveLength(1)
             expect(results[0]?.eventsByWindowId['window1']).toHaveLength(2)
             expect(results[0]?.eventsByWindowId['window1']).toEqual([
-                { type: 1, timestamp: 1234567890 },
-                { type: 4, timestamp: 1234567891 },
+                { type: 1, timestamp: 1672527600000 },
+                { type: 4, timestamp: 1672527601000 },
             ])
             expect(results[0]?.eventsRange).toEqual({
-                start: DateTime.fromMillis(1234567890),
-                end: DateTime.fromMillis(1234567891),
+                start: DateTime.fromMillis(1672527600000),
+                end: DateTime.fromMillis(1672527601000),
             })
         })
 
         it('uses min/max for timestamp range instead of first/last', async () => {
             const snapshotItems = [
-                { type: 1, timestamp: 1234567890 }, // Not the smallest
-                { type: 2, timestamp: 1234567889 }, // Smallest
-                { type: 3, timestamp: 1234567892 }, // Not the largest
-                { type: 4, timestamp: 1234567893 }, // Largest
-                { type: 5, timestamp: 1234567891 }, // Middle
+                { type: 1, timestamp: 1672527600000 }, // Not the smallest
+                { type: 2, timestamp: 1672527599000 }, // Smallest
+                { type: 3, timestamp: 1672527602000 }, // Not the largest
+                { type: 4, timestamp: 1672527603000 }, // Largest
+                { type: 5, timestamp: 1672527601000 }, // Middle
             ]
             const messages = [
                 createMessage({
@@ -340,8 +347,138 @@ describe('KafkaMessageParser', () => {
 
             expect(results).toHaveLength(1)
             expect(results[0]?.eventsRange).toEqual({
-                start: DateTime.fromMillis(1234567889), // Should be smallest timestamp
-                end: DateTime.fromMillis(1234567893), // Should be largest timestamp
+                start: DateTime.fromMillis(1672527599000), // Should be smallest timestamp
+                end: DateTime.fromMillis(1672527603000), // Should be largest timestamp
+            })
+        })
+
+        it('filters out snapshots with events in the future', async () => {
+            const messages = [
+                createMessage({
+                    distinct_id: 'user123',
+                    data: JSON.stringify({
+                        event: '$snapshot_items',
+                        properties: {
+                            $session_id: 'session1',
+                            $window_id: 'window1',
+                            $snapshot_items: [
+                                { type: 1, timestamp: 1672959600000 }, // 6 days in the future, valid timestamp
+                                { type: 2, timestamp: 1672527603000 }, // 3 seconds in the future, valid timestamp
+                                { type: 3, timestamp: 1672527600000 }, // now, valid timestamp
+                            ],
+                        },
+                    }),
+                }),
+                createMessage({
+                    distinct_id: 'user123',
+                    data: JSON.stringify({
+                        event: '$snapshot_items',
+                        properties: {
+                            $session_id: 'session2',
+                            $window_id: 'window2',
+                            $snapshot_items: [
+                                { type: 1, timestamp: 1672959600000 }, // 6 days in the future, valid timestamp
+                                { type: 2, timestamp: 1673218800000 }, // 8 days in the future, invalid timestamp
+                                { type: 3, timestamp: 1672527600000 }, // now, valid timestamp
+                            ],
+                        },
+                    }),
+                }),
+
+                createMessage({
+                    distinct_id: 'user123',
+                    data: JSON.stringify({
+                        event: '$snapshot_items',
+                        properties: {
+                            $session_id: 'session3',
+                            $window_id: 'window3',
+                            $snapshot_items: [
+                                { type: 1, timestamp: 1672959600000 }, // 6 days in the future, valid timestamp
+                                { type: 2, timestamp: 1704063600000 }, // 365 days in the future, invalid timestamp
+                                { type: 3, timestamp: 1672527600000 }, // now, valid timestamp
+                            ],
+                        },
+                    }),
+                }),
+            ]
+
+            const results = await parser.parseBatch(messages)
+
+            expect(results).toHaveLength(1)
+            expect(results[0]?.eventsByWindowId['window1']).toHaveLength(3)
+            expect(results[0]?.eventsByWindowId['window1']).toEqual([
+                { type: 1, timestamp: 1672959600000 },
+                { type: 2, timestamp: 1672527603000 },
+                { type: 3, timestamp: 1672527600000 },
+            ])
+            expect(results[0]?.eventsRange).toEqual({
+                start: DateTime.fromMillis(1672527600000),
+                end: DateTime.fromMillis(1672959600000),
+            })
+        })
+
+        it('filters out snapshots with events in the past', async () => {
+            const messages = [
+                createMessage({
+                    distinct_id: 'user123',
+                    data: JSON.stringify({
+                        event: '$snapshot_items',
+                        properties: {
+                            $session_id: 'session1',
+                            $window_id: 'window1',
+                            $snapshot_items: [
+                                { type: 1, timestamp: 1672095600000 }, // 6 days in the past, valid timestamp
+                                { type: 2, timestamp: 1672527595000 }, // 5 seconds in the past, valid timestamp
+                                { type: 3, timestamp: 1672527600000 }, // now, valid timestamp
+                            ],
+                        },
+                    }),
+                }),
+                createMessage({
+                    distinct_id: 'user123',
+                    data: JSON.stringify({
+                        event: '$snapshot_items',
+                        properties: {
+                            $session_id: 'session2',
+                            $window_id: 'window2',
+                            $snapshot_items: [
+                                { type: 1, timestamp: 1672095600000 }, // 6 days in the past, valid timestamp
+                                { type: 2, timestamp: 1671836400000 }, // 8 days in the past, invalid timestamp
+                                { type: 3, timestamp: 1672527600000 }, // now, valid timestamp
+                            ],
+                        },
+                    }),
+                }),
+
+                createMessage({
+                    distinct_id: 'user123',
+                    data: JSON.stringify({
+                        event: '$snapshot_items',
+                        properties: {
+                            $session_id: 'session3',
+                            $window_id: 'window3',
+                            $snapshot_items: [
+                                { type: 1, timestamp: 1672095600000 }, // 6 days in the past, valid timestamp
+                                { type: 2, timestamp: 1640991600000 }, // 365 days in the past, invalid timestamp
+                                { type: 3, timestamp: 1672527600000 }, // now, valid timestamp
+                            ],
+                        },
+                    }),
+                }),
+            ]
+
+            const results = await parser.parseBatch(messages)
+
+            expect(results).toHaveLength(1)
+            expect(results[0]?.eventsByWindowId['window1']).toHaveLength(3)
+            expect(results[0]?.eventsByWindowId['window1']).toEqual([
+                { type: 1, timestamp: 1672095600000 },
+                { type: 2, timestamp: 1672527595000 },
+                { type: 3, timestamp: 1672527600000 },
+            ])
+            expect(results[0]?.eventsRange).toEqual({
+                start: DateTime.fromMillis(1672095600000),
+                end: DateTime.fromMillis(1672527600000),
             })
         })
     })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.ts
@@ -8,6 +8,7 @@ import { logger } from '../../../../utils/logger'
 import { KafkaMetrics } from './metrics'
 import { EventSchema, ParsedMessageData, RawEventMessageSchema, SnapshotEvent, SnapshotEventSchema } from './types'
 
+const MESSAGE_TIMESTAMP_DIFF_THRESHOLD_DAYS = 7
 const GZIP_HEADER = Uint8Array.from([0x1f, 0x8b, 0x08, 0x00])
 const decompressWithGzip = promisify(gunzip)
 
@@ -120,6 +121,12 @@ export class KafkaMessageParser {
             return dropMessage('message_contained_no_valid_rrweb_events')
         }
         const { validEvents, startDateTime, endDateTime } = result
+
+        const startDiff = Math.abs(startDateTime.diffNow('day').days)
+        const endDiff = Math.abs(endDateTime.diffNow('day').days)
+        if (startDiff >= MESSAGE_TIMESTAMP_DIFF_THRESHOLD_DAYS || endDiff >= MESSAGE_TIMESTAMP_DIFF_THRESHOLD_DAYS) {
+            return dropMessage('message_timestamp_diff_too_large')
+        }
 
         return {
             metadata: {


### PR DESCRIPTION
## Problem

We are seeing some very old events making their way into ClickHouse - blobby v1 had a guard to check for this but blobby v2 doesn't.

## Changes

Added a check in the message parser to drop messages too far in the past or too far in the future.