### PR TITLE
fix(cohorts): Ensure static cohort count is updated even when processing fails

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -440,6 +440,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         from posthog.models.cohort.util import get_static_cohort_size, insert_static_cohort
 
         current_batch_index = -1
+        processing_error = None
         try:
             cursor = connection.cursor()
             for batch_index, batch in batch_iterator:
@@ -467,27 +468,29 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
                 )
                 cursor.execute(query, params)
 
-            count = get_static_cohort_size(cohort_id=self.id, team_id=self.team_id)
-            self.count = count
-
-            self.is_calculating = False
-            self.last_calculation = timezone.now()
-            self.errors_calculating = 0
-            self.save()
-
-            return current_batch_index + 1
         except Exception as err:
+            processing_error = err
             if settings.DEBUG:
                 raise
-            self.is_calculating = False
-            self.errors_calculating = F("errors_calculating") + 1
-            self.last_error_at = timezone.now()
-
-            self.save()
             # Add batch index context to the exception
-            capture_exception(err, additional_properties={"batch_index": current_batch_index})
+            capture_exception(
+                err,
+                additional_properties={"cohort_id": self.id, "team_id": team_id, "batch_index": current_batch_index},
+            )
+        finally:
+            # Always update the count and cohort state, even if processing failed
+            try:
+                count = get_static_cohort_size(cohort_id=self.id, team_id=self.team_id)
+                self.count = count
+            except Exception as count_err:
+                # If count calculation fails, log the error but don't override the processing error
+                logger.exception("Failed to calculate static cohort size", cohort_id=self.id, team_id=team_id)
+                capture_exception(count_err, additional_properties={"cohort_id": self.id, "team_id": team_id})
+                # Leave existing count unchanged - it's better than None
 
-            return current_batch_index + 1
+            self._safe_save_cohort_state(team_id=team_id, processing_error=processing_error)
+
+        return current_batch_index + 1
 
     def to_dict(self) -> dict:
         people_data = [
@@ -519,6 +522,38 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             "people": people_data,
         }
         return {k: v for k, v in base_dict.items() if k not in excluded_fields}
+
+    def _safe_save_cohort_state(self, *, team_id: int, processing_error=None) -> None:
+        """
+        Safely save cohort state with fallback to save only critical fields.
+
+        This prevents cohorts from getting stuck in calculating state when
+        database issues occur during cleanup operations.
+
+        Args:
+            team_id: Team ID for logging context
+            processing_error: Error from processing, if any. Used to update error state.
+        """
+        self.is_calculating = False
+
+        if processing_error is None:
+            self.last_calculation = timezone.now()
+            self.errors_calculating = 0
+        else:
+            self.errors_calculating = F("errors_calculating") + 1
+            self.last_error_at = timezone.now()
+        try:
+            self.save()
+        except Exception as save_err:
+            logger.exception("Failed to save cohort state", cohort_id=self.id, team_id=team_id)
+            capture_exception(save_err, additional_properties={"cohort_id": self.id, "team_id": team_id})
+
+            # Single retry for transient issues
+            try:
+                self.save()
+            except Exception:
+                logger.exception("Failed to save cohort state on retry", cohort_id=self.id, team_id=team_id)
+                # If both attempts fail, the cohort may remain in an inconsistent state
 
     __repr__ = sane_repr("id", "name", "last_calculation")
 


### PR DESCRIPTION
## Problem

Previously, static cohort count updates could fail when exceptions occurred during batch processing (e.g., out-of-memory errors), leaving cohorts with `count=0` despite having people successfully inserted into `posthog_cohortpeople`.

Fixes #33759 

## Changes

This fix moves count calculation and cohort state updates from try blocks to finally blocks to ensure they always execute, regardless of processing errors.

Also made saving the cohort more robust by wrapping the `save()` in its own `try/except` block.

## How did you test this code?

Unit tests
Manual testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
