### PR TITLE
fix: use colorIndex for value-based trend customizations

### DIFF
--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -578,7 +578,13 @@ export function getTrendResultCustomizationColorToken(
     // for result customizations without a configuration, the color is determined
     // by the position in the dataset. colors repeat after all options
     // have been exhausted.
-    const datasetPosition = getTrendDatasetPosition(dataset)
+    // For comparison data (current vs previous periods), use colorIndex to ensure
+    // they get the same base color when customizing by value
+    const isValueBasedCustomization = !resultCustomizationBy || resultCustomizationBy === ResultCustomizationBy.Value
+    const datasetPosition =
+        isValueBasedCustomization && dataset.colorIndex !== undefined
+            ? dataset.colorIndex
+            : getTrendDatasetPosition(dataset)
     const tokenIndex = (datasetPosition % Object.keys(theme).length) + 1
 
     return resultCustomization && resultCustomization.color


### PR DESCRIPTION
## Changes

Before:
  - Current period: Blue
  - Previous period: Red (completely different color)

  Expected:
  - Current period: Blue
  - Previous period: Light blue (same color with opacity)

  Root Cause

  The issue was introduced by the interaction between two systems - see commit [here](https://github.com/PostHog/posthog/commit/898d45b5763367dadeaede90513e86e482c15559#diff-e1af7330385004dfe1896f0cf12d650f7b01a0b9a827c9af7b9526d372dbdaeaL502-R504):

  1. Color assignment logic in `getTrendResultCustomizationColorToken()` was using `getTrendDatasetPosition()` which prioritizes seriesIndex
  2. Comparison data logic in trendsDataLogic.ts correctly assigns the same colorIndex to current and previous periods, but they get different seriesIndex values since they appear at different positions in
  the results array

  For comparison data:
```
  [
    { label: "Page views", seriesIndex: 0, colorIndex: 0, compare_label: "current" },
    { label: "Page views", seriesIndex: 1, colorIndex: 0, compare_label: "previous" }   // Same colorIndex, different seriesIndex
  ]
```

  Since color assignment was using seriesIndex (0, 1), current and previous got different base colors instead of using the shared colorIndex (0, 0).

  Solution

  Modified `getTrendResultCustomizationColorToken()` to use colorIndex instead of seriesIndex specifically for value-based result customizations (which is the default behavior).

  Key changes:
  - For value-based customizations: Use colorIndex to ensure current/previous periods share the same base color
  - For position-based customizations: Continue using seriesIndex to maintain compatibility with PR #35559 

  This preserves the existing opacity logic in LineGraph.tsx where previous periods get ${themeColor}80 (50% opacity) applied to the base color.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
