### PR TITLE
chore: revert "chore: add dagster job resource config"

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -1,5 +1,4 @@
 import re
-import json
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -410,18 +409,6 @@ def wait_for_backup(
 
 @dagster.job(
     executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
-    tags={
-        "dagster-k8s/config": json.dumps(
-            {
-                "container_config": {
-                    "resources": {
-                        "requests": {"cpu": "1", "memory": "8Gi"},
-                        "limits": {"cpu": "2", "memory": "8Gi"},
-                    },
-                },
-            }
-        ),
-    },
 )
 def sharded_backup():
     """
@@ -444,18 +431,6 @@ def sharded_backup():
 
 @dagster.job(
     executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 8}),
-    tags={
-        "dagster-k8s/config": json.dumps(
-            {
-                "container_config": {
-                    "resources": {
-                        "requests": {"cpu": "1", "memory": "8Gi"},
-                        "limits": {"cpu": "2", "memory": "8Gi"},
-                    },
-                },
-            }
-        ),
-    },
 )
 def non_sharded_backup():
     """

--- a/dags/testing.py
+++ b/dags/testing.py
@@ -1,5 +1,3 @@
-import json
-
 import dagster
 
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
@@ -25,17 +23,6 @@ def error_op(
     ).result()
 
 
-@dagster.job(
-    tags={
-        "owner": JobOwners.TEAM_CLICKHOUSE.value,
-        "dagster-k8s/config": json.dumps(
-            {
-                "container_config": {
-                    "resources": {"requests": {"cpu": "1", "memory": "2Gi"}, "limits": {"cpu": "2", "memory": "4Gi"}}
-                }
-            }
-        ),
-    }
-)
+@dagster.job(tags={"owner": JobOwners.TEAM_CLICKHOUSE.value})
 def error():
     error_op()


### PR DESCRIPTION
Reverts PostHog/posthog#38043

We can instead have all jobs inherit the runners config, avoiding needing these overrides per job (though we have the option)

If we do come back to this approach we should make sure to clean it up and make env specific with below or similar:

```
import os

def get_deployment_name() -> str:
    return os.getenv("DAGSTER_CLOUD_DEPLOYMENT_NAME", "dev")

def get_k8s_resources() -> dict:
    deployment = get_deployment_name()

    if deployment == "prod-us":
        return {
            "requests": {"cpu": "1", "memory": "8Gi"},
            "limits": {"memory": "16Gi"},
        }
    elif deployment == "prod-eu":
        return {
            "requests": {"cpu": "1", "memory": "4Gi"},
            "limits": {"memory": "8Gi"},
        }
    elif deployment == "dev":
        return {
            "requests": {"cpu": "1", "memory": "4Gi"},
            "limits": {"memory": "4Gi"},
        }
    else:
        # sensible default
        return {
            "requests": {"cpu": "1", "memory": "4Gi"},
            "limits": {"memory": "4Gi"},
        }

def build_k8s_tag_config() -> str:
    return json.dumps({
        "container_config": {
            "resources": get_k8s_resources(),
        }
    })
    
@dagster.job(
    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
    tags={
        "dagster-k8s/config": build_k8s_tag_config(),
    },
)

@dagster.job(
    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 8}),
    tags={
        "dagster-k8s/config": build_k8s_tag_config(),
    },
)
```