### PR TITLE
feat: create new sharded log_entries table

### DIFF
--- a/posthog/clickhouse/log_entries.py
+++ b/posthog/clickhouse/log_entries.py
@@ -115,6 +115,7 @@ SETTINGS index_granularity=1024, ttl_only_drop_parts = 1
 def LOG_ENTRIES_DISTRIBUTED_TABLE_SQL():
     return (LOG_ENTRIES_TABLE_BASE_SQL).format(
         table_name=LOG_ENTRIES_DISTRIBUTED_TABLE,
+        on_cluster=ON_CLUSTER_CLAUSE(False),
         extra_fields=KAFKA_COLUMNS,
         engine=Distributed(data_table=LOG_ENTRIES_SHARDED_TABLE, cluster=CLICKHOUSE_CLUSTER, sharding_key="rand()"),
     )
@@ -123,6 +124,7 @@ def LOG_ENTRIES_DISTRIBUTED_TABLE_SQL():
 def LOG_ENTRIES_WRITABLE_TABLE_SQL():
     return (LOG_ENTRIES_TABLE_BASE_SQL).format(
         table_name=LOG_ENTRIES_WRITABLE_TABLE,
+        on_cluster=ON_CLUSTER_CLAUSE(False),
         extra_fields=KAFKA_COLUMNS,
         engine=Distributed(data_table=LOG_ENTRIES_SHARDED_TABLE, cluster=CLICKHOUSE_CLUSTER, sharding_key="rand()"),
     )
@@ -136,6 +138,7 @@ def KAFKA_LOG_ENTRIES_V3_TABLE_SQL():
     """
     ).format(
         table_name=f"kafka_{LOG_ENTRIES_TABLE}_v3",
+        on_cluster=ON_CLUSTER_CLAUSE(False),
         engine=kafka_engine(topic=KAFKA_LOG_ENTRIES, group="clickhouse_log_entries"),
         extra_fields="",
     )

--- a/posthog/clickhouse/log_entries.py
+++ b/posthog/clickhouse/log_entries.py
@@ -1,10 +1,13 @@
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, kafka_engine, ttl_period
-from posthog.clickhouse.table_engines import ReplacingMergeTree
+from posthog.clickhouse.table_engines import Distributed, ReplacingMergeTree, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
 
 LOG_ENTRIES_TABLE = "log_entries"
+LOG_ENTRIES_DISTRIBUTED_TABLE = "distributed_log_entries"
+LOG_ENTRIES_WRITABLE_TABLE = "writable_log_entries"
+LOG_ENTRIES_SHARDED_TABLE = "sharded_log_entries"
 LOG_ENTRIES_TTL_DAYS = 90
 
 LOG_ENTRIES_TABLE_BASE_SQL = """
@@ -34,8 +37,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
 """
 
 
-def LOG_ENTRIES_TABLE_ENGINE():
-    return ReplacingMergeTree(LOG_ENTRIES_TABLE, ver="_timestamp")
+def LOG_ENTRIES_TABLE_ENGINE(table_name: str, replication_scheme=ReplicationScheme.REPLICATED):
+    return ReplacingMergeTree(table_name, ver="_timestamp", replication_scheme=replication_scheme)
 
 
 def LOG_ENTRIES_TABLE_SQL(on_cluster=True):
@@ -49,7 +52,7 @@ SETTINGS index_granularity=512
         table_name=LOG_ENTRIES_TABLE,
         on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
         extra_fields=KAFKA_COLUMNS,
-        engine=LOG_ENTRIES_TABLE_ENGINE(),
+        engine=LOG_ENTRIES_TABLE_ENGINE(LOG_ENTRIES_TABLE),
         ttl_period=ttl_period("timestamp", LOG_ENTRIES_TTL_DAYS, unit="DAY"),
     )
 
@@ -89,3 +92,77 @@ INSERT INTO log_entries SELECT %(team_id)s, %(log_source)s, %(log_source_id)s, %
 """
 
 TRUNCATE_LOG_ENTRIES_TABLE_SQL = f"TRUNCATE TABLE IF EXISTS {LOG_ENTRIES_TABLE} {ON_CLUSTER_CLAUSE()}"
