### PR TITLE
fix: configure SECURE_REFERRER_POLICY from environment variable

### DIFF
--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -21,6 +21,7 @@ SESSION_COOKIE_SECURE = secure_cookies
 CSRF_COOKIE_SECURE = secure_cookies
 SECURE_SSL_REDIRECT = secure_cookies
 SECURE_REDIRECT_EXEMPT = [r"^_health/?"]
+SECURE_REFERRER_POLICY = get_from_env("SECURE_REFERRER_POLICY", "same-origin")
 
 if get_from_env("DISABLE_SECURE_SSL_REDIRECT", False, type_cast=str_to_bool):
     SECURE_SSL_REDIRECT = False

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -2,8 +2,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="utf-8">
 
-<!-- Force document to use a safe-but-not-too-restrictive referrer policy -->
-<meta name="referrer" content="strict-origin-when-cross-origin" />
 
 <!-- Favicons & OS-theme configurations -->
 <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon.png?v=2023-07-07">


### PR DESCRIPTION
## Problem
The SECURE_REFERRER_POLICY environment variable was set to \`strict-origin-when-cross-origin\` but Django was still using the default \`same-origin\` policy.

## Root Cause
1. Django's SecurityMiddleware has a default value of \`same-origin\` for SECURE_REFERRER_POLICY
2. The environment variable wasn't being read because there was no explicit setting in Django settings
3. There was also a conflicting meta tag in the HTML template

## Solution
1. **Added SECURE_REFERRER_POLICY setting** to \`posthog/settings/access.py\` to read from environment variable
2. **Removed conflicting meta tag** from \`posthog/templates/head.html\` template
3. Now Django properly uses the environment variable value

## Testing
- Environment variable: \`SECURE_REFERRER_POLICY=strict-origin-when-cross-origin\` ✅
- Django setting now reads from env var ✅
- Meta tag conflict removed ✅

## Result
Django will now properly use \`strict-origin-when-cross-origin\` referrer policy instead of the default \`same-origin\`.