### PR TITLE
fix(charts): delete tooltips on component unmount

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -28,7 +28,7 @@ import { getGraphColors, getSeriesColor } from 'lib/colors'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { hexToRGBA } from 'lib/utils'
-import { ensureTooltip } from 'scenes/insights/views/LineGraph/LineGraph'
+import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 
 import { ChartSettings, GoalLine, YAxisSettings } from '~/queries/schema/schema-general'
 import { ChartDisplayType, GraphType } from '~/types'
@@ -121,7 +121,7 @@ export const LineGraph = ({
     className,
 }: LineGraphProps): JSX.Element => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
-    const chartId = useRef(`linegraph-dataviz-${Math.random().toString(36).substring(2, 11)}`)
+    const { getTooltip } = useInsightTooltip()
     const { ref: containerRef, height } = useResizeObserver()
     const colors = getGraphColors()
 
@@ -352,7 +352,7 @@ export const LineGraph = ({
                             return
                         }
 
-                        const [tooltipRoot, tooltipEl] = ensureTooltip(chartId.current)
+                        const [tooltipRoot, tooltipEl] = getTooltip()
                         if (tooltip.opacity === 0) {
                             tooltipEl.style.opacity = '0'
                             return

--- a/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.tsx
@@ -26,8 +26,7 @@ export function FunnelBarVertical({ showPersonsModal: showPersonsModalProp = tru
     const { visibleStepsWithConversionMetrics } = useValues(funnelDataLogic(insightProps))
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
     const showPersonsModal = canOpenPersonModal && showPersonsModalProp
-    const chartId = useRef(`funnel-vertical-${Math.random().toString(36).substring(2, 11)}`)
-    const vizRef = useFunnelTooltip(showPersonsModal, chartId.current)
+    const vizRef = useFunnelTooltip(showPersonsModal)
 
     const { height: availableHeight } = useResizeObserver({ ref: vizRef })
     const [scrollbarHeightPx, setScrollbarHeightPx] = useState(0)

--- a/frontend/src/scenes/funnels/FunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/FunnelTooltip.tsx
@@ -9,9 +9,9 @@ import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
 import { ClickToInspectActors } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { getActionFilterFromFunnelStep } from 'scenes/insights/views/Funnels/funnelStepTableUtils'
-import { ensureTooltip } from 'scenes/insights/views/LineGraph/LineGraph'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
@@ -106,17 +106,18 @@ export function FunnelTooltip({
     )
 }
 
-export function useFunnelTooltip(showPersonsModal: boolean, chartId: string): React.RefObject<HTMLDivElement> {
+export function useFunnelTooltip(showPersonsModal: boolean): React.RefObject<HTMLDivElement> {
     const { insightProps } = useValues(insightLogic)
     const { breakdownFilter, querySource } = useValues(funnelDataLogic(insightProps))
     const { isTooltipShown, currentTooltip, tooltipOrigin } = useValues(funnelTooltipLogic(insightProps))
     const { aggregationLabel } = useValues(groupsModel)
 
     const vizRef = useRef<HTMLDivElement>(null)
+    const { getTooltip } = useInsightTooltip()
 
     useEffect(() => {
         const svgRect = vizRef.current?.getBoundingClientRect()
-        const [tooltipRoot, tooltipEl] = ensureTooltip(chartId)
+        const [tooltipRoot, tooltipEl] = getTooltip()
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
         const tooltipRect = tooltipEl.getBoundingClientRect()
         if (tooltipOrigin) {

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -1,0 +1,122 @@
+import { useMemo } from 'react'
+import { Root, createRoot } from 'react-dom/client'
+
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+
+const tooltipInstances = new Map<
+    string,
+    { root: Root; element: HTMLElement; isMouseOver: boolean; hideTimeout: NodeJS.Timeout | null }
+>()
+
+export function ensureTooltip(id: string): [Root, HTMLElement] {
+    let instance = tooltipInstances.get(id)
+
+    if (!instance) {
+        const tooltipEl = document.createElement('div')
+        tooltipEl.id = `InsightTooltipWrapper-${id}`
+        tooltipEl.classList.add('InsightTooltipWrapper')
+        document.body.appendChild(tooltipEl)
+
+        const root = createRoot(tooltipEl)
+
+        instance = {
+            root,
+            element: tooltipEl,
+            isMouseOver: false,
+            hideTimeout: null,
+        }
+
+        tooltipInstances.set(id, instance)
+
+        // Add mouse tracking for this specific tooltip
+        tooltipEl.addEventListener(
+            'mouseenter',
+            () => {
+                instance!.isMouseOver = true
+                if (instance!.hideTimeout) {
+                    clearTimeout(instance!.hideTimeout)
+                    instance!.hideTimeout = null
+                }
+            },
+            { passive: true }
+        )
+
+        tooltipEl.addEventListener(
+            'mouseleave',
+            () => {
+                instance!.isMouseOver = false
+                instance!.hideTimeout = setTimeout(() => {
+                    if (!instance!.isMouseOver) {
+                        instance!.element.classList.add('opacity-0', 'invisible')
+                    }
+                }, 100)
+            },
+            { passive: true }
+        )
+    }
+
+    return [instance.root, instance.element]
+}
+
+export function hideTooltip(id?: string): void {
+    if (!id) {
+        // Fallback to old behavior - hide all tooltips
+        tooltipInstances.forEach((instance) => {
+            instance.element.style.opacity = '0'
+        })
+        return
+    }
+
+    const instance = tooltipInstances.get(id)
+    if (!instance) {
+        return
+    }
+
+    if (instance.hideTimeout) {
+        clearTimeout(instance.hideTimeout)
+        instance.hideTimeout = null
+    }
+
+    if (instance.isMouseOver) {
+        return
+    }
+
+    instance.hideTimeout = setTimeout(() => {
+        if (!instance.isMouseOver) {
+            instance.element.classList.add('opacity-0', 'invisible')
+        }
+    }, 100)
+}
+
+export function cleanupTooltip(id: string): void {
+    const instance = tooltipInstances.get(id)
+    if (instance) {
+        if (instance.hideTimeout) {
+            clearTimeout(instance.hideTimeout)
+        }
+        instance.element.remove()
+        tooltipInstances.delete(id)
+    }
+}
+
+export function useInsightTooltip(): {
+    tooltipId: string
+    getTooltip: () => [Root, HTMLElement]
+    hideTooltip: () => void
+    cleanupTooltip: () => void
+} {
+    const tooltipId = useMemo(() => Math.random().toString(36).substring(2, 11), [])
+
+    // Clean up tooltip on unmount
+    useOnMountEffect(() => {
+        return () => {
+            cleanupTooltip(tooltipId)
+        }
+    })
+
+    const getTooltip = (): [Root, HTMLElement] => ensureTooltip(tooltipId)
+    const hide = (): void => hideTooltip(tooltipId)
+    const cleanup = (): void => cleanupTooltip(tooltipId)
+
+    return { tooltipId, getTooltip, hideTooltip: hide, cleanupTooltip: cleanup }
+}

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -15,6 +15,7 @@ import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -23,7 +24,6 @@ import { NodeKind } from '~/queries/schema/schema-general'
 import { ChartParams, TrendResult } from '~/types'
 
 import { insightLogic } from '../../insightLogic'
-import { ensureTooltip } from '../LineGraph/LineGraph'
 import { Textfit } from './Textfit'
 
 /** The tooltip is offset by a few pixels from the cursor to give it some breathing room. */
@@ -33,12 +33,10 @@ function useBoldNumberTooltip({
     showPersonsModal,
     isTooltipShown,
     groupTypeLabel,
-    chartId,
 }: {
     showPersonsModal: boolean
     isTooltipShown: boolean
     groupTypeLabel?: string
-    chartId: string
 }): React.RefObject<HTMLDivElement> {
     const { insightProps } = useValues(insightLogic)
     const { series, insightData, trendsFilter, breakdownFilter } = useValues(insightVizDataLogic(insightProps))
@@ -47,7 +45,8 @@ function useBoldNumberTooltip({
     const divRef = useRef<HTMLDivElement>(null)
 
     const divRect = divRef.current?.getBoundingClientRect()
-    const [tooltipRoot, tooltipEl] = ensureTooltip(chartId)
+    const { getTooltip } = useInsightTooltip()
+    const [tooltipRoot, tooltipEl] = getTooltip()
 
     useLayoutEffect(() => {
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
@@ -97,12 +96,10 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
     )
 
     const [isTooltipShown, setIsTooltipShown] = useState(false)
-    const chartId = useRef(`boldnumber-${Math.random().toString(36).substring(2, 11)}`)
     const valueRef = useBoldNumberTooltip({
         showPersonsModal,
         isTooltipShown,
         groupTypeLabel: context?.groupTypeLabel,
-        chartId: chartId.current,
     })
 
     const showComparison = !!compareFilter?.compare && insightData?.result?.length > 1

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -15,12 +15,12 @@ import {
     TooltipModel,
 } from 'lib/Chart'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
-import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { LineGraphProps, ensureTooltip, onChartClick, onChartHover } from 'scenes/insights/views/LineGraph/LineGraph'
+import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
+import { LineGraphProps, onChartClick, onChartHover } from 'scenes/insights/views/LineGraph/LineGraph'
 import { createTooltipData } from 'scenes/insights/views/LineGraph/tooltip-data'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
@@ -84,15 +84,7 @@ export function PieChart({
     const { aggregationLabel } = useValues(groupsModel)
     const { highlightSeries } = useActions(insightLogic)
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
-    const chartId = useRef(`pie-${Math.random().toString(36).substring(2, 11)}`)
-
-    // Remove tooltip element on unmount
-    useOnMountEffect(() => {
-        return () => {
-            const tooltipEl = document.getElementById('InsightTooltipWrapper')
-            tooltipEl?.remove()
-        }
-    })
+    const { getTooltip } = useInsightTooltip()
 
     // Build chart
     useEffect(() => {
@@ -179,7 +171,7 @@ export function PieChart({
                                 return
                             }
 
-                            const [tooltipRoot, tooltipEl] = ensureTooltip(chartId.current)
+                            const [tooltipRoot, tooltipEl] = getTooltip()
                             if (tooltip.opacity === 0) {
                                 // remove highlight from the legend
                                 if (trendsFilter?.showLegend) {

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -9,6 +9,7 @@ import { COUNTRY_CODE_TO_LONG_NAME, countryCodeToFlag } from 'lib/utils/geograph
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -17,7 +18,6 @@ import { QueryContext } from '~/queries/types'
 import { ChartParams, TrendResult } from '~/types'
 
 import { SeriesDatum } from '../../InsightTooltip/insightTooltipUtils'
-import { ensureTooltip } from '../LineGraph/LineGraph'
 import { countryVectors } from './countryVectors'
 import { worldMapLogic } from './worldMapLogic'
 
@@ -26,7 +26,7 @@ const SATURATION_FLOOR = 0.2
 /** The tooltip is offset by a few pixels from the cursor to give it some breathing room. */
 const WORLD_MAP_TOOLTIP_OFFSET_PX = 8
 
-function useWorldMapTooltip(showPersonsModal: boolean, chartId: string): React.RefObject<SVGSVGElement> {
+function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGElement> {
     const { insightProps } = useValues(insightLogic)
     const { series, trendsFilter, breakdownFilter, isTooltipShown, currentTooltip, tooltipCoordinates } = useValues(
         worldMapLogic(insightProps)
@@ -36,7 +36,8 @@ function useWorldMapTooltip(showPersonsModal: boolean, chartId: string): React.R
     const svgRef = useRef<SVGSVGElement>(null)
 
     const svgRect = svgRef.current?.getBoundingClientRect()
-    const [tooltipRoot, tooltipEl] = ensureTooltip(chartId)
+    const { getTooltip } = useInsightTooltip()
+    const [tooltipRoot, tooltipEl] = getTooltip()
 
     useEffect(() => {
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
@@ -211,8 +212,7 @@ export function WorldMap({ showPersonsModal = true, context }: ChartParams): JSX
     const { countryCodeToSeries, maxAggregatedValue, querySource, theme } = useValues(worldMapLogic(insightProps))
     const { showTooltip, hideTooltip, updateTooltipCoordinates } = useActions(worldMapLogic(insightProps))
 
-    const chartId = useRef(`worldmap-${Math.random().toString(36).substring(2, 11)}`)
-    const svgRef = useWorldMapTooltip(showPersonsModal, chartId.current)
+    const svgRef = useWorldMapTooltip(showPersonsModal)
 
     const backgroundColor = theme?.['preset-1'] || '#000000' // Default to black if no color found
 


### PR DESCRIPTION
## Problem

I noticed a annoying UI issue with tooltips while working with funnels today. It's likely a side effect of this change: https://github.com/PostHog/posthog/pull/37256

The tooltips are not removed or hidden when the chart updates. The only way to get rid of them is to refresh the page.

https://github.com/user-attachments/assets/e421e99e-07b8-4cf3-8472-0f0a577d701c

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adds some refactoring to better manage the tooltips across charts. Also adds unmount effect to remove them.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

It's a bit tough to reproduce but you'd have to hover over charts while updating the date range. Easier way to test would be to just search the source code (through browser console) for instances of `.InsightTooltipWrapper`. There should only be one instance of tooltip per chart.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
