### PR TITLE
fix: export type enum issue

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -258,7 +258,7 @@ class ExportedAssetViewSet(
 
             # Add export format filter
             export_format_filter = self.request.query_params.get("export_format")
-            if export_format_filter and export_format_filter in ExportedAsset.SUPPORTED_FORMATS:
+            if export_format_filter and export_format_filter in ExportedAsset.get_supported_format_values():
                 queryset = queryset.filter(export_format=export_format_filter)
 
         return queryset

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -133,6 +133,10 @@ class ExportedAsset(models.Model):
         logger.info("deleting_expired_assets", count=expired_assets.count())
         expired_assets.delete()
 
+    @classmethod
+    def get_supported_format_values(cls):
+        return [format_choice.value for format_choice in cls.SUPPORTED_FORMATS]
+
 
 def get_public_access_token(asset: ExportedAsset, expiry_delta: Optional[timedelta] = None) -> str:
     if not expiry_delta:


### PR DESCRIPTION
Export format filtering was broken because the validation logic was comparing URL-decoded MIME type strings (e.g., "video/webm") against Django enum objects (ExportFormat.WEBM) instead of their string values.

I overcomplicated it here https://github.com/PostHog/posthog/pull/38162

The issue was way simpler.