### PR TITLE
fix(ux): various fixes

### DIFF
--- a/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
+++ b/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
@@ -275,11 +275,6 @@ export function EnvironmentSwitcherOverlay({
                     ) : (
                         <span className="truncate">{currentProject?.name ?? 'Project'}</span>
                     )}
-                    {!iconOnly && (
-                        <LemonTag size="small" className="border-text-3000 uppercase ml-1.5">
-                            <span className="truncate max-w-[100px]">{currentTeam.name}</span>
-                        </LemonTag>
-                    )}
                     {!iconOnly && <DropdownMenuOpenIndicator />}
                 </ButtonPrimitive>
             </PopoverPrimitiveTrigger>

--- a/frontend/src/layout/panel-layout/OrganizationDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/OrganizationDropdownMenu.tsx
@@ -85,8 +85,34 @@ export function OrganizationDropdownMenu({
                     <Combobox>
                         <Combobox.Search placeholder="Filter organizations..." />
                         <Combobox.Content>
-                            <Label intent="menu" className="px-2">
-                                Organizations
+                            {preflight?.can_create_org && (
+                                <Combobox.Item asChild>
+                                    <ButtonPrimitive
+                                        menuItem
+                                        data-attr="new-organization-button"
+                                        onClick={() =>
+                                            guardAvailableFeature(
+                                                AvailableFeature.ORGANIZATIONS_PROJECTS,
+                                                () => {
+                                                    closeAccountPopover()
+                                                    showCreateOrganizationModal()
+                                                },
+                                                {
+                                                    guardOnCloud: false,
+                                                }
+                                            )
+                                        }
+                                        tooltip="Create a new organization"
+                                        tooltipPlacement="right"
+                                    >
+                                        <IconPlusSmall className="size-4" />
+                                        New organization
+                                    </ButtonPrimitive>
+                                </Combobox.Item>
+                            )}
+
+                            <Label intent="menu" className="px-2 mt-2">
+                                Current organization
                             </Label>
                             <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
 
@@ -118,6 +144,11 @@ export function OrganizationDropdownMenu({
                                 </Combobox.Group>
                             )}
 
+                            <Label intent="menu" className="px-2 mt-2">
+                                Other organizations
+                            </Label>
+                            <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+
                             {otherOrganizations.map((otherOrganization) => (
                                 <Combobox.Group value={[otherOrganization.name]} key={otherOrganization.id}>
                                     <Combobox.Item key={otherOrganization.id} asChild>
@@ -143,32 +174,6 @@ export function OrganizationDropdownMenu({
                                     </Combobox.Item>
                                 </Combobox.Group>
                             ))}
-
-                            {preflight?.can_create_org && (
-                                <Combobox.Item asChild>
-                                    <ButtonPrimitive
-                                        menuItem
-                                        data-attr="new-organization-button"
-                                        onClick={() =>
-                                            guardAvailableFeature(
-                                                AvailableFeature.ORGANIZATIONS_PROJECTS,
-                                                () => {
-                                                    closeAccountPopover()
-                                                    showCreateOrganizationModal()
-                                                },
-                                                {
-                                                    guardOnCloud: false,
-                                                }
-                                            )
-                                        }
-                                        tooltip="Create a new organization"
-                                        tooltipPlacement="right"
-                                    >
-                                        <IconPlusSmall className="size-4" />
-                                        New organization
-                                    </ButtonPrimitive>
-                                </Combobox.Item>
-                            )}
                         </Combobox.Content>
                     </Combobox>
                 </PopoverPrimitiveContent>

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -295,7 +295,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                     ref={containerRef}
                 >
                     <div
-                        className={`flex justify-between p-1 pl-[5px] h-[var(--scene-layout-header-height)] items-center ${isLayoutNavCollapsed ? 'justify-center' : ''}`}
+                        className={`flex justify-between p-1 pl-[5px] items-center ${isLayoutNavCollapsed ? 'justify-center' : 'h-[var(--scene-layout-header-height)]'}`}
                     >
                         {newSceneLayout ? (
                             <div className={cn('flex gap-1 rounded-md w-full', isLayoutNavCollapsed && 'flex-col')}>

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -288,7 +288,7 @@ export const SETTINGS_MAP: SettingSection[] = [
             {
                 id: 'marketing-settings',
                 title: 'Marketing settings',
-                component: <MarketingAnalyticsSettings />,
+                component: <MarketingAnalyticsSettings hideTitle />,
             },
         ],
     },

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/MarketingAnalyticsSettings.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/MarketingAnalyticsSettings.tsx
@@ -13,12 +13,12 @@ import { NativeExternalDataSourceConfiguration } from './NativeExternalDataSourc
 import { NonNativeExternalDataSourceConfiguration } from './NonNativeExternalDataSourceConfiguration'
 import { SelfManagedExternalDataSourceConfiguration } from './SelfManagedExternalDataSourceConfiguration'
 
-export function MarketingAnalyticsSettings(): JSX.Element {
+export function MarketingAnalyticsSettings({ hideTitle = false }: { hideTitle?: boolean }): JSX.Element {
     const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
 
     return (
         <SceneContent className={cn(!newSceneLayout && 'gap-8 mb-10')}>
-            {newSceneLayout && (
+            {newSceneLayout && !hideTitle && (
                 <SceneTitleSection
                     name="Marketing analytics"
                     description={null}


### PR DESCRIPTION
## Problem
* nav bar org + project buttons were messed up when nav is collapsed
* org dropdown didn't match the visual design of project dropdown
* project dropdown (when `environments` flag enabled) was truncating the project name too much!
* Marketing analytics scene title section is leaking into `settings/project-marketing-analytics`

## Changes

* fix nav bar org + project when nav is collapsed
<img width="268" height="131" alt="image" src="https://github.com/user-attachments/assets/d5eadaec-9f53-42ee-9688-fd385953e58b" />

---

* add labels `current org` & `other orgs`, and move new org button to top to match project dropdown
<img width="250" height="270" alt="image" src="https://github.com/user-attachments/assets/072f4860-7561-4a28-b507-ad91e242acd4" />

---

* remove lemon tag from org switcher trigger (demoted anyways so it's cool)
<img width="511" height="356" alt="image" src="https://github.com/user-attachments/assets/373d5beb-ac49-4061-b1e6-3da80ef4d45d" />

---

* Hide scene title section in marketing analytics when in settings
<img width="681" height="223" alt="image" src="https://github.com/user-attachments/assets/4f9ec5ff-f3e5-4d03-b475-98289e5b37bd" />



## How did you test this code?
Clickin'