### PR TITLE
chore(flags): Log as JSON in production, but ANSI when `DEBUG`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7650,6 +7650,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7659,12 +7669,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -19,7 +19,7 @@ envconfig = { workspace = true }
 limiters = { path = "../common/limiters" }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 bytes = { workspace = true }
 once_cell = "1.18.0"
 rand = { workspace = true }

--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -67,7 +67,7 @@ async fn main() {
     //   - stdout with a level configured by the RUST_LOG envvar
     //   - OpenTelemetry if enabled, for levels INFO and higher
     // Read DEBUG environment variable (same as Django)
-    let debug = std::env::var("DEBUG").unwrap_or("false".to_string()).to_lowercase() == "true";
+    let debug: bool = *config.debug;
 
     let log_layer = {
         let base_layer = fmt::layer()
@@ -80,10 +80,16 @@ async fn main() {
 
         if debug {
             // Development: Pretty colored output (like Django's ConsoleRenderer(colors=DEBUG))
-            base_layer.with_ansi(true).with_filter(EnvFilter::from_default_env()).boxed()
+            base_layer
+                .with_ansi(true)
+                .with_filter(EnvFilter::from_default_env())
+                .boxed()
         } else {
             // Production: JSON format (like Django's JSONRenderer())
-            base_layer.json().with_filter(EnvFilter::from_default_env()).boxed()
+            base_layer
+                .json()
+                .with_filter(EnvFilter::from_default_env())
+                .boxed()
         }
     };
 

--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -63,18 +63,29 @@ fn init_tracer(sink_url: &str, sampling_rate: f64, service_name: &str) -> Tracer
 async fn main() {
     let config = Config::init_from_env().expect("Invalid configuration:");
 
-    // Instantiate tracing outputs:
+    // Instantiate tracing outputs following Django's DEBUG-based approach:
     //   - stdout with a level configured by the RUST_LOG envvar
     //   - OpenTelemetry if enabled, for levels INFO and higher
-    let log_layer = fmt::layer()
-        .with_span_events(
-            FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
-        )
-        .with_target(true)
-        .with_thread_ids(true)
-        .with_level(true)
-        .with_ansi(false)
-        .with_filter(EnvFilter::from_default_env());
+    // Read DEBUG environment variable (same as Django)
+    let debug = std::env::var("DEBUG").unwrap_or("false".to_string()).to_lowercase() == "true";
+
+    let log_layer = {
+        let base_layer = fmt::layer()
+            .with_span_events(
+                FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
+            )
+            .with_target(true)
+            .with_thread_ids(true)
+            .with_level(true);
+
+        if debug {
+            // Development: Pretty colored output (like Django's ConsoleRenderer(colors=DEBUG))
+            base_layer.with_ansi(true).with_filter(EnvFilter::from_default_env()).boxed()
+        } else {
+            // Production: JSON format (like Django's JSONRenderer())
+            base_layer.json().with_filter(EnvFilter::from_default_env()).boxed()
+        }
+    };
 
     let otel_layer = if let Some(ref otel_url) = config.otel_url {
         Some(


### PR DESCRIPTION
This makes local logging human friendly, but ensures logs in production are structured so we can extract the log level label.

## Problem

Logs in production aren't indexed by log level. This, combined with this Promtail config change, will fix that.

## Changes

Log as JSON when in production. This change depends on [this Promtail config being deployed first](https://github.com/PostHog/charts/pull/5909).

## How did you test this code?

Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
