### PR TITLE
fix(myke): avoid crashloop for errored plugins

### DIFF
--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -239,7 +239,19 @@ export class LazyPluginVM implements PluginInstance {
                     PluginLogEntryType.Error
                 )
                 this.initRetryTimeout = setTimeout(async () => {
-                    await this._setupPlugin(vm)
+                    try {
+                        await this._setupPlugin(vm)
+                    } catch (error) {
+                        // Handle the error to prevent unhandled promise rejection
+                        logger.error('🚨', `Plugin setup failed after retry timeout`, {
+                            error: error instanceof Error ? error.message : String(error),
+                            pluginId: this.pluginConfig.plugin?.id,
+                            pluginConfigId: this.pluginConfig.id,
+                            teamId: this.pluginConfig.team_id,
+                        })
+                        // The plugin is already marked as errored and disabled at this point
+                        // so we just need to prevent the process from crashing
+                    }
                 }, nextRetryMs)
             } else {
                 this.inErroredState = true


### PR DESCRIPTION
## Problem

We get crashlooping pods when we encounter errors in our plugin setup e.g. 

```
rb9vq","backgroundTaskCount":0,"msg":"[CDP-LEGACY-ON-EVENT] 🔁 waiting_for_background_tasks_before_disconnect"}
{"level":"error","time":1757922407324,"pid":1,"hostname":"cdp-legacy-events-consumer-fd854c865-rb9vq","error":{"name":"SetupPluginError"},"stack":"SetupPluginError: setupPlugin failed with RetryError (attempt 5/5): Error: Unable to connect to Hubspot. Please make sure your API key is correct. for plugin Hubspot ID 60 (organization ID 4dc8564d-bd82-1065-2f40-97f7c50f67cf - global). Disabled the app!\n at LazyPluginVM._setupPlugin (/code/plugin-server/dist/worker/vm/lazy.js:189:23)\n at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n at async Timeout.<anonymous> (/code/plugin-server/dist/worker/vm/lazy.js:182:21)","msg":"[CDP-LEGACY-ON-EVENT] 🤮 unhandledRejection!"}
```

this seems to be expected as customer provide their own api key for plugins and if they e.g. delete their hubspot app or provide a faulty api key this error will occur and should not lead to our pods crashing.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- catches the error instead of it leading to an unhandled promise rejection

the new behaviour is:

1. During retries 1-4: The error is caught in the _setupPlugin method (lines 219-243), which logs a warning and schedules the next
  retry. The original error logging still happens at line 236:
  logger.warn('⚠️', `setupPlugin failed with ${error} for ${logInfo}. ${nextRetryInfo}`)
  2. On the 5th (final) retry: When it fails, the code throws a SetupPluginError. This thrown
  error would previously crash the process because it was unhandled in the setTimeout callback.
  3. Our fix: The try-catch we added only catches the error thrown on the final attempt when it bubbles up through
  the setTimeout callback. This prevents the unhandled promise rejection that was crashing your pods.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- tests still pass

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
