### PR TITLE
feat(experiments): add "How to read results" tooltip

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -303,6 +303,7 @@ export const FEATURE_FLAGS = {
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     ADVANCED_ACTIVITY_LOGS: 'advanced-activity-logs', // owner: @yasen-posthog #team-platform-features
     SIMPLIFIED_PRELAUNCH_CHECKLIST: 'simplified-prelaunch-checklist', // owner: @jurajmajerik #team-experiments
+    HOW_TO_READ_METRICS_EXPLANATION: 'how-to-read-metrics-explanation', // owner: @jurajmajerik #team-experiments
     DWH_JOIN_TABLE_PREVIEW: 'dwh-join-table-preview', // owner: @arthurdedeus #team-crm
     DASHBOARD_TILE_OVERRIDES: 'dashboard-tile-overrides', // owner: @gesh #team-product-analytics
     REPLAY_HOVER_UI: 'replay-hover-ui', // owner: @pauldambra #team-replay

--- a/frontend/src/scenes/experiments/MetricsView/new/HowToReadTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/HowToReadTooltip.tsx
@@ -1,0 +1,97 @@
+import { useValues } from 'kea'
+
+import { IconTrending } from '@posthog/icons'
+import { LemonDivider, Tooltip } from '@posthog/lemon-ui'
+
+import { Link } from 'lib/lemon-ui/Link'
+import { IconTrendingDown } from 'lib/lemon-ui/icons'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+import { ExperimentStatsMethod } from '~/types'
+
+import { experimentLogic } from '../../experimentLogic'
+
+export function HowToReadTooltip(): JSX.Element {
+    const { statsMethod } = useValues(experimentLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
+
+    return (
+        <>
+            <LemonDivider vertical className="mx-2" />
+            <Tooltip
+                title={
+                    <div className="p-2">
+                        <p className="mb-3 font-semibold">Is my variant significant?</p>
+                        <p className="mb-3">
+                            Look at the <strong>Delta column</strong> for each variant:
+                        </p>
+                        <div className="mb-3 space-y-2">
+                            <div className="flex items-center gap-3">
+                                <span
+                                    className="inline-flex items-center gap-1 w-20 font-semibold"
+                                    style={{ color: isDarkModeOn ? '#388600' : 'rgb(5, 223, 114)' }}
+                                >
+                                    <IconTrending className="w-3 h-3" />
+                                    Green
+                                </span>
+                                <span>Variant won</span>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <span
+                                    className="inline-flex items-center gap-1 w-20 font-semibold"
+                                    style={{ color: isDarkModeOn ? '#df4b20' : 'rgb(255, 102, 102)' }}
+                                >
+                                    <IconTrendingDown className="w-3 h-3" />
+                                    Red
+                                </span>
+                                <span>Variant lost</span>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <span className="inline-flex items-center gap-1 w-20 font-semibold">No color</span>
+                                <span>Not statistically significant</span>
+                            </div>
+                        </div>
+                        <img
+                            src={
+                                isDarkModeOn
+                                    ? 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/sig_light_2_4f2a9648ec.png'
+                                    : 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/sign_dark_2_ce4e9018ad.png'
+                            }
+                            width={350}
+                            className="rounded border object-contain mb-3"
+                            alt="Significance indicators example"
+                        />
+                        <p className="mb-3">
+                            The bars show{' '}
+                            {statsMethod === ExperimentStatsMethod.Bayesian
+                                ? '95% credible intervals'
+                                : '95% confidence intervals'}
+                            . When an interval doesn't cross the 0% line, the result is significant.
+                        </p>
+                        <img
+                            src={
+                                isDarkModeOn
+                                    ? statsMethod === ExperimentStatsMethod.Bayesian
+                                        ? 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/interval_bayesian_light_cc0eab723d.png'
+                                        : 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/interval_frequentist_light_de8a266b6f.png'
+                                    : statsMethod === ExperimentStatsMethod.Bayesian
+                                      ? 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/interval_b_1d344c42f6.png'
+                                      : 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/interval_f_9b8ae12438.png'
+                            }
+                            width={350}
+                            className="rounded border object-contain mb-2"
+                            alt="How to read metrics"
+                        />
+                        <p className="text-sm mb-0">
+                            <Link to="https://posthog.com/docs/experiments/analyzing-results">
+                                Learn more about analyzing results
+                            </Link>
+                        </p>
+                    </div>
+                }
+            >
+                <span className="text-xs text-secondary cursor-help">How to read</span>
+            </Tooltip>
+        </>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconInfo, IconList } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
 
 import { ExperimentMetric } from '~/queries/schema/schema-general'
@@ -11,6 +12,7 @@ import { experimentLogic } from '../../experimentLogic'
 import { modalsLogic } from '../../modalsLogic'
 import { MetricsReorderModal } from '../MetricsReorderModal'
 import { AddPrimaryMetric, AddSecondaryMetric } from '../shared/AddMetric'
+import { HowToReadTooltip } from './HowToReadTooltip'
 import { MetricsTable } from './MetricsTable'
 import { ResultDetails } from './ResultDetails'
 
@@ -24,6 +26,7 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
         secondaryMetricsResultsErrors,
         primaryMetricsResultsErrors,
         hasMinimumExposureForResults,
+        featureFlags,
     } = useValues(experimentLogic)
 
     const { openPrimaryMetricsReorderModal, openSecondaryMetricsReorderModal } = useActions(modalsLogic)
@@ -63,6 +66,10 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
     const errors = metrics.map((metric) => errorsMap.get(metric.uuid))
 
     const showResultDetails = metrics.length === 1 && results[0] && hasMinimumExposureForResults && !isSecondary
+    const hasSomeResults =
+        results?.some((result) => result?.variant_results && result.variant_results.length > 0) &&
+        hasMinimumExposureForResults
+    const hasHowToReadTooltip = featureFlags[FEATURE_FLAGS.HOW_TO_READ_METRICS_EXPLANATION] === 'test'
 
     return (
         <div className="mb-4 -mt-2">
@@ -89,6 +96,7 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                                 <IconInfo className="text-secondary text-lg" />
                             </Tooltip>
                         )}
+                        {hasSomeResults && !isSecondary && hasHowToReadTooltip && <HowToReadTooltip />}
                     </div>
                 </div>
 


### PR DESCRIPTION
## Changes
In the legacy results view, we had a "How to read" tooltip to help explain how to interpret results. I've now brought it back in the new metrics view, with an improved design.

I also thought it would be interesting to run an [experiment](https://us.posthog.com/project/2/experiments/164933) on this, so I’m shipping it behind a flag.

<img width="678" height="626" alt="image" src="https://github.com/user-attachments/assets/1a394610-a14f-413d-9319-2575349772d2" />