### PR TITLE
fix(max): exclude deleted datasets from evals

### DIFF
--- a/dags/tests/max_ai/test_run_evaluation.py
+++ b/dags/tests/max_ai/test_run_evaluation.py
@@ -1,0 +1,70 @@
+from uuid import uuid4
+
+import pytest
+from posthog.test.base import setup_test_organization_team_and_user
+from unittest.mock import patch
+
+import dagster
+
+from posthog.models import Dataset, DatasetItem
+
+from dags.max_ai.run_evaluation import prepare_dataset
+
+
+@patch("dags.max_ai.run_evaluation._get_team_id")
+@pytest.mark.django_db
+def test_prepare_dataset_handles_deleted_field_correctly(mock_get_team_id):
+    """Test that prepare_dataset correctly filters datasets and items with deleted=False or deleted=None"""
+    _, _, team, user, _ = setup_test_organization_team_and_user(
+        "test", str(uuid4()), "test_run_evaluation@test.com", "testpassword12345"
+    )
+    mock_get_team_id.return_value = team.id
+
+    # Create datasets with different deleted states
+    dataset_false = Dataset.objects.create(name="Dataset False", team=team, deleted=False, created_by=user)
+    dataset_none = Dataset.objects.create(name="Dataset None", team=team, deleted=None, created_by=user)
+    dataset_true = Dataset.objects.create(name="Dataset True", team=team, deleted=True, created_by=user)
+
+    # Create dataset items with different deleted states for each dataset
+    input = {"test": "data"}
+    output = {"output": "data"}
+    metadata = {"team_id": team.id}
+    DatasetItem.objects.create(
+        dataset=dataset_false, team=team, deleted=False, input=input, output=output, metadata=metadata
+    )
+    DatasetItem.objects.create(
+        dataset=dataset_false, team=team, deleted=None, input=input, output=output, metadata=metadata
+    )
+    DatasetItem.objects.create(
+        dataset=dataset_false, team=team, deleted=True, input=input, output=output, metadata=metadata
+    )
+
+    DatasetItem.objects.create(
+        dataset=dataset_none, team=team, deleted=False, input=input, output=output, metadata=metadata
+    )
+    DatasetItem.objects.create(
+        dataset=dataset_none, team=team, deleted=None, input=input, output=output, metadata=metadata
+    )
+    DatasetItem.objects.create(
+        dataset=dataset_none, team=team, deleted=True, input=input, output=output, metadata=metadata
+    )
+
+    context = dagster.build_op_context(op_config={"dataset_id": str(dataset_false.id)})
+    result = prepare_dataset(context)
+
+    # Should find the dataset and only non-deleted items (deleted=False or deleted=None)
+    assert result.dataset_id == dataset_false.id
+    assert result.dataset_name == "Dataset False"
+    assert len(result.dataset_inputs) == 2  # Only deleted=False and deleted=None items
+
+    context = dagster.build_op_context(op_config={"dataset_id": str(dataset_none.id)})
+    result = prepare_dataset(context)
+
+    # Should find the dataset and only non-deleted items (deleted=False or deleted=None)
+    assert result.dataset_id == dataset_none.id
+    assert result.dataset_name == "Dataset None"
+    assert len(result.dataset_inputs) == 2  # Only deleted=False and deleted=None items
+
+    context = dagster.build_op_context(op_config={"dataset_id": str(dataset_true.id)})
+    with pytest.raises(Dataset.DoesNotExist):
+        prepare_dataset(context)

--- a/ee/hogai/eval/schema.py
+++ b/ee/hogai/eval/schema.py
@@ -117,7 +117,7 @@ class GroupTypeMappingSnapshot(BaseSnapshot[GroupTypeMapping]):
 class DataWarehouseTableSnapshot(BaseSnapshot[DataWarehouseTable]):
     name: str
     format: str
-    columns: dict
+    columns: str
 
     @classmethod
     def serialize_for_team(cls, *, team_id: int):
