### PR TITLE
feat(cohorts): support column with person UUIDs in static cohort CSV imports

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
 
-import { IconCopy, IconTrash } from '@posthog/icons'
+import { IconCopy, IconInfo, IconTrash } from '@posthog/icons'
 import { LemonBanner, LemonDivider, LemonFileInput, LemonSkeleton, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
@@ -380,12 +380,37 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                     {({ onChange }) => (
                                         <>
                                             {!newSceneLayout && !isNewCohort && (
-                                                <span>
-                                                    Upload a CSV file to add users to your cohort. For single-column
-                                                    files, include one distinct ID per row (all rows will be processed
-                                                    as data). Fo`r multi-column files, include a header row with a
-                                                    'distinct_id' column containing the user identifiers.
-                                                </span>
+                                                <div className="flex items-center gap-2">
+                                                    <span>
+                                                        Upload a CSV file to add users to your cohort using distinct IDs
+                                                        or person UUIDs.
+                                                    </span>
+                                                    <Tooltip
+                                                        title={
+                                                            <>
+                                                                <div className="space-y-2">
+                                                                    <div>
+                                                                        <strong>Distinct IDs:</strong> Use "
+                                                                        <code>distinct_id</code>" (or "
+                                                                        <code>distinct-id</code>") as the column header
+                                                                        (for multi-column CSV uploads) or include one
+                                                                        distinct ID per row (no header needed) for a
+                                                                        single-column CSV.
+                                                                    </div>
+                                                                    <div>
+                                                                        <strong>Person UUIDs:</strong> Use "
+                                                                        <code>person_id</code>" (or "
+                                                                        <code>person-id</code>" or "
+                                                                        <code>Person .id</code>") as the column header
+                                                                        (for single-column or multi-column CSV uploads).
+                                                                    </div>
+                                                                </div>
+                                                            </>
+                                                        }
+                                                    >
+                                                        <IconInfo className="text-secondary text-lg" />
+                                                    </Tooltip>
+                                                </div>
                                             )}
                                             <LemonFileInput
                                                 accept=".csv"

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -190,17 +190,14 @@ logger = structlog.get_logger(__name__)
 class CSVConfig:
     """Configuration constants for CSV processing"""
 
+    PERSON_ID_HEADERS = ["person_id", "person-id", "Person .id"]
     DISTINCT_ID_HEADERS = ["distinct_id", "distinct-id"]
     ENCODING = "utf-8"
 
     class ErrorMessages:
         EMPTY_FILE = "CSV file is empty. Please upload a CSV file with at least one row of data."
-        MISSING_DISTINCT_ID = (
-            "Multi-column CSV must contain a 'distinct_id' or 'distinct-id' column header. Found columns: {columns}"
-        )
-        NO_VALID_IDS = (
-            "CSV file contains no valid distinct IDs. Please ensure your file has data rows with distinct IDs."
-        )
+        MISSING_ID_COLUMN = "Multi-column CSV must contain at least one column with a supported ID header: 'person_id', 'Person .id' (PostHog export format), 'distinct_id', or 'distinct-id'. Found columns: {columns}"
+        NO_VALID_IDS = "CSV file contains no valid person or distinct IDs. Please ensure your file has data rows with person IDs or distinct IDs."
         ENCODING_ERROR = "CSV file encoding is not supported. Please save your file as UTF-8 and try again."
         FORMAT_ERROR = "CSV file format is invalid. Please check your file format and try again."
         GENERIC_ERROR = "An error occurred while processing your CSV file. Please try again or contact support if the problem persists."
@@ -329,17 +326,39 @@ class CohortSerializer(serializers.ModelSerializer):
         non_empty_cols = [col for col in first_row if col.strip()]
         return len(non_empty_cols) <= 1
 
-    def _find_distinct_id_column(self, headers: list[str]) -> int | None:
-        """Find the index of the distinct_id column in headers"""
-        normalized_headers = [h.lower().strip() for h in headers]
-        for i, header in enumerate(normalized_headers):
+    def _is_person_id_header(self, header: str) -> bool:
+        """Check if header indicates person_id column"""
+        person_id_headers_lower = [h.lower() for h in CSVConfig.PERSON_ID_HEADERS]
+        return header.strip().lower() in person_id_headers_lower
+
+    def _find_id_column(self, headers: list[str]) -> tuple[int, str] | None:
+        """Find the index and type of the ID column in headers with person_id preference over distinct_id"""
+        normalized_headers = [h.strip() for h in headers]
+        normalized_lower_headers = [h.lower() for h in normalized_headers]
+
+        # First, look for person_id columns (preferred) - use case-insensitive matching
+        person_id_headers_lower = [h.lower() for h in CSVConfig.PERSON_ID_HEADERS]
+        for i, header in enumerate(normalized_lower_headers):
+            if header in person_id_headers_lower:
+                return i, "person_id"
+
+        # Then, look for distinct_id columns
+        for i, header in enumerate(normalized_lower_headers):
             if header in CSVConfig.DISTINCT_ID_HEADERS:
-                return i
+                return i, "distinct_id"
+
         return None
 
-    def _extract_distinct_ids_single_column(self, first_row: list[str], reader: Iterator[list[str]]) -> list[str]:
+    def _extract_ids_single_column(
+        self, first_row: list[str], reader: Iterator[list[str]], skip_header: bool = False
+    ) -> list[str]:
         """Process single-column CSV format"""
-        distinct_ids = [first_row[0].strip()] if first_row and first_row[0].strip() != "" else []
+        distinct_ids = []
+
+        # Include first row only if it's not a header
+        if not skip_header and first_row and first_row[0].strip() != "":
+            distinct_ids.append(first_row[0].strip())
+
         for row in reader:
             if len(row) > 0:
                 stripped_id = row[0].strip()
@@ -347,36 +366,34 @@ class CohortSerializer(serializers.ModelSerializer):
                     distinct_ids.append(stripped_id)
         return distinct_ids
 
-    def _extract_distinct_ids_multi_column(
-        self, reader: Iterator[list[str]], distinct_id_col: int, cohort_pk: int
-    ) -> list[str]:
+    def _extract_ids_multi_column(self, reader: Iterator[list[str]], id_col: int, cohort_pk: int) -> list[str]:
         """Process multi-column CSV format with robust error handling"""
-        distinct_ids = []
+        ids = []
         skipped_rows = 0
 
         for row in reader:
             # Skip rows with incorrect number of columns
-            if len(row) <= distinct_id_col:
+            if len(row) <= id_col:
                 skipped_rows += 1
                 continue
 
-            # Extract distinct ID if present and non-empty
-            distinct_id = row[distinct_id_col].strip()
-            if distinct_id != "":
-                distinct_ids.append(distinct_id)
+            # Extract ID if present and non-empty
+            id_value = row[id_col].strip()
+            if id_value != "":
+                ids.append(id_value)
 
         if skipped_rows > 0:
             logger.info(f"Skipped {skipped_rows} rows with incorrect column count in CSV for cohort {cohort_pk}")
 
-        return distinct_ids
+        return ids
 
-    def _validate_and_process_distinct_ids(self, distinct_ids: list[str], cohort: Cohort) -> None:
+    def _validate_and_process_ids(self, ids: list[str], id_type: str, cohort: Cohort) -> None:
         """Final validation and task scheduling"""
-        if not distinct_ids:
+        if not ids:
             raise ValidationError({"csv": [CSVConfig.ErrorMessages.NO_VALID_IDS]})
 
-        logger.info(f"Processing CSV upload for cohort {cohort.pk} with {len(distinct_ids)} distinct IDs")
-        calculate_cohort_from_list.delay(cohort.pk, distinct_ids, team_id=self.context["team_id"])
+        logger.info(f"Processing CSV upload for cohort {cohort.pk} with {len(ids)} {id_type}s")
+        calculate_cohort_from_list.delay(cohort.pk, ids, team_id=self.context["team_id"], id_type=id_type)
 
     def _handle_csv_errors(self, e: Exception, cohort: Cohort) -> None:
         """Centralized error handling with consistent exception capture"""
@@ -399,24 +416,33 @@ class CohortSerializer(serializers.ModelSerializer):
             first_row, reader = self._parse_csv_file(file)
 
             if self._is_single_column_format(first_row):
-                distinct_ids = self._extract_distinct_ids_single_column(first_row, reader)
+                # Check if single column header indicates person_id
+                if first_row and self._is_person_id_header(first_row[0]):
+                    ids = self._extract_ids_single_column(first_row, reader, skip_header=True)
+                    id_type = "person_id"
+                else:
+                    # Single column format treated as distinct_ids for backwards compatibility
+                    ids = self._extract_ids_single_column(first_row, reader, skip_header=False)
+                    id_type = "distinct_id"
             else:
-                distinct_id_col = self._find_distinct_id_column(first_row)
-                if distinct_id_col is None:
+                result = self._find_id_column(first_row)
+
+                if result is None:
                     available_headers = [h for h in first_row if h.strip()]
                     raise ValidationError(
                         {
                             "csv": [
-                                CSVConfig.ErrorMessages.MISSING_DISTINCT_ID.format(
+                                CSVConfig.ErrorMessages.MISSING_ID_COLUMN.format(
                                     columns=", ".join(available_headers) if available_headers else "none"
                                 )
                             ]
                         }
                     )
 
-                distinct_ids = self._extract_distinct_ids_multi_column(reader, distinct_id_col, cohort.pk)
+                id_col, id_type = result
+                ids = self._extract_ids_multi_column(reader, id_col, cohort.pk)
 
-            self._validate_and_process_distinct_ids(distinct_ids, cohort)
+            self._validate_and_process_ids(ids, id_type, cohort)
 
         except Exception as e:
             self._handle_csv_errors(e, cohort)

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -17,6 +17,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import Client
 from django.utils import timezone
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.schema import PersonsOnEventsMode, PropertyOperator
@@ -31,6 +32,7 @@ from posthog.models.property import BehavioralPropertyType
 from posthog.models.team.team import Team
 from posthog.tasks.calculate_cohort import (
     calculate_cohort_ch,
+    calculate_cohort_from_list,
     get_cohort_calculation_candidates_queryset,
     increment_version_and_enqueue_calculate_cohort,
 )
@@ -390,17 +392,20 @@ User ID
             distinct_ids.update(person.distinct_ids)
         self.assertIn("456", distinct_ids)  # Should still contain 456
 
-    @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
-    def test_static_cohort_csv_upload_with_distinct_id_column(self, patch_calculate_cohort_from_list):
+    @parameterized.expand([("distinct-id",), ("distinct_id",)])
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay", side_effect=calculate_cohort_from_list)
+    def test_static_cohort_csv_upload_with_distinct_id_column(
+        self, distinct_id_column_header, patch_calculate_cohort_from_list
+    ):
         """Test multi-column CSV upload with distinct_id column"""
-        Person.objects.create(team=self.team, distinct_ids=["user123"])
-        Person.objects.create(team=self.team, distinct_ids=["user456"])
-        Person.objects.create(team=self.team, distinct_ids=["0"])  # Test edge case: '0' as distinct_id
+        person1 = Person.objects.create(team=self.team, distinct_ids=["user123"])
+        person2 = Person.objects.create(team=self.team, distinct_ids=["user456"])
+        person3 = Person.objects.create(team=self.team, distinct_ids=["0"])  # Test edge case: '0' as distinct_id
 
         csv = SimpleUploadedFile(
             "multicolumn.csv",
             str.encode(
-                """name,distinct_id,email
+                f"""name,{distinct_id_column_header},email
 John Doe,user123,john@example.com
 Jane Smith,user456,jane@example.com
 Zero User,0,zero@example.com
@@ -416,36 +421,17 @@ Zero User,0,zero@example.com
         )
 
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(patch_calculate_cohort_from_list.call_count, 1)
-        # Verify the correct distinct IDs were extracted, including '0'
-        patch_calculate_cohort_from_list.assert_called_with(
-            response.json()["id"], ["user123", "user456", "0"], team_id=self.team.id
-        )
+        cohort = Cohort.objects.get(pk=response.json()["id"])
 
-    @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
-    def test_static_cohort_csv_upload_with_distinct_hyphen_id_column(self, patch_calculate_cohort_from_list):
-        """Test multi-column CSV upload with distinct-id column (with hyphen)"""
-        Person.objects.create(team=self.team, distinct_ids=["user789"])
+        # Verify all three persons were actually added to the cohort
+        people_in_cohort = Person.objects.filter(cohort__id=cohort.pk)
+        self.assertEqual(people_in_cohort.count(), 3)
 
-        csv = SimpleUploadedFile(
-            "multicolumn_hyphen.csv",
-            str.encode(
-                """name,distinct-id,email
-Test User,user789,test@example.com
-"""
-            ),
-            content_type="application/csv",
-        )
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/cohorts/",
-            {"name": "test_hyphen", "csv": csv, "is_static": True},
-            format="multipart",
-        )
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(patch_calculate_cohort_from_list.call_count, 1)
-        patch_calculate_cohort_from_list.assert_called_with(response.json()["id"], ["user789"], team_id=self.team.id)
+        # Verify specific persons are in the cohort
+        person_uuids_in_cohort = {str(p.uuid) for p in people_in_cohort}
+        self.assertIn(str(person1.uuid), person_uuids_in_cohort)
+        self.assertIn(str(person2.uuid), person_uuids_in_cohort)
+        self.assertIn(str(person3.uuid), person_uuids_in_cohort)
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
     def test_static_cohort_csv_upload_multicolumn_without_distinct_id_fails(self, patch_calculate_cohort_from_list):
@@ -473,6 +459,130 @@ Jane Smith,jane@example.com,25
         self.assertIn("distinct_id", response_data["detail"])
         self.assertIn("name, email, age", response_data["detail"])
         self.assertEqual(patch_calculate_cohort_from_list.call_count, 0)
+
+    @parameterized.expand([("person-id",), ("person_id",), ("Person .id",)])
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay", side_effect=calculate_cohort_from_list)
+    def test_static_cohort_csv_upload_with_person_uuid_column(
+        self, person_id_column_header, patch_calculate_cohort_from_list
+    ):
+        """Test CSV upload with person_id column using async task"""
+        person1 = Person.objects.create(team=self.team, distinct_ids=["user123"])
+        person2 = Person.objects.create(team=self.team, distinct_ids=["user456"])
+
+        csv = SimpleUploadedFile(
+            f"{person_id_column_header}.csv",
+            str.encode(
+                f"""name,{person_id_column_header},email
+John Doe,{person1.uuid},john@example.com
+Jane Smith,{person2.uuid},jane@example.com
+"""
+            ),
+            content_type="application/csv",
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts/",
+            {"name": f"test_{person_id_column_header}", "csv": csv, "is_static": True},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        cohort = Cohort.objects.get(pk=response.json()["id"])
+
+        # Verify the persons were actually added to the cohort
+        people_in_cohort = Person.objects.filter(cohort__id=cohort.pk)
+        self.assertEqual(people_in_cohort.count(), 2)
+
+        # Verify specific persons are in the cohort
+        person_uuids_in_cohort = {str(p.uuid) for p in people_in_cohort}
+        self.assertIn(str(person1.uuid), person_uuids_in_cohort)
+        self.assertIn(str(person2.uuid), person_uuids_in_cohort)
+
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
+    def test_static_cohort_csv_upload_person_id_preference_over_distinct_id(self, patch_calculate_cohort_from_list):
+        """Test that person_id is preferred over distinct_id when both columns are present"""
+        person1 = Person.objects.create(team=self.team, distinct_ids=["distinct123"])
+        person2 = Person.objects.create(team=self.team, distinct_ids=["distinct456"])
+
+        csv = SimpleUploadedFile(
+            "both_columns.csv",
+            str.encode(
+                f"""name,person_id,distinct_id,email
+John Doe,{person1.uuid},ignore_this_distinct_id,john@example.com
+Jane Smith,{person2.uuid},ignore_this_too,jane@example.com
+"""
+            ),
+            content_type="application/csv",
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts/",
+            {"name": "test_preference", "csv": csv, "is_static": True},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        # Should use person_id task, not distinct_id task
+        patch_calculate_cohort_from_list.assert_called_once_with(
+            response.json()["id"], [str(person1.uuid), str(person2.uuid)], team_id=self.team.id, id_type="person_id"
+        )
+
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
+    def test_static_cohort_csv_upload_with_empty_person_ids(self, patch_calculate_cohort_from_list):
+        """Test CSV with person_id column but some empty values"""
+        person1 = Person.objects.create(team=self.team, distinct_ids=["user123"])
+
+        csv = SimpleUploadedFile(
+            "empty_person_ids.csv",
+            str.encode(
+                f"""name,person_id,email
+John Doe,{person1.uuid},john@example.com
+Empty Person,,empty@example.com
+Jane Smith,   ,jane@example.com
+"""
+            ),
+            content_type="application/csv",
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts/",
+            {"name": "test_empty_person_ids", "csv": csv, "is_static": True},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        # Should only include the non-empty person_id
+        patch_calculate_cohort_from_list.assert_called_once_with(
+            response.json()["id"], [str(person1.uuid)], team_id=self.team.id, id_type="person_id"
+        )
+
+    def test_static_cohort_csv_upload_multicolumn_without_any_id_fails(self):
+        """Test that multi-column CSV without person_id or distinct_id column fails with updated error message"""
+        csv = SimpleUploadedFile(
+            "no_id_columns.csv",
+            str.encode(
+                """name,email,age
+John Doe,john@example.com,30
+Jane Smith,jane@example.com,25
+"""
+            ),
+            content_type="application/csv",
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts/",
+            {"name": "test_fail", "csv": csv, "is_static": True},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        response_data = response.json()
+        self.assertEqual(response_data["attr"], "csv")
+        # Should reference all supported ID column types with clearer messaging
+        self.assertIn("at least one column with a supported ID header", response_data["detail"])
+        self.assertIn("person_id", response_data["detail"])
+        self.assertIn("distinct_id", response_data["detail"])
+        self.assertIn("name, email, age", response_data["detail"])
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
     def test_static_cohort_csv_upload_empty_file_fails(self, patch_calculate_cohort_from_list):
@@ -518,7 +628,7 @@ Jane Smith,jane@example.com,25
         self.assertEqual(response.status_code, 400)
         response_data = response.json()
         self.assertEqual(response_data["attr"], "csv")
-        self.assertIn("no valid distinct IDs", response_data["detail"])
+        self.assertIn("no valid person or distinct IDs", response_data["detail"])
         self.assertEqual(patch_calculate_cohort_from_list.call_count, 0)
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
@@ -545,7 +655,37 @@ another_user
         self.assertEqual(response.status_code, 201)
         self.assertEqual(patch_calculate_cohort_from_list.call_count, 1)
         patch_calculate_cohort_from_list.assert_called_with(
-            response.json()["id"], ["legacy_user", "another_user"], team_id=self.team.id
+            response.json()["id"], ["legacy_user", "another_user"], team_id=self.team.id, id_type="distinct_id"
+        )
+
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
+    def test_static_cohort_csv_upload_single_column_person_ids(self, patch_calculate_cohort_from_list):
+        """Test that single-column CSV with person_id header is treated as person UUIDs"""
+        person1 = Person.objects.create(team=self.team)
+        person2 = Person.objects.create(team=self.team)
+
+        csv = SimpleUploadedFile(
+            "person_ids.csv",
+            str.encode(
+                f"""person_id
+{person1.uuid}
+{person2.uuid}
+"""
+            ),
+            content_type="application/csv",
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts/",
+            {"name": "test_person_ids", "csv": csv, "is_static": True},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(patch_calculate_cohort_from_list.call_count, 1)
+        # Single column format with person_id header uses person UUID processing
+        patch_calculate_cohort_from_list.assert_called_with(
+            response.json()["id"], [str(person1.uuid), str(person2.uuid)], team_id=self.team.id, id_type="person_id"
         )
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
@@ -575,7 +715,7 @@ Jane Smith,	user456	,jane@example.com
         self.assertEqual(patch_calculate_cohort_from_list.call_count, 1)
         # Verify whitespace is trimmed from distinct IDs
         patch_calculate_cohort_from_list.assert_called_with(
-            response.json()["id"], ["user123", "user456"], team_id=self.team.id
+            response.json()["id"], ["user123", "user456"], team_id=self.team.id, id_type="distinct_id"
         )
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
@@ -605,7 +745,7 @@ Jane Smith,	user456	,jane@example.com
         self.assertEqual(patch_calculate_cohort_from_list.call_count, 1)
         # Verify comma-containing distinct IDs are correctly parsed
         patch_calculate_cohort_from_list.assert_called_with(
-            response.json()["id"], ["user,123", "user,456,special"], team_id=self.team.id
+            response.json()["id"], ["user,123", "user,456,special"], team_id=self.team.id, id_type="distinct_id"
         )
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
@@ -635,7 +775,7 @@ Jane Smith,	user456	,jane@example.com
         self.assertEqual(patch_calculate_cohort_from_list.call_count, 1)
         # Verify quote-containing distinct IDs are correctly parsed
         patch_calculate_cohort_from_list.assert_called_with(
-            response.json()["id"], ['user"123', 'user"special"456'], team_id=self.team.id
+            response.json()["id"], ['user"123', 'user"special"456'], team_id=self.team.id, id_type="distinct_id"
         )
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
@@ -670,7 +810,7 @@ user789
         # Should skip: "incomplete_row_missing_distinct_id", "another_incomplete_row", "user789"
         # Should include: "user123", "user456"
         patch_calculate_cohort_from_list.assert_called_with(
-            response.json()["id"], ["user123", "user456"], team_id=self.team.id
+            response.json()["id"], ["user123", "user456"], team_id=self.team.id, id_type="distinct_id"
         )
 
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -408,7 +408,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         batchsize=DEFAULT_COHORT_INSERT_BATCH_SIZE,
         *,
         team_id: int,
-    ) -> None:
+    ) -> int:
         """
         Insert a list of users identified by their UUID into the cohort, for the given team.
 
@@ -417,10 +417,13 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             insert_in_clickhouse: Whether the data should also be inserted into ClickHouse.
             batchsize: Number of UUIDs to process in each batch.
             team_id: The ID of the team to which the cohort belongs.
+
+        Returns:
+            The number of batches processed.
         """
 
         batch_iterator = ArrayBatchIterator(items, batch_size=batchsize)
-        self._insert_users_list_with_batching(batch_iterator, insert_in_clickhouse, team_id=team_id)
+        return self._insert_users_list_with_batching(batch_iterator, insert_in_clickhouse, team_id=team_id)
 
     def _insert_users_list_with_batching(
         self, batch_iterator: BatchIterator[str], insert_in_clickhouse: bool = False, *, team_id: int


### PR DESCRIPTION
Add support for `person_id` columns in CSV uploads with preference over `distinct_id`:

Fixes #37525

## Problem

Customers often export users from queries or other sources, manipulate the export, and then want to upload them as a new static cohort. Often, these exports include person UUID rather than distinct ID to identify each person. But our static cohort upload only works with distinct IDs. That's really cumbersome.

## Changes

Adds support for uploading a static cohort CSV file with person UUIDs. A few caveats:

1. When uploading a CSV with person UUIDs, a column header is required (for single or multi-column uploads). We support the following headers: `person_id`, `person-id`, `Person .id` (The last one is common with PostHog exports, so by supporting it, there's less manipulation customers need to do).
2. When uploading a single-column upload, if the header doesn't match one of the person ID headers, we assume every row is a distinct id (for backwards compatibility).
3. If an upload contains both `distinct_id` and `person_id` column headers, the `person_id` column takes precedence.

## How did you test this code?

Unit Tests
Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
