### PR TITLE
fix: Add librdkafka++1 to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,6 +209,7 @@ RUN apt-get update && \
     "gettext-base" \
     "ffmpeg=7:5.1.7-0+deb12u1" \
     "librdkafka1=2.10.1-1.cflt~deb12" \
+    "librdkafka++1=2.10.1-1.cflt~deb12" \
     "libssl-dev=3.0.17-1~deb12u2" \
     "libssl3=3.0.17-1~deb12u2" \
     && \


### PR DESCRIPTION
## Problem

Build image links librdkafka library with librdkafka++1 library available, but librdkafka++ is not present in the runtime image

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
