### PR TITLE
fix: set value prop for first name input in InviteRow

### DIFF
--- a/frontend/src/scenes/settings/organization/InviteModal.tsx
+++ b/frontend/src/scenes/settings/organization/InviteModal.tsx
@@ -241,6 +241,7 @@ export function InviteRow({ index, isDeletable }: { index: number; isDeletable: 
                         <LemonInput
                             placeholder={name}
                             className="flex-1"
+                            value={invitesToSend[index].first_name}
                             onChange={(v) => {
                                 updateInviteAtIndex({ first_name: v }, index)
                             }}


### PR DESCRIPTION
## Changes

Customer report: https://posthog.slack.com/archives/C09ED7A2MQ8/p1757925080388619

Added the value prop to the LemonInput for first name in the InviteRow component to ensure the input is controlled and reflects the current state.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
