### PR TITLE
feat(cohorts): Allow user to manually add people during static cohort creation (#37967)

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -55,14 +55,8 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     } = useActions(logic)
     const modalLogic = addPersonToCohortModalLogic(logicProps)
     const { showAddPersonToCohortModal } = useActions(modalLogic)
-    const {
-        cohort,
-        cohortLoading,
-        cohortMissing,
-        query,
-        creationPersonQuery,
-        personsToCreateStaticCohort,
-    } = useValues(logic)
+    const { cohort, cohortLoading, cohortMissing, query, creationPersonQuery, personsToCreateStaticCohort } =
+        useValues(logic)
     const isNewCohort = cohort.id === 'new' || cohort.id === undefined
     const dataNodeLogicKey = createCohortDataNodeLogicKey(cohort.id)
 

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -341,13 +341,23 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                         />
                                     )}
                                 </LemonField>
-                                <LemonDivider label="OR" />
-                                <Query
-                                    query={creationPersonQuery}
-                                    setQuery={setCreationPersonQuery}
-                                    context={createStaticCohortContext}
-                                />
                             </SceneSection>
+                            {isNewCohort && (
+                                <>
+                                    <LemonDivider label="OR" />
+                                    <div>
+                                        <h3 className="font-semibold my-0 mb-1 max-w-prose">Add users manually</h3>
+                                        <span className="max-w-prose">
+                                            Select the users that you would like to add to the new cohort.
+                                        </span>
+                                    </div>
+                                    <Query
+                                        query={creationPersonQuery}
+                                        setQuery={setCreationPersonQuery}
+                                        context={createStaticCohortContext}
+                                    />
+                                </>
+                            )}
                             {!isNewCohort && (
                                 <>
                                     <LemonDivider label="OR" />

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
 
-import { IconCopy, IconTrash } from '@posthog/icons'
+import { IconCopy, IconMinusSmall, IconPlusSmall, IconTrash } from '@posthog/icons'
 import { LemonBanner, LemonDivider, LemonFileInput, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
@@ -31,6 +31,7 @@ import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { Query } from '~/queries/Query/Query'
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
+import { QueryContext } from '~/queries/types'
 
 import { AddPersonToCohortModal } from './AddPersonToCohortModal'
 import { addPersonToCohortModalLogic } from './addPersonToCohortModalLogic'
@@ -42,12 +43,58 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const logicProps = { id }
 
     const logic = cohortEditLogic(logicProps)
-    const { deleteCohort, setOuterGroupsType, setQuery, duplicateCohort, setCohortValue } = useActions(logic)
+    const {
+        deleteCohort,
+        setOuterGroupsType,
+        setQuery,
+        duplicateCohort,
+        setCohortValue,
+        addPersonToCreateStaticCohort,
+        removePersonFromCreateStaticCohort,
+        setCreationPersonQuery,
+    } = useActions(logic)
     const modalLogic = addPersonToCohortModalLogic(logicProps)
     const { showAddPersonToCohortModal } = useActions(modalLogic)
-    const { cohort, cohortLoading, cohortMissing, query } = useValues(logic)
+    const {
+        cohort,
+        cohortLoading,
+        cohortMissing,
+        query,
+        creationPersonQuery,
+        personsToCreateStaticCohort,
+    } = useValues(logic)
     const isNewCohort = cohort.id === 'new' || cohort.id === undefined
     const dataNodeLogicKey = createCohortDataNodeLogicKey(cohort.id)
+
+    const createStaticCohortContext: QueryContext = {
+        columns: {
+            id: {
+                renderTitle: () => null,
+                render: (props) => {
+                    const id = props.value as string
+                    const isAdded = personsToCreateStaticCohort[id] != null
+                    return (
+                        <LemonButton
+                            type="secondary"
+                            status={isAdded ? 'danger' : 'default'}
+                            size="small"
+                            onClick={(e) => {
+                                e.preventDefault()
+                                if (isAdded) {
+                                    removePersonFromCreateStaticCohort(id)
+                                } else {
+                                    addPersonToCreateStaticCohort(id)
+                                }
+                            }}
+                        >
+                            {isAdded ? <IconMinusSmall /> : <IconPlusSmall />}
+                        </LemonButton>
+                    )
+                },
+            },
+        },
+        showOpenEditorButton: false,
+    }
 
     if (cohortMissing) {
         return <NotFound object="cohort" />
@@ -294,6 +341,12 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                         />
                                     )}
                                 </LemonField>
+                                <LemonDivider label="OR" />
+                                <Query
+                                    query={creationPersonQuery}
+                                    setQuery={setCreationPersonQuery}
+                                    context={createStaticCohortContext}
+                                />
                             </SceneSection>
                             {!isNewCohort && (
                                 <>

--- a/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
@@ -618,7 +618,7 @@ describe('cohortEditLogic', () => {
                     id: 'new',
                 })
                 logic.actions.submitCohort()
-            }).toDispatchActions(['setCohort', 'submitCohort', 'submitCohortFailure'])
+            }).toDispatchActions(['setCohort', 'submitCohort'])
             expect(api.update).toHaveBeenCalledTimes(0)
         })
 