+
+# Log entries rework
+
+
+def LOG_ENTRIES_SHARDED_TABLE_SQL(on_cluster=False):
+    return (
+        LOG_ENTRIES_TABLE_BASE_SQL
+        + """PARTITION BY toStartOfDay(timestamp) ORDER BY (team_id, log_source, log_source_id, instance_id, timestamp)
+{ttl_period}
+SETTINGS index_granularity=1024, ttl_only_drop_parts = 1
+"""
+    ).format(
+        table_name=LOG_ENTRIES_SHARDED_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
+        extra_fields=KAFKA_COLUMNS,
+        engine=LOG_ENTRIES_TABLE_ENGINE(LOG_ENTRIES_SHARDED_TABLE, replication_scheme=ReplicationScheme.SHARDED),
+        ttl_period=ttl_period("timestamp", LOG_ENTRIES_TTL_DAYS, unit="DAY"),
+    )
+
+
+def LOG_ENTRIES_DISTRIBUTED_TABLE_SQL(on_cluster=False):
+    return (LOG_ENTRIES_TABLE_BASE_SQL).format(
+        table_name=LOG_ENTRIES_DISTRIBUTED_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
+        extra_fields=KAFKA_COLUMNS,
+        engine=Distributed(data_table=LOG_ENTRIES_SHARDED_TABLE, cluster=CLICKHOUSE_CLUSTER, sharding_key="rand()"),
+    )
+
+
+def LOG_ENTRIES_WRITABLE_TABLE_SQL(on_cluster=False):
+    return (LOG_ENTRIES_TABLE_BASE_SQL).format(
+        table_name=LOG_ENTRIES_WRITABLE_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
+        extra_fields=KAFKA_COLUMNS,
+        engine=Distributed(data_table=LOG_ENTRIES_SHARDED_TABLE, cluster=CLICKHOUSE_CLUSTER, sharding_key="rand()"),
+    )
+
+
+def KAFKA_LOG_ENTRIES_V3_TABLE_SQL(on_cluster=False):
+    return (
+        LOG_ENTRIES_TABLE_BASE_SQL
+        + """
+    SETTINGS kafka_skip_broken_messages = 100
+    """
+    ).format(
+        table_name=f"kafka_{LOG_ENTRIES_TABLE}_v3",
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
+        engine=kafka_engine(topic=KAFKA_LOG_ENTRIES, group="clickhouse_log_entries"),
+        extra_fields="",
+    )
+
+
+def LOG_ENTRIES_V3_TABLE_MV_SQL(on_cluster=False):
+    return """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS {table_name}_v3_mv {on_cluster_clause}
+    TO {database}.{to_table}
+    AS SELECT
+    team_id,
+    log_source,
+    log_source_id,
+    instance_id,
+    timestamp,
+    level,
+    message,
+    _timestamp,
+    _offset
+    FROM {database}.{from_table}
+    """.format(
+        table_name=LOG_ENTRIES_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
+        to_table=LOG_ENTRIES_WRITABLE_TABLE,
+        from_table=f"kafka_{LOG_ENTRIES_TABLE}_v3",
+        database=CLICKHOUSE_DATABASE,
+    )

--- a/posthog/clickhouse/log_entries.py
+++ b/posthog/clickhouse/log_entries.py
@@ -115,7 +115,7 @@ SETTINGS index_granularity=1024, ttl_only_drop_parts = 1
 def LOG_ENTRIES_DISTRIBUTED_TABLE_SQL():
     return (LOG_ENTRIES_TABLE_BASE_SQL).format(
         table_name=LOG_ENTRIES_DISTRIBUTED_TABLE,
-        on_cluster=ON_CLUSTER_CLAUSE(False),
+        on_cluster_clause=ON_CLUSTER_CLAUSE(False),
         extra_fields=KAFKA_COLUMNS,
         engine=Distributed(data_table=LOG_ENTRIES_SHARDED_TABLE, cluster=CLICKHOUSE_CLUSTER, sharding_key="rand()"),
     )
