### PR TITLE
chore(persons): ff to test person db reads

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -267,6 +267,7 @@ export const FEATURE_FLAGS = {
     LLM_OBSERVABILITY_PLAYGROUND: 'llm-observability-playground', // owner: #team-llm-analytics
     USAGE_SPEND_DASHBOARDS: 'usage-spend-dashboards', // owner: @pawel-cebula #team-billing
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-messaging-cdp
+    PERSON_READ_TEST_FLAG: 'person-read-test-flag', // owner: @nickbest - #team-ingestion
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-messaging-cdp
     SCREENSHOT_EDITOR: 'screenshot-editor', // owner: @veryayskiy #team-replay
     ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -10,7 +10,6 @@ import { SceneDashboardChoiceModal } from 'lib/components/SceneDashboardChoice/S
 import { SceneDashboardChoiceRequired } from 'lib/components/SceneDashboardChoice/SceneDashboardChoiceRequired'
 import { sceneDashboardChoiceModalLogic } from 'lib/components/SceneDashboardChoice/sceneDashboardChoiceModalLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
@@ -43,8 +42,8 @@ export function ProjectHomepage(): JSX.Element {
     const aaTestBayesianLegacy = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_LEGACY]
     const aaTestBayesianNew = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_NEW]
 
-    // Test feature flag for validating database reads
-    const personReadTestFlag = useFeatureFlag('PERSON_READ_TEST_FLAG')
+    // #team-ingestion/nickbest TODO: remove after person database migration tests are complete
+    const personReadTestFlag = featureFlags[FEATURE_FLAGS.PERSON_READ_TEST_FLAG]
 
     const headerButtons = (
         <>

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -10,6 +10,7 @@ import { SceneDashboardChoiceModal } from 'lib/components/SceneDashboardChoice/S
 import { SceneDashboardChoiceRequired } from 'lib/components/SceneDashboardChoice/SceneDashboardChoiceRequired'
 import { sceneDashboardChoiceModalLogic } from 'lib/components/SceneDashboardChoice/sceneDashboardChoiceModalLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
@@ -42,6 +43,9 @@ export function ProjectHomepage(): JSX.Element {
     const aaTestBayesianLegacy = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_LEGACY]
     const aaTestBayesianNew = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_NEW]
 
+    // Test feature flag for validating database reads
+    const personReadTestFlag = useFeatureFlag('PERSON_READ_TEST_FLAG')
+
     const headerButtons = (
         <>
             <LemonButton
@@ -70,6 +74,14 @@ export function ProjectHomepage(): JSX.Element {
             <span className="hidden" data-attr="aa-test-flag-result">
                 AA test flag result: {String(aaTestBayesianLegacy)} {String(aaTestBayesianNew)}
             </span>
+
+            {/* Hidden element for person read feature flag validation */}
+            {personReadTestFlag && (
+                <span className="hidden" data-attr="person-read-test-flag-active">
+                    Person read test flag is active: {String(personReadTestFlag)}
+                </span>
+            )}
+
             <PageHeader buttons={headerButtons} />
             {dashboardLogicProps ? (
                 <HomeDashboard dashboardLogicProps={dashboardLogicProps} />


### PR DESCRIPTION
## Problem

During persons database migration it will be nice to verify if ff service is properly reading from the new persons database. This flag will be used to target my specific person with a specific property set. We'll trigger an event to write that property onto a person during the dual write phase, then we'll check to see if the flag evaluates to true.

## Changes

A hidden span that will exist if this feature flag evaluates to true

## How did you test this code?

Tested out the other hidden spans that already existed to make sure i could search for them through my dev tools
