### PR TITLE
fix(cdp): Segment should always write fetch metrics

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker-plugins.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker-plugins.test.ts
@@ -1,4 +1,5 @@
 import { mockProducerObserver } from '~/tests/helpers/mocks/producer.mock'
+import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { DateTime } from 'luxon'
 
@@ -6,7 +7,6 @@ import { RetryError } from '@posthog/plugin-scaffold'
 
 import { forSnapshot } from '~/tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
-import { FetchResponse, fetch } from '~/utils/request'
 
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
@@ -30,7 +30,6 @@ describe('CdpCyclotronWorkerPlugins', () => {
     let team: Team
     let fn: HogFunctionType
     let globals: HogFunctionInvocationGlobalsWithInputs
-    let mockFetch: jest.Mock<Promise<FetchResponse>, Parameters<typeof fetch>>
     const insertHogFunction = async (hogFunction: Partial<HogFunctionType>) => {
         const item = await _insertHogFunction(hub.postgres, team.id, {
             ...hogFunction,
@@ -44,6 +43,13 @@ describe('CdpCyclotronWorkerPlugins', () => {
     const intercomPlugin = DESTINATION_PLUGINS_BY_ID['plugin-posthog-intercom-plugin']
 
     beforeEach(async () => {
+        mockFetch.mockResolvedValue({
+            status: 200,
+            json: () => Promise.resolve({}),
+            text: () => Promise.resolve(JSON.stringify({})),
+            headers: {},
+        })
+
         await resetTestDatabase()
         hub = await createHub()
 
@@ -51,15 +57,6 @@ describe('CdpCyclotronWorkerPlugins', () => {
         processor = new CdpCyclotronWorker(hub)
 
         await processor.start()
-
-        processor['pluginDestinationExecutorService'].fetch = mockFetch = jest.fn((_url, _options) =>
-            Promise.resolve({
-                status: 200,
-                json: () => Promise.resolve({}),
-                text: () => Promise.resolve(JSON.stringify({})),
-                headers: {},
-            } as any)
-        )
 
         jest.spyOn(processor['cyclotronJobQueue']!, 'queueInvocationResults').mockImplementation(() =>
             Promise.resolve()

--- a/plugin-server/src/cdp/legacy-plugins/types.ts
+++ b/plugin-server/src/cdp/legacy-plugins/types.ts
@@ -1,6 +1,6 @@
 import { PluginEvent, ProcessedPluginEvent, StorageExtension } from '@posthog/plugin-scaffold'
 
-import { FetchResponse, fetch } from '../../utils/request'
+import { FetchOptions, FetchResponse } from '../../utils/request'
 import { HogFunctionTemplate } from '../types'
 
 export type LegacyPluginLogger = {
@@ -23,7 +23,7 @@ export type LegacyTransformationPluginMeta = LegacyPluginMeta & {
 }
 
 export type LegacyDestinationPluginMeta = LegacyTransformationPluginMeta & {
-    fetch: (...args: Parameters<typeof fetch>) => Promise<FetchResponse>
+    fetch: (url: string, fetchParams: FetchOptions) => Promise<FetchResponse>
     storage: Pick<StorageExtension, 'get' | 'set'>
 }
 

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
@@ -1,19 +1,14 @@
+import { mockFetch } from '~/tests/helpers/mocks/request.mock'
+
 import { DateTime } from 'luxon'
 
 import { forSnapshot } from '~/tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
-import { FetchResponse } from '~/utils/request'
-import { fetch } from '~/utils/request'
 
 import { createPlugin, createPluginConfig } from '../../../tests/helpers/sql'
 import { Hub, PluginConfig, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
-import {
-    insertHogFunction as _insertHogFunction,
-    createExampleInvocation,
-    createHogExecutionGlobals,
-    createHogFunction,
-} from '../_tests/fixtures'
+import { createExampleInvocation, createHogExecutionGlobals, createHogFunction } from '../_tests/fixtures'
 import { DESTINATION_PLUGINS_BY_ID, TRANSFORMATION_PLUGINS_BY_ID } from '../legacy-plugins'
 import { LegacyDestinationPlugin, LegacyTransformationPlugin } from '../legacy-plugins/types'
 import {
@@ -40,7 +35,6 @@ describe('LegacyPluginExecutorService', () => {
     let team: Team
     let globals: HogFunctionInvocationGlobalsWithInputs
     let fn: HogFunctionType
-    let mockFetch: jest.Mock<Promise<FetchResponse>, Parameters<typeof fetch>>
     let pluginConfig: PluginConfig
 
     const customerIoPlugin = DESTINATION_PLUGINS_BY_ID['plugin-customerio-plugin']
@@ -78,7 +72,7 @@ describe('LegacyPluginExecutorService', () => {
             plugin_id: plugin.id,
         } as any)
 
-        mockFetch = jest.fn((_url, _options) =>
+        mockFetch.mockImplementation((_url, _options) =>
             Promise.resolve({
                 status: 200,
                 json: () =>
@@ -94,8 +88,6 @@ describe('LegacyPluginExecutorService', () => {
                 headers: {},
             })
         )
-
-        jest.spyOn(service, 'fetch').mockImplementation(mockFetch)
 
         globals = {
             ...createHogExecutionGlobals({

--- a/plugin-server/src/cdp/services/native-destination-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/native-destination-executor.service.test.ts
@@ -1,8 +1,9 @@
+import { mockFetch } from '~/tests/helpers/mocks/request.mock'
+
 import { DateTime, Settings } from 'luxon'
 
 import { defaultConfig } from '~/config/config'
 import { forSnapshot } from '~/tests/helpers/snapshots'
-import { FetchResponse, fetch } from '~/utils/request'
 
 import { createHogFunction } from '../_tests/fixtures'
 import { createExampleNativeInvocation } from '../_tests/fixtures-native'
@@ -22,13 +23,12 @@ const inputs = {
 
 describe('NativeDestinationExecutorService', () => {
     let service: NativeDestinationExecutorService
-    let mockFetch: jest.Mock<Promise<FetchResponse>, Parameters<typeof fetch>>
 
     beforeEach(() => {
         Settings.defaultZone = 'UTC'
         service = new NativeDestinationExecutorService(defaultConfig)
 
-        service.fetch = mockFetch = jest.fn((_url, _options) =>
+        mockFetch.mockImplementation((_url, _options) =>
             Promise.resolve({
                 status: 200,
                 json: () => Promise.resolve({}),

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.test.ts
@@ -1,8 +1,9 @@
+import { mockFetch } from '~/tests/helpers/mocks/request.mock'
+
 import { DateTime, Settings } from 'luxon'
 
 import { defaultConfig } from '~/config/config'
 import { forSnapshot } from '~/tests/helpers/snapshots'
-import { FetchResponse, fetch } from '~/utils/request'
 
 import { createHogFunction } from '../_tests/fixtures'
 import {
@@ -16,7 +17,6 @@ import { SegmentDestinationExecutorService } from './segment-destination-executo
 
 describe('SegmentDestinationExecutorService', () => {
     let service: SegmentDestinationExecutorService
-    let mockFetch: jest.Mock<Promise<FetchResponse>, Parameters<typeof fetch>>
 
     const amplitudePlugin = SEGMENT_DESTINATIONS_BY_ID['segment-actions-amplitude']
     const amplitudeAction = amplitudePlugin.destination.actions['logEventV2']
@@ -28,10 +28,12 @@ describe('SegmentDestinationExecutorService', () => {
     const pipedriveAction = pipedrivePlugin.destination.actions['createUpdatePerson']
 
     beforeEach(() => {
+        mockFetch.mockReset()
+
         Settings.defaultZone = 'UTC'
         service = new SegmentDestinationExecutorService(defaultConfig)
 
-        service.fetch = mockFetch = jest.fn((_url, _options) =>
+        mockFetch.mockImplementation((_url, _options) =>
             Promise.resolve({
                 status: 200,
                 json: () => Promise.resolve({}),

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.ts
@@ -200,19 +200,19 @@ export class SegmentDestinationExecutorService {
                         body,
                     }
 
+                    result.metrics!.push({
+                        team_id: invocation.hogFunction.team_id,
+                        app_source_id: invocation.hogFunction.id,
+                        metric_kind: 'other',
+                        metric_name: 'fetch',
+                        count: 1,
+                    })
+
                     if (isTestFunction && options?.method?.toUpperCase() !== 'GET') {
                         // For testing we mock out all non-GET requests
                         addLog('info', 'Fetch called but mocked due to test function', {
                             url: endpoint,
                             options: fetchOptions,
-                        })
-
-                        result.metrics!.push({
-                            team_id: invocation.hogFunction.team_id,
-                            app_source_id: invocation.hogFunction.id,
-                            metric_kind: 'other',
-                            metric_name: 'fetch',
-                            count: 1,
                         })
                         // Simulate a mini bit of fetch delay
                         await new Promise((resolve) => setTimeout(resolve, 200))

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.ts
@@ -4,14 +4,13 @@ import { ReadableStream } from 'stream/web'
 import { PluginsServerConfig } from '~/types'
 
 import { parseJSON } from '../../utils/json-parse'
-import { FetchOptions, FetchResponse, Response, fetch } from '../../utils/request'
-import { tryCatch } from '../../utils/try-catch'
+import { FetchOptions, FetchResponse, Response } from '../../utils/request'
 import { LegacyPluginLogger } from '../legacy-plugins/types'
 import { SEGMENT_DESTINATIONS_BY_ID } from '../segment/segment-templates'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
 import { CDP_TEST_ID, createAddLogFunction, isSegmentPluginHogFunction } from '../utils'
 import { createInvocationResult } from '../utils/invocation-utils'
-import { getNextRetryTime, isFetchResponseRetriable } from './hog-executor.service'
+import { cdpTrackedFetch, getNextRetryTime, isFetchResponseRetriable } from './hog-executor.service'
 
 const pluginExecutionDuration = new Histogram({
     name: 'cdp_segment_execution_duration_ms',
@@ -97,10 +96,6 @@ const convertFetchResponse = <Data = unknown>(response: FetchResponse, text: str
 
 export class SegmentDestinationExecutorService {
     constructor(private serverConfig: PluginsServerConfig) {}
-
-    public async fetch(...args: Parameters<typeof fetch>): Promise<FetchResponse> {
-        return fetch(...args)
-    }
 
     public async execute(
         invocation: CyclotronJobInvocationHogFunction
@@ -232,9 +227,13 @@ export class SegmentDestinationExecutorService {
                         addLog('debug', 'fetchOptions', fetchOptions)
                     }
 
-                    const [fetchError, fetchResponse] = await tryCatch(() =>
-                        this.fetch(`${endpoint}${params.toString() ? '?' + params.toString() : ''}`, fetchOptions)
-                    )
+                    const url = `${endpoint}${params.toString() ? '?' + params.toString() : ''}`
+                    const { fetchError, fetchResponse } = await cdpTrackedFetch({
+                        url,
+                        fetchParams: fetchOptions,
+                        templateId: invocation.hogFunction.template_id ?? '',
+                    })
+
                     const fetchResponseText = (await fetchResponse?.text()) ?? 'unknown'
 
                     if (fetchError || !fetchResponse || fetchResponse.status >= 400) {

--- a/plugin-server/src/cdp/templates/_destinations/native_webhook/webhook.template.test.ts
+++ b/plugin-server/src/cdp/templates/_destinations/native_webhook/webhook.template.test.ts
@@ -1,21 +1,24 @@
-import { SAMPLE_GLOBALS } from '~/cdp/_tests/fixtures'
+import '~/tests/helpers/mocks/date.mock'
+import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { NATIVE_HOG_FUNCTIONS_BY_ID } from '../../index'
-import { DestinationTester, generateTestData } from '../../test/test-helpers'
+import { TemplateTester, generateTestData } from '../../test/test-helpers'
 
 const template = NATIVE_HOG_FUNCTIONS_BY_ID['native-webhook']
-
 describe(`${template.name} template`, () => {
-    const tester = new DestinationTester(template!)
-
-    beforeEach(() => {
-        tester.beforeEach()
+    const tester = new TemplateTester({ ...template, code: '', code_language: 'javascript' })
+    beforeEach(async () => {
+        await tester.beforeEach()
+        mockFetch.mockResolvedValue({
+            status: 200,
+            json: () => Promise.resolve({ status: 'OK' }),
+            text: () => Promise.resolve(JSON.stringify({ status: 'OK' })),
+            headers: { 'content-type': 'application/json' },
+        })
     })
-
     afterEach(() => {
         tester.afterEach()
     })
-
     it('should work with default mapping', async () => {
         const payload = {
             url: 'https://example.com/webhook',
@@ -24,13 +27,13 @@ describe(`${template.name} template`, () => {
             headers: { 'Content-Type': 'application/json' },
             debug_mode: true,
         }
-        const response = await tester.invoke(SAMPLE_GLOBALS, payload)
-
-        expect(response.logs).toMatchInlineSnapshot(`
+        const response = await tester.invoke({ ...payload })
+        expect(tester.logsForSnapshot(response.logs)).toMatchInlineSnapshot(
+            `
             [
               {
                 "level": "debug",
-                "message": "config, {"method":"POST","body":{"event":{"uuid":"uuid","event":"test","distinct_id":"distinct_id","properties":{"email":"test@posthog.com"},"timestamp":"","elements_chain":"","url":""},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}},"headers":{"Content-Type":"application/json"},"debug":false,"debug_mode":true,"url":"https://example.com/webhook"}",
+                "message": "config, {"method":"POST","body":{"event":{"uuid":"event-id","event":"event-name","distinct_id":"distinct-id","properties":{"$current_url":"https://example.com"},"timestamp":"2024-01-01T00:00:00Z","elements_chain":"","url":"https://us.posthog.com/projects/1/events/1234"},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}},"headers":{"Content-Type":"application/json"},"debug":false,"debug_mode":true,"url":"https://example.com/webhook"}",
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
               {
@@ -40,12 +43,12 @@ describe(`${template.name} template`, () => {
               },
               {
                 "level": "debug",
-                "message": "options, {"method":"POST","headers":{"Content-Type":"application/json"},"json":{"event":{"uuid":"uuid","event":"test","distinct_id":"distinct_id","properties":{"email":"test@posthog.com"},"timestamp":"","elements_chain":"","url":""},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}}}",
+                "message": "options, {"method":"POST","headers":{"Content-Type":"application/json"},"json":{"event":{"uuid":"event-id","event":"event-name","distinct_id":"distinct-id","properties":{"$current_url":"https://example.com"},"timestamp":"2024-01-01T00:00:00Z","elements_chain":"","url":"https://us.posthog.com/projects/1/events/1234"},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}}}",
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
               {
                 "level": "debug",
-                "message": "fetchOptions, {"method":"POST","headers":{"User-Agent":"PostHog.com/1.0","Content-Type":"application/json"},"body":"{\\"event\\":{\\"uuid\\":\\"uuid\\",\\"event\\":\\"test\\",\\"distinct_id\\":\\"distinct_id\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"},\\"timestamp\\":\\"\\",\\"elements_chain\\":\\"\\",\\"url\\":\\"\\"},\\"person\\":{\\"id\\":\\"person-id\\",\\"name\\":\\"person-name\\",\\"properties\\":{\\"email\\":\\"example@posthog.com\\"},\\"url\\":\\"https://us.posthog.com/projects/1/persons/1234\\"}}"}",
+                "message": "fetchOptions, {"method":"POST","headers":{"User-Agent":"PostHog.com/1.0","Content-Type":"application/json"},"body":"{\\"event\\":{\\"uuid\\":\\"event-id\\",\\"event\\":\\"event-name\\",\\"distinct_id\\":\\"distinct-id\\",\\"properties\\":{\\"$current_url\\":\\"https://example.com\\"},\\"timestamp\\":\\"2024-01-01T00:00:00Z\\",\\"elements_chain\\":\\"\\",\\"url\\":\\"https://us.posthog.com/projects/1/events/1234\\"},\\"person\\":{\\"id\\":\\"person-id\\",\\"name\\":\\"person-name\\",\\"properties\\":{\\"email\\":\\"example@posthog.com\\"},\\"url\\":\\"https://us.posthog.com/projects/1/persons/1234\\"}}"}",
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
               {
@@ -59,25 +62,24 @@ describe(`${template.name} template`, () => {
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
             ]
-        `)
+        `
+        )
     })
-
     it('should handle a failing request', async () => {
         const inputs = generateTestData(template.id, template.inputs_schema)
-
-        tester.mockFetchResponse({
+        mockFetch.mockResolvedValue({
             status: 400,
-            body: { status: 'ERROR' },
+            json: () => Promise.resolve({ status: 'ERROR' }),
+            text: () => Promise.resolve(JSON.stringify({ status: 'ERROR' })),
             headers: { 'content-type': 'application/json' },
         })
-
-        const response = await tester.invoke(SAMPLE_GLOBALS, { ...inputs, debug_mode: true })
-
-        expect(response.logs).toMatchInlineSnapshot(`
+        const response = await tester.invoke({ ...inputs, debug_mode: true })
+        expect(response.logs).toMatchInlineSnapshot(
+            `
             [
               {
                 "level": "debug",
-                "message": "config, {"method":"POST","body":{"event":{"uuid":"uuid","event":"test","distinct_id":"distinct_id","properties":{"email":"test@posthog.com"},"timestamp":"","elements_chain":"","url":""},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}},"headers":{"Content-Type":"application/json"},"debug":false,"debug_mode":true,"url":"http://jaj.mu/iroti"}",
+                "message": "config, {"method":"POST","body":{"event":{"uuid":"event-id","event":"event-name","distinct_id":"distinct-id","properties":{"$current_url":"https://example.com"},"timestamp":"2024-01-01T00:00:00Z","elements_chain":"","url":"https://us.posthog.com/projects/1/events/1234"},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}},"headers":{"Content-Type":"application/json"},"debug":false,"debug_mode":true,"url":"http://jaj.mu/iroti"}",
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
               {
@@ -87,12 +89,12 @@ describe(`${template.name} template`, () => {
               },
               {
                 "level": "debug",
-                "message": "options, {"method":"POST","headers":{"Content-Type":"application/json"},"json":{"event":{"uuid":"uuid","event":"test","distinct_id":"distinct_id","properties":{"email":"test@posthog.com"},"timestamp":"","elements_chain":"","url":""},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}}}",
+                "message": "options, {"method":"POST","headers":{"Content-Type":"application/json"},"json":{"event":{"uuid":"event-id","event":"event-name","distinct_id":"distinct-id","properties":{"$current_url":"https://example.com"},"timestamp":"2024-01-01T00:00:00Z","elements_chain":"","url":"https://us.posthog.com/projects/1/events/1234"},"person":{"id":"person-id","name":"person-name","properties":{"email":"example@posthog.com"},"url":"https://us.posthog.com/projects/1/persons/1234"}}}",
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
               {
                 "level": "debug",
-                "message": "fetchOptions, {"method":"POST","headers":{"User-Agent":"PostHog.com/1.0","Content-Type":"application/json"},"body":"{\\"event\\":{\\"uuid\\":\\"uuid\\",\\"event\\":\\"test\\",\\"distinct_id\\":\\"distinct_id\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"},\\"timestamp\\":\\"\\",\\"elements_chain\\":\\"\\",\\"url\\":\\"\\"},\\"person\\":{\\"id\\":\\"person-id\\",\\"name\\":\\"person-name\\",\\"properties\\":{\\"email\\":\\"example@posthog.com\\"},\\"url\\":\\"https://us.posthog.com/projects/1/persons/1234\\"}}"}",
+                "message": "fetchOptions, {"method":"POST","headers":{"User-Agent":"PostHog.com/1.0","Content-Type":"application/json"},"body":"{\\"event\\":{\\"uuid\\":\\"event-id\\",\\"event\\":\\"event-name\\",\\"distinct_id\\":\\"distinct-id\\",\\"properties\\":{\\"$current_url\\":\\"https://example.com\\"},\\"timestamp\\":\\"2024-01-01T00:00:00Z\\",\\"elements_chain\\":\\"\\",\\"url\\":\\"https://us.posthog.com/projects/1/events/1234\\"},\\"person\\":{\\"id\\":\\"person-id\\",\\"name\\":\\"person-name\\",\\"properties\\":{\\"email\\":\\"example@posthog.com\\"},\\"url\\":\\"https://us.posthog.com/projects/1/persons/1234\\"}}"}",
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
               {
@@ -102,10 +104,11 @@ describe(`${template.name} template`, () => {
               },
               {
                 "level": "error",
-                "message": "Function failed: Error executing function on event uuid: Request failed with status 400 ({"status":"ERROR"})",
+                "message": "Function failed: Error executing function on event event-id: Request failed with status 400 ({"status":"ERROR"})",
                 "timestamp": "2025-01-01T00:00:00.000Z",
               },
             ]
-        `)
+        `
+        )
     })
 })

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -189,15 +189,15 @@ export const fixLogDeduplication = (logs: LogEntry[]): LogEntrySerialized[] => {
     return preparedLogs
 }
 
-export function isLegacyPluginHogFunction(hogFunction: HogFunctionType): boolean {
+export function isLegacyPluginHogFunction(hogFunction: Pick<HogFunctionType, 'template_id'>): boolean {
     return hogFunction.template_id?.startsWith('plugin-') ?? false
 }
 
-export function isSegmentPluginHogFunction(hogFunction: HogFunctionType): boolean {
+export function isSegmentPluginHogFunction(hogFunction: Pick<HogFunctionType, 'template_id'>): boolean {
     return hogFunction.template_id?.startsWith('segment-') ?? false
 }
 
-export function isNativeHogFunction(hogFunction: HogFunctionType): boolean {
+export function isNativeHogFunction(hogFunction: Pick<HogFunctionType, 'template_id'>): boolean {
     return hogFunction.template_id?.startsWith('native-') ?? false
 }
 


### PR DESCRIPTION
## Problem

Realised the fetch metric was missing for segment calls

## Changes

Moved it from inside the test function check

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
