### PR TITLE
fix(experiments): remove hardcoded metric modal width

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/ExperimentMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/ExperimentMetricModal.tsx
@@ -60,7 +60,6 @@ export function ExperimentMetricModal({
         <LemonModal
             isOpen={isSecondary ? isSecondaryMetricModalOpen : isPrimaryMetricModalOpen}
             onClose={onClose}
-            width={1000}
             title="Edit experiment metric"
             footer={
                 <div className="flex items-center w-full">


### PR DESCRIPTION
## Problem

This modal changed after https://github.com/PostHog/posthog/pull/38051

<img width="1116" height="1223" alt="Screenshot 2025-09-15 at 19 53 37" src="https://github.com/user-attachments/assets/7bd18051-8c1b-4e0b-b320-78d2f8921292" />


## Changes

Remove the hardcoded width such that the modal does not take up more space than the inner content.

<img width="695" height="1226" alt="Screenshot 2025-09-15 at 19 53 27" src="https://github.com/user-attachments/assets/71258476-d2d9-4ac7-a1f4-3f43161485ae" />


Should perhaps rework this more closely, but suggest we do this for now.

## How did you test this code?
- Tested locally
