### PR TITLE
feat(flags): Use Contour request ID from x-request-id header

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -32,6 +32,7 @@ struct LogContext<'a> {
 }
 
 /// Extracts request ID from x-request-id header, falling back to generating a new UUID if not present or invalid
+/// Good for tracing logs from the Contour layer all the way to the property evaluation
 fn extract_request_id(headers: &HeaderMap) -> Uuid {
     headers
         .get("x-request-id")

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -31,11 +31,11 @@ struct LogContext<'a> {
     response_format: &'a str,
 }
 
-/// Extracts request ID from x-request-id header, falling back to generating a new UUID if not present or invalid
+/// Extracts request ID from X-REQUEST-ID header, falling back to generating a new UUID if not present or invalid
 /// Good for tracing logs from the Contour layer all the way to the property evaluation
 fn extract_request_id(headers: &HeaderMap) -> Uuid {
     headers
-        .get("x-request-id")
+        .get("X-REQUEST-ID")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<Uuid>().ok())
         .unwrap_or_else(Uuid::new_v4)


### PR DESCRIPTION
## Problem

The `/flags` service generates its own unique request id on every request. However, the request to `/flags` originates in Contour which passes flags a request id via the `x-request-id` header.

## Changes

Use the existing request ID from Contour's `x-request-id` header instead of generating a new random UUID for better request tracing consistency.

Fixes #37770

## How did you test this code?

Unit tests
Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
