### PR TITLE
fix: Stop creating Rev Analytics views for disabled DWH sources

### DIFF
--- a/products/revenue_analytics/backend/views/orchestrator.py
+++ b/products/revenue_analytics/backend/views/orchestrator.py
@@ -46,8 +46,9 @@ def _iter_source_handles(team: Team, timings: HogQLTimings) -> Iterable[SourceHa
         )
 
         for source in queryset:
-            with timings.measure(f"source.{source.pk}"):
-                yield SourceHandle(type=source.source_type.lower(), team=team, source=source)
+            if source.revenue_analytics_config_safe.enabled:
+                with timings.measure(f"source.{source.pk}"):
+                    yield SourceHandle(type=source.source_type.lower(), team=team, source=source)
 
 
 def _query_to_view(

--- a/products/revenue_analytics/backend/views/test/test_orchestrator.py
+++ b/products/revenue_analytics/backend/views/test/test_orchestrator.py
@@ -88,6 +88,15 @@ class TestRevenueAnalyticsViews(BaseTest):
         self.assertEqual(len(charge_views), 1)
         self.assertEqual(charge_views[0].name, "stripe.charge_revenue_view")
 
+    def test_revenue_view_with_disabled_source(self):
+        """Test that the orchestrator returns None for disabled sources"""
+        self.source.revenue_analytics_config.enabled = False
+        self.source.revenue_analytics_config.save()
+
+        views = build_all_revenue_analytics_views(self.team, self.timings)
+        source_views = [v for v in views if v.source_id == str(self.source.id)]
+        self.assertEqual(len(source_views), 0)
+
     def test_revenue_view_non_stripe_source(self):
         """Test that the orchestrator returns None for non-Stripe sources"""
         self.source.source_type = "Salesforce"


### PR DESCRIPTION
In the middle of all of our refactors we ended up removing the check and were creating views for disabled DWH sources. Oops!