### PR TITLE
feat(data-warehouse): Use s3Cluster for large tables

### DIFF
--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -16,7 +16,12 @@ def build_function_call(
     access_secret: Optional[str] = None,
     structure: Optional[str] = None,
     context: Optional[HogQLContext] = None,
+    table_size_mib: Optional[float] = None,
 ) -> str:
+    use_s3_cluster = False
+    if table_size_mib is not None and table_size_mib >= 1024:  # 1 GiB
+        use_s3_cluster = True
+
     raw_params: dict[str, str] = {}
 
     def add_param(value: str, is_sensitive: bool = True) -> str:
@@ -45,7 +50,10 @@ def build_function_call(
         if structure:
             escaped_structure = add_param(structure, False)
 
-        expr = f"s3({escaped_url}"
+        if use_s3_cluster:
+            expr = f"s3Cluster('posthog', {escaped_url}"
+        else:
+            expr = f"s3({escaped_url}"
 
         if access_key and access_secret:
             escaped_access_key = add_param(access_key)
@@ -114,7 +122,10 @@ def build_function_call(
     if structure:
         escaped_structure = add_param(structure, False)
 
-    expr = f"s3({escaped_url}"
+    if use_s3_cluster:
+        expr = f"s3Cluster('posthog', {escaped_url}"
+    else:
+        expr = f"s3({escaped_url}"
 
     if access_key and access_secret:
         escaped_access_key = add_param(access_key)
@@ -138,6 +149,7 @@ class S3Table(FunctionCallTable):
     access_secret: Optional[str] = None
     structure: Optional[str] = None
     table_id: Optional[str] = None
+    table_size_mib: Optional[float] = None
 
     def to_printed_hogql(self):
         return escape_hogql_identifier(self.name)
@@ -150,6 +162,7 @@ class S3Table(FunctionCallTable):
             access_secret=self.access_secret,
             structure=self.structure,
             context=context,
+            table_size_mib=self.table_size_mib,
         )
 
 

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -320,3 +320,9 @@ class TestS3Table(BaseTest):
             res
             == "azureBlobStorage(%(hogql_val_0_sensitive)s, %(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s, %(hogql_val_5)s, 'auto')"
         )
+
+    def test_s3_build_function_call_with_large_table(self):
+        res = build_function_call(
+            "http://url.com", DataWarehouseTable.TableFormat.Parquet, "key", "secret", "some structure", None, 4000.0
+        )
+        assert res == "s3Cluster('posthog', 'http://url.com', 'key', 'secret', 'Parquet', 'some structure')"

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -174,6 +174,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             access_key=self.credential.access_key,
             access_secret=self.credential.access_secret,
             context=placeholder_context,
+            table_size_mib=self.size_in_s3_mib,
         )
         try:
             # chdb hangs in CI during tests
@@ -241,6 +242,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 access_key=self.credential.access_key,
                 access_secret=self.credential.access_secret,
                 context=placeholder_context,
+                table_size_mib=self.size_in_s3_mib,
             )
 
             result = sync_execute(
@@ -261,6 +263,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             access_key=self.credential.access_key,
             access_secret=self.credential.access_secret,
             context=placeholder_context,
+            table_size_mib=self.size_in_s3_mib,
         )
         try:
             # chdb hangs in CI during tests
@@ -302,6 +305,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 access_key=self.credential.access_key,
                 access_secret=self.credential.access_secret,
                 context=placeholder_context,
+                table_size_mib=self.size_in_s3_mib,
             )
 
         except Exception as err:


### PR DESCRIPTION
## Problem
- We've been using the `s3(...)` table function for running warehouse queries, this is great, but it doesnt take advantage of the fact that we have a distributed cluster 
- This wasnt possible before due to a bug in `s3Cluster` on older CH versions 

## Changes
- if a warehouse table is above 1 GiB, then use `s3Cluster(...)` instead of `s3(...)` for better performance on tables with many parquet files

## How did you test this code?
Unit test
