### PR TITLE
chore: Revert "feat(crm): Endpoint to upsert multiple group properties"

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -20,7 +20,6 @@ from posthog.api.capture import capture_internal
 from posthog.api.documentation import extend_schema
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
-from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
@@ -417,71 +416,6 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                     ],
                 ),
             )
-            return response.Response(self.get_serializer(group).data)
-        except Group.DoesNotExist:
-            raise NotFound()
-
-    @action(
-        methods=["POST"],
-        detail=False,
-        required_scopes=["group:write"],
-        authentication_classes=[PersonalAPIKeyAuthentication],
-    )
-    def upsert_properties(self, request: request.Request, **_kw) -> response.Response:
-        try:
-            group = self.get_object()
-
-            original_values = {}
-            new_properties = {}
-            for prop_key, prop_value in request.data.items():
-                original_values[prop_key] = group.group_properties.get(prop_key, None)
-                new_properties[prop_key] = prop_value
-
-            group.group_properties.update(new_properties)
-            group.save()
-
-            # Need to update ClickHouse too
-            timestamp = timezone.now()
-            raw_create_group_ch(
-                team_id=self.team.pk,
-                group_type_index=group.group_type_index,
-                group_key=group.group_key,
-                properties=group.group_properties,
-                created_at=group.created_at,
-                timestamp=timestamp,
-            )
-
-            # another internal event submission where we best-effort and don't handle failures...
-            try:
-                self.trigger_group_identify(
-                    group=group,
-                    operation="group properties upsert",
-                    group_properties=new_properties,
-                )
-            except TriggerGroupIdentifyException as exc:
-                return response.Response(data=exc.exception_data, status=exc.status_code)
-
-            for property in new_properties:
-                log_activity(
-                    organization_id=self.organization.id,
-                    team_id=self.team.id,
-                    user=cast(User, request.user),
-                    was_impersonated=is_impersonated_session(request),
-                    item_id=group.pk,
-                    scope="Group",
-                    activity="upsert_properties",
-                    detail=Detail(
-                        name=str(property),
-                        changes=[
-                            Change(
-                                type="Group",
-                                action="created" if original_values[property] is None else "changed",
-                                before=original_values[property],
-                                after=new_properties[property],
-                            )
-                        ],
-                    ),
-                )
             return response.Response(self.get_serializer(group).data)
         except Group.DoesNotExist:
             raise NotFound()

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
@@ -1,4 +1,93 @@
 # serializer version: 1
