### PR TITLE
feat: compute max_capacity per pod

### DIFF
--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -309,24 +309,27 @@ impl DeduplicationStore {
         let cleanup_timestamp = if let Some(Ok((first_key, _))) = iter.next() {
             let first_key_parsed: TimestampKey = first_key.as_ref().try_into()?;
             let first_timestamp = first_key_parsed.timestamp;
-            
+
             // Get current time in milliseconds
             let now = chrono::Utc::now().timestamp_millis() as u64;
-            
+
             // Calculate the time range of data we have
             let time_range = now.saturating_sub(first_timestamp);
-            
+
             // Calculate how much of the time range to clean up (percentage)
             let cleanup_duration = (time_range as f64 * cleanup_percentage) as u64;
-            
+
             // Calculate the cutoff timestamp
             let cleanup_timestamp = first_timestamp + cleanup_duration;
-            
+
             info!(
                 "Store {}:{} - Cleaning up {}% of time range. First: {}, Now: {}, Cutoff: {}",
-                self.topic, self.partition, 
+                self.topic,
+                self.partition,
                 (cleanup_percentage * 100.0) as u32,
-                first_timestamp, now, cleanup_timestamp
+                first_timestamp,
+                now,
+                cleanup_timestamp
             );
 
             let first_key_bytes: Vec<u8> = first_key_parsed.into();

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -1,9 +1,14 @@
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use crate::kafka::types::Partition;
+use crate::metrics::MetricsHelper;
+use crate::rocksdb::metrics_consts::*;
 use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
 
 /// Manages the lifecycle of deduplication stores, handling concurrent access
@@ -20,14 +25,20 @@ pub struct StoreManager {
 
     /// Configuration for creating new stores
     store_config: DeduplicationStoreConfig,
+
+    /// Metrics helper for global metrics
+    metrics: MetricsHelper,
 }
 
 impl StoreManager {
     /// Create a new store manager with the given configuration
     pub fn new(store_config: DeduplicationStoreConfig) -> Self {
+        let metrics = MetricsHelper::new().with_label("service", "kafka-deduplicator");
+
         Self {
             stores: DashMap::new(),
             store_config,
+            metrics,
         }
     }
 
@@ -181,6 +192,166 @@ impl StoreManager {
         self.stores.len()
     }
 
+    /// Cleanup old entries across all stores to maintain global capacity
+    ///
+    /// This method checks the total size across all stores and triggers cleanup
+    /// on individual stores if the global capacity is exceeded.
+    pub fn cleanup_old_entries_if_needed(&self) -> Result<u64> {
+        let start_time = Instant::now();
+
+        // If max_capacity is 0, no cleanup needed (unlimited)
+        if self.store_config.max_capacity == 0 {
+            return Ok(0);
+        }
+
+        // Calculate total size across all stores
+        let mut total_size = 0u64;
+        for entry in self.stores.iter() {
+            let store = entry.value();
+            // Get size of all column families for this store
+            if let Ok(size) = store.get_total_size() {
+                total_size += size;
+            }
+        }
+
+        // Check if we're under capacity
+        if total_size <= self.store_config.max_capacity {
+            return Ok(0); // Under capacity, no cleanup needed
+        }
+
+        info!(
+            "Global store size {} exceeds max capacity {}, triggering cleanup",
+            total_size, self.store_config.max_capacity
+        );
+
+        // We need to clean up - target 80% of max capacity
+        let target_size = (self.store_config.max_capacity as f64 * 0.8) as u64;
+        let bytes_to_free = total_size.saturating_sub(target_size);
+
+        // Cleanup stores proportionally or by age
+        let mut total_bytes_freed = 0u64;
+
+        // Iterate through stores and trigger cleanup until we've freed enough
+        for entry in self.stores.iter() {
+            if total_bytes_freed >= bytes_to_free {
+                break;
+            }
+
+            let store = entry.value();
+            match store.cleanup_old_entries() {
+                Ok(bytes_freed) => {
+                    total_bytes_freed += bytes_freed;
+                    if bytes_freed > 0 {
+                        info!(
+                            "Freed {} bytes from store {}:{}",
+                            bytes_freed,
+                            store.get_topic(),
+                            store.get_partition()
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to cleanup store {}:{}: {}",
+                        store.get_topic(),
+                        store.get_partition(),
+                        e
+                    );
+                }
+            }
+        }
+
+        // Emit cleanup metrics
+        let duration = start_time.elapsed();
+        self.metrics
+            .counter(CLEANUP_OPERATIONS_COUNTER)
+            .increment(1);
+        self.metrics
+            .histogram(CLEANUP_DURATION_HISTOGRAM)
+            .record(duration.as_secs_f64());
+        self.metrics
+            .histogram(CLEANUP_BYTES_FREED_HISTOGRAM)
+            .record(total_bytes_freed as f64);
+
+        info!(
+            "Global cleanup completed: freed {} bytes in {:?}",
+            total_bytes_freed, duration
+        );
+
+        Ok(total_bytes_freed)
+    }
+
+    /// Check if cleanup is needed based on current global size
+    pub fn needs_cleanup(&self) -> bool {
+        if self.store_config.max_capacity == 0 {
+            return false;
+        }
+
+        let mut total_size = 0u64;
+        for entry in self.stores.iter() {
+            if let Ok(size) = entry.value().get_total_size() {
+                total_size += size;
+            }
+        }
+
+        total_size > self.store_config.max_capacity
+    }
+
+    /// Start a periodic cleanup task that runs in the background
+    /// Returns a handle that can be used to stop the task
+    pub fn start_periodic_cleanup(
+        self: Arc<Self>,
+        cleanup_interval: Duration,
+    ) -> CleanupTaskHandle {
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+        let manager = self;
+
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(cleanup_interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            info!(
+                "Started periodic cleanup task with interval of {:?}",
+                cleanup_interval
+            );
+
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        debug!("Running periodic cleanup check");
+
+                        if manager.needs_cleanup() {
+                            info!("Global capacity exceeded, triggering cleanup");
+                            match manager.cleanup_old_entries_if_needed() {
+                                Ok(bytes_freed) => {
+                                    if bytes_freed > 0 {
+                                        info!("Periodic cleanup freed {} bytes", bytes_freed);
+                                    }
+                                }
+                                Err(e) => {
+                                    error!("Periodic cleanup failed: {}", e);
+                                }
+                            }
+                        } else {
+                            debug!("No cleanup needed, stores within capacity");
+                        }
+                    }
+                    _ = &mut shutdown_rx => {
+                        info!("Cleanup task received shutdown signal");
+                        break;
+                    }
+                }
+            }
+
+            info!("Cleanup task shutting down");
+        });
+
+        CleanupTaskHandle {
+            handle,
+            shutdown_tx: Some(shutdown_tx),
+        }
+    }
+
     /// Shutdown all stores cleanly
     ///
     /// This closes all RocksDB instances but does NOT delete the files
