### PR TITLE
fix: move skip inactivity

### DIFF
--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
@@ -1,17 +1,27 @@
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { IconDownload, IconEllipsis, IconMinusSmall, IconNotebook, IconPlusSmall, IconTrash } from '@posthog/icons'
+import {
+    IconCheck,
+    IconDownload,
+    IconEllipsis,
+    IconMinusSmall,
+    IconNotebook,
+    IconPlusSmall,
+    IconTrash,
+} from '@posthog/icons'
 import { LemonButton, LemonButtonProps, LemonDialog, LemonMenu, LemonMenuItems, LemonTag } from '@posthog/lemon-ui'
 
 import { AccessControlAction, getAccessControlDisabledReason } from 'lib/components/AccessControlAction'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { IconBlank } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { useNotebookNode } from 'scenes/notebooks/Nodes/NotebookNodeContext'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { NotebookNodeType } from 'scenes/notebooks/types'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
+import { playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
 import { PlaylistPopoverButton } from 'scenes/session-recordings/player/playlist-popover/PlaylistPopover'
 import {
     SessionRecordingPlayerMode,
@@ -157,6 +167,8 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
     const { deleteRecording, setIsFullScreen, exportRecordingToFile, exportRecordingToVideoFile } =
         useActions(sessionRecordingPlayerLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { skipInactivitySetting } = useValues(playerSettingsLogic)
+    const { setSkipInactivitySetting } = useActions(playerSettingsLogic)
 
     const isStandardMode =
         (logicProps.mode ?? SessionRecordingPlayerMode.Standard) === SessionRecordingPlayerMode.Standard
@@ -184,6 +196,16 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
         const itemsArray: LemonMenuItems = [
             {
                 label: () => <AddToNotebookButton fullWidth={true} />,
+            },
+            {
+                label: 'Skip inactivity',
+                'data-attr': 'skip-inactivity-menu-item',
+                title: 'Skip inactive parts of the recording',
+                onClick: () => {
+                    return setSkipInactivitySetting(!skipInactivitySetting)
+                },
+                status: skipInactivitySetting ? 'danger' : 'default',
+                icon: skipInactivitySetting ? <IconCheck /> : <IconBlank />,
             },
             isStandardMode && {
                 label: 'PostHog .json',
@@ -231,7 +253,7 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
         }
         return itemsArray
         // oxlint-disable-next-line exhaustive-deps
-    }, [logicProps.playerKey, onDelete, exportRecordingToFile, size])
+    }, [logicProps.playerKey, onDelete, exportRecordingToFile, size, skipInactivitySetting])
 
     return (
         <LemonMenu items={items} buttonSize="xsmall">

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaTopSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaTopSettings.tsx
@@ -1,24 +1,17 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconEllipsis, IconHourglass, IconRabbit, IconSearch, IconTortoise } from '@posthog/icons'
+import { IconRabbit, IconSearch, IconTortoise } from '@posthog/icons'
 import { LemonButton, LemonDialog, Link } from '@posthog/lemon-ui'
 
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { IconHeatmap } from 'lib/lemon-ui/icons'
 import { humanFriendlyDuration } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
-import {
-    SettingsBar,
-    SettingsButton,
-    SettingsMenu,
-    SettingsToggle,
-} from 'scenes/session-recordings/components/PanelSettings'
+import { SettingsBar, SettingsButton, SettingsMenu } from 'scenes/session-recordings/components/PanelSettings'
 import { PlayerInspectorButton } from 'scenes/session-recordings/player/player-meta/PlayerInspectorButton'
 import { PlayerMetaBreakpoints } from 'scenes/session-recordings/player/player-meta/PlayerMeta'
-import { playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
 import {
     PLAYBACK_SPEEDS,
     sessionRecordingPlayerLogic,
@@ -53,22 +46,6 @@ function SetPlaybackSpeed(): JSX.Element {
                 status: speed === speedToggle ? 'danger' : 'default',
             }))}
             label={`Speed ${speed}x`}
-        />
-    )
-}
-
-function SkipInactivity(): JSX.Element {
-    const { skipInactivitySetting } = useValues(playerSettingsLogic)
-    const { setSkipInactivitySetting } = useActions(playerSettingsLogic)
-
-    return (
-        <SettingsToggle
-            title="Skip inactive parts of the recording"
-            label="Skip inactivity"
-            active={skipInactivitySetting}
-            data-attr="skip-inactivity"
-            onClick={() => setSkipInactivitySetting(!skipInactivitySetting)}
-            icon={<IconHourglass />}
         />
     )
 }
@@ -143,36 +120,13 @@ export function PlayerMetaTopSettings({ size }: { size: PlayerMetaBreakpoints })
         logicProps: { noInspector },
     } = useValues(sessionRecordingPlayerLogic)
     const { setPause, openHeatmap } = useActions(sessionRecordingPlayerLogic)
-    const { skipInactivitySetting } = useValues(playerSettingsLogic)
-    const { setSkipInactivitySetting } = useActions(playerSettingsLogic)
     const isSmall = size === 'small'
-
-    const menuItems: LemonMenuItem[] = [
-        isSmall
-            ? {
-                  label: 'Skip inactivity',
-                  active: skipInactivitySetting,
-                  'data-attr': 'skip-inactivity-in-menu',
-                  onClick: () => setSkipInactivitySetting(!skipInactivitySetting),
-                  icon: <IconHourglass />,
-              }
-            : undefined,
-    ].filter(Boolean) as LemonMenuItem[]
 
     return (
         <SettingsBar border="top">
             <div className="flex w-full justify-between items-center gap-0.5">
                 <div className="flex flex-row gap-0.5 h-full items-center">
                     <SetPlaybackSpeed />
-                    {!isSmall && <SkipInactivity />}
-                    {isSmall && (
-                        <SettingsMenu
-                            icon={<IconEllipsis />}
-                            items={menuItems}
-                            highlightWhenActive={false}
-                            closeOnClickInside={false}
-                        />
-                    )}
                 </div>
                 {!isSmall && (
                     <div>


### PR DESCRIPTION
looking at usage of skip inactitivity

it's pretty high ~15% from recording viewed to clicking it
but every click of skip inactivity is followed by another within less than a minute

so my guess is that people are turning it off (it defaults to on), and then just turning it back on again

i.e. that 15% is mostly people wondering what it does 

so let's move it out of people's sight-line

![2025-09-16 10 12 43](https://github.com/user-attachments/assets/655e1d0c-cbf7-4dab-9a7f-06dc1d3c0611)
