### PR TITLE
fix: unhides annotation overlay on max sidebar

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -645,7 +645,7 @@
     --z-top: 9999;
     --z-modal: 1100;
     --z-hedgehog-buddy: 1050;
-    --z-annotation-popover: 100;
+    --z-annotation-popover: 800;
     --z-drawer: 900;
     --z-notifications-popover: 800; // below the TZ aware popover but over the main-nav
     --z-scene-layout-content-panel: 770;


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
![image.png](https://app.gitbutler.com/uploads/9a2d209d-6a2c-4d49-a2f9-0fd1c32da3d1)
Annotation is all the way back in the back in the back

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="618" height="357" alt="image" src="https://github.com/user-attachments/assets/ea897b9b-feac-4114-a508-743c1ae7e76f" />


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
