### PR TITLE
chore: Enable auto-reviewer assignment for external contributor PRs

### DIFF
--- a/.github/scripts/assign-reviewers.js
+++ b/.github/scripts/assign-reviewers.js
@@ -54,7 +54,14 @@ function fileMatchesPattern(filePath, pattern) {
 
 function getChangedFiles() {
     try {
-        const output = execSync('git diff --name-only origin/master...HEAD', {
+        const { BASE_SHA, HEAD_SHA } = process.env
+        
+        if (!BASE_SHA || !HEAD_SHA) {
+            console.error('BASE_SHA and HEAD_SHA environment variables are required')
+            return []
+        }
+
+        const output = execSync(`git diff --name-only ${BASE_SHA}...${HEAD_SHA}`, {
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
         })

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,7 +1,7 @@
 name: Auto Assign Reviewers
 
 on:
-    pull_request:
+    pull_request_target:
         # Only opened or when clicking ready otherwise you can never remove the reviewers
         types: [opened, ready_for_review]
 
@@ -19,6 +19,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -33,5 +34,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
               run: |
                   node .github/scripts/assign-reviewers.js


### PR DESCRIPTION
External PRs are not getting auto assigned :cry: and I want to fix it.

## Problem

The `auto-assign-reviewers.yml` workflow previously used the `pull_request` event, which requires manual approval for external contributor PRs before running. This prevented automatic reviewer assignment.

## Changes

Changed to `pull_request_target` event which runs immediately for external PRs with full permissions. Fixed the `git diff` command to compare the correct commit range (`BASE_SHA...HEAD_SHA`) since `pull_request_target` runs in the base branch context.

This is safe to do _because_ this workflow doesn't run the contributed code.

## How did you test this code?

Sadly, I can't test it until I deploy it. 😦 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
