### PR TITLE
fix(messaging): fix hidden headers after redesign

### DIFF
--- a/products/messaging/frontend/Campaigns/CampaignScene.tsx
+++ b/products/messaging/frontend/Campaigns/CampaignScene.tsx
@@ -9,6 +9,8 @@ import { LogsViewer } from 'scenes/hog-functions/logs/LogsViewer'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+
 import { CampaignMetrics } from './CampaignMetrics'
 import { CampaignOverview } from './CampaignOverview'
 import { CampaignSceneHeader } from './CampaignSceneHeader'
@@ -72,13 +74,13 @@ export function CampaignScene(props: CampaignSceneLogicProps): JSX.Element {
     ]
 
     return (
-        <div className="flex flex-col space-y-4">
+        <SceneContent className="flex flex-col">
             <CampaignSceneHeader {...props} />
             <LemonTabs
                 activeKey={currentTab}
                 onChange={(tab) => router.actions.push(urls.messagingCampaign(props.id ?? 'new', tab))}
                 tabs={tabs}
             />
-        </div>
+        </SceneContent>
     )
 }

--- a/products/messaging/frontend/Campaigns/CampaignSceneHeader.tsx
+++ b/products/messaging/frontend/Campaigns/CampaignSceneHeader.tsx
@@ -4,6 +4,8 @@ import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
 import { PageHeader } from 'lib/components/PageHeader'
 
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
 import { campaignLogic } from './campaignLogic'
 import { CampaignSceneLogicProps } from './campaignSceneLogic'
 
@@ -15,57 +17,60 @@ export const CampaignSceneHeader = (props: CampaignSceneLogicProps = {}): JSX.El
     const isSavedCampaign = props.id && props.id !== 'new'
 
     return (
-        <PageHeader
-            buttons={
-                <>
-                    {isSavedCampaign && (
-                        <>
-                            <LemonButton
-                                type="primary"
-                                onClick={() =>
-                                    saveCampaign({
-                                        status: campaign?.status === 'draft' ? 'active' : 'draft',
-                                    })
-                                }
-                                loading={campaignLoading}
-                                disabledReason={campaignChanged ? 'Save changes first' : undefined}
-                            >
-                                {campaign?.status === 'draft' ? 'Enable' : 'Disable'}
-                            </LemonButton>
-                            <LemonDivider vertical />
-                        </>
-                    )}
+        <>
+            <PageHeader
+                buttons={
+                    <>
+                        {isSavedCampaign && (
+                            <>
+                                <LemonButton
+                                    type="primary"
+                                    onClick={() =>
+                                        saveCampaign({
+                                            status: campaign?.status === 'draft' ? 'active' : 'draft',
+                                        })
+                                    }
+                                    loading={campaignLoading}
+                                    disabledReason={campaignChanged ? 'Save changes first' : undefined}
+                                >
+                                    {campaign?.status === 'draft' ? 'Enable' : 'Disable'}
+                                </LemonButton>
+                                <LemonDivider vertical />
+                            </>
+                        )}
 
-                    {isSavedCampaign && campaignChanged && (
-                        <>
-                            <LemonButton
-                                data-attr="discard-campaign-changes"
-                                type="secondary"
-                                onClick={() => discardChanges()}
-                            >
-                                Discard changes
-                            </LemonButton>
-                        </>
-                    )}
+                        {isSavedCampaign && campaignChanged && (
+                            <>
+                                <LemonButton
+                                    data-attr="discard-campaign-changes"
+                                    type="secondary"
+                                    onClick={() => discardChanges()}
+                                >
+                                    Discard changes
+                                </LemonButton>
+                            </>
+                        )}
 
-                    <LemonButton
-                        type="primary"
-                        htmlType="submit"
-                        form="campaign"
-                        onClick={submitCampaign}
-                        loading={isCampaignSubmitting}
-                        disabledReason={
-                            campaignHasErrors
-                                ? 'Some fields still need work'
-                                : campaignChanged
-                                  ? undefined
-                                  : 'No changes to save'
-                        }
-                    >
-                        {props.id === 'new' ? 'Create' : 'Save'}
-                    </LemonButton>
-                </>
-            }
-        />
+                        <LemonButton
+                            type="primary"
+                            htmlType="submit"
+                            form="campaign"
+                            onClick={submitCampaign}
+                            loading={isCampaignSubmitting}
+                            disabledReason={
+                                campaignHasErrors
+                                    ? 'Some fields still need work'
+                                    : campaignChanged
+                                      ? undefined
+                                      : 'No changes to save'
+                            }
+                        >
+                            {props.id === 'new' ? 'Create' : 'Save'}
+                        </LemonButton>
+                    </>
+                }
+            />
+            <SceneTitleSection name={campaign.name} resourceType={{ type: 'campaign' }} />
+        </>
     )
 }

