### PR TITLE
feat(cohorts): Recalculate all affected cohorts on create, update

### DIFF
--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -3145,6 +3145,7 @@ email@example.org,
             f"/api/projects/{self.team.id}/cohorts",
             data={"name": "cohort A", "groups": [{"properties": {"team_id": 5}}]},
         )
+
         response_b = self.client.patch(
             f"/api/projects/{self.team.id}/cohorts/{response_a.json()['id']}",
             data={"name": "cohort A", "groups": [{"properties": [{"key": "email", "value": "email@example.org"}]}]},
@@ -3154,6 +3155,101 @@ email@example.org,
         self.assertEqual(patch_cohort_changed.call_count, 2)
         self.assertEqual(patch_calculate.call_count, 2)
         self.assertEqual(calls, [patch_cohort_changed, patch_calculate, patch_cohort_changed, patch_calculate])
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
+    @patch("posthog.api.cohort.report_user_action")
+    @patch("posthog.tasks.calculate_cohort.chain")
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.si")
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
+    def test_cohort_dependencies_calculated(
+        self,
+        patch_calculate_cohort_delay,
+        patch_calculate_cohort_si,
+        patch_chain,
+        patch_capture,
+        patch_on_commit,
+    ) -> None:
+        mock_chain_instance = MagicMock()
+        patch_chain.return_value = mock_chain_instance
+
+        # Count total calculation calls (both delay and chain)
+        def get_total_calculation_calls():
+            return patch_calculate_cohort_delay.call_count + patch_chain.call_count
+
+        # Cohort A
+        response_a = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={"name": "cohort A", "groups": [{"properties": {"team_id": 5}}]},
+        )
+        self.assertEqual(get_total_calculation_calls(), 1)
+
+        # Cohort B that depends on Cohort A
+        response_b = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={
+                "name": "cohort B",
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "type": "cohort",
+                                "value": response_a.json()["id"],
+                                "key": "id",
+                            }
+                        ]
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(get_total_calculation_calls(), 2)
+
+        # Cohort C that depends on Cohort B
+        response_c = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={
+                "name": "cohort C",
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "type": "cohort",
+                                "value": response_b.json()["id"],
+                                "key": "id",
+                            }
+                        ]
+                    }
+                ],
+            },
+        )
+        self.assertEqual(get_total_calculation_calls(), 3)
+
+        # Update Cohort A, should trigger dependency recalculation of B, then C
+        self.client.patch(
+            f"/api/projects/{self.team.id}/cohorts/{response_a.json()['id']}",
+            data={
+                "name": "Cohort A, reloaded",
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "$some_prop",
+                                "type": "person",
+                                "operator": "is_set",
+                            }
+                        ]
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(get_total_calculation_calls(), 4)
+
+        # Verify that all 3 cohorts (A, B, C) were included in the dependency chain to be recalculated
+        si_calls = patch_calculate_cohort_si.call_args_list
+        chain_cohort_ids = [call[0][0] for call in si_calls[-3:]]  # Last 3 si() calls for the chain
+        expected_cohort_ids = {response_a.json()["id"], response_b.json()["id"], response_c.json()["id"]}
+        self.assertEqual(set(chain_cohort_ids), expected_cohort_ids)
 
 
 class TestCalculateCohortCommand(APIBaseTest):

--- a/posthog/models/cohort/__init__.py
+++ b/posthog/models/cohort/__init__.py
@@ -1,1 +1,2 @@
 from .cohort import *
+from .dependencies import *

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -67,18 +67,34 @@ def get_cohort_dependencies(cohort: Cohort) -> list[int]:
     return result or []
 
 
-def get_cohort_dependents(cohort: Cohort) -> list[int]:
+def get_cohort_dependents(cohort: Cohort | int) -> list[int]:
     """
     Get the list of cohort IDs that depend on the given cohort.
+    Can accept either a Cohort object or a cohort ID. If only an ID is provided
+    and there's a cache miss, the team_id will be queried from the database.
     """
-    cache_key = _cohort_dependents_key(cohort.id)
+    cohort_id = cohort.id if isinstance(cohort, Cohort) else cohort
+    cache_key = _cohort_dependents_key(cohort_id)
 
     # Check if value exists in cache first
     cache_hit = cache.has_key(cache_key)
 
     def compute_or_fallback() -> list[int]:
         COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependents", result="miss").inc()
-        warm_team_cohort_dependency_cache(cohort.team_id)
+        # If we only have an ID, query the database for team_id
+        if isinstance(cohort, int):
+            try:
+                team_id = Cohort.objects.filter(pk=cohort_id, deleted=False).values_list("team_id", flat=True).first()
+                if team_id is None:
+                    logger.warning("Cohort not found when computing dependents", cohort_id=cohort_id)
+                    return []
+            except Exception as e:
+                logger.exception("Failed to fetch team_id for cohort", cohort_id=cohort_id, error=str(e))
+                return []
+        else:
+            team_id = cohort.team_id
+
+        warm_team_cohort_dependency_cache(team_id)
         return cache.get(cache_key, [])
 
     if cache_hit:
@@ -86,7 +102,7 @@ def get_cohort_dependents(cohort: Cohort) -> list[int]:
 
     result = cache.get_or_set(cache_key, compute_or_fallback, timeout=DEPENDENCY_CACHE_TIMEOUT)
     if result is None:
-        logger.error("Cohort dependents cache returned None", cohort_id=cohort.id)
+        logger.error("Cohort dependents cache returned None", cohort_id=cohort_id)
     return result or []
 
 

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -284,6 +284,17 @@ class TestCohortDependencies(BaseTest):
         # it has to iterate all cohorts in the team
         self._assert_depends_on(cohort_b, cohort_a)
 
