### PR TITLE
fix: Keep Rev Analytics onboarding state active while not finished

### DIFF
--- a/products/revenue_analytics/frontend/Onboarding/InlineSetup.tsx
+++ b/products/revenue_analytics/frontend/Onboarding/InlineSetup.tsx
@@ -20,9 +20,9 @@ interface RevenueSource {
     isConnected: boolean
 }
 
-// NOTE: This should NOT be used except for testing purposes (storybook)
 interface InlineSetupProps {
-    initialSetupView?: InlineSetupView
+    closeOnboarding: () => void
+    initialSetupView?: InlineSetupView // NOTE: This should NOT be used except for testing purposes (storybook)
 }
 
 export type InlineSetupView = 'overview' | 'add-source'
@@ -32,7 +32,7 @@ export type InlineSetupView = 'overview' | 'add-source'
 const REVENUE_SOURCE_TYPES: ExternalDataSourceType[] = ['Stripe', 'Chargebee', 'Polar', 'RevenueCat']
 const AVAILABLE_REVENUE_SOURCE_TYPES: Set<ExternalDataSourceType> = new Set(['Stripe'])
 
-export function InlineSetup({ initialSetupView }: InlineSetupProps): JSX.Element {
+export function InlineSetup({ closeOnboarding, initialSetupView }: InlineSetupProps): JSX.Element {
     const { events, enabledDataWarehouseSources } = useValues(revenueAnalyticsSettingsLogic)
 
     const hasEvents = events.length > 0
@@ -82,7 +82,7 @@ export function InlineSetup({ initialSetupView }: InlineSetupProps): JSX.Element
                             <LemonButton
                                 type="primary"
                                 size="small"
-                                onClick={() => window.location.reload()}
+                                onClick={closeOnboarding}
                                 icon={<IconCheckCircle />}
                             >
                                 View Dashboard

--- a/products/revenue_analytics/frontend/Onboarding/Onboarding.stories.tsx
+++ b/products/revenue_analytics/frontend/Onboarding/Onboarding.stories.tsx
@@ -39,5 +39,5 @@ const meta: Meta = {
 export default meta
 
 type Story = StoryObj<typeof meta>
-export const Onboarding: Story = {}
-export const OnboardingAddSource: Story = { args: { initialSetupView: 'add-source' } }
+export const Onboarding: Story = { args: { closeOnboarding: () => {} } }
+export const OnboardingAddSource: Story = { args: { initialSetupView: 'add-source', closeOnboarding: () => {} } }

--- a/products/revenue_analytics/frontend/Onboarding/Onboarding.tsx
+++ b/products/revenue_analytics/frontend/Onboarding/Onboarding.tsx
@@ -3,12 +3,12 @@ import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductI
 import { PRODUCT_DESCRIPTION, PRODUCT_KEY, PRODUCT_NAME, PRODUCT_THING_NAME } from '../RevenueAnalyticsScene'
 import { InlineSetup, InlineSetupView } from './InlineSetup'
 
-// NOTE: This should NOT be used except for testing purposes (storybook)
 interface OnboardingProps {
-    initialSetupView?: InlineSetupView
+    closeOnboarding: () => void
+    initialSetupView?: InlineSetupView // NOTE: This should NOT be used except for testing purposes (storybook)
 }
 
-export const Onboarding = ({ initialSetupView }: OnboardingProps): JSX.Element => {
+export const Onboarding = ({ initialSetupView, closeOnboarding }: OnboardingProps): JSX.Element => {
     return (
         <div className="space-y-6">
             <ProductIntroduction
@@ -20,7 +20,7 @@ export const Onboarding = ({ initialSetupView }: OnboardingProps): JSX.Element =
                 titleOverride="Get started with Revenue Analytics"
             />
 
-            <InlineSetup initialSetupView={initialSetupView} />
+            <InlineSetup initialSetupView={initialSetupView} closeOnboarding={closeOnboarding} />
         </div>
     )
 }

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -1,4 +1,5 @@
 import { BindLogic, useValues } from 'kea'
+import { useEffect, useState } from 'node_modules/@types/react'
 
 import { LemonBanner, SpinnerOverlay } from '@posthog/lemon-ui'
 
@@ -97,9 +98,19 @@ export function RevenueAnalyticsScene(): JSX.Element {
 }
 
 const RevenueAnalyticsSceneContent = (): JSX.Element => {
+    const [isOnboarding, setIsOnboarding] = useState(false)
     const { hasRevenueTables, hasRevenueEvents } = useValues(revenueAnalyticsLogic)
 
     const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
+
+    // Turn onboarding on if we haven't connected any revenue sources or events yet
+    // We'll keep that stored in the state to make sure we don't "leave" the onboarding state
+    // after we've entered it once
+    useEffect(() => {
+        if (!isOnboarding && !hasRevenueTables && !hasRevenueEvents) {
+            setIsOnboarding(true)
+        }
+    }, [hasRevenueTables, hasRevenueEvents, isOnboarding])
 
     // Still loading from the server, so we'll show a spinner
     if (hasRevenueTables === null) {
@@ -107,8 +118,10 @@ const RevenueAnalyticsSceneContent = (): JSX.Element => {
     }
 
     // Hasn't connected any revenue sources or events yet, so we'll show the onboarding
-    if (!hasRevenueTables && !hasRevenueEvents) {
-        return <Onboarding />
+    // Also, once we've entered the onboarding state, we'll stay in it until we purposefully leave it
+    // rather than leaving as soon as we've connected a revenue source or event
+    if (isOnboarding || (!hasRevenueTables && !hasRevenueEvents)) {
+        return <Onboarding closeOnboarding={() => setIsOnboarding(false)} />
     }
 
     return (

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useValues } from 'kea'
-import { useEffect, useState } from 'node_modules/@types/react'
+import { useEffect, useState } from 'react'
 
 import { LemonBanner, SpinnerOverlay } from '@posthog/lemon-ui'
 


### PR DESCRIPTION
We were previously automatically leaving the Revenue Analytics onboarding as soon as we connected a source/event but that's not ideal since the user might not have finished configuring Revenue Analytics yet.

Instead, let's now "block" the user inside the onboarding until we actually finish onboarding and the user clicks "view dashboard".