### PR TITLE
fix(experiments): enable analyzer and increase timeout on exposure query

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -167,7 +167,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                 team=self.team,
                 timings=self.timings,
                 modifiers=create_default_modifiers_for_team(self.team),
-                settings=HogQLGlobalSettings(max_execution_time=180),
+                settings=HogQLGlobalSettings(max_execution_time=600, allow_experimental_analyzer=True),
             )
 
             response.results = self._fill_date_gaps(response.results)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
@@ -22,12 +22,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -66,12 +67,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -100,12 +102,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -134,12 +137,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -168,12 +172,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -195,12 +200,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -229,12 +235,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -263,12 +270,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -297,12 +305,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1
@@ -331,12 +340,13 @@
            subq.variant
   ORDER BY subq.day ASC
   LIMIT 5000 SETTINGS readonly=2,
-                      max_execution_time=180,
+                      max_execution_time=600,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=4000000,
                       max_expanded_ast_elements=4000000,
                       max_bytes_before_external_group_by=0,
+                      allow_experimental_analyzer=1,
                       transform_null_in=1,
                       optimize_min_equality_disjunction_chain_length=4294967295,
                       allow_experimental_join_condition=1


### PR DESCRIPTION
## Changes

* Enable new clickhouse query analyzer on exposure queries (already enabled on metric queries)
* Set timeout to be the same as for metric queries.

## How did you test this code?
* tests passes