### PR TITLE
fix: shared dashboards 500'ing

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -507,12 +507,16 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
         """Override to ensure we don't apply any session authentication."""
         # Save and clear any existing user to ensure we start fresh
         self._original_user = getattr(request, "user", None)
-        request.user = None
-        super().initial(request, *args, **kwargs)
-        # If no sharing auth succeeded, ensure user is anonymous
-        if not request.user:
-            from django.contrib.auth.models import AnonymousUser
 
+        # Set user to AnonymousUser before calling super() to ensure throttle checks work
+        from django.contrib.auth.models import AnonymousUser
+
+        request.user = AnonymousUser()
+
+        super().initial(request, *args, **kwargs)
+
+        # If no sharing auth succeeded, ensure user remains anonymous
+        if not request.user:
             request.user = AnonymousUser()
 
     def get_object(self) -> Optional[SharingConfiguration | ExportedAsset]:


### PR DESCRIPTION
## Problem
Shared dashboards are broken in prod because the rate limiter (rate_limit.py) assumes user is non null (old non-type checked python code).

Our new password sharing auth was calling it with the user set to None.

This wasn't tested or caught in development because the rate_limiter doesn't run in development.

https://grafana.prod-us.posthog.dev/goto/5Q7qmwrNg?orgId=1

## Changes
Set the user to anonymoususer before calling the superclass so that the rate limiter succeeds.

## How did you test this code?
Wrote a test for it. 
