### PR TITLE
feat(MA): Adding back linkedin integration

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -295,7 +295,7 @@ class OauthIntegration:
                 token_url="https://www.linkedin.com/oauth/v2/accessToken",
                 client_id=settings.LINKEDIN_APP_CLIENT_ID,
                 client_secret=settings.LINKEDIN_APP_CLIENT_SECRET,
-                scope="r_ads rw_conversions openid profile email",
+                scope="r_ads rw_conversions r_ads_reporting openid profile email",
                 id_path="sub",
                 name_path="email",
             )

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -36,7 +36,7 @@ class LinkedInAdsSource(BaseSource[LinkedinAdsSourceConfig]):
             name=SchemaExternalDataSourceType.LINKEDIN_ADS,
             label="LinkedIn Ads",
             caption="Ensure you have granted PostHog access to your LinkedIn Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/linkedin-ads).",
-            unreleasedSource=True,
+            betaSource=True,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

I disabled Linkedin integration because I was missing a scope in production app.

## Changes

I had access to prod app and requested the scope:
<img width="793" height="342" alt="image" src="https://github.com/user-attachments/assets/3050d541-3a88-4b5e-a0c5-d560f05e1c2b" />


## How did you test this code?
Manually
<img width="953" height="681" alt="image" src="https://github.com/user-attachments/assets/6f74ad3c-5a21-4268-8365-b2fde19f4d2e" />
<img width="653" height="280" alt="image" src="https://github.com/user-attachments/assets/6a091ecd-c099-47a5-b5f1-7386a523d29f" />
