### PR TITLE
feat(dual-writes): observability into prepared txs

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -133,6 +133,12 @@ export const twoPhaseCommitFailuresCounter = new Counter({
     labelNames: ['tag', 'phase'], // phase: fn_failed, prepare_left_failed, prepare_right_failed, commit_left_failed, commit_right_failed, rollback_left_failed, rollback_right_failed, run_failed
 })
 
+export const maxPreparedTransactionsExceededCounter = new Counter({
+    name: 'person_dualwrite_max_prepared_transactions_exceeded_total',
+    help: 'Number of times max_prepared_transactions limit was exceeded during two-phase commit',
+    labelNames: ['tag', 'side'], // side: left, right
+})
+
 export const dualWriteComparisonCounter = new Counter({
     name: 'person_dualwrite_comparison_total',
     help: 'Comparison results between primary and secondary databases in dual-write mode',


### PR DESCRIPTION
## Problem

We set the configuration `max_prepared_transactions` to support a two phase commits while we dual write. We'd like some observability into any breaches of this configured value.

## Changes

Emit logs and a metric anytime we experience a configuration limit exceeded error that corresponds to max_prepared_transactions

## How did you test this code?

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
