### PR TITLE
chore: cleaning html-to-image

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,6 @@
         "fuse.js": "^6.6.2",
         "heatmap.js": "^2.0.5",
         "hls.js": "^1.5.15",
-        "html-to-image": "^1.11.13",
         "husky": "^7.0.4",
         "idb": "^8.0.3",
         "image-blob-reduce": "^4.1.0",

--- a/frontend/src/lib/components/TakeScreenshot/ScreenShotEditor.tsx
+++ b/frontend/src/lib/components/TakeScreenshot/ScreenShotEditor.tsx
@@ -30,7 +30,6 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
         dragStartOffset,
         textInputPosition,
         isLoading,
-        html,
         lineWidth,
         fontSize,
     } = useValues(takeScreenshotLogic({ screenshotKey: screenshotKey }))
@@ -44,7 +43,6 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
         setSelectedTextIndex,
         setDragStartOffset,
         setTextInputPosition,
-        setHtml,
         setImageFile,
         setLineWidth,
         setFontSize,
@@ -68,7 +66,6 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
         setSelectedTextIndex(null)
         setDragStartOffset(null)
         setMode('draw')
-        setHtml(null)
         setImageFile(null)
     }, [
         setIsOpen,
@@ -78,7 +75,6 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
         setSelectedTextIndex,
         setDragStartOffset,
         setMode,
-        setHtml,
         setImageFile,
     ])
 
@@ -182,9 +178,8 @@ export function ScreenShotEditor({ screenshotKey }: { screenshotKey: string }): 
             setTexts([])
             setHistoryStack([])
             setSelectedTextIndex(null)
-            setHtml(null)
         }
