### PR TITLE
refactor: accept objects in event data field

### DIFF
--- a/plugin-server/src/ingestion/event-preprocessing/parse-kafka-message.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/parse-kafka-message.ts
@@ -7,9 +7,15 @@ import { logger } from '../../utils/logger'
 
 export function parseKafkaMessage(message: Message): IncomingEvent | null {
     try {
-        // Parse the message payload into the event object
-        const { data: dataStr, ...rawEvent } = parseJSON(message.value!.toString())
-        const combinedEvent: PipelineEvent = { ...parseJSON(dataStr), ...rawEvent }
+        const { data, ...rawEvent } = parseJSON(message.value!.toString())
+
+        if (data === undefined) {
+            logger.warn('Failed to parse Kafka message', { error: new Error('Missing data field') })
+            return null
+        }
+
+        const eventData = typeof data === 'string' ? parseJSON(data) : data
+        const combinedEvent: PipelineEvent = { ...eventData, ...rawEvent }
         const event: PipelineEvent = normalizeEvent(combinedEvent)
 
         return { message, event }


### PR DESCRIPTION
## Problem

When redirecting messages we don't serialize the data field for the second time, so parsing it later fails.

## Changes

Accepts objects in the event data field to skip double serialization.

## How did you test this code?

Added new tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
