### PR TITLE
feat: Add support for filters placeholder in groups table

### DIFF
--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -72,7 +72,7 @@ class ReplaceFilters(CloningVisitor):
                         found_logs = True
                     if last_join.table.chain == ["groups"]:
                         found_groups = True
-                    if found_events and found_sessions:
+                    if found_events and found_sessions or found_groups:
                         break
                 last_join = last_join.next_join
 

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -61,6 +61,7 @@ class ReplaceFilters(CloningVisitor):
             found_events = False
             found_sessions = False
             found_logs = False
+            found_groups = False
             while last_join is not None:
                 if isinstance(last_join.table, ast.Field):
                     if last_join.table.chain == ["events"]:
@@ -69,13 +70,15 @@ class ReplaceFilters(CloningVisitor):
                         found_sessions = True
                     if last_join.table.chain == ["logs"]:
                         found_logs = True
+                    if last_join.table.chain == ["groups"]:
+                        found_groups = True
                     if found_events and found_sessions:
                         break
                 last_join = last_join.next_join
 
-            if not found_events and not found_sessions and not found_logs:
+            if not any([found_events, found_sessions, found_logs, found_groups]):
                 raise QueryError(
-                    "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions or logs table."
+                    "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs or groups table."
                 )
 
             if no_filters:
@@ -96,14 +99,16 @@ class ReplaceFilters(CloningVisitor):
                         )
                     exprs.append(property_to_expr(session_properties, self.team, scope="session"))
                     exprs.append(property_to_expr(non_session_properties, self.team, scope="event"))
+                elif found_groups:
+                    exprs.append(property_to_expr(self.filters.properties, self.team, scope="group"))
                 else:
                     exprs.append(property_to_expr(self.filters.properties, self.team, scope="event"))
 
-            timestamp_field = (
-                ast.Field(chain=["timestamp"])
-                if (found_events or found_logs)
-                else ast.Field(chain=["$start_timestamp"])
-            )
+            timestamp_field = ast.Field(chain=["$start_timestamp"])
+            if found_events or found_logs:
+                timestamp_field = ast.Field(chain=["timestamp"])
+            if found_groups:
+                timestamp_field = ast.Field(chain=["created_at"])
 
             dateTo = self.filters.dateRange.date_to if self.filters.dateRange else None
             if dateTo is not None:

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1,3 +1,4 @@
+import re
 from typing import Literal, Optional, cast
 
 from django.db import models
