### PR TITLE
fix: export video close old connections

### DIFF
--- a/posthog/temporal/exports_video/activities.py
+++ b/posthog/temporal/exports_video/activities.py
@@ -5,6 +5,8 @@ import datetime as dt
 import tempfile
 from typing import Any
 
+from django.db import close_old_connections
+
 from temporalio import activity
 
 from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content
@@ -16,6 +18,7 @@ from posthog.utils import absolute_uri
 
 @activity.defn
 def build_export_context_activity(exported_asset_id: int) -> dict[str, Any]:
+    close_old_connections()
     asset = ExportedAsset.objects.select_related("team", "dashboard", "insight").get(pk=exported_asset_id)
     # recordings-only
     if not (asset.export_context and asset.export_context.get("session_recording_id")):
@@ -84,6 +87,7 @@ def record_replay_video_activity(build: dict[str, Any]) -> dict[str, Any]:
 
 @activity.defn
 def persist_exported_asset_activity(inputs: dict[str, Any]) -> None:
+    close_old_connections()
     asset = ExportedAsset.objects.select_related("team").get(pk=inputs["exported_asset_id"])
     tmp_path = inputs["tmp_path"]
 


### PR DESCRIPTION
Fix database connection issues in video export Temporal activities by adding close_old_connections() calls before Django ORM queries. This prevents "the connection is closed" errors that occur when Temporal workers attempt to use stale database connections that have been closed by the database server. 
[Examples](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows?query=%60WorkflowType%60%3D%22export-video%22+AND+%60ExecutionStatus%60%3D%22Failed%22) 
