### PR TITLE
Revert "chore: disable events backup"

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -30,6 +30,7 @@ SHARDED_TABLES = [
     "sharded_session_replay_events",
     "sharded_session_replay_events_v2_test",
     "sharded_sessions",
+    "sharded_events",
 ]
 
 NON_SHARDED_TABLES = [


### PR DESCRIPTION
Reverts PostHog/posthog#36826 - turning on sharded_events backups and will accompany this with a PR to limit backup resources in server configs