### PR TITLE
feat: Open specific new source docs in the sidebar

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
@@ -135,21 +135,8 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
         },
     })),
 
-    afterMount(({ actions, values, cache }) => {
-        // If a destination was set in the options, use that
-        // otherwise the default for the current scene
-        // otherwise, whatever it last was set to
-        if (values.selectedTabOptions) {
-            const initialPath = getPathFromUrl(values.selectedTabOptions)
-            actions.setInitialPath(initialPath)
-        } else if (values.sceneConfig?.defaultDocsPath) {
-            const docsPath =
-                typeof values.sceneConfig?.defaultDocsPath === 'function'
-                    ? values.sceneConfig?.defaultDocsPath()
-                    : values.sceneConfig?.defaultDocsPath
-            actions.setInitialPath(docsPath)
-        }
-
+    afterMount(async ({ actions, values, cache }) => {
+        // Set message receiver for the iframe very early on the `afterMount` hook
         cache.onWindowMessage = (event: MessageEvent): void => {
             if (event.origin === POSTHOG_WEBSITE_ORIGIN) {
                 if (event.data.type === 'internal-navigation') {
@@ -181,11 +168,26 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
         }
 
         window.addEventListener('message', cache.onWindowMessage)
+
+        // After that's set up can run stuff that's slower - such as await-ing the default docs path
+        //
+        // If a destination was set in the options, use that
+        // otherwise the default for the current scene
+        // otherwise, whatever it last was set to
+        if (values.selectedTabOptions) {
+            const initialPath = getPathFromUrl(values.selectedTabOptions)
+            actions.setInitialPath(initialPath)
+        } else if (values.sceneConfig?.defaultDocsPath) {
+            const docsPath =
+                typeof values.sceneConfig?.defaultDocsPath === 'function'
+                    ? await values.sceneConfig?.defaultDocsPath()
+                    : values.sceneConfig?.defaultDocsPath
+            actions.setInitialPath(docsPath)
+        }
     }),
 
     beforeUnmount(({ actions, values, cache }) => {
         actions.setInitialPath(values.currentPath ?? '/docs')
-
         window.removeEventListener('message', cache.onWindowMessage)
     }),
 ])

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
@@ -143,7 +143,11 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
             const initialPath = getPathFromUrl(values.selectedTabOptions)
             actions.setInitialPath(initialPath)
         } else if (values.sceneConfig?.defaultDocsPath) {
-            actions.setInitialPath(values.sceneConfig?.defaultDocsPath)
+            const docsPath =
+                typeof values.sceneConfig?.defaultDocsPath === 'function'
+                    ? values.sceneConfig?.defaultDocsPath()
+                    : values.sceneConfig?.defaultDocsPath
+            actions.setInitialPath(docsPath)
         }
 
         cache.onWindowMessage = (event: MessageEvent): void => {

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -200,7 +200,7 @@ export interface SceneConfig {
     /** Set the scope of the activity (affects activity and discussion panel) */
     activityScope?: ActivityScope | string
     /** Default docs path - what the docs side panel will open by default when this scene is active  */
-    defaultDocsPath?: string | (() => string)
+    defaultDocsPath?: string | (() => string) | (() => Promise<string>)
     /** Component import, used only in manifests */
     import?: () => Promise<any>
 }

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -199,8 +199,8 @@ export interface SceneConfig {
     projectBased?: boolean
     /** Set the scope of the activity (affects activity and discussion panel) */
     activityScope?: ActivityScope | string
-    /** Default docs path - what the docs side panel will open by default if this scene is active  */
-    defaultDocsPath?: string
+    /** Default docs path - what the docs side panel will open by default when this scene is active  */
+    defaultDocsPath?: string | (() => string)
     /** Component import, used only in manifests */
     import?: () => Promise<any>
 }

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -16,6 +16,7 @@ import { ActivityScope, ActivityTab, InsightShortId, PropertyFilterType, ReplayT
 
 import { BillingSectionId } from './billing/types'
 import { DataPipelinesSceneTab } from './data-pipelines/DataPipelinesScene'
+import { sourceWizardLogic } from './data-warehouse/new/sourceWizardLogic'
 
 export const emptySceneParams = { params: {}, searchParams: {}, hashParams: {} }
 
@@ -88,10 +89,29 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     [Scene.DataWarehouseSource]: {
         projectBased: true,
         name: 'Data warehouse source',
+        defaultDocsPath: '/docs/cdp/sources',
     },
     [Scene.DataWarehouseSourceNew]: {
         projectBased: true,
         name: 'New data warehouse source',
+        defaultDocsPath: () => {
+            try {
+                const logic = sourceWizardLogic.findMounted()
+                if (logic) {
+                    const { selectedConnector } = logic.values
+
+                    // `docsUrl` includes the full URL, we only need the pathname when opening docs in the sidepanel
+                    if (selectedConnector?.docsUrl) {
+                        const parsedUrl = new URL(selectedConnector.docsUrl)
+                        return parsedUrl.pathname
+                    }
+                }
+            } catch (error) {
+                console.error('Failed to get default docs path for new data warehouse source', error)
+            }
+
+            return '/docs/cdp/sources'
+        },
     },
     [Scene.DeadLetterQueue]: { instanceLevel: true },
     [Scene.DebugHog]: { projectBased: true, name: 'Hog Repl' },

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -16,7 +16,6 @@ import { ActivityScope, ActivityTab, InsightShortId, PropertyFilterType, ReplayT
 
 import { BillingSectionId } from './billing/types'
 import { DataPipelinesSceneTab } from './data-pipelines/DataPipelinesScene'
-import { sourceWizardLogic } from './data-warehouse/new/sourceWizardLogic'
 
 export const emptySceneParams = { params: {}, searchParams: {}, hashParams: {} }
 
@@ -94,9 +93,12 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     [Scene.DataWarehouseSourceNew]: {
         projectBased: true,
         name: 'New data warehouse source',
-        defaultDocsPath: () => {
+        defaultDocsPath: async () => {
             try {
+                // Importing here to avoid problems with importing logics from such a global file like this one
+                const { sourceWizardLogic } = await import('./data-warehouse/new/sourceWizardLogic')
                 const logic = sourceWizardLogic.findMounted()
+
                 if (logic) {
                     const { selectedConnector } = logic.values
 


### PR DESCRIPTION
Now, when we are in the `Scene.DataWarehouseSourceNew` source we'll look at the selected connector and open the appropriate sidepanel docs when clicking on the docs button.

We have appropriate error handling to avoid this from crashing and just going to the base page instead

https://www.loom.com/share/51765df5b6f847869694f5aa528b7423

Tagging the devex team too, since I've added a cool new behavior to the docs button. Should be fine!