### PR TITLE
fix(flags): don't sort condition sets with variant overrides to the top

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -849,15 +849,11 @@ impl FeatureFlagMatcher {
                 }
             }
         }
-        // Sort conditions with variant overrides to the top so that we can evaluate them first
-        let mut sorted_conditions: Vec<(usize, &FlagPropertyGroup)> =
+        let conditions: Vec<(usize, &FlagPropertyGroup)> =
             flag.get_conditions().iter().enumerate().collect();
 
-        sorted_conditions
-            .sort_by_key(|(_, condition)| if condition.variant.is_some() { 0 } else { 1 });
-
         let condition_timer = common_metrics::timing_guard(FLAG_EVALUATE_ALL_CONDITIONS_TIME, &[]);
-        for (index, condition) in sorted_conditions {
+        for (index, condition) in conditions {
             let (is_match, reason) = self.is_condition_match(
                 flag,
                 condition,

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -5507,4 +5507,133 @@ mod tests {
         // - Condition 2: billing_email matches exactly
         assert!(flag_result5.enabled);
     }
+
+    #[tokio::test]
+    async fn test_condition_evaluation_order_with_variant_overrides() {
+        // Unlike decide, we don't sort conditions with variant overrides to the top. 
+        // This test ensures that the order is maintained regardless of the presence of a variant override.
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        
+        let team = insert_new_team_in_pg(reader.clone(), None)
+            .await
+            .expect("Failed to insert team");
+        
+        // Create a flag with:
+        // 1. First condition: specific user match (no variant override)
+        // 2. Second condition: catch-all with variant="test"
+        let flag = FeatureFlag {
+            id: 1,
+            team_id: team.id,
+            name: Some("Test Order Flag".to_string()),
+            key: "test_order_flag".to_string(),
+            filters: FlagFilters {
+                groups: vec![
+                    FlagPropertyGroup {
+                        variant: None,  // No variant override
+                        properties: Some(vec![PropertyFilter {
+                            key: "email".to_string(),
+                            value: Some(json!("specific@example.com")),
+                            operator: Some(OperatorType::Exact),
+                            prop_type: PropertyType::Person,
+                            group_type_index: None,
+                            negation: None,
+                        }]),
+                        rollout_percentage: Some(100.0),
+                    },
+                    FlagPropertyGroup {
+                        variant: Some("test".to_string()),  // Has variant override
+                        properties: Some(vec![]),  // Catch-all
+                        rollout_percentage: Some(100.0),
+                    }
+                ],
+                multivariate: Some(MultivariateFlagOptions {
+                    variants: vec![
+                        MultivariateFlagVariant {
+                            key: "control".to_string(),
+                            name: Some("Control".to_string()),
+                            rollout_percentage: 100.0,
+                        },
+                        MultivariateFlagVariant {
+                            key: "test".to_string(),
+                            name: Some("Test".to_string()),
+                            rollout_percentage: 0.0,
+                        },
+                    ],
+                }),
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            },
+            deleted: false,
+            active: true,
+            ensure_experience_continuity: Some(false),
+            version: Some(1),
+            evaluation_runtime: Some("all".to_string()),
+        };
+        
+        let router = crate::database::PostgresRouter::new(
+            reader.clone(),
+            writer.clone(),
+            reader.clone(),
+            writer.clone(),
+        );
+        
+        // Test 1: User with email "specific@example.com" should match first condition
+        let matcher = FeatureFlagMatcher::new(
+            "specific_user".to_string(),
+            team.id,
+            team.project_id,
+            router.clone(),
+            cohort_cache.clone(),
+            None,
+            None,
+        );
+        
+        // Pass email as a property override to avoid database lookup
+        let mut user_properties = HashMap::new();
+        user_properties.insert("email".to_string(), json!("specific@example.com"));
+        
+        let result = matcher.get_match(&flag, Some(user_properties), None).unwrap();
+        assert!(result.matches, "Flag should match for specific user");
+        assert_eq!(
+            result.variant, 
+            Some("control".to_string()), 
+            "Specific user should get 'control' from multivariate rollout (100% control), not 'test' from catch-all"
+        );
+        assert_eq!(
+            result.condition_index, 
+            Some(0), 
+            "Should match first condition (index 0)"
+        );
+        
+        // Test 2: Different user should match second condition (catch-all)
+        let matcher2 = FeatureFlagMatcher::new(
+            "other_user".to_string(),
+            team.id,
+            team.project_id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        );
+        
+        let mut other_properties = HashMap::new();
+        other_properties.insert("email".to_string(), json!("other@example.com"));
+        
+        let result2 = matcher2.get_match(&flag, Some(other_properties), None).unwrap();
+        assert!(result2.matches, "Flag should match for other user");
+        assert_eq!(
+            result2.variant, 
+            Some("test".to_string()), 
+            "Other user should get 'test' from catch-all variant override"
+        );
+        assert_eq!(
+            result2.condition_index, 
+            Some(1), 
+            "Should match second condition (index 1)"
+        );
+    }
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -1551,7 +1551,7 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
         expected: json!({
             "errorsWhileComputingFlags": false,
             "featureFlags": {
-                "complex-flag": "test"  // Should get "test" variant due to name match
+                "complex-flag": "control"  // First condition matches (regex on created_at), gets control from multivariate
             }
         })
     );


### PR DESCRIPTION
## Problem

Today, we sort condition sets with variant overrides to the top without any indication in our UI or docs. This results in a confusing behavior where the user thinks Condition Set 1 should match (without variant override), but Condition Set 2 matches because it contains a variant override. 

<img width="649" height="460" alt="image" src="https://github.com/user-attachments/assets/3a7414b1-ab25-4cda-9100-467879fd6067" />

More discussion in this thread: https://posthog.slack.com/archives/C07Q2U4BH4L/p1757442003022359

I will send out an email to the teams this will affect before merging this PR. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Don't sort variant overrides to the top. 

Closes https://github.com/PostHog/posthog/issues/37854

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit test. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
