### PR TITLE
fix(retention): pick latest person property value for breakdowns

### DIFF
--- a/frontend/src/scenes/retention/RetentionGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionGraph.tsx
@@ -61,7 +61,6 @@ export function RetentionGraph({ inSharedMode = false }: RetentionGraphProps): J
             isStacked={retentionFilter?.display !== ChartDisplayType.ActionsBar}
             trendsFilter={{ aggregationAxisFormat: 'percentage' } as TrendsFilter}
             tooltip={{
-                rowCutoff: 11, // 11 time units is hardcoded into retention insights
                 renderSeries: function _renderCohortPrefix(value) {
                     // If we're showing mean values per breakdown, show the breakdown value directly
                     if (shouldShowMeanPerBreakdown) {

--- a/frontend/src/scenes/retention/retentionGraphLogic.ts
+++ b/frontend/src/scenes/retention/retentionGraphLogic.ts
@@ -40,7 +40,7 @@ export const retentionGraphLogic = kea<retentionGraphLogicType>([
                     return {
                         ...cohortRetention,
                         id: datasetIndex,
-                        days: cohortRetention.values.map((_, index) => `${period} ${index}`),
+                        days: cohortRetention.values.map((value) => value.cellDate.toISOString()),
                         labels: cohortRetention.values.map((_, index) => `${period} ${index}`),
                         count: 0,
                         label: cohortRetention.date

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -739,11 +739,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                 actor_query_for_breakdowns = self.actor_query()
 
                 # Add max_timestamp to the actor query to find the latest event for each actor-breakdown pair
-                select_queries = (
-                    actor_query_for_breakdowns.select_queries
-                    if isinstance(actor_query_for_breakdowns, ast.SelectSetQuery)
-                    else [actor_query_for_breakdowns]
-                )
+                select_queries = [actor_query_for_breakdowns]
                 for q in select_queries:
                     q.select.append(ast.Alias(alias="max_timestamp", expr=parse_expr("max(events.timestamp)")))
 

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -718,13 +718,68 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         )
 
         if self.breakdowns_in_query:
-            # Step 1: Calculate total cohort size for each breakdown value (size at intervals_from_base = 0)
+            is_cohort_breakdown = (
+                self.query.breakdownFilter is not None
+                and self.query.breakdownFilter.breakdowns is not None
+                and any(b.type == "cohort" for b in self.query.breakdownFilter.breakdowns)
+            )
+
             breakdown_totals: dict[str, int] = {}
             original_results = response.results or []
-            for row in original_results:
-                start_interval, intervals_from_base, breakdown_value, count = row
-                if intervals_from_base == 0:
-                    breakdown_totals[breakdown_value] = breakdown_totals.get(breakdown_value, 0) + count
+
+            if is_cohort_breakdown:
+                # For cohort breakdowns, we rank by the total number of people in the first-day cohorts.
+                for row in original_results:
+                    _start_interval, intervals_from_base, breakdown_value, count = row
+                    if intervals_from_base == 0:
+                        breakdown_totals[breakdown_value] = breakdown_totals.get(breakdown_value, 0) + count
+            else:
+                # For property breakdowns, we rank by the total number of unique actors, ensuring each actor is
+                # associated with their single most recent breakdown value.
+                actor_query_for_breakdowns = self.actor_query()
+
+                # Add max_timestamp to the actor query to find the latest event for each actor-breakdown pair
+                select_queries = (
+                    actor_query_for_breakdowns.select_queries
+                    if isinstance(actor_query_for_breakdowns, ast.SelectSetQuery)
+                    else [actor_query_for_breakdowns]
+                )
+                for q in select_queries:
+                    q.select.append(ast.Alias(alias="max_timestamp", expr=parse_expr("max(events.timestamp)")))
+
+                # Consolidate actors to one breakdown value each, picking the one with the latest timestamp.
+                consolidated_actors_query = parse_select(
+                    """
+                    SELECT
+                        actor_id,
+                        argMax(breakdown_value, max_timestamp) as canonical_breakdown
+                    FROM {actor_query}
+                    GROUP BY actor_id
+                    """,
+                    placeholders={"actor_query": actor_query_for_breakdowns},
+                )
+
+                # Now, count the unique actors for each canonical breakdown value.
+                breakdown_totals_query = parse_select(
+                    """
+                    SELECT
+                        canonical_breakdown,
+                        COUNT(DISTINCT actor_id) as total_count
+                    FROM {consolidated_actors_query}
+                    GROUP BY canonical_breakdown
+                    """,
+                    placeholders={"consolidated_actors_query": consolidated_actors_query},
+                )
+
+                breakdown_totals_response = execute_hogql_query(
+                    query_type="RetentionBreakdownTotalsQuery",
+                    query=breakdown_totals_query,
+                    team=self.team,
+                    timings=self.timings,
+                    modifiers=self.modifiers,
+                    limit_context=self.limit_context,
+                )
+                breakdown_totals = {row[0]: row[1] for row in breakdown_totals_response.results or []}
 
             # Step 2: Rank breakdowns and determine top N and 'Other'
             breakdown_limit = (
@@ -733,7 +788,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                 else get_breakdown_limit_for_context(self.limit_context)
             )
             # Sort by count descending, then by breakdown value ascending for stability
-            sorted_breakdowns = sorted(breakdown_totals.items(), key=lambda item: (-item[1], item[0]), reverse=False)
+            sorted_breakdowns = sorted(breakdown_totals.items(), key=lambda item: (-item[1], item[0]))
             other_values = {item[0] for item in sorted_breakdowns[breakdown_limit:]}
 
             # Step 3: Aggregate results, grouping less frequent breakdowns into 'Other'

--- a/posthog/hogql_queries/insights/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_retention_query_runner.py
@@ -5021,3 +5021,269 @@ class TestClickhouseRetentionGroupAggregation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][0]["id"], person2.uuid)
         self.assertEqual(result[0][1], [0, 2])
+
+    def test_retention_breakdown_person_property_is_stable(self):
+        # This test reproduces the bug where a person's breakdown value splits between
+        # empty string and actual value, causing major countries to drop from top breakdown list
+
+        # Create person who will have country property added later
+        person_no_country = Person.objects.create(team=self.team, distinct_ids=["person_no_country"], properties={})
+
+        # Create person who always has country
+        # person_with_country
+        Person.objects.create(team=self.team, distinct_ids=["person_with_country"], properties={"country": "Taiwan"})
+
+        # Create events for both people
+        _create_events(
+            self.team,
+            [
+                ("person_no_country", _date(0)),  # Event when person has no country
+                ("person_no_country", _date(1)),  # Retention event when person has no country
+                ("person_with_country", _date(0)),  # Event for person with Taiwan
+                ("person_with_country", _date(1)),  # Retention event for person with Taiwan
+            ],
+        )
+
+        # Now update the person to have a country (simulating property being set later)
+        person_no_country.properties = {"country": "Taiwan"}
+        person_no_country.save()
+
+        # Create more events after the property is set
+        _create_events(
+            self.team,
+            [
+                ("person_no_country", _date(2)),  # Event when person now has Taiwan as country
+                ("person_with_country", _date(2)),  # Another event for consistent person
+            ],
+        )
+
+        # Create many other people with unique countries to fill up breakdown slots
+        # This simulates the real scenario where major countries get pushed out
+        for i in range(20):
+            Person.objects.create(team=self.team, distinct_ids=[f"person_{i}"], properties={"country": f"Country_{i}"})
+            _create_events(self.team, [(f"person_{i}", _date(0)), (f"person_{i}", _date(1))])
+
+        query = {
+            "dateRange": {"date_from": _date(0), "date_to": _date(10)},
+            "retentionFilter": {"period": "Day", "totalIntervals": 7},
+            "breakdownFilter": {
+                "breakdown": "country",
+                "breakdown_type": "person",
+            },
+        }
+
+        results = self.run_query(query)
+
+        # Extract breakdown values
+        breakdown_values = {r["breakdown_value"] for r in results}
+
+        # This test will FAIL with current logic because:
+        # 1. person_no_country's events will be split between "" (empty) and "Taiwan"
+        # 2. This makes Taiwan appear to have only 1 person instead of 2
+        # 3. Taiwan gets pushed out by the 20 other countries in the breakdown limit
+
+        # The test expects Taiwan to be in the results (it should have 2 people)
+        # but with the current bug, it might not be due to the splitting issue
+        self.assertIn(
+            "Taiwan",
+            breakdown_values,
+            "Taiwan should appear in breakdown results but got pushed out due to person property splitting bug",
+        )
+
+        # Taiwan should show 2 people in the cohort, not split between empty and Taiwan
+        taiwan_results = [r for r in results if r["breakdown_value"] == "Taiwan"]
+        if taiwan_results:
+            # Day 0 cohort should have 2 people (both person_no_country and person_with_country)
+            taiwan_day0_cohort = next((r for r in taiwan_results if r["label"] == "Day 0"), None)
+            if taiwan_day0_cohort:
+                self.assertEqual(
+                    taiwan_day0_cohort["values"][0]["count"],
+                    2,
+                    "Taiwan cohort should have 2 people, not split due to property timing",
+                )
+
+    def test_retention_breakdown_uses_most_recent_property_value(self):
+        # This test validates that when a user's breakdown property changes over time,
+        # they are counted using their most recent property value for ranking purposes.
+
+        # Create a user whose country changes from '' -> 'Canada' -> 'USA' over time
+        person_changing = Person.objects.create(
+            team=self.team,
+            distinct_ids=["person_changing"],
+            properties={},  # Initially no country
+        )
+
+        # Day 0: Event with no country (empty string)
+        _create_events(self.team, [("person_changing", _date(0))])
+
+        # Update person to have Canada as country
+        person_changing.properties = {"country": "Canada"}
+        person_changing.save()
+
+        # Day 1: Event with Canada
+        _create_events(self.team, [("person_changing", _date(1))])
+
+        # Update person to have USA as country (most recent)
+        person_changing.properties = {"country": "USA"}
+        person_changing.save()
+
+        # Day 2: Event with USA (this should be the canonical value)
+        _create_events(self.team, [("person_changing", _date(2))])
+
+        # Create a baseline USA user to ensure USA gets ranked properly
+        Person.objects.create(team=self.team, distinct_ids=["usa_baseline"], properties={"country": "USA"})
+        _create_events(self.team, [("usa_baseline", _date(0))])
+
+        # Create some other countries to fill up breakdown slots
+        for i in range(15):
+            Person.objects.create(team=self.team, distinct_ids=[f"other_{i}"], properties={"country": f"Other_{i}"})
+            _create_events(self.team, [(f"other_{i}", _date(0))])
+
+        query = {
+            "dateRange": {"date_from": _date(0), "date_to": _date(10)},
+            "retentionFilter": {"period": "Day", "totalIntervals": 7},
+            "breakdownFilter": {
+                "breakdown": "country",
+                "breakdown_type": "person",
+                "breakdown_limit": 5,  # Limit to top 5 to force ranking logic
+            },
+        }
+
+        results = self.run_query(query)
+        breakdown_values = {r["breakdown_value"] for r in results}
+
+        # USA should be in the top results because it has 2 users (person_changing + usa_baseline)
+        # based on the most recent property values
+        self.assertIn(
+            "USA", breakdown_values, "USA should be in top breakdown results based on most recent property values"
+        )
+
+        # Canada should NOT be in the top results because person_changing's final value is USA
+        self.assertNotIn(
+            "Canada",
+            breakdown_values,
+            "Canada should not be in top breakdown results as person_changing's final value is USA",
+        )
+
+        # Verify USA has 2 users in the Day 0 cohort
+        usa_results = [r for r in results if r["breakdown_value"] == "USA"]
+        usa_day0_cohort = next((r for r in usa_results if r["label"] == "Day 0"), None)
+        self.assertEqual(
+            usa_day0_cohort["values"][0]["count"],
+            2,
+            "USA should have 2 users: person_changing (latest value) + usa_baseline",
+        )
+
+    def test_retention_breakdown_other_grouping_logic(self):
+        # This test validates that breakdown values are correctly sorted by frequency
+        # and that the least frequent ones are grouped into "Other"
+
+        # Create countries with different user counts to test ranking
+        # USA: 5 users (should be #1)
+        for i in range(5):
+            Person.objects.create(team=self.team, distinct_ids=[f"usa_user_{i}"], properties={"country": "USA"})
+            _create_events(self.team, [(f"usa_user_{i}", _date(0))])
+
+        # Canada: 3 users (should be #2)
+        for i in range(3):
+            Person.objects.create(team=self.team, distinct_ids=[f"can_user_{i}"], properties={"country": "Canada"})
+            _create_events(self.team, [(f"can_user_{i}", _date(0))])
+
+        # Germany: 2 users (should be #3)
+        for i in range(2):
+            Person.objects.create(team=self.team, distinct_ids=[f"ger_user_{i}"], properties={"country": "Germany"})
+            _create_events(self.team, [(f"ger_user_{i}", _date(0))])
+
+        # France: 1 user (should be grouped into "Other" with breakdown_limit=3)
+        Person.objects.create(team=self.team, distinct_ids=["fra_user"], properties={"country": "France"})
+        _create_events(self.team, [("fra_user", _date(0))])
+
+        # Spain: 1 user (should be grouped into "Other" with breakdown_limit=3)
+        Person.objects.create(team=self.team, distinct_ids=["spa_user"], properties={"country": "Spain"})
+        _create_events(self.team, [("spa_user", _date(0))])
+
+        query = {
+            "dateRange": {"date_from": _date(0), "date_to": _date(10)},
+            "retentionFilter": {"period": "Day", "totalIntervals": 7},
+            "breakdownFilter": {
+                "breakdown": "country",
+                "breakdown_type": "person",
+                "breakdown_limit": 3,  # Only top 3 should be shown individually
+            },
+        }
+
+        results = self.run_query(query)
+        breakdown_values = {r["breakdown_value"] for r in results}
+
+        # Top 3 countries should be present
+        self.assertIn("USA", breakdown_values, "USA should be in top 3 (5 users)")
+        self.assertIn("Canada", breakdown_values, "Canada should be in top 3 (3 users)")
+        self.assertIn("Germany", breakdown_values, "Germany should be in top 3 (2 users)")
+
+        # Bottom 2 countries should be grouped into "Other"
+        self.assertNotIn("France", breakdown_values, "France should be grouped into Other (1 user)")
+        self.assertNotIn("Spain", breakdown_values, "Spain should be grouped into Other (1 user)")
+        self.assertIn(BREAKDOWN_OTHER_STRING_LABEL, breakdown_values, "Other group should be present")
+
+        # Verify the "Other" group has the correct count (France + Spain = 2 users)
+        other_results = [r for r in results if r["breakdown_value"] == BREAKDOWN_OTHER_STRING_LABEL]
+        other_day0_cohort = next((r for r in other_results if r["label"] == "Day 0"), None)
+        self.assertEqual(
+            other_day0_cohort["values"][0]["count"],
+            2,
+            "Other group should contain 2 users (France + Spain)",
+        )
+
+        # Verify the top countries have correct counts
+        usa_results = [r for r in results if r["breakdown_value"] == "USA"]
+        usa_day0_cohort = next((r for r in usa_results if r["label"] == "Day 0"), None)
+        self.assertEqual(usa_day0_cohort["values"][0]["count"], 5, "USA should have 5 users")
+
+        canada_results = [r for r in results if r["breakdown_value"] == "Canada"]
+        canada_day0_cohort = next((r for r in canada_results if r["label"] == "Day 0"), None)
+        self.assertEqual(canada_day0_cohort["values"][0]["count"], 3, "Canada should have 3 users")
+
+    # TRICKY: for later if/when we want a different ranking logic for breakdowns
+    # def test_retention_breakdown_ranking_by_unique_users(self):
+    #     # This test validates that breakdown ranking is based on unique users, not sum of cohort sizes.
+    #     # It creates a scenario where one breakdown value has more unique users, but another has a higher
+    #     # sum of cohort sizes due to very active, recurring users.
+
+    #     # USA: 10 unique users, each starting a cohort once on Day 0
+    #     for i in range(10):
+    #         Person.objects.create(team=self.team, distinct_ids=[f"usa_user_{i}"], properties={"country": "USA"})
+    #         _create_events(self.team, [(f"usa_user_{i}", _date(0))])
+
+    #     # Canada: 3 unique users, but they are very active and start cohorts on 5 different days
+    #     for i in range(3):
+    #         Person.objects.create(team=self.team, distinct_ids=[f"can_user_{i}"], properties={"country": "Canada"})
+    #         for day in range(5):
+    #             _create_events(self.team, [(f"can_user_{i}", _date(day))])
+
+    #     # With the flawed logic (sum of cohorts):
+    #     # USA score = 10 (10 users on day 0)
+    #     # Canada score = 15 (3 users * 5 days)
+    #     # Canada will be ranked higher.
+
+    #     # With the correct logic (unique users):
+    #     # USA score = 10
+    #     # Canada score = 3
+    #     # USA will be ranked higher.
+
+    #     query = {
+    #         "dateRange": {"date_from": _date(0), "date_to": _date(10)},
+    #         "retentionFilter": {"period": "Day", "totalIntervals": 7},
+    #         "breakdownFilter": {
+    #             "breakdown": "country",
+    #             "breakdown_type": "person",
+    #             "breakdown_limit": 1,
+    #         },
+    #     }
+
+    #     results = self.run_query(query)
+    #     breakdown_values = {r["breakdown_value"] for r in results}
+
+    #     # The test asserts that USA is the top breakdown, which should fail with the current logic
+    #     self.assertIn("USA", breakdown_values)
+    #     self.assertNotIn("Canada", breakdown_values)
+    #     self.assertIn(BREAKDOWN_OTHER_STRING_LABEL, breakdown_values)  # Canada should be in "Other"

--- a/posthog/hogql_queries/insights/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_retention_query_runner.py
@@ -5168,6 +5168,7 @@ class TestClickhouseRetentionGroupAggregation(ClickhouseTestMixin, APIBaseTest):
         # Verify USA has 2 users in the Day 0 cohort
         usa_results = [r for r in results if r["breakdown_value"] == "USA"]
         usa_day0_cohort = next((r for r in usa_results if r["label"] == "Day 0"), None)
+        assert usa_day0_cohort is not None
         self.assertEqual(
             usa_day0_cohort["values"][0]["count"],
             2,
@@ -5228,6 +5229,7 @@ class TestClickhouseRetentionGroupAggregation(ClickhouseTestMixin, APIBaseTest):
         # Verify the "Other" group has the correct count (France + Spain = 2 users)
         other_results = [r for r in results if r["breakdown_value"] == BREAKDOWN_OTHER_STRING_LABEL]
         other_day0_cohort = next((r for r in other_results if r["label"] == "Day 0"), None)
+        assert other_day0_cohort is not None
         self.assertEqual(
             other_day0_cohort["values"][0]["count"],
             2,
@@ -5237,10 +5239,12 @@ class TestClickhouseRetentionGroupAggregation(ClickhouseTestMixin, APIBaseTest):
         # Verify the top countries have correct counts
         usa_results = [r for r in results if r["breakdown_value"] == "USA"]
         usa_day0_cohort = next((r for r in usa_results if r["label"] == "Day 0"), None)
+        assert usa_day0_cohort is not None
         self.assertEqual(usa_day0_cohort["values"][0]["count"], 5, "USA should have 5 users")
 
         canada_results = [r for r in results if r["breakdown_value"] == "Canada"]
         canada_day0_cohort = next((r for r in canada_results if r["label"] == "Day 0"), None)
+        assert canada_day0_cohort is not None
         self.assertEqual(canada_day0_cohort["values"][0]["count"], 3, "Canada should have 3 users")
 
     # TRICKY: for later if/when we want a different ranking logic for breakdowns


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/36814 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/40159)

Changes the logic in Retention insights where breakdowns by person properties (e.g., "Latest Country Name") would hide major breakdown values, such as Taiwan and the United States, grouping them into "Other". Retention breakdowns don't yet support SQL breakdowns (where you can always pick latest value of the person property) + in this scenario it makes sense for us to automatically pick latest value.

The root cause was a flaw in how users with changing property values over time were grouped and ranked.
If a user's country property is initially not set, their early events are associated with a breakdown value of '' (empty string). If the property is set later to 'Taiwan', their later events are associated with that value. This creates a "split identity" for the user in the query's intermediate results, where they belong to two different breakdown groups.

When running without a filter, the query processes all events. Users from Taiwan and the USA who had events before their country was set contributed to both the '' group and their respective country groups. This made the '' group appear enormous in the ranking, pushing all major countries down the list and into the "Other" bucket.

When a filter like country IN ('Taiwan', 'United States') is applied, it acts as a pre-filter on the events. This WHERE clause removes all events where the country is '' or NULL before the GROUP BY is applied. This inadvertently "cleaned" the data, hiding the split identity problem and allowing the query to produce the correct result for the filtered set

## Changes
The fix addresses the root cause by ensuring every user is associated with a single, canonical breakdown value before ranking is performed. This is now done only for property-based breakdowns, leaving the distinct logic for cohort breakdowns intact.
The new logic in RetentionQueryRunner works as follows:
Fetch All Breakdown Values: The query first gets all (actor_id, breakdown_value) pairs for each user, along with the timestamp of the latest event for each pair (max(events.timestamp)).
Consolidate to Most Recent Value: A subquery then consolidates these pairs. For each actor_id, it uses argMax(breakdown_value, max_timestamp) to find the single breakdown_value associated with that user's most recent event. This becomes their "canonical" breakdown value.
Rank by Unique Users: Finally, the query counts the number of unique users for each canonical breakdown value. This provides the correct totals for ranking the breakdowns.
This approach ensures that if a user's country changes from '' -> 'Canada' -> 'USA', they are counted only once under 'USA' for the breakdown ranking, guaranteeing an accurate representation of the user base.

Later we should add sql breakdowns so users can control if they want latest or query time properties

+ also fix tooltip issue for users only first 12 items show up in the tooltip.
## How did you test this code?
Added tests