### PR TITLE
feat(messaging): Testing area improvements

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -163,6 +163,7 @@ import {
     UserType,
 } from '~/types'
 
+import { HogflowTestResult } from 'products/messaging/frontend/Campaigns/hogflows/steps/types'
 import { HogFlow } from 'products/messaging/frontend/Campaigns/hogflows/types'
 import { OptOutEntry } from 'products/messaging/frontend/OptOuts/optOutListLogic'
 import { MessageTemplate } from 'products/messaging/frontend/TemplateLibrary/messageTemplatesLogic'
@@ -3920,7 +3921,7 @@ const api = {
                 invocation_id?: string
                 current_action_id?: string
             }
-        ): Promise<any> {
+        ): Promise<HogflowTestResult> {
             return await new ApiRequest().hogFlow(hogFlowId).withAction('invocations').create({ data })
         },
     },

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -480,7 +480,7 @@ export class CdpApi {
             const result = await this.hogFlowExecutor.executeCurrentAction(invocation)
 
             res.json({
-                result,
+                nextActionId: result.invocation.state.currentAction?.id,
                 status: result.error ? 'error' : 'success',
                 errors: result.error ? [result.error] : [],
                 logs: result.logs,

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -223,7 +223,7 @@ describe('Hogflow Executor', () => {
                     {
                         level: 'info',
                         timestamp: expect.any(DateTime),
-                        message: "Workflow moved to action 'exit (exit)'",
+                        message: 'Workflow moved to action [Action:exit]',
                     },
                     {
                         level: 'info',
@@ -297,7 +297,7 @@ describe('Hogflow Executor', () => {
                   "[Action:function_id_1] Fetch 3, 200",
                   "[Action:function_id_1] All fetches done!",
                   "[Action:function_id_1] Function completed in REPLACEDms. Sync: 0ms. Mem: 0.099kb. Ops: 32. Event: 'http://localhost:8000/events/1'",
-                  "Workflow moved to action 'exit (exit)'",
+                  "Workflow moved to action [Action:exit]",
                   "Workflow completed",
                 ]
             `)
@@ -379,7 +379,7 @@ describe('Hogflow Executor', () => {
                 expect(result1.finished).toBe(false)
                 expect(result1.invocation.state.currentAction?.id).toBe('function_id_1')
                 expect(result1.logs.map((log) => log.message)).toEqual([
-                    "Workflow moved to action 'function (function_id_1)'",
+                    'Workflow moved to action [Action:function_id_1]',
                 ])
 
                 // Second step: should process function_id_1 and move to exit, but not complete
@@ -390,7 +390,7 @@ describe('Hogflow Executor', () => {
                     '[Action:function_id_1] Hello, Mr Debug User!',
                     '[Action:function_id_1] Fetch 1, 200',
                     expect.stringContaining('[Action:function_id_1] Function completed in'),
-                    "Workflow moved to action 'exit (exit)'",
+                    'Workflow moved to action [Action:exit]',
                     'Workflow completed',
                 ])
             })

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -31,6 +31,11 @@ import { ensureCurrentAction, findContinueAction, shouldSkipAction } from './hog
 
 export const MAX_ACTION_STEPS_HARD_LIMIT = 1000
 
+// Special format which the frontend understands and can render as a link
+const actionIdForLogging = (action: HogFlowAction) => {
+    return `[Action:${action.id}]`
+}
+
 export class HogFlowExecutorService {
     private readonly actionHandlers: Record<HogFlowAction['type'], ActionHandler>
 
@@ -324,7 +329,7 @@ export class HogFlowExecutorService {
         result.logs.push({
             level: 'info',
             timestamp: DateTime.now(),
-            message: `Workflow moved to action '${nextAction.name} (${nextAction.id})'`,
+            message: `Workflow moved to action ${actionIdForLogging(nextAction)}`,
         })
 
         this.trackActionMetric(result, currentAction, reason === 'filtered' ? 'filtered' : 'succeeded')
@@ -357,7 +362,7 @@ export class HogFlowExecutorService {
         level: LogEntryLevel,
         message: string
     ): void {
-        this.log(result, level, `[Action:${action.id}] ${message}`)
+        this.log(result, level, `${actionIdForLogging(action)} ${message}`)
     }
 
     private log(

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -2,19 +2,22 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useEffect } from 'react'
 
-import { IconPlay, IconPlayFilled, IconRedo } from '@posthog/icons'
+import { IconInfo, IconPlay, IconPlayFilled, IconRedo } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
     LemonCollapse,
     LemonDivider,
     LemonLabel,
+    LemonSwitch,
     Link,
     ProfilePicture,
     Spinner,
+    Tooltip,
 } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LogsViewerTable } from 'scenes/hog-functions/logs/LogsViewer'
 import { asDisplay } from 'scenes/persons/person-utils'
 import { urls } from 'scenes/urls'
@@ -65,6 +68,32 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
             className="flex overflow-hidden flex-col flex-1"
         >
             <div className="flex gap-2 items-center p-2">
+                <LemonField name="mock_async_functions" className="flex-1">
+                    {({ value, onChange }) => (
+                        <LemonSwitch
+                            onChange={(v) => onChange(!v)}
+                            checked={!value}
+                            data-attr="toggle-workflow-test-panel-new-mocking"
+                            className="whitespace-nowrap"
+                            size="small"
+                            label={
+                                <Tooltip
+                                    title={
+                                        <>
+                                            When disabled, message deliveries and other async actions will not be
+                                            called. Instead they will be mocked out and logged.
+                                        </>
+                                    }
+                                >
+                                    <span className="flex gap-2">
+                                        Make real HTTP requests
+                                        <IconInfo className="text-lg" />
+                                    </span>
+                                </Tooltip>
+                            }
+                        />
+                    )}
+                </LemonField>
                 {testResult ? (
                     <>
                         <div className="flex-1" />
@@ -95,32 +124,6 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                     <>
                         <div className="flex-1" />
 
-                        {/* <LemonField name="mock_async_functions" className="flex-1">
-                                    {({ value, onChange }) => (
-                                        <LemonSwitch
-                                            onChange={(v) => onChange(!v)}
-                                            checked={!value}
-                                            data-attr="toggle-workflow-test-panel-new-mocking"
-                                            label={
-                                                <Tooltip
-                                                    title={
-                                                        <>
-                                                            When disabled, message deliveries and other async actions
-                                                            will not be called. Instead they will be mocked out and
-                                                            logged.
-                                                        </>
-                                                    }
-                                                >
-                                                    <span className="flex gap-2">
-                                                        Make real HTTP requests
-                                                        <IconInfo className="text-lg" />
-                                                    </span>
-                                                </Tooltip>
-                                            }
-                                        />
-                                    )}
-                                </LemonField> */}
-
                         <LemonButton
                             type="primary"
                             data-attr="test-workflow-panel-new"
@@ -138,7 +141,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
             <LemonDivider className="my-0" />
             <div className="flex flex-col flex-1 overflow-y-auto">
                 {/* Event Information */}
-                <div className="flex-0">
+                <div className="flex-0 p-2">
                     <LemonCollapse
                         embedded
                         panels={[

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -218,44 +218,42 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                         ]}
                     />
                 </div>
-                {testResult && (
-                    <>
-                        <LemonDivider className="my-0" />
-                        <div className="flex flex-col flex-1 gap-2 p-2">
-                            <div data-attr="test-results" className="flex flex-col gap-2">
-                                <h3 className="mb-0">Test results</h3>
-                                <LemonBanner
-                                    type={
-                                        testResult.status === 'success'
-                                            ? 'success'
-                                            : testResult.status === 'skipped'
-                                              ? 'warning'
-                                              : 'error'
-                                    }
-                                >
-                                    {testResult.status === 'success'
-                                        ? 'Success'
+                <LemonDivider className="my-0" />
+                <div className="flex flex-col flex-1 gap-2 p-2">
+                    <h3 className="mb-0">Test results</h3>
+                    {!testResult ? (
+                        <div className="flex flex-col gap-2">Results will appear here</div>
+                    ) : (
+                        <>
+                            <LemonBanner
+                                type={
+                                    testResult.status === 'success'
+                                        ? 'success'
                                         : testResult.status === 'skipped'
-                                          ? 'Workflow was skipped because the event did not match the filter criteria'
-                                          : 'Error: ' + testResult.errors?.join(', ')}
-                                </LemonBanner>
+                                          ? 'warning'
+                                          : 'error'
+                                }
+                            >
+                                {testResult.status === 'success'
+                                    ? 'Success'
+                                    : testResult.status === 'skipped'
+                                      ? 'Workflow was skipped because the event did not match the filter criteria'
+                                      : 'Error: ' + testResult.errors?.join(', ')}
+                            </LemonBanner>
 
-                                <div className="flex flex-col gap-2">
-                                    <LemonLabel>Logs</LemonLabel>
+                            <div className="flex flex-col gap-2">
+                                <LemonLabel>Logs</LemonLabel>
 
-                                    <LogsViewerTable
-                                        instanceLabel="workflow run"
-                                        renderMessage={(m) => renderWorkflowLogMessage(campaign, m)}
-                                        dataSource={testResult.logs ?? []}
-                                        renderColumns={(columns) =>
-                                            columns.filter((column) => column.key !== 'instanceId')
-                                        }
-                                    />
-                                </div>
+                                <LogsViewerTable
+                                    instanceLabel="workflow run"
+                                    renderMessage={(m) => renderWorkflowLogMessage(campaign, m)}
+                                    dataSource={testResult.logs ?? []}
+                                    renderColumns={(columns) => columns.filter((column) => column.key !== 'instanceId')}
+                                />
                             </div>
-                        </div>
-                    </>
-                )}
+                        </>
+                    )}
+                </div>
             </div>
         </Form>
     )

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -222,7 +222,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                 <div className="flex flex-col flex-1 gap-2 p-2">
                     <h3 className="mb-0">Test results</h3>
                     {!testResult ? (
-                        <div className="flex flex-col gap-2">Results will appear here</div>
+                        <div className="text-muted text-sm">No tests run yet</div>
                     ) : (
                         <>
                             <LemonBanner

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -76,6 +76,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                             data-attr="toggle-workflow-test-panel-new-mocking"
                             className="whitespace-nowrap"
                             size="small"
+                            bordered
                             label={
                                 <Tooltip
                                     title={

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -137,9 +137,10 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
             </div>
             <LemonDivider className="my-0" />
             <div className="flex flex-col flex-1 overflow-y-auto">
-                <div className="flex flex-col flex-1 gap-2 p-2">
-                    {/* Event Information */}
+                {/* Event Information */}
+                <div className="flex-0">
                     <LemonCollapse
+                        embedded
                         panels={[
                             {
                                 key: 'event',
@@ -236,7 +237,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                 </LemonBanner>
 
                                 <div className="flex flex-col gap-2">
-                                    <LemonLabel>Test invocation logs</LemonLabel>
+                                    <LemonLabel>Logs</LemonLabel>
 
                                     <LogsViewerTable
                                         instanceLabel="workflow run"

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -133,11 +133,6 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                 )}
             </div>
             <LemonDivider className="my-0" />
-            <div className="text-sm text-muted p-2">
-                Note: Delays will be logged to indicate when they would have been executed.
-            </div>
-            {/* Body */}
-            <LemonDivider className="my-0" />
             <div className="flex overflow-y-auto flex-col flex-1 gap-2 p-2">
                 {/* Event Information */}
                 {sampleGlobals?.event && (

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -141,7 +141,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
             <LemonDivider className="my-0" />
             <div className="flex flex-col flex-1 overflow-y-auto">
                 {/* Event Information */}
-                <div className="flex-0 p-2">
+                <div className="flex-0">
                     <LemonCollapse
                         embedded
                         panels={[

--- a/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -122,17 +122,6 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                 </LemonField> */}
 
                         <LemonButton
-                            type="secondary"
-                            onClick={() => loadSampleGlobals()}
-                            tooltip="Find the last event matching the trigger event filters, and use it to populate the globals for a test run."
-                            disabledReason={!shouldLoadSampleGlobals ? 'Must configure trigger event' : undefined}
-                            icon={<IconRedo />}
-                            size="small"
-                        >
-                            Load new event
-                        </LemonButton>
-
-                        <LemonButton
                             type="primary"
                             data-attr="test-workflow-panel-new"
                             onClick={() => submitTestInvocation()}
@@ -166,107 +155,102 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                 className: 'bg-surface-secondary',
                                 content: (
                                     <div>
-                                        {sampleGlobals?.event && (
-                                            <div className="bg-surface-secondary">
-                                                <div className="flex flex-wrap gap-1 items-center">
-                                                    {sampleGlobals.person && (
+                                        <div className="bg-surface-secondary">
+                                            <div className="flex gap-2 items-center">
+                                                <ProfilePicture name={display} />
+                                                <div className="flex-1">
+                                                    {sampleGlobals?.person ? (
                                                         <Link to={url} className="flex gap-2 items-center">
-                                                            <ProfilePicture name={display} />{' '}
                                                             <span className="font-semibold">{display}</span>
                                                         </Link>
-                                                    )}
-                                                    <span className="text-muted">performed</span>
-                                                    <div className="space-y-1 font-semibold text-md">
-                                                        {sampleGlobals.event.event}
-                                                    </div>{' '}
-                                                    <div>
+                                                    ) : (
+                                                        <span className="text-muted">Loading...</span>
+                                                    )}{' '}
+                                                    <span className="text-muted">performed</span>{' '}
+                                                    <span className="space-y-1 font-semibold text-md">
+                                                        {sampleGlobals?.event.event}
+                                                    </span>{' '}
+                                                    {sampleGlobals?.event.timestamp && (
                                                         <TZLabel time={sampleGlobals.event.timestamp} />
-                                                    </div>
-                                                </div>
-
-                                                {/* Event Properties */}
-                                                {sampleGlobals.event.properties &&
-                                                    Object.keys(sampleGlobals.event.properties).length > 0 && (
-                                                        <div className="mt-3">
-                                                            <div className="mb-2 text-sm">Event properties</div>
-                                                            <div className="overflow-auto max-h-32 rounded border bg-surface-primary">
-                                                                <pre className="p-2 text-xs whitespace-pre-wrap text-muted">
-                                                                    {JSON.stringify(
-                                                                        sampleGlobals.event.properties,
-                                                                        null,
-                                                                        2
-                                                                    )}
-                                                                </pre>
-                                                            </div>
-                                                        </div>
                                                     )}
+                                                </div>
+                                                <LemonButton
+                                                    type="secondary"
+                                                    onClick={() => loadSampleGlobals()}
+                                                    tooltip="Find the last event matching the trigger event filters, and use it to populate the globals for a test run."
+                                                    disabledReason={
+                                                        !shouldLoadSampleGlobals
+                                                            ? 'Must configure trigger event'
+                                                            : undefined
+                                                    }
+                                                    icon={<IconRedo />}
+                                                    size="small"
+                                                >
+                                                    Load new event
+                                                </LemonButton>
                                             </div>
-                                        )}
+
+                                            {/* Event Properties */}
+                                            {sampleGlobals?.event.properties &&
+                                                Object.keys(sampleGlobals.event.properties).length > 0 && (
+                                                    <div className="mt-3">
+                                                        <div className="mb-2 text-sm">Event properties</div>
+                                                        <div className="overflow-auto max-h-32 rounded border bg-surface-primary">
+                                                            <pre className="p-2 text-xs whitespace-pre-wrap text-muted">
+                                                                {JSON.stringify(
+                                                                    sampleGlobals.event.properties,
+                                                                    null,
+                                                                    2
+                                                                )}
+                                                            </pre>
+                                                        </div>
+                                                    </div>
+                                                )}
+                                        </div>
                                     </div>
                                 ),
                             },
                         ]}
                     />
                 </div>
-                <LemonDivider className="my-0" />
-                <div className="flex flex-col flex-1 gap-2 p-2">
-                    {/* Test Results */}
-                    {testResult ? (
-                        <div data-attr="test-results" className="flex flex-col gap-2">
-                            <div className="flex gap-2 justify-between items-center">
+                {testResult && (
+                    <>
+                        <LemonDivider className="my-0" />
+                        <div className="flex flex-col flex-1 gap-2 p-2">
+                            <div data-attr="test-results" className="flex flex-col gap-2">
                                 <h3 className="mb-0">Test results</h3>
-                                <LemonButton
-                                    type="secondary"
-                                    onClick={() => setTestResult(null)}
-                                    loading={isTestInvocationSubmitting}
-                                    size="small"
-                                    data-attr="clear-workflow-test-panel-new-result"
+                                <LemonBanner
+                                    type={
+                                        testResult.status === 'success'
+                                            ? 'success'
+                                            : testResult.status === 'skipped'
+                                              ? 'warning'
+                                              : 'error'
+                                    }
                                 >
-                                    Clear test result
-                                </LemonButton>
-                            </div>
-                            <LemonBanner
-                                type={
-                                    testResult.status === 'success'
-                                        ? 'success'
+                                    {testResult.status === 'success'
+                                        ? 'Success'
                                         : testResult.status === 'skipped'
-                                          ? 'warning'
-                                          : 'error'
-                                }
-                            >
-                                {testResult.status === 'success'
-                                    ? 'Success'
-                                    : testResult.status === 'skipped'
-                                      ? 'Workflow was skipped because the event did not match the filter criteria'
-                                      : 'Error: ' + testResult.errors?.join(', ')}
-                            </LemonBanner>
+                                          ? 'Workflow was skipped because the event did not match the filter criteria'
+                                          : 'Error: ' + testResult.errors?.join(', ')}
+                                </LemonBanner>
 
-                            <div className="flex flex-col gap-2">
-                                <LemonLabel>Test invocation logs</LemonLabel>
+                                <div className="flex flex-col gap-2">
+                                    <LemonLabel>Test invocation logs</LemonLabel>
 
-                                <LogsViewerTable
-                                    instanceLabel="workflow run"
-                                    renderMessage={(m) => renderWorkflowLogMessage(campaign, m)}
-                                    dataSource={testResult.logs ?? []}
-                                    renderColumns={(columns) => columns.filter((column) => column.key !== 'instanceId')}
-                                />
+                                    <LogsViewerTable
+                                        instanceLabel="workflow run"
+                                        renderMessage={(m) => renderWorkflowLogMessage(campaign, m)}
+                                        dataSource={testResult.logs ?? []}
+                                        renderColumns={(columns) =>
+                                            columns.filter((column) => column.key !== 'instanceId')
+                                        }
+                                    />
+                                </div>
                             </div>
                         </div>
-                    ) : (
-                        <LemonButton
-                            type="primary"
-                            data-attr="test-workflow-panel-new"
-                            onClick={() => submitTestInvocation()}
-                            icon={<IconPlay />}
-                            loading={isTestInvocationSubmitting}
-                            disabledReason={sampleGlobals ? undefined : 'Must load event to run test'}
-                            size="small"
-                            fullWidth
-                        >
-                            Run test
-                        </LemonButton>
-                    )}
-                </div>
+                    </>
+                )}
             </div>
         </Form>
     )

--- a/products/messaging/frontend/Campaigns/hogflows/steps/types.ts
+++ b/products/messaging/frontend/Campaigns/hogflows/steps/types.ts
@@ -1,6 +1,8 @@
 import { Handle, NodeProps } from '@xyflow/react'
 import { z } from 'zod'
 
+import { LogEntry } from 'scenes/hog-functions/logs/logsViewerLogic'
+
 import { Optional } from '~/types'
 
 import { HogFlowAction } from '../types'
@@ -158,4 +160,11 @@ export const isFunctionAction = (
     action: HogFlowAction
 ): action is Extract<HogFlowAction, { type: 'function' | 'function_sms' | 'function_email' }> => {
     return ['function', 'function_sms', 'function_email'].includes(action.type)
+}
+
+export interface HogflowTestResult {
+    status: 'success' | 'error' | 'skipped'
+    logs?: LogEntry[]
+    nextActionId: string | null
+    errors?: string[]
 }


### PR DESCRIPTION
## Problem

The messaging testing area had a few issues.

## Changes

![2025-09-05 13 05 03](https://github.com/user-attachments/assets/8346b670-515c-46d9-90fd-3278ba1d7aa1)

* Dont return the invocation result - waaaay too much potentially sensitive info in there - we should be super strict about that return type
* Make a button to move to the next action rather than automatically doing so
* Common log viewer component
* Modified "moved to" log to use the action format

I think we should revamp the event properties area to make that way more customiseable but we can come back to that later

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
