### PR TITLE
feat(sidebar): make side action buttons hoverable

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -578,7 +578,11 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                 <DropdownMenu>
                                                     <DropdownMenuTrigger asChild>
                                                         {itemSideActionButton?.(item) ?? (
-                                                            <ButtonPrimitive iconOnly isSideActionRight className="z-2">
+                                                            <ButtonPrimitive
+                                                                iconOnly
+                                                                isSideActionRight
+                                                                className="z-2 opacity-0 group-hover/lemon-tree-button-group:opacity-100 data-[state=open]:opacity-100 transition-opacity"
+                                                            >
                                                                 <IconEllipsis className="size-3 text-tertiary" />
                                                             </ButtonPrimitive>
                                                         )}


### PR DESCRIPTION
## Problem

We have *a lot* of action buttons in the sidebar right now. But only 3 of them (Dashboards, Session Replay, Product Analytics) actually have custom functionality attached to them. The rest of them are identical in what they do. This (IMO) causes visual clutter and actually points out the buttons with special functionality more clearly.



<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Made side action buttons that don't have specific functionality attached to them hoverable.

<table>
<tr>
<td>

**Before**
<img width="auto" height="600" alt="Pasted image 20250912114405" src="https://github.com/user-attachments/assets/a9ce1338-8fcb-46fc-84ef-a1c7681e6790" />
</td>
<td>

**After**
<img width="auto" height="600" alt="image" src="https://github.com/user-attachments/assets/f1315dcb-f74d-4d79-87eb-adeb5fa03179" /></td>

<td>

**After:** Hovering item reveals button
<img width="auto" height="600" alt="image" src="https://github.com/user-attachments/assets/3f1bd4a8-a594-4310-9c88-67f72a90787f" />
</td>


<td>

**After:** Clicking keeps the button revealed
<img width="auto" height="600" alt="image" src="https://github.com/user-attachments/assets/f0763b2d-1c07-4ed1-9cb1-565826944143" />
</td>

</tr>

</table>



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
