### PR TITLE
fix: do not require .git when computing git repo name

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1498,7 +1498,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1908,7 +1908,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.5",
  "subtle",
  "zeroize",
 ]
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2581,9 +2581,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-id-start"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f322b60f6b9736017344fa0635d64be2f458fbc04eef65f6be22976dd1ffd5b"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.4.5"
+version = "0.4.6"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -46,7 +46,7 @@ fn find_git_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
     }
 }
 
-fn get_remote_url(git_dir: &Path) -> Option<String> {
+pub fn get_remote_url(git_dir: &Path) -> Option<String> {
     // Try grab it from the git config
     let config_path = git_dir.join("config");
     if config_path.exists() {
@@ -72,7 +72,7 @@ fn get_remote_url(git_dir: &Path) -> Option<String> {
     None
 }
 
-fn get_repo_name(git_dir: &Path) -> Option<String> {
+pub fn get_repo_name(git_dir: &Path) -> Option<String> {
     // Try grab it from the configured remote, otherwise just use the directory name
     let config_path = git_dir.join("config");
     if config_path.exists() {

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -83,7 +83,7 @@ fn get_repo_name(git_dir: &Path) -> Option<String> {
 
         for line in config_content.lines() {
             let line = line.trim();
-            if line.starts_with("url = ") && line.ends_with(".git") {
+            if line.starts_with("url = ") {
                 let url = line.trim_start_matches("url = ");
                 if let Some(repo_name) = url.split('/').next_back() {
                     let clean_name = repo_name.trim_end_matches(".git");

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -1,0 +1,78 @@
+use posthog_cli::utils::git::{get_remote_url, get_repo_name};
+use std::fs;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+fn make_git_dir_with_config(config_content: &str) -> PathBuf {
+    let temp_root = std::env::temp_dir().join(format!(
+        "posthog_cli_git_test_{}",
+        Uuid::now_v7()
+    ));
+    let git_dir = temp_root.join(".git");
+    fs::create_dir_all(&git_dir).expect("failed to create .git directory");
+    let config_path = git_dir.join("config");
+    fs::write(&config_path, config_content).expect("failed to write config");
+    git_dir
+}
+
+#[test]
+fn test_get_remote_url_with_dot_git() {
+    let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = https://github.com/PostHog/posthog.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#;
+    let git_dir = make_git_dir_with_config(cfg);
+    let url = get_remote_url(&git_dir).expect("expected some url");
+    assert_eq!(url, "https://github.com/PostHog/posthog.git");
+    let _ = fs::remove_dir_all(git_dir.parent().unwrap());
+}
+
+#[test]
+fn test_get_remote_url_without_dot_git() {
+    let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = https://github.com/PostHog/posthog
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#;
+    let git_dir = make_git_dir_with_config(cfg);
+    let url = get_remote_url(&git_dir).expect("expected some url");
+    assert_eq!(url, "https://github.com/PostHog/posthog.git");
+    let _ = fs::remove_dir_all(git_dir.parent().unwrap());
+}
+
+#[test]
+fn test_get_repo_name_with_dot_git() {
+    let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = https://github.com/PostHog/posthog.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#;
+    let git_dir = make_git_dir_with_config(cfg);
+    let name = get_repo_name(&git_dir).expect("expected some name");
+    assert_eq!(name, "posthog");
+    let _ = fs::remove_dir_all(git_dir.parent().unwrap());
+}
+
+#[test]
+fn test_get_repo_name_without_dot_git() {
+    let cfg = r#"
+[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = https://github.com/PostHog/posthog
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#;
+    let git_dir = make_git_dir_with_config(cfg);
+    let name = get_repo_name(&git_dir).expect("expected some name");
+    assert_eq!(name, "posthog");
+    let _ = fs::remove_dir_all(git_dir.parent().unwrap());
+}
+
+

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -16,7 +16,7 @@ fn make_git_dir_with_config(config_content: &str) -> PathBuf {
 }
 
 #[test]
-fn test_get_remote_url_with_dot_git() {
+fn test_get_repo_infos_https_with_dot_git() {
     let cfg = r#"
 [core]
     repositoryformatversion = 0
@@ -25,13 +25,16 @@ fn test_get_remote_url_with_dot_git() {
     fetch = +refs/heads/*:refs/remotes/origin/*
 "#;
     let git_dir = make_git_dir_with_config(cfg);
-    let url = get_remote_url(&git_dir).expect("expected some url");
-    assert_eq!(url, "https://github.com/PostHog/posthog.git");
+    assert_eq!(
+        get_remote_url(&git_dir).as_deref(),
+        Some("https://github.com/PostHog/posthog.git")
+    );
+    assert_eq!(get_repo_name(&git_dir).as_deref(), Some("posthog"));
     let _ = fs::remove_dir_all(git_dir.parent().unwrap());
 }
 
 #[test]
-fn test_get_remote_url_without_dot_git() {
+fn test_get_repo_infos_https_without_dot_git() {
     let cfg = r#"
 [core]
     repositoryformatversion = 0
@@ -40,38 +43,47 @@ fn test_get_remote_url_without_dot_git() {
     fetch = +refs/heads/*:refs/remotes/origin/*
 "#;
     let git_dir = make_git_dir_with_config(cfg);
-    let url = get_remote_url(&git_dir).expect("expected some url");
-    assert_eq!(url, "https://github.com/PostHog/posthog.git");
+    assert_eq!(
+        get_remote_url(&git_dir).as_deref(),
+        Some("https://github.com/PostHog/posthog.git")
+    );
+    assert_eq!(get_repo_name(&git_dir).as_deref(), Some("posthog"));
     let _ = fs::remove_dir_all(git_dir.parent().unwrap());
 }
 
 #[test]
-fn test_get_repo_name_with_dot_git() {
+fn test_get_repo_infos_ssh_with_dot_git() {
     let cfg = r#"
 [core]
     repositoryformatversion = 0
 [remote "origin"]
-    url = https://github.com/PostHog/posthog.git
+    url = git@github.com:PostHog/posthog.git
     fetch = +refs/heads/*:refs/remotes/origin/*
 "#;
     let git_dir = make_git_dir_with_config(cfg);
-    let name = get_repo_name(&git_dir).expect("expected some name");
-    assert_eq!(name, "posthog");
+    assert_eq!(
+        get_remote_url(&git_dir).as_deref(),
+        Some("git@github.com:PostHog/posthog.git")
+    );
+    assert_eq!(get_repo_name(&git_dir).as_deref(), Some("posthog"));
     let _ = fs::remove_dir_all(git_dir.parent().unwrap());
 }
 
 #[test]
-fn test_get_repo_name_without_dot_git() {
+fn test_get_repo_infos_ssh_without_dot_git() {
     let cfg = r#"
 [core]
     repositoryformatversion = 0
 [remote "origin"]
-    url = https://github.com/PostHog/posthog
+    url = git@github.com:PostHog/posthog
     fetch = +refs/heads/*:refs/remotes/origin/*
 "#;
     let git_dir = make_git_dir_with_config(cfg);
-    let name = get_repo_name(&git_dir).expect("expected some name");
-    assert_eq!(name, "posthog");
+    assert_eq!(
+        get_remote_url(&git_dir).as_deref(),
+        Some("git@github.com:PostHog/posthog.git")
+    );
+    assert_eq!(get_repo_name(&git_dir).as_deref(), Some("posthog"));
     let _ = fs::remove_dir_all(git_dir.parent().unwrap());
 }
 


### PR DESCRIPTION
## Problem

CLI does not work properly for `.git`less remote urls. It is a continuation of https://github.com/PostHog/posthog/pull/37879. I did not notice we were using the same logic for repo name.

