### PR TITLE
feat: Implement basic join validation

### DIFF
--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -415,7 +415,7 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
         isJoinValidating,
         isJoinValid,
         validationError,
-        keyTypeMismatch,
+        validationWarning,
     } = useValues(viewLinkLogic)
     const {
         selectJoiningTable,
@@ -696,7 +696,7 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                     }
                 />
             )}
-            {keyTypeMismatch && <LemonBanner className="mt-2" type="warning" children={keyTypeMismatch} />}
+            {validationWarning && <LemonBanner className="mt-2" type="warning" children={validationWarning} />}
             <LemonDivider className="mt-4 mb-4" />
             <div className="flex flex-row gap-2 justify-end w-full">
                 {isJoinValid ? (
@@ -715,7 +715,7 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                             type="primary"
                             onClick={validateJoin}
                             loading={isJoinValidating}
-                            disabledReason={validationError}
+                            disabledReason={validationError || validationWarning}
                         >
                             Validate join
                         </LemonButton>

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -411,16 +411,18 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
         joiningTablePreviewData,
         sourceTablePreviewLoading,
         joiningTablePreviewLoading,
+        isJoinValidating,
+        isJoinValid,
     } = useValues(viewLinkLogic)
     const {
         selectJoiningTable,
-        toggleJoinTableModal,
         selectSourceTable,
         setFieldName,
         selectSourceKey,
         selectJoiningKey,
         setExperimentsOptimized,
         selectExperimentsTimestampKey,
+        validateJoin,
     } = useActions(viewLinkLogic)
     const [advancedSettingsExpanded, setAdvancedSettingsExpanded] = useState(false)
 
@@ -667,13 +669,24 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                 )}
             </div>
             <LemonDivider className="mt-4 mb-4" />
-            <div className="flex flex-row justify-end w-full">
-                <LemonButton className="mr-3" type="secondary" onClick={toggleJoinTableModal}>
-                    Close
-                </LemonButton>
-                <LemonButton type="primary" htmlType="submit" loading={isViewLinkSubmitting}>
-                    Save
-                </LemonButton>
+            <div className="flex flex-row gap-2 justify-end w-full">
+                {isJoinValid ? (
+                    <>
+                        <LemonButton disabledReason="Join is valid">Join is valid</LemonButton>
+                        <LemonButton type="primary" onClick={validateJoin} loading={isJoinValidating}>
+                            Save join
+                        </LemonButton>
+                    </>
+                ) : (
+                    <>
+                        <LemonButton htmlType="submit" loading={isViewLinkSubmitting}>
+                            Save join without validating
+                        </LemonButton>
+                        <LemonButton type="primary" onClick={validateJoin} loading={isJoinValidating}>
+                            Validate join
+                        </LemonButton>
+                    </>
+                )}
             </div>
         </Form>
     )

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -705,8 +705,6 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                         <LemonButton type="primary" htmlType="submit" loading={isViewLinkSubmitting}>
                             Save join
                         </LemonButton>
