### PR TITLE
feat: auto create github issue

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/integrations/CyclotronJobInputIntegrationField.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/CyclotronJobInputIntegrationField.tsx
@@ -7,6 +7,7 @@ import {
     ClickUpSpacePicker,
     ClickUpWorkspacePicker,
 } from 'lib/integrations/ClickUpIntegrationHelpers'
+import { GitHubRepositoryPicker } from 'lib/integrations/GitHubIntegrationHelpers'
 import {
     GoogleAdsConversionActionPicker,
     GoogleAdsCustomerIdPicker,
@@ -146,6 +147,9 @@ export function CyclotronJobInputIntegrationField({
     }
     if (schema.integration_field === 'linear_team') {
         return <LinearTeamPicker value={value} onChange={(x) => onChange?.(x)} integration={integration} />
+    }
+    if (schema.integration_field === 'github_repository') {
+        return <GitHubRepositoryPicker value={value} onChange={(x) => onChange?.(x)} integrationId={integration.id} />
     }
     if (schema.integration_field === 'twilio_phone_number') {
         return <TwilioPhoneNumberPicker value={value} onChange={(x) => onChange?.(x)} integration={integration} />

--- a/frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx
@@ -7,6 +7,32 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { githubIntegrationLogic } from './githubIntegrationLogic'
 
+export type GitHubRepositoryPickerProps = {
+    integrationId: number
+    value: string
+    onChange: (value: string) => void
+}
+
+export const GitHubRepositoryPicker = ({
+    value,
+    onChange,
+    integrationId,
+}: GitHubRepositoryPickerProps): JSX.Element => {
+    const { options, loading } = useRepositories(integrationId)
+
+    return (
+        <LemonInputSelect
+            onChange={(val) => onChange?.(val[0] ?? null)}
+            value={value ? [value] : []}
+            mode="single"
+            data-attr="select-github-repository"
+            placeholder="Select a repository..."
+            options={options}
+            loading={loading}
+        />
+    )
+}
+
 export const GitHubRepositorySelectField = ({ integrationId }: { integrationId: number }): JSX.Element => {
     const { options, loading } = useRepositories(integrationId)
 

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -323,6 +323,34 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             template_id: 'template-linear',
             name: 'Linear issue on issue created',
             description: 'Create an issue in Linear when an issue is created.',
+            inputs: {
+                title: {
+                    value: '{event.properties.name}',
+                },
+                description: {
+                    value: '{event.properties.description}',
+                },
+                posthog_issue_id: {
+                    value: '{event.properties.distinct_id}',
+                },
+            },
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-created'],
+            template_id: 'template-github',
+            name: 'GitHub issue on issue created',
+            description: 'Create an issue in GitHub when an issue is created.',
+            inputs: {
+                title: {
+                    value: '{event.properties.name}',
+                },
+                description: {
+                    value: '{event.properties.description}',
+                },
+                posthog_issue_id: {
+                    value: '{event.properties.distinct_id}',
+                },
+            },
         },
     ],
     'error-tracking-issue-reopened': [

--- a/plugin-server/src/cdp/templates/_destinations/github/github.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/github/github.template.ts
@@ -1,0 +1,91 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    status: 'stable',
+    free: false,
+    type: 'destination',
+    id: 'template-github',
+    name: 'GitHub',
+    description: 'Creates an issue in a GitHub repository',
+    icon_url: '/static/services/github.png',
+    category: ['Error tracking'],
+    code_language: 'hog',
+    code: `let owner := inputs.github_installation.account.name
+let repo := inputs.repository
+
+if (not owner) {
+    throw Error('Owner is required')
+}
+
+if (not repo) {
+    throw Error('Repository is required')
+}
+
+let posthog_issue_url := f'{project.url}/error_tracking/{inputs.posthog_issue_id}'
+let payload := {
+    'method': 'POST',
+    'headers': {
+        'Authorization': f'Bearer {inputs.github_installation.access_token}',
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'PostHog Github App'
+    },
+    'body': {
+        'title': inputs.title,
+        'body': f'{inputs.description}\n\n[View in PostHog]({posthog_issue_url})'
+    }
+}
+
+let res := fetch(f'https://api.github.com/repos/{owner}/{repo}/issues', payload)
+if (res.status < 200 or res.status >= 300) {
+    throw Error(f'Failed to create GitHub issue: {res.status}: {res.body}')
+}`,
+    inputs_schema: [
+        {
+            key: 'github_installation',
+            type: 'integration',
+            integration: 'github',
+            label: 'GitHub installation',
+            secret: false,
+            hidden: false,
+            required: true,
+        },
+        {
+            key: 'repository',
+            type: 'integration_field',
+            integration_key: 'github_installation',
+            integration_field: 'github_repository',
+            label: 'Repository',
+            secret: false,
+            hidden: false,
+            required: true,
+        },
+        {
+            key: 'title',
+            type: 'string',
+            label: 'Title',
+            secret: false,
+            hidden: false,
+            required: true,
+            default: '{event.properties.$exception_types[1]}',
+        },
+        {
+            key: 'description',
+            type: 'string',
+            label: 'Description',
+            secret: false,
+            hidden: false,
+            required: true,
+            default: '{event.properties.$exception_values[1]}',
+        },
+        {
+            key: 'posthog_issue_id',
+            type: 'string',
+            label: 'PostHog issue ID',
+            secret: false,
+            hidden: true,
+            required: true,
+            default: '{event.properties.$exception_issue_id}',
+        },
+    ],
+}

--- a/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
@@ -23,7 +23,7 @@ export const template: HogFunctionTemplate = {
     })
 }
 
