### PR TITLE
refactor: adding tests and some tweaks for reddit and linkedin

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.models.integration import Integration
-from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
+from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value, initial_datetime
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import LinkedinAdsSourceConfig
 from posthog.warehouse.types import IncrementalFieldType
@@ -136,8 +136,7 @@ def linkedin_ads_source(
                 date_start = last_value
 
         else:
-            # Default to last 5 years for analytics resources
-            start_date = now - dt.timedelta(days=365 * 5)
+            start_date = initial_datetime
             date_start = start_date.strftime("%Y-%m-%d")
 
         data_pages = client.get_data_by_resource(

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -69,7 +69,7 @@ class RedditAdsSource(BaseSource[RedditAdsSourceConfig], OAuthMixin):
             SourceSchema(
                 name=str(endpoint_config.resource["name"]),
                 supports_incremental=endpoint_config.incremental_fields is not None,
-                supports_append=endpoint_config.incremental_fields is not None,
+                supports_append=False,
                 incremental_fields=endpoint_config.incremental_fields or [],
             )
             for endpoint_config in REDDIT_ADS_CONFIG.values()

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
@@ -73,6 +73,7 @@ class TestGetResource:
         assert resource["name"] == "campaigns"
         assert resource["table_name"] == "campaigns"
         assert resource["primary_key"] == ["id"]
+        assert isinstance(resource["endpoint"], dict)
         assert resource["endpoint"]["path"] == "/ad_accounts/test_account/campaigns"
         assert resource["endpoint"]["method"] == "GET"
         assert resource["write_disposition"] == "replace"
@@ -81,21 +82,29 @@ class TestGetResource:
         """Test getting campaigns resource with incremental configuration."""
         resource = get_resource("campaigns", "test_account", True, dt.datetime(2024, 3, 15, 14, 30))
 
-        assert resource["write_disposition"]["disposition"] == "merge"
-        assert resource["write_disposition"]["strategy"] == "upsert"
-        assert "modified_at[after]" in resource["endpoint"]["params"]
+        assert isinstance(resource["write_disposition"], dict)
+        write_disposition = resource["write_disposition"]
+        assert write_disposition["disposition"] == "merge"
+        assert write_disposition["strategy"] == "upsert"  # type: ignore[typeddict-item]
+        assert isinstance(resource["endpoint"], dict)
+        endpoint_params = resource["endpoint"]["params"]
+        assert endpoint_params is not None
+        assert "modified_at[after]" in endpoint_params
 
     def test_get_resource_campaign_report_incremental(self):
         """Test getting campaign report resource with incremental configuration."""
         resource = get_resource("campaign_report", "test_account", True, dt.datetime(2024, 3, 15, 14, 30))
 
-        assert resource["write_disposition"]["disposition"] == "merge"
-        assert resource["write_disposition"]["strategy"] == "upsert"
+        assert isinstance(resource["write_disposition"], dict)
+        write_disposition = resource["write_disposition"]
+        assert write_disposition["disposition"] == "merge"
+        assert write_disposition["strategy"] == "upsert"  # type: ignore[typeddict-item]
+        assert isinstance(resource["endpoint"], dict)
         assert resource["endpoint"]["method"] == "POST"
-        assert resource["endpoint"]["json"]["data"]["starts_at"] == "2024-03-15T14:00:00Z"
-        assert resource["endpoint"]["json"]["data"]["ends_at"].endswith(
-            ":00:00Z"
-        )  # Should be next hour (rounded to hour)
+        endpoint_json = resource["endpoint"]["json"]
+        assert endpoint_json is not None
+        assert endpoint_json["data"]["starts_at"] == "2024-03-15T14:00:00Z"
+        assert endpoint_json["data"]["ends_at"].endswith(":00:00Z")  # Should be next hour (rounded to hour)
 
     def test_get_resource_unknown_endpoint(self):
         """Test getting unknown endpoint raises ValueError."""

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
@@ -1,0 +1,177 @@
+import datetime as dt
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.reddit_ads.reddit_ads import (
+    RedditAdsPaginator,
+    _get_incremental_date_range,
+    get_resource,
+)
+
+
+class TestRedditAdsHelperFunctions:
+    """Test helper functions in reddit_ads.py."""
+
+    def test_get_incremental_date_range_with_datetime(self):
+        """Test getting date range with datetime incremental value."""
+        last_value = dt.datetime(2024, 3, 15, 14, 30, 0)
+        starts_at, ends_at = _get_incremental_date_range(True, last_value)
+
+        assert starts_at == "2024-03-15T14:00:00Z"
+        assert ends_at.endswith(":00:00Z")  # Should be next hour (rounded to hour)
+
+    def test_get_incremental_date_range_with_date(self):
+        """Test getting date range with date incremental value."""
+        last_value = dt.date(2024, 3, 15)
+        starts_at, ends_at = _get_incremental_date_range(True, last_value)
+
+        assert starts_at == "2024-03-15T00:00:00Z"
+        assert ends_at.endswith(":00:00Z")  # Should be next hour (rounded to hour)
+
+    def test_get_incremental_date_range_with_string(self):
+        """Test getting date range with string incremental value."""
+        last_value = "2024-03-15T14:30:00Z"
+        starts_at, ends_at = _get_incremental_date_range(True, last_value)
+
+        assert starts_at == "2024-03-15T14:00:00Z"
+        assert ends_at.endswith(":00:00Z")  # Should be next hour (rounded to hour)
+
+    def test_get_incremental_date_range_with_invalid_string(self):
+        """Test getting date range with invalid string falls back to initial datetime."""
+        last_value = "invalid-date"
+        starts_at, ends_at = _get_incremental_date_range(True, last_value)
+
+        # Should fall back to initial_datetime
+        assert starts_at is not None
+        assert ends_at.endswith(":00:00Z")  # Should be next hour (rounded to hour)
+
+    def test_get_incremental_date_range_no_incremental(self):
+        """Test getting date range without incremental field."""
+        starts_at, ends_at = _get_incremental_date_range(False)
+
+        # Should use initial_datetime
+        assert starts_at is not None
+        assert ends_at.endswith(":00:00Z")  # Should be next hour (rounded to hour)
+
+    def test_get_incremental_date_range_none_value(self):
+        """Test getting date range with None incremental value."""
+        starts_at, ends_at = _get_incremental_date_range(True, None)
+
+        # Should use initial_datetime
+        assert starts_at is not None
+        assert ends_at.endswith(":00:00Z")  # Should be next hour (rounded to hour)
+
+
+class TestGetResource:
+    """Test get_resource function."""
+
+    def test_get_resource_campaigns(self):
+        """Test getting campaigns resource configuration."""
+        resource = get_resource("campaigns", "test_account", False)
+
+        assert resource["name"] == "campaigns"
+        assert resource["table_name"] == "campaigns"
+        assert resource["primary_key"] == ["id"]
+        assert resource["endpoint"]["path"] == "/ad_accounts/test_account/campaigns"
+        assert resource["endpoint"]["method"] == "GET"
+        assert resource["write_disposition"] == "replace"
+
+    def test_get_resource_campaigns_incremental(self):
+        """Test getting campaigns resource with incremental configuration."""
+        resource = get_resource("campaigns", "test_account", True, dt.datetime(2024, 3, 15, 14, 30))
+
+        assert resource["write_disposition"]["disposition"] == "merge"
+        assert resource["write_disposition"]["strategy"] == "upsert"
+        assert "modified_at[after]" in resource["endpoint"]["params"]
+
+    def test_get_resource_campaign_report_incremental(self):
+        """Test getting campaign report resource with incremental configuration."""
+        resource = get_resource("campaign_report", "test_account", True, dt.datetime(2024, 3, 15, 14, 30))
+
+        assert resource["write_disposition"]["disposition"] == "merge"
+        assert resource["write_disposition"]["strategy"] == "upsert"
+        assert resource["endpoint"]["method"] == "POST"
+        assert resource["endpoint"]["json"]["data"]["starts_at"] == "2024-03-15T14:00:00Z"
+        assert resource["endpoint"]["json"]["data"]["ends_at"].endswith(
+            ":00:00Z"
+        )  # Should be next hour (rounded to hour)
+
+    def test_get_resource_unknown_endpoint(self):
+        """Test getting unknown endpoint raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown endpoint: unknown_endpoint"):
+            get_resource("unknown_endpoint", "test_account", False)
+
+    def test_get_resource_invalid_endpoint_type(self):
+        """Test getting resource with invalid endpoint type raises ValueError."""
+        # This would require mocking REDDIT_ADS_CONFIG to have invalid endpoint
+        # For now, we'll test the happy path since the config is properly structured
+        resource = get_resource("campaigns", "test_account", False)
+        assert isinstance(resource["endpoint"], dict)
+
+
+class TestRedditAdsPaginator:
+    """Test RedditAdsPaginator class."""
+
+    def test_paginator_init(self):
+        """Test paginator initialization."""
+        paginator = RedditAdsPaginator()
+        assert paginator._next_url is None
+        assert paginator._has_next_page is False
+
+    def test_update_state_with_pagination(self):
+        """Test updating state with pagination data."""
+        paginator = RedditAdsPaginator()
+
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {"pagination": {"next_url": "https://api.reddit.com/next-page"}}
+
+        paginator.update_state(mock_response)
+
+        assert paginator._next_url == "https://api.reddit.com/next-page"
+        assert paginator._has_next_page is True
+
+    def test_update_state_without_pagination(self):
+        """Test updating state without pagination data."""
+        paginator = RedditAdsPaginator()
+
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {"data": []}
+
+        paginator.update_state(mock_response)
+
+        assert paginator._next_url is None
+        assert paginator._has_next_page is False
+
+    def test_update_state_invalid_json(self):
+        """Test updating state with invalid JSON."""
+        paginator = RedditAdsPaginator()
+
+        mock_response = mock.MagicMock()
+        mock_response.json.side_effect = Exception("Invalid JSON")
+
+        paginator.update_state(mock_response)
+
+        assert paginator._next_url is None
+        assert paginator._has_next_page is False
+
+    def test_update_request_with_next_url(self):
+        """Test updating request with next URL."""
+        paginator = RedditAdsPaginator()
+        paginator._next_url = "https://api.reddit.com/next-page"
+
+        mock_request = mock.MagicMock()
+        paginator.update_request(mock_request)
+
+        assert mock_request.url == "https://api.reddit.com/next-page"
+
+    def test_update_request_without_next_url(self):
+        """Test updating request without next URL."""
+        paginator = RedditAdsPaginator()
+
+        mock_request = mock.MagicMock()
+        original_url = mock_request.url
+        paginator.update_request(mock_request)
+
+        # URL should remain unchanged
+        assert mock_request.url == original_url

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest import mock
 
+from posthog.schema import SourceFieldInputConfig, SourceFieldOauthConfig
+
 from posthog.temporal.data_imports.sources.generated_configs import RedditAdsSourceConfig
 from posthog.temporal.data_imports.sources.reddit_ads.source import RedditAdsSource
 from posthog.warehouse.types import ExternalDataSourceType
@@ -30,6 +32,7 @@ class TestRedditAdsSource:
 
         # Check account_id field
         account_field = config.fields[0]
+        assert isinstance(account_field, SourceFieldInputConfig)
         assert account_field.name == "account_id"
         assert account_field.label == "Reddit Ads Account ID"
         assert account_field.required is True
@@ -37,6 +40,7 @@ class TestRedditAdsSource:
 
         # Check oauth field
         oauth_field = config.fields[1]
+        assert isinstance(oauth_field, SourceFieldOauthConfig)
         assert oauth_field.name == "reddit_integration_id"
         assert oauth_field.label == "Reddit Ads account"
         assert oauth_field.required is True
@@ -54,7 +58,7 @@ class TestRedditAdsSource:
 
     def test_validate_credentials_missing_integration_id(self):
         """Test credential validation with missing integration ID."""
-        invalid_config = RedditAdsSourceConfig(reddit_integration_id=None, account_id="789")
+        invalid_config = RedditAdsSourceConfig(reddit_integration_id=0, account_id="789")
 
         is_valid, error_message = self.source.validate_credentials(invalid_config, self.team_id)
 

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -1,0 +1,187 @@
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.generated_configs import RedditAdsSourceConfig
+from posthog.temporal.data_imports.sources.reddit_ads.source import RedditAdsSource
+from posthog.warehouse.types import ExternalDataSourceType
+
+
+class TestRedditAdsSource:
+    """Test suite for RedditAdsSource class."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.source = RedditAdsSource()
+        self.team_id = 123
+        self.config = RedditAdsSourceConfig(reddit_integration_id=456, account_id="789")
+
+    def test_source_type(self):
+        """Test source type property."""
+        assert self.source.source_type == ExternalDataSourceType.REDDITADS
+
+    def test_get_source_config(self):
+        """Test get_source_config returns proper configuration."""
+        config = self.source.get_source_config
+
+        assert config.name.value == "RedditAds"
+        assert config.label == "Reddit Ads"
+        assert config.betaSource is True
+        assert len(config.fields) == 2
+
+        # Check account_id field
+        account_field = config.fields[0]
+        assert account_field.name == "account_id"
+        assert account_field.label == "Reddit Ads Account ID"
+        assert account_field.required is True
+        assert account_field.placeholder == "Your Reddit Ads account ID"
+
+        # Check oauth field
+        oauth_field = config.fields[1]
+        assert oauth_field.name == "reddit_integration_id"
+        assert oauth_field.label == "Reddit Ads account"
+        assert oauth_field.required is True
+        assert oauth_field.kind == "reddit-ads"
+
+    def test_validate_credentials_missing_account_id(self):
+        """Test credential validation with missing account ID."""
+        invalid_config = RedditAdsSourceConfig(reddit_integration_id=456, account_id="")
+
+        is_valid, error_message = self.source.validate_credentials(invalid_config, self.team_id)
+
+        assert is_valid is False
+        assert error_message is not None
+        assert "Account ID and Reddit Ads integration are required" in error_message
+
+    def test_validate_credentials_missing_integration_id(self):
+        """Test credential validation with missing integration ID."""
+        invalid_config = RedditAdsSourceConfig(reddit_integration_id=None, account_id="789")
+
+        is_valid, error_message = self.source.validate_credentials(invalid_config, self.team_id)
+
+        assert is_valid is False
+        assert error_message is not None
+        assert "Account ID and Reddit Ads integration are required" in error_message
+
+    @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
+    def test_validate_credentials_success(self, mock_get_oauth_integration):
+        """Test successful credential validation."""
+        mock_integration = mock.MagicMock()
+        mock_integration.access_token = "test_token"
+        mock_get_oauth_integration.return_value = mock_integration
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is True
+        assert error_message is None
+        mock_get_oauth_integration.assert_called_once_with(self.config.reddit_integration_id, self.team_id)
+
+    @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
+    @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.capture_exception")
+    def test_validate_credentials_integration_error(self, mock_capture_exception, mock_get_oauth_integration):
+        """Test credential validation with integration error."""
+        mock_get_oauth_integration.side_effect = Exception("Integration not found")
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is False
+        assert error_message is not None
+        assert "Failed to validate Reddit Ads credentials" in error_message
+        assert "Integration not found" in error_message
+        mock_capture_exception.assert_called_once()
+
+    def test_get_schemas(self):
+        """Test get_schemas returns all endpoint schemas."""
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        # Should have schemas for all endpoints in REDDIT_ADS_CONFIG
+        expected_endpoints = ["campaigns", "ad_groups", "ads", "campaign_report", "ad_group_report", "ad_report"]
+        assert len(schemas) == len(expected_endpoints)
+
+        schema_names = [schema.name for schema in schemas]
+        for endpoint in expected_endpoints:
+            assert endpoint in schema_names
+
+    @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
+    def test_source_for_pipeline_success(self, mock_get_oauth_integration):
+        """Test source_for_pipeline with valid integration."""
+        mock_integration = mock.MagicMock()
+        mock_integration.access_token = "test_token"
+        mock_get_oauth_integration.return_value = mock_integration
+
+        # Mock the reddit_ads_source function
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.reddit_ads.source.reddit_ads_source"
+        ) as mock_reddit_ads_source:
+            mock_response = mock.MagicMock()
+            mock_reddit_ads_source.return_value = mock_response
+
+            inputs = mock.MagicMock()
+            inputs.team_id = self.team_id
+            inputs.job_id = "test_job"
+            inputs.schema_name = "campaigns"
+            inputs.should_use_incremental_field = False
+            inputs.db_incremental_field_last_value = None
+
+            result = self.source.source_for_pipeline(self.config, inputs)
+
+            assert result == mock_response
+            mock_get_oauth_integration.assert_called_once_with(self.config.reddit_integration_id, self.team_id)
+            mock_reddit_ads_source.assert_called_once_with(
+                account_id=self.config.account_id,
+                endpoint="campaigns",
+                team_id=self.team_id,
+                job_id="test_job",
+                access_token="test_token",
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=None,
+            )
+
+    @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
+    def test_source_for_pipeline_no_access_token(self, mock_get_oauth_integration):
+        """Test source_for_pipeline with no access token raises error."""
+        mock_integration = mock.MagicMock()
+        mock_integration.access_token = None
+        mock_get_oauth_integration.return_value = mock_integration
+
+        inputs = mock.MagicMock()
+        inputs.team_id = self.team_id
+        inputs.job_id = "test_job"
+        inputs.schema_name = "campaigns"
+        inputs.should_use_incremental_field = False
+        inputs.db_incremental_field_last_value = None
+
+        with pytest.raises(ValueError, match="Reddit Ads access token not found for job test_job"):
+            self.source.source_for_pipeline(self.config, inputs)
+
+    @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
+    def test_source_for_pipeline_with_incremental(self, mock_get_oauth_integration):
+        """Test source_for_pipeline with incremental field."""
+        mock_integration = mock.MagicMock()
+        mock_integration.access_token = "test_token"
+        mock_get_oauth_integration.return_value = mock_integration
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.reddit_ads.source.reddit_ads_source"
+        ) as mock_reddit_ads_source:
+            mock_response = mock.MagicMock()
+            mock_reddit_ads_source.return_value = mock_response
+
+            inputs = mock.MagicMock()
+            inputs.team_id = self.team_id
+            inputs.job_id = "test_job"
+            inputs.schema_name = "campaign_report"
+            inputs.should_use_incremental_field = True
+            inputs.db_incremental_field_last_value = "2024-03-15"
+
+            result = self.source.source_for_pipeline(self.config, inputs)
+
+            assert result == mock_response
+            mock_reddit_ads_source.assert_called_once_with(
+                account_id=self.config.account_id,
+                endpoint="campaign_report",
+                team_id=self.team_id,
+                job_id="test_job",
+                access_token="test_token",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value="2024-03-15",
+            )


### PR DESCRIPTION
## Changes

Adding missing tests for reddit integration. Disabling append bc it generates duplicated and fixing linkedin default dates to use the same as reddit (the first existing epoch)


## How did you test this code?
Tests and manually
Reddit append disabled:
<img width="1368" height="462" alt="Screenshot 2025-09-12 at 4 18 36 PM" src="https://github.com/user-attachments/assets/bf471a37-b25a-464b-9038-d9a983df3865" />
Linkedin sync with full refresh ok:
<img width="1226" height="382" alt="Screenshot 2025-09-12 at 4 16 41 PM" src="https://github.com/user-attachments/assets/53619190-5f05-4174-b208-e9fb8ba1e9cf" />
