### PR TITLE
fix(new-tab): add persons/cohorts

### DIFF
--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -9,6 +9,7 @@ import {
     ProductIconWrapper,
     getDefaultTreeData,
     getDefaultTreeNew,
+    getDefaultTreePersons,
     getDefaultTreeProducts,
     iconForType,
 } from '~/layout/panel-layout/ProjectTree/defaultTree'
@@ -110,7 +111,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     }))
                     .filter(({ flag }) => !flag || featureFlags[flag as keyof typeof featureFlags])
 
-                const products = getDefaultTreeProducts()
+                const products = [...getDefaultTreeProducts(), ...getDefaultTreePersons()]
                     .map((fs) => ({
                         href: fs.href,
                         name: fs.path,
@@ -118,6 +119,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         flag: fs.flag,
                     }))
                     .filter(({ flag }) => !flag || featureFlags[flag as keyof typeof featureFlags])
+                    .toSorted((a, b) => a.name.localeCompare(b.name))
 
                 const data = getDefaultTreeData()
                     .map((fs) => ({


### PR DESCRIPTION
## Problem

The persons and cohorts pages were missing on the new tab page.

## Changes

![2025-09-13 10 16 31](https://github.com/user-attachments/assets/ae7ff8e2-f62e-43ec-b201-a283c24c787b)

I kept it as "Persons" for now, as that's the name of the menu entry, however we probably should talk if we want to rename it.

## How did you test this code?

👀 