### PR TITLE
fix(experiments): correctly show who performed an experiment update

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -114,14 +114,12 @@ class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
 
 @receiver(model_activity_signal, sender=ExperimentSavedMetric)
 def handle_experiment_saved_metric_change(
-    sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
     log_activity(
         organization_id=after_update.team.organization_id,
         team_id=after_update.team_id,
-        user=after_update.created_by
-        if activity == "created"
-        else getattr(after_update, "last_modified_by", after_update.created_by),
+        user=user,
         was_impersonated=was_impersonated,
         item_id=after_update.id,
         scope="Experiment",  # log under Experiment scope so it appears in experiment activity log

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -686,13 +686,13 @@ class EnterpriseExperimentsViewSet(ForbidDestroyModel, TeamAndOrgViewSetMixin, v
 
 
 @receiver(model_activity_signal, sender=Experiment)
-def handle_experiment_change(sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs):
+def handle_experiment_change(
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
+):
     log_activity(
         organization_id=after_update.team.organization_id,
         team_id=after_update.team_id,
-        user=after_update.created_by
-        if activity == "created"
-        else getattr(after_update, "last_modified_by", after_update.created_by),
+        user=user,
         was_impersonated=was_impersonated,
         item_id=after_update.id,
         scope=scope,

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -882,12 +882,12 @@ class LegacyInsightViewSet(InsightViewSet):
 
 @receiver(model_activity_signal, sender=Dashboard)
 def handle_dashboard_change(
-    sender, scope, before_update, after_update, activity, user=None, was_impersonated=False, **kwargs
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
     log_activity(
         organization_id=after_update.team.organization_id,
         team_id=after_update.team_id,
-        user=user if user else (after_update.created_by if activity == "created" else None),
+        user=user,
         was_impersonated=was_impersonated,
         item_id=after_update.id,
         scope=scope,


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/38100

The ModelActivityMixin correctly captures the current user making changes and passes it as the user parameter in the model_activity_signal. However, several signal handlers were ignoring this correct user information and instead trying to derive the user from model fields like created_by or non-existent fields like last_modified_by.

## Changes
Use the correct user information from the ModelActivityMixin that is already being passed in by the signal handler.
Fixes https://github.com/PostHog/posthog/issues/38100

## How did you test this code?
- tests added
- tests pass