### PR TITLE
chore: Add ffmpeg dependency to flox manifest

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -44,6 +44,7 @@ mprocs = { pkg-path = "mprocs" }
 cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql
+ffmpeg.pkg-path = "ffmpeg"
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first


### PR DESCRIPTION
This keeps getting added by `bin/check_video_deps` but hasn't been committed. I'm going to assume we need it because `bin/check_video_deps` keeps adding it.

This only affects dev.