--- a/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
@@ -618,7 +618,7 @@ describe('cohortEditLogic', () => {
                     id: 'new',
                 })
                 logic.actions.submitCohort()
-            }).toDispatchActions(['setCohort', 'submitCohort'])
+            }).toDispatchActions(['setCohort', 'submitCohort', 'submitCohortFailure'])
             expect(api.update).toHaveBeenCalledTimes(0)
         })
 

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -162,8 +162,8 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                                 isCohortCriteriaGroup(oldCriteria)
                                     ? oldCriteria
                                     : criteriaI === criteriaIndex
-                                      ? cleanCriteria({ ...oldCriteria, ...newCriteria })
-                                      : oldCriteria
+                                        ? cleanCriteria({ ...oldCriteria, ...newCriteria })
+                                        : oldCriteria
                             ),
                         groupIndex
                     ),
@@ -437,6 +437,11 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                 fallbackErrorMessage:
                     'There was an error submitting this cohort. Make sure the cohort filters are correct.',
             })
+        },
+        submitCohort: () => {
+            if (values.cohortHasErrors) {
+                lemonToast.error('There was an error submitting this cohort. Make sure the cohort filters are correct.')
+            }
         },
         checkIfFinishedCalculating: async ({ cohort }, breakpoint) => {
             if (cohort.is_calculating) {

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -234,12 +234,12 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         ],
     })),
 
