### PR TITLE
chore: allow clearing live events from view

### DIFF
--- a/frontend/src/scenes/activity/live/LiveEventsTable.tsx
+++ b/frontend/src/scenes/activity/live/LiveEventsTable.tsx
@@ -11,6 +11,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { IconRefresh } from 'lib/lemon-ui/icons'
 import { liveEventsTableLogic } from 'scenes/activity/live/liveEventsTableLogic'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -78,7 +79,7 @@ const columns: LemonTableColumns<LiveEvent> = [
 
 export function LiveEventsTable(): JSX.Element {
     const { events, stats, streamPaused, filters } = useValues(liveEventsTableLogic)
-    const { pauseStream, resumeStream, setFilters } = useActions(liveEventsTableLogic)
+    const { pauseStream, resumeStream, setFilters, clearEvents } = useActions(liveEventsTableLogic)
     const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
 
     return (
@@ -135,6 +136,13 @@ export function LiveEventsTable(): JSX.Element {
                 </div>
 
                 <div className="flex gap-2">
+                    <LemonButton
+                        icon={<IconRefresh className="w-4 h-4" />}
+                        type="secondary"
+                        onClick={clearEvents}
+                        size="small"
+                        tooltip="Clear events"
+                    />
                     <EventName
                         value={filters.eventType}
                         onChange={(value) => setFilters({ ...filters, eventType: value })}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
a lil UX improvement, motivated by wanting to see when and how many times my event is fired. similar to how browser's network tab allows to clear it up.
<img width="219" height="68" alt="image" src="https://github.com/user-attachments/assets/bcd7368a-3c7d-4982-8c3e-cc660fd2b768" />

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- add a button to clear live stream events from the table
	- I am torn between a 🗑️ and :refresh: Icon here, as refresh can be confused for refreshing to see the events stream in, whereas the 🗑️ can be confused for binning them. 
	- I would most like a 🧹 Icon, might need to see with @corywatilo how to add that and from where

<img width="275" height="65" alt="image" src="https://github.com/user-attachments/assets/b278914e-fd35-43d2-bb31-da0e43e82cbe" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
locally
<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->
<img width="533" height="90" alt="image" src="https://github.com/user-attachments/assets/ac2cf693-3170-4e35-a0cf-0c899a19d4ff" />
I think it would be superfluous to add this to the above docs line.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
