### PR TITLE
fix: allow empty s3 prefix in managed migrations

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -92,7 +92,7 @@ class BatchImportS3SourceCreateSerializer(BatchImportSerializer):
         required=True,
     )
     s3_bucket = serializers.CharField(write_only=True, required=False)
-    s3_prefix = serializers.CharField(write_only=True, required=False)
+    s3_prefix = serializers.CharField(write_only=True, required=False, allow_blank=True)
     s3_region = serializers.CharField(write_only=True, required=False)
     access_key = serializers.CharField(write_only=True, required=False)
     secret_key = serializers.CharField(write_only=True, required=False)
@@ -144,7 +144,7 @@ class BatchImportS3SourceCreateSerializer(BatchImportSerializer):
 
         batch_import.config.json_lines(content_type).from_s3(
             bucket=validated_data["s3_bucket"],
-            prefix=validated_data["s3_prefix"],
+            prefix=validated_data.get("s3_prefix", ""),
             region=validated_data["s3_region"],
             access_key_id=validated_data["access_key"],
             secret_access_key=validated_data["secret_key"],


### PR DESCRIPTION
## Problem

It's not possible to use files from the root of an S3 bucket, as we don't allow empty S3 prefixes.

## Changes

Allows empty string as S3 prefix.

## How did you test this code?

Added new tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
