### PR TITLE
fix: include sent_at ms in timestamp headers

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -436,9 +436,9 @@ pub fn process_single_event(
     })?;
 
     // Compute the actual event timestamp using our timestamp parsing logic
-    let sent_at_utc = context
-        .sent_at
-        .map(|sa| DateTime::from_timestamp(sa.unix_timestamp(), 0).unwrap_or_default());
+    let sent_at_utc = context.sent_at.map(|sa| {
+        DateTime::from_timestamp(sa.unix_timestamp(), sa.nanosecond()).unwrap_or_default()
+    });
     let ignore_sent_at = event
         .properties
         .get("$ignore_sent_at")
@@ -560,9 +560,9 @@ pub async fn process_replay_events<'a>(
     Span::current().record("request_id", &context.request_id);
 
     // Compute the actual event timestamp using our timestamp parsing logic from the first event
-    let sent_at_utc = context
-        .sent_at
-        .map(|sa| DateTime::from_timestamp(sa.unix_timestamp(), 0).unwrap_or_default());
+    let sent_at_utc = context.sent_at.map(|sa| {
+        DateTime::from_timestamp(sa.unix_timestamp(), sa.nanosecond()).unwrap_or_default()
+    });
     let ignore_sent_at = events[0]
         .properties
         .get("$ignore_sent_at")


### PR DESCRIPTION
## Problem

The Rust algorithm was accounting sent_at at only second-resolution.

## Changes

Increases the sent_at parsing resolution to ns.

## How did you test this code?

- Added a new test
- Will verify metrics on prod

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