-    forms(({ actions }) => ({
+    forms(({ actions, values }) => ({
         cohort: {
             defaults: NEW_COHORT,
-            errors: ({ id, name, csv, is_static, filters }) => ({
+            errors: ({ name, is_static, filters }) => ({
                 name: !name ? 'Cohort name cannot be empty' : undefined,
-                csv: is_static && id === 'new' && !csv ? 'You need to upload a CSV file' : (null as any),
+                csv: undefined,
                 filters: {
                     properties: {
                         values: is_static ? undefined : filters.properties.values.map(validateGroup),
@@ -251,6 +251,10 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     actions.saveCohort(cohort)
                 } else {
                     const personIds = Object.keys(values.personsToCreateStaticCohort)
+                    if (cohort.csv == null && personIds.length === 0) {
+                        lemonToast.error('You need to upload a csv file or add a person manually.')
+                        return
+                    }
                     actions.saveCohort({
                         ...cohort,
                         _create_in_folder: 'Unfiled/Cohorts',

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -162,8 +162,8 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                                 isCohortCriteriaGroup(oldCriteria)
                                     ? oldCriteria
                                     : criteriaI === criteriaIndex
-                                        ? cleanCriteria({ ...oldCriteria, ...newCriteria })
-                                        : oldCriteria
+                                      ? cleanCriteria({ ...oldCriteria, ...newCriteria })
+                                      : oldCriteria
                             ),
                         groupIndex
                     ),

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -251,7 +251,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     actions.saveCohort(cohort)
                 } else {
                     const personIds = Object.keys(values.personsToCreateStaticCohort)
-                    if (cohort.csv == null && personIds.length === 0) {
+                    if (cohort.is_static && cohort.csv == null && personIds.length === 0) {
                         lemonToast.error('You need to upload a csv file or add a person manually.')
                         return
                     }

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -44,6 +44,22 @@ export type CohortLogicProps = {
     id?: CohortType['id']
 }
 
+function errorForCsvInForm(
+    isStatic: boolean | undefined,
+    id: number | 'new',
+    csv: File | undefined,
+    personsToCreateStaticCohort: Record<string, boolean>
+): string | undefined {
+    if (isStatic && id === 'new' && !csv) {
+        const personIds = Object.keys(personsToCreateStaticCohort)
+        if (personIds.length > 0) {
+            return
+        }
+        return 'You need to upload a CSV file or add people manually'
+    }
+    return
+}
+
 export const cohortEditLogic = kea<cohortEditLogicType>([
     props({} as CohortLogicProps),
     key((props) => props.id || 'new'),
@@ -237,9 +253,9 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
     forms(({ actions, values }) => ({
         cohort: {
             defaults: NEW_COHORT,
-            errors: ({ name, is_static, filters }) => ({
+            errors: ({ name, is_static, id, csv, filters }) => ({
                 name: !name ? 'Cohort name cannot be empty' : undefined,
-                csv: undefined,
+                csv: errorForCsvInForm(is_static, id, csv, values.personsToCreateStaticCohort),
                 filters: {
                     properties: {
                         values: is_static ? undefined : filters.properties.values.map(validateGroup),

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -267,10 +267,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     actions.saveCohort(cohort)
                 } else {
                     const personIds = Object.keys(values.personsToCreateStaticCohort)
-                    if (cohort.is_static && cohort.csv == null && personIds.length === 0) {
-                        lemonToast.error('You need to upload a csv file or add a person manually.')
-                        return
-                    }
                     actions.saveCohort({
                         ...cohort,
                         _create_in_folder: 'Unfiled/Cohorts',

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -438,11 +438,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     'There was an error submitting this cohort. Make sure the cohort filters are correct.',
             })
         },
-        submitCohort: () => {
-            if (values.cohortHasErrors) {
-                lemonToast.error('There was an error submitting this cohort. Make sure the cohort filters are correct.')
-            }
-        },
         checkIfFinishedCalculating: async ({ cohort }, breakpoint) => {
             if (cohort.is_calculating) {
                 actions.setPollTimeout(

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -98,7 +98,7 @@ export function createCohortFormData(cohort: CohortType): FormData {
         ...(cohort.csv ? { csv: cohort.csv } : {}),
         ...(cohort.is_static ? { is_static: cohort.is_static } : {}),
         ...(typeof cohort._create_in_folder === 'string' ? { _create_in_folder: cohort._create_in_folder } : {}),
-        _create_static_person_ids: cohort._create_static_person_ids,
+        ...(cohort._create_static_person_ids ? { _create_static_person_ids: cohort._create_static_person_ids } : {}),
         filters: JSON.stringify(
             cohort.is_static
                 ? {

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -98,6 +98,7 @@ export function createCohortFormData(cohort: CohortType): FormData {
         ...(cohort.csv ? { csv: cohort.csv } : {}),
         ...(cohort.is_static ? { is_static: cohort.is_static } : {}),
         ...(typeof cohort._create_in_folder === 'string' ? { _create_in_folder: cohort._create_in_folder } : {}),
+        _create_static_person_ids: cohort._create_static_person_ids,
         filters: JSON.stringify(
             cohort.is_static
                 ? {

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -98,7 +98,6 @@ export function createCohortFormData(cohort: CohortType): FormData {
         ...(cohort.csv ? { csv: cohort.csv } : {}),
         ...(cohort.is_static ? { is_static: cohort.is_static } : {}),
         ...(typeof cohort._create_in_folder === 'string' ? { _create_in_folder: cohort._create_in_folder } : {}),
-        ...(cohort._create_static_person_ids ? { _create_static_person_ids: cohort._create_static_person_ids } : {}),
         filters: JSON.stringify(
             cohort.is_static
                 ? {
@@ -136,6 +135,12 @@ export function createCohortFormData(cohort: CohortType): FormData {
     const cohortFormData = new FormData()
     for (const [itemKey, value] of Object.entries(rawCohort)) {
         cohortFormData.append(itemKey, value as string | Blob)
+    }
+
+    if (cohort._create_static_person_ids != null) {
+        cohort._create_static_person_ids.forEach((personId) => {
+            cohortFormData.append('_create_static_person_ids', personId)
+        })
     }
     return cohortFormData
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1479,6 +1479,7 @@ export interface CohortType {
     }
     experiment_set?: number[]
     _create_in_folder?: string | null
+    _create_static_person_ids?: string[]
 }
 
 export interface InsightHistory {

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -302,7 +302,7 @@ class CohortSerializer(serializers.ModelSerializer):
             validated_data["is_calculating"] = True
         if validated_data.get("query") and validated_data.get("filters"):
             raise ValidationError("Cannot set both query and filters at the same time.")
-        person_ids = validated_data.pop("_create_static_person_ids")
+        person_ids = validated_data.pop("_create_static_person_ids", None)
         cohort = Cohort.objects.create(team_id=self.context["team_id"], **validated_data)
 
         if cohort.is_static:

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -200,6 +200,7 @@ class CohortSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     earliest_timestamp_func = get_earliest_timestamp
     _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
+    _create_static_person_ids = serializers.ListField(required=False, child=serializers.CharField(), write_only=True)
 
     # If this cohort is an exposure cohort for an experiment
     experiment_set: serializers.PrimaryKeyRelatedField = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
@@ -224,6 +225,7 @@ class CohortSerializer(serializers.ModelSerializer):
             "cohort_type",
             "experiment_set",
             "_create_in_folder",
+            "_create_static_person_ids",
         ]
         read_only_fields = [
             "id",
@@ -259,18 +261,26 @@ class CohortSerializer(serializers.ModelSerializer):
                 raise ValidationError(type_serializer.errors["cohort_type"][0])
             raise ValidationError("Invalid cohort type for the given filters")
 
-        return value
+        return value    
 
-    def _handle_static(self, cohort: Cohort, context: dict, validated_data: dict) -> None:
+    def _handle_static(self, cohort: Cohort, context: dict, validated_data: dict, person_ids: list[str] | None) -> None:
         from posthog.tasks.calculate_cohort import (
             insert_cohort_from_feature_flag,
             insert_cohort_from_insight_filter,
             insert_cohort_from_query,
         )
-
         request = self.context["request"]
-        if request.FILES.get("csv"):
-            self._calculate_static_by_csv(request.FILES["csv"], cohort)
+        if request.FILES.get("csv") or person_ids is not None:
+            if person_ids is not None:
+                uuids = [
+                    str(uuid)
+                    for uuid in Person.objects.db_manager(READ_DB_FOR_PERSONS)
+                    .filter(team_id=self.context["team_id"], uuid__in=person_ids)
+                    .values_list("uuid", flat=True)
+                ]
+                cohort.insert_users_list_by_uuid(uuids, team_id=self.context["team_id"])
+            if request.FILES.get("csv"):
+                self._calculate_static_by_csv(request.FILES["csv"], cohort)
         elif context.get("from_feature_flag_key"):
             insert_cohort_from_feature_flag.delay(cohort.pk, context["from_feature_flag_key"], self.context["team_id"])
         elif validated_data.get("query"):
@@ -292,11 +302,11 @@ class CohortSerializer(serializers.ModelSerializer):
             validated_data["is_calculating"] = True
         if validated_data.get("query") and validated_data.get("filters"):
             raise ValidationError("Cannot set both query and filters at the same time.")
-
+        person_ids = validated_data.pop("_create_static_person_ids")
         cohort = Cohort.objects.create(team_id=self.context["team_id"], **validated_data)
 
         if cohort.is_static:
-            self._handle_static(cohort, self.context, validated_data)
+            self._handle_static(cohort, self.context, validated_data, person_ids)
         elif cohort.query is not None:
             raise ValidationError("Cannot create a dynamic cohort with a query. Set is_static to true.")
         else:

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -261,7 +261,7 @@ class CohortSerializer(serializers.ModelSerializer):
                 raise ValidationError(type_serializer.errors["cohort_type"][0])
             raise ValidationError("Invalid cohort type for the given filters")
 
-        return value    
+        return value
 
     def _handle_static(self, cohort: Cohort, context: dict, validated_data: dict, person_ids: list[str] | None) -> None:
         from posthog.tasks.calculate_cohort import (
@@ -269,6 +269,7 @@ class CohortSerializer(serializers.ModelSerializer):
             insert_cohort_from_insight_filter,
             insert_cohort_from_query,
         )
+
         request = self.context["request"]
         if request.FILES.get("csv") or person_ids is not None:
             if person_ids is not None:


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/37967

## Changes

We allow the user to either:
1) Upload a CSV file
2) Add users manually

In the event that the user does both, we will first process the CSV file followed by adding the users. 

https://github.com/user-attachments/assets/a489a5c7-58dd-463d-bc15-4c7b8b4718c9



## How did you test this code?

Locally:
1) Go to the cohort creation page
2) Switch to creating a static cohort
3) Enter a cohort name and add a user in the manual add section
4) Save the cohort
5) Cohort should be created with the user added. 

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
