### PR TITLE
fix(web-analytics): Fix applying path cleaning to all property filters

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -29,17 +29,17 @@ posthog/clickhouse/migrations/** @PostHog/clickhouse
 
 # Web Analytics team owns web analytics code
 
-products/web_analytics/** @PostHog/web-analytics
-frontend/src/scenes/web-analytics/** @PostHog/web-analytics
-posthog/hogql_queries/web_analytics/** @PostHog/web-analytics
-frontend/src/toolbar/web-vitals/** @PostHog/web-analytics
-posthog/hogql/database/schema/sessions_v1.py @PostHog/web-analytics
-posthog/hogql/database/schema/sessions_v2.py @PostHog/web-analytics
-posthog/models/raw_sessions/** @PostHog/web-analytics
-posthog/models/sessions/** @PostHog/web-analytics
-rust/common/cookieless/** @PostHog/web-analytics
-plugin-server/src/ingestion/cookieless/** @PostHog/web-analytics
-dags/locations/web_analytics.py @PostHog/web-analytics
+products/web_analytics/** @PostHog/team-web-analytics
+frontend/src/scenes/web-analytics/** @PostHog/team-web-analytics
+posthog/hogql_queries/web_analytics/** @PostHog/team-web-analytics
+frontend/src/toolbar/web-vitals/** @PostHog/team-web-analytics
+posthog/hogql/database/schema/sessions_v1.py @PostHog/team-web-analytics
+posthog/hogql/database/schema/sessions_v2.py @PostHog/team-web-analytics
+posthog/models/raw_sessions/** @PostHog/team-web-analytics
+posthog/models/sessions/** @PostHog/team-web-analytics
+rust/common/cookieless/** @PostHog/team-web-analytics
+plugin-server/src/ingestion/cookieless/** @PostHog/team-web-analytics
+dags/locations/web_analytics.py @PostHog/team-web-analytics
 
 # Revenue Analytics team owns revenue analytics stuff
 

--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -386,3 +386,12 @@ export const checkCustomEventConversionGoalHasSessionIdsHelper = async (
         setConversionGoalWarning(null)
     }
 }
+
+export const eventPropertiesToPathClean = new Set(['$pathname', '$current_url', '$prev_pageview_pathname'])
+export const sessionPropertiesToPathClean = new Set([
+    '$entry_pathname',
+    '$end_pathname',
+    '$entry_current_url',
+    '$end_current_url',
+])
+export const personPropertiesToPathClean = new Set(['$initial_pathname', '$initial_current_url'])

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -16,6 +16,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Link } from 'lib/lemon-ui/Link/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
+    UnexpectedNeverError,
     getDefaultInterval,
     isNotNil,
     isValidRelativeOrAbsoluteDate,
@@ -100,8 +101,11 @@ import {
     WebAnalyticsStatusCheck,
     WebAnalyticsTile,
     WebVitalsPercentile,
+    eventPropertiesToPathClean,
     getWebAnalyticsBreakdownFilter,
     loadPriorityMap,
+    personPropertiesToPathClean,
+    sessionPropertiesToPathClean,
 } from './common'
 import { getDashboardItemId, getNewInsightUrlFactory } from './insightsUtils'
 import { marketingAnalyticsTilesLogic } from './tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic'
@@ -573,13 +577,32 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                 // Translate exact path filters to cleaned path filters
                 if (isPathCleaningEnabled) {
-                    filters = filters.map((filter) => ({
-                        ...filter,
-                        operator:
-                            filter.operator === PropertyOperator.Exact
-                                ? PropertyOperator.IsCleanedPathExact
-                                : filter.operator,
-                    }))
+                    filters = filters.map((filter) => {
+                        if (filter.operator !== PropertyOperator.Exact) {
+                            return filter
+                        }
+                        let propertiesToPathClean: Set<string>
+                        switch (filter.type) {
+                            case PropertyFilterType.Event:
+                                propertiesToPathClean = eventPropertiesToPathClean
+                                break
+                            case PropertyFilterType.Person:
+                                propertiesToPathClean = personPropertiesToPathClean
+                                break
+                            case PropertyFilterType.Session:
+                                propertiesToPathClean = sessionPropertiesToPathClean
+                                break
+                            default:
+                                throw new UnexpectedNeverError(filter)
+                        }
+                        if (propertiesToPathClean.has(filter.key)) {
+                            return {
+                                ...filter,
+                                operator: PropertyOperator.IsCleanedPathExact,
+                            }
+                        }
+                        return filter
+                    })
                 }
 
                 return filters


### PR DESCRIPTION
## Problem

We were changing all Exact property filters to IsCleanedPathExact, even if they weren't paths. This caused problems if the property was e.g. a Boolean, but also, it's just not wrong and potentially a lot of wasted CPU.

## Changes

Only change the property filters if the property is in a hardcoded list.

In the future, we might want to get this list from taxonomy.

## How did you test this code?

Ran web analytics manually and checked that the JSON object representing the trends query looks correct
