### PR TITLE
feat: actions on pause

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
@@ -11,12 +11,32 @@ import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/se
 import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 import { SessionPlayerState } from '~/types'
 
+import { CommentOnRecordingButton } from './commenting/CommentOnRecordingButton'
+import { ClipRecording } from './controller/ClipRecording'
+import { Screenshot } from './controller/PlayerController'
+import { playerSettingsLogic } from './playerSettingsLogic'
+import { SessionRecordingPlayerMode } from './sessionRecordingPlayerLogic'
+
+const PlayerFrameOverlayActions = (): JSX.Element | null => {
+    return (
+        <div className="flex gap-1 mt-4">
+            <CommentOnRecordingButton className="text-2xl text-white" />
+            <Screenshot className="text-2xl text-white" />
+            <ClipRecording className="text-2xl text-white" />
+        </div>
+    )
+}
+
 const PlayerFrameOverlayContent = (): JSX.Element | null => {
-    const { currentPlayerState, endReached } = useValues(sessionRecordingPlayerLogic)
+    const { currentPlayerState, endReached, logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { isCinemaMode } = useValues(playerSettingsLogic)
+
     let content = null
     const pausedState =
         currentPlayerState === SessionPlayerState.PAUSE || currentPlayerState === SessionPlayerState.READY
     const isInExportContext = !!getCurrentExporterData()
+    const playerMode = logicProps.mode ?? SessionRecordingPlayerMode.Standard
+    const showActionsOnOverlay = !isCinemaMode && playerMode === SessionRecordingPlayerMode.Standard && pausedState
 
     if (currentPlayerState === SessionPlayerState.ERROR) {
         content = (
@@ -58,7 +78,10 @@ const PlayerFrameOverlayContent = (): JSX.Element | null => {
         content = endReached ? (
             <IconRewindPlay className="text-6xl text-white" />
         ) : (
-            <IconPlay className="text-6xl text-white" />
+            <div className="flex flex-col items-center justify-center">
+                <IconPlay className="text-6xl text-white" />
+                {showActionsOnOverlay && <PlayerFrameOverlayActions />}
+            </div>
         )
     }
     if (currentPlayerState === SessionPlayerState.SKIP) {

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
@@ -2,7 +2,7 @@ import './PlayerFrameOverlay.scss'
 
 import { useActions, useValues } from 'kea'
 
-import { IconPlay, IconRewindPlay, IconWarning } from '@posthog/icons'
+import { IconEmoji, IconPlay, IconRewindPlay, IconWarning } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { cn } from 'lib/utils/css-classes'
@@ -18,11 +18,22 @@ import { playerSettingsLogic } from './playerSettingsLogic'
 import { SessionRecordingPlayerMode } from './sessionRecordingPlayerLogic'
 
 const PlayerFrameOverlayActions = (): JSX.Element | null => {
+    const { setQuickEmojiIsOpen } = useActions(sessionRecordingPlayerLogic)
+    const { quickEmojiIsOpen } = useValues(sessionRecordingPlayerLogic)
+
     return (
         <div className="flex gap-1 mt-4">
-            <CommentOnRecordingButton className="text-2xl text-white" />
-            <Screenshot className="text-2xl text-white" />
-            <ClipRecording className="text-2xl text-white" />
+            <CommentOnRecordingButton className="text-2xl text-white" data-attr="replay-overlay-comment" />
+            <LemonButton
+                size="xsmall"
+                icon={<IconEmoji className="text-2xl text-white" />}
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setQuickEmojiIsOpen(!quickEmojiIsOpen)
+                }}
+            />
+            <Screenshot className="text-2xl text-white" data-attr="replay-overlay-screenshot" />
+            <ClipRecording className="text-2xl text-white" data-attr="replay-overlay-clip" />
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/commenting/CommentOnRecordingButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/commenting/CommentOnRecordingButton.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonDropdown } from '@posthog/lemon-ui'
 
 import { EmojiPickerPopover } from 'lib/components/EmojiPicker/EmojiPickerPopover'
 import { emojiUsageLogic } from 'lib/lemon-ui/LemonTextArea/emojiUsageLogic'
+import { cn } from 'lib/utils/css-classes'
 import { playerCommentOverlayLogic } from 'scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
@@ -40,7 +41,7 @@ export function EmojiCommentRow({ onSelectEmoji }: { onSelectEmoji?: () => void 
     )
 }
 
-export function CommentOnRecordingButton(): JSX.Element {
+export function CommentOnRecordingButton({ className }: { className?: string }): JSX.Element {
     const { setIsCommenting, setQuickEmojiIsOpen } = useActions(sessionRecordingPlayerLogic)
     const { isCommenting, quickEmojiIsOpen } = useValues(sessionRecordingPlayerLogic)
 
@@ -55,7 +56,10 @@ export function CommentOnRecordingButton(): JSX.Element {
         <>
             <LemonButton
                 size="xsmall"
-                onClick={() => setIsCommenting(!isCommenting)}
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setIsCommenting(!isCommenting)
+                }}
                 tooltip={
                     isCommenting ? (
                         <>
@@ -69,7 +73,7 @@ export function CommentOnRecordingButton(): JSX.Element {
                 }
                 data-attr={isCommenting ? 'stop-annotating-recording' : 'annotate-recording'}
                 active={isCommenting}
-                icon={<IconComment className="text-lg" />}
+                icon={<IconComment className={cn('text-lg', className)} />}
             />
             <LemonDropdown
                 overlay={
@@ -91,7 +95,10 @@ export function CommentOnRecordingButton(): JSX.Element {
             >
                 <LemonButton
                     size="xsmall"
-                    onClick={() => setQuickEmojiIsOpen(!quickEmojiIsOpen)}
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        setQuickEmojiIsOpen(!quickEmojiIsOpen)
+                    }}
                     tooltip={
                         quickEmojiIsOpen ? (
                             <>
@@ -106,7 +113,7 @@ export function CommentOnRecordingButton(): JSX.Element {
                     data-attr={quickEmojiIsOpen ? 'close-emoji-picker' : 'emoji-comment-dropdown'}
                     active={quickEmojiIsOpen}
                     disabledReason={isLoading ? 'Loading...' : undefined}
-                    icon={<IconEmoji className="text-lg" />}
+                    icon={<IconEmoji className={cn('text-lg', className)} />}
                 />
             </LemonDropdown>
         </>

--- a/frontend/src/scenes/session-recordings/player/commenting/CommentOnRecordingButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/commenting/CommentOnRecordingButton.tsx
@@ -42,15 +42,8 @@ export function EmojiCommentRow({ onSelectEmoji }: { onSelectEmoji?: () => void 
 }
 
 export function CommentOnRecordingButton({ className }: { className?: string }): JSX.Element {
-    const { setIsCommenting, setQuickEmojiIsOpen } = useActions(sessionRecordingPlayerLogic)
-    const { isCommenting, quickEmojiIsOpen } = useValues(sessionRecordingPlayerLogic)
-
-    const {
-        sessionPlayerData: { sessionRecordingId },
-        logicProps,
-    } = useValues(sessionRecordingPlayerLogic)
-    const theBuiltOverlayLogic = playerCommentOverlayLogic({ recordingId: sessionRecordingId, ...logicProps })
-    const { isLoading } = useValues(theBuiltOverlayLogic)
+    const { setIsCommenting } = useActions(sessionRecordingPlayerLogic)
+    const { isCommenting } = useValues(sessionRecordingPlayerLogic)
 
     return (
         <>
@@ -75,47 +68,62 @@ export function CommentOnRecordingButton({ className }: { className?: string }):
                 active={isCommenting}
                 icon={<IconComment className={cn('text-lg', className)} />}
             />
-            <LemonDropdown
-                overlay={
-                    <EmojiCommentRow
-                        onSelectEmoji={() => {
-                            setQuickEmojiIsOpen(!quickEmojiIsOpen)
-                        }}
-                    />
-                }
-                placement="bottom-end"
-                visible={quickEmojiIsOpen}
-                closeOnClickInside={false}
-                onClickOutside={() => {
-                    setQuickEmojiIsOpen(!quickEmojiIsOpen)
-                }}
-                onVisibilityChange={(visible) => {
-                    setQuickEmojiIsOpen(visible)
-                }}
-            >
-                <LemonButton
-                    size="xsmall"
-                    onClick={(e) => {
-                        e.stopPropagation()
+        </>
+    )
+}
+
+export function EmojiCommentOnRecordingButton({ className }: { className?: string }): JSX.Element {
+    const { setQuickEmojiIsOpen } = useActions(sessionRecordingPlayerLogic)
+    const { quickEmojiIsOpen } = useValues(sessionRecordingPlayerLogic)
+
+    const {
+        sessionPlayerData: { sessionRecordingId },
+        logicProps,
+    } = useValues(sessionRecordingPlayerLogic)
+    const theBuiltOverlayLogic = playerCommentOverlayLogic({ recordingId: sessionRecordingId, ...logicProps })
+    const { isLoading } = useValues(theBuiltOverlayLogic)
+
+    return (
+        <LemonDropdown
+            overlay={
+                <EmojiCommentRow
+                    onSelectEmoji={() => {
                         setQuickEmojiIsOpen(!quickEmojiIsOpen)
                     }}
-                    tooltip={
-                        quickEmojiIsOpen ? (
-                            <>
-                                Close emoji picker <KeyboardShortcut e />
-                            </>
-                        ) : (
-                            <>
-                                Emoji react at the current timestamp <KeyboardShortcut e />
-                            </>
-                        )
-                    }
-                    data-attr={quickEmojiIsOpen ? 'close-emoji-picker' : 'emoji-comment-dropdown'}
-                    active={quickEmojiIsOpen}
-                    disabledReason={isLoading ? 'Loading...' : undefined}
-                    icon={<IconEmoji className={cn('text-lg', className)} />}
                 />
-            </LemonDropdown>
-        </>
+            }
+            placement="bottom-end"
+            visible={quickEmojiIsOpen}
+            closeOnClickInside={false}
+            onClickOutside={() => {
+                setQuickEmojiIsOpen(!quickEmojiIsOpen)
+            }}
+            onVisibilityChange={(visible) => {
+                setQuickEmojiIsOpen(visible)
+            }}
+        >
+            <LemonButton
+                size="xsmall"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setQuickEmojiIsOpen(!quickEmojiIsOpen)
+                }}
+                tooltip={
+                    quickEmojiIsOpen ? (
+                        <>
+                            Close emoji picker <KeyboardShortcut e />
+                        </>
+                    ) : (
+                        <>
+                            Emoji react at the current timestamp <KeyboardShortcut e />
+                        </>
+                    )
+                }
+                data-attr={quickEmojiIsOpen ? 'close-emoji-picker' : 'emoji-comment-dropdown'}
+                active={quickEmojiIsOpen}
+                disabledReason={isLoading ? 'Loading...' : undefined}
+                icon={<IconEmoji className={cn('text-lg', className)} />}
+            />
+        </LemonDropdown>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/controller/ClipRecording.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/ClipRecording.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonSegmentedButton, LemonTag } from '@posthog/lemon-ui'
 import { LemonSegmentedSelect } from 'lib/lemon-ui/LemonSegmentedSelect'
 import { IconRecordingClip } from 'lib/lemon-ui/icons'
 import { colonDelimitedDuration } from 'lib/utils'
+import { cn } from 'lib/utils/css-classes'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
@@ -127,7 +128,7 @@ export function ClipOverlay(): JSX.Element | null {
     )
 }
 
-export function ClipRecording(): JSX.Element {
+export function ClipRecording({ className }: { className?: string }): JSX.Element {
     const { showingClipParams, currentPlayerTime, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
     const { setPause, setShowingClipParams } = useActions(sessionRecordingPlayerLogic)
 
@@ -137,7 +138,8 @@ export function ClipRecording(): JSX.Element {
         <LemonButton
             size="xsmall"
             active={showingClipParams}
-            onClick={() => {
+            onClick={(e) => {
+                e.stopPropagation()
                 setPause()
                 setShowingClipParams(!showingClipParams)
             }}
@@ -151,7 +153,7 @@ export function ClipRecording(): JSX.Element {
                     </LemonTag>
                 </div>
             }
-            icon={<IconRecordingClip className="text-xl" />}
+            icon={<IconRecordingClip className={cn('text-xl', className)} />}
             data-attr="replay-clip"
             tooltipPlacement="top"
         />

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -5,6 +5,7 @@ import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { IconFullScreen } from 'lib/lemon-ui/icons'
+import { cn } from 'lib/utils/css-classes'
 import { PlayerUpNext } from 'scenes/session-recordings/player/PlayerUpNext'
 import { CommentOnRecordingButton } from 'scenes/session-recordings/player/commenting/CommentOnRecordingButton'
 import {
@@ -97,19 +98,22 @@ function CinemaMode(): JSX.Element {
     )
 }
 
-function Screenshot(): JSX.Element {
+export function Screenshot({ className }: { className?: string }): JSX.Element {
     const { takeScreenshot } = useActions(sessionRecordingPlayerLogic)
 
     return (
         <LemonButton
             size="xsmall"
-            onClick={takeScreenshot}
+            onClick={(e) => {
+                e.stopPropagation()
+                takeScreenshot()
+            }}
             tooltip={
                 <>
                     Take a screenshot of this point in the recording <KeyboardShortcut s />
                 </>
             }
-            icon={<IconCamera className="text-xl" />}
+            icon={<IconCamera className={cn('text-xl', className)} />}
             data-attr="replay-screenshot-png"
             tooltipPlacement="top"
         />

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -7,7 +7,10 @@ import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { IconFullScreen } from 'lib/lemon-ui/icons'
 import { cn } from 'lib/utils/css-classes'
 import { PlayerUpNext } from 'scenes/session-recordings/player/PlayerUpNext'
-import { CommentOnRecordingButton } from 'scenes/session-recordings/player/commenting/CommentOnRecordingButton'
+import {
+    CommentOnRecordingButton,
+    EmojiCommentOnRecordingButton,
+} from 'scenes/session-recordings/player/commenting/CommentOnRecordingButton'
 import {
     SessionRecordingPlayerMode,
     sessionRecordingPlayerLogic,
@@ -145,6 +148,7 @@ export function PlayerController(): JSX.Element {
                     {!isCinemaMode && playerMode === SessionRecordingPlayerMode.Standard && (
                         <>
                             <CommentOnRecordingButton />
+                            <EmojiCommentOnRecordingButton />
                             <Screenshot />
                             <ClipRecording />
                             {playlistLogic ? <PlayerUpNext playlistLogic={playlistLogic} /> : undefined}


### PR DESCRIPTION
We want people not only to watch recordings, but to take action on them.

So far, we’ve built:
- the ability to comment
- the ability to screenshot a moment
- the ability to create a clip around a moment

Some users are not yet familiar with these features, so let’s show them at the moment when a user interacts with a recording.

For example, if a user pauses a recording to look more closely, we can surface these actions.

Important: 
We show that only when the recording is ready / paused and not on publicly shared.
Also, not if you are in the cinema mode.

## Before
<img width="1319" height="817" alt="Screenshot 2025-09-09 at 12 54 07" src="https://github.com/user-attachments/assets/00dc5c66-26bf-4652-978f-8f8326acf9c2" />


## After

<img width="1308" height="822" alt="Screenshot 2025-09-09 at 12 46 36" src="https://github.com/user-attachments/assets/5756dea0-f4f7-426e-9dba-3517ed2d2065" />
<img width="377" height="235" alt="Screenshot 2025-09-09 at 12 37 34" src="https://github.com/user-attachments/assets/cb732b04-92fe-4126-8415-16813175efc6" />
<img width="415" height="260" alt="Screenshot 2025-09-09 at 12 37 24" src="https://github.com/user-attachments/assets/4b19c360-3b86-4ab3-bce9-947f4d91d9b6" />
