### PR TITLE
fix: pass headers to normalize step correctly

### DIFF
--- a/plugin-server/src/ingestion/cookieless/cookieless-manager.ts
+++ b/plugin-server/src/ingestion/cookieless/cookieless-manager.ts
@@ -14,7 +14,14 @@ import * as siphashDouble from '@posthog/siphash/lib/siphash-double'
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
 import { cookielessRedisErrorCounter, eventDroppedCounter } from '../../main/ingestion-queues/metrics'
-import { CookielessServerHashMode, IncomingEventWithTeam, PipelineEvent, PluginsServerConfig, Team } from '../../types'
+import {
+    CookielessServerHashMode,
+    EventHeaders,
+    IncomingEventWithTeam,
+    PipelineEvent,
+    PluginsServerConfig,
+    Team,
+} from '../../types'
 import { ConcurrencyController } from '../../utils/concurrencyController'
 import { RedisOperationError } from '../../utils/db/error'
 import { TeamManager } from '../../utils/team-manager'
@@ -297,7 +304,7 @@ export class CookielessManager {
         for (const { event, team, message, headers } of events) {
             if (!event.properties?.[COOKIELESS_MODE_FLAG_PROPERTY]) {
                 // push the event as is, we don't need to do anything with it, but preserve the ordering
-                eventsWithStatus.push({ event, team, message })
+                eventsWithStatus.push({ event, team, message, headers })
                 continue
             }
 
@@ -400,6 +407,7 @@ export class CookielessManager {
                 event,
                 team,
                 message,
+                headers,
                 firstPass: {
                     timestampMs,
                     eventTimeZone,
@@ -605,7 +613,7 @@ export class CookielessManager {
         }
 
         // remove the extra processing state from the returned object
-        return eventsWithStatus.map(({ event, team, message }) => ({ event, team, message }))
+        return eventsWithStatus.map(({ event, team, message, headers }) => ({ event, team, message, headers }))
     }
 
     dropAllCookielessEvents(events: IncomingEventWithTeam[], dropCause: string): IncomingEventWithTeam[] {
@@ -630,6 +638,7 @@ type EventWithStatus = {
     message: Message
     event: PipelineEvent
     team: Team
+    headers: EventHeaders
     // Store temporary processing state. Nest the passes to make type-checking easier
     firstPass?: {
         timestampMs: number

--- a/plugin-server/src/ingestion/event-preprocessing/resolve-team.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/resolve-team.ts
@@ -41,6 +41,6 @@ export async function resolveTeam(
         event,
         team,
         message: incomingEvent.message,
-        headers: incomingEvent.headers,
+        headers: incomingEvent.headers || {},
     }
 }

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -680,7 +680,7 @@ export class IngestionConsumer {
         const groupedEvents: IncomingEventsByDistinctId = {}
 
         for (const eventWithTeam of messages) {
-            const { message, event, team } = eventWithTeam
+            const { message, event, team, headers } = eventWithTeam
             const token = event.token ?? ''
             const distinctId = event.distinct_id ?? ''
             const eventKey = `${token}:${distinctId}`
@@ -695,7 +695,7 @@ export class IngestionConsumer {
                 }
             }
 
-            groupedEvents[eventKey].events.push({ message, event, team })
+            groupedEvents[eventKey].events.push({ message, event, team, headers })
         }
 
         return groupedEvents

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1359,7 +1359,7 @@ export interface IncomingEventWithTeam {
     message: Message
     event: PipelineEvent
     team: Team
-    headers?: EventHeaders
+    headers: EventHeaders
 }
 
 export type RedisPool = GenericPool<Redis>

--- a/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
@@ -21,7 +21,7 @@ export function normalizeEventStep(
         timestamp = parseEventTimestamp(event)
 
         // Compare timestamp from headers with event.timestamp - they should be equal if implemented correctly
-        if (event.timestamp && headers) {
+        if (headers) {
             compareTimestamps(
                 event.timestamp,
                 headers,

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
@@ -23,6 +23,22 @@ describe('compareTimestamps', () => {
         }).not.toThrow()
     })
 
+    it('should handle missing event timestamp without throwing', () => {
+        expect(() => {
+            compareTimestamps(undefined, undefined, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+    })
+
+    it('should handle missing event timestamp with headers without throwing', () => {
+        const headers: EventHeaders = {
+            timestamp: '1672574400000', // 2023-01-01T12:00:00Z
+        }
+
+        expect(() => {
+            compareTimestamps(undefined, headers, 123, 'test-uuid', 'test-context')
+        }).not.toThrow()
+    })
+
     it('should handle missing timestamp header without throwing', () => {
         const headers: EventHeaders = {
             token: 'test-token',

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.ts
@@ -28,7 +28,7 @@ function shouldSampleLog(sampleRate: number): boolean {
  * Compare timestamp from headers with current parsing logic and log differences
  */
 export function compareTimestamps(
-    currentTimestamp: string,
+    currentTimestamp: string | undefined,
     headers: EventHeaders | undefined,
     teamId: number,
     eventUuid?: string,
@@ -36,6 +36,16 @@ export function compareTimestamps(
     loggingSampleRate: number = 0.0
 ): void {
     const contextLabel = context || 'timestamp_comparison'
+
+    if (!currentTimestamp) {
+        timestampComparisonCounter
+            .labels({
+                result: 'event_timestamp_missing',
+                context: contextLabel,
+            })
+            .inc()
+        return
+    }
 
     if (!headers?.timestamp) {
         timestampComparisonCounter

--- a/plugin-server/tests/ingestion/event-preprocessing/validate-event-uuid.test.ts
+++ b/plugin-server/tests/ingestion/event-preprocessing/validate-event-uuid.test.ts
@@ -36,6 +36,7 @@ describe('validateEventUuid', () => {
                 person_processing_opt_out: false,
             } as any,
             message: {} as any,
+            headers: {},
         }
 
         jest.clearAllMocks()


### PR DESCRIPTION
## Problem

We're not passing the headers to normalize correctly, so the timestamp comparison function is not returning any results.

## Changes

Fixes the headers in the event type.

## How did you test this code?

Added tests. 

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
