### PR TITLE
fix: don't show anonymous users in the top active users table

### DIFF
--- a/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
@@ -52,7 +52,7 @@ export const replayActiveUsersTableLogic = kea<replayActiveUsersTableLogicType>(
                   -- that this replaces, so it's at least no worse 🙈
                   AND event IN ('$pageview', '$screen', '$autocapture', '$feature_flag_called', '$pageleave', '$identify', '$web_vitals', '$set', 'Application Opened', 'Application Backgrounded')
                   -- exclude anonymous users since we don't care if user "anonymous" watched a gajillion recordings
-                  AND properties.$process_person_profile != false
+                  AND (properties.$process_person_profile != false or properties.is_identified = true)
                 GROUP BY $session_id
             )
             -- now we can count the distinct sessions per person

--- a/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveUsersTableLogic.ts
@@ -52,7 +52,7 @@ export const replayActiveUsersTableLogic = kea<replayActiveUsersTableLogicType>(
                   -- that this replaces, so it's at least no worse 🙈
                   AND event IN ('$pageview', '$screen', '$autocapture', '$feature_flag_called', '$pageleave', '$identify', '$web_vitals', '$set', 'Application Opened', 'Application Backgrounded')
                   -- exclude anonymous users since we don't care if user "anonymous" watched a gajillion recordings
-                  AND (properties.$process_person_profile != false or properties.is_identified = true)
+                  AND (properties.$process_person_profile != false or properties.$is_identified = true)
                 GROUP BY $session_id
             )
             -- now we can count the distinct sessions per person


### PR DESCRIPTION
on the replay templates page we're still showing anonymous users 
despite the person processing check
we can't really link to anonymous users recordings (certainly not the way we're trying to here)

so let's also check if `$is_identfied` - since we don't want anonymous users in this view