### PR TITLE
fix(flags): Affected user counts stay synchronized with condition sets 

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -204,7 +204,10 @@ export function FeatureFlagReleaseConditions({
                                             disabledReason={
                                                 index === filterGroups.length - 1
                                                     ? 'Cannot move last condition set down'
-                                                    : null
+                                                    : affectedUsers[index] === undefined ||
+                                                        affectedUsers[index + 1] === undefined
+                                                      ? 'Cannot move condition sets while calculating affected users'
+                                                      : null
                                             }
                                             onClick={() => moveConditionSetDown(index)}
                                         />
@@ -213,7 +216,14 @@ export function FeatureFlagReleaseConditions({
                                             icon={<IconArrowUp />}
                                             noPadding
                                             tooltip="Move condition set up in precedence"
-                                            disabledReason={index === 0 ? 'Cannot move first condition set up' : null}
+                                            disabledReason={
+                                                index === 0
+                                                    ? 'Cannot move first condition set up'
+                                                    : affectedUsers[index] === undefined ||
+                                                        affectedUsers[index - 1] === undefined
+                                                      ? 'Cannot move condition sets while calculating affected users'
+                                                      : null
+                                            }
                                             onClick={() => moveConditionSetUp(index)}
                                         />
                                     </div>

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -508,6 +508,25 @@ describe('the feature flag release conditions logic', () => {
                 },
             ])
         })
+
+        it('preserves affected user calculations when reordering', () => {
+            const filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'C' },
+            ])
+            logic.actions.setFilters(filters)
+
+            for (let i = 0; i < 3; i++) {
+                logic.actions.setAffectedUsers(i, i * 100)
+            }
+
+            logic.actions.moveConditionSetDown(0)
+            expect(logic.values.affectedUsers).toEqual({ 0: 100, 1: 0, 2: 200 })
+
+            logic.actions.moveConditionSetUp(1)
+            expect(logic.values.affectedUsers).toEqual({ 0: 0, 1: 100, 2: 200 })
+        })
     })
 
     describe('condition set descriptions', () => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -52,7 +52,7 @@ function swapAffectedUsers(
     fromIndex: number,
     toIndex: number
 ): void {
-    if (!(fromIndex in affectedUsers && toIndex in affectedUsers)) {
+    if (!(fromIndex in affectedUsers) || !(toIndex in affectedUsers)) {
         return
     }
 

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -45,6 +45,23 @@ function moveConditionSet<T>(groups: T[], index: number, newIndex: number): T[] 
     return updatedGroups
 }
 
+// Helper function to swap affected users between two indices
+function swapAffectedUsers(
+    affectedUsers: Record<number, number | undefined>,
+    actions: { setAffectedUsers: (index: number, count?: number) => void },
+    fromIndex: number,
+    toIndex: number
+): void {
+    if (!(fromIndex in affectedUsers && toIndex in affectedUsers)) {
+        return
+    }
+
+    const fromCount = affectedUsers[fromIndex]
+    const toCount = affectedUsers[toIndex]
+    actions.setAffectedUsers(toIndex, fromCount)
+    actions.setAffectedUsers(fromIndex, toCount)
+}
+
 // TODO: Type onChange errors properly
 export interface FeatureFlagReleaseConditionsLogicProps {
     filters: FeatureFlagFilters
@@ -410,6 +427,12 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 // Clear loading state
                 actions.setFlagKeysLoading(false)
             }
+        },
+        moveConditionSetUp: ({ index }) => {
+            swapAffectedUsers(values.affectedUsers, actions, index, index - 1)
+        },
+        moveConditionSetDown: ({ index }) => {
+            swapAffectedUsers(values.affectedUsers, actions, index, index + 1)
         },
     })),
     selectors({


### PR DESCRIPTION
## Problem

When creating a feature flag with multiple condition sets and re-ordering them, estimated affected users would remain in the original order, out of sync from their associated condition set.

Resolves #36759

## Changes

Affected user counts will now properly move along with their associated condition set. In addition, condition sets cannot be moved while their affect user counts are being populated.

Before & after

https://github.com/user-attachments/assets/16e1eb40-35de-44cb-81ce-a6dc98a06592

## How did you test this code?

I've added a unit test to ensure affected user counts are properly moved along with their associated condition set.