-                            Save join
-                        </LemonButton>
                     </>
                 ) : (
                     <>

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -702,7 +702,9 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                 {isJoinValid ? (
                     <>
                         <LemonButton disabledReason="Join is valid">Join is valid</LemonButton>
-                        <LemonButton type="primary" onClick={validateJoin} loading={isJoinValidating}>
+                        <LemonButton type="primary" htmlType="submit" loading={isViewLinkSubmitting}>
+                            Save join
+                        </LemonButton>
                             Save join
                         </LemonButton>
                     </>

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 
 import { IconCollapse, IconExpand } from '@posthog/icons'
 import {
+    LemonBanner,
     LemonButton,
     LemonButtonProps,
     LemonCard,
@@ -413,6 +414,7 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
         joiningTablePreviewLoading,
         isJoinValidating,
         isJoinValid,
+        validationError,
     } = useValues(viewLinkLogic)
     const {
         selectJoiningTable,
@@ -668,6 +670,31 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                     </div>
                 )}
             </div>
+            {validationError && (
+                <LemonBanner
+                    className="mt-2"
+                    type="error"
+                    children={
+                        <div className="flex flex-row items-center">
+                            <div>
+                                Validation error:
+                                <br />
+                                {validationError}
+                            </div>
+                            <LemonButton
+                                children="Get help"
+                                type="secondary"
+                                onClick={() => {
+                                    window.open(
+                                        'https://posthog.com/support?utm_medium=in-product&utm_campaign=join-modal-validation-error',
+                                        '_blank'
+                                    )
+                                }}
+                            />
+                        </div>
+                    }
+                />
+            )}
             <LemonDivider className="mt-4 mb-4" />
             <div className="flex flex-row gap-2 justify-end w-full">
                 {isJoinValid ? (
@@ -679,10 +706,15 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                     </>
                 ) : (
                     <>
-                        <LemonButton htmlType="submit" loading={isViewLinkSubmitting}>
+                        <LemonButton htmlType="submit" loading={isViewLinkSubmitting} disabledReason={validationError}>
                             Save join without validating
                         </LemonButton>
-                        <LemonButton type="primary" onClick={validateJoin} loading={isJoinValidating}>
+                        <LemonButton
+                            type="primary"
+                            onClick={validateJoin}
+                            loading={isJoinValidating}
+                            disabledReason={validationError}
+                        >
                             Validate join
                         </LemonButton>
                     </>

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -415,6 +415,7 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
         isJoinValidating,
         isJoinValid,
         validationError,
+        keyTypeMismatch,
     } = useValues(viewLinkLogic)
     const {
         selectJoiningTable,
@@ -675,7 +676,7 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                     className="mt-2"
                     type="error"
                     children={
-                        <div className="flex flex-row items-center">
+                        <div className="flex flex-row items-center justify-between">
                             <div>
                                 Validation error:
                                 <br />
@@ -695,6 +696,7 @@ export function ViewLinkFormWithPreview({ mode }: ViewLinkModalProps): JSX.Eleme
                     }
                 />
             )}
+            {keyTypeMismatch && <LemonBanner className="mt-2" type="warning" children={keyTypeMismatch} />}
             <LemonDivider className="mt-4 mb-4" />
             <div className="flex flex-row gap-2 justify-end w-full">
                 {isJoinValid ? (

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -67,8 +67,6 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
         loadJoiningTablePreview: (tableName: string) => ({ tableName }),
         setSourceTablePreviewData: (data: Record<string, any>[]) => ({ data }),
         setJoiningTablePreviewData: (data: Record<string, any>[]) => ({ data }),
-        setSourceTablePreviewLoading: (loading: boolean) => ({ loading }),
-        setJoiningTablePreviewLoading: (loading: boolean) => ({ loading }),
         setIsJoinValid: (isValid: boolean) => ({ isValid }),
         validateJoin: () => {},
     })),
@@ -199,15 +197,15 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
         sourceTablePreviewLoading: [
             false as boolean,
             {
-                setSourceTablePreviewLoading: (_, { loading }) => loading,
                 loadSourceTablePreview: () => true,
+                setSourceTablePreviewData: () => false,
             },
         ],
         joiningTablePreviewLoading: [
             false as boolean,
             {
-                setJoiningTablePreviewLoading: (_, { loading }) => loading,
                 loadJoiningTablePreview: () => true,
+                setJoiningTablePreviewData: () => false,
             },
         ],
     }),
