### PR TITLE
fix: Handle single quotes in exclude_events

### DIFF
--- a/posthog/api/test/test_search.py
+++ b/posthog/api/test/test_search.py
@@ -101,10 +101,9 @@ class TestSearch(APIBaseTest):
         response = self.client.get("/api/projects/@current/search?entities=insight")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.json()["results"][0]["extra_fields"],
-            {"name": None, "description": None, "query": None},
-        )
+        results = response.json()["results"]
+        for result in results:
+            self.assertEqual(set(result["extra_fields"].keys()), {"name", "description", "query"})
 
     def test_search_with_fully_invalid_query(self):
         response = self.client.get("/api/projects/@current/search?q=%3E")

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -420,6 +420,9 @@ class ClickHouseClient:
                     continue
 
                 if isinstance(value, list):
+                    # Encode lists of strings in case they contain single quotes.
+                    # This is intended only to handle `exclude_events` from batch
+                    # exports. A further refactor of this whole block is pending.
                     params[f"param_{key}"] = encode_clickhouse_data(value).decode("utf-8")
                 else:
                     params[f"param_{key}"] = str(value)

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -416,7 +416,12 @@ class ClickHouseClient:
         # TODO: Let clickhouse handle all parameter formatting.
         if query_parameters is not None:
             for key, value in query_parameters.items():
-                if key in query:
+                if key not in query:
+                    continue
+
+                if isinstance(value, list):
+                    params[f"param_{key}"] = encode_clickhouse_data(value).decode("utf-8")
+                else:
                     params[f"param_{key}"] = str(value)
         add_log_comment_param(params)
 

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -154,7 +154,7 @@ async def insert_event_values_in_clickhouse(
                 ],
             )
             break  # Success, exit the loop
