### PR TITLE
feat: re-enable events backup and add resource limits

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -22,6 +22,7 @@ NO_SHARD_PATH = "noshard"
 SHARDED_TABLES = [
     "sharded_app_metrics",
     "sharded_app_metrics2",
+    "sharded_events",
     "sharded_heatmaps",
     "sharded_ingestion_warnings",
     "sharded_performance_events",
@@ -111,6 +112,9 @@ class Backup:
     def create(self, client: Client):
         backup_settings = {
             "async": "1",
+            "max_backup_bandwidth": "100000000",  # 100MB/s to limit resource usage
+            "max_backups_io_thread_pool_size": "8",  # Conservative thread count for m8g.8xlarge
+            "max_backups_io_thread_pool_free_size": "2",  # Keep some threads available
         }
         if self.base_backup:
             backup_settings["base_backup"] = "S3('{bucket_base_path}/{path}')".format(


### PR DESCRIPTION
## Summary
Re-enables ClickHouse events backup that was previously disabled and adds resource limiting settings to prevent IO exhaustion on nodes.

## Changes
- **Re-enable sharded_events backup**: Adds `sharded_events` back to `SHARDED_TABLES` list (reverting #36826)
- **Add backup resource limits**:
  - `max_backup_bandwidth`: 100MB/s to prevent network/disk saturation
  - `max_backups_io_thread_pool_size`: 8 threads (conservative for m8g.8xlarge)
  - `max_backups_io_thread_pool_free_size`: 2 threads for quick response

## Motivation
Recent backup operations have been consuming too many IO resources on ClickHouse nodes. These settings limit resource usage while maintaining reasonable backup performance for m8g.8xlarge instances with gp3 volumes.

## Testing
- Settings are applied to all backup operations via the `backup_settings` dictionary
- Values are tuned conservatively to prevent resource exhaustion