### PR TITLE
fix(trends): Support multiple styles of table names in trends

### DIFF
--- a/posthog/warehouse/models/util.py
+++ b/posthog/warehouse/models/util.py
@@ -23,17 +23,18 @@ if TYPE_CHECKING:
 def get_view_or_table_by_name(team, name) -> Union["DataWarehouseSavedQuery", "DataWarehouseTable", None]:
     from posthog.warehouse.models import DataWarehouseSavedQuery, DataWarehouseTable
 
-    table_name = name
+    table_names = [name]
     if "." in name:
         chain = name.split(".")
         if len(chain) == 2:
-            table_name = f"{chain[0]}_{chain[1]}"
+            table_names = [f"{chain[0]}_{chain[1]}"]
         elif len(chain) == 3:
-            table_name = f"{chain[1]}_{chain[0]}_{chain[2]}"
+            # Support both `_` suffixed source prefix and without - e.g. postgres_table_name and postgrestable_name
+            table_names = [f"{chain[1]}_{chain[0]}_{chain[2]}", f"{chain[1]}{chain[0]}_{chain[2]}"]
 
     table: DataWarehouseSavedQuery | DataWarehouseTable | None = (
         DataWarehouseTable.objects.filter(Q(deleted__isnull=True) | Q(deleted=False))
-        .filter(team=team, name=table_name)
+        .filter(team=team, name__in=table_names)
         .first()
     )
     if table is None:


### PR DESCRIPTION
## Problem
- https://posthog.slack.com/archives/C0450KBMQBS/p1757405353966129?thread_ts=1757340660.737639&cid=C0450KBMQBS
- We presume a warehouse source that has a prefix will have a `_` suffix in the prefix name, this isn't always the case, and so we need to support source prefixes both with and without a `_` suffix

## Changes
- fixes ^
