### PR TITLE
fix: new survey button margin on new scene

### DIFF
--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -55,17 +55,7 @@ export const scene: SceneExport = {
 function NewSurveyButton(): JSX.Element {
     const { loadSurveys, addProductIntent } = useActions(surveysLogic)
     const { user } = useValues(userLogic)
-
-    const button = (
-        <LemonButton to={urls.surveyTemplates()} type="primary" data-attr="new-survey">
-            <span className="pr-3">New survey</span>
-        </LemonButton>
-    )
-
-    // If the user is not loaded, just show the button without Max tool
-    if (!user?.uuid) {
-        return button
-    }
+    const { isOnNewSceneLayout } = useValues(surveysLogic)
 
     return (
         <MaxTool
@@ -78,7 +68,7 @@ function NewSurveyButton(): JSX.Element {
                 'Create a quick satisfaction survey for support interactions',
             ]}
             context={{
-                user_id: user.uuid,
+                user_id: user?.uuid,
             }}
             callback={(toolOutput: {
                 survey_id?: string
@@ -105,8 +95,12 @@ function NewSurveyButton(): JSX.Element {
                 router.actions.push(urls.survey(toolOutput.survey_id))
             }}
             position="bottom-right"
+            active={!!user?.uuid}
+            className={cn(isOnNewSceneLayout && 'mr-3')}
         >
-            {button}
+            <LemonButton to={urls.surveyTemplates()} type="primary" data-attr="new-survey">
+                <span className="pr-3">New survey</span>
+            </LemonButton>
         </MaxTool>
     )
 }

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -341,6 +341,12 @@ export const surveysLogic = kea<surveysLogicType>([
         },
     })),
     selectors({
+        isOnNewSceneLayout: [
+            (s) => [s.enabledFlags],
+            (enabledFlags: FeatureFlagsSet): boolean => {
+                return !!enabledFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]
+            },
+        ],
         isOnNewEmptyStateExperiment: [
             (s) => [s.enabledFlags],
             (enabledFlags: FeatureFlagsSet): boolean => {


### PR DESCRIPTION
## Problem

small margin issue in the new survey button on the new scene layout

## Changes

before:

![CleanShot 2025-09-10 at 01 58 46@2x](https://github.com/user-attachments/assets/6b5679a1-b6e0-4e53-a478-48dc83cbf331)

after:

![CleanShot 2025-09-10 at 02 00 07@2x](https://github.com/user-attachments/assets/e91b9c0f-e1c2-407f-a01b-1a382f6f71e0)

## How did you test this code?

locally