### PR TITLE
chore: switch quota limiting back to thread_sensitive=True

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -221,7 +221,7 @@ jobs:
             - name: Check for changes that affect general purpose temporal worker
               id: check_changes_general_purpose_temporal_worker
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/subscriptions|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/usage_reports|^posthog/temporal/quota_limiting|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/subscriptions|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/usage_reports|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Check for changes that affect billing temporal worker
               id: check_changes_billing_temporal_worker

--- a/posthog/temporal/quota_limiting/run_quota_limiting.py
+++ b/posthog/temporal/quota_limiting/run_quota_limiting.py
@@ -4,10 +4,10 @@ import dataclasses
 from datetime import timedelta
 
 import structlog
+from asgiref.sync import sync_to_async
 from temporalio import activity, common, workflow
 
 from posthog.exceptions_capture import capture_exception
-from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 
@@ -33,7 +33,7 @@ async def run_quota_limiting_all_orgs(
         try:
             from ee.billing.quota_limiting import update_all_orgs_billing_quotas
 
-            @database_sync_to_async(thread_sensitive=False)
+            @sync_to_async
             def async_update_all_orgs_billing_quotas():
                 update_all_orgs_billing_quotas()
 


### PR DESCRIPTION
## Problem

- A couple of weeks ago we switched quota limiting temporal task from using `sync_to_async` to `database_sync_to_async` with `thread_sensitive=False` so that it doesn't block DB connections ([context](https://posthog.slack.com/archives/C08ERRQT41E/p1755879652283729))

> thread_sensitive=True (the default): the sync function will run in the same thread as all other thread_sensitive functions.

> thread_sensitive=False: the sync function will run in a brand new thread which is then closed once the invocation completes.

- That change resulted in the quota limiting runs taking 2.5-3 times longer than previously, and the failure rates increased considerably
- Since then, we've moved quota limiting from the general-purpose temporal worker to a dedicated billing worker, which improved reliability but it's still taking 2.5-3 times longer per run
- I've researched `thread_sensitive=False` setting a bit and found that it's recommended to use it for CPU-bound operations (where it results in performance gains) but it's not recommended to use it with e.g. Django ORM operations as it impacts performance negatively (esp. with `"CONN_MAX_AGE": 0`) and e.g. DB adapters expect to be accessed in the same thread they were created

## Changes

- Switch back quota limiting to use `sync_to_async`, which defaults to `thread_sensitive=True`

## How did you test this code?

n/a