### PR TITLE
fix(dockerfile): needs dev pkg for compliing system librdkafka

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get update && \
     "gcc" \
     "python3" \
     "librdkafka1=2.10.1-1.cflt~deb12" \
+    "librdkafka++1=2.10.1-1.cflt~deb12" \
     "librdkafka-dev=2.10.1-1.cflt~deb12" \
     "libssl-dev=3.0.17-1~deb12u2" \
     "libssl3=3.0.17-1~deb12u2" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update && \
     "gcc" \
     "python3" \
     "librdkafka1=2.10.1-1.cflt~deb12" \
-		"librdkafka-dev=2.10.1-1.cflt~deb12" \
+    "librdkafka-dev=2.10.1-1.cflt~deb12" \
     "libssl-dev=3.0.17-1~deb12u2" \
     "libssl3=3.0.17-1~deb12u2" \
     "zlib1g-dev" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get update && \
     "gcc" \
     "python3" \
     "librdkafka1=2.10.1-1.cflt~deb12" \
+		"librdkafka-dev=2.10.1-1.cflt~deb12" \
     "libssl-dev=3.0.17-1~deb12u2" \
     "libssl3=3.0.17-1~deb12u2" \
     "zlib1g-dev" \


### PR DESCRIPTION
## Problem

After trying to use a system installed librdkafka so that we can pin certain dependencies, the dockerfile builds started failing. I believe it is because we were missing the development headers that are needed for compilation.

## Changes

Includes dev pkg to bring in development headers so that we can properly install librdkafka at the system level.

## How did you test this code?

