### PR TITLE
chore(max): capture conversation state

### DIFF
--- a/ee/hogai/assistant/deep_research_assistant.py
+++ b/ee/hogai/assistant/deep_research_assistant.py
@@ -135,5 +135,6 @@ class DeepResearchAssistant(BaseAssistant):
             {
                 "prompt": self._latest_message.content if self._latest_message else None,
                 "output": last_ai_message,
+                "is_new_conversation": self._is_new_conversation,
             },
         )

--- a/ee/hogai/assistant/insights_assistant.py
+++ b/ee/hogai/assistant/insights_assistant.py
@@ -136,6 +136,7 @@ class InsightsAssistant(BaseAssistant):
                 "output": last_ai_message,
                 "response": visualization_response,
                 "tool_name": "create_and_query_insight",
+                "is_new_conversation": False,
             },
         )
 

--- a/ee/hogai/assistant/main_assistant.py
+++ b/ee/hogai/assistant/main_assistant.py
@@ -158,6 +158,7 @@ class MainAssistant(BaseAssistant):
                 "prompt": self._latest_message.content if self._latest_message else None,
                 "output": output,
                 "response": visualization_response,
+                "is_new_conversation": self._is_new_conversation,
             },
         )
 


### PR DESCRIPTION
## Problem

Max PostHog events don't capture whether the conversation is new or resumed.

## Changes

- Track the conversation state across assistant classes.

## How did you test this code?

Manual testing