### PR TITLE
fix(max): redirect visualizations to existing insights

### DIFF
--- a/ee/hogai/graph/insights/nodes.py
+++ b/ee/hogai/graph/insights/nodes.py
@@ -750,6 +750,7 @@ class InsightSearchNode(AssistantNode):
                 plan=f"Showing existing insight: {insight_name}",
                 answer=query_obj,
                 id=str(uuid4()),
+                short_id=insight["short_id"],
             )
 
             return visualization_message

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -25076,6 +25076,9 @@
                     "default": "",
                     "type": "string"
                 },
+                "short_id": {
+                    "$ref": "#/definitions/InsightShortId"
+                },
                 "type": {
                     "const": "ai/viz",
                     "type": "string"

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -1,6 +1,8 @@
 import type { MaxBillingContext } from 'scenes/max/maxBillingContextLogic'
 import type { MaxUIContext } from 'scenes/max/maxTypes'
 
+import { InsightShortId } from '~/types'
+
 import {
     AssistantFunnelsQuery,
     AssistantHogQLQuery,
@@ -112,6 +114,7 @@ export interface VisualizationItem {
 
 export interface VisualizationMessage extends BaseAssistantMessage, VisualizationItem {
     type: AssistantMessageType.Visualization
+    short_id?: InsightShortId
 }
 
 export interface FailureMessage extends BaseAssistantMessage {

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -61,10 +61,11 @@ import {
     TaskExecutionMessage,
     TaskExecutionStatus,
     VisualizationItem,
+    VisualizationMessage,
 } from '~/queries/schema/schema-assistant-messages'
 import { DataVisualizationNode, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
-import { ProductKey } from '~/types'
+import { InsightShortId, ProductKey } from '~/types'
 
 import { ContextSummary } from './Context'
 import { MarkdownMessage } from './MarkdownMessage'
@@ -683,7 +684,7 @@ const VisualizationAnswer = React.memo(function VisualizationAnswer({
     status,
     isEditingInsight,
 }: {
-    message: VisualizationItem
+    message: VisualizationMessage
     status?: MessageStatus
     isEditingInsight: boolean
 }): JSX.Element | null {
@@ -727,11 +728,15 @@ const VisualizationAnswer = React.memo(function VisualizationAnswer({
                               )}
                               {!isEditingInsight && (
                                   <LemonButton
-                                      to={urls.insightNew({ query })}
+                                      to={
+                                          message.short_id
+                                              ? urls.insightView(message.short_id as InsightShortId)
+                                              : urls.insightNew({ query })
+                                      }
                                       icon={<IconOpenInNew />}
                                       size="xsmall"
                                       targetBlank
-                                      tooltip="Open as new insight"
+                                      tooltip={message.short_id ? 'Open insight' : 'Open as new insight'}
                                   />
                               )}
                               <LemonButton

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -13489,6 +13489,7 @@ class VisualizationMessage(BaseModel):
     initiator: Optional[str] = None
     plan: Optional[str] = None
     query: Optional[str] = ""
+    short_id: Optional[str] = None
     type: Literal["ai/viz"] = "ai/viz"
 
 


### PR DESCRIPTION
## Problem
If we respond to a question with existing insights, the "Open" button in the `VisualizationAnswer` component creates a new insight, instead of redirecting to the existing one. 

## Changes
- Correctly pass the insight's `short_id` to the frontend, so the button can correctly link to the existing insight

## How did you test this code?
Locally