### PR TITLE
chore: Make sure flox gives precedence to flox binaries (other shells)

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -155,6 +155,8 @@ bash = '''
     # ensure even with your shell prefs in place we know this is a Flox.dev env
     export PS1="\033[47m(flox)\033[0m $PS1"
   fi
+  # Ensure flox binaries (especially Node.js) take precedence over system binaries
+  export PATH="$FLOX_ENV/bin:$PATH"
   source $UV_PROJECT_ENVIRONMENT/bin/activate
 '''
 zsh = '''
@@ -168,9 +170,13 @@ zsh = '''
   source $UV_PROJECT_ENVIRONMENT/bin/activate
 '''
 fish = '''
+  # Ensure flox binaries (especially Node.js) take precedence over system binaries
+  set -gx PATH "$FLOX_ENV/bin" $PATH
   source $UV_PROJECT_ENVIRONMENT/bin/activate.fish
 '''
 tcsh = '''
+  # Ensure flox binaries (especially Node.js) take precedence over system binaries
+  setenv PATH "$FLOX_ENV/bin:$PATH"
   source $UV_PROJECT_ENVIRONMENT/bin/activate.csh
 '''
 

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -171,7 +171,7 @@ zsh = '''
 '''
 fish = '''
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
-  set -gx PATH "$FLOX_ENV/bin" $PATH
+  fish_add_path "$FLOX_ENV/bin"
   source $UV_PROJECT_ENVIRONMENT/bin/activate.fish
 '''
 tcsh = '''


### PR DESCRIPTION
This is a follow-up to the zshrc change made in https://github.com/PostHog/posthog/pull/37720, but for bash, fish, and tcsh. I'm not using these other shells so I wanted to make sure someone who does reviews this change.

## Problem

The node I have installed on my system was being used to run plugin-server which failed. After activating flox, I checked my node version and it was v24.6.0 But flox requires is configured with node 22.17.0. This is important because some of the node packages we use can't be built with v24.6.0. The problem is that my homebrew installed version of node took precedence over the flox versions when working in a flox activated directory.

## Changes

In the flox manifest, make sure the PATH gives precedence to the flox binaries.

## How did you test this code?

I tested it for zshrc but not the other shells.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
