### PR TITLE
Update embedded analytics chart label

### DIFF
--- a/frontend/src/scenes/embedded-analytics/embeddedAnalyticsLogic.tsx
+++ b/frontend/src/scenes/embedded-analytics/embeddedAnalyticsLogic.tsx
@@ -153,7 +153,7 @@ export const embeddedAnalyticsLogic = kea<embeddedAnalyticsLogicType>([
                                 xAxis: { column: 'event_date' },
                                 yAxis: [
                                     {
-                                        column: 'number_of_queries',
+                                        column: 'number_of_api_requests',
                                         settings: { formatting: { prefix: '', suffix: '' } },
                                     },
                                 ],

--- a/frontend/src/scenes/embedded-analytics/queries.tsx
+++ b/frontend/src/scenes/embedded-analytics/queries.tsx
@@ -80,7 +80,7 @@ export const createApiQueriesCountQuery = ({ dateFrom, dateTo, requestNameBreakd
     select 
         event_date, 
         ${requestNameBreakdownEnabled ? 'name,' : ''} 
-        count(1) as number_of_queries
+        count(1) as number_of_api_requests
     from query_log
     where is_personal_api_key_request 
         and event_date >= '${dateFrom}' 


### PR DESCRIPTION
## Problem

The 'Number of API requests per day' chart on the Embedded Analytics product incorrectly used `number_of_queries` as its y-axis label and data column. This needed to be updated to `number_of_api_requests` for clarity and accuracy.

## Changes

- Updated the y-axis column reference for the 'Number of API requests per day' chart in `embeddedAnalyticsLogic.tsx`.
- Modified the SQL query alias in `createApiQueriesCountQuery` in `queries.tsx` to align with the new label.

## How did you test this code?

Manually verified that the 'Number of API requests per day' chart in Embedded Analytics now displays `number_of_api_requests` as the y-axis label and uses the correct data.

---
[Slack Thread](https://posthog.slack.com/archives/D09F4NR6W1L/p1757839587469739?thread_ts=1757839587.469739&cid=D09F4NR6W1L)

<a href="https://cursor.com/background-agent?bcId=bc-3a02f380-6118-4063-adee-6996d7388299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a02f380-6118-4063-adee-6996d7388299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

