### PR TITLE
fix(ux): app icons for darkmode

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -101,10 +101,7 @@ export function convertFileSystemEntryToTreeDataItem({
         const displayName = <SearchHighlightMultiple string={itemName} substring={searchTerm ?? ''} />
         const user: UserBasicType | undefined = item.meta?.created_by ? users?.[item.meta.created_by] : undefined
 
-        const icon = iconForType(
-            ('iconType' in item ? item.iconType : undefined) || (item.type as FileSystemIconType),
-            'iconColor' in item ? item.iconColor : undefined
-        )
+        const icon = iconForType(('iconType' in item ? item.iconType : undefined) || (item.type as FileSystemIconType))
         const node: TreeDataItem = {
             id: nodeId,
             name: itemName,


### PR DESCRIPTION
## Problem
oops.
<img width="338" height="681" alt="image" src="https://github.com/user-attachments/assets/de669946-b57d-4d72-88fa-1972bac46078" />

## Changes
Remove `getIcon` second prop from project tree i added by accident.

<img width="459" height="559" alt="image" src="https://github.com/user-attachments/assets/9c67e688-ba51-4968-99f2-84c33c120f9c" />


## How did you test this code?
Dark mode works, light mode works.