### PR TITLE
fix(onboarding): delay opening side panel to prevent race condition

### DIFF
--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -316,7 +316,11 @@ export const onboardingLogic = kea<onboardingLogicType>([
             }
 
             if (values.isFirstProductOnboarding && !values.modalMode) {
-                actions.openSidePanel(SidePanelTab.Activation)
+                // Because the side panel opening has it's own actionToUrl,
+                // we delay opening it to avoid a race condition with the updateCurrentTeamSuccess redirect
+                setTimeout(() => {
+                    actions.openSidePanel(SidePanelTab.Activation)
+                }, 100)
             }
         },
         skipOnboarding: () => {

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -316,7 +316,7 @@ export const onboardingLogic = kea<onboardingLogicType>([
             }
 
             if (values.isFirstProductOnboarding && !values.modalMode) {
-                // Because the side panel opening has it's own actionToUrl,
+                // Because the side panel opening has its own actionToUrl,
                 // we delay opening it to avoid a race condition with the updateCurrentTeamSuccess redirect
                 setTimeout(() => {
                     actions.openSidePanel(SidePanelTab.Activation)


### PR DESCRIPTION
## Problem

When completing onboarding, the user needs to press the "Finish" button twice to complete onboarding. This seems to be caused by a race condition between the `urlToAction` triggered by opening the sidepanel, and the page to redirect to after completing onboarding which is set in `updateCurrentTeamSuccess` .  

![2025-09-17 14 02 47](https://github.com/user-attachments/assets/f72dc665-c1a3-406f-80f7-24efc3262e6c)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Because the side panel opening has it's own actionToUrl, we delay opening it to avoid a race condition with the updateCurrentTeamSuccess redirect. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually. While I could not exactly reproduce the described problem, not having this fix caused the invite teammates page to flash white briefly. Applying this fix did resolve that issue.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
