### PR TITLE
feat(hogql): Add postgres tables to hogql

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -47,6 +47,7 @@ from posthog.hogql.database.models import (
     UnknownDatabaseField,
     VirtualTable,
 )
+from posthog.hogql.database.postgres_table import PostgresTable
 from posthog.hogql.database.schema.app_metrics2 import AppMetrics2Table
 from posthog.hogql.database.schema.channel_type import create_initial_channel_type, create_initial_domain_type
 from posthog.hogql.database.schema.cohort_people import CohortPeople, RawCohortPeople
@@ -175,6 +176,22 @@ class Database(BaseModel):
 
     # system tables
     numbers: NumbersTable = NumbersTable()
+
+    # Postgres tables
+    dashboards: PostgresTable = PostgresTable(
+        name="dashboards",
+        postgres_table_name="posthog_dashboard",
+        fields={
+            "id": IntegerDatabaseField(name="id"),
+            "team_id": IntegerDatabaseField(name="team_id"),
+            "name": StringDatabaseField(name="name"),
+            "description": StringDatabaseField(name="description"),
+            "created_at": DateTimeDatabaseField(name="created_at"),
+            "deleted": BooleanDatabaseField(name="deleted"),
+            "filters": StringJSONDatabaseField(name="filters"),
+            "variables": StringJSONDatabaseField(name="variables"),
+        },
+    )
 
     # These are the tables exposed via SQL editor autocomplete and data management
     _table_names: ClassVar[list[str]] = [

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -273,6 +273,7 @@ class FunctionCallTable(Table):
     """
 
     name: str
+    requires_args: bool = True
     min_args: Optional[int] = None
     max_args: Optional[int] = None
 

--- a/posthog/hogql/database/postgres_table.py
+++ b/posthog/hogql/database/postgres_table.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+from django.conf import settings
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.models import FunctionCallTable
+from posthog.hogql.escape_sql import escape_hogql_identifier
+
+
+def build_function_call(postgres_table_name: str, context: Optional[HogQLContext] = None):
+    raw_params: dict[str, str] = {}
+
+    def add_param(value: str, is_sensitive: bool = True) -> str:
+        if context is not None:
+            if is_sensitive:
+                return context.add_sensitive_value(value)
+            return context.add_value(value)
+
+        param_name = f"value_{len(raw_params.items())}"
+        raw_params[param_name] = value
+        return f"%({param_name})s"
+
+    databases = settings.DATABASES
+    database = databases["default"]
+
+    if "replica" in settings.DATABASES:
+        database = databases["replica"]
+
+    address = add_param(f"{database['HOST']}:{database['PORT']}")
+    if settings.DEBUG:
+        address = add_param("db:5432")  # docker container for clickhouse
+
+    db = add_param(database["NAME"])
+    table = add_param(postgres_table_name)
+    user = add_param(database["USER"])
+    password = add_param(database["PASSWORD"])
+
+    return f"postgresql({address}, {db}, {table}, {user}, {password})"
+
+
+class PostgresTable(FunctionCallTable):
+    requires_args: bool = False
+    postgres_table_name: str
+
+    def to_printed_hogql(self):
+        return escape_hogql_identifier(self.name)
+
+    def to_printed_clickhouse(self, context):
+        return build_function_call(self.postgres_table_name, context)

--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -131,6 +131,7 @@ def build_function_call(
 
 
 class S3Table(FunctionCallTable):
+    requires_args: bool = False
     url: str
     format: str = "CSVWithNames"
     access_key: Optional[str] = None

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -1,0 +1,56 @@
+from typing import Literal
+
+from posthog.test.base import BaseTest
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.models import IntegerDatabaseField, StringDatabaseField
+from posthog.hogql.database.postgres_table import PostgresTable
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import print_ast
+from posthog.hogql.query import create_default_modifiers_for_team
+
+
+class TestPostgresTable(BaseTest):
+    def _init_database(self):
+        self.database = create_hogql_database(team=self.team)
+
+        setattr(  # noqa: B010
+            self.database,
+            "postgres_table",
+            PostgresTable(
+                name="postgres_table",
+                postgres_table_name="some_table_on_postgres",
+                fields={
+                    "id": IntegerDatabaseField(name="id"),
+                    "team_id": IntegerDatabaseField(name="team_id"),
+                    "name": StringDatabaseField(name="name"),
+                },
+            ),
+        )
+
+        self.context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=self.database,
+            modifiers=create_default_modifiers_for_team(self.team),
+        )
+
+    def _select(self, query: str, dialect: Literal["hogql", "clickhouse"] = "clickhouse") -> str:
+        return print_ast(parse_select(query), self.context, dialect=dialect)
+
+    def test_postgres_table_select(self):
+        self._init_database()
+
+        hogql = self._select(query="SELECT * FROM postgres_table LIMIT 10", dialect="hogql")
+        self.assertEqual(
+            hogql,
+            "SELECT id, team_id, name FROM postgres_table LIMIT 10",
+        )
+
+        clickhouse = self._select(query="SELECT * FROM postgres_table LIMIT 10", dialect="clickhouse")
+
+        self.assertEqual(
+            clickhouse,
+            f"SELECT postgres_table.id AS id, postgres_table.team_id AS team_id, postgres_table.name AS name FROM postgresql(%(hogql_val_0_sensitive)s, %(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE equals(postgres_table.team_id, {self.team.id}) LIMIT 10",
+        )

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -541,7 +541,7 @@ class _Printer(Visitor[str]):
             else:
                 sql = table_type.table.to_printed_hogql()
 
-            if isinstance(table_type.table, FunctionCallTable) and not isinstance(table_type.table, S3Table):
+            if isinstance(table_type.table, FunctionCallTable) and table_type.table.requires_args:
                 if node.table_args is None:
                     raise QueryError(f"Table function '{table_type.table.name}' requires arguments")
 


### PR DESCRIPTION
## Changes
- Proof of concept for exposing postgres tables in hogql from our DB
- Added a `PostgresTable` type
- Ensured queries get filtered down by `team_id`
- Only added one table to test in prod, not exposed via the table viewer in-app. I'm keen to put these behind some "schema" - like `system.dashboards` (but with a better name to show that it's like internal stuff for the logged in team as opposed to `events`/`persons`/etc) - name suggestions are welcome

**Example of generated clickhouse SQL:**
```
SELECT
    dashboards.id AS id,
    dashboards.team_id AS team_id,
    dashboards.name AS name,
    dashboards.description AS description,
    toTimeZone(dashboards.created_at, %(hogql_val_6)s) AS created_at,
    dashboards.deleted AS deleted,
    dashboards.filters AS filters,
    dashboards.variables AS variables
FROM
    postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s, %(hogql_val_5_sensitive)s) AS dashboards
WHERE
    equals(dashboards.team_id, 1)
LIMIT 101
OFFSET 0 SETTINGS readonly=2, max_execution_time=600, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1
```

## How did you test this code?
- Added a test
- Ran it locally
