### PR TITLE
feat(messaging): add duplicate, enable/disable, and delete to campaign table

### DIFF
--- a/products/messaging/frontend/Campaigns/CampaignsTable.tsx
+++ b/products/messaging/frontend/Campaigns/CampaignsTable.tsx
@@ -180,6 +180,7 @@ export function CampaignsTable(): JSX.Element {
                                                 <p>
                                                     Are you sure you want to delete the campaign "
                                                     <strong>{campaign.name}</strong>"? This action cannot be undone.
+                                                    In-progress workflows will end immediately.
                                                 </p>
                                             ),
                                             primaryButton: {

--- a/products/messaging/frontend/Campaigns/CampaignsTable.tsx
+++ b/products/messaging/frontend/Campaigns/CampaignsTable.tsx
@@ -153,6 +153,11 @@ export function CampaignsTable(): JSX.Element {
                                     fullWidth
                                     status={campaign.status === 'draft' ? 'default' : 'danger'}
                                     onClick={() => toggleCampaignStatus(campaign)}
+                                    tooltip={
+                                        campaign.status === 'draft'
+                                            ? 'Enables the campaign to start sending messages'
+                                            : 'Disables the campaign from sending any new messages. In-progress workflows will end immediately.'
+                                    }
                                 >
                                     {campaign.status === 'draft' ? 'Enable' : 'Disable'}
                                 </LemonButton>

--- a/products/messaging/frontend/Campaigns/CampaignsTable.tsx
+++ b/products/messaging/frontend/Campaigns/CampaignsTable.tsx
@@ -1,7 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonDialog, LemonDivider, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { AppMetricsSparkline } from 'lib/components/AppMetrics/AppMetricsSparkline'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -66,7 +66,7 @@ function CampaignActionsSummary({ campaign }: { campaign: HogFlow }): JSX.Elemen
 export function CampaignsTable(): JSX.Element {
     useMountedLogic(campaignsLogic)
     const { campaigns, campaignsLoading } = useValues(campaignsLogic)
-    const { deleteCampaign } = useActions(campaignsLogic)
+    const { toggleCampaignStatus, duplicateCampaign, deleteCampaign } = useActions(campaignsLogic)
 
     const columns: LemonTableColumns<HogFlow> = [
         {
@@ -149,10 +149,44 @@ export function CampaignsTable(): JSX.Element {
                         overlay={
                             <>
                                 <LemonButton
+                                    data-attr="campaign-edit"
+                                    fullWidth
+                                    status={campaign.status === 'draft' ? 'default' : 'danger'}
+                                    onClick={() => toggleCampaignStatus(campaign)}
+                                >
+                                    {campaign.status === 'draft' ? 'Enable' : 'Disable'}
+                                </LemonButton>
+                                <LemonButton
+                                    data-attr="campaign-duplicate"
+                                    fullWidth
+                                    onClick={() => duplicateCampaign(campaign)}
+                                >
+                                    Duplicate
+                                </LemonButton>
+                                <LemonDivider />
+                                <LemonButton
                                     data-attr="campaign-delete"
                                     fullWidth
                                     status="danger"
-                                    onClick={() => deleteCampaign(campaign)}
+                                    onClick={() => {
+                                        LemonDialog.open({
+                                            title: 'Delete campaign',
+                                            description: (
+                                                <p>
+                                                    Are you sure you want to delete the campaign "
+                                                    <strong>{campaign.name}</strong>"? This action cannot be undone.
+                                                </p>
+                                            ),
+                                            primaryButton: {
+                                                children: 'Delete',
+                                                status: 'danger',
+                                                onClick: () => {
+                                                    deleteCampaign(campaign)
+                                                },
+                                            },
+                                            secondaryButton: { children: 'Cancel' },
+                                        })
+                                    }}
                                 >
                                     Delete
                                 </LemonButton>

--- a/products/messaging/frontend/Campaigns/campaignsLogic.ts
+++ b/products/messaging/frontend/Campaigns/campaignsLogic.ts
@@ -9,6 +9,8 @@ import type { HogFlow } from './hogflows/types'
 export const campaignsLogic = kea<campaignsLogicType>([
     path(['products', 'messaging', 'frontend', 'campaignsLogic']),
     actions({
+        toggleCampaignStatus: (campaign: HogFlow) => ({ campaign }),
+        duplicateCampaign: (campaign: HogFlow) => ({ campaign }),
         deleteCampaign: (campaign: HogFlow) => ({ campaign }),
         loadCampaigns: () => ({}),
     }),
@@ -19,6 +21,20 @@ export const campaignsLogic = kea<campaignsLogicType>([
                 loadCampaigns: async () => {
                     const response = await api.hogFlows.getHogFlows()
                     return response.results
+                },
+                toggleCampaignStatus: async ({ campaign }) => {
+                    const updatedCampaign = await api.hogFlows.updateHogFlow(campaign.id, {
+                        status: campaign.status === 'active' ? 'draft' : 'active',
+                    })
+                    return values.campaigns.map((c) => (c.id === updatedCampaign.id ? updatedCampaign : c))
+                },
+                duplicateCampaign: async ({ campaign }) => {
+                    const duplicatedCampaign = await api.hogFlows.createHogFlow({
+                        ...campaign,
+                        status: 'draft',
+                        name: `${campaign.name} (copy)`,
+                    })
+                    return [duplicatedCampaign, ...values.campaigns]
                 },
                 deleteCampaign: async ({ campaign }) => {
                     await api.hogFlows.deleteHogFlow(campaign.id)


### PR DESCRIPTION
## Problem

There's no easy way to duplicate currently, and the other options were too unpolished

## Changes
<img width="611" height="263" alt="Screenshot 2025-09-16 at 5 39 56 PM" src="https://github.com/user-attachments/assets/7bda9c63-5997-4893-b7bb-da6b56a39232" />
<img width="1260" height="397" alt="Screenshot 2025-09-16 at 5 40 02 PM" src="https://github.com/user-attachments/assets/b1cdd427-1fca-4a14-9ca1-56064e8856b7" />





## How did you test this code?

Validated behavior locally