+# name: ClickhouseTestGroupsApi.test_related_groups
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT pdi.person_id
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND $group_0 = '0::0'
+  '''
+# ---
+# name: ClickhouseTestGroupsApi.test_related_groups.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND $group_0 = '0::0'
+  ORDER BY group_key
+  '''
+# ---
+# name: ClickhouseTestGroupsApi.test_related_groups_person
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT $group_0 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 0
+     GROUP BY group_key) groups ON $group_0 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND pdi.person_id = '01795392-cc00-0003-7dc7-67a694604d72'
+  ORDER BY group_key
+  '''
+# ---
+# name: ClickhouseTestGroupsApi.test_related_groups_person.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2021-02-09T00:00:00.000000'
+    AND timestamp < '2021-05-10T00:00:00.000000'
+    AND group_key != ''
+    AND pdi.person_id = '01795392-cc00-0003-7dc7-67a694604d72'
+  ORDER BY group_key
+  '''
+# ---
 # name: GroupsViewSetTestCase.test_related_groups
   '''
   /* user_id:0 request:_snapshot_ */

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -12,8 +12,6 @@ from flaky import flaky
 from orjson import orjson
 from rest_framework import status
 
-from posthog.schema import HogQLQueryResponse
-
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
@@ -817,193 +815,12 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 404)
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
-    @flaky(max_runs=3, min_passes=1)
-    def test_upsert_properties_add_success(self, mock_capture):
-        group_type_mapping = create_group_type_mapping_without_created_at(
-            team=self.team,
-            project_id=self.team.project_id,
-            group_type_index=0,
-            group_type="organization",
-        )
-        group = create_group(
-            team_id=self.team.pk,
-            group_type_index=group_type_mapping.group_type_index,
-            group_key="org:5",
-            properties={"name": "Mr. Krabs"},
-        )
-        create_group(
-            team_id=self.team.pk,
-            group_type_index=group_type_mapping.group_type_index,
-            group_key="org:55",
-            properties={"name": "Mr. Krabs"},
-        )
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/groups/upsert_properties?group_key=org:5&group_type_index=0",
-            {"industry": "technology", "plan": "enterprise"},
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.json(),
-            {
-                "created_at": "2021-05-02T00:00:00Z",
-                "group_key": "org:5",
-                "group_properties": {"industry": "technology", "name": "Mr. Krabs", "plan": "enterprise"},
-                "group_type_index": 0,
-            },
-        )
-
-        query_response: HogQLQueryResponse = execute_hogql_query(
-            parse_select(
-                """
-                select properties
-                from groups
-                where index = {index}
-                  and key = {key}
-                """,
-                placeholders={
-                    "index": ast.Constant(value=group.group_type_index),
-                    "key": ast.Constant(value=group.group_key),
-                },
-            ),
-            self.team,
-        )
-        self.assertEqual(
-            query_response.results,
-            [('{"name": "Mr. Krabs", "industry": "technology", "plan": "enterprise"}',)],
-        )
-
-        mock_capture.assert_called_once_with(
-            token=self.team.api_token,
-            event_name="$groupidentify",
-            event_source="ee_ch_views_groups",
-            distinct_id=str(self.team.uuid),
-            timestamp=mock.ANY,
-            properties={
-                "$group_type": group_type_mapping.group_type,
-                "$group_key": group.group_key,
-                "$group_set": {"industry": "technology", "plan": "enterprise"},
-            },
-            process_person_profile=False,
-        )
-
-        activity_response = self.client.get(
-            f"/api/projects/{self.team.id}/groups/activity?group_key=org:5&group_type_index=0",
-        )
-
-        self.assertEqual(activity_response.status_code, 200)
-        self.assertIn("results", activity_response.json())
-        self.assertEqual(len(activity_response.json()["results"]), 2)
-        self.assertEqual(activity_response.json()["results"][0]["activity"], "upsert_properties")
-        self.assertEqual(activity_response.json()["results"][0]["scope"], "Group")
-        self.assertEqual(activity_response.json()["results"][0]["item_id"], str(group.pk))
-        self.assertEqual(activity_response.json()["results"][0]["detail"]["changes"][0]["type"], "Group")
-        self.assertEqual(activity_response.json()["results"][0]["detail"]["changes"][0]["action"], "created")
-        self.assertEqual(activity_response.json()["results"][0]["detail"]["changes"][0]["before"], None)
-        self.assertEqual(activity_response.json()["results"][0]["detail"]["changes"][0]["after"], "technology")
-        self.assertEqual(activity_response.json()["results"][1]["detail"]["changes"][0]["type"], "Group")
-        self.assertEqual(activity_response.json()["results"][1]["detail"]["changes"][0]["action"], "created")
-        self.assertEqual(activity_response.json()["results"][1]["detail"]["changes"][0]["before"], None)
-        self.assertEqual(activity_response.json()["results"][1]["detail"]["changes"][0]["after"], "enterprise")
-
-    @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
-    @flaky(max_runs=3, min_passes=1)
-    def test_upsert_properties_update_success(self, mock_capture):
-        group_type_mapping = create_group_type_mapping_without_created_at(
-            team=self.team,
-            project_id=self.team.project_id,
-            group_type_index=0,
-            group_type="organization",
-        )
-        group = create_group(
-            team_id=self.team.pk,
-            group_type_index=0,
-            group_key="org:5",
-            properties={"industry": "finance", "name": "Mr. Krabs", "plan": "startup"},
-        )
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/groups/upsert_properties?group_key=org:5&group_type_index=0",
-            {"industry": "technology", "plan": "enterprise"},
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.json(),
-            {
-                "created_at": "2021-05-02T00:00:00Z",
-                "group_key": "org:5",
-                "group_properties": {"industry": "technology", "name": "Mr. Krabs", "plan": "enterprise"},
-                "group_type_index": 0,
-            },
-        )
-
-        query_response: HogQLQueryResponse = execute_hogql_query(
-            parse_select(
-                """
-                select properties
-                from groups
-                where index = {index}
-                  and key = {key}
-                """,
-                placeholders={
-                    "index": ast.Constant(value=group.group_type_index),
-                    "key": ast.Constant(value=group.group_key),
-                },
-            ),
-            self.team,
-        )
-        # Check properties regardless of JSON key order
-        self.assertEqual(len(query_response.results), 1)
-        self.assertEqual(len(query_response.results[0]), 1)
-        self.assertEqual(
-            orjson.loads(query_response.results[0][0]),
-            {"name": "Mr. Krabs", "industry": "technology", "plan": "enterprise"},
-        )
-
-        mock_capture.assert_called_once_with(
-            token=self.team.api_token,
-            event_name="$groupidentify",
-            event_source="ee_ch_views_groups",
-            distinct_id=str(self.team.uuid),
-            timestamp=mock.ANY,
-            properties={
-                "$group_type": group_type_mapping.group_type,
-                "$group_key": group.group_key,
-                "$group_set": {"industry": "technology", "plan": "enterprise"},
-            },
-            process_person_profile=False,
-        )
-
-        response = self.client.get(
-            f"/api/projects/{self.team.id}/groups/activity?group_key=org:5&group_type_index=0",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("results", response.json())
-        self.assertEqual(len(response.json()["results"]), 2)
-        self.assertEqual(response.json()["results"][0]["activity"], "upsert_properties")
-        self.assertEqual(response.json()["results"][0]["scope"], "Group")
-        self.assertEqual(response.json()["results"][0]["item_id"], str(group.pk))
-        self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["type"], "Group")
-        self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["action"], "changed")
-        self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["before"], "finance")
-        self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["after"], "technology")
-        self.assertEqual(response.json()["results"][1]["detail"]["changes"][0]["type"], "Group")
-        self.assertEqual(response.json()["results"][1]["detail"]["changes"][0]["action"], "changed")
-        self.assertEqual(response.json()["results"][1]["detail"]["changes"][0]["before"], "startup")
-        self.assertEqual(response.json()["results"][1]["detail"]["changes"][0]["after"], "enterprise")
-
-    @freeze_time("2021-05-02")
     @patch("ee.clickhouse.views.groups.capture_internal")
     def test_get_group_activities_success(self, mock_capture):
         # Mock the response to return a 200 OK
         mock_capture.return_value = mock.MagicMock(status_code=200)
 
-        create_group_type_mapping_without_created_at(
+        group_type_mapping = create_group_type_mapping_without_created_at(
             team=self.team,
             project_id=self.team.project_id,
             group_type_index=0,
@@ -1011,7 +828,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         )
         group = create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
@@ -1043,7 +860,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         # Mock the response to return a 200 OK
         mock_capture.return_value = mock.MagicMock(status_code=200)
 
-        create_group_type_mapping_without_created_at(
+        group_type_mapping = create_group_type_mapping_without_created_at(
             team=self.team,
             project_id=self.team.project_id,
             group_type_index=0,
@@ -1051,7 +868,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         )
         create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )


### PR DESCRIPTION
Reverts PostHog/posthog#37349

we don't need this anymore, as we now have a [destination template](https://github.com/PostHog/posthog/pull/37581) to update group properties