### PR TITLE
fix(experiments): prefill feature flag name

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -129,7 +129,21 @@ const ExperimentFormFields = (): JSX.Element => {
                         </div>
                     }
                 >
-                    <LemonInput placeholder="pricing-page-conversion" data-attr="experiment-feature-flag-key" />
+                    <LemonInput
+                        placeholder="pricing-page-conversion"
+                        data-attr="experiment-feature-flag-key"
+                        onFocus={() => {
+                            // Auto-generate feature flag key from experiment name when focusing on empty field
+                            if (!experiment.feature_flag_key && experiment.name) {
+                                setExperiment({
+                                    feature_flag_key: generateFeatureFlagKey(
+                                        experiment.name,
+                                        unavailableFeatureFlagKeys
+                                    ),
+                                })
+                            }
+                        }}
+                    />
                 </LemonField>
             </SceneSection>
 

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -86,20 +86,7 @@ const ExperimentFormFields = (): JSX.Element => {
             )}
             {!newSceneLayout && (
                 <LemonField name="name" label="Name" className="max-w-120">
-                    <LemonInput
-                        placeholder="Pricing page conversion"
-                        data-attr="experiment-name"
-                        onBlur={() => {
-                            // bail if feature flag key is already set
-                            if (experiment.feature_flag_key) {
-                                return
-                            }
-
-                            setExperiment({
-                                feature_flag_key: generateFeatureFlagKey(experiment.name, unavailableFeatureFlagKeys),
-                            })
-                        }}
-                    />
+                    <LemonInput placeholder="Pricing page conversion" data-attr="experiment-name" />
                 </LemonField>
             )}
 


### PR DESCRIPTION
## Problem
Prefilling feature flag name stopped working with the new scene layout thing. There is no longer an `onBlur()` event it seems?

## Changes
Use `onFocus()` on the flag name input instead. 

https://github.com/user-attachments/assets/3884cb54-6652-4b7f-bc3b-1e3a2be10c09

## How did you test this code?

- Tested locally
