### PR TITLE
fix: compare event timestamps in normalize step

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
@@ -23,7 +23,7 @@ export function normalizeEventStep(
         // Compare timestamp from headers with event.timestamp - they should be equal if implemented correctly
         if (headers) {
             compareTimestamps(
-                event.timestamp,
+                timestamp.toISO() || undefined,
                 headers,
                 event.team_id,
                 event.uuid,


### PR DESCRIPTION
## Problem

Timestamp comparisons between headers and event timestamps don't work in normalize because we're comparing non-normalized timestamps.

## Changes

Switches the normalize step to use the normalized timestamp for comparisons.

## How did you test this code?

Regression tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
