### PR TITLE
fix: /flags 502 in linux dev

### DIFF
--- a/docker-compose.dev-minimal.yml
+++ b/docker-compose.dev-minimal.yml
@@ -60,7 +60,7 @@ services:
                     }
 
                     handle @flags {
-                        reverse_proxy host.docker.internal:3001
+                        reverse_proxy feature-flags:3001
                     }
 
                     handle @webhooks {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -59,7 +59,7 @@ services:
                     }
 
                     handle @flags {
-                        reverse_proxy host.docker.internal:3001
+                        reverse_proxy feature-flags:3001
                     }
 
                     handle @webhooks {


### PR DESCRIPTION
## Problem
linux docker engine doesn't set host.docker.internal (which resolves to the host machine). This makes flags not work in development.

## Changes
instead of host.docker.engine, use feature-flags, which is mapped to host-gateway elsewhere in the docker file

## How did you test this code?
Worked locally for flags (no 502)