### PR TITLE
fix: surveys api validating linked flag without conditions

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -385,7 +385,8 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 raise serializers.ValidationError("Feature Flag with this ID does not exist")
 
         # Validate linkedFlagVariant if provided
-        linked_flag_variant = data.get("conditions", {}).get("linkedFlagVariant")
+        conditions = data.get("conditions") or {}
+        linked_flag_variant = conditions.get("linkedFlagVariant")
         if linked_flag_variant and linked_flag and linked_flag_variant != "any":
             # Get available variants from the linked feature flag
             available_variants = [variant["key"] for variant in linked_flag.variants]


### PR DESCRIPTION
## Problem

Closes https://us.posthog.com/project/2/error_tracking/0198bdba-3b2b-7e10-bfa3-58085a49a806?timestamp=2025-09-11T23%3A37%3A30.753000-07%3A00
'NoneType' object has no attribute 'get'
Cooses https://github.com/PostHog/posthog/issues/37961

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
