### PR TITLE
fix: bin start after swtiching to vite

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -1,6 +1,8 @@
 procs:
     backend:
         shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-backend'
+        env:
+            POSTHOG_USE_VITE: '1'
 
     celery-worker:
         shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
@@ -13,6 +15,8 @@ procs:
 
     frontend:
         shell: './bin/start-frontend'
+        env:
+            POSTHOG_USE_VITE: '1'
 
     temporal-worker-general-purpose:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue general-purpose-task-queue'

--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -8,5 +8,8 @@ set -e
 # In particular, DEBUG=1 enables a lot of Tailwind logging we don't need, so let's set 0 instead
 export DEBUG=0
 
+# Set Vite usage flag to prevent ESBUILD script injection
+export POSTHOG_USE_VITE=1
+
 pnpm --filter=@posthog/frontend... install
 bin/turbo --filter=@posthog/frontend start-vite


### PR DESCRIPTION
## Problem
I did a oopsie and didn't properly port over bin/start --vite to normal bin/start (was missing flags `POSTHOG_USE_VITE: '1'`

context: https://github.com/PostHog/posthog/pull/38177