### PR TITLE
fix(docker): removing ffmpeg pinned version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ RUN apt-get update && \
     "libxmlsec1-dev" \
     "libxml2" \
     "gettext-base" \
-    "ffmpeg=7:5.1.6-0+deb12u1"
+    "ffmpeg"
 
 # Install MS SQL dependencies
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc


### PR DESCRIPTION
## Problem

Docker build is failing because the pinned ffmpeg version `7:5.1.6-0+deb12u1` is no longer available in Debian bookworm repositories. This version was replaced by `7:5.1.7-0+deb12u1` in [Debian Security Advisory DSA-5985-1](https://lists.debian.org/debian-security-announce/2025/msg00149.html) (released August 25, 2025), which patched 9 CVEs, including potential arbitrary code execution vulnerabilities.

```
failed with: Error: failed to solve: process "/bin/bash -e -o pipefail -c apt-get update &&     apt-get install -y --no-install-recommends     \"chromium\"     \"chromium-driver\"     \"libpq-dev\"     \"libxmlsec1\"     \"libxmlsec1-dev\"     \"libxml2\"     \"gettext-base\"     \"ffmpeg=7:5.1.6-0+deb12u1\"" did not complete successfully: exit code: 100
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Remove the version pin from ffmpeg dependency to allow automatic security updates. This aligns with all other dependencies in the same apt-get install command, which are also unpinned.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
