### PR TITLE
fix(data-warehouse): Dont try to serialize a deleted table

### DIFF
--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -106,6 +106,9 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
         if not hogql_context:
             hogql_context = create_hogql_database(team_id=self.context["team_id"])
 
+        if schema.table and schema.table.deleted:
+            return None
+
         return SimpleTableSerializer(schema.table, context={"database": hogql_context}).data or None
 
     def get_sync_frequency(self, schema: ExternalDataSchema):


### PR DESCRIPTION
## Problem
- https://posthoghelp.zendesk.com/agent/tickets/38109 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/38297)
- Trying to serialize a deleted table raises an error 

## Changes
- Dont serialize a deleted table 🤔 
