### PR TITLE
fix(batch-exports): Ensure backfill end date is not in the future

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
@@ -83,30 +83,9 @@ export const batchExportBackfillModalLogic = kea<batchExportBackfillModalLogicTy
                 }
 
                 let upperBound = dayjs().tz(teamLogic.values.timezone)
-                let period = '1 hour'
-
-                if (values.batchExportConfig && end_at) {
-                    if (values.batchExportConfig.interval == 'hour') {
-                        upperBound = upperBound.add(1, 'hour')
-                    } else if (values.batchExportConfig.interval == 'day') {
-                        upperBound = upperBound.hour(0).minute(0).second(0)
-                        upperBound = upperBound.add(1, 'day')
-                        period = '1 day'
-                    } else if (values.batchExportConfig.interval.endsWith('minutes')) {
-                        // TODO: Make this generic for all minute frequencies.
-                        // Currently, only 5 minute batch exports are supported.
-                        upperBound = upperBound.add(5, 'minute')
-                        period = '5 minutes'
-                    } else {
-                        upperBound = upperBound.add(1, 'hour')
-                    }
-
-                    if (end_at > upperBound) {
-                        lemonToast.error(
-                            `Requested backfill end date lies too far into the future. Use an end date that is no more than ${period} from now (in your project's timezone)`
-                        )
-                        return
-                    }
+                if (values.batchExportConfig && end_at && end_at > upperBound) {
+                    lemonToast.error('Requested backfill end date lies in the future')
+                    return
                 }
 
                 await api.batchExports

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -809,10 +809,8 @@ def create_backfill(
     if start_at >= end_at:
         raise ValidationError("The initial backfill datetime 'start_at' happens after 'end_at'")
 
-    if end_at > dt.datetime.now(dt.UTC) + batch_export.interval_time_delta:
-        raise ValidationError(
-            f"The provided 'end_at' ({end_at.isoformat()}) is too far into the future. Cannot backfill beyond 1 batch period into the future."
-        )
+    if end_at > dt.datetime.now(dt.UTC):
+        raise ValidationError(f"The provided 'end_at' ({end_at.isoformat()}) is in the future")
 
     try:
         return backfill_export(temporal, str(batch_export.pk), team.pk, start_at, end_at)


### PR DESCRIPTION
## Problem

Currently we permit backfills up to one interval into the future. However this can cause problems because we can have runs that start and need to wait until they complete. These take up worker task slots, are more likely to trigger SLA warnings and can cause confusion (I recently spent some time trying to figure out why a run was 'stuck' before realising the end date was several hours in the future). I'm also not sure there is any benefit to allowing backfills in the future, so think it makes sense for both us and users if we forbid this behaviour.

## Changes

Update checks on both frontend and backend to prevent backfills being created with an `end_date` in the future (rather than up to 1 time interval in the future).

## How did you test this code?

- Automated tests on the backend.
- Manual testing for frontend

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
