### PR TITLE
fix: exports types filtering

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
@@ -50,9 +50,9 @@ const ExportsContent = (): JSX.Element => {
                                 label: 'All',
                                 value: null,
                             },
-                            ...Object.entries(ExporterFormat).map(([key, value]) => ({
+                            ...Object.keys(ExporterFormat).map((key) => ({
                                 label: key,
-                                value: value,
+                                value: key,
                             })),
                         ]}
                         value={assetFormat}

--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -33,7 +33,7 @@ export const exportsLogic = kea<exportsLogicType>([
         addFresh: (exportedAsset: ExportedAssetType) => ({ exportedAsset }),
         removeFresh: (exportedAsset: ExportedAssetType) => ({ exportedAsset }),
         createStaticCohort: (name: string, query: AnyDataNode) => ({ query, name }),
-        setAssetFormat: (format: ExporterFormat | null) => ({ format }),
+        setAssetFormat: (format: string | null) => ({ format }),
         startReplayExport: (
             sessionRecordingId: string,
             format?: ExporterFormat,
@@ -62,7 +62,7 @@ export const exportsLogic = kea<exportsLogicType>([
             },
         ],
         assetFormat: [
-            null as ExporterFormat | null,
+            null as string | null,
             {
                 setAssetFormat: (_, { format }) => format,
             },

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -258,8 +258,9 @@ class ExportedAssetViewSet(
 
             # Add export format filter
             export_format_filter = self.request.query_params.get("export_format")
-            if export_format_filter and export_format_filter in ExportedAsset.SUPPORTED_FORMATS:
-                queryset = queryset.filter(export_format=export_format_filter)
+            if export_format_filter and export_format_filter in ExportedAsset.get_supported_format_keys():
+                format_enum = getattr(ExportedAsset.ExportFormat, export_format_filter)
+                queryset = queryset.filter(export_format=format_enum)
 
         return queryset
 

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -597,9 +597,9 @@ class TestExports(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("image/png", 2, "png_export"),  # PNG format with 2 expected results
-            ("text/csv", 1, "csv_export"),  # CSV format with 1 expected result
-            ("image/jpeg", 3, None),  # Unsupported format returns all (3)
+            ("PNG", 2, "png_export"),  # PNG enum key with 2 expected results
+            ("CSV", 1, "csv_export"),  # CSV enum key with 1 expected result
+            ("JPEG", 3, None),  # Unsupported format returns all (3)
             (None, 3, None),  # No filter returns all (3)
         ]
     )

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -133,6 +133,11 @@ class ExportedAsset(models.Model):
         logger.info("deleting_expired_assets", count=expired_assets.count())
         expired_assets.delete()
 
+    @classmethod
+    def get_supported_format_keys(cls):
+        """Get list of supported format keys (e.g., ['PNG', 'CSV', 'WEBM'])"""
+        return [format_choice.name for format_choice in cls.SUPPORTED_FORMATS]
+
 
 def get_public_access_token(asset: ExportedAsset, expiry_delta: Optional[timedelta] = None) -> str:
     if not expiry_delta:


### PR DESCRIPTION
Export format filtering was broken due to URL encoding issues with MIME types containing forward slashes (e.g., video/webm, image/png). When these formats were passed as query parameters, the / characters got URL encoded, causing the backend filtering to fail sometimes (!!?!?).


![ezgif-3fcadd8ebc49cf](https://github.com/user-attachments/assets/0af394f6-03df-483e-87de-0cb308a9f4d1)
