### PR TITLE
feat(llma): Add timestamp to trace span details

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay.tsx
@@ -40,6 +40,7 @@ export function ConversationDisplay({ eventProperties }: { eventProperties: Even
                     totalCostUsd={eventProperties.$ai_total_cost_usd}
                     model={eventProperties.$ai_model}
                     latency={eventProperties.$ai_latency}
+                    timestamp={eventProperties.timestamp}
                 />
 
                 {showPlaygroundButton && (

--- a/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
@@ -36,11 +36,7 @@ export function MetadataHeader({
             {typeof latency === 'number' && (
                 <MetadataTag label="Latency">{`${Math.round(latency * 10e2) / 10e2} s of latency`}</MetadataTag>
             )}
-            {timestamp && (
-                <MetadataTag label="Timestamp">
-                    {dayjs(timestamp).format('MMM D, YYYY h:mm A')}
-                </MetadataTag>
-            )}
+            {timestamp && <MetadataTag label="Timestamp">{dayjs(timestamp).format('MMM D, YYYY h:mm A')}</MetadataTag>}
             {typeof inputTokens === 'number' && typeof outputTokens === 'number' && (
                 <MetadataTag label="Token usage">
                     {`${inputTokens} prompt tokens → ${outputTokens} completion tokens (∑ ${

--- a/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/MetadataHeader.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 
 import { LemonTag } from '@posthog/lemon-ui'
 
+import { dayjs } from 'lib/dayjs'
 import { lowercaseFirstLetter } from 'lib/utils'
 
 import { MetadataTag } from '../components/MetadataTag'
@@ -16,6 +17,7 @@ export function MetadataHeader({
     isError,
     cacheReadTokens,
     cacheWriteTokens,
+    timestamp,
 }: {
     inputTokens?: number
     outputTokens?: number
@@ -26,12 +28,18 @@ export function MetadataHeader({
     latency?: number
     isError?: boolean
     className?: string
+    timestamp?: string
 }): JSX.Element {
     return (
         <div className={classNames('flex flex-wrap gap-2', className)}>
             {isError && <LemonTag type="danger">Error</LemonTag>}
             {typeof latency === 'number' && (
                 <MetadataTag label="Latency">{`${Math.round(latency * 10e2) / 10e2} s of latency`}</MetadataTag>
+            )}
+            {timestamp && (
+                <MetadataTag label="Timestamp">
+                    {dayjs(timestamp).format('MMM D, YYYY h:mm A')}
+                </MetadataTag>
             )}
             {typeof inputTokens === 'number' && typeof outputTokens === 'number' && (
                 <MetadataTag label="Token usage">

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -584,6 +584,7 @@ const EventContent = React.memo(
                                     totalCostUsd={event.properties.$ai_total_cost_usd}
                                     model={event.properties.$ai_model}
                                     latency={event.properties.$ai_latency}
+                                    timestamp={event.createdAt}
                                 />
                             ) : (
                                 <MetadataHeader
@@ -591,6 +592,7 @@ const EventContent = React.memo(
                                     outputTokens={event.outputTokens}
                                     totalCostUsd={event.totalCost}
                                     latency={event.totalLatency}
+                                    timestamp={event.createdAt}
                                 />
                             )}
                             {isLLMTraceEvent(event) && <ParametersHeader eventProperties={event.properties} />}


### PR DESCRIPTION
## Problem

Users currently lack a visible timestamp for LLM traces and spans, requiring them to inspect raw event data to find this information. [See Slack thread.](https://posthog.slack.com/archives/C087XQ7K9K7/p1757412451769539)

## Changes

Adds a timestamp display next to the latency in the LLM trace/span details. Format inspired by the `detailedTime()` util, but without seconds.