### PR TITLE
fix(data-warehouse): Wrap table creation in an atomic operation

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from typing import Any, Optional
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Prefetch
 
 import dlt
@@ -112,61 +113,77 @@ def validate_schema_and_update_table_sync(
 
     # Check
     try:
-        logger.info(f"Row count for {_schema_name} ({_schema_id}) is {row_count}")
+        with transaction.atomic():
+            logger.info(f"Row count for {_schema_name} ({_schema_id}) is {row_count}")
 
-        table_params = {
-            "credential": credential,
-            "name": table_name,
-            "format": table_format,
-            "url_pattern": new_url_pattern,
-            "team_id": team_id,
-            "row_count": row_count,
-        }
+            table_params = {
+                "credential": credential,
+                "name": table_name,
+                "format": table_format,
+                "url_pattern": new_url_pattern,
+                "team_id": team_id,
+                "row_count": row_count,
+            }
 
-        # create or update
-        table_created: DataWarehouseTable | None = external_data_schema.table
-        if table_created:
-            table_created.credential = table_params["credential"]
-            table_created.format = table_params["format"]
-            table_created.url_pattern = new_url_pattern
-            if incremental_or_append:
-                table_created.row_count = table_created.get_count()
-            else:
-                table_created.row_count = row_count
+            # create or update
+            table_created: DataWarehouseTable | None = external_data_schema.table
+            if table_created:
+                table_created.credential = table_params["credential"]
+                table_created.format = table_params["format"]
+                table_created.url_pattern = new_url_pattern
+                if incremental_or_append:
+                    table_created.row_count = table_created.get_count()
+                else:
+                    table_created.row_count = row_count
+                table_created.save()
+
+            if not table_created:
+                # Check if we already have an orphaned table that we can repurpose
+                existing_tables = DataWarehouseTable.objects.filter(
+                    team_id=team_id, name=table_name, external_data_source_id=job.pipeline.id, deleted=False
+                )
+                existing_tables_count = existing_tables.count()
+                if existing_tables_count > 0:
+                    table_created = existing_tables[0]
+                    logger.debug(
+                        f"Found {existing_tables_count} existing tables - skipping creating and using {table_created.id}"
+                    )
+
+                if not table_created:
+                    logger.debug(f"Creating table for schema: {str(schema_id)}")
+                    table_created = DataWarehouseTable.objects.create(
+                        external_data_source_id=job.pipeline.id, **table_params
+                    )
+
+            assert isinstance(table_created, DataWarehouseTable) and table_created is not None
+
+            raw_db_columns: dict[str, dict[str, str]] = table_created.get_columns()
+            db_columns = {key: column.get("clickhouse", "") for key, column in raw_db_columns.items()}
+
+            columns = {}
+            for column_name, db_column_type in db_columns.items():
+                hogql_type = table_schema_dict.get(column_name)
+
+                if hogql_type is None:
+                    capture_exception(Exception(f"HogQL type not found for column: {column_name}"))
+                    continue
+
+                columns[column_name] = {
+                    "clickhouse": db_column_type,
+                    "hogql": hogql_type,
+                }
+            table_created.columns = columns
             table_created.save()
 
-        if not table_created:
-            table_created = DataWarehouseTable.objects.create(external_data_source_id=job.pipeline.id, **table_params)
+            # schema could have been deleted by this point
+            schema_model = (
+                ExternalDataSchema.objects.prefetch_related("source")
+                .exclude(deleted=True)
+                .get(id=_schema_id, team_id=team_id)
+            )
 
-        assert isinstance(table_created, DataWarehouseTable) and table_created is not None
-
-        raw_db_columns: dict[str, dict[str, str]] = table_created.get_columns()
-        db_columns = {key: column.get("clickhouse", "") for key, column in raw_db_columns.items()}
-
-        columns = {}
-        for column_name, db_column_type in db_columns.items():
-            hogql_type = table_schema_dict.get(column_name)
-
-            if hogql_type is None:
-                capture_exception(Exception(f"HogQL type not found for column: {column_name}"))
-                continue
-
-            columns[column_name] = {
-                "clickhouse": db_column_type,
-                "hogql": hogql_type,
-            }
-        table_created.columns = columns
-        table_created.save()
-
-        # schema could have been deleted by this point
-        schema_model = (
-            ExternalDataSchema.objects.prefetch_related("source")
-            .exclude(deleted=True)
-            .get(id=_schema_id, team_id=team_id)
-        )
-
-        schema_model.table = table_created
-        schema_model.save()
+            schema_model.table = table_created
+            schema_model.save()
 
     except ServerException as err:
         if err.code == 636:


### PR DESCRIPTION
## Problem
- We have duplicate tables causing mayhem with hogql 
- See https://posthog.slack.com/archives/C019RAX2XBN/p1756213184755039 for numbers
- But duplicate tables are not expected (sadly we have no db constraints here)

## Changes
- Wrap table creation in a sjango atomic operation, so it rolls back the creation in an issue
- Look for existing tables before creating a new one

