### PR TITLE
feat(ux): sql editor improvements, part 1

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -9,6 +9,7 @@ import { TreeNodeDisplayIcon } from 'lib/lemon-ui/LemonTree/LemonTreeUtils'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { cn } from 'lib/utils/css-classes'
 import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsLogic'
 import { urls } from 'scenes/urls'
 
@@ -90,14 +91,19 @@ export const QueryDatabase = (): JSX.Element => {
                 return (
                     <span className="truncate">
                         {hasMatches && searchTerm ? (
-                            <SearchHighlightMultiple
-                                string={item.name}
-                                substring={searchTerm}
-                                className="font-mono text-xs"
-                            />
+                            <SearchHighlightMultiple string={item.name} substring={searchTerm} className="text-xs" />
                         ) : (
                             <div className="flex flex-row gap-1 justify-between">
-                                <span className="font-mono text-xs truncate">{item.name}</span>
+                                <span
+                                    className={cn(
+                                        ['managed-views', 'views', 'sources', 'drafts'].includes(item.record?.type) &&
+                                            'font-bold',
+                                        item.record?.type === 'column' && 'font-mono text-xs',
+                                        'truncate'
+                                    )}
+                                >
+                                    {item.name}
+                                </span>
                                 {renderTableCount(item.record?.row_count)}
                             </div>
                         )}

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -691,6 +691,9 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     })
                 }
 
+                viewsChildren.sort((a, b) => a.name.localeCompare(b.name))
+                managedViewsChildren.sort((a, b) => a.name.localeCompare(b.name))
+
                 const draftsChildren: TreeDataItem[] = []
 
                 if (featureFlags[FEATURE_FLAGS.EDITOR_DRAFTS]) {


### PR DESCRIPTION
## Problem

Starting to split out work from the SQL editor "tabless mode" big PR: https://github.com/PostHog/posthog/pull/37114

## Changes

- Improve fonts on the Database panel. Only columns remain in monospace, the rest looks consistent with other parts of the app now.
- Sort the views and managed views alphabetically.

<img width="743" height="987" alt="Screenshot 2025-09-17 at 09 46 43" src="https://github.com/user-attachments/assets/a88d5be5-4a0f-4d22-899f-255e45cdeb16" />


## Next steps

- I'll try to add the tabs you currently have open/persisted into the sidebar as "Unsaved queries".
- I'll then try to make the tabs global while changing as little in the scene as possible
- Finally we'll have a look at perhaps moving the database panel into the scene itself.

## How did you test this code?

👀 