+    def test_cache_miss_get_cohort_dependent_int_param(self) -> None:
+        cohort_a = self._create_cohort(name="Test Cohort A")
+        cohort_b = self._create_cohort(
+            name="Test Cohort B", groups=[{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.id}]}]
+        )
+
+        cache.clear()
+
+        self.assertEqual(get_cohort_dependents(cohort_a.id), [cohort_b.id])
+        self._assert_depends_on(cohort_b, cohort_a)
+
     @parameterized.expand(
         [
             ("dependencies",),

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -557,50 +557,33 @@ def get_all_cohort_dependencies(
     return cohorts
 
 
-def get_all_cohort_dependents(
-    cohort: Cohort,
-    using_database: str = "default",
-    seen_cohorts_cache: Optional[dict[int, CohortOrEmpty]] = None,
-) -> list[Cohort]:
+def get_all_cohort_dependents(cohort: Cohort, using_database: str = "default") -> list[Cohort]:
     """
     Get all cohorts that reference the given cohort, traversing the full dependent chain.
     For example: if A depends on B, and B depends on C, this returns [A, B] for cohort C.
     This is the reverse traversal of get_dependency_cohorts.
     """
-    if seen_cohorts_cache is None:
-        seen_cohorts_cache = {}
-
-    cohorts = []
-    seen_cohort_ids = {cohort.id}
-    queue = [cohort.id]
+    cohorts: list[int] = []
+    seen_cohort_ids: set[int] = {cohort.id}
+    queue: list[int] = [cohort.id]
 
     while queue:
         cohort_id = queue.pop()
 
-        try:
-            if cohort_id in seen_cohorts_cache:
-                current_cohort = seen_cohorts_cache[cohort_id]
-                if not current_cohort:
-                    continue
-            else:
-                current_cohort = Cohort.objects.db_manager(using_database).get(
-                    pk=cohort_id, team__project_id=cohort.team.project_id, deleted=False
-                )
-                seen_cohorts_cache[cohort_id] = current_cohort
+        for related_id in get_cohort_dependents(cohort_id):
+            if related_id not in seen_cohort_ids:
+                queue.append(related_id)
+                seen_cohort_ids.add(related_id)
 
-            for related_id in get_cohort_dependents(current_cohort):
-                if related_id not in seen_cohort_ids:
-                    queue.append(related_id)
-                    seen_cohort_ids.add(related_id)
+        if cohort_id != cohort.id:
+            cohorts.append(cohort_id)
 
-            if cohort_id != cohort.id:
-                cohorts.append(current_cohort)
-
-        except Cohort.DoesNotExist:
-            seen_cohorts_cache[cohort_id] = ""
-            continue
-
-    return cohorts
+    try:
+        dependent_cohorts = Cohort.objects.db_manager(using_database).filter(id__in=cohorts, deleted=False).all()
+        return list(dependent_cohorts)
+    except Exception as e:
+        logger.exception("Failed to fetch cohorts", error=str(e))
+    return []
 
 
 def sort_cohorts_topologically(cohort_ids: set[int], seen_cohorts_cache: dict[int, CohortOrEmpty]) -> list[int]:

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -18,7 +18,11 @@ from posthog.clickhouse.query_tagging import QueryTags, update_tags
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Cohort
 from posthog.models.cohort import CohortOrEmpty
-from posthog.models.cohort.util import get_all_cohort_dependencies, sort_cohorts_topologically
+from posthog.models.cohort.util import (
+    get_all_cohort_dependencies,
+    get_all_cohort_dependents,
+    sort_cohorts_topologically,
+)
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.tasks.utils import CeleryQueue
@@ -185,15 +189,17 @@ def enqueue_cohorts_to_calculate(parallel_count: int) -> None:
 
 
 def increment_version_and_enqueue_calculate_cohort(cohort: Cohort, *, initiating_user: Optional[User]) -> None:
-    dependent_cohorts = get_all_cohort_dependencies(cohort)
-    if dependent_cohorts:
-        logger.info("cohort_has_dependencies", cohort_id=cohort.id, dependent_count=len(dependent_cohorts))
+    dependent_cohorts = get_all_cohort_dependents(cohort)
+    dependency_cohorts = get_all_cohort_dependencies(cohort)
+    related_cohorts = dependent_cohorts + dependency_cohorts
+    if related_cohorts:
+        logger.info("cohort_has_dependencies", cohort_id=cohort.id, related_cohort_count=len(related_cohorts))
 
-        all_cohort_ids = {dep.id for dep in dependent_cohorts}
+        all_cohort_ids = {dep.id for dep in related_cohorts}
         all_cohort_ids.add(cohort.id)
 
         # Sort cohorts (dependencies first)
-        seen_cohorts_cache: dict[int, CohortOrEmpty] = {dep.id: dep for dep in dependent_cohorts}
+        seen_cohorts_cache: dict[int, CohortOrEmpty] = {dep.id: dep for dep in related_cohorts}
         seen_cohorts_cache[cohort.id] = cohort
 
         try:


### PR DESCRIPTION
## Problem

Currently when a cohort is recalculated, it also recalculates its dependent graph. E.g., in the case of:
```
A <- B <- C
```

If C updates, so will B, then A. However the reverse is not true. If A updates, B and C will still reference stale data until they're recalculated by schedule or by manual intervention.

Resolves #36134

## Changes

When recalculating a cohort, its dependency graph is now also automatically enqueued for recalculation. This change uses the new [cohort dependency cache](#37897) to build the dependency graph.

## How did you test this code?

Automated tests are added to validate:
- Recalculation properly enqueues dependencies for recalulation
- API integration tests to ensure recalculation works as expected when changing or creating cohorts
- Model properties for cohort dependents / dependencies
