### PR TITLE
fix: Fix Dagster dynamic mapping in sharded_backup job

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -420,9 +420,10 @@ def sharded_backup():
     """
 
     def run_backup_for_shard(shard: int):
-        latest_backup = get_latest_backup(shard)
-        new_backup = run_backup(check_latest_backup_status(latest_backup), shard)
-        wait_for_backup(new_backup)
+        latest_backup = get_latest_backup(shard=shard)
+        checked_backup = check_latest_backup_status(latest_backup=latest_backup)
+        new_backup = run_backup(latest_backup=checked_backup, shard=shard)
+        wait_for_backup(backup=new_backup)
 
     shards: dagster.DynamicOutput = get_shards()
     shards.map(run_backup_for_shard)


### PR DESCRIPTION
## Summary
- Fixed DagsterExecutionStepNotFoundError in sharded_backup job by using keyword arguments for ops
- Changed run_backup_for_shard to pass inputs via named parameters matching op definitions

## Problem
The sharded_backup job was failing with:
```
DagsterExecutionStepNotFoundError: Can not build subset plan from unknown steps: check_latest_backup_status[shard_1], get_latest_backup[shard_1], run_backup[shard_1], wait_for_backup[shard_1]
```

This occurred because ops were being called with positional arguments, but Dagster's dynamic mapping requires keyword arguments to properly pass inputs between ops in dynamically mapped executions.

## Solution
Updated the `run_backup_for_shard` function to use explicit keyword arguments when calling ops:
- `get_latest_backup(shard=shard)` 
- `check_latest_backup_status(latest_backup=latest_backup)`
- `run_backup(latest_backup=checked_backup, shard=shard)`
- `wait_for_backup(backup=new_backup)`

This ensures proper input/output mapping for dynamic execution.

## Test plan
- [ ] Verify sharded_backup job executes without DagsterExecutionStepNotFoundError
- [ ] Confirm dynamic mapping creates proper execution steps for each shard
- [ ] Test that backups complete successfully for all shards