--- a/products/messaging/frontend/Campaigns/campaignSceneLogic.ts
+++ b/products/messaging/frontend/Campaigns/campaignSceneLogic.ts
@@ -36,11 +36,6 @@ export const campaignSceneLogic = kea<campaignSceneLogicType>([
             (id): Breadcrumb[] => {
                 return [
                     {
-                        key: Scene.Messaging,
-                        name: 'Messaging',
-                        path: urls.messaging('campaigns'),
-                    },
-                    {
                         key: [Scene.Messaging, 'campaigns'],
                         name: 'Campaigns',
                         path: urls.messaging('campaigns'),

--- a/products/messaging/frontend/Channels/MessageChannels.tsx
+++ b/products/messaging/frontend/Channels/MessageChannels.tsx
@@ -63,7 +63,7 @@ export function MessageChannels(): JSX.Element {
         <>
             <PageHeader
                 buttons={
-                    <div className="flex items-center m-2 shrink-0">
+                    <div className="flex items-center shrink-0">
                         <LemonMenu items={menuItems}>
                             <LemonButton
                                 data-attr="new-channel-button"

--- a/products/messaging/frontend/MessagingScene.tsx
+++ b/products/messaging/frontend/MessagingScene.tsx
@@ -11,6 +11,8 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { Breadcrumb } from '~/types'
 
 import { CampaignsTable } from './Campaigns/CampaignsTable'
@@ -46,10 +48,6 @@ export const messagingSceneLogic = kea<messagingSceneLogicType>([
             (_, p) => [p.tab],
             (tab): Breadcrumb[] => {
                 return [
-                    {
-                        key: Scene.Messaging,
-                        name: 'Messaging',
-                    },
                     {
                         key: [Scene.Messaging, tab],
                         name: capitalizeFirstLetter(tab.replaceAll('_', ' ')),
@@ -159,5 +157,10 @@ export function MessagingScene(): JSX.Element {
         },
     ]
 
-    return <LemonTabs activeKey={currentTab} tabs={tabs} onChange={setCurrentTab} />
+    return (
+        <SceneContent className="messaging">
+            <SceneTitleSection name={capitalizeFirstLetter(currentTab)} resourceType={{ type: 'message' }} />
+            <LemonTabs activeKey={currentTab} tabs={tabs} onChange={setCurrentTab} />
+        </SceneContent>
+    )
 }

--- a/products/messaging/frontend/TemplateLibrary/MessageTemplate.tsx
+++ b/products/messaging/frontend/TemplateLibrary/MessageTemplate.tsx
@@ -9,6 +9,9 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { EmailTemplater } from 'scenes/hog-functions/email-templater/EmailTemplater'
 import { SceneExport } from 'scenes/sceneTypes'
 
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
 import { MessageTemplateLogicProps, messageTemplateLogic } from './messageTemplateLogic'
 
 export const scene: SceneExport<MessageTemplateLogicProps> = {
@@ -26,8 +29,8 @@ export function MessageTemplate({ id }: MessageTemplateLogicProps): JSX.Element 
         useValues(messageTemplateLogic)
 
     return (
-        <div className="space-y-4">
-            <Form logic={messageTemplateLogic} formKey="template">
+        <SceneContent>
+            <Form logic={messageTemplateLogic} formKey="template" className="flex flex-col gap-4">
                 <PageHeader
                     buttons={
                         <>
@@ -53,6 +56,8 @@ export function MessageTemplate({ id }: MessageTemplateLogicProps): JSX.Element 
                         </>
                     }
                 />
+                <SceneTitleSection name={template.name} resourceType={{ type: 'template' }} />
+
                 <div className="flex flex-wrap gap-4 items-start">
                     <div className="flex-1 self-start p-3 space-y-2 rounded border min-w-100 bg-surface-primary">
                         <LemonField name="name" label="Name">
@@ -95,6 +100,6 @@ export function MessageTemplate({ id }: MessageTemplateLogicProps): JSX.Element 
                     </div>
                 </div>
             </Form>
-        </div>
+        </SceneContent>
     )
 }

--- a/products/messaging/frontend/TemplateLibrary/messageTemplateLogic.ts
+++ b/products/messaging/frontend/TemplateLibrary/messageTemplateLogic.ts
@@ -33,11 +33,6 @@ export const messageTemplateLogic = kea<messageTemplateLogicType>([
             (id): Breadcrumb[] => {
                 return [
                     {
-                        key: Scene.Messaging,
-                        name: 'Messaging',
-                        path: urls.messaging(),
-                    },
-                    {
                         key: [Scene.Messaging, 'library'],
                         name: 'Library',
                         path: urls.messaging('library'),


### PR DESCRIPTION
## Problem
 
https://github.com/PostHog/posthog/pull/37884 hid the nav headers from messaging pages, which is fine except for the pages with action buttons in the header. This PR fixes forward as suggested by Marius

## Changes

Before: 
<img width="1358" height="385" alt="image" src="https://github.com/user-attachments/assets/803259a8-abf4-41f6-ad8e-bbf0be807c10" />

<img width="1512" height="251" alt="Screenshot 2025-09-11 at 8 53 17 PM" src="https://github.com/user-attachments/assets/4b8c2e06-aaa9-45a6-995f-60857b3dcc68" />

After:

<img width="1334" height="396" alt="Screenshot 2025-09-11 at 9 18 22 PM" src="https://github.com/user-attachments/assets/6b583bb3-f057-444a-869a-747784e539a3" />
<img width="1327" height="483" alt="Screenshot 2025-09-11 at 9 18 26 PM" src="https://github.com/user-attachments/assets/d5e44aaf-37c3-4406-856c-119125e4a5eb" />
<img width="1329" height="465" alt="Screenshot 2025-09-11 at 9 18 31 PM" src="https://github.com/user-attachments/assets/a34a19f7-0a4a-41a5-afbd-1976789c7418" />
<img width="1331" height="561" alt="Screenshot 2025-09-11 at 9 18 35 PM" src="https://github.com/user-attachments/assets/44657d1f-8527-4457-b49c-88e48c0ad183" />
<img width="1322" height="464" alt="Screenshot 2025-09-11 at 9 18 40 PM" src="https://github.com/user-attachments/assets/2a715087-a652-48dd-a677-1785781775c9" />
<img width="1321" height="409" alt="Screenshot 2025-09-11 at 9 18 45 PM" src="https://github.com/user-attachments/assets/1829d624-768a-48f4-8fd2-346f4a973a1e" />

## How did you test this code?
See above