### PR TITLE
fix(max): nodemon restarts

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -35,8 +35,7 @@ procs:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue data-modeling-task-queue --metrics-port 8005'
 
     temporal-worker-max-ai:
-        # added a sleep to give the docker stuff time to start
-        shell: 'nodemon -e py,toml,lock --signal SIGTERM --exec "bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue max-ai-task-queue --metrics-port 8006"'
+        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue max-ai-task-queue --metrics-port 8006"'
 
     temporal-worker-tasks-agent:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue tasks-task-queue --metrics-port 8007'


### PR DESCRIPTION
## Problem

Rust has lots of lock files, so nodemon restarts the Max worker too frequently.

## Changes

- Change nodemon to watch specific folders, py files, and exclude `*.pyc`.

## How did you test this code?

N/A
