### PR TITLE
feat: try to capture errors in player

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -65,6 +65,13 @@ const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 export const PLAYBACK_SPEEDS = [0.5, 1, 1.5, 2, 3, 4, 8, 16]
 export const ONE_FRAME_MS = 100 // We don't really have frames but this feels granular enough
 
+export interface ResourceErrorDetails {
+    resourceType: string
+    resourceUrl: string
+    message: string
+    error?: any
+}
+
 export interface PlayerTimeTracking {
     state: 'buffering' | 'playing' | 'paused' | 'errored' | 'ended' | 'unknown'
     lastTimestamp: number | null
@@ -213,13 +220,6 @@ const updatePlayerTimeTrackingIfChanged = (
     }
 
     return updatePlayerTimeTracking(current, newState)
-}
-
-interface ResourceErrorDetails {
-    resourceType: string
-    resourceUrl: string
-    message: string
-    error?: any
 }
 
 function wrapFetchAndReport({

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -253,6 +253,19 @@ function isHTMLElement(target: EventTarget | null): target is HTMLElement {
     return !!target && 'tagName' in target && typeof target.tagName === 'string'
 }
 
+function isHtmlImageElement(target: HTMLElement): target is HTMLImageElement {
+    return target.tagName.toLowerCase() === 'img' && 'src' in target && typeof (target as any).src === 'string'
+}
+
+function isHtmlStyleLinkElement(target: HTMLElement): target is HTMLLinkElement {
+    return (
+        target.tagName.toLowerCase() === 'link' &&
+        'href' in target &&
+        typeof (target as any).href === 'string' &&
+        (target as HTMLLinkElement).rel === 'stylesheet'
+    )
+}
+
 function registerErrorListeners({
     iframeWindow,
     onError,
@@ -268,14 +281,14 @@ function registerErrorListeners({
         }
 
         const tag = t.tagName.toLowerCase()
-        if (tag === 'img' && t instanceof HTMLImageElement) {
+        if (isHtmlImageElement(t)) {
             onError({
                 resourceType: 'img',
                 resourceUrl: t.src,
                 message: 'Failed to load image',
                 error: e.error,
             })
-        } else if (tag === 'link' && t instanceof HTMLLinkElement && t.rel === 'stylesheet') {
+        } else if (isHtmlStyleLinkElement(t)) {
             onError({
                 resourceType: 'stylesheet',
                 resourceUrl: t.href,
@@ -286,8 +299,8 @@ function registerErrorListeners({
             onError({
                 resourceType: tag,
                 resourceUrl: (t as any).src || (t as any).href || '',
-                message: `Failed to load resource of type ${tag}`,
-                error: e.error,
+                message: `Failed to load resource of type ${tag}. ${typeof t}`,
+                error: e,
             })
         }
     }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1799,26 +1799,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             actions.setIsFullScreen(document.fullscreenElement !== null)
         }
 
-        // Create message listener for resource errors
-        cache.resourceErrorListener = (e: MessageEvent) => {
-            if (e.data?.__rrweb_instrumentation) {
-                const errorDetails = {
-                    resourceType: e.data.tagName,
-                    resourceUrl: e.data.src,
-                    message: e.data.message,
-                }
-
-                actions.incrementErrorCount()
-                actions.caughtAssetErrorFromIframe(errorDetails)
-                posthog.capture('recording_resource_error', {
-                    sessionId: props.sessionRecordingId,
-                    ...errorDetails,
-                })
-            }
-        }
-
         document.addEventListener('fullscreenchange', cache.fullScreenListener)
-        window.addEventListener('message', cache.resourceErrorListener)
 
         if (props.sessionRecordingId) {
             actions.maybeLoadRecordingMeta()

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1749,12 +1749,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
         cache.hasInitialized = false
         document.removeEventListener('fullscreenchange', cache.fullScreenListener)
-        if (cache.resourceErrorListener) {
-            window.removeEventListener('message', cache.resourceErrorListener)
-        }
-        if (cache.resourceMonitorCleanup) {
-            cache.resourceMonitorCleanup()
-        }
         cache.pausedMediaElements = []
         values.player?.replayer?.destroy()
         actions.setPlayer(null)

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1087,9 +1087,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             }
             const replayer = new Replayer(values.sessionPlayerData.snapshotsByWindowId[windowId], config)
 
-            // Expose replayer on window for testing
-            ;(window as any).__posthog_replayer__ = replayer
-
             // Listen for resource errors from rrweb
             replayer.on('fullsnapshot-rebuilded', () => {
                 const iframeFetch = replayer.iframe.contentWindow?.fetch

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -964,7 +964,10 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         ],
     }),
     listeners(({ props, values, actions, cache }) => ({
-        caughtAssetErrorFromIframe: ({ errorDetails }) => {},
+        caughtAssetErrorFromIframe: ({ errorDetails }) => {
+            // eslint-disable-next-line no-console
+            console.log('caughtAssetErrorFromIframe', errorDetails)
+        },
         [playerCommentModel.actionTypes.startCommenting]: async ({ comment }) => {
             actions.setIsCommenting(true)
             if (comment) {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1083,10 +1083,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     actions.playerErrorSeen(error)
                 },
                 logger: logging.logger,
-                enableResourceErrorTracking: {
-                    enabled: true,
-                    nonce: `posthog-resource-monitor-${Math.random().toString(36).substring(2, 15)}`,
-                },
             }
             const replayer = new Replayer(values.sessionPlayerData.snapshotsByWindowId[windowId], config)
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1088,21 +1088,21 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
             // Listen for resource errors from rrweb
             replayer.on('fullsnapshot-rebuilded', () => {
+                const iframeContentWindow = replayer.iframe.contentWindow
                 const iframeFetch = replayer.iframe.contentWindow?.fetch
 
-                if (iframeFetch && !(iframeFetch as any).__isWrappedForErrorReporting) {
+                if (iframeFetch && !(iframeFetch as any).__isWrappedForErrorReporting && iframeContentWindow) {
                     // We have to monkey patch fetch as rrweb doesn't provide a way to listen for these errors
                     // We do this after every fullsnapshot-rebuilded as rrweb creates a new iframe each time
-                    replayer.iframe.contentWindow!.fetch = wrapFetchAndReport({
+                    iframeContentWindow.fetch = wrapFetchAndReport({
                         fetch: iframeFetch,
                         onError: (errorDetails: ResourceErrorDetails) => {
                             actions.caughtAssetErrorFromIframe(errorDetails)
                         },
                     })
-                    ;(replayer.iframe.contentWindow!.fetch as any).__isWrappedForErrorReporting = true
+                    ;(iframeContentWindow.fetch as any).__isWrappedForErrorReporting = true
                 }
 
-                const iframeContentWindow = replayer.iframe.contentWindow
                 if (iframeContentWindow) {
                     // Clean up any previous listeners before adding new ones
                     cache.iframeErrorListenerCleanup?.()


### PR DESCRIPTION
there are some errors that customers experience
we need to look in the console when they report them
and then point them to the troubleshooting page
let's try to automate that

i _think_ this is only working locally because everything appears to be same origin
and that it won't work in production
but i want to check

---

if i manually insert a failing image into the iframe then i get the expected error message

<img width="479" height="332" alt="Screenshot 2025-09-13 at 21 59 20" src="https://github.com/user-attachments/assets/cf4bec20-9021-404e-96a4-f96798fee5e7" />
