### PR TITLE
fix: using string transformation for any datetime 

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingCostTile.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingCostTile.tsx
@@ -68,7 +68,6 @@ export const redditAdsCostTile = (source: NativeSource): DataWarehouseNode | nul
         table_name: table.name,
         math: PropertyMathType.Sum,
         math_property: 'spend',
-        math_property_revenue_currency: { static: CurrencyCode.USD },
         math_multiplier: COST_MICROS_MULTIPLIER,
     }
 }

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingCostTile.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingCostTile.tsx
@@ -68,6 +68,7 @@ export const redditAdsCostTile = (source: NativeSource): DataWarehouseNode | nul
         table_name: table.name,
         math: PropertyMathType.Sum,
         math_property: 'spend',
+        math_property_revenue_currency: { static: CurrencyCode.USD },
         math_multiplier: COST_MICROS_MULTIPLIER,
     }
 }

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -207,7 +207,7 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
                         name="ifNull",
                         args=[
                             ast.Field(chain=[self.series.timestamp_field]),
-                            ast.Call(name="toDateTime", args=[ast.Constant(value=0), ast.Constant(value="UTC")]),
+                            ast.Call(name="toDate", args=[ast.Constant(value="1970-01-01")]),
                         ],
                     )
             else:

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -203,11 +203,13 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
                     # We use today's date as the timestamp to avoid this issue.
                     timestamp_expr = ast.Call(name="today", args=[])
                 else:
+                    # Handle different timestamp field types in DataWarehouse
+                    # Convert both to String format for coalesce, then _toDate will handle final conversion
                     timestamp_expr = ast.Call(
-                        name="ifNull",
+                        name="coalesce",
                         args=[
-                            ast.Field(chain=[self.series.timestamp_field]),
-                            ast.Call(name="toDate", args=[ast.Constant(value="1970-01-01")]),
+                            ast.Call(name="toString", args=[ast.Field(chain=[self.series.timestamp_field])]),
+                            ast.Constant(value="1970-01-01"),
                         ],
                     )
             else:


### PR DESCRIPTION
## Problem

I'm getting an error when using reddit cost + USD transformation

## Changes

It fails because we have a toDatetime conversion of 0 throwing this error:
```
There is a problem with this query
There is no supertype for types String, DateTime('UTC') because some of them are String/FixedString/Enum and some of them are not: While processing if('USD' = 'USD', toDecimal64(spend * 0.000001, 10), if(dictGetOrDefault(posthog.exchange_rate_dict, 'rate', 'USD', toDate(ifNull(date, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(spend * 0.000001, 10), dictGetOrDefault(posthog.exchange_rate_dict, 'rate', 'USD', toDate(ifNull(date, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(posthog.exchange_rate_dict, 'rate', 'USD', toDate(ifNull(date, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))).
```


## How did you test this code?
The MA is working fine 
<img width="1040" height="366" alt="image" src="https://github.com/user-attachments/assets/c488ea58-d58d-4342-9d75-7f644e84c485" />


With these queries

- this will throw There is no supertype for types String, DateTime('UTC') because some of them are String/FixedString/Enum and some of them are not: In scope SELECT toDateOrNull(ifNull(redditads__campaign_report.date, toDateTime(0, 'UTC'))) AS converted_date FROM s3('http://objectstorage:19000/data-.....
```
SELECT 
  toDate(ifNull(date, toDateTime(0, 'UTC'))) as converted_date
FROM redditads.campaign_report
LIMIT 1
```
And this will work:
```
SELECT toDate(coalesce(toString(date), '1970-01-01')) FROM redditads.campaign_report LIMIT 1
UNION ALL
SELECT toDate(coalesce(toString(date_start), '1970-01-01')) FROM linkedinads.campaign_stats LIMIT 1
```
<img width="717" height="203" alt="image" src="https://github.com/user-attachments/assets/9c5624ba-3450-48e6-be8c-9c12f2a81843" />

