### PR TITLE
fix: Attempt to type cast when validating batch export config

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -545,6 +545,7 @@ export const batchExportConfigurationLogic = kea<batchExportConfigurationLogicTy
                         end_at,
                         model,
                         filters,
+                        json_config_file,
                         ...config
                     } = formdata
                     const destinationObj = {

--- a/posthog/api/test/batch_exports/test_test.py
+++ b/posthog/api/test/batch_exports/test_test.py
@@ -20,6 +20,7 @@ from posthog.api.test.test_user import create_user
 from posthog.models import BatchExportDestination
 
 from products.batch_exports.backend.api.destination_tests import (
+    BigQueryProjectTestStep,
     DestinationTestStepResult,
     SnowflakeEstablishConnectionTestStep,
     Status,
@@ -339,6 +340,67 @@ def test_can_run_s3_test_step_with_additional_fields(client: HttpClient, bucket_
             {**{"step": 0}, **batch_export_data},
             content_type="application/json",
         )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    destination_test = response.json()
+
+    assert destination_test["result"]["status"] == "Passed", destination_test
+    assert destination_test["result"]["message"] is None
+
+
+@pytest.fixture
+def bigquery_config() -> dict[str, str]:
+    """Return a BigQuery configuration dictionary to use in tests."""
+    return {
+        "project_id": "project",
+        "private_key": "private_key",
+        "private_key_id": "private_key_id",
+        "token_uri": "token_uri",
+        "client_email": "client_email",
+        "dataset_id": "dataset",
+    }
+
+
+def test_can_run_bigquery_test_step_with_castable_type(client: HttpClient, bigquery_config, temporal):
+    """Test a destination test with invalid types that can be casted to required teypes."""
+    config = {"use_json_type": "True", **bigquery_config}  # "True" (string) can be casted to True (bool)
+
+    destination_data = {
+        "type": "BigQuery",
+        "config": config,
+    }
+
+    batch_export_data = {
+        "name": "my-production-bigquery-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        batch_export = create_batch_export_ok(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+
+        with unittest.mock.patch(
+            "products.batch_exports.backend.api.destination_tests.DestinationTest.run_step"
+        ) as run_step_mocked:
+            fake_test_step = BigQueryProjectTestStep()
+            fake_test_step.result = DestinationTestStepResult(status=Status.PASSED, message=None)
+            run_step_mocked.return_value = fake_test_step
+
+            response = client.post(
+                f"/api/projects/{team.pk}/batch_exports/{batch_export['id']}/run_test_step",
+                {**{"step": 0}, **batch_export_data},
+                content_type="application/json",
+            )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
 

--- a/posthog/api/test/batch_exports/test_test.py
+++ b/posthog/api/test/batch_exports/test_test.py
@@ -363,7 +363,7 @@ def bigquery_config() -> dict[str, str]:
 
 
 def test_can_run_bigquery_test_step_with_castable_type(client: HttpClient, bigquery_config, temporal):
-    """Test a destination test with invalid types that can be casted to required teypes."""
+    """Test a destination test with invalid types that can be casted to required types."""
     config = {"use_json_type": "True", **bigquery_config}  # "True" (string) can be casted to True (bool)
 
     destination_data = {

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -1,4 +1,5 @@
 import typing
+import builtins
 import datetime as dt
 import dataclasses
 import collections.abc
@@ -49,7 +50,7 @@ from posthog.models import BatchExport, BatchExportBackfill, BatchExportDestinat
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.signals import model_activity_signal
 from posthog.temporal.common.client import sync_connect
-from posthog.utils import relative_date_parse
+from posthog.utils import relative_date_parse, str_to_bool
 
 from products.batch_exports.backend.api.destination_tests import get_destination_test
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import SUPPORTED_COMPRESSIONS
@@ -239,9 +240,14 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
                 continue
 
             if not isinstance(config_value, field_type):
-                raise serializers.ValidationError(
-                    f"Configuration has invalid type: got '{type(config_value).__name__}', expected '{field_type.__name__}'"
-                )
+                config_value, success = try_convert_to_type(config_value, field_type)
+
+                if not success:
+                    raise serializers.ValidationError(
+                        f"Configuration has invalid type: got '{type(config_value).__name__}', expected '{field_type.__name__}'"
+                    )
+
+                config[destination_field.name] = config_value
 
         return data
 
@@ -251,6 +257,35 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
             k: v for k, v in data["config"].items() if k not in BatchExportDestination.secret_fields[instance.type]
         }
         return data
+
+
+Success = bool
+
+
+def try_convert_to_type(value: typing.Any, target_type: type) -> tuple[typing.Any, Success]:
+    """Attempt to convert value to target type based on well-known casting functions.
+
+    This doesn't raise any exceptions but rather returns a tuple with a bool indicating
+    if the value in the first position was successfully casted to `target_type` or not.
+    If casting fails, the value in the first position is returned unchanged, otherwise a
+    new value of type `target_type` is returned.
+    """
+    current_type = type(value)
+
+    match (current_type, target_type):
+        case (builtins.str, builtins.bool):
+            cast_func: typing.Callable[[typing.Any], typing.Any] = str_to_bool
+        case (builtins.str, builtins.int):
+            cast_func = int
+        case _:
+            return (value, False)
+
+    try:
+        new_value = cast_func(value)
+    except Exception:
+        return (value, False)
+
+    return (new_value, True)
 
 
 class HogQLSelectQueryField(serializers.Field):

--- a/products/batch_exports/backend/api/destination_tests.py
+++ b/products/batch_exports/backend/api/destination_tests.py
@@ -926,14 +926,7 @@ class SnowflakeSchemaTestStep(DestinationTestStep):
 
 
 class SnowflakeDestinationTest(DestinationTest):
-    """A concrete implementation of a `DestinationTest` for Snowflake.
-
-    Attributes:
-        project_id: ID of BigQuery project we are batch exporting to.
-        dataset_id: ID of BigQuery dataset we are batch exporting to.
-        table_id: ID of BigQuery table we are batch exporting to.
-        service_account_info: Service account credentials used to access BigQuery.
-    """
+    """A concrete implementation of a `DestinationTest` for Snowflake."""
 
     def __init__(self):
         self.account = None


### PR DESCRIPTION
## Problem

Type precision is lost when encrypting fields in our database. This can cause batch export configuration validation to fail.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Safely attempt to cast values from a well-known type to another when validating configuration for batch exports. This is only implemented for str->int and str->bool for now.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
