### PR TITLE
feat(web-analytics): Move AST-to-AST transformations to new modifier

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13785,6 +13785,10 @@
                 "useMaterializedViews": {
                     "type": "boolean"
                 },
+                "usePreaggregatedTableTransforms": {
+                    "description": "Try to automatically convert HogQL queries to use preaggregated tables at the AST level *",
+                    "type": "boolean"
+                },
                 "usePresortedEventsTable": {
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -348,6 +348,8 @@ export interface HogQLQueryModifiers {
     useWebAnalyticsPreAggregatedTables?: boolean
     formatCsvAllowDoubleQuotes?: boolean
     convertToProjectTimezone?: boolean
+    /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level **/
+    usePreaggregatedTableTransforms?: boolean
 }
 
 export interface DataWarehouseEventsModifier {

--- a/frontend/src/scenes/debug/Modifiers.tsx
+++ b/frontend/src/scenes/debug/Modifiers.tsx
@@ -155,7 +155,7 @@ export function Modifiers<Q extends { response?: Record<string, any>; modifiers?
             )}
 
             <LemonLabel className={labelClassName}>
-                <div>Use pre-aggregated tables:</div>
+                <div>Pre-aggregation transformation:</div>
                 <LemonSelect
                     options={[
                         { value: true, label: 'true' },
@@ -164,12 +164,12 @@ export function Modifiers<Q extends { response?: Record<string, any>; modifiers?
                     onChange={(value) =>
                         setQuery({
                             ...query,
-                            modifiers: { ...query.modifiers, useWebAnalyticsPreAggregatedTables: value },
+                            modifiers: { ...query.modifiers, usePreaggregatedTableTransforms: value },
                         })
                     }
                     value={
-                        query.modifiers?.useWebAnalyticsPreAggregatedTables ??
-                        response?.modifiers?.useWebAnalyticsPreAggregatedTables
+                        query.modifiers?.usePreaggregatedTableTransforms ??
+                        response?.modifiers?.usePreaggregatedTableTransforms
                     }
                 />
             </LemonLabel>

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -119,7 +119,7 @@ class HogQLQueryExecutor:
 
     @tracer.start_as_current_span("HogQLQueryExecutor._apply_optimizers")
     def _apply_optimizers(self):
-        if self.query_modifiers.useWebAnalyticsPreAggregatedTables:
+        if self.query_modifiers.usePreaggregatedTableTransforms:
             with self.timings.measure("preaggregated_table_transforms"):
                 assert self.hogql_context is not None
                 assert self.hogql_context.team is not None

--- a/posthog/hogql/transforms/test/test_preaggregated_table_transformation.py
+++ b/posthog/hogql/transforms/test/test_preaggregated_table_transformation.py
@@ -881,7 +881,7 @@ class TestPreaggregatedTableTransformationIntegration(APIBaseTest, ClickhouseTes
         response = execute_hogql_query(
             parse_select("select count(), uniq(person_id) from events where equals(event, '$pageview')"),
             team=self.team,
-            modifiers=HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True),
+            modifiers=HogQLQueryModifiers(usePreaggregatedTableTransforms=True),
         )
         assert response.hogql and PREAGGREGATED_TABLE_NAME in response.hogql
         assert response.results == [(1, 1)]
@@ -896,7 +896,7 @@ class TestPreaggregatedTableTransformationIntegration(APIBaseTest, ClickhouseTes
                 "select count() as c, uniq(person_id) as p, uniq($session_id) as s, toStartOfDay(timestamp) as t, properties.utm_source as u from events where equals(event, '$pageview') and properties.utm_campaign == '' group by t, u, properties.utm_medium having c > 0 and u == ''"
             ),
             team=self.team,
-            modifiers=HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True),
+            modifiers=HogQLQueryModifiers(usePreaggregatedTableTransforms=True),
         )
         assert response.hogql and PREAGGREGATED_TABLE_NAME in response.hogql
         assert len(response.results) == 1
@@ -924,7 +924,7 @@ class TestPreaggregatedTableTransformationIntegration(APIBaseTest, ClickhouseTes
         response = execute_hogql_query(
             parse_select(original_query),
             team=self.team,
-            modifiers=HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True),
+            modifiers=HogQLQueryModifiers(usePreaggregatedTableTransforms=True),
         )
         assert response.results == [(1, self.TEST_DATA_DATE)]
 
@@ -936,7 +936,7 @@ class TestPreaggregatedTableTransformationIntegration(APIBaseTest, ClickhouseTes
         original_query = TrendsQuery(
             series=[EventsNode(name="$pageview", event="$pageview", math=BaseMathType.TOTAL)],
             dateRange=DateRange(date_from="2024-11-22", date_to="2024-11-26"),
-            modifiers=HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True),
+            modifiers=HogQLQueryModifiers(usePreaggregatedTableTransforms=True),
         )
         tqr = TrendsQueryRunner(team=self.team, query=original_query)
         response = tqr.calculate()
@@ -960,7 +960,7 @@ class TestPreaggregatedTableTransformationIntegration(APIBaseTest, ClickhouseTes
         original_query = TrendsQuery(
             series=[EventsNode(name="$pageview", event="$pageview", math=BaseMathType.DAU)],
             dateRange=DateRange(date_from="2024-11-22", date_to="2024-11-26"),
-            modifiers=HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True),
+            modifiers=HogQLQueryModifiers(usePreaggregatedTableTransforms=True),
         )
         tqr = TrendsQueryRunner(team=self.team, query=original_query)
         response = tqr.calculate()

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3916,6 +3916,10 @@ class HogQLQueryModifiers(BaseModel):
     sessionsV2JoinMode: Optional[SessionsV2JoinMode] = None
     timings: Optional[bool] = None
     useMaterializedViews: Optional[bool] = None
+    usePreaggregatedTableTransforms: Optional[bool] = Field(
+        default=None,
+        description="Try to automatically convert HogQL queries to use preaggregated tables at the AST level *",
+    )
     usePresortedEventsTable: Optional[bool] = None
     useWebAnalyticsPreAggregatedTables: Optional[bool] = None
 


### PR DESCRIPTION
## Problem

We don't want customers to use this modifier atm, as there are some problems with the source data.

## Changes

Let's put this on its own modifier, so that it can only be accessed from the debug scene

## How did you test this code?

Existing tests pass
