### PR TITLE
fix(flags): rotate db connections perodically

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -43,6 +43,8 @@ pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::E
         .max_connections(max_connections)
         .acquire_timeout(Duration::from_secs(1))
         .test_before_acquire(false)
+        .idle_timeout(Duration::from_secs(300))  // Close idle connections after 5 minutes
+        .max_lifetime(Duration::from_secs(1800)) // Force refresh every 30 minutes
         .connect(url)
         .await
 }

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -43,7 +43,7 @@ pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::E
         .max_connections(max_connections)
         .acquire_timeout(Duration::from_secs(1))
         .test_before_acquire(false)
-        .idle_timeout(Duration::from_secs(300))  // Close idle connections after 5 minutes
+        .idle_timeout(Duration::from_secs(300)) // Close idle connections after 5 minutes
         .max_lifetime(Duration::from_secs(1800)) // Force refresh every 30 minutes
         .connect(url)
         .await

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::E
     PgPoolOptions::new()
         .max_connections(max_connections)
         .acquire_timeout(Duration::from_secs(1))
-        .test_before_acquire(false)
+        .test_before_acquire(true)
         .idle_timeout(Duration::from_secs(300)) // Close idle connections after 5 minutes
         .max_lifetime(Duration::from_secs(1800)) // Force refresh every 30 minutes
         .connect(url)

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::E
     PgPoolOptions::new()
         .max_connections(max_connections)
         .acquire_timeout(Duration::from_secs(1))
-        .test_before_acquire(true)
+        .test_before_acquire(false)
         .connect(url)
         .await
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

flags occasionally has latency spikes that can result in 504s. During these spikes, there are increased reads to the reader db instance, but the actual queries themselves are still averaging below 1ms (see this [comment](https://github.com/PostHog/posthog/issues/34916#issuecomment-3275370966)). My theory is that most of the time is being spent waiting for a connection. 

Currently, we don't rotate connections so they can technically live forever and go unhealthy without the service knowing. This is mitigated by `test_before_acquire(true)` but in the scenario where most of the connections go unhealthy, and we get a spike in traffic, then it's possible many new connections need to be established, slowing requests down. 

## Changes

Rotate the connections periodically. Note that `idle_timeout` and `max_lifetime` be default are not set so we need to set them explicitly. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

test in prod

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
