### PR TITLE
feat: replace staging tables in pre-agg v2

### DIFF
--- a/dags/web_preaggregated.py
+++ b/dags/web_preaggregated.py
@@ -8,7 +8,12 @@ from dagster import BackfillPolicy, DailyPartitionsDefinition
 from posthog.clickhouse import query_tagging
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.cluster import ClickhouseCluster
-from posthog.models.web_preaggregated.sql import WEB_BOUNCES_INSERT_SQL, WEB_STATS_INSERT_SQL
+from posthog.models.web_preaggregated.sql import (
+    REPLACE_WEB_BOUNCES_V2_STAGING_SQL,
+    REPLACE_WEB_STATS_V2_STAGING_SQL,
+    WEB_BOUNCES_INSERT_SQL,
+    WEB_STATS_INSERT_SQL,
+)
 
 from dags.common import JobOwners, dagster_tags
 from dags.web_preaggregated_utils import (
@@ -19,8 +24,8 @@ from dags.web_preaggregated_utils import (
     WEB_PRE_AGGREGATED_CLICKHOUSE_SETTINGS,
     check_for_concurrent_runs,
     clear_all_staging_partitions,
-    drop_partitions_for_date_range,
     merge_clickhouse_settings,
+    recreate_staging_table,
     swap_partitions_from_staging,
     web_analytics_retry_policy_def,
 )
@@ -29,6 +34,11 @@ MAX_PARTITIONS_PER_RUN_ENV_VAR = "DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_R
 max_partitions_per_run = int(os.getenv(MAX_PARTITIONS_PER_RUN_ENV_VAR, 1))
 backfill_policy_def = BackfillPolicy.multi_run(max_partitions_per_run=max_partitions_per_run)
 partition_def = DailyPartitionsDefinition(start_date="2024-01-01", end_offset=1)
+
+REPLACE_TEMPLATES_BY_STAGING_TABLE_NAME = {
+    "web_pre_aggregated_stats_staging": REPLACE_WEB_STATS_V2_STAGING_SQL,
+    "web_pre_aggregated_bounces_staging": REPLACE_WEB_BOUNCES_V2_STAGING_SQL,
+}
 
 
 def pre_aggregate_web_analytics_data(
@@ -54,9 +64,12 @@ def pre_aggregate_web_analytics_data(
     staging_table_name = f"{table_name}_staging"
 
     try:
-        # 1. Clean staging table partitions for the date range
-        context.log.info(f"Cleaning staging partitions for {date_start} to {date_end}")
-        drop_partitions_for_date_range(context, cluster, staging_table_name, date_start, date_end)
+        # 1. Recreate staging table (replaces partition cleaning)
+        if staging_table_name not in REPLACE_TEMPLATES_BY_STAGING_TABLE_NAME:
+            raise dagster.Failure(f"No REPLACE TABLE function found for {staging_table_name}")
+
+        replace_sql_func = REPLACE_TEMPLATES_BY_STAGING_TABLE_NAME[staging_table_name]
+        recreate_staging_table(context, cluster, staging_table_name, replace_sql_func)
 
         # 2. Generate hourly data into staging table
         insert_query = sql_generator(
@@ -75,10 +88,6 @@ def pre_aggregate_web_analytics_data(
         # 3. Atomically swap partitions from staging to target
         context.log.info(f"Swapping partitions from {staging_table_name} to {table_name}")
         swap_partitions_from_staging(context, cluster, table_name, staging_table_name)
-
-        # 4. Clean up staging partitions to speed up next run
-        context.log.info(f"Cleaning up staging partitions")
-        drop_partitions_for_date_range(context, cluster, staging_table_name, date_start, date_end)
 
     except Exception as e:
         raise dagster.Failure(f"Failed to pre-aggregate data {table_name}: {str(e)}") from e

--- a/dags/web_preaggregated.py
+++ b/dags/web_preaggregated.py
@@ -24,7 +24,6 @@ from dags.web_preaggregated_utils import (
     WEB_PRE_AGGREGATED_CLICKHOUSE_SETTINGS,
     check_for_concurrent_runs,
     clear_all_staging_partitions,
-    drop_partitions_for_date_range,
     merge_clickhouse_settings,
     recreate_staging_table,
     swap_partitions_from_staging,
@@ -86,12 +85,7 @@ def pre_aggregate_web_analytics_data(
         context.log.info(insert_query)
         sync_execute(insert_query)
 
-        # 3. Drop partitions from destination table for the date range
-        # This is hopefully temporary as we're facing a problem on the v2 that some days are getting a high % difference on the data accuracy.
-        context.log.info(f"Dropping partitions from destination table {table_name} for {date_start} to {date_end}")
-        drop_partitions_for_date_range(context, cluster, table_name, date_start, date_end)
-
-        # 4. Atomically swap partitions from staging to target
+        # 3. Atomically swap partitions from staging to target
         context.log.info(f"Swapping partitions from {staging_table_name} to {table_name}")
         swap_partitions_from_staging(context, cluster, table_name, staging_table_name)
 

--- a/dags/web_preaggregated.py
+++ b/dags/web_preaggregated.py
@@ -24,6 +24,7 @@ from dags.web_preaggregated_utils import (
     WEB_PRE_AGGREGATED_CLICKHOUSE_SETTINGS,
     check_for_concurrent_runs,
     clear_all_staging_partitions,
+    drop_partitions_for_date_range,
     merge_clickhouse_settings,
     recreate_staging_table,
     swap_partitions_from_staging,
@@ -85,7 +86,12 @@ def pre_aggregate_web_analytics_data(
         context.log.info(insert_query)
         sync_execute(insert_query)
 
-        # 3. Atomically swap partitions from staging to target
+        # 3. Drop partitions from destination table for the date range
+        # This is hopefully temporary as we're facing a problem on the v2 that some days are getting a high % difference on the data accuracy.
+        context.log.info(f"Dropping partitions from destination table {table_name} for {date_start} to {date_end}")
+        drop_partitions_for_date_range(context, cluster, table_name, date_start, date_end)
+
+        # 4. Atomically swap partitions from staging to target
         context.log.info(f"Swapping partitions from {staging_table_name} to {table_name}")
         swap_partitions_from_staging(context, cluster, table_name, staging_table_name)
 

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -116,6 +116,28 @@ def REPLACE_WEB_STATS_HOURLY_STAGING_SQL():
     )
 
 
+def REPLACE_WEB_STATS_V2_STAGING_SQL():
+    return TABLE_TEMPLATE(
+        "web_pre_aggregated_stats_staging",
+        WEB_STATS_COLUMNS,
+        WEB_STATS_ORDER_BY_FUNC("period_bucket"),
+        force_unique_zk_path=True,
+        replace=True,
+        on_cluster=False,
+    )
+
+
+def REPLACE_WEB_BOUNCES_V2_STAGING_SQL():
+    return TABLE_TEMPLATE(
+        "web_pre_aggregated_bounces_staging",
+        WEB_BOUNCES_COLUMNS,
+        WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
+        force_unique_zk_path=True,
+        replace=True,
+        on_cluster=False,
+    )
+
+
 WEB_ANALYTICS_DIMENSIONS = [
     "entry_pathname",
     "end_pathname",


### PR DESCRIPTION
## Problem

We've been seeing weird data consistency issues in v2 web analytics pre-aggregation where values can differ wildly from source data (sometimes up to 40%). After digging into our sql to generate the data and compare it step by step, we found some days were very close (0.1%) and others had the up to 40% diff. I still could not find any clear reason for that since running the SQL query to generate that day would match the values.

Things I crossed out:

- Dagster partition defs jumping days or mixing the timestamps
- Boundary effects (Could still happen, but not for event-level metrics)
- Multiple partitions/parts attached
- Epoch partitions/period_buckets inflating data
- Errors/excpetions on backfill being swallowed

The **really weird** part is that re-running the same job multiple times would randomly fix some days but not others 🤷‍♂️

This suggests something funky is probably happening with ClickHouse replication or metadata/partition swap. Since v1 tables don't seem to have this issue (or not as much), let's copy what works there - specifically the staging table recreation approach from PR #37928 that fixed similar cluster performance issues.

## Changes

- Replacing the tables like we did v1.

## How did you test this code?

- Manually running it locally