### PR TITLE
fix(persons): make rate limits work as expected

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -57,12 +57,7 @@ from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.lifecycle import Lifecycle
 from posthog.queries.trends.trends_actors import TrendsActors
 from posthog.queries.util import get_earliest_timestamp
-from posthog.rate_limit import (
-    BreakGlassBurstThrottle,
-    BreakGlassSustainedThrottle,
-    ClickHouseBurstRateThrottle,
-    ClickHouseSustainedRateThrottle,
-)
+from posthog.rate_limit import BreakGlassBurstThrottle, BreakGlassSustainedThrottle, ClickHouseBurstRateThrottle
 from posthog.renderers import SafeJSONRenderer
 from posthog.settings import EE_AVAILABLE
 from posthog.tasks.split_person import split_person

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -130,21 +130,14 @@ def get_person_name_helper(
     return str(person_pk)
 
 
-class PersonsThrottle(ClickHouseSustainedRateThrottle):
-    # Throttle class that's scoped just to the person endpoint.
-    # This makes the rate limit apply to all endpoints under /api/person/
-    # and independent of other endpoints.
-    scope = "persons"
-
-
 class PersonsBreakGlassBurstThrottle(BreakGlassBurstThrottle):
-    scope = "persons"
-    rate = "60/minute"
+    scope = "persons_burst"
+    rate = "180/minute"
 
 
 class PersonsBreakGlassSustainedThrottle(BreakGlassSustainedThrottle):
-    scope = "persons"
-    rate = "300/hour"
+    scope = "persons_sustained"
+    rate = "1200/hour"
 
 
 class PersonSerializer(serializers.HyperlinkedModelSerializer):
@@ -229,7 +222,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     pagination_class = PersonLimitOffsetPagination
     throttle_classes = [
         ClickHouseBurstRateThrottle,
-        PersonsThrottle,
         PersonsBreakGlassBurstThrottle,
         PersonsBreakGlassSustainedThrottle,
     ]


### PR DESCRIPTION
## Problem

We have a report that the rate limits on the `/persons` api don't send an appropriate `Retry-After` header. Turns out this is because we have two throttles with the same scope, so each request counts twice towards the rate limit. Therefore the method that computes the header, would return early https://github.com/encode/django-rest-framework/blob/main/rest_framework/throttling.py#L158-L160. 

Ticket: https://posthoghelp.zendesk.com/agent/tickets/36397. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38475)

## Changes

- Uses a unique scope for each rate limit.
- Removes the `PersonsThrottle`, which inherits from `ClickHouseSustainedRateThrottle`, which is also used in the endpoint. Since `PersonsThrottle` does not have a different limit, `ClickHouseSustainedRateThrottle` would always trigger with or before `PersonsThrottle`.
- Increases the limits.

## How did you test this code?

Debugger with `"justMyCode": false,` and 

```
curl -s -D - -o /dev/null \   
    -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
    "http://localhost:8000/api/projects/1/persons/"
```