-let issue_mutation := f'mutation IssueCreate \\{ issueCreate(input: \\{ title: "{event.properties.name}" description: "{event.properties.description}" teamId: "{inputs.team}" }) \\{ success issue \\{ identifier } } }';
+let issue_mutation := f'mutation IssueCreate \\{ issueCreate(input: \\{ title: "{inputs.title}" description: "{inputs.description}" teamId: "{inputs.team}" }) \\{ success issue \\{ identifier } } }';
 
 let issue_response := query(issue_mutation);
 
@@ -33,7 +33,7 @@ if (issue_response.status != 200) {
 
 let linear_issue_id := issue_response.body.data.issueCreate.issue.identifier;
 
-let attachment_url := f'{project.url}/error_tracking/{event.distinct_id}';
+let attachment_url := f'{project.url}/error_tracking/{inputs.posthog_issue_id}';
 let attachment_mutation := f'mutation AttachmentCreate \\{ attachmentCreate(input: \\{ issueId: "{linear_issue_id}", title: "PostHog issue", url: "{attachment_url}" }) \\{ success } }';
 
 query(attachment_mutation);`,
@@ -56,6 +56,33 @@ query(attachment_mutation);`,
             secret: false,
             hidden: false,
             required: true,
+        },
+        {
+            key: 'title',
+            type: 'string',
+            label: 'Title',
+            secret: false,
+            hidden: false,
+            required: true,
+            default: '{event.properties.$exception_types[1]}',
+        },
+        {
+            key: 'description',
+            type: 'string',
+            label: 'Description',
+            secret: false,
+            hidden: false,
+            required: true,
+            default: '{event.properties.$exception_values[1]}',
+        },
+        {
+            key: 'posthog_issue_id',
+            type: 'string',
+            label: 'PostHog issue ID',
+            secret: false,
+            hidden: true,
+            required: true,
+            default: '{event.properties.$exception_issue_id}',
         },
     ],
 }

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -4,6 +4,7 @@ import { HogFunctionTemplate, NativeTemplate } from '../types'
 import { template as clickupTemplate } from './_destinations/clickup/clickup.template'
 import { allComingSoonTemplates } from './_destinations/coming-soon/coming-soon-destinations.template'
 import { template as emailTemplate } from './_destinations/email/email.template'
+import { template as githubTemplate } from './_destinations/github/github.template'
 import { template as googleTagManagerTemplate } from './_destinations/google-tag-manager/google-tag-manager.template'
 import { template as googleAdsTemplate } from './_destinations/google_ads/google.template'
 import { template as googleSheetsTemplate } from './_destinations/google_sheets/google_sheets.template'
@@ -38,6 +39,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     tiktokAdsTemplate,
     snapchatAdsTemplate,
     linearTemplate,
+    githubTemplate,
     googleAdsTemplate,
     redditAdsTemplate,
     twilioTemplate,


### PR DESCRIPTION
## Problem

We want to be able to add github auto issue creation as a new alert destination in error tracking configuration.

## Changes

While investigating this I discovered that it is possible to use existing linear template in CDP which does not work because
- you can't filter for events this is intended for (as this is an internal event which should trigger that),
- this internal event has special fields which are not available in normal event so reading the template is confusing,
- to my knowledge it just doesn't work. Seems like Data pipelines ignores internal events. Yes, confirmed with @daibhin. It does not have access to internal events.

Together with @daibhin we discussed that the best option would be to have separate inputs for CDP vs sub templates.

Thanks to that this is CDP setup (it works for exceptions)
<img width="1653" height="881" alt="image" src="https://github.com/user-attachments/assets/9877b030-9ae6-41b9-8dcf-945fca5b5197" />


And this is alert setup (it works for issue created event)
<img width="1666" height="780" alt="image" src="https://github.com/user-attachments/assets/856a6a92-b024-43b2-994b-028224bf6cdd" />



## How did you test this code?

I did local Github external connection set up (thanks for explaining that @daibhin) and just ran all the steps.
I updated the docs (Github section) https://github.com/PostHog/product-internal/issues/679 to explain how to set up local github app.
