### PR TITLE
fix(linkedin): temporarily disabling linkedin source 

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -295,7 +295,7 @@ class OauthIntegration:
                 token_url="https://www.linkedin.com/oauth/v2/accessToken",
                 client_id=settings.LINKEDIN_APP_CLIENT_ID,
                 client_secret=settings.LINKEDIN_APP_CLIENT_SECRET,
-                scope="r_ads rw_conversions r_ads_reporting openid profile email",
+                scope="r_ads rw_conversions openid profile email",
                 id_path="sub",
                 name_path="email",
             )

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -36,7 +36,7 @@ class LinkedInAdsSource(BaseSource[LinkedinAdsSourceConfig]):
             name=SchemaExternalDataSourceType.LINKEDIN_ADS,
             label="LinkedIn Ads",
             caption="Ensure you have granted PostHog access to your LinkedIn Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/linkedin-ads).",
-            betaSource=True,
+            unreleasedSource=True,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

The current app doesn't have the scope I need for ads integration.

More context here: https://posthog.slack.com/archives/C05LJK1N3CP/p1757103998218639

## Changes

Put it back into an unreleased source and remove the scope that doesn't have permissions

## How did you test this code?
Manually:
<img width="1363" height="646" alt="image" src="https://github.com/user-attachments/assets/b4b3cbfb-7051-41ef-8afc-222b672bde15" />

Redirect from cdp in OAuth flow working 
<img width="527" height="503" alt="image" src="https://github.com/user-attachments/assets/c9ca0a17-73c6-40e5-b572-6cda0302ea31" />

