### PR TITLE
chore(batch-exports): Increase timeout for hourly runs on old pipeline

### DIFF
--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -892,7 +892,7 @@ async def execute_batch_export_insert_activity(
         heartbeat_timeout_seconds = settings.BATCH_EXPORT_HEARTBEAT_TIMEOUT_SECONDS
 
     if interval == "hour":
-        start_to_close_timeout = dt.timedelta(hours=1)
+        start_to_close_timeout = dt.timedelta(hours=2)
     elif interval == "day":
         start_to_close_timeout = dt.timedelta(days=1)
     elif interval.startswith("every"):


### PR DESCRIPTION
## Problem

Some batch exports that are using the old pipeline (only Redshift and Postgres left now) are occasionally timing out. Let's increase the timeout for hourly batch exports to 2h to give them enough time. Once we migrate everything over to the new pipeline we can hopefully improve performance.

## Changes

Update Temporal start-to-close timeout from 1h to 2h.
