### PR TITLE
chore: remove `value` from `PersonalAPIKey` model

### DIFF
--- a/posthog/models/personal_api_key.py
+++ b/posthog/models/personal_api_key.py
@@ -6,6 +6,8 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils import timezone
 
+from django_deprecate_fields import deprecate_field
+
 from .utils import generate_random_token
 
 ModeType = Literal["sha256", "pbkdf2"]
@@ -39,7 +41,6 @@ class PersonalAPIKey(models.Model):
     id = models.CharField(primary_key=True, max_length=50, default=generate_random_token)
     user = models.ForeignKey("posthog.User", on_delete=models.CASCADE, related_name="personal_api_keys")
     label = models.CharField(max_length=40)
-    value = models.CharField(unique=True, max_length=50, editable=False, null=True, blank=True)
     mask_value = models.CharField(max_length=11, editable=False, null=True)
     secure_value = models.CharField(
         unique=True,
@@ -54,6 +55,8 @@ class PersonalAPIKey(models.Model):
     scoped_teams: ArrayField = ArrayField(models.IntegerField(), null=True)
     scoped_organizations: ArrayField = ArrayField(models.CharField(max_length=100), null=True)
 
+    # DEPRECATED: value is no longer persisted; use secure_value for hash of value
+    value = deprecate_field(models.CharField(unique=True, max_length=50, editable=False, null=True, blank=True))
     # DEPRECATED: personal API keys are now specifically personal, without team affiliation
     team = models.ForeignKey(
         "posthog.Team",


### PR DESCRIPTION
## Problem

This field is no longer used and is NULL in every row. `PersonalAPIKey` serves as an example for future API key types, and we don't want those types to include this field.

## Changes

Deprecate the field.

## How did you test this code?

Existing tests + verified creation of new personal api keys + verified rolling of existing personal api keys