### PR TITLE
fix: error tracking empty timeline

### DIFF
--- a/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
+++ b/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
@@ -26,6 +26,7 @@ function generateFallbackData(dateRange: DateRange, volumeResolution: number): S
     }
 
     const totalMs = dateTo.diff(dateFrom, 'ms')
+
     const binSize = totalMs / volumeResolution
 
     if (binSize === 0) {

--- a/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
+++ b/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
@@ -11,8 +11,12 @@ import { ERROR_TRACKING_DETAILS_RESOLUTION } from '../utils'
 
 type NotUndefined<T> = T extends undefined ? never : T
 
-function generateFallbackData(dateRange: DateRange, volumeResolution: number): SparklineData {
+function generateFallbackData(dateRange: DateRange | undefined, volumeResolution: number): SparklineData {
     const defaultData = new Array(volumeResolution).fill({ value: 0, date: new Date() })
+
+    if (!dateRange) {
+        return defaultData
+    }
 
     if (!dateRange.date_from) {
         return defaultData
@@ -51,7 +55,7 @@ function generateDataFromVolumeBuckets(
 export function useSparklineData(
     aggregations: ErrorTrackingIssueAggregations | undefined,
     volumeResolution: number,
-    dateRange: DateRange
+    dateRange?: DateRange
 ): SparklineData {
     return useMemo(() => {
         if (aggregations?.volume_buckets) {

--- a/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
+++ b/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
@@ -14,11 +14,7 @@ type NotUndefined<T> = T extends undefined ? never : T
 function generateFallbackData(dateRange: DateRange | undefined, volumeResolution: number): SparklineData {
     const defaultData = new Array(volumeResolution).fill({ value: 0, date: new Date() })
 
-    if (!dateRange) {
-        return defaultData
-    }
-
-    if (!dateRange.date_from) {
+    if (!dateRange || !dateRange.date_from) {
         return defaultData
     }
 

--- a/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
+++ b/products/error_tracking/frontend/hooks/use-sparkline-data.tsx
@@ -1,13 +1,42 @@
 import { useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { ErrorTrackingIssueAggregations } from '~/queries/schema/schema-general'
+import { dateStringToDayJs } from 'lib/utils'
+
+import { DateRange, ErrorTrackingIssueAggregations } from '~/queries/schema/schema-general'
 
 import { SparklineData } from '../components/SparklineChart/SparklineChart'
 import { errorTrackingIssueSceneLogic } from '../scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic'
 import { ERROR_TRACKING_DETAILS_RESOLUTION } from '../utils'
 
 type NotUndefined<T> = T extends undefined ? never : T
+
+function generateFallbackData(dateRange: DateRange, volumeResolution: number): SparklineData {
+    const defaultData = new Array(volumeResolution).fill({ value: 0, date: new Date() })
+
+    if (!dateRange.date_from) {
+        return defaultData
+    }
+
+    const dateFrom = dateStringToDayJs(dateRange.date_from)
+    const dateTo = dateStringToDayJs(dateRange.date_to ?? new Date().toISOString())
+
+    if (!dateFrom || !dateTo) {
+        return defaultData
+    }
+
+    const totalMs = dateTo.diff(dateFrom, 'ms')
+    const binSize = totalMs / volumeResolution
+
+    if (binSize === 0) {
+        return defaultData
+    }
+
+    return defaultData.map(({ value }, index) => ({
+        value,
+        date: dateFrom.add(index * binSize, 'ms').toDate(),
+    }))
+}
 
 function generateDataFromVolumeBuckets(
     volumeBuckets: NotUndefined<ErrorTrackingIssueAggregations['volume_buckets']>
@@ -20,17 +49,19 @@ function generateDataFromVolumeBuckets(
 
 export function useSparklineData(
     aggregations: ErrorTrackingIssueAggregations | undefined,
-    volumeResolution: number
+    volumeResolution: number,
+    dateRange: DateRange
 ): SparklineData {
     return useMemo(() => {
         if (aggregations?.volume_buckets) {
             return generateDataFromVolumeBuckets(aggregations.volume_buckets)
         }
-        return new Array(volumeResolution).fill({ value: 0, date: new Date() })
-    }, [aggregations, volumeResolution])
+
+        return generateFallbackData(dateRange, volumeResolution)
+    }, [aggregations, volumeResolution, dateRange])
 }
 
 export function useSparklineDataIssueScene(): SparklineData {
-    const { aggregations } = useValues(errorTrackingIssueSceneLogic)
-    return useSparklineData(aggregations, ERROR_TRACKING_DETAILS_RESOLUTION)
+    const { aggregations, dateRange } = useValues(errorTrackingIssueSceneLogic)
+    return useSparklineData(aggregations, ERROR_TRACKING_DETAILS_RESOLUTION, dateRange)
 }


### PR DESCRIPTION
## Problem

Right now when there are no events, timeline looks very wrong.

## Changes

| Changes |
|--------|
| Before |
| <img width="1234" height="381" alt="image" src="https://github.com/user-attachments/assets/ea2fb8cc-9677-4873-976d-4240989e863e" /> |
| After |
| <img width="1230" height="376" alt="image" src="https://github.com/user-attachments/assets/6460539f-0755-408b-b90e-18609e23c3be" /> | 

## How did you test this code?

Locally
