### PR TITLE
chore(kafka-dedup): make noisy info logs debug

### DIFF
--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -176,7 +176,7 @@ impl MessageProcessor for DeduplicationProcessor {
         let partition = message.kafka_message().partition();
         let offset = message.kafka_message().offset();
 
-        info!(
+        debug!(
             "Processing message from topic {} partition {} offset {}",
             topic, partition, offset
         );

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -8,7 +8,7 @@ use rdkafka::{ClientConfig, Message};
 use serde_json;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::kafka::message::{AckableMessage, MessageProcessor};
 use crate::store::{DeduplicationStore, DeduplicationStoreConfig};

--- a/rust/kafka-deduplicator/src/kafka/message.rs
+++ b/rust/kafka-deduplicator/src/kafka/message.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rdkafka::message::OwnedMessage;
 use rdkafka::Message;
 use tokio::sync::OwnedSemaphorePermit;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::kafka::metrics_consts::MESSAGES_AUTO_NACKED;
 use crate::kafka::tracker::{MessageCompletion, MessageHandle};

--- a/rust/kafka-deduplicator/src/kafka/message.rs
+++ b/rust/kafka-deduplicator/src/kafka/message.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rdkafka::message::OwnedMessage;
 use rdkafka::Message;
 use tokio::sync::OwnedSemaphorePermit;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::kafka::metrics_consts::MESSAGES_AUTO_NACKED;
 use crate::kafka::tracker::{MessageCompletion, MessageHandle};
@@ -54,7 +54,7 @@ impl AckableMessage {
         self.handle.complete(MessageResult::Success).await;
         self.acked = true;
 
-        info!(
+        debug!(
             "Acked message: id={}, offset={}",
             self.handle.message_id, offset
         );
@@ -73,7 +73,7 @@ impl AckableMessage {
             .await;
         self.acked = true;
 
-        info!(
+        debug!(
             "Nacked message: id={}, offset={}, error={}",
             self.handle.message_id, offset, error
         );


### PR DESCRIPTION
## Problem

These logs are being too noisy and no longer add value, we can move them to debug.
