### PR TITLE
chore: fix a typo when sending insight refreshed event

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -691,6 +691,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 description_length: insightModel.description?.length ?? 0,
                 tags_count: insightModel.tags?.length ?? 0,
                 insight: sanitizeInsight(insightModel),
+                insight_id: insightModel.id,
+                insight_short_id: insightModel.short_id,
                 ...sanitizeQuery(query),
             }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1520,7 +1520,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                                 values.urlFilters,
                                 values.urlVariables,
                                 Math.floor(performance.now() - insightRefreshStartTime),
-                                true
+                                false
                             )
                         } else {
                             actions.setRefreshError(insight.short_id)


### PR DESCRIPTION
individual_refresh should be false when insight is being refreshed as part of a group of dashboard tiles.

also adds the insight_id to the insight viewed event (we do already have it under the `insight` object but we can't aggregate a funnel based on different fields in each step for now).
