### PR TITLE
fix: add missing fields to get

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -15,6 +15,7 @@ use axum::response::{IntoResponse, Response};
 use axum::{debug_handler, Json};
 use axum_client_ip::InsecureClientIp;
 use bytes::Bytes;
+use serde_json;
 use std::collections::HashMap;
 use tracing::Instrument;
 use uuid::Uuid;
@@ -56,6 +57,10 @@ fn get_minimal_flags_response(version: Option<&str>) -> Result<Json<ServiceRespo
     // Create minimal config response
     let config = ConfigResponse {
         supported_compression: vec!["gzip".to_string(), "gzip-js".to_string()],
+        config: Some(serde_json::json!({"enable_collect_everything": true})),
+        toolbar_params: Some(serde_json::json!({})),
+        is_authenticated: Some(false),
+        session_recording: Some(crate::api::types::SessionRecordingField::Disabled(false)),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

get requests to flags don't match get requests to decide. decide looks like this 

https://github.com/PostHog/posthog/blob/62bc34c52d6d4ce5da33bf95a4dc1f5bfc877c03/posthog/api/decide.py#L227-L243

flags was missing `config`, `toolbar_params`, `is_authenticated`, and `session_recording`



## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

locally, get requests to flags have the missing fields now

```
curl http://localhost:8010/decide/?v=4

{
  "config": { "enable_collect_everything": true },
  "toolbarParams": {},
  "isAuthenticated": false,
  "supportedCompression": ["gzip", "gzip-js"],
  "sessionRecording": false,
  "featureFlags": {}
}
```

```
curl http://localhost:8010/flags/?v=2

{
  "errorsWhileComputingFlags": false,
  "flags": {},
  "requestId": "e8e7b522-85bc-47d5-af34-edfaa53d3d07",
  "supportedCompression": ["gzip", "gzip-js"],
  "config": { "enable_collect_everything": true },
  "sessionRecording": false,
  "toolbarParams": {},
  "isAuthenticated": false
}

```

there are still some differences.
- flags returns empty dict of flags with key `flags` (v2) or `featureflags` (v1) where as decide always returns `featureflags`
- flags includes  `errorsWhileComputingFlags` and `requestId` whereas decide doesn't 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
