### PR TITLE
fix: lower max connections more

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -125,7 +125,7 @@ pub struct Config {
     #[envconfig(default = "1000")]
     pub max_concurrency: usize,
 
-    #[envconfig(default = "25")]
+    #[envconfig(default = "10")]
     pub max_pg_connections: u32,
 
     #[envconfig(default = "redis://localhost:6379/")]
@@ -350,7 +350,7 @@ mod tests {
             "postgres://posthog:posthog@localhost:5432/posthog"
         );
         assert_eq!(config.max_concurrency, 1000);
-        assert_eq!(config.max_pg_connections, 25);
+        assert_eq!(config.max_pg_connections, 10);
         assert_eq!(config.redis_url, "redis://localhost:6379/");
         assert_eq!(config.team_ids_to_track, TeamIdCollection::All);
         assert_eq!(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We are still getting 504s and latency spikes that correlate with new connections to pg from feature flag pods. 

<img width="856" height="314" alt="Screenshot 2025-09-15 at 2 53 00 PM" src="https://github.com/user-attachments/assets/b0007499-7eb6-477f-81bc-9e2fd887e371" />
<img width="853" height="307" alt="Screenshot 2025-09-15 at 2 54 43 PM" src="https://github.com/user-attachments/assets/d932a3bf-36e2-41fe-8ad7-9b0dee4e0641" />

Time box: {"from":"2025-09-15T14:28:39.000+00:00","to":"2025-09-15T14:50:55.000+00:00"}

I believe this is because my last change wasn't aggressive enough: https://github.com/PostHog/posthog/pull/38040

I am not really sure what the optimal number of connections is, but I know lower is better because in theory, establishing new connections creates more CPU contention. FWIW `property-defs-rs` uses 10 connections per pod. 

## Changes

Lower from 25 to 10 connections. 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Test in prod 🤞 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
