### PR TITLE
feat(insight): persist detailed results table aggregation

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -23593,11 +23593,6 @@
                 "computedAs": {
                     "$ref": "#/definitions/StickinessComputationMode"
                 },
-                "detailedResultsAggregationType": {
-                    "description": "detailed results table",
-                    "enum": ["total", "average", "median"],
-                    "type": "string"
-                },
                 "display": {
                     "$ref": "#/definitions/ChartDisplayType"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -23593,6 +23593,11 @@
                 "computedAs": {
                     "$ref": "#/definitions/StickinessComputationMode"
                 },
+                "detailedResultsAggregationType": {
+                    "description": "detailed results table",
+                    "enum": ["total", "average", "median"],
+                    "type": "string"
+                },
                 "display": {
                     "$ref": "#/definitions/ChartDisplayType"
                 },
@@ -24745,6 +24750,11 @@
                 },
                 "decimalPlaces": {
                     "type": "number"
+                },
+                "detailedResultsAggregationType": {
+                    "description": "detailed results table",
+                    "enum": ["total", "average", "median"],
+                    "type": "string"
                 },
                 "display": {
                     "$ref": "#/definitions/ChartDisplayType",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1461,8 +1461,6 @@ export type StickinessFilter = {
     resultCustomizations?:
         | Record<string, ResultCustomizationByValue>
         | Record<numerical_key, ResultCustomizationByPosition>
-    /** detailed results table */
-    detailedResultsAggregationType?: 'total' | 'average' | 'median'
 }
 
 export const STICKINESS_FILTER_PROPERTIES = new Set<keyof StickinessFilter>([

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1127,6 +1127,8 @@ export type TrendsFilter = {
     showTrendLines?: boolean
     showMovingAverage?: boolean
     movingAverageIntervals?: number
+    /** detailed results table */
+    detailedResultsAggregationType?: 'total' | 'average' | 'median'
 }
 
 export type CalendarHeatmapFilter = {
@@ -1459,6 +1461,8 @@ export type StickinessFilter = {
     resultCustomizations?:
         | Record<string, ResultCustomizationByValue>
         | Record<numerical_key, ResultCustomizationByPosition>
+    /** detailed results table */
+    detailedResultsAggregationType?: 'total' | 'average' | 'median'
 }
 
 export const STICKINESS_FILTER_PROPERTIES = new Set<keyof StickinessFilter>([

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -235,9 +235,6 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                 if (isTrendsQuery(querySource)) {
                     return querySource.trendsFilter?.detailedResultsAggregationType as AggregationType | undefined
                 }
-                if (isStickinessQuery(querySource)) {
-                    return querySource.stickinessFilter?.detailedResultsAggregationType as AggregationType | undefined
-                }
             },
         ],
         funnelsFilter: [(s) => [s.querySource], (q) => (isFunnelsQuery(q) ? q.funnelsFilter : null)],

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -17,6 +17,7 @@ import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { getClampedFunnelStepRange } from 'scenes/funnels/funnelUtils'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
+import { AggregationType } from 'scenes/insights/views/InsightsTable/insightsTableDataLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 import { BASE_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
@@ -114,6 +115,9 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         setTimedOutQueryId: (id: string | null) => ({ id }),
         setIsIntervalManuallySet: (isIntervalManuallySet: boolean) => ({ isIntervalManuallySet }),
         toggleFormulaMode: true,
+        setDetailedResultsAggregationType: (aggregationType: AggregationType) => ({
+            aggregationType,
+        }),
     }),
 
     reducers({
@@ -225,6 +229,17 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         goalLines: [(s) => [s.querySource], (q) => (isTrendsQuery(q) || isFunnelsQuery(q) ? getGoalLines(q) : null)],
         insightFilter: [(s) => [s.querySource], (q) => (q ? filterForQuery(q) : null)],
         trendsFilter: [(s) => [s.querySource], (q) => (isTrendsQuery(q) ? q.trendsFilter : null)],
+        detailedResultsAggregationType: [
+            (s) => [s.querySource],
+            (querySource) => {
+                if (isTrendsQuery(querySource)) {
+                    return querySource.trendsFilter?.detailedResultsAggregationType
+                }
+                if (isStickinessQuery(querySource)) {
+                    return querySource.stickinessFilter?.detailedResultsAggregationType
+                }
+            },
+        ],
         funnelsFilter: [(s) => [s.querySource], (q) => (isFunnelsQuery(q) ? q.funnelsFilter : null)],
         retentionFilter: [(s) => [s.querySource], (q) => (isRetentionQuery(q) ? q.retentionFilter : null)],
         pathsFilter: [(s) => [s.querySource], (q) => (isPathsQuery(q) ? q.pathsFilter : null)],
@@ -566,6 +581,12 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         // insight filter properties
         updateDisplay: ({ display }) => {
             actions.updateInsightFilter({ display })
+        },
+
+        setDetailedResultsAggregationType: ({ aggregationType }) => {
+            actions.updateInsightFilter({
+                detailedResultsAggregationType: aggregationType,
+            })
         },
 
         // data loading side effects i.e. displaying loading screens for queries with longer duration

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -231,12 +231,12 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         trendsFilter: [(s) => [s.querySource], (q) => (isTrendsQuery(q) ? q.trendsFilter : null)],
         detailedResultsAggregationType: [
             (s) => [s.querySource],
-            (querySource) => {
+            (querySource): AggregationType | undefined => {
                 if (isTrendsQuery(querySource)) {
-                    return querySource.trendsFilter?.detailedResultsAggregationType
+                    return querySource.trendsFilter?.detailedResultsAggregationType as AggregationType | undefined
                 }
                 if (isStickinessQuery(querySource)) {
-                    return querySource.stickinessFilter?.detailedResultsAggregationType
+                    return querySource.stickinessFilter?.detailedResultsAggregationType as AggregationType | undefined
                 }
             },
         ],

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -115,8 +115,8 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         setTimedOutQueryId: (id: string | null) => ({ id }),
         setIsIntervalManuallySet: (isIntervalManuallySet: boolean) => ({ isIntervalManuallySet }),
         toggleFormulaMode: true,
-        setDetailedResultsAggregationType: (aggregationType: AggregationType) => ({
-            aggregationType,
+        setDetailedResultsAggregationType: (detailedResultsAggregationType: AggregationType) => ({
+            detailedResultsAggregationType,
         }),
     }),
 

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -583,9 +583,9 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             actions.updateInsightFilter({ display })
         },
 
-        setDetailedResultsAggregationType: ({ aggregationType }) => {
+        setDetailedResultsAggregationType: ({ detailedResultsAggregationType }) => {
             actions.updateInsightFilter({
-                detailedResultsAggregationType: aggregationType,
+                detailedResultsAggregationType: detailedResultsAggregationType,
             })
         },
 

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -166,6 +166,7 @@ export const cleanInsightQuery = (query: InsightQueryNode, opts?: CompareQueryOp
             showMovingAverage: undefined,
             movingAverageIntervals: undefined,
             stacked: undefined,
+            detailedResultsAggregationType: undefined,
         }
 
         cleanedQuery.dataColorTheme = undefined

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -89,7 +89,7 @@ export function InsightsTable({
     } = useValues(trendsDataLogic(insightProps))
     const { toggleResultHidden, toggleAllResultsHidden } = useActions(trendsDataLogic(insightProps))
     const { aggregation, allowAggregation } = useValues(insightsTableDataLogic(insightProps))
-    const { setAggregationType } = useActions(insightsTableDataLogic(insightProps))
+    const { setDetailedResultsAggregationType } = useActions(insightsTableDataLogic(insightProps))
     const { weekStartDay, timezone } = useValues(teamLogic)
 
     const handleSeriesEditClick = (item: IndexedTrendResult): void => {
@@ -251,7 +251,9 @@ export function InsightsTable({
                 <AggregationColumnTitle
                     isNonTimeSeriesDisplay={isNonTimeSeriesDisplay}
                     aggregation={aggregation}
-                    setAggregationType={(state: CalcColumnState) => setAggregationType(state as AggregationType)}
+                    setAggregationType={(state: CalcColumnState) =>
+                        setDetailedResultsAggregationType(state as AggregationType)
+                    }
                 />
             ),
             render: (_: any, item: IndexedTrendResult) => (

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.test.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.test.ts
@@ -99,13 +99,21 @@ describe('insightsTableDataLogic', () => {
             const query: TrendsQuery = {
                 kind: NodeKind.TrendsQuery,
                 series: [{ kind: NodeKind.EventsNode, event: '$pageview', math: BaseMathType.TotalCount }],
+                trendsFilter: {},
             }
 
-            insightVizDataLogic(props).actions.updateQuerySource(query)
+            // Make sure insightVizDataLogic is mounted
+            const vizLogic = insightVizDataLogic(props)
+            vizLogic.mount()
 
-            await expectLogic(logic, () => {
-                logic.actions.setAggregationType(AggregationType.Median)
-            }).toMatchValues({
+            vizLogic.actions.updateQuerySource(query)
+
+            // Wait for the async updateInsightFilter to complete
+            await expectLogic(vizLogic, () => {
+                logic.actions.setDetailedResultsAggregationType(AggregationType.Median)
+            }).toFinishAllListeners()
+
+            await expectLogic(logic).toMatchValues({
                 aggregation: AggregationType.Median,
             })
         })

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
+import { connect, kea, key, path, props, selectors } from 'kea'
 
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -19,21 +19,12 @@ export const insightsTableDataLogic = kea<insightsTableDataLogicType>([
     path((key) => ['scenes', 'insights', 'InsightsTable', 'insightsTableDataLogic', key]),
 
     connect((props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['isTrends', 'display', 'series']],
-    })),
-
-    actions({
-        setAggregationType: (type: AggregationType) => ({ type }),
-    }),
-
-    reducers({
-        aggregationType: [
-            null as AggregationType | null,
-            {
-                setAggregationType: (_, { type }) => type,
-            },
+        values: [
+            insightVizDataLogic(props),
+            ['isTrends', 'display', 'series', 'detailedResultsAggregationType as persistedAggregationType'],
         ],
-    }),
+        actions: [insightVizDataLogic(props), ['setDetailedResultsAggregationType']],
+    })),
 
     selectors({
         /** Only allow table aggregation options when the math is total volume
@@ -50,14 +41,14 @@ export const insightsTableDataLogic = kea<insightsTableDataLogicType>([
             },
         ],
         aggregation: [
-            (s) => [s.series, s.aggregationType],
-            (series, aggregationType) => {
-                if (aggregationType === null) {
-                    const hasMathUniqueFilter = !!series?.find(({ math }) => math === 'dau')
-                    return hasMathUniqueFilter ? AggregationType.Average : AggregationType.Total
+            (s) => [s.series, s.persistedAggregationType],
+            (series, persistedAggregationType) => {
+                if (persistedAggregationType) {
+                    return persistedAggregationType
                 }
 
-                return aggregationType
+                const hasMathUniqueFilter = !!series?.find(({ math }) => math === 'dau')
+                return hasMathUniqueFilter ? AggregationType.Average : AggregationType.Total
             },
         ],
     }),

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2501,12 +2501,6 @@ class StickinessComputationMode(StrEnum):
     CUMULATIVE = "cumulative"
 
 
-class DetailedResultsAggregationType(StrEnum):
-    TOTAL = "total"
-    AVERAGE = "average"
-    MEDIAN = "median"
-
-
 class StickinessFilterLegacy(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -2686,6 +2680,12 @@ class TimelineEntry(BaseModel):
     events: list[EventType]
     recording_duration_s: Optional[float] = Field(default=None, description="Duration of the recording in seconds.")
     sessionId: Optional[str] = Field(default=None, description="Session ID. None means out-of-session events")
+
+
+class DetailedResultsAggregationType(StrEnum):
+    TOTAL = "total"
+    AVERAGE = "average"
+    MEDIAN = "median"
 
 
 class TrendsFilterLegacy(BaseModel):
@@ -4744,9 +4744,6 @@ class StickinessFilter(BaseModel):
         extra="forbid",
     )
     computedAs: Optional[StickinessComputationMode] = None
-    detailedResultsAggregationType: Optional[DetailedResultsAggregationType] = Field(
-        default=None, description="detailed results table"
-    )
     display: Optional[ChartDisplayType] = None
     hiddenLegendIndexes: Optional[list[int]] = None
     resultCustomizationBy: Optional[ResultCustomizationBy] = Field(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2501,6 +2501,12 @@ class StickinessComputationMode(StrEnum):
     CUMULATIVE = "cumulative"
 
 
+class DetailedResultsAggregationType(StrEnum):
+    TOTAL = "total"
+    AVERAGE = "average"
+    MEDIAN = "median"
+
+
 class StickinessFilterLegacy(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4738,6 +4744,9 @@ class StickinessFilter(BaseModel):
         extra="forbid",
     )
     computedAs: Optional[StickinessComputationMode] = None
+    detailedResultsAggregationType: Optional[DetailedResultsAggregationType] = Field(
+        default=None, description="detailed results table"
+    )
     display: Optional[ChartDisplayType] = None
     hiddenLegendIndexes: Optional[list[int]] = None
     resultCustomizationBy: Optional[ResultCustomizationBy] = Field(
@@ -5008,6 +5017,9 @@ class TrendsFilter(BaseModel):
     breakdown_histogram_bin_count: Optional[float] = None
     confidenceLevel: Optional[float] = None
     decimalPlaces: Optional[float] = None
+    detailedResultsAggregationType: Optional[DetailedResultsAggregationType] = Field(
+        default=None, description="detailed results table"
+    )
     display: Optional[ChartDisplayType] = ChartDisplayType.ACTIONS_LINE_GRAPH
     formula: Optional[str] = None
     formulaNodes: Optional[list[TrendsFormulaNode]] = Field(

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -108,6 +108,7 @@ def to_dict(query: BaseModel) -> dict:
                         "showMovingAverage",
                         "movingAverageIntervals",
                         "stacked",
+                        "detailedResultsAggregationType",
                     ]
                 }
 


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/37955 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39097)

## Changes
Saves the aggregation you use in the detailed results table
<img width="587" height="240" alt="image" src="https://github.com/user-attachments/assets/1f9db114-8866-42b0-9e31-530da238c0bd" />


## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