@@ -125,7 +125,7 @@ class DataWarehouseTableSnapshot(BaseSnapshot[DataWarehouseTable]):
             yield DataWarehouseTableSnapshot(
                 name=table.name,
                 format=table.format,
-                columns=table.columns,
+                columns=json.dumps(table.columns) if table.columns else "",
             )
 
     @classmethod
@@ -134,7 +134,7 @@ class DataWarehouseTableSnapshot(BaseSnapshot[DataWarehouseTable]):
             yield DataWarehouseTable(
                 name=model.name,
                 format=model.format,
-                columns=model.columns,
+                columns=json.loads(model.columns) if model.columns else {},
                 url_pattern="http://localhost",  # Hardcoded. It's not important for evaluations what the value is.
                 team_id=team_id,
             )

--- a/ee/hogai/test/test_eval_schema.py
+++ b/ee/hogai/test/test_eval_schema.py
@@ -1,0 +1,204 @@
+import json
+from io import BytesIO
+
+from posthog.test.base import BaseTest
+
+import fastavro
+
+from posthog.models import DataWarehouseTable
+from posthog.warehouse.models import DataWarehouseCredential
+
+from ee.hogai.eval.schema import DataWarehouseTableSnapshot
+
+
+class TestEvalSchema(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.credential = DataWarehouseCredential.objects.create(
+            access_key="test_key",
+            access_secret="test_secret",
+            team=self.team,
+        )
+
+    def test_serialize_deserialize_for_team(self):
+        columns = {
+            "id": {"hogql": "IntegerDatabaseField", "valid": True, "clickhouse": "Int64"},
+        }
+        # Create test data warehouse tables
+        DataWarehouseTable.objects.create(
+            name="users_table",
+            format="Parquet",
+            team=self.team,
+            credential=self.credential,
+            url_pattern="http://example.com/users.parquet",
+            columns=columns,
+        )
+
+        DataWarehouseTable.objects.create(
+            name="events_table",
+            format="CSV",
+            team=self.team,
+            credential=self.credential,
+            url_pattern="http://example.com/events.csv",
+            columns=columns,
+        )
+
+        # Test serialization
+        snapshots = list(DataWarehouseTableSnapshot.serialize_for_team(team_id=self.team.id))
+
+        self.assertEqual(len(snapshots), 2)
+
+        # Test first table snapshot
+        self.assertEqual(snapshots[0].name, "users_table")
+        self.assertEqual(snapshots[0].format, "Parquet")
+        self.assertTrue(isinstance(snapshots[0].columns, str))
+        self.assertEqual(json.loads(snapshots[0].columns), columns)
+
+        # Test second table snapshot
+        self.assertEqual(snapshots[1].name, "events_table")
+        self.assertEqual(snapshots[1].format, "CSV")
+        self.assertTrue(isinstance(snapshots[1].columns, str))
+        self.assertEqual(json.loads(snapshots[1].columns), columns)
+
+        deserialized_snapshots = list(
+            DataWarehouseTableSnapshot.deserialize_for_team(snapshots, team_id=self.team.id, project_id=self.project.id)
+        )
+
+        self.assertEqual(len(deserialized_snapshots), 2)
+
+        self.assertEqual(deserialized_snapshots[0].name, "users_table")
+        self.assertEqual(deserialized_snapshots[0].format, "Parquet")
+        self.assertEqual(deserialized_snapshots[0].columns, columns)
+
+        self.assertEqual(deserialized_snapshots[1].name, "events_table")
+        self.assertEqual(deserialized_snapshots[1].format, "CSV")
+        self.assertEqual(deserialized_snapshots[1].columns, columns)
+
+    def test_serialize_deserialize_for_team_empty_columns(self):
+        # Create test data warehouse tables
+        DataWarehouseTable.objects.create(
+            name="users_table",
+            format="Parquet",
+            team=self.team,
+            credential=self.credential,
+            url_pattern="http://example.com/users.parquet",
+            columns=None,
+        )
+
+        snapshots = list(DataWarehouseTableSnapshot.serialize_for_team(team_id=self.team.id))
+
+        self.assertEqual(len(snapshots), 1)
+
+        self.assertEqual(snapshots[0].name, "users_table")
+        self.assertEqual(snapshots[0].format, "Parquet")
+        self.assertEqual(snapshots[0].columns, "")
+
+        deserialized_snapshots = list(
+            DataWarehouseTableSnapshot.deserialize_for_team(snapshots, team_id=self.team.id, project_id=self.project.id)
+        )
+
+        self.assertEqual(len(deserialized_snapshots), 1)
+
+        self.assertEqual(deserialized_snapshots[0].name, "users_table")
+        self.assertEqual(deserialized_snapshots[0].format, "Parquet")
+        self.assertEqual(deserialized_snapshots[0].columns, {})
+
+    def test_fastavro_serialization(self):
+        """Test that a serialized DataWarehouseTableSnapshot can be dumped with fastavro"""
+        columns = {
+            "id": {"hogql": "IntegerDatabaseField", "valid": True, "clickhouse": "Int64"},
+        }
+
+        # Create test data warehouse table
+        DataWarehouseTable.objects.create(
+            name="test_table",
+            format="Parquet",
+            team=self.team,
+            credential=self.credential,
+            url_pattern="http://example.com/test.parquet",
+            columns=columns,
+        )
+
+        # Serialize to snapshot
+        snapshots = list(DataWarehouseTableSnapshot.serialize_for_team(team_id=self.team.id))
+        self.assertEqual(len(snapshots), 1)
+        snapshot = snapshots[0]
+
+        # Get the Avro schema from the snapshot
+        avro_schema = snapshot.avro_schema()
+
+        # Test that we can serialize the snapshot to Avro using fastavro
+        buffer = BytesIO()
+
+        # Convert snapshot to dict for fastavro
+        snapshot_dict = snapshot.model_dump()
+
+        # Write to Avro format
+        fastavro.writer(buffer, avro_schema, [snapshot_dict])
+
+        # Verify we can read it back
+        buffer.seek(0)
+        reader = fastavro.reader(buffer)
+
+        # Read back the data
+        records = list(
+            DataWarehouseTableSnapshot.deserialize_for_team(
+                [DataWarehouseTableSnapshot.model_validate(record) for record in reader],
+                team_id=self.team.id,
+                project_id=self.project.id,
+            )
+        )
+        self.assertEqual(len(records), 1)
+
+        record = records[0]
+        self.assertEqual(record.name, "test_table")
+        self.assertEqual(record.format, "Parquet")
+        self.assertEqual(record.columns, columns)
+
+    def test_fastavro_serialization_empty_columns(self):
+        """Test that a serialized DataWarehouseTableSnapshot can be dumped with fastavro"""
+        # Create test data warehouse table
+        DataWarehouseTable.objects.create(
+            name="test_table",
+            format="Parquet",
+            team=self.team,
+            credential=self.credential,
+            url_pattern="http://example.com/test.parquet",
+            columns=None,
+        )
+
+        # Serialize to snapshot
+        snapshots = list(DataWarehouseTableSnapshot.serialize_for_team(team_id=self.team.id))
+        self.assertEqual(len(snapshots), 1)
+        snapshot = snapshots[0]
+
+        # Get the Avro schema from the snapshot
+        avro_schema = snapshot.avro_schema()
+
+        # Test that we can serialize the snapshot to Avro using fastavro
+        buffer = BytesIO()
+
+        # Convert snapshot to dict for fastavro
+        snapshot_dict = snapshot.model_dump()
+
+        # Write to Avro format
+        fastavro.writer(buffer, avro_schema, [snapshot_dict])
+
+        # Verify we can read it back
+        buffer.seek(0)
+        reader = fastavro.reader(buffer)
+
+        # Read back the data
+        records = list(
+            DataWarehouseTableSnapshot.deserialize_for_team(
+                [DataWarehouseTableSnapshot.model_validate(record) for record in reader],
+                team_id=self.team.id,
+                project_id=self.project.id,
+            )
+        )
+        self.assertEqual(len(records), 1)
+
+        record = records[0]
+        self.assertEqual(record.name, "test_table")
+        self.assertEqual(record.format, "Parquet")
+        self.assertEqual(record.columns, {})

--- a/ee/hogai/test/test_snapshot_loader.py
+++ b/ee/hogai/test/test_snapshot_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from io import BytesIO
 from typing import Any
 
@@ -104,8 +105,8 @@ class TestSnapshotLoader(BaseTest):
             )
             return
         if schema is DataWarehouseTableSnapshot:
