### PR TITLE
fix(flags): test lower max_connections

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -347,7 +347,7 @@ mod tests {
             "postgres://posthog:posthog@localhost:5432/posthog"
         );
         assert_eq!(config.max_concurrency, 1000);
-        assert_eq!(config.max_pg_connections, 50);
+        assert_eq!(config.max_pg_connections, 25);
         assert_eq!(config.redis_url, "redis://localhost:6379/");
         assert_eq!(config.team_ids_to_track, TeamIdCollection::All);
         assert_eq!(

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -122,7 +122,7 @@ pub struct Config {
     #[envconfig(default = "1000")]
     pub max_concurrency: usize,
 
-    #[envconfig(default = "50")]
+    #[envconfig(default = "25")]
     pub max_pg_connections: u32,
 
     #[envconfig(default = "redis://localhost:6379/")]


### PR DESCRIPTION
## Problem

from: https://github.com/PostHog/posthog/issues/34916

I noticed that our idle connections don't seem to decrease during the spike but active connections do increase. It seems like we open new connections instead of using idle ones. 

<img width="1159" height="314" alt="Image" src="https://github.com/user-attachments/assets/196acbfb-59de-4f34-b05f-055a3bdc58d4" />


This open issue looks related https://github.com/launchbadge/sqlx/issues/2848. I think what could be happening is that sqlx doesn't make efficient use of the idle connections, opening a bunch of new ones causing CPU contention on the db, leading to more CPU waits, longer queries and again, more connections. 


Looking closer at the sqlx code (we are on 0.8.3), I can see that if an idle connection is not usable, then it will only try to open new connections as long as we are below `max_connections`.
https://github.com/launchbadge/sqlx/blob/v0.8.3/sqlx-core/src/pool/inner.rs#L259-L291

Then, like the issue says: 
> If a nonfatal connection error happens, it just continues in the backoff loop in connect() and never touches the idle queue again: ... 
Right now, only the Postgres driver overrides DatabaseError::is_transient_in_connect_phase(), but one of the error codes it considers transient is the "too many connections" error: ... 
This means that if the max_connections of the pool exceeds what is currently available on the server, tasks can get stuck in a loop trying to open new connections despite there being idle connections available, leading to surprising PoolTimedOut errors.

If I lower `max_connections`, then that will prevent a new connection from being opened and make the loop attempt to get from the idle pool again. 

Additionally, Our db instance has a max connections set at 5000 and feature-flags hovers around 80 to 100 pods meaning we could easily overwhelm the db which we are likely doing to some degree already during these spikes.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Lower max_connections

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Test in prod. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
