### PR TITLE
fix: disallow members from deleting org invites

### DIFF
--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -293,7 +293,7 @@ class OrganizationInviteViewSet(
     ordering = "-created_at"
 
     def dangerously_get_permissions(self):
-        if self.action == "create":
+        if self.action in ["create", "bulk"]:
             write_permissions = [
                 permission()
                 for permission in [permissions.IsAuthenticated, OrganizationMemberPermissions, UserCanInvitePermission]

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -293,13 +293,26 @@ class OrganizationInviteViewSet(
     ordering = "-created_at"
 
     def dangerously_get_permissions(self):
-        if self.action in ["create", "destroy"]:
+        if self.action == "create":
             write_permissions = [
                 permission()
                 for permission in [permissions.IsAuthenticated, OrganizationMemberPermissions, UserCanInvitePermission]
             ]
-
             return write_permissions
+
+        if self.action == "destroy":
+            # Only admins and owners can delete invites
+            from posthog.permissions import OrganizationAdminWritePermissions
+
+            delete_permissions = [
+                permission()
+                for permission in [
+                    permissions.IsAuthenticated,
+                    OrganizationMemberPermissions,
+                    OrganizationAdminWritePermissions,
+                ]
+            ]
+            return delete_permissions
 
         raise NotImplementedError()
 


### PR DESCRIPTION
## Problem

There was a mismatch between our frontend logic and our API permission checks. Our frontend hid the invite delete button from Members, but our API explicitly allowed them to delete invites.

## Changes

We now disallow Members from deleting invites.

## How did you test this code?

Tests!
