### PR TITLE
feat(rust): Add common compression library

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1644,6 +1644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-compression"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "common-cookieless"
 version = "0.0.1"
 dependencies = [
@@ -1948,9 +1957,9 @@ name = "cyclotron-core"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "common-compression",
  "common-metrics",
  "csv",
- "flate2",
  "futures",
  "hex",
  "serde",
@@ -2483,6 +2492,7 @@ dependencies = [
  "bytes",
  "chrono",
  "common-alloc",
+ "common-compression",
  "common-cookieless",
  "common-database",
  "common-geoip",
@@ -2491,7 +2501,6 @@ dependencies = [
  "common-types",
  "dateparser",
  "envconfig",
- "flate2",
  "futures",
  "health",
  "json5",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "common/metrics",
     "common/symbol_data",
     "common/types",
+    "common-compression",
     "feature-flags",
     "hook-api",
     "hook-common",

--- a/rust/common-compression/Cargo.toml
+++ b/rust/common-compression/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "common-compression"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+flate2 = "1.0"
+base64 = "0.22"
+thiserror = "2.0"
+

--- a/rust/common-compression/src/lib.rs
+++ b/rust/common-compression/src/lib.rs
@@ -1,0 +1,169 @@
+//! Common compression utilities for PostHog Rust services
+//!
+//! This crate provides gzip compression and decompression capabilities
+//! that are shared across PostHog's Rust services, including feature-flags.
+//!
+//! Supports:
+//! - gzip compression/decompression
+//! - Base64 encoding/decoding
+
+use base64::{engine::general_purpose, Engine as _};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use std::io::{Read, Write};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CompressionError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Base64 decoding error: {0}")]
+    Base64(#[from] base64::DecodeError),
+}
+
+/// Gzip decompression
+pub fn decompress_gzip(bytes: &[u8]) -> Result<Vec<u8>, CompressionError> {
+    let mut decoder = GzDecoder::new(bytes);
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed)?;
+    Ok(decompressed)
+}
+
+/// Gzip compression
+pub fn compress_gzip(data: &[u8]) -> Result<Vec<u8>, CompressionError> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    encoder.write_all(data)?;
+    let compressed = encoder.finish()?;
+    Ok(compressed)
+}
+
+/// Base64 encode
+pub fn encode_base64(data: &[u8]) -> String {
+    general_purpose::STANDARD.encode(data)
+}
+
+/// Base64 decode
+pub fn decode_base64(data: &str) -> Result<Vec<u8>, CompressionError> {
+    Ok(general_purpose::STANDARD.decode(data)?)
+}
+
+// Cyclotron compatibility layer
+
+/// Compression format enum for cyclotron compatibility
+pub enum CompressionFormat {
+    Gzip,
+}
+
+/// High-level compression function with format selection (cyclotron compatibility)
+pub fn compress_data(data: &[u8], format: CompressionFormat) -> Result<Vec<u8>, CompressionError> {
+    match format {
+        CompressionFormat::Gzip => compress_gzip(data),
+    }
+}
+
+/// Decompression function for cyclotron compatibility
+/// Tries gzip decompression first, then falls back to direct UTF-8 conversion
+pub fn decompress_data(input: &[u8]) -> Result<String, CompressionError> {
+    // Try gzip decompression first
+    match decompress_gzip(input) {
+        Ok(gzip_decompressed) => match String::from_utf8(gzip_decompressed) {
+            Ok(decompressed_str) => Ok(decompressed_str),
+            Err(e) => Err(CompressionError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Decompressed data is not valid UTF-8: {e}"),
+            ))),
+        },
+        Err(_) => {
+            // If gzip fails, try direct UTF-8 conversion (uncompressed data)
+            match String::from_utf8(input.to_vec()) {
+                Ok(direct_string) => Ok(direct_string),
+                Err(e) => Err(CompressionError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Data is neither valid gzip nor valid UTF-8: {e}"),
+                ))),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gzip_compression_decompression() {
+        let original = r#"{"large": "json", "with": ["many", "fields"], "number": 42}"#;
+        let compressed = compress_gzip(original.as_bytes()).unwrap();
+        let decompressed = decompress_gzip(&compressed).unwrap();
+        let decompressed_str = String::from_utf8(decompressed).unwrap();
+        assert_eq!(decompressed_str, original);
+    }
+
+    #[test]
+    fn test_base64_encode_decode() {
+        let original = b"Hello, World!";
+        let encoded = encode_base64(original);
+        let decoded = decode_base64(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_gzip_with_empty_data() {
+        let original = b"";
+        let compressed = compress_gzip(original).unwrap();
+        let decompressed = decompress_gzip(&compressed).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn test_invalid_gzip_data() {
+        let corrupted_gzip = vec![0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00]; // Incomplete gzip header
+        let result = decompress_gzip(&corrupted_gzip);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_base64_data() {
+        let invalid_base64 = "Invalid Base64!";
+        let result = decode_base64(invalid_base64);
+        assert!(result.is_err());
+    }
+
+    // Cyclotron compatibility tests
+    #[test]
+    fn test_compress_data_gzip() {
+        let original = r#"{"test": "cyclotron_data"}"#;
+        let compressed = compress_data(original.as_bytes(), CompressionFormat::Gzip).unwrap();
+        let decompressed = decompress_gzip(&compressed).unwrap();
+        let decompressed_str = String::from_utf8(decompressed).unwrap();
+        assert_eq!(decompressed_str, original);
+    }
+
+    #[test]
+    fn test_decompress_data_uncompressed_utf8() {
+        let json_str = r#"{"test": "uncompressed"}"#;
+        let result = decompress_data(json_str.as_bytes()).unwrap();
+        assert_eq!(result, json_str);
+
+        // Test non-JSON UTF-8 data too
+        let text_str = "Plain text data";
+        let result = decompress_data(text_str.as_bytes()).unwrap();
+        assert_eq!(result, text_str);
+    }
+
+    #[test]
+    fn test_decompress_data_gzip() {
+        let original = r#"{"test": "compressed_cyclotron"}"#;
+        let compressed = compress_gzip(original.as_bytes()).unwrap();
+        let decompressed = decompress_data(&compressed).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn test_decompress_data_invalid_data() {
+        // Data that is neither valid gzip nor valid UTF-8
+        let invalid_data = vec![0xFF, 0xFE, 0xFD, 0xFC];
+        let result = decompress_data(&invalid_data);
+        assert!(result.is_err());
+    }
+}

--- a/rust/cyclotron-core/Cargo.toml
+++ b/rust/cyclotron-core/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
-flate2 = { workspace = true }
+common-compression = { path = "../common-compression" }
 common-metrics = { path = "../common/metrics" }
 csv = "1.3.1"
 hex = "0.4.3"

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -35,10 +35,10 @@ json5 = "0.4"
 thiserror = { workspace = true }
 sha1 = "0.10.6"
 regex.workspace = true
+base64.workspace = true
 sqlx = { workspace = true, features = ["rust_decimal"] }
 uuid = { workspace = true }
-base64.workspace = true
-flate2.workspace = true
+common-compression = { path = "../common-compression" }
 common-alloc = { path = "../common/alloc" }
 strum = { version = "0.26", features = ["derive"] }
 health = { path = "../common/health" }


### PR DESCRIPTION
These are used by Cyclotron and feature flags

## Problem

There's some code duplication between Cyclotron and Feature Flags when it comes to GZip compression/decompression code. Since compression is a pretty common and universal, I wanted to move compression into a common library.

Also, I'll be adding other compression formats such as `Ztsd` to this library to support upcoming use-cases (such as usage of the HyperCache). Cyclotron could potentially benefit from `Ztsd`, but that's on my roadmap or a current goal.

## Changes

Move Gzip compression/decompression code into a new `common-compression` crate.
Update the `feature-flags` and `cyclotron` crates to use the new common methods.

## How did you test this code?

Manual testing of `/flags`
Unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
