### PR TITLE
fix(experiments): handle sorting for computed status and duration fields

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -2,8 +2,8 @@ from enum import Enum
 from typing import Any, Literal
 
 from django.db.models import Case, F, Q, QuerySet, Value, When
+from django.db.models.functions import Now
 from django.dispatch import receiver
-from django.utils import timezone
 
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -499,7 +499,7 @@ class EnterpriseExperimentsViewSet(ForbidDestroyModel, TeamAndOrgViewSetMixin, v
                     computed_duration=Case(
                         When(start_date__isnull=True, then=Value(None)),
                         When(end_date__isnull=False, then=F("end_date") - F("start_date")),
-                        default=Value(timezone.now()) - F("start_date"),
+                        default=Now() - F("start_date"),
                     )
                 )
                 queryset = queryset.order_by(f"{'-' if order.startswith('-') else ''}computed_duration")


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/35397

## Problem
Sorting experiments table by `status` or `duration` fields throws error because these are computed fields that don't exist in the database model.

## Changes  
Added logic to handle sorting for `status` and `duration` by using db-level computations with Django ORM annotations.

## How did you test this code?
Locally tested that the error is no longer thrown.