### PR TITLE
fix: Ignore additional fields in batch export tests

### DIFF
--- a/posthog/api/test/batch_exports/test_test.py
+++ b/posthog/api/test/batch_exports/test_test.py
@@ -17,6 +17,7 @@ from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import create_batch_export_ok
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.models import BatchExportDestination
 
 from products.batch_exports.backend.api.destination_tests import (
     DestinationTestStepResult,
@@ -283,6 +284,61 @@ def test_can_run_snowflake_test_step_for_partial_config(client: HttpClient, snow
                 {**{"step": 0}, **batch_export_data},
                 content_type="application/json",
             )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    destination_test = response.json()
+
+    assert destination_test["result"]["status"] == "Passed", destination_test
+    assert destination_test["result"]["message"] is None
+
+
+def test_can_run_s3_test_step_with_additional_fields(client: HttpClient, bucket_name, minio_client, temporal):
+    """Test we can run test steps successfully even with additional configuration fields.
+
+    Configuration can change over time, and we should ensure backwards compatibility in
+    the presence of unknown fields. We create a batch export with a valid config and then
+    update it with an unknown field to simulate this.
+    """
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": bucket_name,
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+            "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        batch_export = create_batch_export_ok(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+        dest = BatchExportDestination.objects.get(batchexport=batch_export["id"])
+        dest.config["unknown_field"] = "unknown"
+        dest.save()
+
+        response = client.post(
+            f"/api/projects/{team.pk}/batch_exports/{batch_export['id']}/run_test_step",
+            {**{"step": 0}, **batch_export_data},
+            content_type="application/json",
+        )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
 


### PR DESCRIPTION
## Problem

Batch export configurations can change over time. To ensure backwards compatibility in destination tests, we should only consider fields in the current valid set of inputs.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Ignore fields in stored batch export configuration if they are not part of current set of inputs when running a destination test.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
