### PR TITLE
fix: button data attribute in events table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -50,7 +50,7 @@ export function EventRowActions({ event }: EventActionProps): JSX.Element {
                         sessionId={event.properties.$session_id}
                         recordingStatus={event.properties.$recording_status}
                         timestamp={event.timestamp}
-                        data-attr="events-table-usage"
+                        data-attr="events-table-view-recordings"
                     />
                     {event.event === '$exception' && '$exception_issue_id' in event.properties ? (
                         <LemonButton


### PR DESCRIPTION
data-attr on the view recordings button in the events table was wrong

well, not any more