@@ -303,18 +301,10 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
             }
         },
         loadSourceTablePreview: async ({ tableName }) => {
-            await loadTablePreviewData(
-                tableName,
-                actions.setSourceTablePreviewData,
-                actions.setSourceTablePreviewLoading
-            )
+            await loadTablePreviewData(tableName, actions.setSourceTablePreviewData)
         },
         loadJoiningTablePreview: async ({ tableName }) => {
-            await loadTablePreviewData(
-                tableName,
-                actions.setJoiningTablePreviewData,
-                actions.setJoiningTablePreviewLoading
-            )
+            await loadTablePreviewData(tableName, actions.setJoiningTablePreviewData)
         },
         validateJoin: async () => {
             if (
@@ -436,8 +426,7 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
 
 async function loadTablePreviewData(
     tableName: string,
-    setDataAction: (data: Record<string, any>[]) => void,
-    setLoadingAction: (loading: boolean) => void
+    setDataAction: (data: Record<string, any>[]) => void
 ): Promise<void> {
     try {
         const response = await hogqlQuery(hogql`SELECT * FROM ${hogql.identifier(tableName)} LIMIT 10`)
@@ -448,7 +437,5 @@ async function loadTablePreviewData(
     } catch (error) {
         posthog.captureException(error)
         setDataAction([])
-    } finally {
-        setLoadingAction(false)
     }
 }

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -127,6 +127,7 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
                 selectSourceKey: (_, { selectedKey }) => selectedKey,
                 toggleNewJoinModal: (_, { join }) => join?.source_table_key ?? null,
                 toggleEditJoinModal: (_, { join }) => join.source_table_key ?? null,
+                clearModalFields: () => null,
             },
         ],
         selectedJoiningKey: [
@@ -135,6 +136,7 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
                 selectJoiningKey: (_, { selectedKey }) => selectedKey,
                 toggleNewJoinModal: (_, { join }) => join?.joining_table_key ?? null,
                 toggleEditJoinModal: (_, { join }) => join.joining_table_key ?? null,
+                clearModalFields: () => null,
             },
         ],
         fieldName: [
@@ -291,14 +293,22 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
             }
         },
         selectSourceTable: async ({ selectedTableName }) => {
+            actions.setIsJoinValid(false)
             if (selectedTableName) {
                 actions.loadSourceTablePreview(selectedTableName)
             }
         },
         selectJoiningTable: async ({ selectedTableName }) => {
+            actions.setIsJoinValid(false)
             if (selectedTableName) {
                 actions.loadJoiningTablePreview(selectedTableName)
             }
+        },
+        selectSourceKey: () => {
+            actions.setIsJoinValid(false)
+        },
+        selectJoiningKey: () => {
+            actions.setIsJoinValid(false)
         },
         loadSourceTablePreview: async ({ tableName }) => {
             await loadTablePreviewData(tableName, actions.setSourceTablePreviewData)

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -68,6 +68,7 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
         setSourceTablePreviewData: (data: Record<string, any>[]) => ({ data }),
         setJoiningTablePreviewData: (data: Record<string, any>[]) => ({ data }),
         setIsJoinValid: (isValid: boolean) => ({ isValid }),
+        setValidationError: (errorMessage: string) => ({ errorMessage }),
         validateJoin: () => {},
     })),
     reducers({
@@ -180,6 +181,15 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
             {
                 setError: (_, { error }) => error,
                 clearModalFields: () => null,
+            },
+        ],
+        validationError: [
+            null as null | string,
+            {
+                setValidationError: (_, { errorMessage }) => errorMessage,
+                clearModalFields: () => null,
+                selectSourceKey: () => null,
+                selectJoiningKey: () => null,
             },
         ],
         sourceTablePreviewData: [
@@ -340,7 +350,8 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
                     LIMIT 10`
                 )
                 actions.setIsJoinValid(true)
-            } catch {
+            } catch (error) {
+                actions.setValidationError(error.detail)
                 actions.setIsJoinValid(false)
             }
         },

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -379,7 +379,7 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
                 const joiningKey = hogql.identifier(values.selectedJoiningKey)
                 const response = await hogqlQuery(
                     hogql`
-                    SELECT ${sourceTable}.${sourceKey}, ${sourceTable}.${sourceKey}
+                    SELECT ${sourceTable}.${sourceKey}, ${joiningTable}.${joiningKey}
                     FROM ${sourceTable}
                     JOIN ${joiningTable}
                     ON ${sourceTable}.${sourceKey} = ${joiningTable}.${joiningKey}


### PR DESCRIPTION
## Problem
Even though now we can preview the tables we're joining, there's still no way to make sure the join will work (or at least to have a better idea). This PR provides that by adding a way to validate the join before creating it.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/37911
## Changes
- Run a test query performing the intended join
- Surface any errors from this test query - a bit rough around the edges
- Warn the user that the types of the key columns mismatch (when they do)
- Warn the user when the validation query does not return any rows

Warnings should not block user from creating the join, while errors should. However, warnings disable `Validate join` button, so the user has to save without validation.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Initial state
<img width="1213" height="660" alt="image" src="https://github.com/user-attachments/assets/0c2149eb-b91b-4e32-8ed6-f45173924d35" />

### Key type mismatch
<img width="1333" height="695" alt="image" src="https://github.com/user-attachments/assets/a2a0a5b7-fca3-4bd0-bfb5-6c2ad1cc5d8d" />

### No rows in validation query
<img width="1346" height="701" alt="image" src="https://github.com/user-attachments/assets/43b968da-d402-4768-b7a6-16e2f35e10d5" />

### Error in validation query
<img width="1223" height="697" alt="image" src="https://github.com/user-attachments/assets/53a2153d-f5d3-47a6-b29f-1566ac2b966b" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
