### PR TITLE
fix: value type mismatch on dagster asset check metadata result

### DIFF
--- a/dags/tests/test_web_preaggregated_asset_checks.py
+++ b/dags/tests/test_web_preaggregated_asset_checks.py
@@ -1,0 +1,42 @@
+from dags.web_preaggregated_asset_checks import create_accuracy_check_result
+
+
+def test_create_accuracy_check_result_handles_integer_values_for_dagster():
+    """
+    Test that create_accuracy_check_result properly handles integer values that would
+    cause Dagster's MetadataValue.float() to fail with ParameterCheckError.
+
+    This test ensures our fix will continue to work - if the float() conversion is ever
+    removed, this test will fail when Dagster validates the parameters.
+    """
+    comparison_data = {
+        "team_id": 123,
+        "date_from": "2023-01-01",
+        "date_to": "2023-01-07",
+        "table_version": "v2",
+        "metrics": {
+            "unique_visitors": {
+                "pre_aggregated": 0,
+                "regular": 0,
+                "pct_difference": 0,
+                "within_tolerance": True,
+            }
+        },
+        "all_within_tolerance": True,
+        "tolerance_pct": 1.0,
+        "timing": {"pre_aggregated": 0.5, "regular": 1.2},
+    }
+
+    # This should NOT raise: ParameterCheckError: Param "value" is not a float. Got 0 which is type <class 'int'>
+    # If our fix is removed, this will fail with that exact error
+    result = create_accuracy_check_result(comparison_data, team_id=123, table_version="v2")
+
+    # Verify the function completed successfully
+    assert result is not None
+    assert result.passed is True
+    assert result.metadata is not None
+
+    # Verify the problematic metadata fields were created successfully
+    assert "unique_visitors_pre_aggregated" in result.metadata
+    assert "unique_visitors_regular" in result.metadata
+    assert "unique_visitors_percentage_difference" in result.metadata

--- a/dags/web_preaggregated_asset_checks.py
+++ b/dags/web_preaggregated_asset_checks.py
@@ -356,7 +356,7 @@ def execute_accuracy_check(
 
         # Convert results to dict for easier comparison
         def results_to_dict(results: list[WebOverviewItem]) -> dict[str, float]:
-            return {item.key: item.value for item in results if item.value is not None}
+            return {item.key: float(item.value) for item in results if item.value is not None}
 
         pre_agg_metrics = results_to_dict(pre_agg_response.results)
         regular_metrics = results_to_dict(regular_response.results)
@@ -449,9 +449,11 @@ def create_accuracy_check_result(comparison_data: dict[str, Any], team_id: int, 
     for metric_name, metric_values in metrics.items():
         metadata.update(
             {
-                f"{metric_name}_pre_aggregated": MetadataValue.float(metric_values.get("pre_aggregated", 0.0)),
-                f"{metric_name}_regular": MetadataValue.float(metric_values.get("regular", 0.0)),
-                f"{metric_name}_percentage_difference": MetadataValue.float(metric_values.get("pct_difference", 0.0)),
+                f"{metric_name}_pre_aggregated": MetadataValue.float(float(metric_values.get("pre_aggregated", 0.0))),
+                f"{metric_name}_regular": MetadataValue.float(float(metric_values.get("regular", 0.0))),
+                f"{metric_name}_percentage_difference": MetadataValue.float(
+                    float(metric_values.get("pct_difference", 0.0))
+                ),
                 f"{metric_name}_within_tolerance": MetadataValue.bool(metric_values.get("within_tolerance", True)),
             }
         )


### PR DESCRIPTION
## Problem

This came up as one of the noisy alerts for web analytics last week; it expects floats specifically, so it complains when it gets an `int`. It wasn't related to the logic or materialization at all.

```
dagster_shared.check.functions.ParameterCheckError: Param "value" is not a float. Got 0 which is type <class 'int'>.
```

## Changes

Parse to float where appropriate.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
