### PR TITLE
fix(logs): optimise logs query to use a CTE, and fix edge case bug

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -139,7 +139,7 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
             resource_attributes,
             instrumentation_scope,
             event_name
-            FROM logs
+            FROM logs, time_bucket_cte
         """
         )
         assert isinstance(query, ast.SelectQuery)
@@ -153,7 +153,7 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
         count_query = parse_select(
             f"""
             SELECT
-                [{min_or_max_if}(time_bucket, cumulative_count == 0), {min_or_max_if}(time_bucket, cumulative_count == {{limit}}) + toIntervalMinute(10)] AS time_buckets
+                arraySort([{min_or_max_if}(time_bucket, cumulative_count == 0) + toIntervalMinute({{offset_desc}}), {min_or_max_if}(time_bucket, cumulative_count == {{limit}}) + toIntervalMinute({{offset_asc}})]) AS time_buckets
             FROM
             (
                 WITH cumulative_counts AS
@@ -176,6 +176,8 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
         """,
             placeholders={
                 "limit": limit_ast,
+                "offset_desc": ast.Constant(value=10 if order_dir == "DESC" else 0),
+                "offset_asc": ast.Constant(value=10 if order_dir == "ASC" else 0),
                 "min_limit": limit_ast if order_dir == "ASC" else ast.Constant(value=0),
                 "max_limit": limit_ast if order_dir == "DESC" else ast.Constant(value=0),
                 "date_from": ast.Constant(value=self.query_date_range.date_from()),
@@ -185,20 +187,13 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
 
         # this query always parses the same so safe to ignore typing
         count_query.select_from.table.initial_select_query.ctes["cumulative_counts"].expr.where = self.where()  # type: ignore
+        query.ctes = {"time_bucket_cte": ast.CTE(name="time_buckets", cte_type="subquery", expr=count_query)}
 
         query.where = ast.And(
             exprs=[
                 self.where(),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.ArrayAccess(array=count_query, property=ast.Constant(value=1)),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.ArrayAccess(array=count_query, property=ast.Constant(value=2)),
-                ),
+                parse_expr("timestamp >= time_bucket_cte.time_buckets[1]"),
+                parse_expr("timestamp < time_bucket_cte.time_buckets[2]"),
             ]
         )
         query.order_by = [


### PR DESCRIPTION
## Problem

tidied up the logs count_query to be run as a CTE as was originally intended (it was being executed twice before)

also fixed an edge case bug where sometimes the logs search was outside the expected range

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
