### PR TITLE
chore: compare timestamps in ingestion

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -281,6 +281,9 @@ export function getDefaultConfig(): PluginsServerConfig {
         COOKIELESS_REDIS_HOST: '',
         COOKIELESS_REDIS_PORT: 6379,
 
+        // Timestamp comparison logging (0.0 = disabled, 1.0 = 100% sampling)
+        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: isDevEnv() || isTestEnv() ? 1.0 : 0.0,
+
         PERSON_BATCH_WRITING_DB_WRITE_MODE: 'NO_ASSERT',
         PERSON_BATCH_WRITING_OPTIMISTIC_UPDATES_ENABLED: false,
         PERSON_BATCH_WRITING_MAX_CONCURRENT_UPDATES: 10,

--- a/plugin-server/src/ingestion/cookieless/cookieless-manager.ts
+++ b/plugin-server/src/ingestion/cookieless/cookieless-manager.ts
@@ -83,6 +83,7 @@ interface CookielessConfig {
     identifiesTtlSeconds: number
     sessionTtlSeconds: number
     saltTtlSeconds: number
+    timestampLoggingSampleRate: number
     sessionInactivityMs: number
 }
 
@@ -107,6 +108,7 @@ export class CookielessManager {
             saltTtlSeconds: config.COOKIELESS_SALT_TTL_SECONDS,
             sessionInactivityMs: config.COOKIELESS_SESSION_INACTIVITY_MS,
             identifiesTtlSeconds: config.COOKIELESS_IDENTIFIES_TTL_SECONDS,
+            timestampLoggingSampleRate: config.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
         }
 
         this.redisHelpers = new RedisHelpers(redis)
@@ -351,7 +353,14 @@ export class CookielessManager {
             }
 
             // Compare timestamp from headers with current parsing logic
-            compareTimestamps(timestamp, headers, team.id, event.uuid, 'cookieless_processing')
+            compareTimestamps(
+                timestamp,
+                headers,
+                team.id,
+                event.uuid,
+                'cookieless_processing',
+                this.config.timestampLoggingSampleRate
+            )
 
             const {
                 userAgent,

--- a/plugin-server/src/ingestion/event-preprocessing/apply-drop-events-restrictions.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/apply-drop-events-restrictions.ts
@@ -1,26 +1,12 @@
-import { Message } from 'node-rdkafka'
-
-import { eventDroppedCounter } from '../../main/ingestion-queues/metrics'
 import { EventHeaders } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
 
 export function applyDropEventsRestrictions(
-    message: Message,
     eventIngestionRestrictionManager: EventIngestionRestrictionManager,
     headers?: EventHeaders
-): Message | null {
+): boolean {
     const distinctId = headers?.distinct_id
     const token = headers?.token
 
-    if (eventIngestionRestrictionManager.shouldDropEvent(token, distinctId)) {
-        eventDroppedCounter
-            .labels({
-                event_type: 'analytics',
-                drop_cause: 'blocked_token',
-            })
-            .inc()
-        return null
-    }
-
-    return message
+    return eventIngestionRestrictionManager.shouldDropEvent(token, distinctId)
 }

--- a/plugin-server/src/ingestion/event-preprocessing/apply-drop-events-restrictions.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/apply-drop-events-restrictions.ts
@@ -1,23 +1,16 @@
 import { Message } from 'node-rdkafka'
 
 import { eventDroppedCounter } from '../../main/ingestion-queues/metrics'
+import { EventHeaders } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
 
 export function applyDropEventsRestrictions(
     message: Message,
-    eventIngestionRestrictionManager: EventIngestionRestrictionManager
+    eventIngestionRestrictionManager: EventIngestionRestrictionManager,
+    headers?: EventHeaders
 ): Message | null {
-    let distinctId: string | undefined
-    let token: string | undefined
-
-    message.headers?.forEach((header) => {
-        if ('distinct_id' in header) {
-            distinctId = header['distinct_id'].toString()
-        }
-        if ('token' in header) {
-            token = header['token'].toString()
-        }
-    })
+    const distinctId = headers?.distinct_id
+    const token = headers?.token
 
     if (eventIngestionRestrictionManager.shouldDropEvent(token, distinctId)) {
         eventDroppedCounter

--- a/plugin-server/src/ingestion/event-preprocessing/apply-force-overflow-restrictions.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/apply-force-overflow-restrictions.ts
@@ -1,5 +1,3 @@
-import { Message } from 'node-rdkafka'
-
 import { EventHeaders } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
 
@@ -9,7 +7,6 @@ export type ForceOverflowDecision = {
 }
 
 export function applyForceOverflowRestrictions(
-    message: Message,
     eventIngestionRestrictionManager: EventIngestionRestrictionManager,
     headers?: EventHeaders
 ): ForceOverflowDecision {

--- a/plugin-server/src/ingestion/event-preprocessing/apply-force-overflow-restrictions.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/apply-force-overflow-restrictions.ts
@@ -1,5 +1,6 @@
 import { Message } from 'node-rdkafka'
 
+import { EventHeaders } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
 
 export type ForceOverflowDecision = {
@@ -9,19 +10,11 @@ export type ForceOverflowDecision = {
 
 export function applyForceOverflowRestrictions(
     message: Message,
-    eventIngestionRestrictionManager: EventIngestionRestrictionManager
+    eventIngestionRestrictionManager: EventIngestionRestrictionManager,
+    headers?: EventHeaders
 ): ForceOverflowDecision {
-    let distinctId: string | undefined
-    let token: string | undefined
-
-    message.headers?.forEach((header) => {
-        if ('distinct_id' in header) {
-            distinctId = header['distinct_id'].toString()
-        }
-        if ('token' in header) {
-            token = header['token'].toString()
-        }
-    })
+    const distinctId = headers?.distinct_id
+    const token = headers?.token
 
     const shouldForceOverflow = eventIngestionRestrictionManager.shouldForceOverflow(token, distinctId)
 

--- a/plugin-server/src/ingestion/event-preprocessing/resolve-team.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/resolve-team.ts
@@ -41,5 +41,6 @@ export async function resolveTeam(
         event,
         team,
         message: incomingEvent.message,
+        headers: incomingEvent.headers,
     }
 }

--- a/plugin-server/src/kafka/consumer.test.ts
+++ b/plugin-server/src/kafka/consumer.test.ts
@@ -1,9 +1,9 @@
-import { CODES, Message, KafkaConsumer as RdKafkaConsumer } from 'node-rdkafka'
+import { CODES, Message, MessageHeader, KafkaConsumer as RdKafkaConsumer } from 'node-rdkafka'
 
 import { defaultConfig } from '~/config/config'
 
 import { delay } from '../utils/utils'
-import { KafkaConsumer } from './consumer'
+import { KafkaConsumer, parseEventHeaders, parseKafkaHeaders } from './consumer'
 
 jest.mock('./admin', () => ({
     ensureTopicExists: jest.fn().mockResolvedValue(undefined),
@@ -368,6 +368,237 @@ describe('consumer', () => {
             ])
 
             await consumerDisabled.disconnect()
+        })
+    })
+})
+
+describe('parseKafkaHeaders', () => {
+    it('should return empty object when headers is undefined', () => {
+        const result = parseKafkaHeaders(undefined)
+        expect(result).toEqual({})
+    })
+
+    it('should return empty object when headers is empty array', () => {
+        const result = parseKafkaHeaders([])
+        expect(result).toEqual({})
+    })
+
+    it('should parse single header', () => {
+        const headers: MessageHeader[] = [{ token: Buffer.from('test-token') }]
+        const result = parseKafkaHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+        })
+    })
+
+    it('should parse multiple headers in single object', () => {
+        const headers: MessageHeader[] = [
+            {
+                token: Buffer.from('test-token'),
+                distinct_id: Buffer.from('user-123'),
+                timestamp: Buffer.from('1234567890'),
+            },
+        ]
+        const result = parseKafkaHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+            distinct_id: 'user-123',
+            timestamp: '1234567890',
+        })
+    })
+
+    it('should parse multiple header objects', () => {
+        const headers: MessageHeader[] = [
+            { token: Buffer.from('test-token') },
+            { distinct_id: Buffer.from('user-123') },
+            { timestamp: Buffer.from('1234567890') },
+        ]
+        const result = parseKafkaHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+            distinct_id: 'user-123',
+            timestamp: '1234567890',
+        })
+    })
+
+    it('should handle arbitrary header keys', () => {
+        const headers: MessageHeader[] = [
+            {
+                custom_header: Buffer.from('custom-value'),
+                another_key: Buffer.from('another-value'),
+            },
+        ]
+        const result = parseKafkaHeaders(headers)
+        expect(result).toEqual({
+            custom_header: 'custom-value',
+            another_key: 'another-value',
+        })
+    })
+
+    it('should handle non-string buffer values', () => {
+        const headers: MessageHeader[] = [{ numeric: Buffer.from('123') }, { boolean: Buffer.from('true') }]
+        const result = parseKafkaHeaders(headers)
+        expect(result).toEqual({
+            numeric: '123',
+            boolean: 'true',
+        })
+    })
+
+    it('should handle empty buffer values', () => {
+        const headers: MessageHeader[] = [{ empty: Buffer.from('') }]
+        const result = parseKafkaHeaders(headers)
+        expect(result).toEqual({
+            empty: '',
+        })
+    })
+
+    it('should handle duplicate keys by overwriting', () => {
+        const headers: MessageHeader[] = [{ token: Buffer.from('first-token') }, { token: Buffer.from('second-token') }]
+        const result = parseKafkaHeaders(headers)
+        expect(result).toEqual({
+            token: 'second-token',
+        })
+    })
+})
+
+describe('parseEventHeaders', () => {
+    it('should return empty object when headers is undefined', () => {
+        const result = parseEventHeaders(undefined)
+        expect(result).toEqual({})
+    })
+
+    it('should return empty object when headers is empty array', () => {
+        const result = parseEventHeaders([])
+        expect(result).toEqual({})
+    })
+
+    it('should parse token header only', () => {
+        const headers: MessageHeader[] = [{ token: Buffer.from('test-token') }]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+        })
+    })
+
+    it('should parse distinct_id header only', () => {
+        const headers: MessageHeader[] = [{ distinct_id: Buffer.from('user-123') }]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            distinct_id: 'user-123',
+        })
+    })
+
+    it('should parse timestamp header only', () => {
+        const headers: MessageHeader[] = [{ timestamp: Buffer.from('1234567890') }]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            timestamp: '1234567890',
+        })
+    })
+
+    it('should parse all supported headers', () => {
+        const headers: MessageHeader[] = [
+            {
+                token: Buffer.from('test-token'),
+                distinct_id: Buffer.from('user-123'),
+                timestamp: Buffer.from('1234567890'),
+            },
+        ]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+            distinct_id: 'user-123',
+            timestamp: '1234567890',
+        })
+    })
+
+    it('should parse supported headers from multiple objects', () => {
+        const headers: MessageHeader[] = [
+            { token: Buffer.from('test-token') },
+            { distinct_id: Buffer.from('user-123') },
+            { timestamp: Buffer.from('1234567890') },
+        ]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+            distinct_id: 'user-123',
+            timestamp: '1234567890',
+        })
+    })
+
+    it('should ignore unsupported headers', () => {
+        const headers: MessageHeader[] = [
+            {
+                token: Buffer.from('test-token'),
+                custom_header: Buffer.from('ignored'),
+                another_key: Buffer.from('also-ignored'),
+                distinct_id: Buffer.from('user-123'),
+            },
+        ]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+            distinct_id: 'user-123',
+        })
+    })
+
+    it('should handle empty buffer values', () => {
+        const headers: MessageHeader[] = [
+            {
+                token: Buffer.from(''),
+                distinct_id: Buffer.from(''),
+                timestamp: Buffer.from(''),
+            },
+        ]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: '',
+            distinct_id: '',
+            timestamp: '',
+        })
+    })
+
+    it('should handle duplicate keys by overwriting', () => {
+        const headers: MessageHeader[] = [
+            { token: Buffer.from('first-token') },
+            { token: Buffer.from('second-token') },
+            { distinct_id: Buffer.from('first-id') },
+            { distinct_id: Buffer.from('second-id') },
+        ]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: 'second-token',
+            distinct_id: 'second-id',
+        })
+    })
+
+    it('should handle mixed supported and unsupported headers', () => {
+        const headers: MessageHeader[] = [
+            { unsupported1: Buffer.from('ignored') },
+            { token: Buffer.from('test-token') },
+            { unsupported2: Buffer.from('also-ignored') },
+            { timestamp: Buffer.from('1234567890') },
+            { unsupported3: Buffer.from('still-ignored') },
+        ]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+            timestamp: '1234567890',
+        })
+    })
+
+    it('should handle partial header sets', () => {
+        // Test with only token and timestamp (missing distinct_id)
+        const headers: MessageHeader[] = [
+            {
+                token: Buffer.from('test-token'),
+                timestamp: Buffer.from('1234567890'),
+            },
+        ]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual({
+            token: 'test-token',
+            timestamp: '1234567890',
         })
     })
 })

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -15,7 +15,13 @@ import {
 import { hostname } from 'os'
 import { Gauge, Histogram } from 'prom-client'
 
-import { HealthCheckResult, HealthCheckResultDegraded, HealthCheckResultError, HealthCheckResultOk } from '~/types'
+import {
+    EventHeaders,
+    HealthCheckResult,
+    HealthCheckResultDegraded,
+    HealthCheckResultError,
+    HealthCheckResultOk,
+} from '~/types'
 import { isTestEnv } from '~/utils/env-utils'
 import { parseJSON } from '~/utils/json-parse'
 
@@ -777,6 +783,28 @@ export const parseKafkaHeaders = (headers?: MessageHeader[]): Record<string, str
     headers?.forEach((header) => {
         Object.keys(header).forEach((key) => {
             result[key] = header[key].toString()
+        })
+    })
+
+    return result
+}
+
+export const parseEventHeaders = (headers?: MessageHeader[]): EventHeaders => {
+    // Kafka headers come from librdkafka as an array of objects with keys value pairs per header.
+    // We extract the specific headers we care about into a structured format.
+
+    const result: EventHeaders = {}
+
+    headers?.forEach((header) => {
+        Object.keys(header).forEach((key) => {
+            const value = header[key].toString()
+            if (key === 'token') {
+                result.token = value
+            } else if (key === 'distinct_id') {
+                result.distinct_id = value
+            } else if (key === 'timestamp') {
+                result.timestamp = value
+            }
         })
     })
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1340,7 +1340,7 @@ export interface PipelineEvent extends Omit<PluginEvent, 'team_id'> {
     token?: string
 }
 
-export interface KafkaEventHeaders {
+export interface EventHeaders {
     token?: string
     distinct_id?: string
     timestamp?: string
@@ -1349,14 +1349,14 @@ export interface KafkaEventHeaders {
 export interface IncomingEvent {
     message: Message
     event: PipelineEvent
-    headers?: KafkaEventHeaders
+    headers?: EventHeaders
 }
 
 export interface IncomingEventWithTeam {
     message: Message
     event: PipelineEvent
     team: Team
-    headers?: KafkaEventHeaders
+    headers?: EventHeaders
 }
 
 export type RedisPool = GenericPool<Redis>

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -422,6 +422,9 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     COOKIELESS_REDIS_HOST: string
     COOKIELESS_REDIS_PORT: number
 
+    // Timestamp comparison logging (0.0 = disabled, 1.0 = 100% sampling)
+    TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
+
     SESSION_RECORDING_MAX_BATCH_SIZE_KB: number
     SESSION_RECORDING_MAX_BATCH_AGE_MS: number
     SESSION_RECORDING_V2_S3_BUCKET: string

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1340,15 +1340,23 @@ export interface PipelineEvent extends Omit<PluginEvent, 'team_id'> {
     token?: string
 }
 
+export interface KafkaEventHeaders {
+    token?: string
+    distinct_id?: string
+    timestamp?: string
+}
+
 export interface IncomingEvent {
     message: Message
     event: PipelineEvent
+    headers?: KafkaEventHeaders
 }
 
 export interface IncomingEventWithTeam {
     message: Message
     event: PipelineEvent
     team: Team
+    headers?: KafkaEventHeaders
 }
 
 export type RedisPool = GenericPool<Redis>

--- a/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
@@ -21,7 +21,7 @@ export function normalizeEventStep(
         timestamp = parseEventTimestamp(event)
 
         // Compare timestamp from headers with event.timestamp - they should be equal if implemented correctly
-        if (event.timestamp) {
+        if (event.timestamp && headers) {
             compareTimestamps(
                 event.timestamp,
                 headers,

--- a/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { KafkaEventHeaders } from '../../../types'
+import { EventHeaders } from '../../../types'
 import { normalizeEvent, normalizeProcessPerson } from '../../../utils/event'
 import { logger } from '../../../utils/logger'
 import { compareTimestamps } from '../timestamp-comparison'
@@ -11,7 +11,7 @@ import { parseEventTimestamp } from '../timestamps'
 export function normalizeEventStep(
     event: PluginEvent,
     processPerson: boolean,
-    headers?: KafkaEventHeaders
+    headers?: EventHeaders
 ): Promise<[PluginEvent, DateTime]> {
     let timestamp: DateTime
     try {

--- a/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
@@ -11,7 +11,8 @@ import { parseEventTimestamp } from '../timestamps'
 export function normalizeEventStep(
     event: PluginEvent,
     processPerson: boolean,
-    headers?: EventHeaders
+    headers?: EventHeaders,
+    timestampLoggingSampleRate?: number
 ): Promise<[PluginEvent, DateTime]> {
     let timestamp: DateTime
     try {
@@ -21,7 +22,14 @@ export function normalizeEventStep(
 
         // Compare timestamp from headers with event.timestamp - they should be equal if implemented correctly
         if (event.timestamp) {
-            compareTimestamps(event.timestamp, headers, event.team_id, event.uuid, 'normalize_event_step')
+            compareTimestamps(
+                event.timestamp,
+                headers,
+                event.team_id,
+                event.uuid,
+                'normalize_event_step',
+                timestampLoggingSampleRate
+            )
         }
     } catch (error) {
         logger.warn('⚠️', 'Failed normalizing event', {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -2,7 +2,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { HogTransformerService } from '../../../cdp/hog-transformations/hog-transformer.service'
 import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
-import { Hub, KafkaConsumerBreadcrumb, PipelineEvent, Team } from '../../../types'
+import { Hub, KafkaConsumerBreadcrumb, KafkaEventHeaders, PipelineEvent, Team } from '../../../types'
 import { DependencyUnavailableError } from '../../../utils/db/error'
 import { timeoutGuard } from '../../../utils/db/utils'
 import { normalizeProcessPerson } from '../../../utils/event'
@@ -63,6 +63,7 @@ export class EventPipelineRunner {
     personsStoreForBatch: PersonsStoreForBatch
     groupStoreForBatch: GroupStoreForBatch
     mergeMode: MergeMode
+    headers?: KafkaEventHeaders
 
     constructor(
         hub: Hub,
@@ -70,7 +71,8 @@ export class EventPipelineRunner {
         hogTransformer: HogTransformerService | null = null,
         breadcrumbs: KafkaConsumerBreadcrumb[] = [],
         personsStoreForBatch: PersonsStoreForBatch,
-        groupStoreForBatch: GroupStoreForBatch
+        groupStoreForBatch: GroupStoreForBatch,
+        headers?: KafkaEventHeaders
     ) {
         this.hub = hub
         this.originalEvent = event
@@ -80,6 +82,7 @@ export class EventPipelineRunner {
         this.personsStoreForBatch = personsStoreForBatch
         this.groupStoreForBatch = groupStoreForBatch
         this.mergeMode = determineMergeMode(hub)
+        this.headers = headers
     }
 
     isEventDisallowed(event: PipelineEvent): boolean {
@@ -303,7 +306,7 @@ export class EventPipelineRunner {
 
         const [normalizedEvent, timestamp] = await this.runStep(
             normalizeEventStep,
-            [transformedEvent, processPerson],
+            [transformedEvent, processPerson, this.headers],
             event.team_id
         )
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -2,7 +2,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { HogTransformerService } from '../../../cdp/hog-transformations/hog-transformer.service'
 import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
-import { Hub, KafkaConsumerBreadcrumb, KafkaEventHeaders, PipelineEvent, Team } from '../../../types'
+import { EventHeaders, Hub, KafkaConsumerBreadcrumb, PipelineEvent, Team } from '../../../types'
 import { DependencyUnavailableError } from '../../../utils/db/error'
 import { timeoutGuard } from '../../../utils/db/utils'
 import { normalizeProcessPerson } from '../../../utils/event'
@@ -63,7 +63,7 @@ export class EventPipelineRunner {
     personsStoreForBatch: PersonsStoreForBatch
     groupStoreForBatch: GroupStoreForBatch
     mergeMode: MergeMode
-    headers?: KafkaEventHeaders
+    headers?: EventHeaders
 
     constructor(
         hub: Hub,
@@ -72,7 +72,7 @@ export class EventPipelineRunner {
         breadcrumbs: KafkaConsumerBreadcrumb[] = [],
         personsStoreForBatch: PersonsStoreForBatch,
         groupStoreForBatch: GroupStoreForBatch,
-        headers?: KafkaEventHeaders
+        headers?: EventHeaders
     ) {
         this.hub = hub
         this.originalEvent = event

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -306,7 +306,7 @@ export class EventPipelineRunner {
 
         const [normalizedEvent, timestamp] = await this.runStep(
             normalizeEventStep,
-            [transformedEvent, processPerson, this.headers],
+            [transformedEvent, processPerson, this.headers, this.hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE],
             event.team_id
         )
 

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 
-import { KafkaEventHeaders } from '../../types'
+import { EventHeaders } from '../../types'
 import { compareTimestamps } from './timestamp-comparison'
 
 // Mock the logger
@@ -40,7 +40,7 @@ describe('compareTimestamps', () => {
     })
 
     it('should handle missing timestamp header without throwing', () => {
-        const headers: KafkaEventHeaders = {
+        const headers: EventHeaders = {
             token: 'test-token',
             distinct_id: 'test-id',
             // timestamp is missing
@@ -55,7 +55,7 @@ describe('compareTimestamps', () => {
     })
 
     it('should handle invalid timestamp header without throwing', () => {
-        const headers: KafkaEventHeaders = {
+        const headers: EventHeaders = {
             timestamp: 'not-a-number',
         }
 
@@ -70,7 +70,7 @@ describe('compareTimestamps', () => {
     it('should handle exact match without throwing', () => {
         const timestamp = '2023-01-01T12:00:00Z'
         const timestampMs = DateTime.fromISO(timestamp).toMillis()
-        const headers: KafkaEventHeaders = {
+        const headers: EventHeaders = {
             timestamp: timestampMs.toString(),
         }
 
@@ -86,7 +86,7 @@ describe('compareTimestamps', () => {
         const timestamp = '2023-01-01T12:00:00Z'
         const timestampMs = DateTime.fromISO(timestamp).toMillis()
         const differentTimestampMs = timestampMs + 5000 // 5 seconds difference
-        const headers: KafkaEventHeaders = {
+        const headers: EventHeaders = {
             timestamp: differentTimestampMs.toString(),
         }
 
@@ -107,7 +107,7 @@ describe('compareTimestamps', () => {
     })
 
     it('should use default context when not provided', () => {
-        const headers: KafkaEventHeaders = {
+        const headers: EventHeaders = {
             timestamp: '1672574400000', // 2023-01-01T12:00:00Z
         }
 
@@ -123,7 +123,7 @@ describe('compareTimestamps', () => {
         // Test with RFC2822 format - the function should handle it via parseDate
         const timestamp = 'Sun, 01 Jan 2023 12:00:00 GMT'
         const timestampMs = DateTime.fromRFC2822(timestamp).toMillis()
-        const headers: KafkaEventHeaders = {
+        const headers: EventHeaders = {
             timestamp: timestampMs.toString(),
         }
 
@@ -136,7 +136,7 @@ describe('compareTimestamps', () => {
     })
 
     it('should work without optional parameters', () => {
-        const headers: KafkaEventHeaders = {
+        const headers: EventHeaders = {
             timestamp: '1672574400000',
         }
 
@@ -162,7 +162,7 @@ describe('compareTimestamps', () => {
         ]
 
         testCases.forEach(({ timestamp, header }) => {
-            const headers: KafkaEventHeaders = { timestamp: header }
+            const headers: EventHeaders = { timestamp: header }
 
             expect(() => {
                 compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context')

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
@@ -91,7 +91,7 @@ describe('compareTimestamps', () => {
         }
 
         expect(() => {
-            compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context')
+            compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context', 1.0)
         }).not.toThrow()
 
         expect(mockLabels).toHaveBeenCalled()
@@ -186,7 +186,6 @@ describe('compareTimestamps', () => {
         expect(mockLabels).toHaveBeenCalledWith({
             result: 'difference_detected',
             context: 'test-context',
-            team_id: '123',
         })
     })
 
@@ -203,7 +202,6 @@ describe('compareTimestamps', () => {
         expect(mockLabels).toHaveBeenCalledWith({
             result: 'difference_detected',
             context: 'test-context',
-            team_id: '123',
         })
     })
 
@@ -214,11 +212,10 @@ describe('compareTimestamps', () => {
 
         compareTimestamps('invalid-date-format', headers, 123, 'test-uuid', 'test-context', 1.0)
 
-        expect(mockLoggerWarn).toHaveBeenCalledWith('Failed to compare timestamps', expect.any(Object))
+        expect(mockLoggerWarn).not.toHaveBeenCalled() // No logging for header_invalid
         expect(mockLabels).toHaveBeenCalledWith({
-            result: 'parse_error',
+            result: 'header_invalid',
             context: 'test-context',
-            team_id: '123',
         })
     })
 
@@ -231,9 +228,8 @@ describe('compareTimestamps', () => {
 
         expect(mockLoggerWarn).not.toHaveBeenCalled()
         expect(mockLabels).toHaveBeenCalledWith({
-            result: 'parse_error',
+            result: 'header_invalid',
             context: 'test-context',
-            team_id: '123',
         })
     })
 

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
@@ -1,0 +1,175 @@
+import { DateTime } from 'luxon'
+
+import { KafkaEventHeaders } from '../../types'
+import { compareTimestamps } from './timestamp-comparison'
+
+// Mock the logger
+const mockLoggerInfo = jest.fn()
+const mockLoggerWarn = jest.fn()
+
+jest.mock('../../utils/logger', () => ({
+    logger: {
+        info: mockLoggerInfo,
+        warn: mockLoggerWarn,
+    },
+}))
+
+// Mock prom-client
+const mockLabels = jest.fn().mockReturnThis()
+const mockInc = jest.fn()
+
+jest.mock('prom-client', () => ({
+    Counter: jest.fn(() => ({
+        labels: mockLabels,
+        inc: mockInc,
+    })),
+}))
+
+describe('compareTimestamps', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should handle missing headers without throwing', () => {
+        expect(() => {
+            compareTimestamps('2023-01-01T12:00:00Z', undefined, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+
+    it('should handle missing timestamp header without throwing', () => {
+        const headers: KafkaEventHeaders = {
+            token: 'test-token',
+            distinct_id: 'test-id',
+            // timestamp is missing
+        }
+
+        expect(() => {
+            compareTimestamps('2023-01-01T12:00:00Z', headers, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+
+    it('should handle invalid timestamp header without throwing', () => {
+        const headers: KafkaEventHeaders = {
+            timestamp: 'not-a-number',
+        }
+
+        expect(() => {
+            compareTimestamps('2023-01-01T12:00:00Z', headers, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+
+    it('should handle exact match without throwing', () => {
+        const timestamp = '2023-01-01T12:00:00Z'
+        const timestampMs = DateTime.fromISO(timestamp).toMillis()
+        const headers: KafkaEventHeaders = {
+            timestamp: timestampMs.toString(),
+        }
+
+        expect(() => {
+            compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+
+    it('should detect timestamp difference and log it', () => {
+        const timestamp = '2023-01-01T12:00:00Z'
+        const timestampMs = DateTime.fromISO(timestamp).toMillis()
+        const differentTimestampMs = timestampMs + 5000 // 5 seconds difference
+        const headers: KafkaEventHeaders = {
+            timestamp: differentTimestampMs.toString(),
+        }
+
+        expect(() => {
+            compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+        expect(mockLoggerInfo).toHaveBeenCalledWith(
+            'Timestamp difference detected',
+            expect.objectContaining({
+                context: 'test-context',
+                team_id: 123,
+                event_uuid: 'test-uuid',
+            })
+        )
+    })
+
+    it('should use default context when not provided', () => {
+        const headers: KafkaEventHeaders = {
+            timestamp: '1672574400000', // 2023-01-01T12:00:00Z
+        }
+
+        expect(() => {
+            compareTimestamps('2023-01-01T12:00:00Z', headers, 123, 'test-uuid')
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+
+    it('should work with different timestamp formats', () => {
+        // Test with RFC2822 format - the function should handle it via parseDate
+        const timestamp = 'Sun, 01 Jan 2023 12:00:00 GMT'
+        const timestampMs = DateTime.fromRFC2822(timestamp).toMillis()
+        const headers: KafkaEventHeaders = {
+            timestamp: timestampMs.toString(),
+        }
+
+        expect(() => {
+            compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+
+    it('should work without optional parameters', () => {
+        const headers: KafkaEventHeaders = {
+            timestamp: '1672574400000',
+        }
+
+        expect(() => {
+            compareTimestamps('2023-01-01T12:00:00Z', headers, 123)
+        }).not.toThrow()
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+
+    it('should handle edge cases gracefully', () => {
+        const testCases = [
+            { timestamp: '1970-01-01T00:00:00Z', header: '0' }, // Zero timestamp
+            {
+                timestamp: '2023-01-01T12:00:00.123Z',
+                header: DateTime.fromISO('2023-01-01T12:00:00.123Z').toMillis().toString(),
+            }, // With milliseconds
+            {
+                timestamp: '2099-12-31T23:59:59Z',
+                header: DateTime.fromISO('2099-12-31T23:59:59Z').toMillis().toString(),
+            }, // Future date
+        ]
+
+        testCases.forEach(({ timestamp, header }) => {
+            const headers: KafkaEventHeaders = { timestamp: header }
+
+            expect(() => {
+                compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context')
+            }).not.toThrow()
+        })
+
+        expect(mockLabels).toHaveBeenCalled()
+        expect(mockInc).toHaveBeenCalled()
+    })
+})

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.ts
@@ -1,6 +1,6 @@
 import { Counter } from 'prom-client'
 
-import { KafkaEventHeaders } from '../../types'
+import { EventHeaders } from '../../types'
 import { logger } from '../../utils/logger'
 import { parseDate } from './timestamps'
 
@@ -16,7 +16,7 @@ const timestampComparisonCounter = new Counter({
  */
 export function compareTimestamps(
     currentTimestamp: string,
-    headers: KafkaEventHeaders | undefined,
+    headers: EventHeaders | undefined,
     teamId: number,
     eventUuid?: string,
     context?: string

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.ts
@@ -1,0 +1,103 @@
+import { Counter } from 'prom-client'
+
+import { KafkaEventHeaders } from '../../types'
+import { logger } from '../../utils/logger'
+import { parseDate } from './timestamps'
+
+// Metrics for tracking timestamp header comparisons
+const timestampComparisonCounter = new Counter({
+    name: 'timestamp_header_comparison_total',
+    help: 'Count of timestamp header comparisons by result',
+    labelNames: ['result', 'context', 'team_id'],
+})
+
+/**
+ * Compare timestamp from headers with current parsing logic and log differences
+ */
+export function compareTimestamps(
+    currentTimestamp: string,
+    headers: KafkaEventHeaders | undefined,
+    teamId: number,
+    eventUuid?: string,
+    context?: string
+): void {
+    const contextLabel = context || 'timestamp_comparison'
+    const teamIdLabel = teamId.toString()
+
+    if (!headers?.timestamp) {
+        timestampComparisonCounter
+            .labels({
+                result: 'header_missing',
+                context: contextLabel,
+                team_id: teamIdLabel,
+            })
+            .inc()
+        return
+    }
+
+    try {
+        const headerTimestampMs = parseInt(headers.timestamp, 10)
+        if (isNaN(headerTimestampMs)) {
+            timestampComparisonCounter
+                .labels({
+                    result: 'header_invalid',
+                    context: contextLabel,
+                    team_id: teamIdLabel,
+                })
+                .inc()
+            return
+        }
+
+        const headerDate = new Date(headerTimestampMs)
+        const currentDate = parseDate(currentTimestamp).toJSDate()
+
+        const headerTime = headerDate.getTime()
+        const currentTime = currentDate.getTime()
+
+        if (headerTime === currentTime) {
+            timestampComparisonCounter
+                .labels({
+                    result: 'exact_match',
+                    context: contextLabel,
+                    team_id: teamIdLabel,
+                })
+                .inc()
+        } else {
+            timestampComparisonCounter
+                .labels({
+                    result: 'difference_detected',
+                    context: contextLabel,
+                    team_id: teamIdLabel,
+                })
+                .inc()
+
+            logger.info('Timestamp difference detected', {
+                context: contextLabel,
+                team_id: teamId,
+                event_uuid: eventUuid,
+                current_timestamp: currentTimestamp,
+                header_timestamp_ms: headerTimestampMs,
+                current_parsed: currentDate.toISOString(),
+                header_parsed: headerDate.toISOString(),
+                difference_ms: Math.abs(headerTime - currentTime),
+            })
+        }
+    } catch (error) {
+        timestampComparisonCounter
+            .labels({
+                result: 'parse_error',
+                context: contextLabel,
+                team_id: teamIdLabel,
+            })
+            .inc()
+
+        logger.warn('Failed to compare timestamps', {
+            context: contextLabel,
+            error: error.message,
+            team_id: teamId,
+            event_uuid: eventUuid,
+            header_timestamp: headers.timestamp,
+            current_timestamp: currentTimestamp,
+        })
+    }
+}

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.ts
@@ -12,6 +12,19 @@ const timestampComparisonCounter = new Counter({
 })
 
 /**
+ * Determine if we should log based on sample rate
+ */
+function shouldSampleLog(sampleRate: number): boolean {
+    if (sampleRate <= 0) {
+        return false
+    }
+    if (sampleRate >= 1) {
+        return true
+    }
+    return Math.random() < sampleRate
+}
+
+/**
  * Compare timestamp from headers with current parsing logic and log differences
  */
 export function compareTimestamps(
@@ -19,7 +32,8 @@ export function compareTimestamps(
     headers: EventHeaders | undefined,
     teamId: number,
     eventUuid?: string,
-    context?: string
+    context?: string,
+    loggingSampleRate: number = 0.0
 ): void {
     const contextLabel = context || 'timestamp_comparison'
     const teamIdLabel = teamId.toString()
@@ -71,16 +85,18 @@ export function compareTimestamps(
                 })
                 .inc()
 
-            logger.info('Timestamp difference detected', {
-                context: contextLabel,
-                team_id: teamId,
-                event_uuid: eventUuid,
-                current_timestamp: currentTimestamp,
-                header_timestamp_ms: headerTimestampMs,
-                current_parsed: currentDate.toISOString(),
-                header_parsed: headerDate.toISOString(),
-                difference_ms: Math.abs(headerTime - currentTime),
-            })
+            if (shouldSampleLog(loggingSampleRate)) {
+                logger.info('Timestamp difference detected', {
+                    context: contextLabel,
+                    team_id: teamId,
+                    event_uuid: eventUuid,
+                    current_timestamp: currentTimestamp,
+                    header_timestamp_ms: headerTimestampMs,
+                    current_parsed: currentDate.toISOString(),
+                    header_parsed: headerDate.toISOString(),
+                    difference_ms: Math.abs(headerTime - currentTime),
+                })
+            }
         }
     } catch (error) {
         timestampComparisonCounter
@@ -91,13 +107,15 @@ export function compareTimestamps(
             })
             .inc()
 
-        logger.warn('Failed to compare timestamps', {
-            context: contextLabel,
-            error: error.message,
-            team_id: teamId,
-            event_uuid: eventUuid,
-            header_timestamp: headers.timestamp,
-            current_timestamp: currentTimestamp,
-        })
+        if (shouldSampleLog(loggingSampleRate)) {
+            logger.warn('Failed to compare timestamps', {
+                context: contextLabel,
+                error: error.message,
+                team_id: teamId,
+                event_uuid: eventUuid,
+                header_timestamp: headers.timestamp,
+                current_timestamp: currentTimestamp,
+            })
+        }
     }
 }

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.ts
@@ -8,7 +8,7 @@ import { parseDate } from './timestamps'
 const timestampComparisonCounter = new Counter({
     name: 'timestamp_header_comparison_total',
     help: 'Count of timestamp header comparisons by result',
-    labelNames: ['result', 'context', 'team_id'],
+    labelNames: ['result', 'context'],
 })
 
 /**
@@ -36,14 +36,12 @@ export function compareTimestamps(
     loggingSampleRate: number = 0.0
 ): void {
     const contextLabel = context || 'timestamp_comparison'
-    const teamIdLabel = teamId.toString()
 
     if (!headers?.timestamp) {
         timestampComparisonCounter
             .labels({
                 result: 'header_missing',
                 context: contextLabel,
-                team_id: teamIdLabel,
             })
             .inc()
         return
@@ -56,7 +54,6 @@ export function compareTimestamps(
                 .labels({
                     result: 'header_invalid',
                     context: contextLabel,
-                    team_id: teamIdLabel,
                 })
                 .inc()
             return
@@ -73,7 +70,6 @@ export function compareTimestamps(
                 .labels({
                     result: 'exact_match',
                     context: contextLabel,
-                    team_id: teamIdLabel,
                 })
                 .inc()
         } else {
@@ -81,7 +77,6 @@ export function compareTimestamps(
                 .labels({
                     result: 'difference_detected',
                     context: contextLabel,
-                    team_id: teamIdLabel,
                 })
                 .inc()
 
@@ -103,7 +98,6 @@ export function compareTimestamps(
             .labels({
                 result: 'parse_error',
                 context: contextLabel,
-                team_id: teamIdLabel,
             })
             .inc()
 

--- a/plugin-server/tests/ingestion/event-preprocessing/apply-drop-events-restrictions.test.ts
+++ b/plugin-server/tests/ingestion/event-preprocessing/apply-drop-events-restrictions.test.ts
@@ -8,6 +8,7 @@ describe('applyDropEventsRestrictions', () => {
     beforeEach(() => {
         eventIngestionRestrictionManager = {
             applyDropEventsRestrictions: jest.fn(),
+            shouldDropEvent: jest.fn(),
         } as unknown as EventIngestionRestrictionManager
     })
 

--- a/plugin-server/tests/ingestion/event-preprocessing/apply-drop-events-restrictions.test.ts
+++ b/plugin-server/tests/ingestion/event-preprocessing/apply-drop-events-restrictions.test.ts
@@ -1,83 +1,61 @@
-import { Message } from 'node-rdkafka'
-
 import { applyDropEventsRestrictions } from '../../../src/ingestion/event-preprocessing/apply-drop-events-restrictions'
+import { EventHeaders } from '../../../src/types'
 import { EventIngestionRestrictionManager } from '../../../src/utils/event-ingestion-restriction-manager'
-import { getMetricValues, resetMetrics } from '../../helpers/metrics'
 
 describe('applyDropEventsRestrictions', () => {
     let eventIngestionRestrictionManager: EventIngestionRestrictionManager
 
     beforeEach(() => {
-        resetMetrics()
         eventIngestionRestrictionManager = {
-            shouldDropEvent: jest.fn(),
+            applyDropEventsRestrictions: jest.fn(),
         } as unknown as EventIngestionRestrictionManager
     })
 
-    it('should return message when token is present and not dropped', () => {
-        const message = {
-            headers: [{ token: Buffer.from('valid-token-123') }, { distinct_id: Buffer.from('user-456') }],
-        } as unknown as Message
+    it('should return false when token is present and not dropped', () => {
+        const headers: EventHeaders = {
+            token: 'valid-token-123',
+            distinct_id: 'user-456',
+        }
         jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(false)
 
-        const result = applyDropEventsRestrictions(message, eventIngestionRestrictionManager)
+        const result = applyDropEventsRestrictions(eventIngestionRestrictionManager, headers)
 
-        expect(result).toBe(message)
+        expect(result).toBe(false)
         expect(eventIngestionRestrictionManager.shouldDropEvent).toHaveBeenCalledWith('valid-token-123', 'user-456')
     })
 
-    it('should return null when token is present but should be dropped', () => {
-        const message = {
-            headers: [{ token: Buffer.from('blocked-token-abc') }, { distinct_id: Buffer.from('blocked-user-def') }],
-        } as unknown as Message
+    it('should return true when token is present but should be dropped', () => {
+        const headers: EventHeaders = {
+            token: 'blocked-token-abc',
+            distinct_id: 'blocked-user-def',
+        }
         jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(true)
 
-        const result = applyDropEventsRestrictions(message, eventIngestionRestrictionManager)
+        const result = applyDropEventsRestrictions(eventIngestionRestrictionManager, headers)
 
-        expect(result).toBeNull()
+        expect(result).toBe(true)
         expect(eventIngestionRestrictionManager.shouldDropEvent).toHaveBeenCalledWith(
             'blocked-token-abc',
             'blocked-user-def'
         )
     })
 
-    it('should handle message without headers', () => {
-        const message = {} as unknown as Message
+    it('should handle undefined headers', () => {
         jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(false)
 
-        const result = applyDropEventsRestrictions(message, eventIngestionRestrictionManager)
+        const result = applyDropEventsRestrictions(eventIngestionRestrictionManager, undefined)
 
-        expect(result).toBe(message)
+        expect(result).toBe(false)
         expect(eventIngestionRestrictionManager.shouldDropEvent).toHaveBeenCalledWith(undefined, undefined)
     })
 
-    it('should handle message with empty headers', () => {
-        const message = { headers: [] } as unknown as Message
+    it('should handle empty headers', () => {
+        const headers: EventHeaders = {}
         jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(false)
 
-        const result = applyDropEventsRestrictions(message, eventIngestionRestrictionManager)
+        const result = applyDropEventsRestrictions(eventIngestionRestrictionManager, headers)
 
-        expect(result).toBe(message)
+        expect(result).toBe(false)
         expect(eventIngestionRestrictionManager.shouldDropEvent).toHaveBeenCalledWith(undefined, undefined)
-    })
-
-    it('should increment metrics when dropping events', async () => {
-        const message = {
-            headers: [{ token: Buffer.from('metrics-token-xyz') }, { distinct_id: Buffer.from('metrics-user-123') }],
-        } as unknown as Message
-        jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(true)
-
-        applyDropEventsRestrictions(message, eventIngestionRestrictionManager)
-
-        const metrics = await getMetricValues('ingestion_event_dropped_total')
-        expect(metrics).toEqual([
-            {
-                labels: {
-                    drop_cause: 'blocked_token',
-                    event_type: 'analytics',
-                },
-                value: 1,
-            },
-        ])
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -48,6 +48,8 @@ exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
     "normalizeEventStep",
     [
       true,
+      null,
+      0,
     ],
   ],
   [

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -166,6 +166,7 @@ describe('EventPipelineRunner', () => {
                 fetchPerson: jest.fn(),
             },
             eventsToDropByToken: createEventsToDropByToken('drop_token:drop_id,drop_token_all:*'),
+            TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: 0.0,
         }
 
         const personsStoreForBatch = new BatchWritingPersonsStoreForBatch(
@@ -183,7 +184,8 @@ describe('EventPipelineRunner', () => {
             undefined,
             undefined,
             personsStoreForBatch,
-            groupStoreForBatch
+            groupStoreForBatch,
+            undefined // headers
         )
 
         jest.mocked(processPersonsStep).mockResolvedValue(
@@ -433,7 +435,8 @@ describe('EventPipelineRunner', () => {
                     undefined,
                     undefined,
                     personsStore,
-                    groupStoreForBatch
+                    groupStoreForBatch,
+                    undefined // headers
                 )
 
                 const heatmapPreIngestionEvent = {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "flate2",
  "futures",
  "health",
+ "jiff",
  "limiters",
  "lz-str",
  "metrics",
@@ -3723,6 +3724,32 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a46169c7a10358cdccfb179910e8a5a392fc291bdb409da9aeece5b19786d8"
+dependencies = [
+ "jiff-tzdb-platform",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1383,6 +1383,7 @@ dependencies = [
  "common-alloc",
  "common-redis",
  "common-types",
+ "dateparser",
  "envconfig",
  "flate2",
  "futures",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -48,6 +48,7 @@ uuid = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 chrono = { workspace = true }
+jiff = "0.1"
 lz-str = { workspace = true }
 
 [dev-dependencies]

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -49,6 +49,7 @@ aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 chrono = { workspace = true }
 jiff = "0.1"
+dateparser = "0.2"
 lz-str = { workspace = true }
 
 [dev-dependencies]

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -48,6 +48,8 @@ pub enum CaptureError {
     MissingDistinctId,
     #[error("event submitted with invalid cookieless mode")]
     InvalidCookielessMode,
+    #[error("event submitted with invalid timestamp")]
+    InvalidTimestamp,
     #[error("replay event submitted without snapshot data")]
     MissingSnapshotData,
     #[error("replay event submitted without session id")]
@@ -98,6 +100,7 @@ impl CaptureError {
             CaptureError::MissingEventName => "no_event_name",
             CaptureError::MissingDistinctId => "no_distinct_id",
             CaptureError::InvalidCookielessMode => "invalid_cookieless",
+            CaptureError::InvalidTimestamp => "invalid_timestamp",
             CaptureError::MissingSnapshotData => "no_snapshot",
             CaptureError::MissingSessionId => "no_session_id",
             CaptureError::MissingWindowId => "no_window_id",
@@ -126,6 +129,7 @@ impl IntoResponse for CaptureError {
             | CaptureError::MissingEventName
             | CaptureError::MissingDistinctId
             | CaptureError::InvalidCookielessMode
+            | CaptureError::InvalidTimestamp
             | CaptureError::NonRetryableSinkError
             | CaptureError::MissingSessionId
             | CaptureError::MissingWindowId

--- a/rust/capture/src/lib.rs
+++ b/rust/capture/src/lib.rs
@@ -7,6 +7,7 @@ pub mod server;
 pub mod sinks;
 pub mod test_endpoint;
 pub mod time;
+pub mod timestamp;
 pub mod token;
 pub mod utils;
 pub mod v0_endpoint;

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -188,6 +188,7 @@ mod tests {
             metadata: ProcessedEventMetadata {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
+                computed_timestamp: None,
             },
         };
 
@@ -225,6 +226,7 @@ mod tests {
             metadata: ProcessedEventMetadata {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
+                computed_timestamp: None,
             },
         };
 

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -330,6 +330,7 @@ mod tests {
             metadata: ProcessedEventMetadata {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
+                computed_timestamp: None,
             },
         }
     }

--- a/rust/capture/src/time.rs
+++ b/rust/capture/src/time.rs
@@ -1,16 +1,15 @@
+use chrono::{DateTime, Utc};
+
 pub trait TimeSource {
-    // Return an ISO timestamp
-    fn current_time(&self) -> String;
+    // Return a UTC timestamp
+    fn current_time(&self) -> DateTime<Utc>;
 }
 
 #[derive(Clone)]
 pub struct SystemTime {}
 
 impl TimeSource for SystemTime {
-    fn current_time(&self) -> String {
-        let time = time::OffsetDateTime::now_utc();
-
-        time.format(&time::format_description::well_known::Rfc3339)
-            .expect("failed to format timestamp")
+    fn current_time(&self) -> DateTime<Utc> {
+        Utc::now()
     }
 }

--- a/rust/capture/src/timestamp.rs
+++ b/rust/capture/src/timestamp.rs
@@ -256,16 +256,14 @@ mod tests {
         for date_str in valid_cases {
             assert!(
                 parse_date(date_str).is_some(),
-                "Failed to parse: {}",
-                date_str
+                "Failed to parse: {date_str}"
             );
         }
 
         for date_str in invalid_cases {
             assert!(
                 parse_date(date_str).is_none(),
-                "Unexpectedly parsed: {}",
-                date_str
+                "Unexpectedly parsed: {date_str}"
             );
         }
     }
@@ -434,8 +432,8 @@ mod tests {
 
         // The large offset creates an underflow, resulting in a very old timestamp
         // Our implementation actually does generate a warning for out-of-bounds results!
-        println!("Result timestamp: {}", result);
-        println!("Expected (now): {}", now);
+        println!("Result timestamp: {result}");
+        println!("Expected (now): {now}");
 
         // The result should be epoch time due to underflow
         assert_eq!(result.year(), 1970); // Epoch time
@@ -526,8 +524,7 @@ mod tests {
             let result = parse_date(timestamp_str);
             assert!(
                 result.is_some(),
-                "Failed to parse ISO 8601 variant: {}",
-                timestamp_str
+                "Failed to parse ISO 8601 variant: {timestamp_str}"
             );
 
             let dt = result.unwrap();
@@ -538,8 +535,8 @@ mod tests {
                 dt.month(),
                 dt.day()
             );
-            assert_eq!(dt.year(), 2021, "Wrong year for: {}", timestamp_str);
-            assert_eq!(dt.month(), 10, "Wrong month for: {}", timestamp_str);
+            assert_eq!(dt.year(), 2021, "Wrong year for: {timestamp_str}");
+            assert_eq!(dt.month(), 10, "Wrong month for: {timestamp_str}");
             // Some formats might be interpreted differently by dateparser
             // Let's be more flexible and just ensure we get a valid October 2021 date
             assert!(
@@ -564,12 +561,10 @@ mod tests {
             let result = parse_date(timestamp_str);
             assert!(
                 result.is_none(),
-                "Expected advanced ISO format to be rejected: {}",
-                timestamp_str
+                "Expected advanced ISO format to be rejected: {timestamp_str}"
             );
             println!(
-                "✅ Advanced ISO format '{}' correctly rejected by Rust implementation",
-                timestamp_str
+                "✅ Advanced ISO format '{timestamp_str}' correctly rejected by Rust implementation"
             );
         }
     }

--- a/rust/capture/src/timestamp.rs
+++ b/rust/capture/src/timestamp.rs
@@ -20,27 +20,28 @@ pub struct TimestampResult {
 /// Parse event timestamp with clock skew adjustment and validation
 ///
 /// # Arguments
-/// * `event_data` - The event data containing timestamp, sent_at, offset fields
+/// * `timestamp` - The event timestamp string (optional)
+/// * `offset` - The offset in milliseconds (optional)
+/// * `sent_at` - The client-sent timestamp (optional)
+/// * `ignore_sent_at` - Whether to ignore sent_at for clock skew adjustment
 /// * `now` - The current server timestamp
 ///
 /// # Returns
 /// * `TimestampResult` - Contains the parsed timestamp and any ingestion warnings
 pub fn parse_event_timestamp(
-    event_data: &HashMap<String, Value>,
+    timestamp: Option<&str>,
+    offset: Option<i64>,
+    sent_at: Option<DateTime<Utc>>,
+    ignore_sent_at: bool,
     now: DateTime<Utc>,
 ) -> TimestampResult {
     let mut warnings = Vec::new();
 
-    // Extract and validate 'sent_at' if present
-    let sent_at = extract_sent_at(event_data, &mut warnings);
+    // Use sent_at only if not ignored
+    let effective_sent_at = if ignore_sent_at { None } else { sent_at };
 
-    // Get team_id for error reporting
-    let team_id = event_data
-        .get("team_id")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-
-    let mut parsed_ts = handle_timestamp(event_data, now, sent_at, team_id);
+    // Handle timestamp parsing and clock skew adjustment
+    let mut parsed_ts = handle_timestamp(timestamp, offset, effective_sent_at, now);
 
     // Check for future events
     let now_diff = parsed_ts.signed_duration_since(now).num_milliseconds();
@@ -48,79 +49,42 @@ pub fn parse_event_timestamp(
         let mut details = HashMap::new();
         details.insert(
             "timestamp".to_string(),
-            event_data
-                .get("timestamp")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
+            Value::String(timestamp.unwrap_or("").to_string()),
         );
         details.insert(
             "sentAt".to_string(),
-            event_data
-                .get("sent_at")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
+            Value::String(sent_at.map_or("".to_string(), |sa| sa.to_rfc3339())),
         );
         details.insert(
             "offset".to_string(),
-            event_data
-                .get("offset")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
+            offset.map_or(Value::String("".to_string()), |o| Value::Number(o.into())),
         );
         details.insert("now".to_string(), Value::String(now.to_rfc3339()));
         details.insert("result".to_string(), Value::String(parsed_ts.to_rfc3339()));
-        details.insert(
-            "eventUuid".to_string(),
-            event_data
-                .get("uuid")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
-        );
-        details.insert(
-            "eventName".to_string(),
-            event_data
-                .get("event")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
-        );
 
         warnings.push(IngestionWarning {
             warning_type: "event_timestamp_in_future".to_string(),
             details,
         });
 
-        parsed_ts = now; // Fix the timestamp to now
+        parsed_ts = now;
     }
 
     // Check if timestamp is out of bounds
     if parsed_ts.year() < 0 || parsed_ts.year() > 9999 {
         let mut details = HashMap::new();
-        details.insert(
-            "eventUuid".to_string(),
-            event_data
-                .get("uuid")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
-        );
         details.insert("field".to_string(), Value::String("timestamp".to_string()));
         details.insert(
             "value".to_string(),
-            event_data
-                .get("timestamp")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
+            Value::String(timestamp.unwrap_or("").to_string()),
         );
         details.insert(
             "reason".to_string(),
             Value::String("out of bounds".to_string()),
         );
-        details.insert(
-            "offset".to_string(),
-            event_data
-                .get("offset")
-                .cloned()
-                .unwrap_or(Value::String("".to_string())),
-        );
+        if let Some(offset_val) = offset {
+            details.insert("offset".to_string(), Value::Number(offset_val.into()));
+        }
         details.insert(
             "parsed_year".to_string(),
             Value::Number(parsed_ts.year().into()),
@@ -140,89 +104,31 @@ pub fn parse_event_timestamp(
     }
 }
 
-fn extract_sent_at(
-    event_data: &HashMap<String, Value>,
-    warnings: &mut Vec<IngestionWarning>,
-) -> Option<DateTime<Utc>> {
-    // Check if $ignore_sent_at is set in properties
-    if let Some(properties) = event_data.get("properties").and_then(|p| p.as_object()) {
-        if properties
-            .get("$ignore_sent_at")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
-            return None;
-        }
-    }
-
-    // Extract sent_at and parse it
-    event_data
-        .get("sent_at")
-        .and_then(|v| v.as_str())
-        .and_then(|sent_at_str| {
-            match DateTime::parse_from_rfc3339(sent_at_str) {
-                Ok(dt) => Some(dt.with_timezone(&Utc)),
-                Err(_) => {
-                    let mut details = HashMap::new();
-                    details.insert(
-                        "eventUuid".to_string(),
-                        event_data
-                            .get("uuid")
-                            .cloned()
-                            .unwrap_or(Value::String("".to_string())),
-                    );
-                    details.insert("field".to_string(), Value::String("sent_at".to_string()));
-                    details.insert(
-                        "value".to_string(),
-                        Value::String(sent_at_str.to_string()),
-                    );
-                    details.insert(
-                        "reason".to_string(),
-                        Value::String("invalid format".to_string()),
-                    );
-
-                    warnings.push(IngestionWarning {
-                        warning_type: "ignored_invalid_timestamp".to_string(),
-                        details,
-                    });
-                    None
-                }
-            }
-        })
-}
-
 fn handle_timestamp(
-    event_data: &HashMap<String, Value>,
-    now: DateTime<Utc>,
+    timestamp: Option<&str>,
+    offset: Option<i64>,
     sent_at: Option<DateTime<Utc>>,
-    _team_id: i64,
+    now: DateTime<Utc>,
 ) -> DateTime<Utc> {
     let mut parsed_ts = now;
 
-    if let Some(timestamp_value) = event_data.get("timestamp") {
-        if let Some(timestamp_str) = timestamp_value.as_str() {
-            let timestamp = parse_date(timestamp_str);
+    if let Some(timestamp_str) = timestamp {
+        let timestamp_parsed = parse_date(timestamp_str);
 
-            if let (Some(sent_at), Some(timestamp)) = (sent_at, timestamp) {
-                // Handle clock skew between client and server
-                // skew = sent_at - now
-                // x = now + (timestamp - sent_at)
-                match timestamp.signed_duration_since(sent_at) {
-                    duration => {
-                        parsed_ts = now + duration;
-                    }
-                }
-            } else if let Some(timestamp) = timestamp {
-                parsed_ts = timestamp;
-            }
+        if let (Some(sent_at), Some(timestamp_parsed)) = (sent_at, timestamp_parsed) {
+            // Handle clock skew between client and server
+            // skew = sent_at - now
+            // x = now + (timestamp - sent_at)
+            let duration = timestamp_parsed.signed_duration_since(sent_at);
+            parsed_ts = now + duration;
+        } else if let Some(timestamp_parsed) = timestamp_parsed {
+            parsed_ts = timestamp_parsed;
         }
     }
 
     // Handle offset if present
-    if let Some(offset_value) = event_data.get("offset") {
-        if let Some(offset_num) = offset_value.as_i64() {
-            parsed_ts = now - Duration::milliseconds(offset_num);
-        }
+    if let Some(offset_ms) = offset {
+        parsed_ts = now - Duration::milliseconds(offset_ms);
     }
 
     parsed_ts
@@ -267,49 +173,15 @@ fn convert_jiff_to_chrono(jiff_timestamp: jiff::Zoned) -> Option<DateTime<Utc>> 
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
-    use serde_json::Map;
-
-    fn create_test_event(
-        now: &str,
-        timestamp: Option<&str>,
-        sent_at: Option<&str>,
-        offset: Option<i64>,
-        ignore_sent_at: Option<bool>,
-    ) -> HashMap<String, Value> {
-        let mut event = HashMap::new();
-        event.insert("now".to_string(), Value::String(now.to_string()));
-        event.insert("team_id".to_string(), Value::Number(123.into()));
-        event.insert("uuid".to_string(), Value::String("test-uuid".to_string()));
-        event.insert("event".to_string(), Value::String("test_event".to_string()));
-
-        if let Some(ts) = timestamp {
-            event.insert("timestamp".to_string(), Value::String(ts.to_string()));
-        }
-
-        if let Some(sa) = sent_at {
-            event.insert("sent_at".to_string(), Value::String(sa.to_string()));
-        }
-
-        if let Some(off) = offset {
-            event.insert("offset".to_string(), Value::Number(off.into()));
-        }
-
-        if let Some(ignore) = ignore_sent_at {
-            let mut properties = Map::new();
-            properties.insert("$ignore_sent_at".to_string(), Value::Bool(ignore));
-            event.insert("properties".to_string(), Value::Object(properties));
-        }
-
-        event
-    }
 
     #[test]
     fn test_parse_event_timestamp_basic() {
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
-        let event = create_test_event(now_str, None, None, None, None);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(None, None, None, false, now);
 
         assert_eq!(result.timestamp, now);
         assert_eq!(result.warnings.len(), 0);
@@ -318,13 +190,16 @@ mod tests {
     #[test]
     fn test_parse_event_timestamp_with_clock_skew() {
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let sent_at_str = "2023-01-01T12:00:05Z"; // 5 seconds ahead
         let timestamp_str = "2023-01-01T11:59:55Z"; // 10 seconds before sent_at
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let event = create_test_event(now_str, Some(timestamp_str), Some(sent_at_str), None, None);
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, Some(sent_at), false, now);
         // Expected: now + (timestamp - sent_at) = 12:00:00 + (11:59:55 - 12:00:05) = 12:00:00 - 00:00:10 = 11:59:50
         let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 59, 50).unwrap();
 
@@ -335,12 +210,12 @@ mod tests {
     #[test]
     fn test_parse_event_timestamp_with_offset() {
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let offset = 5000; // 5 seconds
 
-        let event = create_test_event(now_str, None, None, Some(offset), None);
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(None, Some(offset), None, false, now);
         let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 59, 55).unwrap();
 
         assert_eq!(result.timestamp, expected);
@@ -350,19 +225,16 @@ mod tests {
     #[test]
     fn test_parse_event_timestamp_ignore_sent_at() {
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let sent_at_str = "2023-01-01T12:00:05Z";
         let timestamp_str = "2023-01-01T11:00:00Z";
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let event = create_test_event(
-            now_str,
-            Some(timestamp_str),
-            Some(sent_at_str),
-            None,
-            Some(true),
-        );
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, Some(sent_at), true, now);
         // Should use timestamp directly since sent_at is ignored
         let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 0, 0).unwrap();
 
@@ -373,12 +245,12 @@ mod tests {
     #[test]
     fn test_parse_event_timestamp_future_event() {
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let future_timestamp = "2023-01-02T12:00:00Z"; // 24 hours in the future
 
-        let event = create_test_event(now_str, Some(future_timestamp), None, None, None);
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(future_timestamp), None, None, false, now);
 
         // Should clamp to now for future events
         let expected = DateTime::parse_from_rfc3339(now_str)
@@ -392,12 +264,12 @@ mod tests {
     #[test]
     fn test_parse_event_timestamp_out_of_bounds() {
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let invalid_timestamp = "0001-01-01T12:00:00Z"; // Year 1 is within bounds, this will be parsed successfully
 
-        let event = create_test_event(now_str, Some(invalid_timestamp), None, None, None);
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(invalid_timestamp), None, None, false, now);
 
         // Should use the parsed timestamp (year 1 is valid)
         let expected = DateTime::parse_from_rfc3339(invalid_timestamp)
@@ -410,12 +282,12 @@ mod tests {
     #[test]
     fn test_parse_event_timestamp_unparseable() {
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let invalid_timestamp = "99999-01-01T12:00:00Z"; // This should fail to parse due to year being too large
 
-        let event = create_test_event(now_str, Some(invalid_timestamp), None, None, None);
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(invalid_timestamp), None, None, false, now);
 
         // Should fall back to 'now' when timestamp fails to parse
         let expected = DateTime::parse_from_rfc3339(now_str)
@@ -426,30 +298,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_event_timestamp_invalid_sent_at() {
-        let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
-        let timestamp_str = "2023-01-01T11:00:00Z";
-        let invalid_sent_at = "invalid-date";
-
-        let event = create_test_event(
-            now_str,
-            Some(timestamp_str),
-            Some(invalid_sent_at),
-            None,
-            None,
-        );
-
-        let result = parse_event_timestamp(&event, now);
-
-        // Should use timestamp directly since sent_at is invalid
-        let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 0, 0).unwrap();
-        assert_eq!(result.timestamp, expected);
-        assert_eq!(result.warnings.len(), 1);
-        assert_eq!(result.warnings[0].warning_type, "ignored_invalid_timestamp");
-    }
-
-    #[test]
     fn test_parse_date_various_formats() {
         // Test core date parsing functionality across different format types
         let valid_cases = vec![
@@ -457,17 +305,13 @@ mod tests {
             "2023-01-01T12:00:00Z",
             "2023-01-01T12:00:00+02:00",
             "2023-01-01",
-
             // Civil datetime (jiff fallback)
             "2023-01-01T12:00:00",
-
             // Slash-separated (dateparser)
             "01/01/2023",
             "2023/01/01",
-
             // RFC2822 (dateparser)
             "Tue, 1 Jul 2003 10:52:37 +0200",
-
             // Numeric timestamps (dateparser)
             "1672574400000",
             "1672574400",
@@ -476,31 +320,41 @@ mod tests {
         let invalid_cases = vec![
             "invalid-date",
             "99999-01-01T12:00:00Z", // Year too large
-            "13/32/2023", // Invalid month/day
+            "13/32/2023",            // Invalid month/day
             "",
         ];
 
         for date_str in valid_cases {
-            assert!(parse_date(date_str).is_some(), "Failed to parse: {}", date_str);
+            assert!(
+                parse_date(date_str).is_some(),
+                "Failed to parse: {}",
+                date_str
+            );
         }
 
         for date_str in invalid_cases {
-            assert!(parse_date(date_str).is_none(), "Unexpectedly parsed: {}", date_str);
+            assert!(
+                parse_date(date_str).is_none(),
+                "Unexpectedly parsed: {}",
+                date_str
+            );
         }
     }
-
 
     #[test]
     fn test_complex_timestamp_scenario() {
         // Test complex scenario with all components
         let now_str = "2023-01-01T12:00:00Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let sent_at_str = "2023-01-01T12:00:02Z"; // 2 seconds ahead of server
         let timestamp_str = "2023-01-01T11:59:58Z"; // 4 seconds before sent_at
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let event = create_test_event(now_str, Some(timestamp_str), Some(sent_at_str), None, None);
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, Some(sent_at), false, now);
 
         // Expected calculation:
         // skew = sent_at - now = 12:00:02 - 12:00:00 = +2s
@@ -519,12 +373,16 @@ mod tests {
     fn test_sent_at_timestamp_adjustment() {
         // Matches: "captures sent_at to adjusts timestamp"
         let now_str = "2021-10-29T01:44:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let timestamp_str = "2021-10-30T03:02:00.000Z";
         let sent_at_str = "2021-10-30T03:12:00.000Z"; // 10 minutes ahead of timestamp
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let event = create_test_event(now_str, Some(timestamp_str), Some(sent_at_str), None, None);
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, Some(sent_at), false, now);
 
         // Expected: now + (timestamp - sent_at) = 01:44:00 + (03:02:00 - 03:12:00) = 01:44:00 - 00:10:00 = 01:34:00
         let expected = Utc.with_ymd_and_hms(2021, 10, 29, 1, 34, 0).unwrap();
@@ -536,21 +394,21 @@ mod tests {
     fn test_ignore_sent_at_property() {
         // Matches: "Ignores sent_at if $ignore_sent_at set"
         let now_str = "2021-11-29T01:44:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let timestamp_str = "2021-10-30T03:02:00.000Z";
         let sent_at_str = "2021-10-30T03:12:00.000Z";
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let event = create_test_event(
-            now_str,
-            Some(timestamp_str),
-            Some(sent_at_str),
-            None,
-            Some(true), // $ignore_sent_at = true
-        );
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, Some(sent_at), true, now);
 
         // Should use timestamp directly, ignoring sent_at
-        let expected = DateTime::parse_from_rfc3339(timestamp_str).unwrap().with_timezone(&Utc);
+        let expected = DateTime::parse_from_rfc3339(timestamp_str)
+            .unwrap()
+            .with_timezone(&Utc);
         assert_eq!(result.timestamp, expected);
         assert_eq!(result.warnings.len(), 0);
     }
@@ -559,12 +417,16 @@ mod tests {
     fn test_timezone_info_handling() {
         // Matches: "captures sent_at with timezone info"
         let now_str = "2021-10-29T01:44:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let timestamp_str = "2021-10-30T03:02:00.000+04:00"; // +04:00 timezone
         let sent_at_str = "2021-10-30T03:12:00.000+04:00"; // Same timezone
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let event = create_test_event(now_str, Some(timestamp_str), Some(sent_at_str), None, None);
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, Some(sent_at), false, now);
 
         // Should handle timezone conversion properly
         // timestamp in UTC: 2021-10-29T23:02:00Z, sent_at in UTC: 2021-10-29T23:12:00Z
@@ -578,14 +440,17 @@ mod tests {
     fn test_timestamp_no_sent_at() {
         // Matches: "captures timestamp with no sent_at"
         let now_str = "2021-10-30T01:44:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let timestamp_str = "2021-10-30T03:02:00.000Z";
 
-        let event = create_test_event(now_str, Some(timestamp_str), None, None, None);
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, None, false, now);
 
         // Should use timestamp directly when no sent_at
-        let expected = DateTime::parse_from_rfc3339(timestamp_str).unwrap().with_timezone(&Utc);
+        let expected = DateTime::parse_from_rfc3339(timestamp_str)
+            .unwrap()
+            .with_timezone(&Utc);
         assert_eq!(result.timestamp, expected);
         assert_eq!(result.warnings.len(), 0);
     }
@@ -594,12 +459,16 @@ mod tests {
     fn test_offset_ignores_sent_at() {
         // Matches: "captures with time offset and ignores sent_at"
         let now_str = "2021-10-29T01:44:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let sent_at_str = "2021-10-30T03:12:00.000+04:00"; // Should be ignored
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let offset = 6000; // 6 seconds
 
-        let event = create_test_event(now_str, None, Some(sent_at_str), Some(offset), None);
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(None, Some(offset), Some(sent_at), false, now);
 
         // Expected: now - offset = 01:44:00 - 6s = 01:43:54
         let expected = Utc.with_ymd_and_hms(2021, 10, 29, 1, 43, 54).unwrap();
@@ -611,11 +480,12 @@ mod tests {
     fn test_offset_only() {
         // Matches: "captures with time offset"
         let now_str = "2021-10-29T01:44:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let offset = 6000; // 6 seconds
 
-        let event = create_test_event(now_str, None, None, Some(offset), None);
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(None, Some(offset), None, false, now);
 
         // Expected: now - offset = 01:44:00 - 6s = 01:43:54
         let expected = Utc.with_ymd_and_hms(2021, 10, 29, 1, 43, 54).unwrap();
@@ -627,21 +497,18 @@ mod tests {
     fn test_extreme_offset_out_of_bounds() {
         // Matches: "timestamps adjusted way out of bounds are ignored"
         let now_str = "2021-10-28T01:10:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let timestamp_str = "2021-10-28T01:00:00.000Z";
         let sent_at_str = "2021-10-28T01:05:00.000Z";
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let offset = 600000000000000i64; // Extremely large offset
 
-        let mut event = create_test_event(
-            now_str,
-            Some(timestamp_str),
-            Some(sent_at_str),
-            Some(offset),
-            None,
-        );
-        event.insert("uuid".to_string(), Value::String("test-uuid".to_string()));
-
-        let result = parse_event_timestamp(&event, now);
+        let result =
+            parse_event_timestamp(Some(timestamp_str), Some(offset), Some(sent_at), false, now);
 
         // The large offset creates an underflow, resulting in a very old timestamp
         // Our implementation actually does generate a warning for out-of-bounds results!
@@ -659,14 +526,12 @@ mod tests {
     fn test_unparseable_timestamp_fallback() {
         // Matches: "reports timestamp parsing error and fallbacks to DateTime.utc"
         let now_str = "2020-08-12T01:02:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let invalid_timestamp = "notISO";
 
-        let mut event = create_test_event(now_str, Some(invalid_timestamp), None, None, None);
-        event.insert("team_id".to_string(), Value::Number(123.into()));
-        event.insert("uuid".to_string(), Value::String("test-uuid".to_string()));
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(invalid_timestamp), None, None, false, now);
 
         // Should fall back to now when timestamp is unparseable
         assert_eq!(result.timestamp, now);
@@ -680,15 +545,16 @@ mod tests {
     fn test_future_timestamp_with_sent_at_warning() {
         // Matches: "reports event_timestamp_in_future with sent_at"
         let now_str = "2021-10-29T01:00:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let timestamp_str = "2021-10-29T02:30:00.000Z"; // 1.5 hours in future
         let sent_at_str = "2021-10-28T01:00:00.000Z"; // 24 hours ago
+        let sent_at = DateTime::parse_from_rfc3339(sent_at_str)
+            .unwrap()
+            .with_timezone(&Utc);
 
-        let mut event = create_test_event(now_str, Some(timestamp_str), Some(sent_at_str), None, None);
-        event.insert("event".to_string(), Value::String("test event name".to_string()));
-        event.insert("uuid".to_string(), Value::String("12345678-1234-1234-1234-123456789abc".to_string()));
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, Some(sent_at), false, now);
 
         // Should clamp to now and generate warning
         assert_eq!(result.timestamp, now);
@@ -700,14 +566,12 @@ mod tests {
     fn test_future_timestamp_ignore_sent_at_warning() {
         // Matches: "reports event_timestamp_in_future with $ignore_sent_at"
         let now_str = "2021-09-29T01:00:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let timestamp_str = "2021-10-29T02:30:00.000Z"; // 30+ days in future
 
-        let mut event = create_test_event(now_str, Some(timestamp_str), None, None, Some(true));
-        event.insert("event".to_string(), Value::String("test event name".to_string()));
-        event.insert("uuid".to_string(), Value::String("12345678-1234-1234-1234-123456789abc".to_string()));
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(Some(timestamp_str), None, None, true, now);
 
         // Should clamp to now and generate warning
         assert_eq!(result.timestamp, now);
@@ -719,14 +583,12 @@ mod tests {
     fn test_future_timestamp_negative_offset_warning() {
         // Matches: "reports event_timestamp_in_future with negative offset"
         let now_str = "2021-10-29T01:00:00.000Z";
-        let now = DateTime::parse_from_rfc3339(now_str).unwrap().with_timezone(&Utc);
+        let now = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
         let offset = -82860000i64; // Large negative offset (creates future timestamp)
 
-        let mut event = create_test_event(now_str, None, None, Some(offset), None);
-        event.insert("event".to_string(), Value::String("test event name".to_string()));
-        event.insert("uuid".to_string(), Value::String("12345678-1234-1234-1234-123456789abc".to_string()));
-
-        let result = parse_event_timestamp(&event, now);
+        let result = parse_event_timestamp(None, Some(offset), None, false, now);
 
         // Should clamp to now and generate warning
         assert_eq!(result.timestamp, now);
@@ -750,15 +612,30 @@ mod tests {
 
         for timestamp_str in test_cases {
             let result = parse_date(timestamp_str);
-            assert!(result.is_some(), "Failed to parse ISO 8601 variant: {}", timestamp_str);
+            assert!(
+                result.is_some(),
+                "Failed to parse ISO 8601 variant: {}",
+                timestamp_str
+            );
 
             let dt = result.unwrap();
-            println!("Parsed '{}' -> year: {}, month: {}, day: {}", timestamp_str, dt.year(), dt.month(), dt.day());
+            println!(
+                "Parsed '{}' -> year: {}, month: {}, day: {}",
+                timestamp_str,
+                dt.year(),
+                dt.month(),
+                dt.day()
+            );
             assert_eq!(dt.year(), 2021, "Wrong year for: {}", timestamp_str);
             assert_eq!(dt.month(), 10, "Wrong month for: {}", timestamp_str);
             // Some formats might be interpreted differently by dateparser
             // Let's be more flexible and just ensure we get a valid October 2021 date
-            assert!(dt.day() >= 28 && dt.day() <= 29, "Wrong day for: {} (got {})", timestamp_str, dt.day());
+            assert!(
+                dt.day() >= 28 && dt.day() <= 29,
+                "Wrong day for: {} (got {})",
+                timestamp_str,
+                dt.day()
+            );
         }
     }
 
@@ -767,15 +644,21 @@ mod tests {
         // These advanced ISO 8601 formats are supported in Node.js but not in our Rust implementation
         // Explicitly test that they are rejected to document the behavioral difference
         let unsupported_cases = vec![
-            "2021-W43-5",  // ISO week date format (week 43, day 5 = Friday = 2021-10-29)
-            "2021-302",    // ISO ordinal date format (day 302 of 2021 = 2021-10-29)
+            "2021-W43-5", // ISO week date format (week 43, day 5 = Friday = 2021-10-29)
+            "2021-302",   // ISO ordinal date format (day 302 of 2021 = 2021-10-29)
         ];
 
         for timestamp_str in unsupported_cases {
             let result = parse_date(timestamp_str);
-            assert!(result.is_none(), "Expected advanced ISO format to be rejected: {}", timestamp_str);
-            println!("✅ Advanced ISO format '{}' correctly rejected by Rust implementation", timestamp_str);
+            assert!(
+                result.is_none(),
+                "Expected advanced ISO format to be rejected: {}",
+                timestamp_str
+            );
+            println!(
+                "✅ Advanced ISO format '{}' correctly rejected by Rust implementation",
+                timestamp_str
+            );
         }
     }
-
 }

--- a/rust/capture/src/timestamp.rs
+++ b/rust/capture/src/timestamp.rs
@@ -1,0 +1,603 @@
+use chrono::{DateTime, Datelike, Duration, Utc};
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::error;
+
+const FUTURE_EVENT_HOURS_CUTOFF_MILLIS: i64 = 23 * 3600 * 1000; // 23 hours
+
+#[derive(Debug, Clone)]
+pub struct IngestionWarning {
+    pub warning_type: String,
+    pub details: HashMap<String, Value>,
+}
+
+pub type IngestionWarningCallback = Box<dyn Fn(IngestionWarning) + Send + Sync>;
+
+pub fn parse_event_timestamp(
+    event_data: &HashMap<String, Value>,
+    callback: Option<&IngestionWarningCallback>,
+) -> DateTime<Utc> {
+    // Extract 'now' field - set by capture endpoint and assumed valid
+    let now = match event_data.get("now") {
+        Some(Value::String(now_str)) => match DateTime::parse_from_rfc3339(now_str) {
+            Ok(dt) => dt.with_timezone(&Utc),
+            Err(_) => {
+                error!("Invalid 'now' timestamp: {}", now_str);
+                return DateTime::UNIX_EPOCH;
+            }
+        },
+        _ => {
+            error!("Missing or invalid 'now' field");
+            return DateTime::UNIX_EPOCH;
+        }
+    };
+
+    // Extract and validate 'sent_at' if present
+
+    let sent_at = if let Some(properties) = event_data.get("properties").and_then(|p| p.as_object())
+    {
+        if properties
+            .get("$ignore_sent_at")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            None
+        } else {
+            event_data
+                .get("sent_at")
+                .and_then(|v| v.as_str())
+                .map(
+                    |sent_at_str| match DateTime::parse_from_rfc3339(sent_at_str) {
+                        Ok(dt) => Some(dt.with_timezone(&Utc)),
+                        Err(_) => {
+                            if let Some(cb) = callback {
+                                let mut details = HashMap::new();
+                                details.insert(
+                                    "eventUuid".to_string(),
+                                    event_data
+                                        .get("uuid")
+                                        .cloned()
+                                        .unwrap_or(Value::String("".to_string())),
+                                );
+                                details.insert(
+                                    "field".to_string(),
+                                    Value::String("sent_at".to_string()),
+                                );
+                                details.insert(
+                                    "value".to_string(),
+                                    Value::String(sent_at_str.to_string()),
+                                );
+                                details.insert(
+                                    "reason".to_string(),
+                                    Value::String("invalid format".to_string()),
+                                );
+
+                                cb(IngestionWarning {
+                                    warning_type: "ignored_invalid_timestamp".to_string(),
+                                    details,
+                                });
+                            }
+                            None
+                        }
+                    },
+                )
+                .flatten()
+        }
+    } else {
+        event_data
+            .get("sent_at")
+            .and_then(|v| v.as_str())
+            .map(
+                |sent_at_str| match DateTime::parse_from_rfc3339(sent_at_str) {
+                    Ok(dt) => Some(dt.with_timezone(&Utc)),
+                    Err(_) => {
+                        if let Some(cb) = callback {
+                            let mut details = HashMap::new();
+                            details.insert(
+                                "eventUuid".to_string(),
+                                event_data
+                                    .get("uuid")
+                                    .cloned()
+                                    .unwrap_or(Value::String("".to_string())),
+                            );
+                            details
+                                .insert("field".to_string(), Value::String("sent_at".to_string()));
+                            details.insert(
+                                "value".to_string(),
+                                Value::String(sent_at_str.to_string()),
+                            );
+                            details.insert(
+                                "reason".to_string(),
+                                Value::String("invalid format".to_string()),
+                            );
+
+                            cb(IngestionWarning {
+                                warning_type: "ignored_invalid_timestamp".to_string(),
+                                details,
+                            });
+                        }
+                        None
+                    }
+                },
+            )
+            .flatten()
+    };
+
+    // Get team_id for error reporting
+    let team_id = event_data
+        .get("team_id")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    let parsed_ts = handle_timestamp(event_data, now, sent_at, team_id);
+
+    // Check for future events
+    let now_diff = parsed_ts.signed_duration_since(now).num_milliseconds();
+    let parsed_ts = if now_diff > FUTURE_EVENT_HOURS_CUTOFF_MILLIS {
+        if let Some(cb) = callback {
+            let mut details = HashMap::new();
+            details.insert(
+                "timestamp".to_string(),
+                event_data
+                    .get("timestamp")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+            details.insert(
+                "sentAt".to_string(),
+                event_data
+                    .get("sent_at")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+            details.insert(
+                "offset".to_string(),
+                event_data
+                    .get("offset")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+            details.insert("now".to_string(), Value::String(now.to_rfc3339()));
+            details.insert("result".to_string(), Value::String(parsed_ts.to_rfc3339()));
+            details.insert(
+                "eventUuid".to_string(),
+                event_data
+                    .get("uuid")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+            details.insert(
+                "eventName".to_string(),
+                event_data
+                    .get("event")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+
+            cb(IngestionWarning {
+                warning_type: "event_timestamp_in_future".to_string(),
+                details,
+            });
+        }
+        now // Fix the timestamp to now
+    } else {
+        parsed_ts
+    };
+
+    // Check if timestamp is out of bounds
+    let parsed_ts_out_of_bounds = parsed_ts.year() < 0 || parsed_ts.year() > 9999;
+    if parsed_ts_out_of_bounds {
+        if let Some(cb) = callback {
+            let mut details = HashMap::new();
+            details.insert(
+                "eventUuid".to_string(),
+                event_data
+                    .get("uuid")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+            details.insert("field".to_string(), Value::String("timestamp".to_string()));
+            details.insert(
+                "value".to_string(),
+                event_data
+                    .get("timestamp")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+            details.insert(
+                "reason".to_string(),
+                Value::String("out of bounds".to_string()),
+            );
+            details.insert(
+                "offset".to_string(),
+                event_data
+                    .get("offset")
+                    .cloned()
+                    .unwrap_or(Value::String("".to_string())),
+            );
+            details.insert(
+                "parsed_year".to_string(),
+                Value::Number(parsed_ts.year().into()),
+            );
+
+            cb(IngestionWarning {
+                warning_type: "ignored_invalid_timestamp".to_string(),
+                details,
+            });
+        }
+        return DateTime::UNIX_EPOCH;
+    }
+
+    parsed_ts
+}
+
+fn handle_timestamp(
+    event_data: &HashMap<String, Value>,
+    now: DateTime<Utc>,
+    sent_at: Option<DateTime<Utc>>,
+    _team_id: i64,
+) -> DateTime<Utc> {
+    let mut parsed_ts = now;
+
+    if let Some(timestamp_value) = event_data.get("timestamp") {
+        if let Some(timestamp_str) = timestamp_value.as_str() {
+            let timestamp = parse_date(timestamp_str);
+
+            if let (Some(sent_at), Some(timestamp)) = (sent_at, timestamp) {
+                // Handle clock skew between client and server
+                // skew = sent_at - now
+                // x = now + (timestamp - sent_at)
+                match timestamp.signed_duration_since(sent_at) {
+                    duration => {
+                        parsed_ts = now + duration;
+                    }
+                }
+            } else if let Some(timestamp) = timestamp {
+                parsed_ts = timestamp;
+            }
+        }
+    }
+
+    // Handle offset if present
+    if let Some(offset_value) = event_data.get("offset") {
+        if let Some(offset_num) = offset_value.as_i64() {
+            parsed_ts = now - Duration::milliseconds(offset_num);
+        }
+    }
+
+    parsed_ts
+}
+
+fn parse_date(supposed_iso_string: &str) -> Option<DateTime<Utc>> {
+    // First try parsing as a JavaScript Date would (more lenient)
+    if let Ok(js_timestamp) = supposed_iso_string.parse::<f64>() {
+        // Handle numeric timestamps (milliseconds since epoch)
+        if let Some(dt) = DateTime::from_timestamp_millis(js_timestamp as i64) {
+            return Some(dt);
+        }
+    }
+
+    // Try parsing date-only format first (common case)
+    use chrono::NaiveDate;
+    if let Ok(naive_date) = NaiveDate::parse_from_str(supposed_iso_string, "%Y-%m-%d") {
+        if let Some(naive_dt) = naive_date.and_hms_opt(0, 0, 0) {
+            return Some(DateTime::from_naive_utc_and_offset(naive_dt, Utc));
+        }
+    }
+
+    // Try parsing datetime formats with timezone info
+    let tz_formats = [
+        // ISO 8601 variants
+        "%Y-%m-%dT%H:%M:%S%.fZ",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S%.f%:z",
+        "%Y-%m-%dT%H:%M:%S%:z",
+    ];
+
+    for format in &tz_formats {
+        if let Ok(dt) = DateTime::parse_from_str(supposed_iso_string, format) {
+            return Some(dt.with_timezone(&Utc));
+        }
+    }
+
+    // Try parsing naive datetime formats (assume UTC)
+    let naive_formats = [
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
+        "%m/%d/%Y %H:%M:%S",
+        "%m/%d/%Y",
+        "%d/%m/%Y %H:%M:%S",
+        "%d/%m/%Y",
+        "%Y/%m/%d %H:%M:%S",
+        "%Y/%m/%d",
+    ];
+
+    for format in &naive_formats {
+        if let Ok(naive_dt) = chrono::NaiveDateTime::parse_from_str(supposed_iso_string, format) {
+            return Some(DateTime::from_naive_utc_and_offset(naive_dt, Utc));
+        }
+    }
+
+    // Try parsing just date formats and add midnight time
+    let date_formats = ["%m/%d/%Y", "%d/%m/%Y", "%Y/%m/%d"];
+
+    for format in &date_formats {
+        if let Ok(naive_date) = NaiveDate::parse_from_str(supposed_iso_string, format) {
+            if let Some(naive_dt) = naive_date.and_hms_opt(0, 0, 0) {
+                return Some(DateTime::from_naive_utc_and_offset(naive_dt, Utc));
+            }
+        }
+    }
+
+    // Try RFC3339 parsing
+    if let Ok(dt) = DateTime::parse_from_rfc3339(supposed_iso_string) {
+        return Some(dt.with_timezone(&Utc));
+    }
+
+    // Try RFC2822 parsing
+    if let Ok(dt) = DateTime::parse_from_rfc2822(supposed_iso_string) {
+        return Some(dt.with_timezone(&Utc));
+    }
+
+    // If all else fails, try chrono's lenient parsing
+    if let Ok(naive_dt) =
+        chrono::NaiveDateTime::parse_from_str(supposed_iso_string, "%Y-%m-%d %H:%M:%S")
+    {
+        return Some(DateTime::from_naive_utc_and_offset(naive_dt, Utc));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use std::sync::{Arc, Mutex};
+
+    fn create_test_event(
+        now: &str,
+        timestamp: Option<&str>,
+        sent_at: Option<&str>,
+        offset: Option<i64>,
+        ignore_sent_at: Option<bool>,
+    ) -> HashMap<String, Value> {
+        let mut event = HashMap::new();
+        event.insert("now".to_string(), Value::String(now.to_string()));
+        event.insert("team_id".to_string(), Value::Number(123.into()));
+        event.insert("uuid".to_string(), Value::String("test-uuid".to_string()));
+        event.insert("event".to_string(), Value::String("test_event".to_string()));
+
+        if let Some(ts) = timestamp {
+            event.insert("timestamp".to_string(), Value::String(ts.to_string()));
+        }
+
+        if let Some(sa) = sent_at {
+            event.insert("sent_at".to_string(), Value::String(sa.to_string()));
+        }
+
+        if let Some(off) = offset {
+            event.insert("offset".to_string(), Value::Number(off.into()));
+        }
+
+        if let Some(ignore) = ignore_sent_at {
+            let mut properties = Map::new();
+            properties.insert("$ignore_sent_at".to_string(), Value::Bool(ignore));
+            event.insert("properties".to_string(), Value::Object(properties));
+        }
+
+        event
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_basic() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let event = create_test_event(now_str, None, None, None, None);
+
+        let result = parse_event_timestamp(&event, None);
+        let expected = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_with_clock_skew() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let sent_at_str = "2023-01-01T12:00:05Z"; // 5 seconds ahead
+        let timestamp_str = "2023-01-01T11:59:55Z"; // 10 seconds before sent_at
+
+        let event = create_test_event(now_str, Some(timestamp_str), Some(sent_at_str), None, None);
+
+        let result = parse_event_timestamp(&event, None);
+        // Expected: now + (timestamp - sent_at) = 12:00:00 + (11:59:55 - 12:00:05) = 12:00:00 - 00:00:10 = 11:59:50
+        let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 59, 50).unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_with_offset() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let offset = 5000; // 5 seconds
+
+        let event = create_test_event(now_str, None, None, Some(offset), None);
+
+        let result = parse_event_timestamp(&event, None);
+        let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 59, 55).unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_ignore_sent_at() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let sent_at_str = "2023-01-01T12:00:05Z";
+        let timestamp_str = "2023-01-01T11:00:00Z";
+
+        let event = create_test_event(
+            now_str,
+            Some(timestamp_str),
+            Some(sent_at_str),
+            None,
+            Some(true),
+        );
+
+        let result = parse_event_timestamp(&event, None);
+        // Should use timestamp directly since sent_at is ignored
+        let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 0, 0).unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_future_event() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let future_timestamp = "2023-01-02T12:00:00Z"; // 24 hours in the future
+
+        let event = create_test_event(now_str, Some(future_timestamp), None, None, None);
+
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let warnings_clone = warnings.clone();
+        let callback: IngestionWarningCallback = Box::new(move |warning| {
+            warnings_clone.lock().unwrap().push(warning);
+        });
+
+        let result = parse_event_timestamp(&event, Some(&callback));
+
+        // Should clamp to now for future events
+        let expected = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(result, expected);
+
+        let warnings_vec = warnings.lock().unwrap();
+        assert_eq!(warnings_vec.len(), 1);
+        assert_eq!(warnings_vec[0].warning_type, "event_timestamp_in_future");
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_out_of_bounds() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let invalid_timestamp = "0001-01-01T12:00:00Z"; // Year 1 is within bounds, this will be parsed successfully
+
+        let event = create_test_event(now_str, Some(invalid_timestamp), None, None, None);
+
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let warnings_clone = warnings.clone();
+        let callback: IngestionWarningCallback = Box::new(move |warning| {
+            warnings_clone.lock().unwrap().push(warning);
+        });
+
+        let result = parse_event_timestamp(&event, Some(&callback));
+
+        // Should use the parsed timestamp (year 1 is valid)
+        let expected = DateTime::parse_from_rfc3339(invalid_timestamp)
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(result, expected);
+
+        let warnings_vec = warnings.lock().unwrap();
+        assert_eq!(warnings_vec.len(), 0); // No warnings for valid timestamps
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_unparseable() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let invalid_timestamp = "99999-01-01T12:00:00Z"; // This should fail to parse due to year being too large
+
+        let event = create_test_event(now_str, Some(invalid_timestamp), None, None, None);
+
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let warnings_clone = warnings.clone();
+        let callback: IngestionWarningCallback = Box::new(move |warning| {
+            warnings_clone.lock().unwrap().push(warning);
+        });
+
+        let result = parse_event_timestamp(&event, Some(&callback));
+
+        // Should fall back to 'now' when timestamp fails to parse
+        let expected = DateTime::parse_from_rfc3339(now_str)
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(result, expected);
+
+        let warnings_vec = warnings.lock().unwrap();
+        assert_eq!(warnings_vec.len(), 0); // No warnings when parsing fails, just falls back to now
+    }
+
+    #[test]
+    fn test_parse_event_timestamp_invalid_sent_at() {
+        let now_str = "2023-01-01T12:00:00Z";
+        let timestamp_str = "2023-01-01T11:00:00Z";
+        let invalid_sent_at = "invalid-date";
+
+        let event = create_test_event(
+            now_str,
+            Some(timestamp_str),
+            Some(invalid_sent_at),
+            None,
+            None,
+        );
+
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let warnings_clone = warnings.clone();
+        let callback: IngestionWarningCallback = Box::new(move |warning| {
+            warnings_clone.lock().unwrap().push(warning);
+        });
+
+        let result = parse_event_timestamp(&event, Some(&callback));
+
+        // Should use timestamp directly since sent_at is invalid
+        let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 0, 0).unwrap();
+        assert_eq!(result, expected);
+
+        let warnings_vec = warnings.lock().unwrap();
+        assert_eq!(warnings_vec.len(), 1);
+        assert_eq!(warnings_vec[0].warning_type, "ignored_invalid_timestamp");
+    }
+
+    #[test]
+    fn test_parse_date_various_formats() {
+        let test_cases = vec![
+            ("2023-01-01T12:00:00Z", true),
+            ("2023-01-01T12:00:00.123Z", true),
+            ("2023-01-01T12:00:00+02:00", true),
+            ("2023-01-01 12:00:00", true),
+            ("2023-01-01", true),
+            ("01/01/2023", true),
+            ("1672574400000", true), // Timestamp in milliseconds
+            ("invalid-date", false),
+        ];
+
+        for (date_str, should_parse) in test_cases {
+            let result = parse_date(date_str);
+            if should_parse {
+                assert!(result.is_some(), "Failed to parse: {}", date_str);
+            } else {
+                assert!(result.is_none(), "Unexpectedly parsed: {}", date_str);
+            }
+        }
+    }
+
+    #[test]
+    fn test_complex_timestamp_scenario() {
+        // Test complex scenario with all components
+        let now_str = "2023-01-01T12:00:00Z";
+        let sent_at_str = "2023-01-01T12:00:02Z"; // 2 seconds ahead of server
+        let timestamp_str = "2023-01-01T11:59:58Z"; // 4 seconds before sent_at
+
+        let event = create_test_event(now_str, Some(timestamp_str), Some(sent_at_str), None, None);
+
+        let result = parse_event_timestamp(&event, None);
+
+        // Expected calculation:
+        // skew = sent_at - now = 12:00:02 - 12:00:00 = +2s
+        // timestamp_diff = timestamp - sent_at = 11:59:58 - 12:00:02 = -4s
+        // result = now + timestamp_diff = 12:00:00 + (-4s) = 11:59:56
+        let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 59, 56).unwrap();
+
+        assert_eq!(result, expected);
+    }
+}

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -467,7 +467,7 @@ pub fn process_single_event(
             .ok_or(CaptureError::MissingDistinctId)?,
         ip: resolved_ip,
         data,
-        now: context.now.to_rfc3339(),
+        now: context.now.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
         sent_at: context.sent_at,
         token: context.token.clone(),
         is_cookieless_mode: event
@@ -664,7 +664,7 @@ pub async fn process_replay_events<'a>(
             }
         })
         .to_string(),
-        now: context.now.to_rfc3339(),
+        now: context.now.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
         sent_at: context.sent_at,
         token: context.token.clone(),
         is_cookieless_mode,

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -445,8 +445,8 @@ pub fn process_single_event(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Parse the event timestamp (ignore warnings for now as requested)
-    let timestamp_result = timestamp::parse_event_timestamp(
+    // Parse the event timestamp
+    let computed_timestamp = timestamp::parse_event_timestamp(
         event.timestamp.as_deref(),
         event.offset,
         sent_at_utc,
@@ -457,7 +457,7 @@ pub fn process_single_event(
     let mut metadata = ProcessedEventMetadata {
         data_type,
         session_id: None,
-        computed_timestamp: Some(timestamp_result.timestamp),
+        computed_timestamp: Some(computed_timestamp),
     };
 
     let event = CapturedEvent {
@@ -567,7 +567,7 @@ pub async fn process_replay_events<'a>(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let timestamp_result = timestamp::parse_event_timestamp(
+    let computed_timestamp = timestamp::parse_event_timestamp(
         events[0].timestamp.as_deref(),
         events[0].offset,
         sent_at_utc,
@@ -645,7 +645,7 @@ pub async fn process_replay_events<'a>(
     let metadata = ProcessedEventMetadata {
         data_type: DataType::SnapshotMain,
         session_id: Some(session_id_str.to_string()),
-        computed_timestamp: Some(timestamp_result.timestamp), // Use computed event timestamp
+        computed_timestamp: Some(computed_timestamp), // Use computed event timestamp
     };
 
     let event = CapturedEvent {

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -467,7 +467,9 @@ pub fn process_single_event(
             .ok_or(CaptureError::MissingDistinctId)?,
         ip: resolved_ip,
         data,
-        now: context.now.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
+        now: context
+            .now
+            .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
         sent_at: context.sent_at,
         token: context.token.clone(),
         is_cookieless_mode: event
@@ -664,7 +666,9 @@ pub async fn process_replay_events<'a>(
             }
         })
         .to_string(),
-        now: context.now.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
+        now: context
+            .now
+            .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
         sent_at: context.sent_at,
         token: context.token.clone(),
         is_cookieless_mode,

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -17,7 +17,7 @@ use tracing::{debug, error, instrument, warn, Span};
 use crate::{
     api::{CaptureError, CaptureResponse, CaptureResponseCode},
     prometheus::{report_dropped_events, report_internal_error_metrics},
-    router, sinks,
+    router, sinks, timestamp,
     utils::{
         decode_base64, decode_form, extract_and_verify_token, extract_compression,
         extract_lib_version, is_likely_base64, is_likely_urlencoded_form, uuid_v7, Base64Option,
@@ -204,11 +204,16 @@ async fn handle_event_payload(
 
     counter!("capture_events_received_total", &[("legacy", "true")]).increment(events.len() as u64);
 
+    let now_str = state.timesource.current_time();
+    let now = DateTime::parse_from_rfc3339(&now_str)
+        .map_err(|_| CaptureError::InvalidTimestamp)?
+        .with_timezone(&Utc);
+
     let context = ProcessingContext {
         lib_version,
         sent_at,
         token,
-        now: state.timesource.current_time(),
+        now,
         client_ip: ip.to_string(),
         request_id: request_id.to_string(),
         path: path.as_str().to_string(),
@@ -433,9 +438,29 @@ pub fn process_single_event(
         CaptureError::NonRetryableSinkError
     })?;
 
+    // Compute the actual event timestamp using our timestamp parsing logic
+    let sent_at_utc = context
+        .sent_at
+        .map(|sa| DateTime::from_timestamp(sa.unix_timestamp(), 0).unwrap_or_default());
+    let ignore_sent_at = event
+        .properties
+        .get("$ignore_sent_at")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    // Parse the event timestamp (ignore warnings for now as requested)
+    let timestamp_result = timestamp::parse_event_timestamp(
+        event.timestamp.as_deref(),
+        event.offset,
+        sent_at_utc,
+        ignore_sent_at,
+        context.now,
+    );
+
     let mut metadata = ProcessedEventMetadata {
         data_type,
         session_id: None,
+        computed_timestamp: Some(timestamp_result.timestamp),
     };
 
     let event = CapturedEvent {
@@ -445,7 +470,7 @@ pub fn process_single_event(
             .ok_or(CaptureError::MissingDistinctId)?,
         ip: resolved_ip,
         data,
-        now: context.now.clone(),
+        now: context.now.to_rfc3339(),
         sent_at: context.sent_at,
         token: context.token.clone(),
         is_cookieless_mode: event
@@ -535,6 +560,24 @@ pub async fn process_replay_events<'a>(
 ) -> Result<(), CaptureError> {
     Span::current().record("request_id", &context.request_id);
 
+    // Compute the actual event timestamp using our timestamp parsing logic from the first event
+    let sent_at_utc = context
+        .sent_at
+        .map(|sa| DateTime::from_timestamp(sa.unix_timestamp(), 0).unwrap_or_default());
+    let ignore_sent_at = events[0]
+        .properties
+        .get("$ignore_sent_at")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let timestamp_result = timestamp::parse_event_timestamp(
+        events[0].timestamp.as_deref(),
+        events[0].offset,
+        sent_at_utc,
+        ignore_sent_at,
+        context.now,
+    );
+
     // Grab metadata about the whole batch from the first event before
     // we drop all the events as we rip out the snapshot data
     let session_id = events[0]
@@ -605,6 +648,7 @@ pub async fn process_replay_events<'a>(
     let metadata = ProcessedEventMetadata {
         data_type: DataType::SnapshotMain,
         session_id: Some(session_id_str.to_string()),
+        computed_timestamp: Some(timestamp_result.timestamp), // Use computed event timestamp
     };
 
     let event = CapturedEvent {
@@ -623,7 +667,7 @@ pub async fn process_replay_events<'a>(
             }
         })
         .to_string(),
-        now: context.now.clone(),
+        now: context.now.to_rfc3339(),
         sent_at: context.sent_at,
         token: context.token.clone(),
         is_cookieless_mode,
@@ -639,4 +683,146 @@ fn snapshot_library_fallback_from(user_agent: Option<&String>) -> Option<String>
         .map(|s| s.to_string())
         .filter(|s| s.contains("posthog"))
         .or(Some("web".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v0_request::ProcessingContext;
+    use chrono::{DateTime, TimeZone, Utc};
+    use common_types::RawEvent;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use time::OffsetDateTime;
+
+    fn create_test_context(
+        now: DateTime<Utc>,
+        sent_at: Option<OffsetDateTime>,
+    ) -> ProcessingContext {
+        ProcessingContext {
+            lib_version: None,
+            user_agent: None,
+            sent_at,
+            token: "test_token".to_string(),
+            now,
+            client_ip: "127.0.0.1".to_string(),
+            request_id: "test_request".to_string(),
+            path: "/e/".to_string(),
+            is_mirror_deploy: false,
+            historical_migration: false,
+        }
+    }
+
+    fn create_test_event(
+        timestamp: Option<String>,
+        offset: Option<i64>,
+        ignore_sent_at: Option<bool>,
+    ) -> RawEvent {
+        let mut properties = HashMap::new();
+        if let Some(ignore) = ignore_sent_at {
+            properties.insert("$ignore_sent_at".to_string(), json!(ignore));
+        }
+        properties.insert("distinct_id".to_string(), json!("test_user"));
+
+        RawEvent {
+            uuid: Some(uuid_v7()),
+            distinct_id: None,
+            event: "test_event".to_string(),
+            properties,
+            timestamp,
+            offset,
+            set: Some(HashMap::new()),
+            set_once: Some(HashMap::new()),
+            token: Some("test_token".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_process_single_event_with_invalid_sent_at() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        // In real code, invalid sent_at would fail to parse and result in sent_at being None
+        let context = create_test_context(now, None);
+
+        let event = create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None);
+
+        let historical_cfg = router::HistoricalConfig::new(false, 1, None);
+        let result = process_single_event(&event, historical_cfg, &context);
+
+        // Should succeed and use the event timestamp directly since sent_at is None
+        assert!(result.is_ok());
+        let processed = result.unwrap();
+
+        // The computed timestamp should be the event timestamp since no sent_at was provided
+        let expected = DateTime::parse_from_rfc3339("2023-01-01T11:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(processed.metadata.computed_timestamp, Some(expected));
+    }
+
+    #[test]
+    fn test_process_single_event_with_valid_sent_at() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        // Create a valid sent_at
+        let sent_at = OffsetDateTime::parse(
+            "2023-01-01T12:00:05Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        let context = create_test_context(now, Some(sent_at));
+
+        let event = create_test_event(
+            Some("2023-01-01T11:59:55Z".to_string()), // 10 seconds before sent_at
+            None,
+            None,
+        );
+
+        let historical_cfg = router::HistoricalConfig::new(false, 1, None);
+        let result = process_single_event(&event, historical_cfg, &context);
+
+        // Should succeed and apply clock skew correction
+        assert!(result.is_ok());
+        let processed = result.unwrap();
+
+        // Expected: now + (timestamp - sent_at) = 12:00:00 + (11:59:55 - 12:00:05) = 12:00:00 - 00:00:10 = 11:59:50
+        let expected = Utc.with_ymd_and_hms(2023, 1, 1, 11, 59, 50).unwrap();
+        assert_eq!(processed.metadata.computed_timestamp, Some(expected));
+    }
+
+    #[test]
+    fn test_process_single_event_ignore_sent_at() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let sent_at = OffsetDateTime::parse(
+            "2023-01-01T12:00:05Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        let context = create_test_context(now, Some(sent_at));
+
+        let event = create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            Some(true), // $ignore_sent_at = true
+        );
+
+        let historical_cfg = router::HistoricalConfig::new(false, 1, None);
+        let result = process_single_event(&event, historical_cfg, &context);
+
+        // Should succeed and use timestamp directly, ignoring sent_at
+        assert!(result.is_ok());
+        let processed = result.unwrap();
+
+        let expected = DateTime::parse_from_rfc3339("2023-01-01T11:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(processed.metadata.computed_timestamp, Some(expected));
+    }
 }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -204,10 +204,7 @@ async fn handle_event_payload(
 
     counter!("capture_events_received_total", &[("legacy", "true")]).increment(events.len() as u64);
 
-    let now_str = state.timesource.current_time();
-    let now = DateTime::parse_from_rfc3339(&now_str)
-        .map_err(|_| CaptureError::InvalidTimestamp)?
-        .with_timezone(&Utc);
+    let now = state.timesource.current_time();
 
     let context = ProcessingContext {
         lib_version,

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -1,6 +1,7 @@
 use std::io::prelude::*;
 
 use bytes::{Buf, Bytes};
+use chrono::{DateTime, Utc};
 use common_types::{CapturedEvent, RawEngageEvent, RawEvent};
 use flate2::read::GzDecoder;
 use serde::{Deserialize, Deserializer};
@@ -378,7 +379,7 @@ pub struct ProcessingContext {
     pub user_agent: Option<String>,
     pub sent_at: Option<OffsetDateTime>,
     pub token: String,
-    pub now: String,
+    pub now: DateTime<Utc>,
     pub client_ip: String,
     pub request_id: String,
     pub path: String,
@@ -418,6 +419,7 @@ pub struct ProcessedEvent {
 pub struct ProcessedEventMetadata {
     pub data_type: DataType,
     pub session_id: Option<String>,
+    pub computed_timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[cfg(test)]

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -14,6 +14,7 @@ use capture::{
     time::TimeSource,
     v0_request::{DataType, ProcessedEvent},
 };
+use chrono::{DateTime, Utc};
 
 #[path = "./utils.rs"]
 mod test_utils;
@@ -920,12 +921,12 @@ pub fn validate_batch_events_payload(title: &str, got_events: Vec<ProcessedEvent
 //
 
 struct FixedTime {
-    pub time: String,
+    pub time: DateTime<Utc>,
 }
 
 impl TimeSource for FixedTime {
-    fn current_time(&self) -> String {
-        self.time.to_string()
+    fn current_time(&self) -> DateTime<Utc> {
+        self.time
     }
 }
 
@@ -957,7 +958,9 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
     let liveness = HealthRegistry::new("integration_tests");
     let sink = MemorySink::default();
     let timesource = FixedTime {
-        time: unit.fixed_time.to_string(),
+        time: DateTime::parse_from_rfc3339(&unit.fixed_time)
+            .expect("Invalid fixed time format in test case")
+            .with_timezone(&Utc),
     };
     let redis = Arc::new(MockRedisClient::new());
 

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -958,7 +958,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
     let liveness = HealthRegistry::new("integration_tests");
     let sink = MemorySink::default();
     let timesource = FixedTime {
-        time: DateTime::parse_from_rfc3339(&unit.fixed_time)
+        time: DateTime::parse_from_rfc3339(unit.fixed_time)
             .expect("Invalid fixed time format in test case")
             .with_timezone(&Utc),
     };

--- a/rust/capture/tests/kafka_headers.rs
+++ b/rust/capture/tests/kafka_headers.rs
@@ -61,8 +61,7 @@ async fn it_adds_timestamp_header_to_kafka_messages() -> Result<()> {
 
     assert_eq!(
         header_datetime, expected_datetime,
-        "Timestamp header {} should match event timestamp {}",
-        header_datetime, expected_datetime
+        "Timestamp header {header_datetime} should match event timestamp {expected_datetime}"
     );
 
     // Verify other expected headers are present
@@ -127,8 +126,7 @@ async fn it_adds_timestamp_header_for_events_without_timestamp() -> Result<()> {
     let diff = (now - header_datetime).num_seconds().abs();
     assert!(
         diff < 10,
-        "Timestamp should be very recent (diff: {} seconds)",
-        diff
+        "Timestamp should be very recent (diff: {diff} seconds)"
     );
 
     Ok(())
@@ -199,8 +197,7 @@ async fn it_adds_timestamp_header_with_clock_skew_correction() -> Result<()> {
     let diff = (current_time - header_datetime).num_seconds().abs();
     assert!(
         diff < 300,
-        "Timestamp should be within 5 minutes of now (diff: {} seconds)",
-        diff
+        "Timestamp should be within 5 minutes of now (diff: {diff} seconds)"
     );
 
     Ok(())

--- a/rust/capture/tests/kafka_headers.rs
+++ b/rust/capture/tests/kafka_headers.rs
@@ -1,0 +1,207 @@
+#[path = "common/utils.rs"]
+mod utils;
+use utils::*;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use reqwest::StatusCode;
+use serde_json::json;
+
+#[tokio::test]
+async fn it_adds_timestamp_header_to_kafka_messages() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    // Test with explicit timestamp
+    let explicit_timestamp = "2023-01-01T12:00:00Z";
+    let event = json!({
+        "token": token,
+        "event": "testing_timestamp_header",
+        "distinct_id": distinct_id,
+        "timestamp": explicit_timestamp
+    });
+
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Get both event data and headers from the same message
+    let (event_data, headers) = main_topic.next_message_with_headers()?;
+
+    // Check that the event was processed correctly
+    assert!(event_data.is_object(), "Event should be a JSON object");
+    let event_obj = event_data.as_object().unwrap();
+    assert_eq!(event_obj.get("token").unwrap().as_str().unwrap(), token);
+    assert_eq!(
+        event_obj.get("distinct_id").unwrap().as_str().unwrap(),
+        distinct_id
+    );
+
+    // Verify timestamp header exists and is correct
+    assert!(
+        headers.contains_key("timestamp"),
+        "Missing 'timestamp' header. Available headers: {:?}",
+        headers.keys().collect::<Vec<_>>()
+    );
+
+    let header_timestamp = headers.get("timestamp").unwrap();
+    let timestamp_millis: i64 = header_timestamp
+        .parse()
+        .expect("timestamp header should be a valid number");
+
+    // Convert back to DateTime to verify it matches our input
+    let header_datetime =
+        DateTime::from_timestamp_millis(timestamp_millis).expect("timestamp should be valid");
+
+    let expected_datetime = DateTime::parse_from_rfc3339(explicit_timestamp)?.with_timezone(&Utc);
+
+    assert_eq!(
+        header_datetime, expected_datetime,
+        "Timestamp header {} should match event timestamp {}",
+        header_datetime, expected_datetime
+    );
+
+    // Verify other expected headers are present
+    assert_eq!(headers.get("token").unwrap(), &token);
+    assert_eq!(headers.get("distinct_id").unwrap(), &distinct_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_adds_timestamp_header_for_events_without_timestamp() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    // Test without any timestamp - should use server time
+    let event = json!({
+        "token": token,
+        "event": "testing_no_timestamp",
+        "distinct_id": distinct_id
+    });
+
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Get both event data and headers from the same message
+    let (event_data, headers) = main_topic.next_message_with_headers()?;
+
+    // Check that the event was processed correctly
+    assert!(event_data.is_object(), "Event should be a JSON object");
+    let event_obj = event_data.as_object().unwrap();
+    assert_eq!(event_obj.get("token").unwrap().as_str().unwrap(), token);
+    assert_eq!(
+        event_obj.get("distinct_id").unwrap().as_str().unwrap(),
+        distinct_id
+    );
+
+    // Verify timestamp header exists and is reasonable
+    assert!(
+        headers.contains_key("timestamp"),
+        "Missing 'timestamp' header. Available headers: {:?}",
+        headers.keys().collect::<Vec<_>>()
+    );
+
+    let header_timestamp = headers.get("timestamp").unwrap();
+    let timestamp_millis: i64 = header_timestamp
+        .parse()
+        .expect("timestamp header should be a valid number");
+
+    // Should be current server time
+    assert!(timestamp_millis > 0, "Timestamp should be positive");
+
+    let header_datetime =
+        DateTime::from_timestamp_millis(timestamp_millis).expect("timestamp should be valid");
+
+    // Should be very recent (within last 10 seconds)
+    let now = Utc::now();
+    let diff = (now - header_datetime).num_seconds().abs();
+    assert!(
+        diff < 10,
+        "Timestamp should be very recent (diff: {} seconds)",
+        diff
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_adds_timestamp_header_with_clock_skew_correction() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    // Test with recent timestamp and sent_at for clock skew correction
+    let now = Utc::now();
+    let event_timestamp = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let sent_at = (now + chrono::Duration::seconds(5))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string(); // 5 seconds after event timestamp
+
+    let event = json!({
+        "token": token,
+        "event": "testing_clock_skew",
+        "distinct_id": distinct_id,
+        "timestamp": event_timestamp,
+        "sent_at": sent_at
+    });
+
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Get both event data and headers from the same message
+    let (event_data, headers) = main_topic.next_message_with_headers()?;
+
+    // Check that the event was processed correctly
+    assert!(event_data.is_object(), "Event should be a JSON object");
+    let event_obj = event_data.as_object().unwrap();
+    assert_eq!(event_obj.get("token").unwrap().as_str().unwrap(), token);
+    assert_eq!(
+        event_obj.get("distinct_id").unwrap().as_str().unwrap(),
+        distinct_id
+    );
+
+    // Verify timestamp header exists and has been adjusted for clock skew
+    assert!(
+        headers.contains_key("timestamp"),
+        "Missing 'timestamp' header. Available headers: {:?}",
+        headers.keys().collect::<Vec<_>>()
+    );
+
+    let header_timestamp = headers.get("timestamp").unwrap();
+    let timestamp_millis: i64 = header_timestamp
+        .parse()
+        .expect("timestamp header should be a valid number");
+
+    // The timestamp should be adjusted for clock skew
+    // Since we don't know the exact server time, we just verify it's a reasonable value
+    assert!(timestamp_millis > 0, "Timestamp should be positive");
+
+    // Convert to DateTime for basic validation
+    let header_datetime =
+        DateTime::from_timestamp_millis(timestamp_millis).expect("timestamp should be valid");
+
+    // Should be a reasonable date (within last few minutes)
+    let current_time = Utc::now();
+    let diff = (current_time - header_datetime).num_seconds().abs();
+    assert!(
+        diff < 300,
+        "Timestamp should be within 5 minutes of now (diff: {} seconds)",
+        diff
+    );
+
+    Ok(())
+}

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -24,6 +24,7 @@ use capture::router::router;
 use capture::sinks::Event;
 use capture::time::TimeSource;
 use capture::v0_request::ProcessedEvent;
+use chrono::{DateTime, Utc};
 
 #[derive(Default, Clone)]
 struct MemorySink {
@@ -50,12 +51,12 @@ impl MemorySink {
 }
 
 struct FixedTimeSource {
-    time: String,
+    time: DateTime<Utc>,
 }
 
 impl TimeSource for FixedTimeSource {
-    fn current_time(&self) -> String {
-        self.time.clone()
+    fn current_time(&self) -> DateTime<Utc> {
+        self.time
     }
 }
 
@@ -72,7 +73,9 @@ async fn setup_router_with_limits(
     let liveness = HealthRegistry::new("quota_limit_tests");
     let sink = MemorySink::default();
     let timesource = FixedTimeSource {
-        time: "2025-07-31T12:00:00Z".to_string(),
+        time: DateTime::parse_from_rfc3339("2025-07-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
     };
 
     // bootstrap for the CaptureQuotaLimiter. Defines which
@@ -1144,7 +1147,9 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
     let liveness = HealthRegistry::new("billing_limit_tests");
     let sink = MemorySink::default();
     let timesource = FixedTimeSource {
-        time: "2025-07-31T12:00:00Z".to_string(),
+        time: DateTime::parse_from_rfc3339("2025-07-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
     };
 
     // Configure set_nx_ex to return true (key was set successfully, first time seeing this submission)
@@ -1215,7 +1220,9 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
     let liveness = HealthRegistry::new("billing_limit_tests");
     let sink = MemorySink::default();
     let timesource = FixedTimeSource {
-        time: "2025-07-31T12:00:00Z".to_string(),
+        time: DateTime::parse_from_rfc3339("2025-07-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
     };
 
     // Configure MockRedisClient for survey quota limited scenario
@@ -1288,7 +1295,9 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
     let liveness = HealthRegistry::new("billing_limit_tests");
     let sink = MemorySink::default();
     let timesource = FixedTimeSource {
-        time: "2025-07-31T12:00:00Z".to_string(),
+        time: DateTime::parse_from_rfc3339("2025-07-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
     };
 
     // Configure MockRedisClient for survey quota limited scenario
@@ -1704,7 +1713,9 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
     let liveness = HealthRegistry::new("ai_limit_tests");
     let sink = MemorySink::default();
     let timesource = FixedTimeSource {
-        time: "2025-07-31T12:00:00Z".to_string(),
+        time: DateTime::parse_from_rfc3339("2025-07-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
     };
 
     // Configure MockRedisClient for AI quota limited scenario


### PR DESCRIPTION
## Problem

We want to be able to parse Kafka message bodies concurrently, but first we need to know distinct IDs. Cookieless needs timestamps to generate distinct IDs, which right now it extracts from the message body.

## Changes

- Adds verification for the timestamp header in ingestion

## How did you test this code?

- Added unit tests
- Will verify metrics and logs on prod

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
