### PR TITLE
fix: Guard against undefined search results

### DIFF
--- a/frontend/src/lib/components/CommandBar/SearchResultPreview.tsx
+++ b/frontend/src/lib/components/CommandBar/SearchResultPreview.tsx
@@ -29,6 +29,10 @@ export const SearchResultPreview = (): JSX.Element | null => {
 
     const result = combinedSearchResults[activeResultIndex]
 
+    if (!result) {
+        return null
+    }
+
     return (
         <div className="border bg-surface-primary rounded p-4 md:p-6">
             <div className="deprecated-space-y-4">

--- a/frontend/src/lib/components/CommandBar/searchBarLogic.ts
+++ b/frontend/src/lib/components/CommandBar/searchBarLogic.ts
@@ -590,7 +590,11 @@ export const searchBarLogic = kea<searchBarLogicType>([
             actions.loadGroup4Response(_)
         },
         openResult: ({ index }) => {
-            const result = values.combinedSearchResults![index]
+            const results = values.combinedSearchResults
+            if (!results || !results[index]) {
+                return // Early exit if no valid result
+            }
+            const result = results[index]
             router.actions.push(urlForResult(result))
             actions.hideCommandBar()
             actions.reportCommandBarSearchResultOpened(result.type)


### PR DESCRIPTION
## Problem

We were checking search results before they were avaialble, which caused [this issue](https://us.posthog.com/project/2/error_tracking/019716d8-2212-7dc3-96a4-39709bbd6f6b?timestamp=2025-09-15%2004%3A26%3A12.726000-07%3A00&dateRange=%7B%22date_from%22%3A%222025-06-01%22%2C%22date_to%22%3A%222025-09-15T23%3A59%3A59%22%7D).

## Changes

**Guard clause in search preview**

- In `frontend/src/lib/components/CommandBar/SearchResultPreview.tsx`
- Before: We tried rendering even if no result, causing issues when checking type
- After: Exit if no result yet

**Exit early from openResult**

- In `frontend/src/lib/components/CommandBar/searchBarLogic.ts`
- Before: We were only checking if combinedResults wasn't null
- After: Exit early from `openResult` if no result found at index

## How did you test this code?

