### PR TITLE
fix(max): show UI context after first message

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -714,7 +714,6 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             (conversation, featureFlags) =>
                 featureFlags[FEATURE_FLAGS.MAX_DEEP_RESEARCH]
                     ? conversation?.type !== ConversationType.DeepResearch &&
-                      !conversation?.title &&
                       conversation?.status !== ConversationStatus.InProgress
                     : true,
         ],


### PR DESCRIPTION
## Problem
Regression: we don't show the UI context button after the first message for non-deep research conversations, it's a bug currently happening only if the deep research flag is on.

## Changes
- UI context button should be visible after first message

## How did you test this code?
Locally