### PR TITLE
feat: make play and skip bigger

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -43,11 +43,11 @@ function PlayPauseButton(): JSX.Element {
             }
         >
             {showPause ? (
-                <IconPause className="text-2xl" />
+                <IconPause className="text-3xl" />
             ) : endReached ? (
-                <IconRewindPlay className="text-2xl" />
+                <IconRewindPlay className="text-3xl" />
             ) : (
-                <IconPlay className="text-2xl" />
+                <IconPlay className="text-3xl" />
             )}
         </LemonButton>
     )

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonButtonProps, Tooltip } from '@posthog/lemon-ui'
@@ -6,6 +5,7 @@ import { LemonButton, LemonButtonProps, Tooltip } from '@posthog/lemon-ui'
 import { useKeyHeld } from 'lib/hooks/useKeyHeld'
 import { IconSkipBackward } from 'lib/lemon-ui/icons'
 import { capitalizeFirstLetter, colonDelimitedDuration } from 'lib/utils'
+import { cn } from 'lib/utils/css-classes'
 import { SimpleTimeLabel } from 'scenes/session-recordings/components/SimpleTimeLabel'
 import { ONE_FRAME_MS, sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
@@ -119,7 +119,7 @@ export function SeekSkip({ direction }: { direction: 'forward' | 'backward' }): 
                 <div className="PlayerControlSeekIcon">
                     <span className="PlayerControlSeekIcon__seconds">{jumpTimeSeconds}</span>
                     <IconSkipBackward
-                        className={clsx('PlayerControlSeekIcon__icon', {
+                        className={cn('text-2xl PlayerControlSeekIcon__icon', {
                             'PlayerControlSeekIcon__icon--forward': direction === 'forward',
                         })}
                     />


### PR DESCRIPTION
play and skip are the main interactions
but they have the same visual weight...

i'm not super sold on this, but let's make them slightly bigger

| before | after |
| - | - |
| <img width="460" height="395" alt="Screenshot 2025-09-16 at 17 18 31" src="https://github.com/user-attachments/assets/9f0810f4-fbb5-4295-88d3-2bdb75848b71" />| <img width="460" height="392" alt="Screenshot 2025-09-16 at 17 16 10" src="https://github.com/user-attachments/assets/394da691-4f18-48ad-ac50-04cb297ab805" />|