### PR TITLE
feat(msg): oauth placeholders for all integration fields

### DIFF
--- a/plugin-server/src/cdp/services/hog-inputs.service.ts
+++ b/plugin-server/src/cdp/services/hog-inputs.service.ts
@@ -130,10 +130,11 @@ export class HogInputsService {
                     value: {
                         ...integration.config,
                         ...integration.sensitive_config,
-                        ...(key === 'oauth'
+                        ...(integration.sensitive_config.access_token || integration.config.access_token
                             ? {
                                   access_token: ACCESS_TOKEN_PLACEHOLDER + integration.id,
-                                  access_token_raw: integration.sensitive_config.access_token,
+                                  access_token_raw:
+                                      integration.sensitive_config.access_token ?? integration.config.access_token,
                               }
                             : {}),
                     },


### PR DESCRIPTION
## Problem

In a previous attempt to release oauth placeholders for non `oauth` keyed integration fields, we broke the authentication of integrations with their `access_token` in the `config` (instead of the `sensitive_config`).

## Changes

- Fix this with a test
- [x] test on dev
- [ ] [monitor fetch statuses chart](https://grafana.prod-us.posthog.dev/d/cdp/cdp?var-partition=$__all&var-database=posthog-cyclotron-shard0-prod-us-east-1&var-queue=$__all&var-service=$__all&from=now-7d&to=now&timezone=utc&tab=queries&editPanel=99) after rollout