### PR TITLE
feat: Add two new json/array constant types

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -400,6 +400,18 @@ class StringType(ConstantType):
 
 
 @dataclass(kw_only=True)
+class StringJSONType(StringType):
+    def print_type(self) -> str:
+        return "JSON"
+
+
+@dataclass(kw_only=True)
+class StringArrayType(StringType):
+    def print_type(self) -> str:
+        return "Array"
+
+
+@dataclass(kw_only=True)
 class BooleanType(ConstantType):
     data_type: ConstantDataType = field(default="bool", init=False)
 

--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -22,7 +22,13 @@ class AST:
         name = camel_case_pattern.sub("_", self.__class__.__name__).lower()
 
         # NOTE: Sync with ./test/test_visitor.py#test_hogql_visitor_naming_exceptions
-        replacements = {"hog_qlxtag": "hogqlx_tag", "hog_qlxattribute": "hogqlx_attribute", "uuidtype": "uuid_type"}
+        replacements = {
+            "hog_qlxtag": "hogqlx_tag",
+            "hog_qlxattribute": "hogqlx_attribute",
+            "uuidtype": "uuid_type",
+            "string_jsontype": "string_json_type",
+        }
+
         for old, new in replacements.items():
             name = name.replace(old, new)
         method_name = f"visit_{name}"

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -74,16 +74,16 @@ class UnknownDatabaseField(DatabaseField):
 
 class StringJSONDatabaseField(DatabaseField):
     def get_constant_type(self) -> "ConstantType":
-        from posthog.hogql.ast import StringType
+        from posthog.hogql.ast import StringJSONType
 
-        return StringType(nullable=self.is_nullable())
+        return StringJSONType(nullable=self.is_nullable())
 
 
 class StringArrayDatabaseField(DatabaseField):
     def get_constant_type(self) -> "ConstantType":
-        from posthog.hogql.ast import StringType
+        from posthog.hogql.ast import StringArrayType
 
-        return StringType(nullable=self.is_nullable())
+        return StringArrayType(nullable=self.is_nullable())
 
 
 class FloatArrayDatabaseField(DatabaseField):

--- a/posthog/hogql/test/test_visitor.py
+++ b/posthog/hogql/test/test_visitor.py
@@ -152,9 +152,13 @@ class TestVisitor(BaseTest):
             def visit_hogqlx_attribute(self, node: ast.Constant):
                 return "visit_hogqlx_attribute"
 
+            def visit_string_json_type(self, node: ast.Constant):
+                return "visit_string_json_type"
+
         assert NamingCheck().visit(UUIDType()) == "visit_uuid_type"
         assert NamingCheck().visit(HogQLXAttribute(name="a", value="a")) == "visit_hogqlx_attribute"
         assert NamingCheck().visit(HogQLXTag(kind="", attributes=[])) == "visit_hogqlx_tag"
+        assert NamingCheck().visit(ast.StringJSONType()) == "visit_string_json_type"
 
     def test_visit_interval_type(self):
         # Just ensure ``IntervalType`` can be visited without throwing ``NotImplementedError``

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -224,6 +224,12 @@ class TraversingVisitor(Visitor[None]):
     def visit_string_type(self, node: ast.StringType):
         pass
 
+    def visit_string_json_type(self, node: ast.StringJSONType):
+        pass
+
+    def visit_string_array_type(self, node: ast.StringArrayType):
+        pass
+
     def visit_boolean_type(self, node: ast.BooleanType):
         pass
 


### PR DESCRIPTION
These will let us print nicer names in the UI when playing with JSON/Array fields. This does not impact anything else in the codebase since they're still inheriting from `StringType` which means all `isinstance` checks will still work

<img width="839" height="128" alt="image" src="https://github.com/user-attachments/assets/6ebb67ed-afb4-49cb-a830-b75420828b63" />
