### PR TITLE
fix(self-host): Resolve some errors in self hosted deployment

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -105,6 +105,8 @@ services:
             OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
             OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
             SESSION_RECORDING_V2_S3_ENDPOINT: http://objectstorage:19000
+            SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: object_storage_root_user
+            SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: object_storage_root_password
             OBJECT_STORAGE_ENABLED: true
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             OTEL_SERVICE_NAME: 'posthog'

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -115,7 +115,7 @@ pub struct KafkaConfig {
     pub kafka_producer_queue_mib: u32, // Size of the in-memory producer queue in mebibytes
     #[envconfig(default = "20000")]
     pub kafka_message_timeout_ms: u32, // Time before we stop retrying producing a message: 20 seconds
-    #[envconfig(default = "1000000")]
+    #[envconfig(default = "10000000")]
     pub kafka_producer_message_max_bytes: u32, // message.max.bytes - max kafka message size we will produce
     #[envconfig(default = "none")]
     pub kafka_compression_codec: String, // none, gzip, snappy, lz4, zstd


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
self-hosted version

1.ERROR capture::v0_request: from_bytes: GZIP decompression size limit reached buffer_size=1000057
2.posthog logs contain some error: "session_recording_v2_object_storage.read_failed ... error=NoCredentialsError('Unable to locate credentials') "
## Changes
Discovering that there is no environment variable TEST or DEBUG during deployment, and the default SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY and SESSION_RECORDING_V2_S3_ACCESS_KEY_ID environment variables are empty, which can cause the 'Unable to locate credentials' error to occur

Adjust the default value of kafka_producer_message_max_bytes
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
