### PR TITLE
chore: Add `omit-unchanged` option to toolbar bundle size check

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -166,6 +166,7 @@ jobs:
                   compression: 'none'
                   pattern: 'frontend/dist/toolbar.js'
                   # we only care if the toolbar will increase a lot
+                  omit-unchanged: true
                   minimum-change-threshold: 1000
 
             - name: Check toolbar for CSP eval violations


### PR DESCRIPTION
Turns out just including `minimum-change-threshold` isn't enough, we also need to enable `omit-unchanged` to get it to not comment in our PRs when we only change the toolbar by a couple KBs (which happens often because compilation is not always deterministic)

Their docs don't mention it, but you can see in https://github.com/preactjs/compressed-size-action/blob/2a937a1dd255ef04f3ee3611816b630873f5faa3/src/utils.js#L137 and https://github.com/preactjs/compressed-size-action/blob/2a937a1dd255ef04f3ee3611816b630873f5faa3/src/utils.js#L151 how `omitUnchanged` needs to be set if we don't want it to be added to the list