### PR TITLE
feat(experiments): allow setting custom step funnel name

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -219,7 +219,7 @@ export function ExperimentMetricForm({
                         typeKey="experiment-metric"
                         buttonCopy="Add step"
                         showSeriesIndicator={false}
-                        hideRename={true}
+                        hideRename={false}
                         hideDeleteBtn={hideDeleteBtn}
                         sortable={true}
                         showNestedArrow={true}

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -506,11 +506,12 @@ export const getExposureConfigEventsNode = (
     exposureConfig: ExperimentEventExposureConfig,
     options: { featureFlagKey: string; featureFlagVariants: MultivariateFlagVariant[] }
 ): EventsNode => {
+    const expsoure_step_name = 'Experiment exposure'
     if (exposureConfig && exposureConfig.event !== '$feature_flag_called') {
         const { featureFlagKey, featureFlagVariants } = options
         return {
             kind: NodeKind.EventsNode,
-            custom_name: exposureConfig.event,
+            custom_name: expsoure_step_name,
             event: exposureConfig.event,
             properties: [
                 ...(exposureConfig.properties || []),
@@ -526,7 +527,7 @@ export const getExposureConfigEventsNode = (
 
     return {
         kind: NodeKind.EventsNode,
-        custom_name: '$feature_flag_called',
+        custom_name: expsoure_step_name,
         event: '$feature_flag_called',
         properties: [
             {

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -402,6 +402,7 @@ export function filterToMetricConfig(
                         ({
                             kind: NodeKind.EventsNode,
                             event: event.id,
+                            custom_name: event.custom_name,
                             properties: event.properties,
                             order: event.order,
                         }) as EventsNode & { order: number }

--- a/frontend/src/scenes/experiments/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.ts
@@ -506,12 +506,12 @@ export const getExposureConfigEventsNode = (
     exposureConfig: ExperimentEventExposureConfig,
     options: { featureFlagKey: string; featureFlagVariants: MultivariateFlagVariant[] }
 ): EventsNode => {
-    const expsoure_step_name = 'Experiment exposure'
+    const exposure_step_name = 'Experiment exposure'
     if (exposureConfig && exposureConfig.event !== '$feature_flag_called') {
         const { featureFlagKey, featureFlagVariants } = options
         return {
             kind: NodeKind.EventsNode,
-            custom_name: expsoure_step_name,
+            custom_name: exposure_step_name,
             event: exposureConfig.event,
             properties: [
                 ...(exposureConfig.properties || []),
@@ -527,7 +527,7 @@ export const getExposureConfigEventsNode = (
 
     return {
         kind: NodeKind.EventsNode,
-        custom_name: expsoure_step_name,
+        custom_name: exposure_step_name,
         event: '$feature_flag_called',
         properties: [
             {


### PR DESCRIPTION
## Problem
We currently don't allow setting a custom step name. This feature has been requested by a customer.

## Changes
* Allow setting a custom step name
* Set exposure step name to "Experiment exposure" to make it more clear what this is

WIth default experiment exposure criteria
<img width="552" height="249" alt="Screenshot 2025-09-08 at 09 03 25" src="https://github.com/user-attachments/assets/17501951-6b10-4ab4-8602-a10085442445" />

With a custom event as exposure criteria
<img width="503" height="225" alt="Screenshot 2025-09-08 at 09 05 56" src="https://github.com/user-attachments/assets/99c09662-095d-4388-a249-d99c5c9a6be0" />

## How did you test this code?

- Tested locally