-        except aiohttp.client_exceptions.ClientOSError:
+        except (aiohttp.client_exceptions.ClientOSError, aiohttp.client_exceptions.ServerDisconnectedError):
             if attempt >= max_attempts:
                 raise
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -61,7 +61,6 @@ NON_RETRYABLE_ERROR_TYPES = (
 FILE_FORMAT_EXTENSIONS = {
     "Parquet": "parquet",
     "JSONLines": "jsonl",
-    "Arrow": "arrow",
 }
 
 COMPRESSION_EXTENSIONS = {

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -61,6 +61,7 @@ NON_RETRYABLE_ERROR_TYPES = (
 FILE_FORMAT_EXTENSIONS = {
     "Parquet": "parquet",
     "JSONLines": "jsonl",
+    "Arrow": "arrow",
 }
 
 COMPRESSION_EXTENSIONS = {

--- a/products/batch_exports/backend/tests/temporal/destinations/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/conftest.py
@@ -10,7 +10,9 @@ from posthog.temporal.common.clickhouse import ClickHouseClient
 
 
 @retry(
-    retry=retry_if_exception_type(aiohttp.client_exceptions.ClientOSError),
+    retry=retry_if_exception_type(
+        (aiohttp.client_exceptions.ClientOSError, aiohttp.client_exceptions.ServerDisconnectedError)
+    ),
     # on attempts expired, raise the exception encountered in our code, not tenacity's retry error
     reraise=True,
     wait=wait_random_exponential(multiplier=0.2, max=3),

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -171,7 +171,10 @@ async def minio_client(bucket_name):
 
 async def assert_files_in_s3(s3_compatible_client, bucket_name, key_prefix, file_format, compression, json_columns):
     """Assert that there are files in S3 under key_prefix and return the combined contents, and the keys of files found."""
-    expected_file_extension = FILE_FORMAT_EXTENSIONS[file_format]
+    if file_format == "Arrow":
+        expected_file_extension = "arrow"
+    else:
+        expected_file_extension = FILE_FORMAT_EXTENSIONS[file_format]
     if compression is not None:
         expected_file_extension = f"{expected_file_extension}.{COMPRESSION_EXTENSIONS[compression]}"
 

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.test import override_settings
 
 import aioboto3
-import pyarrow.ipc as ipc
 import botocore.exceptions
 from flaky import flaky
 from temporalio import activity
@@ -197,7 +196,7 @@ async def assert_files_in_s3(s3_compatible_client, bucket_name, key_prefix, file
         elif file_format == "Arrow":
             s3_object = await s3_compatible_client.get_object(Bucket=bucket_name, Key=key)
             data = await s3_object["Body"].read()
-            s3_data.extend(ipc.RecordBatchStreamReader(data))
+            s3_data.extend(data)
         elif file_format == "JSONLines":
             s3_object = await s3_compatible_client.get_object(Bucket=bucket_name, Key=key)
             data = await s3_object["Body"].read()

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
@@ -8,12 +8,20 @@ import pytest
 from unittest import mock
 from unittest.mock import patch
 
+from django.conf import settings
+
 from posthog.batch_exports.service import BackfillDetails, BatchExportModel
 from posthog.temporal.common.clickhouse import ClickHouseClient
 
 from products.batch_exports.backend.temporal.pipeline.internal_stage import (
     BatchExportInsertIntoInternalStageInputs,
+    get_s3_staging_folder,
     insert_into_internal_stage_activity,
+)
+from products.batch_exports.backend.tests.temporal.destinations.test_s3_batch_export_workflow import (
+    assert_files_in_s3,
+    create_test_client,
+    delete_all_from_s3,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
@@ -196,4 +204,72 @@ async def test_insert_into_stage_activity_executes_the_expected_query_for_sessio
             "batch_export_id": insert_inputs.batch_export_id,
             "product": "batch_export",
         }
+    )
+
+
+@pytest.fixture
+async def minio_client():
+    """Manage an S3 client to interact with a MinIO bucket."""
+    async with create_test_client(
+        "s3",
+        aws_access_key_id="object_storage_root_user",
+        aws_secret_access_key="object_storage_root_password",
+    ) as minio_client:
+        yield minio_client
+
+        await delete_all_from_s3(minio_client, settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, key_prefix="")
+
+
+@pytest.mark.parametrize("interval", ["day", "every 5 minutes"], indirect=True)
+@pytest.mark.parametrize("exclude_events", [None, ["'"]])
+@pytest.mark.parametrize(
+    "model",
+    [
+        BatchExportModel(name="events", schema=None),
+    ],
+)
+@pytest.mark.parametrize("data_interval_end", [TEST_DATA_INTERVAL_END])
+async def test_insert_into_stage_activity_for_events_model(
+    generate_test_data,
+    interval,
+    activity_environment,
+    data_interval_start,
+    minio_client,
+    data_interval_end,
+    ateam,
+    model: BatchExportModel,
+    exclude_events,
+):
+    """Test that the insert_into_internal_stage_activity produces expected files in S3."""
+
+    include_events = None
+    batch_export_id = str(uuid.uuid4())
+
+    insert_inputs = BatchExportInsertIntoInternalStageInputs(
+        team_id=ateam.pk,
+        batch_export_id=batch_export_id,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        exclude_events=exclude_events,
+        include_events=include_events,
+        run_id=None,
+        batch_export_schema=None,
+        batch_export_model=model,
+        backfill_details=None,
+        destination_default_fields=None,
+    )
+
+    await activity_environment.run(insert_into_internal_stage_activity, insert_inputs)
+
+    await assert_files_in_s3(
+        minio_client,
+        bucket_name=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
+        key_prefix=get_s3_staging_folder(
+            batch_export_id,
+            data_interval_start=data_interval_start.isoformat(),
+            data_interval_end=data_interval_end.isoformat(),
+        ),
+        file_format="Arrow",
+        compression=None,
+        json_columns=None,
     )

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
@@ -221,6 +221,7 @@ async def minio_client():
 
 
 @pytest.mark.parametrize("interval", ["day", "every 5 minutes"], indirect=True)
+# single quotes in parameters have caused query formatting to break in the past
 @pytest.mark.parametrize("exclude_events", [None, ["'"]])
 @pytest.mark.parametrize(
     "model",


### PR DESCRIPTION
## Problem

Sometimes, for some reason, event names can contain single quotes. This is likely not something we should support upstream, but we do. The problem is that when these event names are used as `exclude_events` or `include_events` they can cause our query formatting to break, as we just relied on a very simple `str` call, without proper handling of quotes.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When a `list` parameter is passed to a query, the clickhouse client now escapes it using the `encode_clickhouse_data` function to correctly handle quotes.

To limit the scope of the change (and thus, the risk), this only affects `list` parameters, which should be just `exclude_events` and `include_events`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Our internal stage tests are lacking as they use a mock to execute clickhouse queries. I personally do not like mocks, especially when we have access to the real systems in our testing pipeline. 

So, I had to write a proper internal stage test and pass a `["'"]` as `exclude_events` to verify the fix. Without the fix applied, this test fails. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