@@ -376,6 +377,37 @@ def property_to_expr(
 
     if property.type == "hogql":
         return parse_expr(property.key)
+    elif (
+        property.type == "event_metadata"
+        and scope == "group"
+        and re.match(r"^\$group_[0-4]$", property.key) is not None
+    ):
+        group_type_index = property.key.split("_")[1]
+        operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.EXACT
+        value = property.value
+        if isinstance(property.value, list):
+            if len(property.value) > 1:
+                raise QueryError(f"The '{property.key}' property filter only supports one value in 'group' scope")
+            value = property.value[0]
+
+        # For groups table, $group_N filters should match both index and key
+        # index should equal N, and key should match the value
+        index_condition = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=["index"]),
+            right=ast.Constant(value=int(group_type_index)),
+        )
+
+        key_condition = _expr_to_compare_op(
+            expr=ast.Field(chain=["key"]),
+            value=value,
+            operator=operator,
+            property=property,
+            is_json_field=False,
+            team=team,
+        )
+
+        return ast.And(exprs=[key_condition, index_condition])
     elif (
         property.type == "event"
         or property.type == "event_metadata"

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -51,6 +51,8 @@ from posthog.utils import get_from_dict_or_attr
 from posthog.warehouse.models import DataWarehouseJoin
 from posthog.warehouse.models.util import get_view_or_table_by_name
 
+GROUP_KEY_PATTERN = re.compile(r"^\$group_[0-4]$")
+
 
 def has_aggregation(expr: AST) -> bool:
     finder = AggregationFinder()
@@ -377,11 +379,7 @@ def property_to_expr(
 
     if property.type == "hogql":
         return parse_expr(property.key)
-    elif (
-        property.type == "event_metadata"
-        and scope == "group"
-        and re.match(r"^\$group_[0-4]$", property.key) is not None
-    ):
+    elif property.type == "event_metadata" and scope == "group" and GROUP_KEY_PATTERN.match(property.key) is not None:
         group_type_index = property.key.split("_")[1]
         operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.EXACT
         value = property.value

--- a/posthog/hogql/test/test_filters.py
+++ b/posthog/hogql/test/test_filters.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from posthog.test.base import BaseTest
 
-from posthog.schema import DateRange, EventPropertyFilter, HogQLFilters, PersonPropertyFilter
+from posthog.schema import DateRange, EventPropertyFilter, GroupPropertyFilter, HogQLFilters, PersonPropertyFilter
 
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
@@ -57,13 +57,13 @@ class TestFilters(BaseTest):
 
         with self.assertRaisesMessage(
             QueryError,
-            "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions or logs table.",
+            "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs or groups table.",
         ):
             replace_filters(select, None, self.team)
 
         with self.assertRaisesMessage(
             QueryError,
-            "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions or logs table.",
+            "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs or groups table.",
         ):
             replace_filters(select, HogQLFilters(), self.team)
 
@@ -72,7 +72,7 @@ class TestFilters(BaseTest):
 
         with self.assertRaisesMessage(
             QueryError,
-            "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions or logs table.",
+            "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs or groups table.",
         ):
             replace_filters(select, HogQLFilters(dateRange=DateRange(date_from="2020-02-02")), self.team)
 
@@ -186,3 +186,124 @@ class TestFilters(BaseTest):
             self._print_ast(select),
             f"SELECT event FROM events WHERE notILike(toString(person.properties.email), '%posthog.com%') LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
+
+    def test_replace_filters_groups_empty(self):
+        select = replace_filters(self._parse_select("SELECT group_key FROM groups"), HogQLFilters(), self.team)
+        self.assertEqual(self._print_ast(select), f"SELECT group_key FROM groups LIMIT {MAX_SELECT_RETURNED_ROWS}")
+
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            HogQLFilters(),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select), f"SELECT group_key FROM groups WHERE true LIMIT {MAX_SELECT_RETURNED_ROWS}"
+        )
+
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            None,
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select), f"SELECT group_key FROM groups WHERE true LIMIT {MAX_SELECT_RETURNED_ROWS}"
+        )
+
+    def test_replace_filters_groups_date_range(self):
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            HogQLFilters(dateRange=DateRange(date_from="2020-02-02")),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select),
+            f"SELECT group_key FROM groups WHERE greaterOrEquals(created_at, toDateTime('2020-02-02 00:00:00.000000')) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            HogQLFilters(dateRange=DateRange(date_to="2020-02-02")),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select),
+            f"SELECT group_key FROM groups WHERE less(created_at, toDateTime('2020-02-02 00:00:00.000000')) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            HogQLFilters(dateRange=DateRange(date_from="2020-02-02", date_to="2020-02-03 23:59:59")),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select),
+            "SELECT group_key FROM groups WHERE "
+            "and(less(created_at, toDateTime('2020-02-03 23:59:59.000000')), "
+            f"greaterOrEquals(created_at, toDateTime('2020-02-02 00:00:00.000000'))) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+    def test_replace_filters_groups_property(self):
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            HogQLFilters(
+                properties=[
+                    GroupPropertyFilter(
+                        key="company_name", operator="exact", value="PostHog", type="group", group_type_index=0
+                    )
+                ]
+            ),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select),
+            f"SELECT group_key FROM groups WHERE equals(properties.company_name, 'PostHog') LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+    def test_replace_filters_groups_multiple_properties(self):
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            HogQLFilters(
+                properties=[
+                    GroupPropertyFilter(
+                        key="company_name", operator="exact", value="PostHog", type="group", group_type_index=0
+                    ),
+                    GroupPropertyFilter(
+                        key="industry", operator="exact", value="Software", type="group", group_type_index=0
+                    ),
+                ]
+            ),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select),
+            f"SELECT group_key FROM groups WHERE and(equals(properties.company_name, 'PostHog'), equals(properties.industry, 'Software')) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+    def test_replace_filters_groups_date_and_properties(self):
+        select = replace_filters(
+            self._parse_select("SELECT group_key FROM groups where {filters}"),
+            HogQLFilters(
+                dateRange=DateRange(date_from="2020-02-02"),
+                properties=[
+                    GroupPropertyFilter(
+                        key="company_name", operator="exact", value="PostHog", type="group", group_type_index=0
+                    )
+                ],
+            ),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select),
+            "SELECT group_key FROM groups WHERE "
+            "and(equals(properties.company_name, 'PostHog'), "
+            f"greaterOrEquals(created_at, toDateTime('2020-02-02 00:00:00.000000'))) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+    def test_raises_when_filters_and_not_supported_table_includes_groups(self):
+        select = self._parse_select("SELECT person FROM persons where {filters}")
+
+        with self.assertRaisesMessage(
+            QueryError,
+            "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs or groups table.",
+        ):
+            replace_filters(select, HogQLFilters(dateRange=DateRange(date_from="2020-02-02")), self.team)

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from posthog.schema import EmptyPropertyFilter, HogQLPropertyFilter, RetentionEntity
 
 from posthog.hogql import ast
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import (
     entity_to_expr,
@@ -938,3 +939,31 @@ class TestProperty(BaseTest):
             chain=["person", "properties", 42]
         )
         assert map_virtual_properties(ast.Field(chain=["properties", 42])) == ast.Field(chain=["properties", 42])
