### PR TITLE
chore: exchange log_entries tables

### DIFF
--- a/posthog/clickhouse/log_entries.py
+++ b/posthog/clickhouse/log_entries.py
@@ -91,7 +91,7 @@ INSERT_LOG_ENTRY_SQL = """
 INSERT INTO log_entries SELECT %(team_id)s, %(log_source)s, %(log_source_id)s, %(instance_id)s, %(timestamp)s, %(level)s, %(message)s, now(), 0
 """
 
-TRUNCATE_LOG_ENTRIES_TABLE_SQL = f"TRUNCATE TABLE IF EXISTS {LOG_ENTRIES_TABLE} {ON_CLUSTER_CLAUSE()}"
+TRUNCATE_LOG_ENTRIES_TABLE_SQL = f"TRUNCATE TABLE IF EXISTS {LOG_ENTRIES_SHARDED_TABLE} {ON_CLUSTER_CLAUSE()}"
 
 # Log entries rework
 

--- a/posthog/clickhouse/migrations/0143_log_entries_exchange.py
+++ b/posthog/clickhouse/migrations/0143_log_entries_exchange.py
@@ -1,0 +1,11 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.log_entries import LOG_ENTRIES_DISTRIBUTED_TABLE, LOG_ENTRIES_TABLE
+
+EXCHANGE_LOG_ENTRIES_SQL = f"""
+EXCHANGE TABLES {LOG_ENTRIES_TABLE} AND {LOG_ENTRIES_DISTRIBUTED_TABLE}
+"""
+
+operations = [
+    run_sql_with_exceptions(EXCHANGE_LOG_ENTRIES_SQL, node_roles=[NodeRole.DATA, NodeRole.COORDINATOR]),
+]

--- a/posthog/clickhouse/migrations/0143_log_entries_exchange.py
+++ b/posthog/clickhouse/migrations/0143_log_entries_exchange.py
@@ -6,6 +6,11 @@ EXCHANGE_LOG_ENTRIES_SQL = f"""
 EXCHANGE TABLES {LOG_ENTRIES_TABLE} AND {LOG_ENTRIES_DISTRIBUTED_TABLE}
 """
 
+DROP_LOG_ENTRIES_MV_SQL = f"""
+DROP VIEW {LOG_ENTRIES_TABLE}_mv
+"""
+
 operations = [
+    run_sql_with_exceptions(DROP_LOG_ENTRIES_MV_SQL, node_roles=[NodeRole.DATA]),
     run_sql_with_exceptions(EXCHANGE_LOG_ENTRIES_SQL, node_roles=[NodeRole.DATA, NodeRole.COORDINATOR]),
 ]


### PR DESCRIPTION
## Problem

We need to use the new distributed `log_entries` table.

## Changes

Exchange the tables so the change is transparent.

## How did you test this code?

Ran migrations locally to ensure the exchange is performed properly.


