### PR TITLE
feat: format litellm output

### DIFF
--- a/products/llm_analytics/frontend/types.ts
+++ b/products/llm_analytics/frontend/types.ts
@@ -85,3 +85,21 @@ export interface CompatMessage extends RoleBasedMessage {
     [additionalKey: string]: any
     tool_call_id?: string
 }
+
+export interface LiteLLMChoice {
+    finish_reason: string
+    index: number
+    message: {
+        annotations?: any[]
+        content: string | null
+        function_call?: any
+        role: string
+        tool_calls?: any[] | null
+    }
+    provider_specific_fields?: Record<string, any>
+}
+
+export interface LiteLLMResponse {
+    choices?: LiteLLMChoice[]
+    [additionalKey: string]: any
+}

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -11,6 +11,8 @@ import {
     AnthropicToolResultMessage,
     CompatMessage,
     CompatToolCall,
+    LiteLLMChoice,
+    LiteLLMResponse,
     OpenAICompletionMessage,
     OpenAIToolCall,
     VercelSDKImageMessage,
@@ -214,6 +216,28 @@ export function isVercelSDKInputTextMessage(input: unknown): input is VercelSDKI
         typeof input.text === 'string'
     )
 }
+
+export function isLiteLLMChoice(input: unknown): input is LiteLLMChoice {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'finish_reason' in input &&
+        'index' in input &&
+        'message' in input &&
+        typeof input.message === 'object' &&
+        input.message !== null
+    )
+}
+
+export function isLiteLLMResponse(input: unknown): input is LiteLLMResponse {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'choices' in input &&
+        Array.isArray(input.choices) &&
+        input.choices.every(isLiteLLMChoice)
+    )
+}
 /**
  * Normalizes a message from an LLM provider into a format that is compatible with the PostHog LLM Analytics schema.
  *
@@ -248,6 +272,10 @@ export function normalizeMessage(output: unknown, defaultRole?: string): CompatM
                 content: output.content,
             },
         ]
+    }
+
+    if (isLiteLLMChoice(output)) {
+        return normalizeMessage(output.message, defaultRole)
     }
 
     // Vercel SDK
@@ -403,6 +431,10 @@ export function normalizeMessages(messages: unknown, defaultRole?: string, tools
 
     if (Array.isArray(messages)) {
         normalizedMessages.push(...messages.map((message) => normalizeMessage(message, defaultRole)).flat())
+    } else if (isLiteLLMResponse(messages)) {
+        normalizedMessages.push(
+            ...(messages.choices || []).map((choice) => normalizeMessage(choice, defaultRole)).flat()
+        )
     } else if (typeof messages === 'object' && messages && 'choices' in messages && Array.isArray(messages.choices)) {
         normalizedMessages.push(...messages.choices.map((message) => normalizeMessage(message, defaultRole)).flat())
     } else if (typeof messages === 'string') {


### PR DESCRIPTION
Adds formatting for LiteLLM's output schema. Goes from this:

<img width="702" height="719" alt="Screenshot 2025-09-17 at 14 49 33" src="https://github.com/user-attachments/assets/51f8305b-f39b-4fa7-a0a8-dff6296755c7" />

To this:

<img width="636" height="495" alt="Screenshot 2025-09-17 at 14 49 01" src="https://github.com/user-attachments/assets/7f9a2ac8-93c9-4e97-a368-2e92795bedbc" />
