### PR TITLE
refactor(flags): Remove `insert_in_clickhouse` argument to `insert_users_list_by_uuid`

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -822,7 +822,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         ]
         if len(uuids) == 0:
             raise ValidationError("No valid users to add to cohort")
-        cohort.insert_users_list_by_uuid(uuids, team_id=self.team_id, insert_in_clickhouse=True)
+        cohort.insert_users_list_by_uuid(uuids, team_id=self.team_id)
         log_activity(
             organization_id=cast(UUIDT, self.organization_id),
             team_id=self.team_id,
@@ -957,7 +957,7 @@ def insert_cohort_people_into_pg(cohort: Cohort, *, team_id: int):
         f"SELECT person_id FROM {PERSON_STATIC_COHORT_TABLE} where team_id = %(team_id)s AND cohort_id = %(cohort_id)s",
         {"cohort_id": cohort.pk, "team_id": team_id},
     )
-    cohort.insert_users_list_by_uuid(items=[str(id[0]) for id in ids], team_id=team_id)
+    cohort.insert_users_list_by_uuid_into_pg_only(items=[str(id[0]) for id in ids], team_id=team_id)
 
 
 def insert_cohort_query_actors_into_ch(cohort: Cohort, *, team: Team):
@@ -1154,18 +1154,14 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
                     capture_exception(err)
 
                 if len(uuids_to_add_to_cohort) >= batchsize:
-                    cohort.insert_users_list_by_uuid(
-                        uuids_to_add_to_cohort, insert_in_clickhouse=True, batchsize=batchsize, team_id=team_id
-                    )
+                    cohort.insert_users_list_by_uuid(uuids_to_add_to_cohort, batchsize=batchsize, team_id=team_id)
                     uuids_to_add_to_cohort = []
 
             start += batchsize
             batch_of_persons = queryset[start : start + batchsize]
 
         if len(uuids_to_add_to_cohort) > 0:
-            cohort.insert_users_list_by_uuid(
-                uuids_to_add_to_cohort, insert_in_clickhouse=True, batchsize=batchsize, team_id=team_id
-            )
+            cohort.insert_users_list_by_uuid(uuids_to_add_to_cohort, batchsize=batchsize, team_id=team_id)
 
     except Exception as err:
         if settings.DEBUG or settings.TEST:

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -289,7 +289,7 @@ def calculate_cohort_from_list(
     batch_count = (
         cohort.insert_users_by_list(items, team_id=team_id)
         if id_type == "distinct_id"
-        else cohort.insert_users_list_by_uuid(items, insert_in_clickhouse=True, team_id=team_id)
+        else cohort.insert_users_list_by_uuid(items, team_id=team_id)
     )
     logger.warn(
         "Cohort {}: {:,} items in {} batches from CSV completed in {:.2f}s".format(


### PR DESCRIPTION
## Problem

In 99.9% of cases, when we call `insert_users_list_by_uuid` we want to also insert them into Clickhouse (aka `insert_in_clickhouse=True`). The only time we don't want to do that is when calling `insert_cohort_from_insight_filter` or `insert_cohort_from_query`. And the reason for that is those methods create the cohort in Clickhouse first, and then populate Postgres with the IDs from Clickhouse.

Unfortunately, `insert_in_clickhouse` is defaulted to `False` making it a very big 🦶🏻🔫 . This means it's very easy to introduce a bug if not careful.

## Changes

To avoid that, this PR removes the `insert_in_clickhouse` argument from `insert_users_list_by_uuid` and changes the method to always insert into Clickhouse.

It also adds a new `insert_users_list_by_uuid_into_pg_only` method that those other methods can leverage.

## How did you test this code?

Unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
