### PR TITLE
chore: Give flox binaries precedence

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -163,6 +163,8 @@ zsh = '''
     # ensure even with your shell prefs in place we know this is a Flox.dev env
     export PS1="%K{white}%F{black}(flox)%k%f $PS1"
   fi
+  # Ensure flox binaries (especially Node.js) take precedence over system binaries
+  export PATH="$FLOX_ENV/bin:$PATH"
   source $UV_PROJECT_ENVIRONMENT/bin/activate
 '''
 fish = '''


### PR DESCRIPTION
## Problem

The node I have installed on my system was being used to run `plugin-server` which failed. After activating flox, I checked my node version and it was `v24.6.0` But flox requires is configured with node `22.17.0`. This is important because some of the node packages we use can't be built with `v24.6.0`

## Changes

In the flox manifest, after sourcing `~/.zshrc`, make sure the PATH gives precedence to the flox binaries.

## How did you test this code?

Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