@@ -226,12 +397,172 @@ impl StoreManager {
     }
 }
 
+/// Handle for the cleanup task that allows graceful shutdown
+pub struct CleanupTaskHandle {
+    handle: JoinHandle<()>,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl CleanupTaskHandle {
+    /// Stop the cleanup task gracefully
+    pub async fn stop(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+
+        match tokio::time::timeout(Duration::from_secs(5), self.handle).await {
+            Ok(Ok(())) => info!("Cleanup task shut down successfully"),
+            Ok(Err(e)) => warn!("Cleanup task failed: {}", e),
+            Err(_) => warn!("Cleanup task shutdown timed out"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use common_types::RawEvent;
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_global_capacity_management() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 100, // Very small capacity to test the logic
+        };
+
+        let manager = Arc::new(StoreManager::new(config));
+
+        // Test that needs_cleanup works correctly
+        assert!(
+            !manager.needs_cleanup(),
+            "Should not need cleanup when empty"
+        );
+
+        // Create stores
+        let store1 = manager.get_or_create("test-topic", 0).await.unwrap();
+        let _store2 = manager.get_or_create("test-topic", 1).await.unwrap();
+
+        // Add some events
+        for i in 0..10 {
+            let event = RawEvent {
+                uuid: Some(uuid::Uuid::new_v4()),
+                event: format!("test_event_{i}"),
+                distinct_id: Some(serde_json::Value::String(format!("user_{i}"))),
+                token: Some("test_token".to_string()),
+                timestamp: Some("2021-01-01T00:00:00Z".to_string()),
+                properties: std::collections::HashMap::new(),
+                ..Default::default()
+            };
+            store1.handle_event_with_raw(&event).unwrap();
+        }
+
+        // Test that cleanup can be called without error
+        let result = manager.cleanup_old_entries_if_needed();
+        assert!(result.is_ok(), "Cleanup should not error");
+
+        // Test with zero capacity
+        let zero_config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 0,
+        };
+        let zero_manager = Arc::new(StoreManager::new(zero_config));
+        assert!(
+            !zero_manager.needs_cleanup(),
+            "Should never need cleanup with zero capacity"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_periodic_cleanup_task() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 5_000, // Small capacity
+        };
+
+        let manager = Arc::new(StoreManager::new(config));
+
+        // Start periodic cleanup with short interval for testing
+        let cleanup_handle = manager.clone().start_periodic_cleanup(
+            Duration::from_millis(100), // Very short interval for testing
+        );
+
+        // Create a store and add data
+        let store = manager.get_or_create("test-topic", 0).await.unwrap();
+
+        // Add old events that should be cleaned up
+        for i in 0..50 {
+            let event = RawEvent {
+                uuid: Some(uuid::Uuid::new_v4()),
+                event: "test_event".to_string(),
+                distinct_id: Some(serde_json::Value::String(format!("user_{i}"))),
+                token: Some("test_token".to_string()),
+                timestamp: Some("2021-01-01T00:00:00Z".to_string()), // Old timestamp
+                properties: std::collections::HashMap::from([(
+                    "data".to_string(),
+                    serde_json::json!(format!("value_{}", i)),
+                )]),
+                ..Default::default()
+            };
+            store.handle_event_with_raw(&event).unwrap();
+        }
+
+        store.flush().unwrap();
+
+        // Wait for cleanup task to run at least once
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Stop the cleanup task
+        cleanup_handle.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_task_graceful_shutdown() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 1_000_000,
+        };
+
+        let manager = Arc::new(StoreManager::new(config));
+
+        // Start cleanup task
+        let cleanup_handle = manager.clone().start_periodic_cleanup(
+            Duration::from_secs(60), // Long interval
+        );
+
+        // Give it time to start
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Stop should complete quickly even with long interval
+        let start = std::time::Instant::now();
+        cleanup_handle.stop().await;
+        let elapsed = start.elapsed();
+
+        // Should shutdown within the timeout (5 seconds)
+        assert!(elapsed < Duration::from_secs(6));
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_with_zero_capacity() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 0, // Unlimited capacity
+        };
+
+        let manager = Arc::new(StoreManager::new(config));
+
+        // Should never need cleanup with unlimited capacity
+        assert!(!manager.needs_cleanup());
+
+        // Cleanup should return 0 bytes freed
+        let bytes_freed = manager.cleanup_old_entries_if_needed().unwrap();
+        assert_eq!(bytes_freed, 0);
+    }
 
     #[tokio::test]
     async fn test_get_or_create_store() {


### PR DESCRIPTION
## Problem

Pod's EBS volumes were filling up because the MAX_CAPACITY variable was being computed per store not by the sum of all stores in the pod.

## Changes

- Moves the capacity management responsibility to the store manager

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
