### PR TITLE
fix(data-warehouse): Fix updating tables

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1079,6 +1079,7 @@ posthog/warehouse/api/external_data_source.py:0: error: Incompatible return valu
 posthog/warehouse/api/lineage.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
 posthog/warehouse/api/lineage.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
 posthog/warehouse/api/table.py:0: error: Item "None" of "Any | None" has no attribute "keys"  [union-attr]
+posthog/warehouse/api/table.py:0: error: Item "Sequence[Any]" of "Any | Sequence[Any]" has no attribute "name"  [union-attr]
 posthog/warehouse/api/table.py:0: error: Unsupported target for indexed assignment ("Any | None")  [index]
 posthog/warehouse/api/table.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/warehouse/api/table.py:0: error: Value of type "Any | None" is not indexable  [index]

--- a/posthog/warehouse/api/table.py
+++ b/posthog/warehouse/api/table.py
@@ -121,9 +121,10 @@ class TableSerializer(serializers.ModelSerializer):
         return table
 
     def validate_name(self, name):
-        name_exists_in_hogql_database = self.context["database"].has_table(name)
-        if name_exists_in_hogql_database:
-            raise serializers.ValidationError("A table with this name already exists.")
+        if not self.instance or (self.instance and self.instance.name != name):
+            name_exists_in_hogql_database = self.context["database"].has_table(name)
+            if name_exists_in_hogql_database:
+                raise serializers.ValidationError("A table with this name already exists.")
 
         return name
 

--- a/posthog/warehouse/api/table.py
+++ b/posthog/warehouse/api/table.py
@@ -121,7 +121,7 @@ class TableSerializer(serializers.ModelSerializer):
         return table
 
     def validate_name(self, name):
-        if not self.instance or (self.instance and self.instance.name != name):
+        if not self.instance or self.instance.name != name:
             name_exists_in_hogql_database = self.context["database"].has_table(name)
             if name_exists_in_hogql_database:
                 raise serializers.ValidationError("A table with this name already exists.")

--- a/posthog/warehouse/api/test/test_table.py
+++ b/posthog/warehouse/api/test/test_table.py
@@ -347,6 +347,19 @@ class TestTable(APIBaseTest):
         assert response.status_code == 400
         assert response.json()["detail"] == "A table with this name already exists."
 
+    def test_update_table_name_to_same_name(self):
+        table = DataWarehouseTable.objects.create(
+            name="test_table", format="Parquet", team=self.team, team_id=self.team.pk, columns={}
+        )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/warehouse_tables/{table.id}",
+            {
+                "name": "test_table",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "test_table"
+
     def test_update_table_name(self):
         table = DataWarehouseTable.objects.create(
             name="test_table", format="Parquet", team=self.team, team_id=self.team.pk, columns={}


### PR DESCRIPTION
## Problem
- https://posthoghelp.zendesk.com/agent/tickets/38028 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38288)
- Updating a self managed table with new credentials would throw an error saying the table name already exists 

## Changes
- Dont raise a name validation error when you're updating a table and not changing the name

## How did you test this code?
- Tested loclaly + added a test
