### PR TITLE
feat: Disable XHR credentials in posthog-js

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -72,6 +72,7 @@ export function loadPostHogJS(): void {
             __preview_flags_v2: true,
             __add_tracing_headers: ['eu.posthog.com', 'us.posthog.com'],
             __preview_lazy_load_replay: true,
+            __preview_disable_xhr_credentials: true,
         })
 
         posthog.onFeatureFlags((_flags, _variants, context) => {


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog-js/pull/2318

Disable sending credentials (cookies) when making XHR requests.

Shouldn't affect anything, but I want to try it for us before making it the default

## Changes

Enable this setting

## How did you test this code?

n/a
The change is test in the linked PR
Merging this is the test before making it the default
