### PR TITLE
fix(ingestion): fixes dualwrite bug with forgotten return

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
@@ -302,6 +302,7 @@ export class PostgresDualWritePersonRepository implements PersonRepository {
             }
 
             isMerged = p
+            return true
         })
         return isMerged
     }
@@ -336,6 +337,7 @@ export class PostgresDualWritePersonRepository implements PersonRepository {
             }
 
             isMerged = p
+            return true
         })
         return isMerged
     }


### PR DESCRIPTION
## Problem

The dual write coordinator needs to have the callback function return something based on whether there was a successful transaction or not. There was a missing return statement in the callback function for these methods.

## Changes

Add a return statement.

## How did you test this code?

Unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
