### PR TITLE
fix: minimal navigation when user has no org

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -36,6 +36,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isNotNil } from 'lib/utils'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { editorSceneLogic } from 'scenes/data-warehouse/editor/editorSceneLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { savedSessionRecordingPlaylistsLogic } from 'scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic'
@@ -72,6 +73,8 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             ['mobileLayout'],
             savedSessionRecordingPlaylistsLogic({ tab: ReplayTabs.Home }),
             ['savedFilters', 'savedFiltersLoading'],
+            organizationLogic,
+            ['isCurrentOrganizationUnavailable'],
         ],
         actions: [navigationLogic, ['closeAccountPopover'], sceneLogic, ['setScene']],
     })),
@@ -334,8 +337,11 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
     })),
     selectors({
         mode: [
-            (s) => [s.sceneConfig],
-            (sceneConfig): Navigation3000Mode => {
+            (s) => [s.sceneConfig, s.isCurrentOrganizationUnavailable],
+            (sceneConfig, isCurrentOrganizationUnavailable): Navigation3000Mode => {
+                if (isCurrentOrganizationUnavailable) {
+                    return 'minimal'
+                }
                 return sceneConfig?.layout === 'plain' && !sceneConfig.allowUnauthenticated
                     ? 'minimal'
                     : sceneConfig?.layout !== 'plain'


### PR DESCRIPTION
## Problem

When a user has no orgs (e.g. access removed), the app still shows sidebar and spams toast errors. 

<img width="500" height="283" alt="Screenshot 2025-09-06 at 20 03 59" src="https://github.com/user-attachments/assets/7eabadeb-ff9f-40f9-9b8c-63767e81da2d" />


## Changes
- Show minimal navigation (header only) if no current org

<img width="500" height="281" alt="Screenshot 2025-09-06 at 19 57 27" src="https://github.com/user-attachments/assets/eb1f9d14-c486-4e7c-a444-a51f8e459931" />

## How did you test this code?
Manually
