### PR TITLE
chore: Reduce initial retry interval for batch exports

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -30,7 +30,7 @@ async def execute_batch_export_using_internal_stage(
     interval: str,
     heartbeat_timeout_seconds: int | None = 180,
     maximum_attempts: int = 0,
-    initial_retry_interval_seconds: int = 30,
+    initial_retry_interval_seconds: int = 5,
     maximum_retry_interval_seconds: int = 120,
 ) -> None:
     """


### PR DESCRIPTION
## Problem

An initial retry interval of 30s is a bit too high for 5min batch exports (10% of the implicit SLA!). Since we are seeing intermittent connection errors that can be quickly retried, we should reduce the initial retry interval.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Reduce initial retry interval to 5s.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
