### PR TITLE
fix(data-warehouse): Format log start/end times with the teams timezone

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -88,8 +88,12 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
                                       hideInstanceIdColumn={true}
                                       defaultFilters={{
                                           instanceId: job.workflow_run_id,
-                                          dateFrom: dayjsUtcToTimezone(job.created_at, timezone).toISOString(),
-                                          dateTo: dayjsUtcToTimezone(job.finished_at, timezone).toISOString(),
+                                          dateFrom: dayjsUtcToTimezone(job.created_at, timezone)
+                                              .add(-1, 'day')
+                                              .toISOString(),
+                                          dateTo: dayjsUtcToTimezone(job.finished_at, timezone)
+                                              .add(1, 'day')
+                                              .toISOString(),
                                           levels: showDebugLogs ? ['DEBUG', ...LOG_LEVELS] : LOG_LEVELS,
                                       }}
                                   />

--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -3,7 +3,9 @@ import { useActions, useValues } from 'kea'
 import { LemonButton, LemonTable, LemonTag, LemonTagType, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import { dayjsUtcToTimezone } from 'lib/dayjs'
 import { LogsViewer } from 'scenes/hog-functions/logs/LogsViewer'
+import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { ExternalDataJob, ExternalDataJobStatus, LogEntryLevel } from '~/types'
@@ -25,6 +27,7 @@ interface SyncsProps {
 const LOG_LEVELS: LogEntryLevel[] = ['LOG', 'INFO', 'WARN', 'WARNING', 'ERROR']
 
 export const Syncs = ({ id }: SyncsProps): JSX.Element => {
+    const { timezone } = useValues(teamLogic)
     const { user } = useValues(userLogic)
     const { jobs, jobsLoading, canLoadMoreJobs } = useValues(
         dataWarehouseSourceSettingsLogic({ id, availableSources: {} })
@@ -85,8 +88,8 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
                                       hideInstanceIdColumn={true}
                                       defaultFilters={{
                                           instanceId: job.workflow_run_id,
-                                          dateFrom: job.created_at,
-                                          dateTo: job.finished_at,
+                                          dateFrom: dayjsUtcToTimezone(job.created_at, timezone).toISOString(),
+                                          dateTo: dayjsUtcToTimezone(job.finished_at, timezone).toISOString(),
                                           levels: showDebugLogs ? ['DEBUG', ...LOG_LEVELS] : LOG_LEVELS,
                                       }}
                                   />

--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { LemonButton, LemonTable, LemonTag, LemonTagType, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
-import { dayjsUtcToTimezone } from 'lib/dayjs'
+import { dayjs, dayjsUtcToTimezone } from 'lib/dayjs'
 import { LogsViewer } from 'scenes/hog-functions/logs/LogsViewer'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -91,9 +91,11 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
                                           dateFrom: dayjsUtcToTimezone(job.created_at, timezone)
                                               .add(-1, 'day')
                                               .toISOString(),
-                                          dateTo: dayjsUtcToTimezone(job.finished_at, timezone)
-                                              .add(1, 'day')
-                                              .toISOString(),
+                                          dateTo: job.finished_at
+                                              ? dayjsUtcToTimezone(job.finished_at, timezone)
+                                                    .add(1, 'day')
+                                                    .toISOString()
+                                              : dayjs().add(1, 'day').toISOString(),
                                           levels: showDebugLogs ? ['DEBUG', ...LOG_LEVELS] : LOG_LEVELS,
                                       }}
                                   />


### PR DESCRIPTION
## Problem
- The _new_ log viewer is filtering by UTC timestamp, I think this is getting wrongly converted _somewhere_ causing logs to not show when the project time isn't PST timezone 

## Changes
- Convert the timestamps correctly, and widen the range - we're only using the timestamp filter to make lookups faster, we do log before/after the timestamps in the DB too (and lag can cause log timestamps to drift I think) - so adding an extra day either side means we catch all logs 

