### PR TITLE
fix(experiments): fix empty state while exposures still loading

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -56,6 +56,7 @@ interface MetricRowGroupProps {
     error?: any
     isLoading?: boolean
     hasMinimumExposureForResults?: boolean
+    exposuresLoading?: boolean
     showDetailsModal: boolean
 }
 
@@ -73,6 +74,7 @@ export function MetricRowGroup({
     error,
     isLoading,
     hasMinimumExposureForResults = true,
+    exposuresLoading = false,
     showDetailsModal,
 }: MetricRowGroupProps): JSX.Element {
     const [isModalOpen, setIsModalOpen] = useState(false)
@@ -203,7 +205,7 @@ export function MetricRowGroup({
                     }`}
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
                 >
-                    {isLoading ? (
+                    {isLoading || exposuresLoading ? (
                         <ChartLoadingState height={CELL_HEIGHT} />
                     ) : (
                         <ChartEmptyState

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -31,7 +31,7 @@ export function MetricsTable({
     getInsightType,
     showDetailsModal = true,
 }: MetricsTableProps): JSX.Element {
-    const { experiment, hasMinimumExposureForResults } = useValues(experimentLogic)
+    const { experiment, hasMinimumExposureForResults, exposuresLoading } = useValues(experimentLogic)
     const { duplicateMetric, updateExperimentMetrics, setExperiment } = useActions(experimentLogic)
 
     // Calculate shared axisRange across all metrics
@@ -113,6 +113,7 @@ export function MetricsTable({
                                 error={error}
                                 isLoading={isLoading}
                                 hasMinimumExposureForResults={hasMinimumExposureForResults}
+                                exposuresLoading={exposuresLoading}
                                 showDetailsModal={showDetailsModal}
                             />
                         )


### PR DESCRIPTION
## Problem
When individual metric queries finish before the exposure query completes, they show the empty state `Waiting for 50+ exposures to show results` instead of continuing to show the loading state.

Then, once the exposures are loaded, they suddenly render the results, which is very confusing.

## Changes
Keep showing the loading spinner for a metric while the exposures are still loading.

## How did you test this code?
|Before|After|
|----|----|
|https://www.loom.com/share/a1c3020a033041edbca23d5809b813fd?sid=3c6a4581-60ab-47b9-b461-5125cbb7d6f8|https://www.loom.com/share/49796f048d374ebaad78ee17f6c20d3b?sid=e87dd332-767a-4a50-9eac-3f22439327db|