### PR TITLE
feat(cohorts): Cache Cohort dependencies

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import ClickhouseTestMixin, FuzzyInt, _create_event, _create_person, flush_persons_and_events
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
 
@@ -2773,7 +2773,8 @@ class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
         self.assertEqual(response.json()["feature_flag_key"], ff_key)
         return response
 
-    def test_create_exposure_cohort_for_experiment(self):
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_create_exposure_cohort_for_experiment(self, patch_on_commit: MagicMock):
         response = self._generate_experiment("2024-01-01T10:23")
 
         created_experiment = response.json()["id"]
@@ -2852,7 +2853,8 @@ class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(["person1", "person2"], sorted([res["name"] for res in response.json()["results"]]))
 
-    def test_create_exposure_cohort_for_experiment_with_custom_event_exposure(self):
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_create_exposure_cohort_for_experiment_with_custom_event_exposure(self, patch_on_commit: MagicMock):
         self.maxDiff = None
 
         cohort_extra = Cohort.objects.create(
@@ -2998,7 +3000,10 @@ class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(["person1", "person2"], sorted([res["name"] for res in response.json()["results"]]))
 
-    def test_create_exposure_cohort_for_experiment_with_custom_action_filters_exposure(self):
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_create_exposure_cohort_for_experiment_with_custom_action_filters_exposure(
+        self, patch_on_commit: MagicMock
+    ):
         cohort_extra = Cohort.objects.create(
             team=self.team,
             filters={

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -60,7 +60,7 @@ from posthog.models.activity_logging.activity_log import (
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.cohort import DEFAULT_COHORT_INSERT_BATCH_SIZE, CohortOrEmpty
-from posthog.models.cohort.util import get_dependent_cohorts, print_cohort_hogql_query
+from posthog.models.cohort.util import get_all_cohort_dependencies, print_cohort_hogql_query
 from posthog.models.cohort.validation import CohortTypeValidationSerializer
 from posthog.models.feature_flag.flag_matching import (
     FeatureFlagMatcher,
@@ -554,12 +554,12 @@ class CohortSerializer(serializers.ModelSerializer):
 
     def _validate_nested_cohort_behavioral_filters(self, prop: Any, cohort_used_in_flags: bool):
         nested_cohort = Cohort.objects.get(pk=prop.value, team__project_id=self.context["project_id"])
-        dependent_cohorts = get_dependent_cohorts(nested_cohort)
+        dependency_cohorts = get_all_cohort_dependencies(nested_cohort)
 
-        for dependent_cohort in [nested_cohort, *dependent_cohorts]:
-            if cohort_used_in_flags and any(p.type == "behavioral" for p in dependent_cohort.properties.flat):
+        for dependency_cohort in [nested_cohort, *dependency_cohorts]:
+            if cohort_used_in_flags and any(p.type == "behavioral" for p in dependency_cohort.properties.flat):
                 raise serializers.ValidationError(
-                    detail=f"A dependent cohort ({dependent_cohort.name}) has filters based on events. These cohorts can't be used in feature flags.",
+                    detail=f"A cohort dependency ({dependency_cohort.name}) has filters based on events. These cohorts can't be used in feature flags.",
                     code="behavioral_cohort_found",
                 )
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -44,7 +44,7 @@ from posthog.models.activity_logging.activity_log import Detail, changes_between
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.activity_logging.model_activity import ImpersonatedContext
 from posthog.models.cohort import Cohort
-from posthog.models.cohort.util import get_dependent_cohorts
+from posthog.models.cohort.util import get_all_cohort_dependencies
 from posthog.models.experiment import Experiment
 from posthog.models.feature_flag import FeatureFlagDashboards, get_all_feature_flags, get_user_blast_radius
 from posthog.models.feature_flag.flag_analytics import increment_request_count
@@ -328,8 +328,8 @@ class FeatureFlagSerializer(
                         initial_cohort: Cohort = Cohort.objects.get(
                             pk=prop.value, team__project_id=self.context["project_id"]
                         )
-                        dependent_cohorts = get_dependent_cohorts(initial_cohort)
-                        for cohort in [initial_cohort, *dependent_cohorts]:
+                        dependency_cohorts = get_all_cohort_dependencies(initial_cohort)
+                        for cohort in [initial_cohort, *dependency_cohorts]:
                             if [prop for prop in cohort.properties.flat if prop.type == "behavioral"]:
                                 raise serializers.ValidationError(
                                     detail=f"Cohort '{cohort.name}' with filters on events cannot be used in feature flags.",

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -2213,7 +2213,7 @@ email@example.org,
             {
                 "type": "validation_error",
                 "code": "behavioral_cohort_found",
-                "detail": "A dependent cohort (cohort XX) has filters based on events. These cohorts can't be used in feature flags.",
+                "detail": "A cohort dependency (cohort XX) has filters based on events. These cohorts can't be used in feature flags.",
                 "attr": "filters",
             },
             response.json(),

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -111,10 +111,13 @@ class TestCohort(TestExportMixin, ClickhouseTestMixin, APIBaseTest, QueryMatchin
         assert cohort1.is_calculating is True
         assert cohort1 not in get_cohort_calculation_candidates_queryset()
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay", side_effect=calculate_cohort_ch)
     @patch("posthog.models.cohort.util.sync_execute", side_effect=sync_execute)
-    def test_creating_update_and_calculating(self, patch_sync_execute, patch_calculate_cohort, patch_capture):
+    def test_creating_update_and_calculating(
+        self, patch_sync_execute, patch_calculate_cohort, patch_capture, patch_on_commit
+    ):
         self.team.app_urls = ["http://somewebsite.com"]
         self.team.save()
         Person.objects.create(team=self.team, properties={"team_id": 5})
@@ -188,10 +191,11 @@ class TestCohort(TestExportMixin, ClickhouseTestMixin, APIBaseTest, QueryMatchin
             },
         )
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay", side_effect=calculate_cohort_ch)
     @patch("posthog.models.cohort.util.sync_execute", side_effect=sync_execute)
-    def test_action_persons_on_events(self, patch_sync_execute, patch_calculate_cohort, patch_capture):
+    def test_action_persons_on_events(self, patch_sync_execute, patch_calculate_cohort, patch_capture, patch_on_commit):
         materialize("person", "favorite_number", table_column="properties")
         self.team.modifiers = {"personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS}
         self.team.save()
@@ -884,10 +888,12 @@ user789
 
         csv = SimpleUploadedFile(
             "test.csv",
-            str.encode("""distinct_id
+            str.encode(
+                """distinct_id
 user123
 user456
-"""),
+"""
+            ),
             content_type="application/csv",
         )
 
@@ -933,9 +939,12 @@ user456
         calculating_cohorts = Cohort.objects.filter(team=self.team, name="test_error", is_calculating=True)
         self.assertEqual(calculating_cohorts.count(), 0, "No cohort should be left in calculating state after error")
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
-    def test_static_cohort_to_dynamic_cohort(self, patch_calculate_cohort, patch_calculate_cohort_from_list):
+    def test_static_cohort_to_dynamic_cohort(
+        self, patch_calculate_cohort, patch_calculate_cohort_from_list, patch_on_commit
+    ):
         self.team.app_urls = ["http://somewebsite.com"]
         self.team.save()
         Person.objects.create(team=self.team, properties={"email": "email@example.org"})
@@ -1218,7 +1227,8 @@ email@example.org,
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], regular_cohort.id)
 
-    def test_cohort_activity_log(self):
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_cohort_activity_log(self, patch_on_commit):
         self.team.app_urls = ["http://somewebsite.com"]
         self.team.save()
         Person.objects.create(team=self.team, properties={"prop": 5})
@@ -1451,12 +1461,13 @@ email@example.org,
         response = self.client.get(f"/api/cohort/{cohort.pk}/persons")
         self.assertEqual(len(response.json()["results"]), 2, response)
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.chain")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.si")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
     def test_creating_update_and_calculating_with_cycle(
-        self, patch_calculate_cohort_delay, patch_calculate_cohort_si, patch_chain, patch_capture
+        self, patch_calculate_cohort_delay, patch_calculate_cohort_si, patch_chain, patch_capture, patch_on_commit
     ):
         mock_chain_instance = MagicMock()
         patch_chain.return_value = mock_chain_instance
@@ -1568,12 +1579,13 @@ email@example.org,
         )
         self.assertEqual(get_total_calculation_calls(), 3)
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.chain")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.si")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
     def test_creating_update_with_non_directed_cycle(
-        self, patch_calculate_cohort_delay, patch_calculate_cohort_si, patch_chain, patch_capture
+        self, patch_calculate_cohort_delay, patch_calculate_cohort_si, patch_chain, patch_capture, patch_on_commit
     ):
         mock_chain_instance = MagicMock()
         patch_chain.return_value = mock_chain_instance
@@ -1645,9 +1657,12 @@ email@example.org,
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(get_total_calculation_calls(), 4)
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
-    def test_creating_update_and_calculating_with_invalid_cohort(self, patch_calculate_cohort, patch_capture):
+    def test_creating_update_and_calculating_with_invalid_cohort(
+        self, patch_calculate_cohort, patch_capture, patch_on_commit
+    ):
         # Cohort A
         response_a = self.client.post(
             f"/api/projects/{self.team.id}/cohorts",
@@ -1670,8 +1685,9 @@ email@example.org,
         )
         self.assertEqual(patch_calculate_cohort.call_count, 1)
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
-    def test_creating_update_and_calculating_with_new_cohort_filters(self, patch_capture):
+    def test_creating_update_and_calculating_with_new_cohort_filters(self, patch_capture, patch_on_commit):
         _create_person(
             distinct_ids=["p1"],
             team_id=self.team.pk,
@@ -1748,8 +1764,9 @@ email@example.org,
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(2, len(response.json()["results"]))
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
-    def test_calculating_with_new_cohort_event_filters(self, patch_capture):
+    def test_calculating_with_new_cohort_event_filters(self, patch_capture, patch_on_commit):
         _create_person(
             distinct_ids=["p1"],
             team_id=self.team.pk,
@@ -1993,8 +2010,9 @@ email@example.org,
             query_get_response.json()["errors_calculating"], 1
         )  # Should be because selecting from groups is not allowed
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
-    def test_cohort_with_is_set_filter_missing_value(self, patch_capture):
+    def test_cohort_with_is_set_filter_missing_value(self, patch_capture, patch_on_commit):
         # regression test: Removing `value` was silently failing
 
         _create_person(
@@ -2219,7 +2237,8 @@ email@example.org,
             response.json(),
         )
 
-    def test_duplicating_dynamic_cohort_as_static(self):
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    def test_duplicating_dynamic_cohort_as_static(self, patch_on_commit):
         _create_person(
             distinct_ids=["p1"],
             team_id=self.team.pk,
@@ -2621,8 +2640,9 @@ email@example.org,
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["detail"], "Missing required keys for cohort filter: value")
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     @patch("posthog.api.cohort.report_user_action")
-    def test_behavioral_filter_with_operator_and_operator_value(self, patch_capture):
+    def test_behavioral_filter_with_operator_and_operator_value(self, patch_capture, patch_on_commit):
         # Valid usage: operator and operator_value present
         response = self.client.post(
             f"/api/projects/{self.team.id}/cohorts",
@@ -3012,6 +3032,33 @@ email@example.org,
         assert response.status_code == 404
         assert "Person is not part of the cohort" in response.json()["detail"]
 
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    @patch("posthog.models.cohort.dependencies._on_cohort_changed")
+    @patch("posthog.tasks.calculate_cohort.increment_version_and_enqueue_calculate_cohort")
+    def test_cohort_update_recalculated_after_caching(
+        self,
+        patch_calculate: MagicMock,
+        patch_cohort_changed: MagicMock,
+        patch_on_commit: MagicMock,
+    ) -> None:
+        calls = []
+        patch_calculate.side_effect = lambda *a, **kw: calls.append(patch_calculate)
+        patch_cohort_changed.side_effect = lambda *a, **kw: calls.append(patch_cohort_changed)
+
+        response_a = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={"name": "cohort A", "groups": [{"properties": {"team_id": 5}}]},
+        )
+        response_b = self.client.patch(
+            f"/api/projects/{self.team.id}/cohorts/{response_a.json()['id']}",
+            data={"name": "cohort A", "groups": [{"properties": [{"key": "email", "value": "email@example.org"}]}]},
+        )
+
+        self.assertEqual(response_b.status_code, 200, response_a.json())
+        self.assertEqual(patch_cohort_changed.call_count, 2)
+        self.assertEqual(patch_calculate.call_count, 2)
+        self.assertEqual(calls, [patch_cohort_changed, patch_calculate, patch_cohort_changed, patch_calculate])
+
 
 class TestCalculateCohortCommand(APIBaseTest):
     def test_calculate_cohort_command_success(self):
@@ -3063,7 +3110,8 @@ class TestCalculateCohortCommand(APIBaseTest):
 
 
 def create_cohort(client: Client, team_id: int, name: str, groups: list[dict[str, Any]]):
-    return client.post(f"/api/projects/{team_id}/cohorts", {"name": name, "groups": json.dumps(groups)})
+    with patch("django.db.transaction.on_commit", side_effect=lambda func: func()):
+        return client.post(f"/api/projects/{team_id}/cohorts", {"name": name, "groups": json.dumps(groups)})
 
 
 def create_cohort_ok(client: Client, team_id: int, name: str, groups: list[dict[str, Any]]):

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -1,0 +1,131 @@
+from django.core.cache import cache
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from structlog import get_logger
+
+from posthog.models.cohort.cohort import Cohort
+from posthog.models.team.team import Team
+
+logger = get_logger(__name__)
+DEPENDENCY_CACHE_TIMEOUT = 7 * 24 * 60 * 60  # 1 week
+
+
+def _cohort_dependencies_key(cohort_id: int) -> str:
+    return f"cohort:dependencies:{cohort_id}"
+
+
+def _cohort_dependents_key(cohort_id: int) -> str:
+    return f"cohort:dependents:{cohort_id}"
+
+
+def extract_cohort_dependencies(cohort: Cohort) -> set[int]:
+    """
+    Extract cohort dependencies from the given cohort.
+    """
+    dependencies = set()
+    if not cohort.deleted:
+        for prop in cohort.properties.flat:
+            if prop.type == "cohort" and isinstance(prop.value, int) and prop.value != cohort.id:
+                dependencies.add(prop.value)
+    return dependencies
+
+
+def get_cohort_dependencies(cohort: Cohort) -> list[int]:
+    """
+    Get the list of cohort IDs that the given cohort depends on.
+    """
+    cache_key = _cohort_dependencies_key(cohort.id)
+    result = cache.get_or_set(
+        cache_key,
+        lambda: list(extract_cohort_dependencies(cohort)),
+        timeout=DEPENDENCY_CACHE_TIMEOUT,
+    )
+    if result is None:
+        logger.error("Cohort dependencies cache returned None", cohort_id=cohort.id)
+    return result or []
+
+
+def get_cohort_dependents(cohort: Cohort) -> list[int]:
+    """
+    Get the list of cohort IDs that depend on the given cohort.
+    """
+    cache_key = _cohort_dependents_key(cohort.id)
+
+    def compute_or_fallback() -> list[int]:
+        warm_team_cohort_dependency_cache(cohort.team_id)
+        return cache.get(cache_key, [])
+
+    result = cache.get_or_set(cache_key, lambda: compute_or_fallback(), timeout=DEPENDENCY_CACHE_TIMEOUT)
+    if result is None:
+        logger.error("Cohort dependents cache returned None", cohort_id=cohort.id)
+    return result or []
+
+
+def warm_team_cohort_dependency_cache(team_id: int, batch_size: int = 1000):
+    """
+    Preloads the cohort dependencies and dependents cache for a given team.
+    """
+    dependents_map: dict[str, list[int]] = {}
+    for cohort in Cohort.objects.filter(team_id=team_id, deleted=False).iterator(chunk_size=batch_size):
+        # Any invalidated dependencies cache is rebuilt here
+        dependents_map.setdefault(_cohort_dependents_key(cohort.id), [])
+        dependencies = get_cohort_dependencies(cohort)
+        # Dependency keys aren't fully invalidated; make sure they don't expire.
+        cache.touch(_cohort_dependencies_key(cohort.id), timeout=DEPENDENCY_CACHE_TIMEOUT)
+        # Build reverse map
+        for dep_id in dependencies:
+            dependents_map.setdefault(_cohort_dependents_key(dep_id), []).append(cohort.id)
+    cache.set_many(dependents_map, timeout=DEPENDENCY_CACHE_TIMEOUT)
+
+
+def _on_cohort_changed(cohort: Cohort, always_invalidate: bool = False):
+    new_dependencies = extract_cohort_dependencies(cohort)
+    existing_dependencies = cache.get(_cohort_dependencies_key(cohort.id))
+    dependencies_changed = existing_dependencies is None or set(existing_dependencies) != new_dependencies
+
+    # If the dependencies haven't changed, no need to refresh the cache
+    if not always_invalidate and not cohort.deleted and not dependencies_changed:
+        return
+
+    cache.delete(_cohort_dependencies_key(cohort.id))
+    cache.delete(_cohort_dependents_key(cohort.id))
+
+    if existing_dependencies:
+        for dep_id in existing_dependencies:
+            cache.delete(_cohort_dependents_key(dep_id))
+
+    warm_team_cohort_dependency_cache(cohort.team_id)
+
+
+@receiver(post_save, sender=Cohort)
+def cohort_changed(sender, instance, **kwargs):
+    """
+    Clear and rebuild dependency caches when cohort changes.
+    """
+
+    transaction.on_commit(lambda: _on_cohort_changed(instance))
+
+
+@receiver(post_delete, sender=Cohort)
+def cohort_deleted(sender, instance, **kwargs):
+    """
+    Clear and rebuild dependency caches when cohort is deleted.
+    """
+    transaction.on_commit(lambda: _on_cohort_changed(instance, always_invalidate=True))
+
+
+@receiver(post_delete, sender=Team)
+def clear_team_cohort_dependency_cache(sender, instance: Team, **kwargs):
+    """
+    Clear cohort dependency caches for all cohorts belonging to the deleted team.
+    """
+
+    def clear_cache():
+        team_cohorts = Cohort.objects.filter(team=instance, deleted=False).values_list("id", flat=True)
+        for cohort_id in team_cohorts:
+            cache.delete(_cohort_dependencies_key(cohort_id))
+            cache.delete(_cohort_dependents_key(cohort_id))
+
+    transaction.on_commit(clear_cache)

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -1,0 +1,285 @@
+from posthog.test.base import BaseTest
+from pytest import fixture
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+
+from parameterized import parameterized
+
+from posthog.models import Cohort
+from posthog.models.cohort.dependencies import (
+    DEPENDENCY_CACHE_TIMEOUT,
+    get_cohort_dependencies,
+    get_cohort_dependents,
+    warm_team_cohort_dependency_cache,
+)
+
+
+class TestCohortDependencies(BaseTest):
+    def _create_cohort(self, name: str, **kwargs):
+        return Cohort.objects.create(name=name, team=self.team, **kwargs)
+
+    def _assert_depends_on(self, dependent_cohort: Cohort, dependency_cohort: Cohort) -> None:
+        self.assertEqual(cache.get(f"cohort:dependencies:{dependent_cohort.id}"), [dependency_cohort.id])
+        self.assertEqual(cache.get(f"cohort:dependents:{dependency_cohort.id}"), [dependent_cohort.id])
+        self.assertEqual(list(get_cohort_dependencies(dependent_cohort)), [dependency_cohort.id])
+        self.assertEqual(list(get_cohort_dependents(dependency_cohort)), [dependent_cohort.id])
+
+    def _assert_cohorts_have_no_relationships(self, *cohorts: Cohort) -> None:
+        for cohort in cohorts:
+            self.assertEqual(len(get_cohort_dependencies(cohort)), 0, f"Expected no dependencies for {cohort.name}")
+            self.assertEqual(len(get_cohort_dependents(cohort)), 0, f"Expected no dependents for {cohort.name}")
+
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+
+    @fixture(autouse=True)
+    def mock_transaction(self):
+        with mock.patch("django.db.transaction.on_commit", side_effect=lambda func: func()):
+            yield
+
+    def test_cohort_dependency_created(self) -> None:
+        """
+        When a new cohort is created including a property that references another cohort,
+        a dependency should be created.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        self._assert_depends_on(cohort_b, cohort_a)
+
+    def test_cohort_dependency_updated(self) -> None:
+        """
+        When a cohort's properties are updated to add a dependency, the dependency should be created.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(name="Test Cohort B")
+
+        self._assert_cohorts_have_no_relationships(cohort_a, cohort_b)
+
+        cohort_b.groups = [{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        cohort_b.save()
+
+        self._assert_depends_on(cohort_b, cohort_a)
+
+    def test_cohorts_dependency_updated_delete(self) -> None:
+        """
+        When a cohort's properties are updated to remove a dependency, the dependency should be removed.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        self._assert_depends_on(cohort_b, cohort_a)
+
+        cohort_b.groups = [{"properties": {}}]
+        cohort_b.save()
+
+        self._assert_cohorts_have_no_relationships(cohort_a, cohort_b)
+
+    def test_cohort_dependency_updated_changed(self) -> None:
+        """
+        When a cohort's properties are updated to change a dependency, the dependency should be updated.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A", groups=[])
+        cohort_b = self._create_cohort(name="Test Cohort B", groups=[])
+        cohort_c = self._create_cohort(
+            name="Test Cohort C", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        self._assert_depends_on(cohort_c, cohort_a)
+        self._assert_cohorts_have_no_relationships(cohort_b)
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_a.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), [cohort_c.id])
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_b.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_c.id}"), [cohort_a.id])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_c.id}"), [])
+
+        cohort_c.groups = [{"properties": [{"key": "id", "type": "cohort", "value": cohort_b.id}]}]
+        cohort_c.save()
+
+        self._assert_depends_on(cohort_c, cohort_b)
+        self._assert_cohorts_have_no_relationships(cohort_a)
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_a.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), [])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_b.id}"), [cohort_c.id])
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_c.id}"), [cohort_b.id])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_c.id}"), [])
+
+    def test_cohort_dependency_deleted(self) -> None:
+        """
+        When a cohort is deleted, its dependencies should be removed.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        self._assert_depends_on(cohort_b, cohort_a)
+
+        cohort_b.delete()
+
+        self._assert_cohorts_have_no_relationships(cohort_a)
+
+    def test_cohort_soft_delete(self) -> None:
+        """
+        When a cohort is soft deleted, its dependencies are be retained, though its dependencies
+        are not cached.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        self._assert_depends_on(cohort_b, cohort_a)
+
+        cohort_a.deleted = True
+        cohort_a.save()
+
+        # The dependency is still intact via Cohort B's props
+        # You must filter out deleted cohorts
+        self._assert_depends_on(cohort_b, cohort_a)
+
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_a.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), [cohort_b.id])
+
+    def test_cohort_team_deleted(self) -> None:
+        """
+        When a team is deleted, its cohorts should be deleted.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        self._assert_depends_on(cohort_b, cohort_a)
+
+        self.team.delete()
+
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_a.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_b.id}"), None)
+
+    def test_warm_team_cohort_dependency_cache(self) -> None:
+        """
+        When a team is warmed up, its cohorts should have their dependencies cached.
+        """
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        cache.clear()
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_a.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_b.id}"), None)
+
+        warm_team_cohort_dependency_cache(self.team.id)
+
+        self._assert_depends_on(cohort_b, cohort_a)
+
+    @parameterized.expand(
+        [
+            (1,),  # Process one cohort at a time
+            (2,),  # Process two cohorts at a time
+            (5,),  # Process five cohorts at a time
+            (100,),  # Process more than the number of cohorts
+        ]
+    )
+    def test_warm_team_cohort_dependency_cache_batching(self, batch_size: int) -> None:
+        cohorts: list[Cohort] = []
+        for i in range(5):
+            if i == 0:
+                cohort = self._create_cohort(name=f"Base Cohort {i}")
+            else:
+                cohort = self._create_cohort(
+                    name=f"Dependent Cohort {i}",
+                    groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohorts[i - 1].id}]}],
+                )
+            cohorts.append(cohort)
+
+        cache.clear()
+
+        for cohort in cohorts:
+            self.assertEqual(cache.get(f"cohort:dependencies:{cohort.id}"), None)
+            self.assertEqual(cache.get(f"cohort:dependents:{cohort.id}"), None)
+
+        warm_team_cohort_dependency_cache(self.team.id, batch_size=batch_size)
+
+        for i, cohort in enumerate(cohorts):
+            if i == 0:
+                self.assertEqual(cache.get(f"cohort:dependencies:{cohort.id}"), [])
+                self.assertEqual(cache.get(f"cohort:dependents:{cohort.id}"), [cohorts[1].id])
+            elif i == len(cohorts) - 1:
+                self.assertEqual(cache.get(f"cohort:dependencies:{cohort.id}"), [cohorts[i - 1].id])
+                self.assertEqual(cache.get(f"cohort:dependents:{cohort.id}"), [])
+            else:
+                self.assertEqual(cache.get(f"cohort:dependencies:{cohort.id}"), [cohorts[i - 1].id])
+                self.assertEqual(cache.get(f"cohort:dependents:{cohort.id}"), [cohorts[i + 1].id])
+
+    def test_warm_team_cohort_dependency_cache_refreshes_ttl(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        # Warm the cache initially
+        warm_team_cohort_dependency_cache(self.team.id)
+
+        # Mock cache.touch and cache.set_many to verify TTL refresh
+        with mock.patch.object(cache, "touch") as mock_touch, mock.patch.object(cache, "set_many") as mock_set_many:
+            # Call warm again - should refresh TTL
+            warm_team_cohort_dependency_cache(self.team.id)
+
+            # Verify touch was called for dependency keys
+            expected_dependency_keys = [
+                f"cohort:dependencies:{cohort_a.id}",
+                f"cohort:dependencies:{cohort_b.id}",
+            ]
+
+            for key in expected_dependency_keys:
+                mock_touch.assert_any_call(key, timeout=DEPENDENCY_CACHE_TIMEOUT)
+
+            # Verify set_many was called with timeout for dependents
+            self.assertTrue(mock_set_many.called)
+            args, kwargs = mock_set_many.call_args
+            self.assertEqual(kwargs.get("timeout"), DEPENDENCY_CACHE_TIMEOUT)
+
+    def test_cache_miss_get_cohort_dependencies(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        cache.clear()
+
+        self.assertEqual(get_cohort_dependencies(cohort_b), [cohort_a.id])
+
+        # get_cohort_dependencies is cheap - it doesn't need to warm the entire cache
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_a.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependencies:{cohort_b.id}"), [cohort_a.id])
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_a.id}"), None)
+        self.assertEqual(cache.get(f"cohort:dependents:{cohort_b.id}"), None)
+
+    def test_cache_miss_get_cohort_dependents(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        cache.clear()
+
+        self.assertEqual(get_cohort_dependents(cohort_a), [cohort_b.id])
+
+        # get_cohort_dependents is a more expensive cache miss, it warms the entire cache because
+        # it has to iterate all cohorts in the team
+        self._assert_depends_on(cohort_b, cohort_a)

--- a/posthog/models/cohort/test/test_util.py
+++ b/posthog/models/cohort/test/test_util.py
@@ -4,7 +4,7 @@ from posthog.hogql.hogql import HogQLContext
 
 from posthog.models.cohort import Cohort, CohortOrEmpty
 from posthog.models.cohort.util import (
-    get_dependent_cohorts,
+    get_all_cohort_dependencies,
     print_cohort_hogql_query,
     simplified_cohort_filter_properties,
     sort_cohorts_topologically,
@@ -387,7 +387,7 @@ class TestDependentCohorts(BaseTest):
             groups=[{"properties": [{"key": "name", "value": "test", "type": "person"}]}],
         )
 
-        self.assertEqual(get_dependent_cohorts(cohort), [])
+        self.assertEqual(get_all_cohort_dependencies(cohort), [])
 
     def test_dependent_cohorts_for_nested_cohort(self):
         cohort1 = _create_cohort(
@@ -402,8 +402,8 @@ class TestDependentCohorts(BaseTest):
             groups=[{"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}]}],
         )
 
-        self.assertEqual(get_dependent_cohorts(cohort1), [])
-        self.assertEqual(get_dependent_cohorts(cohort2), [cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort1), [])
+        self.assertEqual(get_all_cohort_dependencies(cohort2), [cohort1])
 
     def test_dependent_cohorts_for_deeply_nested_cohort(self):
         cohort1 = _create_cohort(
@@ -435,9 +435,9 @@ class TestDependentCohorts(BaseTest):
             ],
         )
 
-        self.assertEqual(get_dependent_cohorts(cohort1), [])
-        self.assertEqual(get_dependent_cohorts(cohort2), [cohort1])
-        self.assertEqual(get_dependent_cohorts(cohort3), [cohort2, cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort1), [])
+        self.assertEqual(get_all_cohort_dependencies(cohort2), [cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort3), [cohort2, cohort1])
 
     def test_dependent_cohorts_for_circular_nested_cohort(self):
         cohort1 = _create_cohort(
@@ -472,9 +472,9 @@ class TestDependentCohorts(BaseTest):
         cohort1.groups = [{"properties": [{"key": "id", "value": cohort3.pk, "type": "cohort"}]}]
         cohort1.save()
 
-        self.assertEqual(get_dependent_cohorts(cohort3), [cohort2, cohort1])
-        self.assertEqual(get_dependent_cohorts(cohort2), [cohort1, cohort3])
-        self.assertEqual(get_dependent_cohorts(cohort1), [cohort3, cohort2])
+        self.assertEqual(get_all_cohort_dependencies(cohort3), [cohort2, cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort2), [cohort1, cohort3])
+        self.assertEqual(get_all_cohort_dependencies(cohort1), [cohort3, cohort2])
 
     def test_dependent_cohorts_for_complex_nested_cohort(self):
         cohort1 = _create_cohort(
@@ -554,11 +554,11 @@ class TestDependentCohorts(BaseTest):
             ],
         )
 
-        self.assertEqual(get_dependent_cohorts(cohort1), [])
-        self.assertEqual(get_dependent_cohorts(cohort2), [cohort1])
-        self.assertEqual(get_dependent_cohorts(cohort3), [cohort2, cohort1])
-        self.assertEqual(get_dependent_cohorts(cohort4), [cohort1])
-        self.assertEqual(get_dependent_cohorts(cohort5), [cohort4, cohort1, cohort2])
+        self.assertEqual(get_all_cohort_dependencies(cohort1), [])
+        self.assertEqual(get_all_cohort_dependencies(cohort2), [cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort3), [cohort2, cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort4), [cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort5), [cohort4, cohort1, cohort2])
 
     def test_dependent_cohorts_ignore_invalid_ids(self):
         cohort1 = _create_cohort(
@@ -593,8 +593,8 @@ class TestDependentCohorts(BaseTest):
             ],
         )
 
-        self.assertEqual(get_dependent_cohorts(cohort2), [cohort1])
-        self.assertEqual(get_dependent_cohorts(cohort3), [cohort2, cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort2), [cohort1])
+        self.assertEqual(get_all_cohort_dependencies(cohort3), [cohort2, cohort1])
 
 
 class TestSortCohortsTopologically(BaseTest):
@@ -619,7 +619,7 @@ class TestSortCohortsTopologically(BaseTest):
             groups=[{"properties": [{"key": "id", "value": MISSING_COHORT_ID, "type": "cohort"}]}],
         )
 
-        dependent_cohorts = get_dependent_cohorts(cohort)
+        dependent_cohorts = get_all_cohort_dependencies(cohort)
         all_cohort_ids = {dep.id for dep in dependent_cohorts}
         all_cohort_ids.add(cohort.id)
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -497,7 +497,7 @@ def get_all_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> list[int]:
     return [*cohort_ids, *static_cohort_ids]
 
 
-def get_dependent_cohorts(
+def get_all_cohort_dependencies(
     cohort: Cohort,
     using_database: str = "default",
     seen_cohorts_cache: Optional[dict[int, CohortOrEmpty]] = None,

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -326,7 +326,7 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
         seen_cohorts_cache: Optional[dict[int, CohortOrEmpty]] = None,
         sort_by_topological_order=False,
     ) -> list[int]:
-        from posthog.models.cohort.util import get_dependent_cohorts, sort_cohorts_topologically
+        from posthog.models.cohort.util import get_all_cohort_dependencies, sort_cohorts_topologically
 
         if seen_cohorts_cache is None:
             seen_cohorts_cache = {}
@@ -351,8 +351,8 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
                         cohort_ids.add(cohort.pk)
                         cohort_ids.update(
                             [
-                                dependent_cohort.pk
-                                for dependent_cohort in get_dependent_cohorts(
+                                dependency_cohort.pk
+                                for dependency_cohort in get_all_cohort_dependencies(
                                     cohort,
                                     using_database=using_database,
                                     seen_cohorts_cache=seen_cohorts_cache,

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -18,7 +18,7 @@ from posthog.clickhouse.query_tagging import QueryTags, update_tags
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Cohort
 from posthog.models.cohort import CohortOrEmpty
-from posthog.models.cohort.util import get_dependent_cohorts, sort_cohorts_topologically
+from posthog.models.cohort.util import get_all_cohort_dependencies, sort_cohorts_topologically
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.tasks.utils import CeleryQueue
@@ -185,7 +185,7 @@ def enqueue_cohorts_to_calculate(parallel_count: int) -> None:
 
 
 def increment_version_and_enqueue_calculate_cohort(cohort: Cohort, *, initiating_user: Optional[User]) -> None:
-    dependent_cohorts = get_dependent_cohorts(cohort)
+    dependent_cohorts = get_all_cohort_dependencies(cohort)
     if dependent_cohorts:
         logger.info("cohort_has_dependencies", cohort_id=cohort.id, dependent_count=len(dependent_cohorts))
 


### PR DESCRIPTION
## Problem

This change introduces caching to forward and reverse dependency lookups for Cohorts. Identifying which Cohorts depend on any other given Cohort is an expensive calculation because it requires checking the properties of every other Cohort in the team.

This change is related to #36134. This PR focuses on cache warming and maintenance and a separate follow-up PR will implement usage of this cache for dependency recalculation.

## Changes
This PR introduces three main components:

1. Cohort dependency cache management module (`posthog/models/cohort/dependencies.py`)
2. Celery tasks for cache prewarming (`posthog/tasks/cohort_dependencies.py`)
    - Scheduled task that runs daily at 2 AM to warm caches for teams with many cohorts (>=50)
    - Prometheus metric to monitor active warming chains, for fine tuning if necessary
3. Renamed `get_dependent_cohorts` to `get_all_dependency_cohorts` for clarity

## How did you test this code?

Added automated tests including:
- Cache warming task behavior with different team sizes and batch configurations
- Pagination handling for large numbers of teams
- Error handling and retry logic
- Cache invalidation on cohort, team modifications
- Dependency extraction from cohort properties
