### PR TITLE
revert(docker): repin ffmpeg lib in plugin-server Dockerfile to test revert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ RUN apt-get update && \
     "libxmlsec1-dev" \
     "libxml2" \
     "gettext-base" \
-    "ffmpeg=7:5.1.6-0+deb12u1"
+    "ffmpeg=7:5.1.7-0+deb12u1"
 
 # Install MS SQL dependencies
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ RUN apt-get update && \
     "libxmlsec1-dev" \
     "libxml2" \
     "gettext-base" \
-    "ffmpeg"
+    "ffmpeg=7:5.1.6-0+deb12u1"
 
 # Install MS SQL dependencies
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc


### PR DESCRIPTION
## Problem
Unpinning the `ffmpeg` dependency in the `plugin-server` release Dockerfile appears to be causing trouble with `librdkafka` dependencies.

## Changes
Test repinning `ffmpeg` in Docker image

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
CI - looking to test deploy ASAP

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
