### PR TITLE
fix(myke): fix wrong parametrization format

### DIFF
--- a/posthog/management/commands/analyze_behavioral_cohorts.py
+++ b/posthog/management/commands/analyze_behavioral_cohorts.py
@@ -110,7 +110,7 @@ class Command(BaseCommand):
             raise ValueError(f"Invalid limit value: {limit}")
 
         where_clauses = ["date >= now() - toIntervalDay(%(days)s)"]
-        params = {"days": days}
+        params: dict[str, Any] = {"days": days}
 
         if team_id:
             where_clauses.append("team_id = %(team_id)s")

--- a/posthog/management/commands/analyze_behavioral_cohorts.py
+++ b/posthog/management/commands/analyze_behavioral_cohorts.py
@@ -112,22 +112,15 @@ class Command(BaseCommand):
         where_clauses = ["date >= now() - toIntervalDay(%(days)s)"]
         params = {"days": days}
 
-        param_counter = 0
         if team_id:
-            param_name = f"team_id_{param_counter}"
-            where_clauses.append(f"team_id = %({param_name})s")
-            params[param_name] = team_id
-            param_counter += 1
+            where_clauses.append("team_id = %(team_id)s")
+            params["team_id"] = team_id
         if cohort_id:
-            param_name = f"cohort_id_{param_counter}"
-            where_clauses.append(f"cohort_id = %({param_name})s")
-            params[param_name] = cohort_id
-            param_counter += 1
+            where_clauses.append("cohort_id = %(cohort_id)s")
+            params["cohort_id"] = cohort_id
         if condition:
-            param_name = f"condition_{param_counter}"
-            where_clauses.append(f"condition = %({param_name})s")
-            params[param_name] = condition
-            param_counter += 1
+            where_clauses.append("condition = %(condition)s")
+            params["condition"] = condition
 
         where_clause = " AND ".join(where_clauses)
 


### PR DESCRIPTION
## Problem

wrong format used format should be like in `helpers.py`

```
    rows = client.sync_execute(
        f"""
        SELECT
            query_duration_ms,
            read_rows,
            read_bytes,
            memory_usage
        FROM system.query_log
        WHERE
            query NOT LIKE '%%query_log%%'
            AND query LIKE %(matcher)s
            AND type = 'QueryFinish'
        """,
        {"matcher": f"%benchmark:{uuid}%"},
    )
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

adjusted code

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
