### PR TITLE
chore(flags): log pg connection metrics

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -36,6 +36,14 @@ pub trait Client {
         parameters: Vec<String>,
         timeout_ms: Option<u64>,
     ) -> Result<Vec<PgRow>, CustomDatabaseError>;
+
+    fn get_pool_stats(&self) -> Option<PoolStats>;
+}
+
+#[derive(Debug, Clone)]
+pub struct PoolStats {
+    pub size: u32,
+    pub num_idle: usize,
 }
 
 pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
@@ -49,6 +57,13 @@ pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::E
 
 #[async_trait]
 impl Client for PgPool {
+    fn get_pool_stats(&self) -> Option<PoolStats> {
+        Some(PoolStats {
+            size: self.size(),
+            num_idle: self.num_idle(),
+        })
+    }
+
     async fn run_query(
         &self,
         query: String,

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -122,7 +122,7 @@ pub struct Config {
     #[envconfig(default = "1000")]
     pub max_concurrency: usize,
 
-    #[envconfig(default = "100")]
+    #[envconfig(default = "50")]
     pub max_pg_connections: u32,
 
     #[envconfig(default = "redis://localhost:6379/")]

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -122,7 +122,7 @@ pub struct Config {
     #[envconfig(default = "1000")]
     pub max_concurrency: usize,
 
-    #[envconfig(default = "50")]
+    #[envconfig(default = "100")]
     pub max_pg_connections: u32,
 
     #[envconfig(default = "redis://localhost:6379/")]

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -173,6 +173,11 @@ impl Client for MockPgClient {
         // Simulate a database connection failure
         Err(CustomDatabaseError::Other(SqlxError::PoolTimedOut))
     }
+
+    fn get_pool_stats(&self) -> Option<common_database::PoolStats> {
+        // Return None for mock client
+        None
+    }
 }
 
 pub async fn setup_invalid_pg_client() -> Arc<dyn Client + Send + Sync> {


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/issues/34916

Based on a 5XX and latency spike from 9-10-2025, I noticed that many of the DatabaseErrors errors (~450 of them) were coming from `fetch_and_locally_cache_all_relevant_properties` and had the following log `{"message":"Failed to acquire database connection","conn_acquisition_ms":"1068","error":"Other(PoolTimedOut)"}`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

I am going to log the pool stats when we encounter this error to see if we are exhausting connections or if there is another issue. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
