### PR TITLE
fix(experiments): don't show experiment title always in edit mode

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -123,7 +123,6 @@ export function Info(): JSX.Element {
                 onNameChange={(name) => updateExperiment({ name })}
                 onDescriptionChange={(description) => updateExperiment({ description })}
                 canEdit
-                forceEdit
                 renameDebounceMs={1000}
             />
             <SceneDivider />


### PR DESCRIPTION
## Problem

Experiment title is always
<img width="414" height="137" alt="Screenshot 2025-09-15 at 18 37 13" src="https://github.com/user-attachments/assets/9ee7fe26-e39b-43a1-8233-07b0cd283558" />
 in edit mode


## Changes
Remove `forceEdit` such that it displays better. You now need to click it to edit the name
<img width="406" height="148" alt="Screenshot 2025-09-15 at 18 37 36" src="https://github.com/user-attachments/assets/1634c2d4-98e1-4a53-9672-31f9fc7c7ea8" />


## How did you test this code?
- tested locally
