### PR TITLE
chore(myke): update linear destination to be of type internal

### DIFF
--- a/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/linear/linear.template.ts
@@ -3,7 +3,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 export const template: HogFunctionTemplate = {
     status: 'stable',
     free: false,
-    type: 'destination',
+    type: 'internal_destination',
     id: 'template-linear',
     name: 'Linear',
     description: 'Creates an issue for a Linear team',


### PR DESCRIPTION
## Problem

 Problem Statement

  Error tracking Linear integration template appears in Data Pipelines UI but cannot function there,
  creating confusion.

  Current Issue:
  - Single Linear destination template serves both Error Tracking alerts and Data Pipelines
  - Template relies on internal event $error_tracking_issue_created which CDP doesn't process
  - Users can create non-functional destinations through Data Pipelines UI

related slack thread: https://posthog.slack.com/archives/C06GG249PR6/p1757439650001949

## Changes

- changed linear template to be of type `internal_destination`

typically we would want to adjust `sync_hog_function_templates` management command as well but as we currently only keep the latest version of a template it will be overwritten and only the `internal_destination` template will be persisted in the db. 

## How did you test this code?

- local dev 
- tests still pass
