### PR TITLE
chore(flox): tweak patch version of nodejs in Flox local env 

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -14,8 +14,8 @@ uv = { pkg-path = "uv", pkg-group = "uv", version = "0.7.8" }
 xmlsec = { pkg-path = "xmlsec", version = "1.3.6" }
 freetds = { pkg-path = "freetds" } # For pymssql
 # Node
-nodejs = { pkg-path = "nodejs_22", pkg-group = "nodejs", version = "22.17.1" } # Same as in Dockerfile
-corepack = { pkg-path = "corepack_22", pkg-group = "nodejs", version = "22.17.1" } # Same as in Dockerfile
+nodejs = { pkg-path = "nodejs_22", pkg-group = "nodejs", version = "22.17.0" } # Same maj.min ver as in Dockerfile; diverges from patch ver
+corepack = { pkg-path = "corepack_22", pkg-group = "nodejs", version = "22.17.0" } # Same maj.min as in Dockerfile; diverges from patch ver
 brotli = { pkg-path = "brotli", pkg-group = "nodejs" }
 openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl" }
 nodemon = { pkg-path = "nodemon" }


### PR DESCRIPTION
## Problem
Flox won't activate due to too specific a nodejs version in the manifest

## Changes
* [Get back in parity](https://github.com/PostHog/posthog/pull/38097/files#diff-3486ebd6b7c3165f69d0cd02be3307f07d937b34f25b943825ae3fe361de8125L17-L18) with what we did before in Flox vs. the base images while `nodejs` was on 22.17.x

## How did you test this code?
Locally and in CI - leave other envs same as now, but verified makes local Flox env work again as well ✅ 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
