### PR TITLE
chore(propdefs): add explicit enablement flag for persons DB conn pool creation

### DIFF
--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -52,15 +52,16 @@ impl AppContext {
         // read posthog_grouptypemappings from the new persons DB. Otherwise, we
         // fall back to the std. cloud DB pool above.
         let persons_options = PgPoolOptions::new().max_connections(config.max_pg_connections);
-        let persons_pool: Option<PgPool> = if config.database_persons_url.is_some() {
-            Some(
-                persons_options
-                    .connect(config.database_persons_url.as_ref().unwrap())
-                    .await?,
-            )
-        } else {
-            None
-        };
+        let persons_pool: Option<PgPool> =
+            if config.read_groups_from_persons_db && !config.database_persons_url.is_empty() {
+                Some(
+                    persons_options
+                        .connect(&config.database_persons_url)
+                        .await?,
+                )
+            } else {
+                None
+            };
 
         let liveness: HealthRegistry = HealthRegistry::new("liveness");
         let worker_liveness = liveness

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -14,8 +14,9 @@ pub struct Config {
     #[envconfig(default = "false")]
     pub read_groups_from_persons_db: bool,
 
-    // if populated, we set up a connection pool to the new persons DB for reading group type mappings
-    pub database_persons_url: Option<String>,
+    // connection string for the new persons DB; unused if not enabled with read_groups_from_persons_db
+    #[envconfig(default = "")]
+    pub database_persons_url: String,
 
     #[envconfig(default = "10")]
     pub max_pg_connections: u32,


### PR DESCRIPTION
## Problem
Now that we don't need to separate conn pool creation in prod from read enablement, we can consolidate enablement behind one env var 

## Changes
* Update conditional connection pool creation for persons DB in propdefs svc

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
