### PR TITLE
chore: remove custom upload timeout

### DIFF
--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -50,7 +50,6 @@ ONE_HUNDRED_MEGABYTES = 1024 * 1024 * 100
 JS_DATA_MAGIC = b"posthog_error_tracking"
 JS_DATA_VERSION = 1
 JS_DATA_TYPE_SOURCE_AND_MAP = 2
-PRESIGNED_SINGLE_UPLOAD_TIMEOUT = 60
 PRESIGNED_MULTIPLE_UPLOAD_TIMEOUT = 60 * 5
 
 logger = structlog.get_logger(__name__)
@@ -628,7 +627,6 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
         presigned_url = object_storage.get_presigned_post(
             file_key=file_key,
             conditions=[["content-length-range", 0, ONE_HUNDRED_MEGABYTES]],
-            expiration=PRESIGNED_SINGLE_UPLOAD_TIMEOUT,
         )
 
         symbol_set = create_symbol_set(chunk_id, self.team, release_id, file_key)


### PR DESCRIPTION
## Problem

Towards https://github.com/PostHog/posthog-js/issues/2240#issuecomment-3253991636

## Changes

We were limiting presigned urls to 60 seconds rather than the default of 1 hour. It can take a number of minutes for a large app (>1k source maps) to upload all of their content. This was causing timeouts and the CLI to fail.