### PR TITLE
perf(flags): Some Rust perf optimizations following Rust idioms

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -74,14 +74,17 @@ impl FromStr for TeamIdCollection {
             let mut team_ids = Vec::new();
             for part in s.split(',').map(|p| p.trim()) {
                 if part.contains(':') {
-                    let bounds: Vec<&str> = part.split(':').collect();
-                    if bounds.len() != 2 {
+                    let mut bounds = part.split(':');
+                    let (Some(start_str), Some(end_str)) = (bounds.next(), bounds.next()) else {
+                        return Err(ParseTeamIdsError::InvalidRange(part.to_string()));
+                    };
+                    if bounds.next().is_some() {
                         return Err(ParseTeamIdsError::InvalidRange(part.to_string()));
                     }
-                    let start = bounds[0]
+                    let start = start_str
                         .parse::<i32>()
                         .map_err(ParseTeamIdsError::InvalidNumber)?;
-                    let end = bounds[1]
+                    let end = end_str
                         .parse::<i32>()
                         .map_err(ParseTeamIdsError::InvalidNumber)?;
                     if end < start {

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -276,7 +276,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     // This allows flags to filter on distinct_id even when no other person properties exist
     all_person_properties.insert(
         "distinct_id".to_string(),
-        Value::String(distinct_id.clone()),
+        Value::String(distinct_id),
     );
 
     flag_evaluation_state.set_person_properties(all_person_properties);

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -274,10 +274,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
 
     // Always add distinct_id to person properties to match Python implementation
     // This allows flags to filter on distinct_id even when no other person properties exist
-    all_person_properties.insert(
-        "distinct_id".to_string(),
-        Value::String(distinct_id),
-    );
+    all_person_properties.insert("distinct_id".to_string(), Value::String(distinct_id));
 
     flag_evaluation_state.set_person_properties(all_person_properties);
     person_processing_timer.fin();
@@ -296,7 +293,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         "#;
 
         let group_type_indexes_vec: Vec<GroupTypeIndex> =
-            group_type_indexes.iter().cloned().collect();
+            group_type_indexes.iter().copied().collect();
         let group_keys_vec: Vec<String> = group_keys.iter().cloned().collect();
 
         let group_query_start = Instant::now();

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -164,11 +164,13 @@ impl FlagRequest {
     /// Extracts the properties from the request.
     /// If the request contains person_properties, they are returned.
     pub fn extract_properties(&self) -> HashMap<String, Value> {
-        let mut properties = HashMap::new();
         if let Some(person_properties) = &self.person_properties {
+            let mut properties = HashMap::with_capacity(person_properties.len());
             properties.extend(person_properties.clone());
+            properties
+        } else {
+            HashMap::new()
         }
-        properties
     }
 
     /// Checks if feature flags should be disabled for this request.

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -524,7 +524,7 @@ mod tests {
         ];
 
         // Client runtime should only get client and all flags
-        let filtered = filter_flags_by_runtime(flags.clone(), Some(EvaluationRuntime::Client));
+        let filtered = filter_flags_by_runtime(flags, Some(EvaluationRuntime::Client));
         assert_eq!(filtered.len(), 2);
         assert!(filtered.iter().any(|f| f.key == "client-flag"));
         assert!(filtered.iter().any(|f| f.key == "all-flag"));
@@ -549,19 +549,19 @@ mod tests {
 
         // Simulate a client runtime
         let client_runtime = Some(EvaluationRuntime::Client);
-        let filtered = filter_flags_by_runtime(all_flags.clone(), client_runtime);
+        let client_filtered = filter_flags_by_runtime(all_flags.clone(), client_runtime);
 
         // Client should get: client-only-flag, all-flag, no-runtime-flag
         // But NOT server-only-flag
-        assert_eq!(filtered.len(), 3);
-        assert!(filtered.iter().any(|f| f.key == "client-only-flag"));
-        assert!(filtered.iter().any(|f| f.key == "all-flag"));
-        assert!(filtered.iter().any(|f| f.key == "no-runtime-flag"));
-        assert!(!filtered.iter().any(|f| f.key == "server-only-flag"));
+        assert_eq!(client_filtered.len(), 3);
+        assert!(client_filtered.iter().any(|f| f.key == "client-only-flag"));
+        assert!(client_filtered.iter().any(|f| f.key == "all-flag"));
+        assert!(client_filtered.iter().any(|f| f.key == "no-runtime-flag"));
+        assert!(!client_filtered.iter().any(|f| f.key == "server-only-flag"));
 
         // Simulate a server runtime
         let server_runtime = Some(EvaluationRuntime::Server);
-        let filtered = filter_flags_by_runtime(all_flags.clone(), server_runtime);
+        let filtered = filter_flags_by_runtime(all_flags, server_runtime);
 
         // Server should get: server-only-flag, all-flag, no-runtime-flag
         // But NOT client-only-flag

--- a/rust/feature-flags/src/site_apps/mod.rs
+++ b/rust/feature-flags/src/site_apps/mod.rs
@@ -426,9 +426,9 @@ mod tests {
         assert!(site_app.url.ends_with('/'));
 
         // The hash should be 32 characters (MD5 hex)
-        let url_parts: Vec<&str> = site_app.url.split('/').collect();
-        assert_eq!(url_parts.len(), 6); // ["", "site_app", config_id, token, hash, ""]
-        let hash = url_parts[4];
+        let mut url_parts = site_app.url.split('/');
+        assert_eq!(url_parts.clone().count(), 6); // ["", "site_app", config_id, token, hash, ""]
+        let hash = url_parts.nth(4).expect("URL should have hash part");
         assert_eq!(hash.len(), 32);
         assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
     }


### PR DESCRIPTION
I decided to go on a side-quest.

# Performance optimizations for Rust feature flags

## :bulb: Motivation and Context

This PR implements several targeted performance optimizations for the Rust feature flags service. These micro-optimizations reduce memory allocations and improve execution efficiency in hot code paths commonly executed during flag evaluation.

Each commit has one type of optimization and an explanation. I'll summarize them here:

## :rocket: Changes

### 1. **Iterator Pattern Over Collection Allocations**
- **URL hash extraction** (`site_apps/mod.rs:18`): Replaced `split('/').collect()` with direct `nth(4)` access
- **Team ID parsing** (`config.rs:45`): Replaced `split(':').collect()` with iterator pattern matching
- **Why**: Eliminates unnecessary Vec allocations when we only need specific elements from a split operation

### 2. **HashMap Pre-sizing**
- **LegacyFlagsResponse**: Pre-size both `feature_flags` and `feature_flag_payloads` HashMaps with known capacity
- **FlagRequest property extraction**: Pre-size HashMap when `person_properties` exists  
- **Why**: Avoids expensive hash table resizing and rehashing operations during insertion

### 3. **Clone Elimination**
- **Test code cleanup** (`handler/flags.rs`): Removed unnecessary `.clone()` calls when passing ownership
- **Distinct ID handling** (`flag_matching_utils.rs:89`): Use owned parameter instead of cloning
- **Why**: Eliminates redundant memory allocations where ownership transfer is sufficient

### 4. **Copy Type Optimization**
- **GroupTypeIndex iteration** (`flag_matching_utils.rs:67`): Use `copied()` instead of `cloned()` for `i32` type alias
- **Why**: More efficient bitwise copy for Copy types vs Clone trait overhead

## :green_heart: How did you test it?

- Unit Tests
- Manual Tests

## Additional Notes:

I forgot to mention, I did code gen some perf testing utils, but I want to spend more time with it before submitting a PR. Initial tests show around a 5% improvement in throughput, but I want to make sure I 100% trust our perf tests before I stand by that result. Regardless, these are all good optimization patterns.
