### PR TITLE
fix: user agent inputs should not split on comma

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -216,8 +216,7 @@ export function PropertyValue({
     }
 
     // Disable comma splitting for user agent properties that contain commas in their values
-    const isUserAgentProperty =
-        propertyKey === '$raw_user_agent' || propertyKey === '$initial_raw_user_agent' || propertyKey === '$user_agent'
+    const isUserAgentProperty = ['$raw_user_agent', '$initial_raw_user_agent', '$user_agent'].includes(propertyKey)
 
     return (
         <LemonInputSelect

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -215,6 +215,10 @@ export function PropertyValue({
         return <>{formatPropertyValueForDisplay(propertyKey, name, propertyDefinitionType, groupTypeIndex)}</>
     }
 
+    // Disable comma splitting for user agent properties that contain commas in their values
+    const isUserAgentProperty =
+        propertyKey === '$raw_user_agent' || propertyKey === '$initial_raw_user_agent' || propertyKey === '$user_agent'
+
     return (
         <LemonInputSelect
             className={inputClassName}
@@ -227,6 +231,7 @@ export function PropertyValue({
             onInputChange={onSearchTextChange}
             placeholder={placeholder}
             size={size}
+            disableCommaSplitting={isUserAgentProperty}
             title={
                 PROPERTY_FILTER_TYPES_WITH_TEMPORAL_SUGGESTIONS.includes(type)
                     ? 'Suggested values (last 7 days)'

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -67,6 +67,8 @@ export type LemonInputSelectProps<T = string> = Pick<
     transparentBackground?: boolean
     displayMode?: 'snacks' | 'count'
     bulkActions?: 'clear-all' | 'select-and-clear-all'
+    /** Disable comma splitting for properties that contain commas in their values (e.g., user agent strings) */
+    disableCommaSplitting?: boolean
     action?: LemonInputSelectAction
     virtualized?: boolean
 }
@@ -98,6 +100,7 @@ export function LemonInputSelect<T = string>({
     fullWidth = false,
     displayMode = 'snacks',
     bulkActions,
+    disableCommaSplitting = false,
     action,
     virtualized = false,
 }: LemonInputSelectProps<T>): JSX.Element {
@@ -179,7 +182,7 @@ export function LemonInputSelect<T = string>({
         })
     )
 
-    const separateOnComma = allowCustomValues && mode === 'multiple'
+    const separateOnComma = allowCustomValues && mode === 'multiple' && !disableCommaSplitting
 
     // We stringify the objects to prevent wasteful recalculations (esp. Fuse). Note: labelComponent is not serializable
     const optionsKey = JSON.stringify(options, (key, value) => (key === 'labelComponent' ? value?.name : value))


### PR DESCRIPTION
## Problem

User agent strings contain a comma so are splitting meaning they cannot be pasted 

https://github.com/user-attachments/assets/83eca20e-efdf-4b0f-ab69-e9569bdbd6a6

## How did you test this code?

Locally tested and UA strings can no be selected or pasted and other fields still have the csv QOL

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
