### PR TITLE
feat: Add new `--skip-typegen` option to `bin/start`

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -39,6 +39,10 @@ else
     echo "👉 To start with tracing enabled: bin/start --enable-tracing"
 fi
 
+if [[ "$*" == *"--skip-typegen"* ]]; then
+    export SKIP_TYPEGEN="exit 0"
+fi
+
 if [ -f .env ]; then
     set -o allexport
     source .env


### PR DESCRIPTION
Kea typegen uses up to 6GB memory in my Macbook. I don't need it to be running all the time since I'm used to running `pnpm typegen` every so often anyway. Let's add a new `--skip-typegen` option to the `bin/start` script to make this easier to skip.

I'm aware we should probably not add a new flag but instead just simply turn this on when `--minimal` is running, but we can sort those toggles soon - hopefully the DX team.