### PR TITLE
fix(dashboards): fix dashboard template modal

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -187,7 +187,7 @@ export function DashboardHeader(): JSX.Element | null {
                     {canEditDashboard && <DeleteDashboardModal />}
                     {canEditDashboard && <DuplicateDashboardModal />}
                     {canEditDashboard && <DashboardInsightColorsModal />}
-                    <DashboardTemplateEditor />
+                    {user?.is_staff && <DashboardTemplateEditor />}
                 </>
             )}
 

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -63,6 +63,7 @@ import {
 
 import { DASHBOARD_RESTRICTION_OPTIONS } from './DashboardCollaborators'
 import { DashboardInsightColorsModal } from './DashboardInsightColorsModal'
+import { DashboardTemplateEditor } from './DashboardTemplateEditor'
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { dashboardInsightColorsModalLogic } from './dashboardInsightColorsModalLogic'
@@ -186,6 +187,7 @@ export function DashboardHeader(): JSX.Element | null {
                     {canEditDashboard && <DeleteDashboardModal />}
                     {canEditDashboard && <DuplicateDashboardModal />}
                     {canEditDashboard && <DashboardInsightColorsModal />}
+                    <DashboardTemplateEditor />
                 </>
             )}
 


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/37046 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38690)
https://posthog.slack.com/archives/C02E3BKC78F/p1756483537251349

## Changes

The modal component is missing from the rendering tree. I'm mounting it with other dashboard modals now.

## How did you test this code?

Tested locally