### PR TITLE
fix(logs): use column CTE not subquery CTE for logs count query

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -187,19 +187,18 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
 
         # this query always parses the same so safe to ignore typing
         count_query.select_from.table.initial_select_query.ctes["cumulative_counts"].expr.where = self.where()  # type: ignore
-        query.ctes = {"time_bucket_cte": ast.CTE(name="time_buckets", cte_type="subquery", expr=count_query)}
+        query.ctes = {"time_bucket_cte": ast.CTE(name="time_buckets", cte_type="column", expr=count_query)}
 
         query.where = ast.And(
             exprs=[
                 self.where(),
-                parse_expr("timestamp >= time_bucket_cte.time_buckets[1]"),
-                parse_expr("timestamp < time_bucket_cte.time_buckets[2]"),
+                parse_expr("timestamp >= time_bucket_cte[1]"),
+                parse_expr("timestamp < time_bucket_cte[2]"),
             ]
         )
         query.order_by = [
             parse_order_expr(f"toUnixTimestamp(timestamp) {order_dir}"),
         ]
-
         return query
 
     def where(self):


### PR DESCRIPTION
## Problem

the subquery is slowwww - using column causes it to execute first and be used in the planning for the outer query, which is fast

:ihavenoideawhatimdoing:

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