+
+    def test_property_to_expr_event_metadata_group_scope_basic(self):
+        assert self._property_to_expr(
+            {"type": "event_metadata", "key": "$group_0", "operator": "exact", "value": "1234-abcd"},
+            scope="group",
+        ) == self._parse_expr("key = '1234-abcd' and index = 0")
+
+    def test_property_to_expr_event_metadata_group_scope_list_single_value(self):
+        assert self._property_to_expr(
+            {"type": "event_metadata", "key": "$group_2", "operator": "exact", "value": ["1"]},
+            scope="group",
+        ) == self._parse_expr("key = '1' and index = 2")
+
+    def test_property_to_expr_event_metadata_group_scope_invalid_key(self):
+        with self.assertRaisesMessage(
+            QueryError, "The 'event_metadata' property filter does not work in 'group' scope"
+        ):
+            self._property_to_expr(
+                {"type": "event_metadata", "key": "$group_invalid", "operator": "exact", "value": "test"}, scope="group"
+            )
+
+    def test_property_to_expr_event_metadata_group_scope_multiple_values(self):
+        with self.assertRaisesMessage(
+            QueryError, "The '$group_3' property filter only supports one value in 'group' scope"
+        ):
+            self._property_to_expr(
+                {"type": "event_metadata", "key": "$group_3", "operator": "exact", "value": ["1", "2"]}, scope="group"
+            )


### PR DESCRIPTION
## Problem
We're currently not able to use filters placeholder when querying groups table.
<!-- Who are we building for, what are their needs, why is this important? -->
<img width="1062" height="148" alt="image" src="https://github.com/user-attachments/assets/d7fceffe-9c8f-41bb-9c8f-ad5baf77d349" />

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Add support for filters placeholder for `groups` table (first commit)
- Also support `$group_n` property when querying groups table (second commit)
	- This is important for the dashboard embedded in group details page, as we are already passing in `$group_n` filter. I did a quick implementation supporting single values only, but I'm happy to extend it to a list of values if this can be used in other places.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests and locally, accessing dashboards with filters, mainly groups dashboard template
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
