### PR TITLE
feat: Add links to CDP docs for all sources

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
@@ -3,31 +3,43 @@ import { ReactNode } from 'react'
 import { LemonMarkdown } from '../LemonMarkdown'
 import { Link, LinkProps } from '../Link'
 
+interface LemonTableLinkContentProps {
+    title: JSX.Element | string
+    description?: ReactNode
+}
+
 export function LemonTableLink({
     title,
     description,
     ...props
-}: Pick<LinkProps, 'to' | 'onClick' | 'target' | 'className'> & {
-    title: JSX.Element | string
-    description?: ReactNode
-}): JSX.Element {
+}: Pick<LinkProps, 'to' | 'onClick' | 'target' | 'className'> & LemonTableLinkContentProps): JSX.Element {
+    if (!props.to) {
+        return <LemonTableLinkContent title={title} description={description} />
+    }
+
     return (
         <Link subtle {...props}>
-            <div className="flex flex-col py-1">
-                <div className="flex flex-row items-center font-semibold text-sm gap-1">{title}</div>
-
-                {description ? (
-                    <div className="text-xs text-tertiary mt-1">
-                        {typeof description === 'string' ? (
-                            <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings>
-                                {description}
-                            </LemonMarkdown>
-                        ) : (
-                            description
-                        )}
-                    </div>
-                ) : null}
-            </div>
+            <LemonTableLinkContent title={title} description={description} />
         </Link>
+    )
+}
+
+function LemonTableLinkContent({ title, description }: LemonTableLinkContentProps): JSX.Element {
+    return (
+        <div className="flex flex-col py-1">
+            <div className="flex flex-row items-center font-semibold text-sm gap-1">{title}</div>
+
+            {description ? (
+                <div className="text-xs text-tertiary mt-1">
+                    {typeof description === 'string' ? (
+                        <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings>
+                            {description}
+                        </LemonMarkdown>
+                    ) : (
+                        description
+                    )}
+                </div>
+            ) : null}
+        </div>
     )
 }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -23252,6 +23252,9 @@
                 "disabledReason": {
                     "type": ["string", "null"]
                 },
+                "docsUrl": {
+                    "type": "string"
+                },
                 "existingSource": {
                     "type": "boolean"
                 },
@@ -23277,7 +23280,7 @@
                     "type": "boolean"
                 }
             },
