### PR TITLE
fix(msg): pipedrive updateActivity fix

### DIFF
--- a/plugin-server/src/cdp/services/segment-destination-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.test.ts
@@ -4,6 +4,7 @@ import { DateTime, Settings } from 'luxon'
 
 import { defaultConfig } from '~/config/config'
 import { forSnapshot } from '~/tests/helpers/snapshots'
+import { parseJSON } from '~/utils/json-parse'
 
 import { createHogFunction } from '../_tests/fixtures'
 import {
@@ -434,60 +435,70 @@ describe('SegmentDestinationExecutorService', () => {
             expect(result.finished).toBe(true)
         })
 
-        it('omits empty id field for pipedrive activities action', async () => {
+        it('handles activity_id field correctly for pipedrive activities action', async () => {
             jest.spyOn(pipedriveActivitiesAction as any, 'perform')
 
-            const pipedriveInputs = {
-                domain: 'posthog-sandbox',
-                apiToken: 'api-key',
-                person_match_value: 'e252ca85-9ea2-4d17-9d99-5fda5535995d',
-                activity_id: '',
-                personField: 'id',
-                organization_match_value: '',
-                organizationField: 'id',
-                deal_match_value: null,
-                dealField: 'id',
-                subject: null,
-                type: null,
-                description: null,
-                note: null,
-                due_date: null,
-                due_time: null,
-                duration: null,
-                done: null,
-                internal_partner_action: 'createUpdateActivity',
-                debug_mode: true,
+            const testCases = [
+                { activity_id: null, shouldHaveId: false },
+                { activity_id: '', shouldHaveId: false },
+                { activity_id: '15', shouldHaveId: true },
+            ]
+
+            for (const testCase of testCases) {
+                mockFetch.mockReset()
+
+                const pipedriveInputs = {
+                    domain: 'posthog-sandbox',
+                    apiToken: 'api-key',
+                    person_match_value: 'e252ca85-9ea2-4d17-9d99-5fda5535995d',
+                    activity_id: testCase.activity_id,
+                    personField: 'id',
+                    organization_match_value: '',
+                    organizationField: 'id',
+                    deal_match_value: null,
+                    dealField: 'id',
+                    subject: null,
+                    type: null,
+                    description: null,
+                    note: null,
+                    due_date: null,
+                    due_time: null,
+                    duration: null,
+                    done: null,
+                    internal_partner_action: 'createUpdateActivity',
+                    debug_mode: true,
+                }
+
+                const fn = createHogFunction({
+                    name: 'Plugin test',
+                    template_id: 'segment-actions-pipedrive',
+                })
+
+                const invocation = createExampleSegmentInvocation(fn, pipedriveInputs)
+
+                mockFetch.mockResolvedValue({
+                    status: 200,
+                    json: () => Promise.resolve({ total_count: 1 }),
+                    text: () => Promise.resolve(JSON.stringify(pipedriveResponse)),
+                    headers: {},
+                })
+
+                await service.execute(invocation)
+
+                expect(mockFetch).toHaveBeenCalledTimes(2)
+
+                const requestBody = parseJSON(mockFetch.mock.calls[1][1].body)
+                const endpoint = mockFetch.mock.calls[1][0]
+
+                if (testCase.shouldHaveId) {
+                    expect(endpoint).toBe(
+                        `https://posthog-sandbox.pipedrive.com/api/v1/activities/${testCase.activity_id}?api_token=api-key`
+                    )
+                } else {
+                    expect(requestBody).not.toHaveProperty('id')
+                    expect(endpoint).toBe('https://posthog-sandbox.pipedrive.com/api/v1/activities?api_token=api-key')
+                }
             }
-
-            const fn = createHogFunction({
-                name: 'Plugin test',
-                template_id: 'segment-actions-pipedrive',
-            })
-
-            const invocation = createExampleSegmentInvocation(fn, pipedriveInputs)
-
-            mockFetch.mockResolvedValue({
-                status: 200,
-                json: () => Promise.resolve({ total_count: 1 }),
-                text: () => Promise.resolve(JSON.stringify(pipedriveResponse)),
-                headers: {},
-            })
-
-            await service.execute(invocation)
-
-            expect(mockFetch).toHaveBeenCalledTimes(2)
-            expect(forSnapshot(mockFetch.mock.calls[1])).toMatchInlineSnapshot(`
-                [
-                  "https://posthog-sandbox.pipedrive.com/api/v1/activities?api_token=api-key",
-                  {
-                    "body": "{"subject":null,"type":null,"public_description":null,"note":null,"due_date":null,"due_time":null,"duration":null,"done":0}",
-                    "headers": {
-                      "Content-Type": "application/json",
-                    },
-                    "method": "POST",
-                  },
-                ]
-            `)
         })
     })
 })

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.ts
@@ -165,7 +165,23 @@ export class SegmentDestinationExecutorService {
 
                     let body: string | undefined = undefined
                     if (options?.json) {
-                        body = JSON.stringify(options.json)
+                        let jsonData = options.json
+
+                        // For the pipedrive activities endpoint, we need to omit the id field if it's null or an empty string
+                        // https://devcommunity.pipedrive.com/t/getting-bad-request-for-all-post-and-put-at-activities/345
+                        if (
+                            endpoint.endsWith('.pipedrive.com/api/v1/activities') &&
+                            jsonData &&
+                            typeof jsonData === 'object' &&
+                            'id' in jsonData
+                        ) {
+                            const { id, ...rest } = jsonData as any
+                            if (id === null || id === '') {
+                                jsonData = rest
+                            }
+                        }
+
+                        body = JSON.stringify(jsonData)
                         headers['Content-Type'] = 'application/json'
                     } else if (options?.body && options.body instanceof URLSearchParams) {
                         body = options.body.toString()


### PR DESCRIPTION
## Problem

According to [this post](https://devcommunity.pipedrive.com/t/getting-bad-request-for-all-post-and-put-at-activities/345), we should omit the ID field if the value is null or an empty string. 

https://posthog.slack.com/archives/C06GG249PR6/p1758007387574329

## Changes

- implement a fix

## How did you test this code?

added tests
