### PR TITLE
fix: Fix join tables form validation

### DIFF
--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -78,7 +78,6 @@ export function ViewLinkForm({ mode }: ViewLinkModalProps): JSX.Element {
         error,
         fieldName,
         isNewJoin,
-        selectedSourceKey,
         selectedJoiningKey,
         sourceIsUsingHogQLExpression,
         joiningIsUsingHogQLExpression,
@@ -142,34 +141,37 @@ export function ViewLinkForm({ mode }: ViewLinkModalProps): JSX.Element {
                         <span className="l4">Source Table Key</span>
                         <div className="text-wrap break-all">
                             <Field name="source_table_key">
-                                <>
-                                    <LemonSelect
-                                        fullWidth
-                                        onSelect={selectSourceKey}
-                                        value={sourceIsUsingHogQLExpression ? '' : (selectedSourceKey ?? undefined)}
-                                        disabledReason={
-                                            selectedSourceTableName ? '' : 'Select a table to choose join key'
-                                        }
-                                        options={[
-                                            ...sourceTableKeys,
-                                            { value: '', label: <span>SQL Expression</span> },
-                                        ]}
-                                        placeholder="Select a key"
-                                    />
-                                    {sourceIsUsingHogQLExpression && (
-                                        <HogQLDropdown
-                                            className="mt-2"
-                                            hogQLValue={selectedSourceKey ?? ''}
-                                            onHogQLValueChange={selectSourceKey}
-                                            tableName={selectedSourceTableName ?? ''}
-                                            hogQLEditorPlaceholder={
-                                                mode === 'revenue_analytics'
-                                                    ? HOGQL_EDITOR_PLACEHOLDER_REVENUE_ANALYTICS
-                                                    : HOGQL_EDITOR_PLACEHOLDER
+                                {({ value, onChange }) => (
+                                    <>
+                                        <LemonSelect
+                                            fullWidth
+                                            onSelect={selectSourceKey}
+                                            onChange={onChange}
+                                            value={sourceIsUsingHogQLExpression ? '' : (value ?? undefined)}
+                                            disabledReason={
+                                                selectedSourceTableName ? '' : 'Select a table to choose join key'
                                             }
+                                            options={[
+                                                ...sourceTableKeys,
+                                                { value: '', label: <span>SQL Expression</span> },
+                                            ]}
+                                            placeholder="Select a key"
                                         />
-                                    )}
-                                </>
+                                        {sourceIsUsingHogQLExpression && (
+                                            <HogQLDropdown
+                                                className="mt-2"
+                                                hogQLValue={value}
+                                                onHogQLValueChange={onChange}
+                                                tableName={selectedSourceTableName ?? ''}
+                                                hogQLEditorPlaceholder={
+                                                    mode === 'revenue_analytics'
+                                                        ? HOGQL_EDITOR_PLACEHOLDER_REVENUE_ANALYTICS
+                                                        : HOGQL_EDITOR_PLACEHOLDER
+                                                }
+                                            />
+                                        )}
+                                    </>
+                                )}
                             </Field>
                         </div>
                     </div>
@@ -183,32 +185,33 @@ export function ViewLinkForm({ mode }: ViewLinkModalProps): JSX.Element {
                                 (selectedJoiningKey ?? '')
                             ) : (
                                 <Field name="joining_table_key">
-                                    <>
-                                        <LemonSelect
-                                            fullWidth
-                                            onSelect={selectJoiningKey}
-                                            value={
-                                                joiningIsUsingHogQLExpression ? '' : (selectedJoiningKey ?? undefined)
-                                            }
-                                            disabledReason={
-                                                selectedJoiningTableName ? '' : 'Select a table to choose join key'
-                                            }
-                                            options={[
-                                                ...joiningTableKeys,
-                                                { value: '', label: <span>SQL Expression</span> },
-                                            ]}
-                                            placeholder="Select a key"
-                                        />
-                                        {joiningIsUsingHogQLExpression && (
-                                            <HogQLDropdown
-                                                className="mt-2"
-                                                hogQLValue={selectedJoiningKey ?? ''}
-                                                onHogQLValueChange={selectJoiningKey}
-                                                tableName={selectedJoiningTableName ?? ''}
-                                                hogQLEditorPlaceholder={HOGQL_EDITOR_PLACEHOLDER}
+                                    {({ value, onChange }) => (
+                                        <>
+                                            <LemonSelect
+                                                fullWidth
+                                                onSelect={selectJoiningKey}
+                                                onChange={onChange}
+                                                value={joiningIsUsingHogQLExpression ? '' : (value ?? undefined)}
+                                                disabledReason={
+                                                    selectedJoiningTableName ? '' : 'Select a table to choose join key'
+                                                }
+                                                options={[
+                                                    ...joiningTableKeys,
+                                                    { value: '', label: <span>SQL Expression</span> },
+                                                ]}
+                                                placeholder="Select a key"
                                             />
-                                        )}
-                                    </>
+                                            {joiningIsUsingHogQLExpression && (
+                                                <HogQLDropdown
+                                                    className="mt-2"
+                                                    hogQLValue={value}
+                                                    onHogQLValueChange={onChange}
+                                                    tableName={selectedJoiningTableName ?? ''}
+                                                    hogQLEditorPlaceholder={HOGQL_EDITOR_PLACEHOLDER}
+                                                />
+                                            )}
+                                        </>
+                                    )}
                                 </Field>
                             )}
                         </div>

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -16,7 +16,9 @@ import type { viewLinkLogicType } from './viewLinkLogicType'
 const NEW_VIEW_LINK: DataWarehouseViewLink = {
     id: 'new',
     source_table_name: undefined,
+    source_table_key: undefined,
     joining_table_name: undefined,
+    joining_table_key: undefined,
     field_name: undefined,
 }
 
@@ -161,21 +163,23 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
     forms(({ actions, values }) => ({
         viewLink: {
             defaults: NEW_VIEW_LINK,
-            errors: ({ source_table_name, joining_table_name }) => {
+            errors: ({ source_table_name, source_table_key, joining_table_name, joining_table_key }) => {
                 return {
                     source_table_name: values.isNewJoin && !source_table_name ? 'Must select a table' : undefined,
+                    source_table_key: !source_table_key ? 'Must select a key' : undefined,
                     joining_table_name: !joining_table_name ? 'Must select a table' : undefined,
+                    joining_table_key: joining_table_name && !joining_table_key ? 'Must select a key' : undefined,
                 }
             },
-            submit: async ({ joining_table_name, source_table_name }) => {
+            submit: async ({ source_table_name, source_table_key, joining_table_name, joining_table_key }) => {
                 if (values.joinToEdit?.id && values.selectedSourceTable) {
                     // Edit join
                     try {
                         await api.dataWarehouseViewLinks.update(values.joinToEdit.id, {
                             source_table_name: source_table_name ?? values.selectedSourceTable.name,
-                            source_table_key: values.selectedSourceKey ?? undefined,
+                            source_table_key,
                             joining_table_name,
-                            joining_table_key: values.selectedJoiningKey ?? undefined,
+                            joining_table_key,
                             field_name: values.fieldName,
                             configuration: {
                                 experiments_optimized: values.experimentsOptimized,
@@ -197,9 +201,9 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
                     try {
                         await api.dataWarehouseViewLinks.create({
                             source_table_name: source_table_name ?? values.selectedSourceTable.name,
-                            source_table_key: values.selectedSourceKey ?? undefined,
+                            source_table_key,
                             joining_table_name,
-                            joining_table_key: values.selectedJoiningKey ?? undefined,
+                            joining_table_key,
                             field_name: values.fieldName,
                             configuration: {
                                 experiments_optimized: values.experimentsOptimized,


### PR DESCRIPTION
## Problem
The form was showing error messages for the key fields in the wrong place.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Before
Error message for missing key would show at the bottom
<img width="714" height="484" alt="image" src="https://github.com/user-attachments/assets/f45565c8-1efa-4464-95b9-5e83420fd9af" />

### After
If the table is not selected, we don't show the error message for the key
<img width="707" height="398" alt="image" src="https://github.com/user-attachments/assets/3c28b045-fb07-45d4-9f23-71d08d3b39d1" />

We're also validating HogQL expression field now
<img width="705" height="522" alt="image" src="https://github.com/user-attachments/assets/c24dd44b-ef75-4546-a665-ca0fbc1d201a" />


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
