### PR TITLE
fix: make QueryEditor resizeable again

### DIFF
--- a/frontend/src/queries/QueryEditor/QueryEditor.tsx
+++ b/frontend/src/queries/QueryEditor/QueryEditor.tsx
@@ -40,7 +40,7 @@ export function QueryEditor(props: QueryEditorProps): JSX.Element {
             <div
                 data-attr="query-editor"
                 className={clsx(
-                    'flex flex-col p-2 bg-primary deprecated-space-y-2 resize-y overflow-auto h-80 rounded',
+                    'flex flex-col p-2 bg-primary deprecated-space-y-2 resize-y overflow-auto min-h-80 rounded',
                     props.className
                 )}
             >


### PR DESCRIPTION
## Problem

The query editor in the insight editor should be resizeable. Because the height is fixed you can't drag to resize.<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Changed the query editor height class from `h-80` to `min-h-80` so that it is actually resizeable. Doesn't visually change anything except that you can now drag to resize.

Resizing in action:
<img width="829" height="351" alt="image" src="https://github.com/user-attachments/assets/6c53737a-e8df-407c-ab45-d36caa7276bb" />

*Drag handle to resize*


----

<img width="827" height="625" alt="image" src="https://github.com/user-attachments/assets/2b30aca7-4880-4150-83ad-79cd69645298" />

*Wow look it resizes now*

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I tried to resize it. It's now resizeable. Before this change it wasn't resizeable.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
