### PR TITLE
fix: parse session reply domains like decide

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -44,6 +44,7 @@ mprocs = { pkg-path = "mprocs" }
 cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql
+ffmpeg.pkg-path = "ffmpeg"
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -44,7 +44,6 @@ mprocs = { pkg-path = "mprocs" }
 cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql
-ffmpeg.pkg-path = "ffmpeg"
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 bytes = { workspace = true }
+url = "2.5"
 once_cell = "1.18.0"
 rand = { workspace = true }
 redis = { version = "0.23.3", features = [

--- a/rust/feature-flags/src/handler/session_recording.rs
+++ b/rust/feature-flags/src/handler/session_recording.rs
@@ -175,13 +175,29 @@ fn get_linked_flag_value(linked_flag_config: Option<Value>) -> Option<Value> {
     }
 }
 
+fn parse_domain(url: Option<&str>) -> Option<String> {
+    url.and_then(|u| {
+        // Try to parse as URL. If it starts with http:// or https://, this will work
+        if let Ok(parsed) = url::Url::parse(u) {
+            parsed.host_str().map(|h| h.to_string())
+        } else {
+            // If parsing fails (e.g., bare domain without protocol), return None to match Python
+            None
+        }
+    })
+}
+
 fn on_permitted_recording_domain(recording_domains: &Vec<String>, headers: &HeaderMap) -> bool {
     let origin = headers.get("Origin").and_then(|v| v.to_str().ok());
     let referer = headers.get("Referer").and_then(|v| v.to_str().ok());
     let user_agent = headers.get("User-Agent").and_then(|v| v.to_str().ok());
 
-    let is_authorized_web_client = hostname_in_allowed_url_list(recording_domains, origin)
-        || hostname_in_allowed_url_list(recording_domains, referer);
+    // Parse the domain from the Origin and Referer headers
+    let origin_hostname = parse_domain(origin);
+    let referer_hostname = parse_domain(referer);
+
+    let is_authorized_web_client = hostname_in_allowed_url_list(recording_domains, origin_hostname.as_deref())
+        || hostname_in_allowed_url_list(recording_domains, referer_hostname.as_deref());
 
     let is_authorized_mobile_client =
         user_agent.is_some_and(|ua| AUTHORIZED_MOBILE_CLIENTS.iter().any(|&kw| ua.contains(kw)));
@@ -220,5 +236,61 @@ mod tests {
 
         // Empty domains list should allow recording (return false)
         assert!(!session_recording_domain_not_allowed(&team, &headers));
+    }
+
+    #[test]
+    fn test_parse_domain() {
+        // Test with full URLs - should extract hostname
+        assert_eq!(parse_domain(Some("https://app.example.com")), Some("app.example.com".to_string()));
+        assert_eq!(parse_domain(Some("https://app.example.com/")), Some("app.example.com".to_string()));
+        assert_eq!(parse_domain(Some("http://localhost:3000")), Some("localhost".to_string()));
+        assert_eq!(parse_domain(Some("https://app.example.com/path")), Some("app.example.com".to_string()));
+        
+        // Test with bare domains
+        assert_eq!(parse_domain(Some("app.example.com")), None);
+        assert_eq!(parse_domain(Some("example.com")), None);
+        
+        // Test with empty string and None
+        assert_eq!(parse_domain(Some("")), None);
+        assert_eq!(parse_domain(None), None);
+    }
+
+    #[test]
+    fn test_on_permitted_recording_domain_with_origin() {
+        use axum::http::HeaderMap;
+
+        let recording_domains = vec!["app.example.com".to_string()];
+        
+        // Test with Origin header (without trailing slash)
+        let mut headers = HeaderMap::new();
+        headers.insert("Origin", "https://app.example.com".parse().unwrap());
+        assert!(on_permitted_recording_domain(&recording_domains, &headers));
+        
+        // Test with Origin header (with trailing slash)
+        let mut headers = HeaderMap::new();
+        headers.insert("Origin", "https://app.example.com/".parse().unwrap());
+        assert!(on_permitted_recording_domain(&recording_domains, &headers));
+        
+        // Test with wrong domain
+        let mut headers = HeaderMap::new();
+        headers.insert("Origin", "https://wrong.example.com".parse().unwrap());
+        assert!(!on_permitted_recording_domain(&recording_domains, &headers));
+    }
+
+    #[test]
+    fn test_on_permitted_recording_domain_with_referer() {
+        use axum::http::HeaderMap;
+
+        let recording_domains = vec!["app.example.com".to_string()];
+        
+        // Test with Referer header
+        let mut headers = HeaderMap::new();
+        headers.insert("Referer", "https://app.example.com/some/path".parse().unwrap());
+        assert!(on_permitted_recording_domain(&recording_domains, &headers));
+        
+        // Test with wrong domain
+        let mut headers = HeaderMap::new();
+        headers.insert("Referer", "https://wrong.example.com/path".parse().unwrap());
+        assert!(!on_permitted_recording_domain(&recording_domains, &headers));
     }
 }

--- a/rust/feature-flags/src/handler/session_recording.rs
+++ b/rust/feature-flags/src/handler/session_recording.rs
@@ -273,8 +273,11 @@ mod tests {
         assert_eq!(parse_domain(Some("example.com")), None);
 
         // Test with wildcard domains
-        assert_eq!(parse_domain(Some("https://*.example.com")), Some("*.example.com".to_string()));
-        assert_eq!(parse_domain(Some("*.example.com")), None); 
+        assert_eq!(
+            parse_domain(Some("https://*.example.com")),
+            Some("*.example.com".to_string())
+        );
+        assert_eq!(parse_domain(Some("*.example.com")), None);
 
         // Test with empty string and None
         assert_eq!(parse_domain(Some("")), None);


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When determining if session recording is enabled, flags does a string-to-string comparison of the Origin/Referer header values directly against the strings in `recording_domains`. 

This is prone to mismatches. For example, if `recording_domains` contains URLs with trailing slashes like `https://app.example.com/` but the Origin/Referer header is `https://app.example.com` (without trailing slash), session reply will be disabled. 

decide does hostname-to-hostname comparisson instead
https://github.com/PostHog/posthog/blob/2a6802b32fb9672f818a2c6cd2d06c551566be67/posthog/api/utils.py#L425-L467

## Changes
1. Added parse_domain() function that extracts hostnames from URLs (matching Python's urlparse().hostname)
4. Modified on_permitted_recording_domain() to parse Origin/Referer headers to extract hostnames
5. Modified hostname_in_allowed_url_list() to parse URLs in the allowed list (`recording_domains`) to extract hostnames

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