-            "required": ["name", "caption", "fields", "iconPath"],
+            "required": ["name", "fields", "iconPath"],
             "type": "object"
         },
         "SourceFieldConfig": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3887,7 +3887,8 @@ export type SourceFieldConfig =
 export interface SourceConfig {
     name: ExternalDataSourceType
     label?: string
-    caption: string | any
+    docsUrl?: string
+    caption?: string | any
     fields: SourceFieldConfig[]
     disabledReason?: string | null
     existingSource?: boolean

--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -45,7 +45,9 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                         name: connector.name,
                         icon_url: connector.iconPath,
                         status: connector.unreleasedSource ? 'coming_soon' : connector.betaSource ? 'beta' : 'stable',
-                        description: (
+                        description: connector.unreleasedSource ? (
+                            'Get notified when this source is available to connect'
+                        ) : (
                             <>
                                 Data will be synced to PostHog and regularly refreshed.{' '}
                                 <Link to="https://posthog.com/docs/cdp/sources">Learn more</Link>

--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -42,7 +42,7 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                     (connector: SourceConfig): HogFunctionTemplateType => ({
                         id: `managed-${connector.name}`,
                         type: 'source',
-                        name: connector.name,
+                        name: connector.label ?? connector.name,
                         icon_url: connector.iconPath,
                         status: connector.unreleasedSource ? 'coming_soon' : connector.betaSource ? 'beta' : 'stable',
                         description: connector.unreleasedSource ? (

--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -3,7 +3,7 @@ import posthog from 'posthog-js'
 import { useCallback, useEffect } from 'react'
 
 import { IconBell, IconCheck } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, LemonTable, LemonTag, lemonToast } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonSkeleton, LemonTable, LemonTag, lemonToast } from '@posthog/lemon-ui'
 
 import { PageHeader } from 'lib/components/PageHeader'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -363,6 +363,16 @@ function SecondStep(): JSX.Element {
             {selectedConnector.caption && (
                 <LemonMarkdown className="text-sm">{selectedConnector.caption}</LemonMarkdown>
             )}
+
+            {selectedConnector.docsUrl && (
+                <div className="inline-block">
+                    <LemonButton to={selectedConnector.docsUrl} type="primary" size="small">
+                        View docs
+                    </LemonButton>
+                </div>
+            )}
+
+            <LemonDivider />
 
             <SourceForm sourceConfig={selectedConnector} />
         </div>

--- a/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
@@ -65,7 +65,7 @@ export function HogFunctionTemplateList({
                         render: (_, template) => {
                             return (
                                 <LemonTableLink
-                                    to={urlForTemplate(template)}
+                                    to={urlForTemplate(template) ?? undefined}
                                     title={
                                         <>
                                             {template.name}
@@ -94,12 +94,13 @@ export function HogFunctionTemplateList({
                                     </LemonButton>
                                 )
                             }
+
                             return (
                                 <LemonButton
                                     type="primary"
                                     data-attr="new-destination"
                                     icon={<IconPlusSmall />}
-                                    to={urlForTemplate(template)}
+                                    to={urlForTemplate(template) ?? undefined}
                                     fullWidth
                                 >
                                     Create

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -7,6 +7,7 @@ import posthog from 'posthog-js'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { FeatureFlagKey } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils'
 import { urls } from 'scenes/urls'
@@ -147,7 +148,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
                 }
                 return templates
                     .filter((x) => shouldShowHogFunctionTemplate(x, user))
-                    .filter((x) => !x.flag || !!featureFlags[x.flag])
+                    .filter((x) => !x.flag || !!featureFlags[x.flag as FeatureFlagKey])
                     .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
             },
         ],
@@ -191,9 +192,14 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
 
         urlForTemplate: [
             () => [(_, props) => props],
-            ({ configurationOverrides }): ((template: HogFunctionTemplateWithSubTemplateType) => string) => {
+            ({ configurationOverrides }): ((template: HogFunctionTemplateWithSubTemplateType) => string | null) => {
                 return (template: HogFunctionTemplateWithSubTemplateType) => {
                     if (template.status === 'coming_soon') {
+                        // "Coming soon" sources don't have docs yet
+                        if (template.type === 'source') {
+                            return null
+                        }
+
                         return `https://posthog.com/docs/cdp/${template.type}s/${template.id}`
                     }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -14748,8 +14748,9 @@ class SourceConfig(BaseModel):
         extra="forbid",
     )
     betaSource: Optional[bool] = None
-    caption: Union[str, Any]
+    caption: Optional[Union[str, Any]] = None
     disabledReason: Optional[str] = None
+    docsUrl: Optional[str] = None
     existingSource: Optional[bool] = None
     featureFlag: Optional[str] = None
     fields: list[

--- a/posthog/temporal/data_imports/sources/README.md
+++ b/posthog/temporal/data_imports/sources/README.md
@@ -52,8 +52,9 @@ class TemplateSource(BaseSource[Config]): # Replace this after config generation
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SOURCE_TYPE, # Replace this
-            label="Template", # Replace this
-            caption="",
+            label="Template", # Only needed if the readable name is complex
+            caption=None, # Only needed if you wanna inline docs
+            docsUrl=None, # Link to the docs in the website, full path including https://
             fields=cast(list[FieldType], []), # Add source fields here
         )
     def validate_credentials(self, config: Config, team_id: int) -> tuple[bool, str | None]: # Replace `Config` with your config class

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -152,8 +152,8 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BIG_QUERY,
-            caption="",
             iconPath="/static/services/bigquery.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/bigquery",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/braze/source.py
+++ b/posthog/temporal/data_imports/sources/braze/source.py
@@ -21,9 +21,7 @@ class BrazeSource(BaseSource[BrazeSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BRAZE,
-            label="Braze",
             iconPath="/static/services/braze.png",
-            caption="",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,
         )

--- a/posthog/temporal/data_imports/sources/chargebee/source.py
+++ b/posthog/temporal/data_imports/sources/chargebee/source.py
@@ -68,7 +68,7 @@ class ChargebeeSource(BaseSource[ChargebeeSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CHARGEBEE,
-            caption="",
+            docsUrl="https://posthog.com/docs/cdp/sources/chargebee",
             iconPath="/static/services/chargebee.png",
             fields=cast(
                 list[FieldType],

--- a/posthog/temporal/data_imports/sources/common/test/test_source_config_generator.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_source_config_generator.py
@@ -33,7 +33,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_types(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -136,7 +135,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_required(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -159,7 +157,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_not_required(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -181,7 +178,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_input_non_python_identifier(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -203,7 +199,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_switch_group_non_python_identifier(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -240,7 +235,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_file_upload_non_python_identifier(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -264,7 +258,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_oauth_non_python_identifier(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -288,7 +281,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_ssh_tunnel_non_python_identifier(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -310,7 +302,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_complex_select_non_python_identifier(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -369,7 +360,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_simple_select_non_python_identifier(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -393,7 +383,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_ssh_tunnel_reference(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -410,7 +399,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_type_conversion(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],
@@ -432,7 +420,6 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
     def test_source_config_nested_class(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,
-            caption="",
             iconPath="",
             fields=cast(
                 list[FieldType],

--- a/posthog/temporal/data_imports/sources/doit/source.py
+++ b/posthog/temporal/data_imports/sources/doit/source.py
@@ -51,8 +51,8 @@ class DoItSource(BaseSource[DoItSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.DO_IT,
             label="DoIt",
-            caption="",
             iconPath="/static/services/doit.svg",
+            docsUrl="https://posthog.com/docs/cdp/sources/doit",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -86,6 +86,7 @@ class GoogleAdsSource(BaseSource[GoogleAdsSourceConfig | GoogleAdsServiceAccount
             caption="Ensure you have granted PostHog access to your Google Ads account, learn how to do this in [the docs](https://posthog.com/docs/cdp/sources/google-ads).",
             betaSource=True,
             iconPath="/static/services/google-ads.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/google-ads",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -82,6 +82,7 @@ class GoogleSheetsSource(BaseSource[GoogleSheetsSourceConfig]):
             caption="Ensure you have granted PostHog access to your Google Sheet as instructed in the [documentation](https://posthog.com/docs/cdp/sources/google-sheets)",
             betaSource=True,
             iconPath="/static/services/Google_Sheets.svg",
+            docsUrl="https://posthog.com/docs/cdp/sources/google-sheets",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -38,6 +38,7 @@ class HubspotSource(BaseSource[HubspotSourceConfig | HubspotSourceOldConfig], OA
             name=SchemaExternalDataSourceType.HUBSPOT,
             caption="Select an existing Hubspot account to link to PostHog or create a new connection",
             iconPath="/static/services/hubspot.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/hubspot",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -22,7 +22,6 @@ class KlaviyoSource(BaseSource[KlaviyoSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.KLAVIYO,
             label="Klaviyo",
-            caption="",
             iconPath="/static/services/klaviyo.png",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -38,6 +38,7 @@ class LinkedInAdsSource(BaseSource[LinkedinAdsSourceConfig]):
             caption="Ensure you have granted PostHog access to your LinkedIn Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/linkedin-ads).",
             betaSource=True,
             iconPath="/static/services/linkedin.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/linkedin-ads",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -22,8 +22,8 @@ class MailchimpSource(BaseSource[MailchimpSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.MAILCHIMP,
             label="Mailchimp",
-            caption="",
             iconPath="/static/services/mailchimp.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/mailchimp",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,
         )

--- a/posthog/temporal/data_imports/sources/mailjet/source.py
+++ b/posthog/temporal/data_imports/sources/mailjet/source.py
@@ -22,8 +22,8 @@ class MailJetSource(BaseSource[MailjetSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.MAILJET,
             label="Mailjet",
-            caption="",
             iconPath="/static/services/mailjet.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/mailjet",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,
         )

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -102,6 +102,7 @@ class MongoDBSource(BaseSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
             caption="Enter your MongoDB connection string to automatically pull your MongoDB data into the PostHog Data warehouse.",
             betaSource=True,
             iconPath="/static/services/Mongodb.svg",
+            docsUrl="https://posthog.com/docs/cdp/sources/mongodb",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -44,6 +44,7 @@ class MSSQLSource(BaseSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabas
             label="Microsoft SQL Server",
             caption="Enter your Microsoft SQL Server/Azure SQL Server credentials to automatically pull your SQL data into the PostHog Data warehouse.",
             iconPath="/static/services/sql-azure.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/azure-db",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -40,6 +40,7 @@ class MySQLSource(BaseSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabas
             name=SchemaExternalDataSourceType.MY_SQL,
             caption="Enter your MySQL/MariaDB credentials to automatically pull your MySQL data into the PostHog Data warehouse.",
             iconPath="/static/services/mysql.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/mysql",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/polar/source.py
+++ b/posthog/temporal/data_imports/sources/polar/source.py
@@ -22,7 +22,6 @@ class PolarSource(BaseSource[PolarSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.POLAR,
             label="Polar",
-            caption="",
             iconPath="/static/services/polar.png",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -47,6 +47,7 @@ class PostgresSource(BaseSource[PostgresSourceConfig], SSHTunnelMixin, ValidateD
             name=SchemaExternalDataSourceType.POSTGRES,
             caption="Enter your Postgres credentials to automatically pull your Postgres data into the PostHog Data warehouse",
             iconPath="/static/services/postgres.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/postgres",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -31,9 +31,10 @@ class RedditAdsSource(BaseSource[RedditAdsSourceConfig], OAuthMixin):
         return SourceConfig(
             name=SchemaExternalDataSourceType.REDDIT_ADS,
             label="Reddit Ads",
-            iconPath="/static/services/reddit.png",
             caption="Collect campaign data, ad performance, and advertising metrics from Reddit Ads. Ensure you have granted PostHog access to your Reddit Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/reddit-ads).",
             betaSource=True,
+            iconPath="/static/services/reddit.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/reddit-ads",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -22,7 +22,6 @@ class RedshiftSource(BaseSource[RedshiftSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.REDSHIFT,
             label="Redshift",
-            caption="",
             iconPath="/static/services/redshift.png",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,

--- a/posthog/temporal/data_imports/sources/revenuecat/source.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/source.py
@@ -22,7 +22,6 @@ class RevenueCatSource(BaseSource[RevenueCatSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.REVENUE_CAT,
             label="RevenueCat",
-            caption="",
             iconPath="/static/services/revenuecat.png",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,

--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -44,6 +44,7 @@ class SalesforceSource(BaseSource[SalesforceSourceConfig], OAuthMixin):
             name=SchemaExternalDataSourceType.SALESFORCE,
             caption="Select an existing Salesforce account to link to PostHog or create a new connection",
             iconPath="/static/services/salesforce.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/salesforce",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -45,6 +45,7 @@ class SnowflakeSource(BaseSource[SnowflakeSourceConfig]):
             name=SchemaExternalDataSourceType.SNOWFLAKE,
             caption="Enter your Snowflake credentials to automatically pull your Snowflake data into the PostHog Data warehouse.",
             iconPath="/static/services/snowflake.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/snowflake",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -40,10 +40,14 @@ You can find your account ID [in your Stripe dashboard](https://dashboard.stripe
 
 Currently, **read permissions are required** for the following resources:
 
-- Under the **Core** resource type, select *read* for **Balance transaction sources**, **Charges**, **Customer**, **Product**, **Disputes**, and **Payouts**
-- Under the **Billing** resource type, select *read* for **Invoice**, **Price**, **Subscription**, and **Credit notes**
-- Under the **Connected** resource type, select *read* for the **entire resource**""",
+- Under the **Core** resource type, select *read* for **Balance transaction sources**, **Charges**, **Customers**, **Disputes**, **Payouts**, and **Products**
+- Under the **Billing** resource type, select *read* for **Credit notes**, **Invoices**, **Prices**, and **Subscriptions**
+- Under the **Connect** resource type, select *read* for either the **entire resource** or **Application Fees** and **Transfers**
+
+You can also simplify the setup by selecting **read** for the **entire resource** under **Core**, **Billing**, and **Connect**.
+""",
             iconPath="/static/services/stripe.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/stripe",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -55,8 +55,8 @@ class TemporalIOSource(BaseSource[TemporalIOSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.TEMPORAL_IO,
             label="Temporal.io",
-            caption="",
             iconPath="/static/services/temporal.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/temporal",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -84,8 +84,8 @@ class VitallySource(BaseSource[VitallySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.VITALLY,
-            caption="",
             iconPath="/static/services/vitally.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/vitally",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/zendesk/source.py
+++ b/posthog/temporal/data_imports/sources/zendesk/source.py
@@ -57,6 +57,7 @@ class ZendeskSource(BaseSource[ZendeskSourceConfig]):
             name=SchemaExternalDataSourceType.ZENDESK,
             caption="Enter your Zendesk API key to automatically pull your Zendesk support data into the PostHog Data warehouse.",
             iconPath="/static/services/zendesk.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/zendesk",
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
To make it even easier to point people to the docs when setting a source up, let's add a tiny button to open our sidebar with the appropriate docs. Updating the actual `docs` button on the right sidebar used to be a feature (by using a field in the source config), will check with the UX team if we can get that back.

While at it, I also fixed the Stripe docs to follow https://github.com/PostHog/posthog.com/pull/12807

<img width="815" height="690" alt="image" src="https://github.com/user-attachments/assets/197c96d9-9619-4a26-8cb7-23cdf1be85f1" />
