### PR TITLE
fix: Pin librdkafka version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,8 +219,47 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/truste
     ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
     rm -rf /var/lib/apt/lists/*
 
-# Install exact Node.js 22.17.1 to match build stage
-RUN curl -fsSL https://nodejs.org/dist/v22.17.1/node-v22.17.1-linux-x64.tar.gz | tar -xz -C /usr/local --strip-components=1
+# Install Node.js 22.17.1 with architecture detection and verification
+ENV NODE_VERSION 22.17.1
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && set -ex \
+  && for key in \
+    5BE8A3F6C8A5C01D106C0AD820B1A390B168D356 \
+    C0D6248439F1D5604AAFFB4021D900FFDB233756 \
+    DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
+    CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
+    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+    108F52B48DB57BB0CC439B2997B01419BD92F80A \
+    A363A499291CBBC940DD62E41F10027AF002F8B0 \
+  ; do \
+      { gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" && gpg --batch --fingerprint "$key"; } || \
+      { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key"; } ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && gpgconf --kill all \
+  && rm -rf "$GNUPGHOME" \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && node --version \
+  && npm --version \
+  && rm -rf /tmp/*
 
 # Install and use a non-root user.
 RUN groupadd -g 1000 posthog && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,10 @@ RUN apt-get update && \
     "g++" \
     "gcc" \
     "python3" \
-    "libssl-dev=3.0.15-1~deb12u1" \
-    "libssl3=3.0.15-1~deb12u1" \
+    "librdkafka1=2.10.1-1.cflt~deb12" \
+    "libssl-dev=3.0.17-1~deb12u2" \
+    "libssl3=3.0.17-1~deb12u2" \
     "zlib1g-dev" \
-    "librdkafka-dev=2.10.1-1.cflt~deb12" \
     && \
     rm -rf /var/lib/apt/lists/*
 
@@ -207,8 +207,8 @@ RUN apt-get update && \
     "gettext-base" \
     "ffmpeg=7:5.1.7-0+deb12u1" \
     "librdkafka1=2.10.1-1.cflt~deb12" \
-    "libssl-dev=3.0.15-1~deb12u1" \
-    "libssl3=3.0.15-1~deb12u1" \
+    "libssl-dev=3.0.17-1~deb12u2" \
+    "libssl3=3.0.17-1~deb12u2" \
     && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,28 +51,25 @@ RUN cp frontend/node_modules/@posthog/rrweb/dist/image-bitmap-data-url-worker-*.
 FROM ghcr.io/posthog/rust-node-container:bookworm_rust_1.88-node_22.17.1 AS plugin-server-build
 
 # Compile and install system dependencies
-# Add Confluent's APT repository for librdkafka 2.10.1
+# Add Confluent's client repository for librdkafka 2.10.1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    "curl" \
+    "wget" \
     "gnupg" \
-    "lsb-release" \
     && \
-    curl -fsSL https://packages.confluent.io/deb/7.6/archive.key | gpg --dearmor -o /usr/share/keyrings/confluent-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/7.6 stable main" > /etc/apt/sources.list.d/confluent.list && \
+    mkdir -p /etc/apt/keyrings && \
+    wget -qO - https://packages.confluent.io/clients/deb/archive.key | gpg --dearmor -o /etc/apt/keyrings/confluent-clients.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/confluent-clients.gpg] https://packages.confluent.io/clients/deb/ bookworm main" > /etc/apt/sources.list.d/confluent-clients.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     "make" \
     "g++" \
     "gcc" \
     "python3" \
-    "libssl-dev=3.0.17-1~deb12u2" \
+    "libssl-dev=3.0.15-1~deb12u1" \
+    "libssl3=3.0.15-1~deb12u1" \
     "zlib1g-dev" \
-    "librdkafka-dev=2.10.1-1~deb12" \
-    "libsasl2-dev=2.1.28+dfsg-10" \
-    "libzstd-dev=1.5.4+dfsg2-5" \
-    "liblz4-dev=1.9.4-1" \
-    "libcurl4-openssl-dev=7.88.1-10+deb12u14" \
+    "librdkafka-dev=2.10.1-1.cflt~deb12" \
     && \
     rm -rf /var/lib/apt/lists/*
 
@@ -190,15 +187,15 @@ ENV PYTHONUNBUFFERED 1
 
 # Install OS runtime dependencies.
 # Note: please add in this stage runtime dependences only!
-# Add Confluent's APT repository for librdkafka runtime
+# Add Confluent's client repository for librdkafka runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    "curl" \
+    "wget" \
     "gnupg" \
-    "lsb-release" \
     && \
-    curl -fsSL https://packages.confluent.io/deb/7.6/archive.key | gpg --dearmor -o /usr/share/keyrings/confluent-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/7.6 stable main" > /etc/apt/sources.list.d/confluent.list && \
+    mkdir -p /etc/apt/keyrings && \
+    wget -qO - https://packages.confluent.io/clients/deb/archive.key | gpg --dearmor -o /etc/apt/keyrings/confluent-clients.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/confluent-clients.gpg] https://packages.confluent.io/clients/deb/ bookworm main" > /etc/apt/sources.list.d/confluent-clients.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     "chromium" \
@@ -209,12 +206,9 @@ RUN apt-get update && \
     "libxml2" \
     "gettext-base" \
     "ffmpeg=7:5.1.7-0+deb12u1" \
-    "librdkafka1=2.10.1-1~deb12" \
-    "libssl3=3.0.17-1~deb12u2" \
-    "libsasl2-2=2.1.28+dfsg-10" \
-    "libzstd1=1.5.4+dfsg2-5" \
-    "liblz4-1=1.9.4-1" \
-    "libcurl4=7.88.1-10+deb12u14" \
+    "librdkafka1=2.10.1-1.cflt~deb12" \
+    "libssl-dev=3.0.15-1~deb12u1" \
+    "libssl3=3.0.15-1~deb12u1" \
     && \
     rm -rf /var/lib/apt/lists/*
 

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -547,7 +547,6 @@ export class KafkaConsumer {
                 logger.error('📊', 'Failed to parse consumer statistics', {
                     error: error instanceof Error ? error.message : String(error),
                     errorStack: error instanceof Error ? error.stack : undefined,
-                    stats,
                 })
             }
         })

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -506,7 +506,8 @@ export class KafkaConsumer {
 
                 // Update internal health monitoring state
                 this.lastStatsEmitTime = Date.now()
-                this.consumerState = parsedStats.state
+                // cgrp field only appears when consumer is part of a group
+                this.consumerState = parsedStats.cgrp?.state || 'no-group'
 
                 const brokerStats = parseBrokerStatistics(parsedStats)
 
@@ -517,12 +518,10 @@ export class KafkaConsumer {
                     trackPartitionMetrics(topicName, partitionId, partitionData, this.config.groupId, this.consumerId)
                 }
 
-                // Log key metrics for observability
-                logger.debug('📊', 'Kafka consumer statistics', {
-                    state: parsedStats.state,
-                    rebalance_state: parsedStats.rebalance_state,
+                // Log key metrics for observability - only include cgrp fields if present
+                const logData: any = {
                     rx_msgs: parsedStats.rxmsgs, // Total messages received
-                    rx_bytes: parsedStats.rxbytes, // Total bytes received
+                    rx_bytes: parsedStats.rx_bytes || parsedStats.rxbytes, // Total bytes received
                     topics: Object.keys(parsedStats.topics || {}),
                     broker_count: brokerStats.size,
                     brokers: Array.from(brokerStats.entries()).map(([name, stats]) => ({
@@ -532,9 +531,24 @@ export class KafkaConsumer {
                         connects: stats.connects,
                         disconnects: stats.disconnects,
                     })),
-                })
+                }
+
+                // Only add consumer group fields if cgrp exists
+                if (parsedStats.cgrp) {
+                    logData.consumer_group_state = parsedStats.cgrp.state
+                    logData.rebalance_state = parsedStats.cgrp.join_state
+                    logData.rebalance_age = parsedStats.cgrp.rebalance_age
+                    logData.rebalance_cnt = parsedStats.cgrp.rebalance_cnt
+                    logData.assignment_size = parsedStats.cgrp.assignment_size
+                }
+
+                logger.debug('📊', 'Kafka consumer statistics', logData)
             } catch (error) {
-                logger.error('📊', 'Failed to parse consumer statistics', { error, stats })
+                logger.error('📊', 'Failed to parse consumer statistics', {
+                    error: error instanceof Error ? error.message : String(error),
+                    errorStack: error instanceof Error ? error.stack : undefined,
+                    stats,
+                })
             }
         })
 

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -534,7 +534,7 @@ export class KafkaConsumer {
                     })),
                 })
             } catch (error) {
-                logger.error('📊', 'Failed to parse consumer statistics', { error })
+                logger.error('📊', 'Failed to parse consumer statistics', { error, stats })
             }
         })
 

--- a/plugin-server/src/kafka/kafka-client-metrics.ts
+++ b/plugin-server/src/kafka/kafka-client-metrics.ts
@@ -303,22 +303,19 @@ export function trackPartitionMetrics(
     consumerGroup: string,
     consumerId: string
 ): void {
-    const labels = {
-        topic: topicName,
-        partition: partitionId,
-        leader_broker: String(partitionData.leader || 'unknown'),
-        consumer_group: consumerGroup,
-    }
-
     if (partitionData.fetch_state === 'stopped' || partitionData.fetch_state === 'stopping') {
         kafkaPartitionFetchErrors.inc({
-            ...labels,
             broker_id: String(partitionData.leader),
+            topic: topicName,
+            partition: partitionId,
             fetch_state: String(partitionData.fetch_state || 'unknown'),
+            consumer_group: consumerGroup,
         })
 
         logger.warn('Partition fetching stopped or stopping...', {
-            ...labels,
+            topic: topicName,
+            partition: partitionId,
+            consumer_group: consumerGroup,
             consumer_id: consumerId,
             fetch_state: partitionData.fetch_state,
             consumer_lag: partitionData.consumer_lag,


### PR DESCRIPTION
## Problem

We are currently having issues with the SSL handshake across all node services. It seems that there is a drift between the system libssl versions and the dependencies installed with node rdkafka. 

## Changes

- Install manually librdkafka and libssl, with pinned versions
- Make node-rdkafka use the system installed C libraries

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
