### PR TITLE
fix: handle small numbers in formatWithDecimals

### DIFF
--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -9,6 +9,7 @@ import {
     convertAmountToUsage,
     convertLargeNumberToWords,
     convertUsageToAmount,
+    formatWithDecimals,
     getProration,
     projectUsage,
     summarizeUsage,
@@ -286,5 +287,41 @@ describe('getProration', () => {
             isProrated: false,
             prorationAmount: '0.00',
         })
+    })
+})
+
+describe('formatWithDecimals', () => {
+    it('should format very small numbers without scientific notation', () => {
+        // Test various small decimal places
+        expect(formatWithDecimals(0.000000625)).toEqual('0.000000625') // The exact bug case
+        expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // 7 decimal places
+        expect(formatWithDecimals(0.00000001)).toEqual('0.00000001') // 8 decimal places
+        expect(formatWithDecimals(0.000000001)).toEqual('0.000000001') // 9 decimal places
+
+        // Edge case at the threshold (1e-6)
+        expect(formatWithDecimals(0.000001)).toEqual('0.000001') // Exactly 1e-6
+        expect(formatWithDecimals(0.0000009)).toEqual('0.0000009') // Just below 1e-6
+    })
+
+    it('should remove trailing zeros', () => {
+        expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // No trailing zeros
+        expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // One trailing zero
+        expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // Two trailing zeros
+    })
+
+    it('should handle normal numbers', () => {
+        // Normal numbers
+        expect(formatWithDecimals(0)).toEqual('0')
+        expect(formatWithDecimals(1)).toEqual('1')
+        expect(formatWithDecimals(0.1)).toEqual('0.1')
+        expect(formatWithDecimals(0.01)).toEqual('0.01')
+        expect(formatWithDecimals(100.25)).toEqual('100.25')
+
+        // With explicit decimals
+        expect(formatWithDecimals(10.567, 2)).toEqual('10.57')
+        expect(formatWithDecimals(0.000000625, 9)).toEqual('0.000000625')
+
+        // Negative numbers
+        expect(formatWithDecimals(-0.000000625)).toEqual('-0.000000625')
     })
 })

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -293,20 +293,22 @@ describe('getProration', () => {
 describe('formatWithDecimals', () => {
     it('should format very small numbers without scientific notation', () => {
         // Test various small decimal places
-        expect(formatWithDecimals(0.000000625)).toEqual('0.000000625') // The exact bug case
         expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // 7 decimal places
         expect(formatWithDecimals(0.00000001)).toEqual('0.00000001') // 8 decimal places
         expect(formatWithDecimals(0.000000001)).toEqual('0.000000001') // 9 decimal places
+        expect(formatWithDecimals(0.0000000001)).toEqual('0.0000000001') // 10 decimal places
+        expect(formatWithDecimals(0.00000000001)).toEqual('0') // 11 decimal places - falls back to 10 decimals if not specified, which would be 0.0000000000 so we return 0
 
-        // Edge case at the threshold (1e-6)
+        // Edge case at the scientific notation threshold (1e-6)
         expect(formatWithDecimals(0.000001)).toEqual('0.000001') // Exactly 1e-6
         expect(formatWithDecimals(0.0000009)).toEqual('0.0000009') // Just below 1e-6
     })
 
     it('should remove trailing zeros', () => {
-        expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // No trailing zeros
-        expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // One trailing zero
-        expect(formatWithDecimals(0.0000001)).toEqual('0.0000001') // Two trailing zeros
+        // These numbers naturally produce trailing zeros when using toFixed(10), which is the default
+        expect(formatWithDecimals(1 / 8000000)).toEqual('0.000000125') // 0.000000125 -> toFixed(10) = 0.0000001250
+        expect(formatWithDecimals(5 / 4000000)).toEqual('0.00000125') // 0.00000125 -> toFixed(10) = 0.0000012500
+        expect(formatWithDecimals(1 / 2000000)).toEqual('0.0000005') // 0.0000005 -> toFixed(10) = 0.0000005000
     })
 
     it('should handle normal numbers', () => {

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -493,9 +493,20 @@ export function calculateBillingPeriodMarkers(
 
 const sumSeries = (values: number[]): number => values.reduce((sum, v) => sum + v, 0)
 
-// Keep up to N decimals without trailing zeros
-export const formatWithDecimals = (value: number, decimals?: number): string =>
-    typeof decimals === 'number' ? String(Number(value.toFixed(decimals))) : String(value)
+/**
+ * Keep up to N decimals without trailing zeros.
+ * Falls back to 10 decimals for very small numbers if not specified.
+ */
+export const formatWithDecimals = (value: number, decimals?: number): string => {
+    const needsFixedFormat = typeof decimals === 'number' || (Math.abs(value) < 1e-6 && value !== 0)
+
+    return needsFixedFormat
+        ? value
+              .toFixed(decimals ?? 10)
+              .replace(/0+$/, '')
+              .replace(/\.$/, '')
+        : String(value)
+}
 
 /**
  * Build CSV from the billing usage and spend data:


### PR DESCRIPTION
## Problem
- Backend now correctly returns very small unit amounts like `"0.000000625"` for unit prices
- Frontend still displays these as scientific notation (`$6.25e-7`) instead of decimal format
- JS automatically converts numbers < 1e-6 to scientific notation when using `String(value)`

## Changes
- Updated `formatWithDecimals()` to detect very small numbers
- Added tests