-    }, [isOpen, imageFile, originalImage, handleClose, html, setOriginalImage, setSelectedTextIndex, setHtml])
+    }, [isOpen, imageFile, originalImage, handleClose, setOriginalImage, setSelectedTextIndex])
 
     useEffect(() => {
         if (isOpen && originalImage) {

--- a/frontend/src/lib/components/TakeScreenshot/takeScreenshotLogic.ts
+++ b/frontend/src/lib/components/TakeScreenshot/takeScreenshotLogic.ts
@@ -1,4 +1,3 @@
-import { toBlob } from 'html-to-image'
 import { actions, kea, key, listeners, path, props, reducers } from 'kea'
 import posthog from 'posthog-js'
 
@@ -43,7 +42,6 @@ export const takeScreenshotLogic = kea<takeScreenshotLogicType>([
     actions({
         setIsOpen: (isOpen: boolean) => ({ isOpen }),
         setImageFile: (imageFile: File | null) => ({ imageFile }),
-        setHtml: (html: HTMLElement | null) => ({ html }),
         setMode: (mode: 'draw' | 'text' | 'moveText') => ({ mode }),
         setDrawings: (drawings: DrawingItem[]) => ({ drawings }),
         setTexts: (texts: TextItem[]) => ({ texts }),
@@ -74,12 +72,6 @@ export const takeScreenshotLogic = kea<takeScreenshotLogicType>([
             false,
             {
                 setIsLoading: (_, { isLoading }) => isLoading,
-            },
-        ],
-        html: [
-            null as HTMLElement | null,
-            {
-                setHtml: (_, { html }) => html,
             },
         ],
         imageFile: [
@@ -174,23 +166,6 @@ export const takeScreenshotLogic = kea<takeScreenshotLogicType>([
         ],
     }),
     listeners(({ actions, props }) => ({
-        setHtml: async ({ html }) => {
-            if (html === null) {
-                return
-            }
-            actions.setIsLoading(true)
-            actions.setIsOpen(true)
-            const blob = await toBlob(html)
-            if (blob) {
-                actions.setBlob(blob)
-            } else {
-                lemonToast.error('Failed to generate image blob.')
-                actions.setIsLoading(false)
-                posthog.capture('screenshot_failed', {
-                    screenshot_key: props.screenshotKey,
-                })
-            }
-        },
         setBlob: async ({ blob }) => {
             if (!blob) {
                 lemonToast.error('Cannot take screenshot. Please try again.')

--- a/frontend/src/scenes/heatmaps/IframeHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/IframeHeatmapBrowser.tsx
@@ -8,6 +8,7 @@ import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FilterPanel } from 'scenes/heatmaps/FilterPanel'
@@ -78,7 +79,7 @@ export function IframeHeatmapBrowser({
                 heatmap_fixed_position_mode: heatmapFixedPositionMode,
                 common_filters: commonFilters,
                 heatmap_filters: heatmapFilters,
-                filename: `heatmap-${browserUrl}-${Date.now().toString()}`,
+                filename: `heatmap-${browserUrl.slice(0, 10)}-${dayjs().format('YYYY-MM-DD')}`,
             })
         }
     }

--- a/frontend/src/scenes/heatmaps/IframeHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/IframeHeatmapBrowser.tsx
@@ -79,7 +79,7 @@ export function IframeHeatmapBrowser({
                 heatmap_fixed_position_mode: heatmapFixedPositionMode,
                 common_filters: commonFilters,
                 heatmap_filters: heatmapFilters,
-                filename: `heatmap-${browserUrl.slice(0, 10)}-${dayjs().format('YYYY-MM-DD')}`,
+                filename: `heatmap-${new URL(browserUrl).hostname}/${new URL(browserUrl).pathname.slice(1, 11)}-${dayjs().format('YYYY-MM-DD-HH-mm')}`,
             })
         }
     }

--- a/frontend/src/scenes/session-recordings/player/controller/ClipRecording.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/ClipRecording.tsx
@@ -48,7 +48,8 @@ function calculateClipTimes(currentTimeMs: number | null, sessionDurationMs: num
 }
 
 export function ClipOverlay(): JSX.Element | null {
-    const { currentPlayerTime, sessionPlayerData, showingClipParams } = useValues(sessionRecordingPlayerLogic)
+    const { currentPlayerTime, sessionPlayerData, showingClipParams, sessionRecordingId } =
+        useValues(sessionRecordingPlayerLogic)
     const { getClip, setShowingClipParams } = useActions(sessionRecordingPlayerLogic)
     const [duration, setDuration] = useState(5)
     const [format, setFormat] = useState(ExporterFormat.MP4)
@@ -58,6 +59,8 @@ export function ClipOverlay(): JSX.Element | null {
         sessionPlayerData.durationMs,
         duration
     )
+
+    const filename = `replay-${sessionRecordingId}-${startClip}-${endClip}`
 
     if (!showingClipParams) {
         return null
@@ -112,7 +115,7 @@ export function ClipOverlay(): JSX.Element | null {
 
             <LemonButton
                 onClick={() => {
-                    getClip(format, duration)
+                    getClip(format, duration, filename)
                     setShowingClipParams(false)
                 }}
                 type="primary"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,9 +723,6 @@ importers:
       hls.js:
         specifier: ^1.5.15
         version: 1.5.15
-      html-to-image:
-        specifier: ^1.11.13
-        version: 1.11.13
       husky:
         specifier: ^7.0.4
         version: 7.0.4
@@ -11995,9 +11992,6 @@ packages:
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
-
-  html-to-image@1.11.13:
-    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-to-react@1.5.0:
     resolution: {integrity: sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==}
@@ -31223,8 +31217,6 @@ snapshots:
       terser: 5.19.1
 
   html-tags@3.3.1: {}
-
-  html-to-image@1.11.13: {}
 
   html-to-react@1.5.0:
     dependencies:


### PR DESCRIPTION
As I moved all the exports to celery we don't need html-to-image anymore. 

Let's remove it.

Also quick fix on a long name in export of heatmaps:
<img width="1512" height="982" alt="Screenshot 2025-09-16 at 12 28 40" src="https://github.com/user-attachments/assets/d93cd247-e13f-46f6-8f88-1c7d7bbaee81" />

