### PR TITLE
chore: make web_preaggregated_hourly jobs easier on the cluster

### DIFF
--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -11,11 +11,13 @@ def is_eu_cluster() -> bool:
     return getattr(settings, "CLOUD_DEPLOYMENT", None) == "EU"
 
 
-def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True):
-    engine = MergeTreeEngine(table_name, replication_scheme=ReplicationScheme.REPLICATED)
+def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, force_unique_zk_path=False, replace=False):
+    engine = MergeTreeEngine(
+        table_name, replication_scheme=ReplicationScheme.REPLICATED, force_unique_zk_path=force_unique_zk_path
+    )
 
     return f"""
-    CREATE TABLE IF NOT EXISTS {table_name} {ON_CLUSTER_CLAUSE(on_cluster=on_cluster)}
+    {f"REPLACE TABLE {table_name}" if replace else f"CREATE TABLE IF NOT EXISTS {table_name}"} {ON_CLUSTER_CLAUSE(on_cluster=on_cluster)}
     (
         period_bucket DateTime,
         team_id UInt64,
@@ -28,13 +30,17 @@ def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True):
     """
 
 
-def HOURLY_TABLE_TEMPLATE(table_name, columns, order_by, ttl=None, on_cluster=True):
-    engine = MergeTreeEngine(table_name, replication_scheme=ReplicationScheme.REPLICATED)
+def HOURLY_TABLE_TEMPLATE(
+    table_name, columns, order_by, ttl=None, on_cluster=True, force_unique_zk_path=False, replace=False
+):
+    engine = MergeTreeEngine(
+        table_name, replication_scheme=ReplicationScheme.REPLICATED, force_unique_zk_path=force_unique_zk_path
+    )
 
     ttl_clause = f"TTL period_bucket + INTERVAL {ttl} DELETE" if ttl else ""
 
     return f"""
-    CREATE TABLE IF NOT EXISTS {table_name} {ON_CLUSTER_CLAUSE(on_cluster=on_cluster)}
+    {f"REPLACE TABLE {table_name}" if replace else f"CREATE TABLE IF NOT EXISTS {table_name}"} {ON_CLUSTER_CLAUSE(on_cluster=on_cluster)}
     (
         period_bucket DateTime,
         team_id UInt64,
@@ -82,6 +88,30 @@ def DROP_WEB_STATS_STAGING_SQL():
 
 def DROP_WEB_BOUNCES_STAGING_SQL():
     return _DROP_TABLE_TEMPLATE("web_pre_aggregated_bounces_staging")
+
+
+def REPLACE_WEB_BOUNCES_HOURLY_STAGING_SQL():
+    return HOURLY_TABLE_TEMPLATE(
+        "web_bounces_hourly_staging",
+        WEB_BOUNCES_COLUMNS,
+        WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
+        ttl="24 HOUR",
+        force_unique_zk_path=True,
+        replace=True,
+        on_cluster=False,
+    )
+
+
+def REPLACE_WEB_STATS_HOURLY_STAGING_SQL():
+    return HOURLY_TABLE_TEMPLATE(
+        "web_stats_hourly_staging",
+        WEB_STATS_COLUMNS,
+        WEB_STATS_ORDER_BY_FUNC("period_bucket"),
+        ttl="24 HOUR",
+        force_unique_zk_path=True,
+        replace=True,
+        on_cluster=False,
+    )
 
 
 WEB_ANALYTICS_DIMENSIONS = [

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.conf import settings
 
 from posthog.hogql.database.schema.web_analytics_s3 import get_s3_function_args
@@ -12,9 +14,9 @@ def is_eu_cluster() -> bool:
 
 
 def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, force_unique_zk_path=False, replace=False):
-    engine = MergeTreeEngine(
-        table_name, replication_scheme=ReplicationScheme.REPLICATED, force_unique_zk_path=force_unique_zk_path
-    )
+    engine = MergeTreeEngine(table_name, replication_scheme=ReplicationScheme.REPLICATED)
+    if force_unique_zk_path:
+        engine.set_zookeeper_path_key(str(uuid.uuid4()))
 
     return f"""
     {f"REPLACE TABLE {table_name}" if replace else f"CREATE TABLE IF NOT EXISTS {table_name}"} {ON_CLUSTER_CLAUSE(on_cluster=on_cluster)}
@@ -33,9 +35,9 @@ def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, force_unique_
 def HOURLY_TABLE_TEMPLATE(
     table_name, columns, order_by, ttl=None, on_cluster=True, force_unique_zk_path=False, replace=False
 ):
-    engine = MergeTreeEngine(
-        table_name, replication_scheme=ReplicationScheme.REPLICATED, force_unique_zk_path=force_unique_zk_path
-    )
+    engine = MergeTreeEngine(table_name, replication_scheme=ReplicationScheme.REPLICATED)
+    if force_unique_zk_path:
+        engine.set_zookeeper_path_key(str(uuid.uuid4()))
 
     ttl_clause = f"TTL period_bucket + INTERVAL {ttl} DELETE" if ttl else ""
 


### PR DESCRIPTION
## Problem

The job truncates two tables and performs two inserts. Truncating is not as fast as we thought it could be in the cluster, and lead to replication queue spikes and increased replication lag.

## Changes

Replace the staging table every time the job is run.
Also, instead of doing a second insert, just exchange the staging and final tables, since they are expected to have the same contents.

## How did you test this code?

On it!


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
