### PR TITLE
fix(msg): invocation skipped message

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -355,7 +355,6 @@ export class CdpApi {
                     }
                 }
 
-                // const wasSkipped = filterMetrics.some((m) => m.metric_name === 'filtered')
                 const wasSkipped = invocations.length === 0
 
                 res.json({

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -355,7 +355,8 @@ export class CdpApi {
                     }
                 }
 
-                const wasSkipped = filterMetrics.some((m) => m.metric_name === 'filtered')
+                // const wasSkipped = filterMetrics.some((m) => m.metric_name === 'filtered')
+                const wasSkipped = invocations.length === 0
 
                 res.json({
                     result: result,


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C06GG249PR6/p1758007930641979

We set the status to `skipped` if any of the invocations have been skipped, but this doesn't work with `mapping_templates`, since we expect only one of them to run.

## Changes

Only return the `skipped` status if there haven't been any invocations

## How did you test this code?

added test
