### PR TITLE
fix: use paginator to read and migrate teams in smaller batches

### DIFF
--- a/posthog/management/commands/migrate_replay_retention.py
+++ b/posthog/management/commands/migrate_replay_retention.py
@@ -21,6 +21,8 @@ class Command(BaseCommand):
                 self.style.SUCCESS("Starting Replay retention migration" + (" (DRY RUN)" if dry_run else ""))
             )
 
+            total_teams_migrated = 0
+
             queryset = (
                 Team.objects.filter(session_recording_retention_period="legacy")
                 .order_by("id")
@@ -46,9 +48,11 @@ class Command(BaseCommand):
                         ["session_recording_retention_period"],
                     )
 
+                total_teams_migrated += len(teams_to_migrate)
+
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Success - {len(teams_to_migrate)} teams migrated" + (" (DRY RUN)" if dry_run else "")
+                    f"Success - {total_teams_migrated} teams migrated" + (" (DRY RUN)" if dry_run else "")
                 )
             )
         except Exception as e:

--- a/posthog/management/commands/migrate_replay_retention.py
+++ b/posthog/management/commands/migrate_replay_retention.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from django.core.paginator import Paginator
 
 from posthog.constants import AvailableFeature
 from posthog.models.team import Team
@@ -14,27 +15,36 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         batch_size = options["batch_size"]
-        teams_to_migrate = []
 
         try:
             self.stdout.write(
                 self.style.SUCCESS("Starting Replay retention migration" + (" (DRY RUN)" if dry_run else ""))
             )
 
-            for team in Team.objects.filter(session_recording_retention_period="legacy").only(
-                "id", "organization", "session_recording_retention_period"
-            ):
-                # NOTE: We use file export as a proxy to see if they are subbed to Recordings
-                is_paid = team.organization.is_feature_available(AvailableFeature.RECORDINGS_FILE_EXPORT)
-                team.session_recording_retention_period = "90d" if is_paid else "30d"
+            queryset = (
+                Team.objects.filter(session_recording_retention_period="legacy")
+                .order_by("id")
+                .only("id", "organization", "session_recording_retention_period")
+            )
 
-                teams_to_migrate.append(team)
-                self.stdout.write(self.style.SUCCESS(f"{'Would migrate' if dry_run else 'Migrating'} team {team.id}"))
+            for batch in Paginator(queryset, batch_size):
+                teams_to_migrate = []
+                for team in batch.object_list:
+                    # NOTE: We use file export as a proxy to see if they are subbed to Recordings
+                    is_paid = team.organization.is_feature_available(AvailableFeature.RECORDINGS_FILE_EXPORT)
+                    team.session_recording_retention_period = "90d" if is_paid else "30d"
 
-            if not dry_run:
-                Team.objects.bulk_update(
-                    teams_to_migrate, ["session_recording_retention_period"], batch_size=batch_size
-                )
+                    teams_to_migrate.append(team)
+                    self.stdout.write(
+                        self.style.SUCCESS(f"{'Would migrate' if dry_run else 'Migrating'} team {team.id}")
+                    )
+
+                if not dry_run:
+                    self.stdout.write(self.style.SUCCESS(f"Writing batch..."))
+                    Team.objects.bulk_update(
+                        teams_to_migrate,
+                        ["session_recording_retention_period"],
+                    )
 
             self.stdout.write(
                 self.style.SUCCESS(


### PR DESCRIPTION
Problem: Migrating all 200k teams in one go is too memory intensive for a standard toolbox pod

Fix: Use pagination to migrate teams in smaller batches