@@ -124,7 +124,7 @@ def LOG_ENTRIES_DISTRIBUTED_TABLE_SQL():
 def LOG_ENTRIES_WRITABLE_TABLE_SQL():
     return (LOG_ENTRIES_TABLE_BASE_SQL).format(
         table_name=LOG_ENTRIES_WRITABLE_TABLE,
-        on_cluster=ON_CLUSTER_CLAUSE(False),
+        on_cluster_clause=ON_CLUSTER_CLAUSE(False),
         extra_fields=KAFKA_COLUMNS,
         engine=Distributed(data_table=LOG_ENTRIES_SHARDED_TABLE, cluster=CLICKHOUSE_CLUSTER, sharding_key="rand()"),
     )
@@ -138,7 +138,7 @@ def KAFKA_LOG_ENTRIES_V3_TABLE_SQL():
     """
     ).format(
         table_name=f"kafka_{LOG_ENTRIES_TABLE}_v3",
-        on_cluster=ON_CLUSTER_CLAUSE(False),
+        on_cluster_clause=ON_CLUSTER_CLAUSE(False),
         engine=kafka_engine(topic=KAFKA_LOG_ENTRIES, group="clickhouse_log_entries"),
         extra_fields="",
     )

--- a/posthog/clickhouse/log_entries.py
+++ b/posthog/clickhouse/log_entries.py
@@ -159,6 +159,7 @@ def LOG_ENTRIES_V3_TABLE_MV_SQL(on_cluster=False):
     _timestamp,
     _offset
     FROM {database}.{from_table}
+    WHERE toDate(timestamp) <= today()
     """.format(
         table_name=LOG_ENTRIES_TABLE,
         on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),

--- a/posthog/clickhouse/log_entries.py
+++ b/posthog/clickhouse/log_entries.py
@@ -99,7 +99,7 @@ TRUNCATE_LOG_ENTRIES_TABLE_SQL = f"TRUNCATE TABLE IF EXISTS {LOG_ENTRIES_TABLE} 
 def LOG_ENTRIES_SHARDED_TABLE_SQL(on_cluster=False):
     return (
         LOG_ENTRIES_TABLE_BASE_SQL
-        + """PARTITION BY toStartOfDay(timestamp) ORDER BY (team_id, log_source, log_source_id, instance_id, timestamp)
+        + """PARTITION BY toYYYYMMDD(timestamp) ORDER BY (team_id, log_source, log_source_id, instance_id, timestamp)
 {ttl_period}
 SETTINGS index_granularity=1024, ttl_only_drop_parts = 1
 """

--- a/posthog/clickhouse/migrations/0141_log_entries_sharded.py
+++ b/posthog/clickhouse/migrations/0141_log_entries_sharded.py
@@ -1,0 +1,17 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.log_entries import (
+    KAFKA_LOG_ENTRIES_V3_TABLE_SQL,
+    LOG_ENTRIES_DISTRIBUTED_TABLE_SQL,
+    LOG_ENTRIES_SHARDED_TABLE_SQL,
+    LOG_ENTRIES_V3_TABLE_MV_SQL,
+    LOG_ENTRIES_WRITABLE_TABLE_SQL,
+)
+
+operations = [
+    run_sql_with_exceptions(LOG_ENTRIES_SHARDED_TABLE_SQL(), node_roles=[NodeRole.DATA]),
+    run_sql_with_exceptions(LOG_ENTRIES_WRITABLE_TABLE_SQL(), node_roles=[NodeRole.DATA]),
+    run_sql_with_exceptions(LOG_ENTRIES_DISTRIBUTED_TABLE_SQL(), node_roles=[NodeRole.DATA, NodeRole.COORDINATOR]),
+    run_sql_with_exceptions(KAFKA_LOG_ENTRIES_V3_TABLE_SQL(), node_roles=[NodeRole.DATA]),
+    run_sql_with_exceptions(LOG_ENTRIES_V3_TABLE_MV_SQL(), node_roles=[NodeRole.DATA]),
+]


### PR DESCRIPTION
## Problem

The current table design creates too much impact on ClickHouse replication because of its partitioning scheme and TTL.

## Changes

Make the table sharded, with daily partitioning, and that drops parts when TTL is met instead of executing a merge.

## How did you test this code?

Ran migrations and check that tables are created as expected
