### PR TITLE
fix(ux): move shared metrics under tabs+new layout

### DIFF
--- a/frontend/src/layout/scenes/components/SceneBreadcrumbs.tsx
+++ b/frontend/src/layout/scenes/components/SceneBreadcrumbs.tsx
@@ -3,17 +3,27 @@ import { useValues } from 'kea'
 import { IconArrowLeft } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
+import { cn } from 'lib/utils/css-classes'
+
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { Breadcrumb } from '~/types'
 
-export function SceneBreadcrumbBackButton({ forceBackTo }: { forceBackTo?: Breadcrumb }): JSX.Element | null {
+interface SceneBreadcrumbBackButtonProps {
+    forceBackTo?: Breadcrumb
+    className?: string
+}
+
+export function SceneBreadcrumbBackButton({
+    forceBackTo,
+    className,
+}: SceneBreadcrumbBackButtonProps): JSX.Element | null {
     const { breadcrumbs } = useValues(breadcrumbsLogic)
 
     const backTo = forceBackTo || breadcrumbs[breadcrumbs.length - 2]
 
-    return breadcrumbs.length > 1 ? (
+    return !!forceBackTo || breadcrumbs.length > 1 ? (
         <Link
-            className="flex items-center gap-1 text-tertiary text-xs pl-[var(--button-padding-x-lg)]"
+            className={cn('flex items-center gap-1 text-tertiary text-xs pl-[var(--button-padding-x-lg)]', className)}
             aria-label={`Go back to ${backTo.name}`}
             to={backTo.path}
             buttonProps={{

--- a/frontend/src/layout/scenes/components/SceneSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneSection.tsx
@@ -1,10 +1,14 @@
+import { IconInfo } from '@posthog/icons'
+
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
 
 interface SceneSectionProps {
     title?: React.ReactNode
     description?: React.ReactNode
+    titleHelper?: React.ReactNode
     isLoading?: boolean
     children: React.ReactNode
     className?: string
@@ -17,6 +21,7 @@ interface SceneSectionProps {
 export function SceneSection({
     title,
     description,
+    titleHelper,
     isLoading,
     children,
     className,
@@ -85,12 +90,18 @@ export function SceneSection({
                     <div className="flex flex-col gap-y-0 flex-1 justify-center">
                         <Component
                             className={cn(
-                                'font-semibold my-0 mb-1 max-w-prose',
+                                'font-semibold my-0 mb-1 max-w-prose flex items-center gap-x-1',
                                 titleClassName,
                                 !description && 'mb-0'
                             )}
                         >
                             {title}
+
+                            {titleHelper && (
+                                <ButtonPrimitive tooltip={titleHelper} size="sm">
+                                    <IconInfo className="size-4 text-sm text-secondary" />
+                                </ButtonPrimitive>
+                            )}
                         </Component>
                         {description && <p className="text-sm text-secondary my-0 max-w-prose">{description}</p>}
                     </div>

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -14,7 +14,7 @@ import { cn } from 'lib/utils/css-classes'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { FileSystemIconType } from '~/queries/schema/schema-general'
-import { FileSystemIconColor } from '~/types'
+import { Breadcrumb, FileSystemIconColor } from '~/types'
 
 import '../../panel-layout/ProjectTree/defaultTree'
 import { ProductIconWrapper, iconForType } from '../../panel-layout/ProjectTree/defaultTree'
@@ -64,6 +64,11 @@ type SceneMainTitleProps = {
      * @default false
      */
     actions?: boolean
+    /**
+     * If provided, the back button will be forced to this breadcrumb
+     * @default undefined
+     */
+    forceBackTo?: Breadcrumb
 }
 
 export function SceneTitleSection({
@@ -78,13 +83,14 @@ export function SceneTitleSection({
     forceEdit = false,
     renameDebounceMs,
     actions = true,
+    forceBackTo,
 }: SceneMainTitleProps): JSX.Element | null {
     const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
     const { breadcrumbs } = useValues(breadcrumbsLogic)
     if (!newSceneLayout) {
         return null
     }
-    const willShowBreadcrumbs = breadcrumbs.length > 2
+    const willShowBreadcrumbs = forceBackTo || breadcrumbs.length > 2
 
     const icon = resourceType.forceIcon ? (
         <ProductIconWrapper type={resourceType.type} colorOverride={resourceType.forceIconColorOverride}>
@@ -99,11 +105,11 @@ export function SceneTitleSection({
                 {/* If we're showing breadcrumbs, we want to show the actions inline with the back button */}
                 {willShowBreadcrumbs && (
                     <div className="flex justify-between w-full">
-                        <SceneBreadcrumbBackButton />
+                        <SceneBreadcrumbBackButton forceBackTo={forceBackTo} />
                         {actions && <SceneActions className="shrink-0 ml-auto" />}
                     </div>
                 )}
-                <div className="flex w-full justify-between">
+                <div className="flex w-full justify-between gap-2">
                     <div className="flex gap-2 [&_svg]:size-6 items-center w-full">
                         <span
                             className={buttonPrimitiveVariants({
@@ -317,7 +323,7 @@ function SceneDescription({
                             }),
                             '[&_.LemonIcon]:size-4'
                         )}
-                        markdown
+                        markdown={markdown}
                         placeholder={emptyText}
                         onBlur={() => !forceEdit && setIsEditing(false)}
                         autoFocus={!forceEdit}

--- a/frontend/src/lib/components/Scenes/SceneTags.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTags.tsx
@@ -1,11 +1,14 @@
+import { useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
 import { ScenePanelLabel } from '~/layout/scenes/SceneLayout'
+import { AvailableFeature } from '~/types'
 
 import { ObjectTags } from '../ObjectTags/ObjectTags'
+import { upgradeModalLogic } from '../UpgradeModal/upgradeModalLogic'
 import { SceneCanEditProps, SceneDataAttrKeyProps, SceneSaveCancelButtons } from './utils'
 
 type SceneTagsProps = SceneCanEditProps &
@@ -25,6 +28,13 @@ export const SceneTags = ({
     const [localTags, setLocalTags] = useState(tags)
     const [localIsEditing, setLocalIsEditing] = useState(false)
     const [hasChanged, setHasChanged] = useState(false)
+    const { guardAvailableFeature } = useValues(upgradeModalLogic)
+
+    const onGuardClick = (callback: () => void): void => {
+        guardAvailableFeature(AvailableFeature.TAGGING, () => {
+            callback()
+        })
+    }
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault()
@@ -72,7 +82,7 @@ export const SceneTags = ({
             <ButtonPrimitive
                 className="hyphens-auto flex gap-1 items-center"
                 lang="en"
-                onClick={() => onSave && canEdit && setLocalIsEditing(true)}
+                onClick={() => onSave && canEdit && onGuardClick(() => setLocalIsEditing(true))}
                 tooltip={canEdit ? 'Edit tags' : 'Tags are read-only'}
                 autoHeight
                 menuItem

--- a/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
@@ -5,6 +6,7 @@ import { LemonSelect, LemonSelectOption } from 'lib/lemon-ui/LemonSelect'
 import { capitalizeFirstLetter, pluralize } from 'lib/utils'
 import { TIME_INTERVAL_BOUNDS } from 'scenes/insights/views/Funnels/FunnelConversionWindowFilter'
 
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { ExperimentMetric } from '~/queries/schema/schema-general'
 import { FunnelConversionWindowTimeUnit } from '~/types'
 
@@ -15,6 +17,7 @@ export function ExperimentMetricConversionWindowFilter({
     metric: ExperimentMetric
     handleSetMetric: (newMetric: ExperimentMetric) => void
 }): JSX.Element {
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
     const options: LemonSelectOption<FunnelConversionWindowTimeUnit>[] = Object.keys(TIME_INTERVAL_BOUNDS).map(
         (unit) => ({
             label: capitalizeFirstLetter(pluralize(metric.conversion_window ?? 72, unit, `${unit}s`, false)),
@@ -24,28 +27,48 @@ export function ExperimentMetricConversionWindowFilter({
     const intervalBounds = TIME_INTERVAL_BOUNDS[metric.conversion_window_unit ?? FunnelConversionWindowTimeUnit.Day]
 
     return (
-        <div>
-            <LemonLabel
-                className="mb-1"
-                info={
-                    <>
-                        Controls how long a metric value is considered relevant to an experiment exposure:
-                        <ul className="list-disc pl-4">
-                            <li>
-                                <strong>Experiment duration</strong> considers any data from when a user is first
-                                exposed until the experiment ends.
-                            </li>
-                            <li>
-                                <strong>Time window</strong> only includes data that occurs within the specified time
-                                window after a user's first exposure (also ignoring the experiment end date).
-                            </li>
-                        </ul>
-                    </>
-                }
-            >
-                Conversion window limit
-            </LemonLabel>
-            <div className="flex items-center gap-2">
+        <SceneSection
+            title="Conversion window limit"
+            titleHelper={
+                <>
+                    Controls how long a metric value is considered relevant to an experiment exposure:
+                    <ul className="list-disc pl-4">
+                        <li>
+                            <strong>Experiment duration</strong> considers any data from when a user is first exposed
+                            until the experiment ends.
+                        </li>
+                        <li>
+                            <strong>Time window</strong> only includes data that occurs within the specified time window
+                            after a user's first exposure (also ignoring the experiment end date).
+                        </li>
+                    </ul>
+                </>
+            }
+            hideTitleAndDescription={!newSceneLayout}
+        >
+            {!newSceneLayout && (
+                <LemonLabel
+                    className="mb-1"
+                    info={
+                        <>
+                            Controls how long a metric value is considered relevant to an experiment exposure:
+                            <ul className="list-disc pl-4">
+                                <li>
+                                    <strong>Experiment duration</strong> considers any data from when a user is first
+                                    exposed until the experiment ends.
+                                </li>
+                                <li>
+                                    <strong>Time window</strong> only includes data that occurs within the specified
+                                    time window after a user's first exposure (also ignoring the experiment end date).
+                                </li>
+                            </ul>
+                        </>
+                    }
+                >
+                    Conversion window limit
+                </LemonLabel>
+            )}
+            <div className="flex flex-col gap-2">
                 <LemonRadio
                     className="my-1.5"
                     value={metric.conversion_window_unit === undefined ? 'experiment_duration' : 'time_window'}
@@ -95,6 +118,6 @@ export function ExperimentMetricConversionWindowFilter({
                     </div>
                 )}
             </div>
-        </div>
+        </SceneSection>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
@@ -11,6 +12,9 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { urls } from 'scenes/urls'
 
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { performQuery } from '~/queries/query'
 import {
     ExperimentMetric,
@@ -96,6 +100,7 @@ export function ExperimentMetricForm({
     const allowedMathTypes = getAllowedMathTypes(metric.metric_type)
     const [eventCount, setEventCount] = useState<number | null>(null)
     const [isLoading, setIsLoading] = useState(false)
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
 
     const getEventTypeLabel = (): string => {
         if (isExperimentMeanMetric(metric)) {
@@ -165,18 +170,21 @@ export function ExperimentMetricForm({
     const hideDeleteBtn = (_: any, index: number): boolean => index === 0
 
     return (
-        <div className="deprecated-space-y-4">
-            <div>
-                <LemonLabel className="mb-1">Type</LemonLabel>
-                <LemonRadio
-                    data-attr="metrics-selector"
-                    value={metric.metric_type}
-                    onChange={handleMetricTypeChange}
-                    options={radioOptions}
-                />
-            </div>
-            <div>
-                <LemonLabel className="mb-1">Metric</LemonLabel>
+        <SceneContent forceNewSpacing>
+            <SceneSection title="Shared metric type" hideTitleAndDescription={!newSceneLayout} className="max-w-prose">
+                <div>
+                    {!newSceneLayout && <LemonLabel className="mb-1">Type</LemonLabel>}
+                    <LemonRadio
+                        data-attr="metrics-selector"
+                        value={metric.metric_type}
+                        onChange={handleMetricTypeChange}
+                        options={radioOptions}
+                    />
+                </div>
+            </SceneSection>
+            <SceneDivider />
+            <SceneSection title="Metric" hideTitleAndDescription={!newSceneLayout} className="max-w-prose">
+                {!newSceneLayout && <LemonLabel className="mb-1">Metric</LemonLabel>}
 
                 {isExperimentMeanMetric(metric) && (
                     <>
@@ -297,52 +305,88 @@ export function ExperimentMetricForm({
                         </div>
                     </div>
                 )}
-            </div>
-            <div>
-                <LemonLabel className="mb-1">Goal</LemonLabel>
-                <LemonSelect<ExperimentMetricGoal>
-                    value={metric.goal || ExperimentMetricGoal.Increase}
-                    onChange={(value) => handleSetMetric({ ...metric, goal: value })}
-                    options={[
-                        { value: ExperimentMetricGoal.Increase, label: 'Increase' },
-                        { value: ExperimentMetricGoal.Decrease, label: 'Decrease' },
-                    ]}
-                />
-                <div className="text-muted text-sm mt-1">
-                    For example, conversion rates should increase, while bounce rates should decrease.
+            </SceneSection>
+            <SceneDivider />
+            <SceneSection title="Goal" hideTitleAndDescription={!newSceneLayout} className="max-w-prose">
+                {!newSceneLayout && <LemonLabel className="mb-1">Goal</LemonLabel>}
+                <div className="flex flex-col gap-1">
+                    <LemonSelect<ExperimentMetricGoal>
+                        value={metric.goal || ExperimentMetricGoal.Increase}
+                        onChange={(value) => handleSetMetric({ ...metric, goal: value })}
+                        options={[
+                            { value: ExperimentMetricGoal.Increase, label: 'Increase' },
+                            { value: ExperimentMetricGoal.Decrease, label: 'Decrease' },
+                        ]}
+                    />
+                    <div className="text-muted text-sm">
+                        For example, conversion rates should increase, while bounce rates should decrease.
+                    </div>
                 </div>
-            </div>
+            </SceneSection>
+            <SceneDivider />
             <ExperimentMetricConversionWindowFilter metric={metric} handleSetMetric={handleSetMetric} />
+            <SceneDivider />
             {isExperimentFunnelMetric(metric) && (
-                <ExperimentMetricFunnelOrderSelector metric={metric} handleSetMetric={handleSetMetric} />
+                <>
+                    <ExperimentMetricFunnelOrderSelector metric={metric} handleSetMetric={handleSetMetric} />
+                    <SceneDivider />
+                </>
             )}
             {isExperimentMeanMetric(metric) && (
-                <ExperimentMetricOutlierHandling metric={metric} handleSetMetric={handleSetMetric} />
+                <>
+                    <ExperimentMetricOutlierHandling metric={metric} handleSetMetric={handleSetMetric} />
+                    <SceneDivider />
+                </>
             )}
-            <div>
-                <LemonLabel
-                    className="mb-1"
-                    info={
-                        <div className="flex flex-col gap-2">
-                            <div>This shows recent activity for your selected metric over the past 2 weeks.</div>
-                            <div>
-                                It's a quick health check to ensure your tracking is working properly, so that you'll
-                                receive accurate results when your experiment starts.
-                            </div>
-                            <div>
-                                If you see zero activity, double-check that this metric is being tracked properly in
-                                your application. Head to{' '}
-                                <Link target="_blank" className="font-semibold" to={urls.insightNew()}>
-                                    Product analytics
-                                    <IconOpenInNew fontSize="18" />
-                                </Link>{' '}
-                                to do a detailed analysis of the events received so far.
-                            </div>
+            <SceneSection
+                title="Recent activity"
+                hideTitleAndDescription={!newSceneLayout}
+                className="max-w-prose"
+                titleHelper={
+                    <div className="flex flex-col gap-2">
+                        <div>This shows recent activity for your selected metric over the past 2 weeks.</div>
+                        <div>
+                            It's a quick health check to ensure your tracking is working properly, so that you'll
+                            receive accurate results when your experiment starts.
                         </div>
-                    }
-                >
-                    Recent activity
-                </LemonLabel>
+                        <div>
+                            If you see zero activity, double-check that this metric is being tracked properly in your
+                            application. Head to{' '}
+                            <Link target="_blank" className="font-semibold" to={urls.insightNew()}>
+                                Product analytics
+                                <IconOpenInNew fontSize="18" />
+                            </Link>{' '}
+                            to do a detailed analysis of the events received so far.
+                        </div>
+                    </div>
+                }
+            >
+                {!newSceneLayout && (
+                    <LemonLabel
+                        className="mb-1"
+                        info={
+                            <div className="flex flex-col gap-2">
+                                <div>This shows recent activity for your selected metric over the past 2 weeks.</div>
+                                <div>
+                                    It's a quick health check to ensure your tracking is working properly, so that
+                                    you'll receive accurate results when your experiment starts.
+                                </div>
+                                <div>
+                                    If you see zero activity, double-check that this metric is being tracked properly in
+                                    your application. Head to{' '}
+                                    <Link target="_blank" className="font-semibold" to={urls.insightNew()}>
+                                        Product analytics
+                                        <IconOpenInNew fontSize="18" />
+                                    </Link>{' '}
+                                    to do a detailed analysis of the events received so far.
+                                </div>
+                            </div>
+                        }
+                    >
+                        Recent activity
+                    </LemonLabel>
+                )}
+
                 <div className="border rounded p-4 bg-bg-light">
                     {isLoading ? (
                         <div className="flex items-center gap-2">
@@ -362,7 +406,7 @@ export function ExperimentMetricForm({
                         </div>
                     )}
                 </div>
-            </div>
-        </div>
+            </SceneSection>
+        </SceneContent>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentMetricFunnelOrderSelector.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricFunnelOrderSelector.tsx
@@ -1,6 +1,8 @@
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { ExperimentFunnelMetric, ExperimentMetric } from '~/queries/schema/schema-general'
 import { StepOrderValue } from '~/types'
 
@@ -36,6 +38,8 @@ export function ExperimentMetricFunnelOrderSelector({
     metric: ExperimentFunnelMetric
     handleSetMetric: (newMetric: ExperimentMetric) => void
 }): JSX.Element {
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
+
     const handleFunnelOrderTypeChange = (funnelOrderType: StepOrderValue): void => {
         handleSetMetric({
             ...metric,
@@ -44,8 +48,13 @@ export function ExperimentMetricFunnelOrderSelector({
     }
 
     return (
-        <div className="flex items-center gap-2">
-            <LemonLabel info={<StepOrderInfo />}>Step order</LemonLabel>
+        <SceneSection
+            title="Step order"
+            titleHelper={<StepOrderInfo />}
+            hideTitleAndDescription={!newSceneLayout}
+            className="max-w-prose"
+        >
+            {!newSceneLayout && <LemonLabel info={<StepOrderInfo />}>Step order</LemonLabel>}
             <LemonSelect
                 data-attr="experiment-funnel-order-selector"
                 value={metric.funnel_order_type || StepOrderValue.ORDERED}
@@ -53,6 +62,6 @@ export function ExperimentMetricFunnelOrderSelector({
                 dropdownMatchSelectWidth={false}
                 options={funnelOrderOptions}
             />
-        </div>
+        </SceneSection>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentMetricOutlierHandling.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricOutlierHandling.tsx
@@ -1,8 +1,10 @@
 import { LemonCheckbox } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { ExperimentMeanMetric, ExperimentMetric } from '~/queries/schema/schema-general'
 
 export function ExperimentMetricOutlierHandling({
@@ -12,63 +14,76 @@ export function ExperimentMetricOutlierHandling({
     metric: ExperimentMeanMetric
     handleSetMetric: (newMetric: ExperimentMetric) => void
 }): JSX.Element {
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
     return (
-        <div>
-            <LemonLabel
-                className="mb-1"
-                info="Prevent outliers from skewing results by capping the lower and upper bounds of a metric."
-            >
-                Outlier handling
-            </LemonLabel>
-            <p className="text-sm text-muted-alt">
-                Set winsorization lower and upper bounds to cap metric values at the specified percentiles.
-            </p>
-            <div className="mt-3 flex items-center gap-2">
-                <LemonCheckbox
-                    label="Lower bound percentile"
-                    checked={metric.lower_bound_percentile !== undefined}
-                    onChange={(checked) =>
-                        handleSetMetric({ ...metric, lower_bound_percentile: checked ? 0.05 : undefined })
-                    }
-                />
-                <LemonInput
-                    value={metric.lower_bound_percentile !== undefined ? metric.lower_bound_percentile * 100 : 0}
-                    onChange={(value) =>
-                        metric.lower_bound_percentile !== undefined &&
-                        handleSetMetric({ ...metric, lower_bound_percentile: (value ?? 0) / 100 })
-                    }
-                    type="number"
-                    step={1}
-                    suffix={<span className="text-sm">%</span>}
-                    size="small"
-                    className={`w-20 transition-opacity ${
-                        metric.lower_bound_percentile === undefined ? 'opacity-0 invisible' : 'opacity-100 visible'
-                    }`}
-                />
+        <SceneSection
+            title="Outlier handling"
+            titleHelper={<>Prevent outliers from skewing results by capping the lower and upper bounds of a metric.</>}
+            hideTitleAndDescription={!newSceneLayout}
+            description={
+                <>Set winsorization lower and upper bounds to cap metric values at the specified percentiles.</>
+            }
+        >
+            {!newSceneLayout && (
+                <>
+                    <LemonLabel
+                        className="mb-1"
+                        info="Prevent outliers from skewing results by capping the lower and upper bounds of a metric."
+                    />
+                    <p className="text-sm text-muted-alt">
+                        Set winsorization lower and upper bounds to cap metric values at the specified percentiles.
+                    </p>
+                </>
+            )}
+
+            <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                    <LemonCheckbox
+                        label="Lower bound percentile"
+                        checked={metric.lower_bound_percentile !== undefined}
+                        onChange={(checked) =>
+                            handleSetMetric({ ...metric, lower_bound_percentile: checked ? 0.05 : undefined })
+                        }
+                    />
+                    <LemonInput
+                        value={metric.lower_bound_percentile !== undefined ? metric.lower_bound_percentile * 100 : 0}
+                        onChange={(value) =>
+                            metric.lower_bound_percentile !== undefined &&
+                            handleSetMetric({ ...metric, lower_bound_percentile: (value ?? 0) / 100 })
+                        }
+                        type="number"
+                        step={1}
+                        suffix={<span className="text-sm">%</span>}
+                        size="small"
+                        className={`w-20 transition-opacity ${
+                            metric.lower_bound_percentile === undefined ? 'opacity-0 invisible' : 'opacity-100 visible'
+                        }`}
+                    />
+                </div>
+                <div className="flex items-center gap-2">
+                    <LemonCheckbox
+                        label="Upper bound percentile"
+                        checked={metric.upper_bound_percentile !== undefined}
+                        onChange={(checked) =>
+                            handleSetMetric({ ...metric, upper_bound_percentile: checked ? 0.95 : undefined })
+                        }
+                    />
+                    <LemonInput
+                        value={metric.upper_bound_percentile !== undefined ? metric.upper_bound_percentile * 100 : 0}
+                        onChange={(value) =>
+                            metric.upper_bound_percentile !== undefined &&
+                            handleSetMetric({ ...metric, upper_bound_percentile: (value ?? 0) / 100 })
+                        }
+                        type="number"
+                        step={1}
+                        suffix={<span className="text-sm">%</span>}
+                        size="small"
+                        className={`w-20 transition-opacity ${
+                            metric.upper_bound_percentile === undefined ? 'opacity-0 invisible' : 'opacity-100 visible'
+                        }`}
+                    />
+                </div>
             </div>
-            <div className="mt-3 flex items-center gap-2">
-                <LemonCheckbox
-                    label="Upper bound percentile"
-                    checked={metric.upper_bound_percentile !== undefined}
-                    onChange={(checked) =>
-                        handleSetMetric({ ...metric, upper_bound_percentile: checked ? 0.95 : undefined })
-                    }
-                />
-                <LemonInput
-                    value={metric.upper_bound_percentile !== undefined ? metric.upper_bound_percentile * 100 : 0}
-                    onChange={(value) =>
-                        metric.upper_bound_percentile !== undefined &&
-                        handleSetMetric({ ...metric, upper_bound_percentile: (value ?? 0) / 100 })
-                    }
-                    type="number"
-                    step={1}
-                    suffix={<span className="text-sm">%</span>}
-                    size="small"
-                    className={`w-20 transition-opacity ${
-                        metric.upper_bound_percentile === undefined ? 'opacity-0 invisible' : 'opacity-100 visible'
-                    }`}
-                />
-            </div>
-        </div>
+        </SceneSection>
     )
 }

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -36,6 +36,7 @@ import { DuplicateExperimentModal } from './DuplicateExperimentModal'
 import { StatusTag, createMaxToolExperimentSurveyConfig } from './ExperimentView/components'
 import { ExperimentsSettings } from './ExperimentsSettings'
 import { Holdouts } from './Holdouts'
+import { SharedMetrics } from './SharedMetrics/SharedMetrics'
 import { EXPERIMENTS_PER_PAGE, ExperimentsFilters, experimentsLogic, getExperimentStatus } from './experimentsLogic'
 import { isLegacyExperiment } from './utils'
 
@@ -445,7 +446,7 @@ export function Experiments(): JSX.Element {
                     {
                         key: ExperimentsTabs.SharedMetrics,
                         label: 'Shared metrics',
-                        link: urls.experimentsSharedMetrics(),
+                        content: <SharedMetrics />,
                     },
                     {
                         key: ExperimentsTabs.History,

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { LemonBanner, LemonButton, LemonLabel, LemonModal, Link } from '@posthog/lemon-ui'
 
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
@@ -34,7 +35,7 @@ export function SharedMetricModal({
     } = useActions(experimentLogic({ experimentId }))
     const { closePrimarySharedMetricModal, closeSecondarySharedMetricModal } = useActions(modalsLogic)
     const { isPrimarySharedMetricModalOpen, isSecondarySharedMetricModalOpen } = useValues(modalsLogic)
-
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
     const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
     const mode = editingSharedMetricId ? 'edit' : 'create'
 
@@ -246,7 +247,15 @@ export function SharedMetricModal({
                                 ]}
                                 footer={
                                     <div className="flex items-center justify-center m-2">
-                                        <LemonButton to={urls.experimentsSharedMetrics()} size="xsmall" type="tertiary">
+                                        <LemonButton
+                                            to={
+                                                newSceneLayout
+                                                    ? `${urls.experiments()}?tab=shared-metrics`
+                                                    : urls.experimentsSharedMetrics()
+                                            }
+                                            size="xsmall"
+                                            type="tertiary"
+                                        >
                                             See all shared metrics
                                         </LemonButton>
                                     </div>

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -1,15 +1,25 @@
 import { useActions, useValues } from 'kea'
 
-import { IconCheckCircle } from '@posthog/icons'
+import { IconBalance, IconCheckCircle, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonInput, LemonLabel, Spinner } from '@posthog/lemon-ui'
 
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { PageHeader } from 'lib/components/PageHeader'
+import { SceneTags } from 'lib/components/Scenes/SceneTags'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+import { ScenePanel, ScenePanelActions, ScenePanelDivider, ScenePanelMetaInfo } from '~/layout/scenes/SceneLayout'
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { tagsModel } from '~/models/tagsModel'
 import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
+import { ExperimentsTabs } from '~/types'
 
 import { ExperimentMetricForm } from '../ExperimentMetricForm'
 import { getDefaultFunnelsMetric, getDefaultTrendsMetric } from '../utils'
@@ -30,9 +40,9 @@ export function SharedMetric(): JSX.Element {
     const { sharedMetric, action } = useValues(sharedMetricLogic)
     const { setSharedMetric, createSharedMetric, updateSharedMetric, deleteSharedMetric } =
         useActions(sharedMetricLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
-    const { currentTeam } = useValues(teamLogic)
 
+    const { currentTeam } = useValues(teamLogic)
+    const newSceneLayout = useFeatureFlag('NEW_SCENE_LAYOUT')
     const { tags: allExistingTags } = useValues(tagsModel)
 
     if (!sharedMetric || !sharedMetric.query) {
@@ -44,7 +54,7 @@ export function SharedMetric(): JSX.Element {
     }
 
     return (
-        <div className="max-w-[800px]">
+        <SceneContent forceNewSpacing>
             {sharedMetric.query.kind !== NodeKind.ExperimentMetric && (
                 <div className="flex gap-4 mb-4">
                     <div
@@ -93,64 +103,188 @@ export function SharedMetric(): JSX.Element {
                     </div>
                 </div>
             )}
-            <div className={`border rounded ${isDarkModeOn ? 'bg-light' : 'bg-white'} p-4`}>
-                <div className="mb-4">
-                    <LemonLabel className="mb-1">Name</LemonLabel>
-                    <LemonInput
-                        value={sharedMetric.name}
-                        onChange={(newName) => {
+            <PageHeader
+                buttons={
+                    <>
+                        <LemonButton
+                            className="ml-auto"
+                            disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
+                            size="medium"
+                            type="primary"
+                            onClick={() => {
+                                if (['create', 'duplicate'].includes(action)) {
+                                    createSharedMetric()
+                                    return
+                                }
+
+                                updateSharedMetric()
+                            }}
+                        >
+                            Save
+                        </LemonButton>
+                        {!newSceneLayout && action === 'update' && (
+                            <LemonButton
+                                size="medium"
+                                type="primary"
+                                status="danger"
+                                onClick={() => {
+                                    LemonDialog.open({
+                                        title: 'Delete this metric?',
+                                        content: (
+                                            <div className="text-sm text-secondary">This action cannot be undone.</div>
+                                        ),
+                                        primaryButton: {
+                                            children: 'Delete',
+                                            type: 'primary',
+                                            onClick: () => deleteSharedMetric(),
+                                            size: 'small',
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                            type: 'tertiary',
+                                            size: 'small',
+                                        },
+                                    })
+                                }}
+                            >
+                                Delete
+                            </LemonButton>
+                        )}
+                    </>
+                }
+            />
+
+            <ScenePanel>
+                <ScenePanelMetaInfo>
+                    <SceneTags
+                        onSave={(tags) => {
                             setSharedMetric({
-                                name: newName,
+                                tags: tags,
                             })
                         }}
+                        canEdit
+                        tags={sharedMetric.tags}
+                        tagsAvailable={allExistingTags}
+                        dataAttrKey="shared-metric"
                     />
-                </div>
-                <div className="mb-4">
-                    <LemonLabel className="mb-1">Description (optional)</LemonLabel>
-                    <LemonInput
-                        value={sharedMetric.description}
-                        onChange={(newDescription) => {
-                            setSharedMetric({
-                                description: newDescription,
-                            })
-                        }}
-                    />
-                </div>
-                <div className="mb-4">
-                    <LemonLabel>Tags</LemonLabel>
-                    <div className="mt-2">
-                        <ObjectTags
-                            tags={sharedMetric.tags || []}
-                            onChange={(newTags) => {
-                                setSharedMetric({
-                                    tags: newTags,
+                </ScenePanelMetaInfo>
+                <ScenePanelDivider />
+                <ScenePanelActions>
+                    {action === 'update' && (
+                        <ButtonPrimitive
+                            variant="danger"
+                            menuItem
+                            onClick={() => {
+                                LemonDialog.open({
+                                    title: 'Delete this metric?',
+                                    content: (
+                                        <div className="text-sm text-secondary">This action cannot be undone.</div>
+                                    ),
+                                    primaryButton: {
+                                        children: 'Delete',
+                                        type: 'primary',
+                                        onClick: () => deleteSharedMetric(),
+                                        size: 'small',
+                                    },
+                                    secondaryButton: {
+                                        children: 'Cancel',
+                                        type: 'tertiary',
+                                        size: 'small',
+                                    },
                                 })
                             }}
-                            saving={false}
-                            tagsAvailable={allExistingTags}
-                            data-attr="shared-metric-tags"
+                        >
+                            <IconTrash /> Delete
+                        </ButtonPrimitive>
+                    )}
+                </ScenePanelActions>
+            </ScenePanel>
+
+            <SceneTitleSection
+                name={sharedMetric.name}
+                resourceType={{ type: 'experiment', forceIcon: <IconBalance /> }}
+                description={sharedMetric.description}
+                onNameChange={(newName) => {
+                    setSharedMetric({
+                        name: newName,
+                    })
+                }}
+                onDescriptionChange={(newDescription) => {
+                    setSharedMetric({
+                        description: newDescription,
+                    })
+                }}
+                canEdit
+                forceEdit={!sharedMetric.id}
+                forceBackTo={{
+                    name: 'Experiments / shared metrics',
+                    path: `${urls.experiments()}?tab=${ExperimentsTabs.SharedMetrics}`,
+                    key: ExperimentsTabs.SharedMetrics,
+                }}
+            />
+            <SceneDivider />
+
+            {!newSceneLayout && (
+                <>
+                    <div className="mb-4">
+                        <LemonLabel className="mb-1">Name</LemonLabel>
+                        <LemonInput
+                            value={sharedMetric.name}
+                            onChange={(newName) => {
+                                setSharedMetric({
+                                    name: newName,
+                                })
+                            }}
                         />
                     </div>
-                </div>
-                {sharedMetric.query.kind === NodeKind.ExperimentMetric ? (
-                    <ExperimentMetricForm
-                        metric={sharedMetric.query as ExperimentMetric}
-                        handleSetMetric={(newMetric) => {
-                            setSharedMetric({
-                                ...sharedMetric,
-                                query: newMetric,
-                            })
-                        }}
-                        filterTestAccounts={currentTeam?.test_account_filters?.length ? true : false}
-                    />
-                ) : sharedMetric.query.kind === NodeKind.ExperimentTrendsQuery ? (
-                    <LegacySharedTrendsMetricForm />
-                ) : (
-                    <LegacySharedFunnelsMetricForm />
-                )}
-            </div>
-            <div className="flex justify-between mt-4">
-                {action === 'update' && (
+                    <div className="mb-4">
+                        <LemonLabel className="mb-1">Description (optional)</LemonLabel>
+                        <LemonInput
+                            value={sharedMetric.description}
+                            onChange={(newDescription) => {
+                                setSharedMetric({
+                                    description: newDescription,
+                                })
+                            }}
+                        />
+                    </div>
+                    <div className="mb-4">
+                        <LemonLabel>Tags</LemonLabel>
+                        <div className="mt-2">
+                            <ObjectTags
+                                tags={sharedMetric.tags || []}
+                                onChange={(newTags) => {
+                                    setSharedMetric({
+                                        tags: newTags,
+                                    })
+                                }}
+                                saving={false}
+                                tagsAvailable={allExistingTags}
+                                data-attr="shared-metric-tags"
+                            />
+                        </div>
+                    </div>
+                </>
+            )}
+
+            {sharedMetric.query.kind === NodeKind.ExperimentMetric ? (
+                <ExperimentMetricForm
+                    metric={sharedMetric.query as ExperimentMetric}
+                    handleSetMetric={(newMetric) => {
+                        setSharedMetric({
+                            ...sharedMetric,
+                            query: newMetric,
+                        })
+                    }}
+                    filterTestAccounts={currentTeam?.test_account_filters?.length ? true : false}
+                />
+            ) : sharedMetric.query.kind === NodeKind.ExperimentTrendsQuery ? (
+                <LegacySharedTrendsMetricForm />
+            ) : (
+                <LegacySharedFunnelsMetricForm />
+            )}
+            <div className="flex justify-between">
+                {/* {action === 'update' && (
                     <LemonButton
                         size="medium"
                         type="primary"
@@ -175,9 +309,8 @@ export function SharedMetric(): JSX.Element {
                     >
                         Delete
                     </LemonButton>
-                )}
+                )} */}
                 <LemonButton
-                    className="ml-auto"
                     disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
                     size="medium"
                     type="primary"
@@ -193,6 +326,6 @@ export function SharedMetric(): JSX.Element {
                     Save
                 </LemonButton>
             </div>
-        </div>
+        </SceneContent>
     )
 }

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -12,7 +12,6 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { ScenePanel, ScenePanelActions, ScenePanelDivider, ScenePanelMetaInfo } from '~/layout/scenes/SceneLayout'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconArrowLeft, IconCopy, IconPencil } from '@posthog/icons'
+import { IconCopy, IconPencil } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -125,15 +125,6 @@ export function SharedMetrics(): JSX.Element {
 
     return (
         <div className="deprecated-space-y-4">
-            <LemonButton
-                type="tertiary"
-                className="inline-flex"
-                to={urls.experiments()}
-                icon={<IconArrowLeft />}
-                size="small"
-            >
-                Back to experiments
-            </LemonButton>
             <LemonBanner type="info">
                 Shared metrics let you create reusable metrics that you can quickly add to any experiment. They are
                 ideal for tracking key metrics like conversion rates or revenue across different experiments without

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -5,6 +5,7 @@ import { router, urlToAction } from 'kea-router'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
@@ -99,7 +100,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
                 lemonToast.success('Shared metric created successfully')
                 actions.reportExperimentSharedMetricCreated(response as SharedMetric)
                 actions.loadSharedMetrics()
-                router.actions.push('/experiments/shared-metrics')
+                router.actions.push(`/experiments/shared-metrics/${response.id}`)
             }
         },
         updateSharedMetric: async () => {
@@ -110,7 +111,11 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
             if (response.id) {
                 lemonToast.success('Shared metric updated successfully')
                 actions.loadSharedMetrics()
-                router.actions.push('/experiments/shared-metrics')
+                if (values.featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]) {
+                    router.actions.push('/experiments?tab=shared-metrics')
+                } else {
+                    router.actions.push('/experiments/shared-metrics')
+                }
             }
         },
         deleteSharedMetric: async () => {
@@ -118,7 +123,11 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
                 await api.delete(`api/projects/@current/experiment_saved_metrics/${values.sharedMetricId}`)
                 lemonToast.success('Shared metric deleted successfully')
                 actions.loadSharedMetrics()
-                router.actions.push('/experiments/shared-metrics')
+                if (values.featureFlags[FEATURE_FLAGS.NEW_SCENE_LAYOUT]) {
+                    router.actions.push('/experiments?tab=shared-metrics')
+                } else {
+                    router.actions.push('/experiments/shared-metrics')
+                }
             } catch (error) {
                 lemonToast.error('Failed to delete shared metric')
                 console.error(error)


### PR DESCRIPTION
## Problem
Experiments shared metrics tab was a jarring as it routed to a different scene

![2025-09-12 11 38 32](https://github.com/user-attachments/assets/c8c3fda2-5fe5-41fc-a3d9-2e497b2abeed)

## Changes
Move Shared metrics into tab content,
Update the shared metric scene with better styling
Update save/update logic to go back to tab instead of scene if NEW SCENE LAYOUT flag is on (Enabled on prod)

![2025-09-12 23 43 46](https://github.com/user-attachments/assets/cd98e540-9475-4061-b1da-058548278ff4)
![2025-09-13 06 31 16](https://github.com/user-attachments/assets/19ae84d6-c3e5-4b71-aead-b1999e4e8cb8)