-            yield DataWarehouseTableSnapshot(name="users", format="Parquet", columns={"id": "Int64"})
-            yield DataWarehouseTableSnapshot(name="orders", format="Parquet", columns={"id": "Int64"})
+            yield DataWarehouseTableSnapshot(name="users", format="Parquet", columns=json.dumps({"id": "Int64"}))
+            yield DataWarehouseTableSnapshot(name="orders", format="Parquet", columns=json.dumps({"id": "Int64"}))
             return
         if schema is TeamTaxonomyItemSnapshot:
             yield TeamTaxonomyItemSnapshot(

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -409,14 +409,16 @@ def clean_varying_query_parts(query, replace_all_numbers):
     return query
 
 
-def _setup_test_data(klass):
-    klass.organization = Organization.objects.create(name=klass.CONFIG_ORGANIZATION_NAME)
-    klass.project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=klass.organization)
-    klass.team = Team.objects.create(
-        id=klass.project.id,
-        project=klass.project,
-        organization=klass.organization,
-        api_token=klass.CONFIG_API_TOKEN,
+def setup_test_organization_team_and_user(
+    organization_name: str, team_api_token: str, user_email: str | None = None, user_password: str | None = None
+) -> tuple[Organization, Project, Team, User | None, OrganizationMembership | None]:
+    organization = Organization.objects.create(name=organization_name)
+    project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=organization)
+    team = Team.objects.create(
+        id=project.id,
+        project=project,
+        organization=organization,
+        api_token=team_api_token or str(uuid.uuid4()),
         test_account_filters=[
             {
                 "key": "email",
@@ -427,9 +429,27 @@ def _setup_test_data(klass):
         ],
         has_completed_onboarding_for={"product_analytics": True},
     )
-    if klass.CONFIG_EMAIL:
-        klass.user = User.objects.create_and_join(klass.organization, klass.CONFIG_EMAIL, klass.CONFIG_PASSWORD)
-        klass.organization_membership = klass.user.organization_memberships.get()
+    if user_email and user_password:
+        user = User.objects.create_and_join(organization, user_email, user_password)
+        organization_membership = user.organization_memberships.get()
+    else:
+        user = None
+        organization_membership = None
+    return organization, project, team, user, organization_membership
+
+
+def _setup_test_data(klass):
+    organization, team, project, user, organization_membership = setup_test_organization_team_and_user(
+        organization_name=klass.CONFIG_ORGANIZATION_NAME,
+        team_api_token=klass.CONFIG_API_TOKEN,
+        user_email=klass.CONFIG_EMAIL,
+        user_password=klass.CONFIG_PASSWORD,
+    )
+    klass.organization = organization
+    klass.project = project
+    klass.team = team
+    klass.user = user
+    klass.organization_membership = organization_membership
 
 
 class FuzzyInt(int):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -439,7 +439,7 @@ def setup_test_organization_team_and_user(
 
 
 def _setup_test_data(klass):
-    organization, team, project, user, organization_membership = setup_test_organization_team_and_user(
+    organization, project, team, user, organization_membership = setup_test_organization_team_and_user(
         organization_name=klass.CONFIG_ORGANIZATION_NAME,
         team_api_token=klass.CONFIG_API_TOKEN,
         user_email=klass.CONFIG_EMAIL,


### PR DESCRIPTION
## Problem

Datasets and dataset items are soft deleted (deleted is set to True). The ORM query was retrieving all items, which led to failures in production.

## Changes

- Exclude deleted datasets and dataset items.

## How did you test this code?

Unit tests