### PR TITLE
fix(self-host):Resolve NoCredentialsError by adding S3 env vars to web

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -105,6 +105,8 @@ services:
             OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
             OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
             SESSION_RECORDING_V2_S3_ENDPOINT: http://objectstorage:19000
+            SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: object_storage_root_user
+            SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: object_storage_root_password
             OBJECT_STORAGE_ENABLED: true
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             OTEL_SERVICE_NAME: 'posthog'


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
self-hosted version
posthog logs contain some error: "session_recording_v2_object_storage.read_failed ... error=NoCredentialsError('Unable to locate credentials') " 
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Discovering that there is no environment variable TEST or DEBUG during deployment, and the default `SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY` and `SESSION_RECORDING_V2_S3_ACCESS_KEY_ID` environment variables are empty, which can cause the 'Unable to locate credentials' error to occur
## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
