### PR TITLE
feat(data-warehouse): Added support for google ads mcc accounts

### DIFF
--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -30,6 +30,12 @@ class BigQueryTemporaryDatasetConfig(config.Config):
 
 
 @config.config
+class GoogleAdsIsMccAccountConfig(config.Config):
+    mcc_client_id: str
+    enabled: bool = config.value(converter=config.str_to_bool, default=False)
+
+
+@config.config
 class SnowflakeAuthTypeConfig(config.Config):
     user: str
     password: str
@@ -74,6 +80,7 @@ class DoItSourceConfig(config.Config):
 class GoogleAdsSourceConfig(config.Config):
     customer_id: str
     google_ads_integration_id: int = config.value(converter=config.str_to_int)
+    is_mcc_account: GoogleAdsIsMccAccountConfig | None = None
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -67,6 +67,10 @@ def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> Googl
     if isinstance(config, GoogleAdsSourceConfig):
         integration = Integration.objects.get(id=config.google_ads_integration_id, team_id=team_id)
 
+        login_customer_id: str | None = None
+        if config.is_mcc_account and config.is_mcc_account.enabled:
+            login_customer_id = config.is_mcc_account.mcc_client_id
+
         client = GoogleAdsClient.load_from_dict(
             {
                 "developer_token": settings.GOOGLE_ADS_DEVELOPER_TOKEN,
@@ -74,6 +78,7 @@ def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> Googl
                 "client_id": settings.GOOGLE_ADS_APP_CLIENT_ID,
                 "client_secret": settings.GOOGLE_ADS_APP_CLIENT_SECRET,
                 "use_proto_plus": False,
+                "login_customer_id": login_customer_id,
             }
         )
     else:

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -6,6 +6,7 @@ from posthog.schema import (
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
     SourceFieldOauthConfig,
+    SourceFieldSwitchGroupConfig,
 )
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
@@ -96,6 +97,24 @@ class GoogleAdsSource(BaseSource[GoogleAdsSourceConfig | GoogleAdsServiceAccount
                     ),
                     SourceFieldOauthConfig(
                         name="google_ads_integration_id", label="Google Ads account", required=True, kind="google-ads"
+                    ),
+                    SourceFieldSwitchGroupConfig(
+                        name="is_mcc_account",
+                        label="Using MCC account?",
+                        caption="Whether your logged in account is a Google Ads MCC account and you're accessing a clients account?",
+                        default=False,
+                        fields=cast(
+                            list[FieldType],
+                            [
+                                SourceFieldInputConfig(
+                                    name="mcc_client_id",
+                                    label="Client customer ID",
+                                    type=SourceFieldInputConfigType.TEXT,
+                                    required=True,
+                                    placeholder="",
+                                )
+                            ],
+                        ),
                     ),
                 ],
             ),


### PR DESCRIPTION
## Problem
- Our google ads source doesnt support accessing client accounts from a MCC account

## Changes
- Add support for ^ 

<img width="862" height="384" alt="image" src="https://github.com/user-attachments/assets/79ce0bc6-2c12-48e0-8721-28c9a430b8b7" />


