### PR TITLE
fix: replay tracking player time for imaginary recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1642,7 +1642,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
     }),
 
     afterMount(({ props, actions, cache }) => {
-        if (props.mode === SessionRecordingPlayerMode.Preview) {
+        if (props.mode === SessionRecordingPlayerMode.Preview || props.sessionRecordingId.trim() === '') {
             return
         }
 


### PR DESCRIPTION
when you hit a page that _might_ trigger a replay modal

we end up with a session recording modal logic that has the empty string as a session recording id

its `afterMount` runs so we set up things like player time tracking for it

but since recording id is in the logic key, this orphaned logic will never do anything of any use

i think it's just an artefact of react early in the page lifecycle

let's not setup listeners on a useless logic (since i don't know how to avoid the useless logic)

<img width="751" height="328" alt="Screenshot 2025-09-09 at 18 54 25" src="https://github.com/user-attachments/assets/b6a4a0e7-fd38-4cb1-918f-74aef53395c5" />
