### PR TITLE
feat(logs): add logs optimisation to only scan within known bucket

### DIFF
--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -205,7 +205,7 @@ export const logsLogic = kea<logsLogicType>([
 
                     const response = await api.logs.query({
                         query: {
-                            limit: 999,
+                            limit: 99,
                             offset: values.logs.length,
                             orderBy: values.orderBy,
                             dateRange: values.dateRange,


### PR DESCRIPTION
## Problem

Clickhouse is dumb. Fetching a small sample of logs for some reason involves scanning millions of lines, even though clickhouse could trivially realise it only needs a small subset with a bit of smarts

So lets do the smarts ourselves - we use a magical subquery to get a min/max time bracket within which we know we can find enough logs to satisfy the given limit. This cuts long range logs queries down from >60s (timeout) to a few seconds.

Before / After this optimisation:

https://github.com/user-attachments/assets/41efdaf5-c691-4b5c-8e46-bbfa60155796


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
