### PR TITLE
fix: update settings toolbar to have query params which open the toolbar

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -123,16 +123,18 @@ export function AuthorizedUrlList({
                                     <LemonButton
                                         icon={<IconOpenInApp />}
                                         to={
-                                            // toolbar urls are sent through the backend to be validated
+                                            // toolbar urls and web analytics urls are sent through the backend to be validated
                                             // and have toolbar auth information added
-                                            type === AuthorizedUrlListType.TOOLBAR_URLS
+                                            type === AuthorizedUrlListType.TOOLBAR_URLS ||
+                                            type === AuthorizedUrlListType.WEB_ANALYTICS
                                                 ? launchUrl(keyedURL.url)
                                                 : // other urls are simply opened directly
                                                   `${keyedURL.url}${query ?? ''}`
                                         }
                                         targetBlank
                                         tooltip={
-                                            type === AuthorizedUrlListType.TOOLBAR_URLS
+                                            type === AuthorizedUrlListType.TOOLBAR_URLS ||
+                                            type === AuthorizedUrlListType.WEB_ANALYTICS
                                                 ? 'Launch toolbar'
                                                 : 'Launch url'
                                         }


### PR DESCRIPTION
## Problem

A user flagged that the settings section for authorized toolbar URL's does not open the toolbar because its missing the query strings to do so. 

## Changes

Updated the component to add the queries if the prop is web analytics.

## How did you test this code?

Tested locally and the queries are added now. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
