### PR TITLE
feat(cookieless): Make cookieless redis errors include the key

### DIFF
--- a/rust/common/cookieless/src/manager.rs
+++ b/rust/common/cookieless/src/manager.rs
@@ -40,8 +40,8 @@ pub enum CookielessManagerError {
     #[error("Invalid identify count: {0}")]
     InvalidIdentifyCount(String),
 
-    #[error("Redis error: {0}")]
-    RedisError(String),
+    #[error("Redis error(key={0}): {1}")]
+    RedisError(String, String),
 }
 
 /// Configuration for the CookielessManager
@@ -301,7 +301,7 @@ impl CookielessManager {
         let redis_key = get_redis_identifies_key(hash, team_id);
 
         // Try to get the count from Redis
-        match self.redis_client.get(redis_key).await {
+        match self.redis_client.get(redis_key.clone()).await {
             Ok(count_str) => {
                 // Parse the count string to a u64
                 count_str
@@ -314,7 +314,7 @@ impl CookielessManager {
             }
             Err(e) => {
                 // If there's a Redis error, propagate it
-                Err(CookielessManagerError::RedisError(e.to_string()))
+                Err(CookielessManagerError::RedisError(redis_key, e.to_string()))
             }
         }
     }
@@ -1087,5 +1087,33 @@ mod tests {
 
         // Check that we got a distinct ID
         assert!(result.starts_with(COOKIELESS_DISTINCT_ID_PREFIX));
+    }
+
+    #[tokio::test]
+    async fn test_includes_key_in_redis_error() {
+        // Create a mock Redis client
+        let mut mock_redis = MockRedisClient::new();
+        let hash = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let team_id = 1;
+        let redis_key = get_redis_identifies_key(&hash, team_id);
+
+        // Set up the mock to return NotFound
+        mock_redis = mock_redis.get_ret(&redis_key, Err(common_redis::CustomRedisError::Other(
+            "Some Redis error".to_string(),
+        )));
+        let redis_client = Arc::new(mock_redis);
+
+        // Create a CookielessManager
+        let config = CookielessConfig::default();
+        let manager = CookielessManager::new(config, redis_client);
+
+        // Get the error
+        let result = manager.get_identify_count(&hash, team_id).await.unwrap_err();
+
+        // Check that the error string includes the Redis key and the error message
+        let error_str = result.to_string();
+        assert!(error_str.contains(&redis_key));
+        assert!(error_str.contains("Some Redis error"));
+
     }
 }

--- a/rust/common/cookieless/src/manager.rs
+++ b/rust/common/cookieless/src/manager.rs
@@ -1099,9 +1099,12 @@ mod tests {
 
         // Set up the mock to return NotFound
         // Set up the mock to return an error
-        mock_redis = mock_redis.get_ret(&redis_key, Err(common_redis::CustomRedisError::Other(
-            "Some Redis error".to_string(),
-        )));
+        mock_redis = mock_redis.get_ret(
+            &redis_key,
+            Err(common_redis::CustomRedisError::Other(
+                "Some Redis error".to_string(),
+            )),
+        );
         let redis_client = Arc::new(mock_redis);
 
         // Create a CookielessManager
@@ -1109,12 +1112,14 @@ mod tests {
         let manager = CookielessManager::new(config, redis_client);
 
         // Get the error
-        let result = manager.get_identify_count(&hash, team_id).await.unwrap_err();
+        let result = manager
+            .get_identify_count(&hash, team_id)
+            .await
+            .unwrap_err();
 
         // Check that the error string includes the Redis key and the error message
         let error_str = result.to_string();
         assert!(error_str.contains(&redis_key));
         assert!(error_str.contains("Some Redis error"));
-
     }
 }

--- a/rust/common/cookieless/src/manager.rs
+++ b/rust/common/cookieless/src/manager.rs
@@ -1097,7 +1097,6 @@ mod tests {
         let team_id = 1;
         let redis_key = get_redis_identifies_key(&hash, team_id);
 
-        // Set up the mock to return NotFound
         // Set up the mock to return an error
         mock_redis = mock_redis.get_ret(
             &redis_key,

--- a/rust/common/cookieless/src/manager.rs
+++ b/rust/common/cookieless/src/manager.rs
@@ -1098,6 +1098,7 @@ mod tests {
         let redis_key = get_redis_identifies_key(&hash, team_id);
 
         // Set up the mock to return NotFound
+        // Set up the mock to return an error
         mock_redis = mock_redis.get_ret(&redis_key, Err(common_redis::CustomRedisError::Other(
             "Some Redis error".to_string(),
         )));

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -206,7 +206,7 @@ impl IntoResponse for FlagError {
                     // 500 Internal Server Error - server-side issues
                     err @ (CookielessManagerError::HashError(_) |
                           CookielessManagerError::ChronoError(_) |
-                          CookielessManagerError::RedisError(_) |
+                          CookielessManagerError::RedisError(_, _) |
                           CookielessManagerError::SaltCacheError(_) |
                           CookielessManagerError::InvalidIdentifyCount(_)) => {
                         tracing::error!("Internal cookieless error: {}", err);


### PR DESCRIPTION
## Problem
See https://posthog.slack.com/archives/C0185UNBSJZ/p1758121155814679?thread_ts=1758119401.856179&cid=C0185UNBSJZ

## Changes
Add the key to the logs to aid debugging.

## How did you test this code?

Added a unit test
