### PR TITLE
chore: Update package version in elixir sdk installation docs

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/elixir.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/elixir.tsx
@@ -7,7 +7,7 @@ import { teamLogic } from 'scenes/teamLogic'
 function ElixirInstallSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.Elixir}>
-            {'def deps do\n    [\n        {:posthog, "~> 0.1"}\n    ]\nend'}
+            {'def deps do\n    [\n        {:posthog, "~> 1.1.0"}\n    ]\nend'}
         </CodeSnippet>
     )
 }


### PR DESCRIPTION
## Problem

When you create a new project, the docs presented to install the elixir SDK are out of date.

## Changes

Change v0.1 to v1.1.0

## How did you test this code?

Not tested.