### PR TITLE
feat(crm): Add button to join modal in groups table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -12,6 +12,7 @@ import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { EventDetails } from 'scenes/activity/explore/EventDetails'
+import { ViewLinkButton } from 'scenes/data-warehouse/ViewLinkModal'
 import { groupViewLogic } from 'scenes/groups/groupViewLogic'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
 import { PersonDeleteModal } from 'scenes/persons/PersonDeleteModal'
@@ -686,6 +687,9 @@ export function DataTable({
     ].filter((x) => !!x)
 
     const secondRowRight = [
+        sourceFeatures.has(QueryFeature.linkDataButton) && hasCrmIterationOneEnabled ? (
+            <ViewLinkButton tableName="groups" />
+        ) : null,
         (showColumnConfigurator || showPersistentColumnConfigurator) &&
         sourceFeatures.has(QueryFeature.columnConfigurator) ? (
             <ColumnConfigurator key="column-configurator" query={query} setQuery={setQuery} />

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -25,6 +25,7 @@ export enum QueryFeature {
     eventPropertyFilters,
     personPropertyFilters,
     groupPropertyFilters,
+    linkDataButton,
     personsSearch,
     groupsSearch,
     savedEventsQueries,
@@ -86,6 +87,7 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
         features.add(QueryFeature.columnsInResponse)
         features.add(QueryFeature.resultIsArrayOfArrays)
         features.add(QueryFeature.columnConfigurator)
+        features.add(QueryFeature.linkDataButton)
     }
 
     if (

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 import { IconCollapse, IconExpand } from '@posthog/icons'
 import {
     LemonButton,
+    LemonButtonProps,
     LemonCheckbox,
     LemonDivider,
     LemonInput,
@@ -18,7 +19,7 @@ import {
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { HogQLDropdown } from 'lib/components/HogQLDropdown/HogQLDropdown'
-import { IconSwapHoriz } from 'lib/lemon-ui/icons'
+import { IconLink, IconSwapHoriz } from 'lib/lemon-ui/icons'
 import { viewLinkLogic } from 'scenes/data-warehouse/viewLinkLogic'
 
 import { DatabaseSchemaField } from '~/queries/schema/schema-general'
@@ -318,5 +319,31 @@ export function ViewLinkKeyLabel({ column }: KeyLabelProps): JSX.Element {
                 {column.type}
             </LemonTag>
         </span>
+    )
+}
+
+type ViewLinkButtonProps = LemonButtonProps & {
+    tableName: string
+}
+
+export function ViewLinkButton({ tableName, ...props }: ViewLinkButtonProps): JSX.Element {
+    const { toggleJoinTableModal, selectSourceTable } = useActions(viewLinkLogic)
+
+    const handleClick = (): void => {
+        selectSourceTable(tableName)
+        toggleJoinTableModal()
+    }
+
+    return (
+        <>
+            <LemonButton
+                children="Link your data"
+                icon={<IconLink />}
+                onClick={handleClick}
+                type="primary"
+                {...props}
+            />
+            <ViewLinkModal />
+        </>
     )
 }

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -336,13 +336,7 @@ export function ViewLinkButton({ tableName, ...props }: ViewLinkButtonProps): JS
 
     return (
         <>
-            <LemonButton
-                children="Link your data"
-                icon={<IconLink />}
-                onClick={handleClick}
-                type="primary"
-                {...props}
-            />
+            <LemonButton children="Join data" icon={<IconLink />} onClick={handleClick} type="primary" {...props} />
             <ViewLinkModal />
         </>
     )


### PR DESCRIPTION
## Problem
Data warehouse's join feature is powerful, but quite hidden. Let's add a way for users to find it more easily, especially in the groups table.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/37909
## Changes
_All changes are gated by `crm-iteration-one` feature flag_
- Create `ViewLinkButton`, that triggers the modal open, taking in the name of the table we want to join with
- Add `ViewLinkButton` to groups table
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="1624" height="971" alt="image" src="https://github.com/user-attachments/assets/25338ed0-dbe6-4316-bbab-35622db8d906" />
<img width="1624" height="971" alt="image" src="https://github.com/user-attachments/assets/fcff030d-b838-49cf-bfa5-457b7af31970" />

## How did you test this code?
Locally.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
