### PR TITLE
feat(blobby v2): add teamID to blobby v2 session URL list truncation warning log

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
@@ -201,7 +201,7 @@ export class SnappySessionRecorder {
             this.droppedUrlsCount++
             logger.warn(
                 '🔗',
-                `Dropping URL (count limit reached) for session ${this.sessionId}, dropped ${this.droppedUrlsCount} URLs`
+                `Dropping URL (count limit reached) for session ${this.sessionId} team ${this.teamId}, dropped ${this.droppedUrlsCount} URLs`
             )
         }
     }


### PR DESCRIPTION
## Problem
We're seeing some unexpected session URL lists in the event stream and would like it to be more handy to figure out which team(s) are submitting these.

## Changes
Add team ID to warn log

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
