### PR TITLE
fix(max): propagated NotImplemented

### DIFF
--- a/ee/hogai/graph/base.py
+++ b/ee/hogai/graph/base.py
@@ -42,7 +42,8 @@ class BaseAssistantNode(Generic[StateType, PartialStateType], AssistantContextMi
         try:
             return await self.arun(state, config)
         except NotImplementedError:
-            return await database_sync_to_async(self.run, thread_sensitive=False)(state, config)
+            pass
+        return await database_sync_to_async(self.run, thread_sensitive=False)(state, config)
 
     # DEPRECATED: Use `arun` instead
     def run(self, state: StateType, config: RunnableConfig) -> PartialStateType | None:

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -200,14 +200,16 @@ class MaxTool(AssistantContextMixin, BaseTool):
         try:
             return self._run_impl(*args, **kwargs)
         except NotImplementedError:
-            return async_to_sync(self._arun_impl)(*args, **kwargs)
+            pass
+        return async_to_sync(self._arun_impl)(*args, **kwargs)
 
     async def _arun(self, *args, config: RunnableConfig, **kwargs):
         self._init_run(config)
         try:
             return await self._arun_impl(*args, **kwargs)
         except NotImplementedError:
-            return await super()._arun(*args, config=config, **kwargs)
+            pass
+        return await super()._arun(*args, config=config, **kwargs)
 
     def _init_run(self, config: RunnableConfig):
         self._context = config["configurable"].get("contextual_tools", {}).get(self.get_name(), {})


### PR DESCRIPTION
## Problem

If the exception is raised in a sync Max method, it will show a stack trace that is hard to read:

<img width="445" height="220" alt="Screenshot 2025-09-15 at 14 51 46" src="https://github.com/user-attachments/assets/2ac8ddfa-3e7c-4bbf-b6ef-225ea1726481" />


## Changes

Removed propagation of NotImplemented, so the stack is not messed up.

## How did you test this code?

Manual & unit testing
