### PR TITLE
fix: insight name/description autosave debounce

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -331,7 +331,16 @@ function SceneDescription({
                         )}
                         markdown={markdown}
                         placeholder={emptyText}
-                        onBlur={() => !forceEdit && setIsEditing(false)}
+                        onBlur={() => {
+                            // Save changes when leaving the field
+                            if (onChange && description !== initialDescription) {
+                                onChange(description || '')
+                            }
+                            // Exit edit mode if not forced
+                            if (!forceEdit) {
+                                setIsEditing(false)
+                            }
+                        }}
                         autoFocus={!forceEdit}
                     />
                 ) : (

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -59,6 +59,12 @@ type SceneMainTitleProps = {
      */
     renameDebounceMs?: number
     /**
+     * If true, saves only on blur (when leaving the field)
+     * If false, saves on every change (debounced) - original behavior
+     * @default false
+     */
+    saveOnBlur?: boolean
+    /**
      * If true, the actions from PageHeader will be shown
      * @default false
      */
@@ -81,6 +87,7 @@ export function SceneTitleSection({
     canEdit = false,
     forceEdit = false,
     renameDebounceMs,
+    saveOnBlur = false,
     actions = true,
     forceBackTo,
 }: SceneMainTitleProps): JSX.Element | null {
@@ -124,6 +131,7 @@ export function SceneTitleSection({
                             canEdit={canEdit}
                             forceEdit={forceEdit}
                             renameDebounceMs={renameDebounceMs}
+                            saveOnBlur={saveOnBlur}
                         />
                     </div>
                     {/* If we're not showing breadcrumbs, we want to show the actions inline with the title */}
@@ -141,6 +149,7 @@ export function SceneTitleSection({
                             canEdit={canEdit}
                             forceEdit={forceEdit}
                             renameDebounceMs={renameDebounceMs}
+                            saveOnBlur={saveOnBlur}
                         />
                     </div>
                 )}
@@ -156,6 +165,7 @@ type SceneNameProps = {
     canEdit?: boolean
     forceEdit?: boolean
     renameDebounceMs?: number
+    saveOnBlur?: boolean
 }
 
 function SceneName({
@@ -165,6 +175,7 @@ function SceneName({
     canEdit = false,
     forceEdit = false,
     renameDebounceMs = 100,
+    saveOnBlur = false,
 }: SceneNameProps): JSX.Element {
     const [name, setName] = useState(initialName)
     const [isEditing, setIsEditing] = useState(forceEdit)
@@ -192,6 +203,12 @@ function SceneName({
         }
     }, renameDebounceMs)
 
+    const debouncedOnChange = useDebouncedCallback((value: string) => {
+        if (onChange) {
+            onChange(value)
+        }
+    }, renameDebounceMs)
+
     // If onBlur is provided, we want to show a button that allows the user to edit the name
     // Otherwise, we want to show the name as a text
     const Element =
@@ -204,6 +221,9 @@ function SceneName({
                         value={name || ''}
                         onChange={(e) => {
                             setName(e.target.value)
+                            if (!saveOnBlur) {
+                                debouncedOnChange(e.target.value)
+                            }
                         }}
                         data-attr="scene-title-textarea"
                         className={cn(
@@ -216,8 +236,8 @@ function SceneName({
                         )}
                         placeholder="Enter name"
                         onBlur={() => {
-                            // Save changes when leaving the field (debounced)
-                            if (name !== initialName) {
+                            // Save changes when leaving the field (only if saveOnBlur is true)
+                            if (saveOnBlur && name !== initialName) {
                                 debouncedOnBlurSave(name || '')
                             }
                             // Exit edit mode if not forced
@@ -277,6 +297,7 @@ type SceneDescriptionProps = {
     canEdit?: boolean
     forceEdit?: boolean
     renameDebounceMs?: number
+    saveOnBlur?: boolean
 }
 
 function SceneDescription({
@@ -287,6 +308,7 @@ function SceneDescription({
     canEdit = false,
     forceEdit = false,
     renameDebounceMs = 100,
+    saveOnBlur = false,
 }: SceneDescriptionProps): JSX.Element | null {
     const [description, setDescription] = useState(initialDescription)
     const [isEditing, setIsEditing] = useState(forceEdit)
@@ -315,6 +337,12 @@ function SceneDescription({
         }
     }, renameDebounceMs)
 
+    const debouncedOnDescriptionChange = useDebouncedCallback((value: string) => {
+        if (onChange) {
+            onChange(value)
+        }
+    }, renameDebounceMs)
+
     const Element =
         onChange && canEdit ? (
             <>
@@ -325,6 +353,9 @@ function SceneDescription({
                         value={description || ''}
                         onChange={(e) => {
                             setDescription(e.target.value)
+                            if (!saveOnBlur) {
+                                debouncedOnDescriptionChange(e.target.value)
+                            }
                         }}
                         data-attr="scene-description-textarea"
                         className={cn(
@@ -338,8 +369,8 @@ function SceneDescription({
                         markdown={markdown}
                         placeholder={emptyText}
                         onBlur={() => {
-                            // Save changes when leaving the field (debounced)
-                            if (description !== initialDescription) {
+                            // Save changes when leaving the field (only if saveOnBlur is true)
+                            if (saveOnBlur && description !== initialDescription) {
                                 debouncedOnBlurSaveDescription(description || '')
                             }
                             // Exit edit mode if not forced

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -1,6 +1,5 @@
 import { useValues } from 'kea'
 import { useEffect, useState } from 'react'
-import { useDebouncedCallback } from 'use-debounce'
 
 import { IconPencil } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
@@ -57,7 +56,6 @@ type SceneMainTitleProps = {
      * e.g. insights are renamed too fast, so we need to debounce it with 1000ms
      * @default 100
      */
-    renameDebounceMs?: number
     /**
      * If true, the actions from PageHeader will be shown
      * @default false
@@ -80,7 +78,6 @@ export function SceneTitleSection({
     onDescriptionChange,
     canEdit = false,
     forceEdit = false,
-    renameDebounceMs,
     actions = true,
     forceBackTo,
 }: SceneMainTitleProps): JSX.Element | null {
@@ -123,7 +120,6 @@ export function SceneTitleSection({
                             onChange={onNameChange}
                             canEdit={canEdit}
                             forceEdit={forceEdit}
-                            renameDebounceMs={renameDebounceMs}
                         />
                     </div>
                     {/* If we're not showing breadcrumbs, we want to show the actions inline with the title */}
@@ -140,7 +136,6 @@ export function SceneTitleSection({
                             onChange={onDescriptionChange}
                             canEdit={canEdit}
                             forceEdit={forceEdit}
-                            renameDebounceMs={renameDebounceMs}
                         />
                     </div>
                 )}
@@ -155,7 +150,6 @@ type SceneNameProps = {
     onChange?: (value: string) => void
     canEdit?: boolean
     forceEdit?: boolean
-    renameDebounceMs?: number
 }
 
 function SceneName({
@@ -164,7 +158,6 @@ function SceneName({
     onChange,
     canEdit = false,
     forceEdit = false,
-    renameDebounceMs = 100,
 }: SceneNameProps): JSX.Element {
     const [name, setName] = useState(initialName)
     const [isEditing, setIsEditing] = useState(forceEdit)
@@ -186,8 +179,6 @@ function SceneName({
         }
     }, [isLoading, forceEdit])
 
-    const debouncedOnChange = useDebouncedCallback(onChange || (() => {}), renameDebounceMs)
-
     // If onBlur is provided, we want to show a button that allows the user to edit the name
     // Otherwise, we want to show the name as a text
     const Element =
@@ -200,7 +191,6 @@ function SceneName({
                         value={name || ''}
                         onChange={(e) => {
                             setName(e.target.value)
-                            debouncedOnChange(e.target.value)
                         }}
                         data-attr="scene-title-textarea"
                         className={cn(
@@ -273,7 +263,6 @@ type SceneDescriptionProps = {
     onChange?: (value: string) => void
     canEdit?: boolean
     forceEdit?: boolean
-    renameDebounceMs?: number
 }
 
 function SceneDescription({
@@ -283,7 +272,6 @@ function SceneDescription({
     onChange,
     canEdit = false,
     forceEdit = false,
-    renameDebounceMs = 100,
 }: SceneDescriptionProps): JSX.Element | null {
     const [description, setDescription] = useState(initialDescription)
     const [isEditing, setIsEditing] = useState(forceEdit)
@@ -306,8 +294,6 @@ function SceneDescription({
         }
     }, [isLoading, forceEdit])
 
-    const debouncedOnDescriptionChange = useDebouncedCallback(onChange || (() => {}), renameDebounceMs)
-
     const Element =
         onChange && canEdit ? (
             <>
@@ -318,7 +304,6 @@ function SceneDescription({
                         value={description || ''}
                         onChange={(e) => {
                             setDescription(e.target.value)
-                            debouncedOnDescriptionChange(e.target.value)
                         }}
                         data-attr="scene-description-textarea"
                         className={cn(

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -212,7 +212,16 @@ function SceneName({
                             '[&_.LemonIcon]:size-4'
                         )}
                         placeholder="Enter name"
-                        onBlur={() => !forceEdit && setIsEditing(false)}
+                        onBlur={() => {
+                            // Save changes when leaving the field
+                            if (onChange && name !== initialName) {
+                                onChange(name || '')
+                            }
+                            // Exit edit mode if not forced
+                            if (!forceEdit) {
+                                setIsEditing(false)
+                            }
+                        }}
                         autoFocus={!forceEdit}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter') {

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 import { useEffect, useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
 
 import { IconPencil } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
@@ -56,6 +57,7 @@ type SceneMainTitleProps = {
      * e.g. insights are renamed too fast, so we need to debounce it with 1000ms
      * @default 100
      */
+    renameDebounceMs?: number
     /**
      * If true, the actions from PageHeader will be shown
      * @default false
@@ -78,6 +80,7 @@ export function SceneTitleSection({
     onDescriptionChange,
     canEdit = false,
     forceEdit = false,
+    renameDebounceMs,
     actions = true,
     forceBackTo,
 }: SceneMainTitleProps): JSX.Element | null {
@@ -120,6 +123,7 @@ export function SceneTitleSection({
                             onChange={onNameChange}
                             canEdit={canEdit}
                             forceEdit={forceEdit}
+                            renameDebounceMs={renameDebounceMs}
                         />
                     </div>
                     {/* If we're not showing breadcrumbs, we want to show the actions inline with the title */}
@@ -136,6 +140,7 @@ export function SceneTitleSection({
                             onChange={onDescriptionChange}
                             canEdit={canEdit}
                             forceEdit={forceEdit}
+                            renameDebounceMs={renameDebounceMs}
                         />
                     </div>
                 )}
@@ -150,6 +155,7 @@ type SceneNameProps = {
     onChange?: (value: string) => void
     canEdit?: boolean
     forceEdit?: boolean
+    renameDebounceMs?: number
 }
 
 function SceneName({
@@ -158,6 +164,7 @@ function SceneName({
     onChange,
     canEdit = false,
     forceEdit = false,
+    renameDebounceMs = 100,
 }: SceneNameProps): JSX.Element {
     const [name, setName] = useState(initialName)
     const [isEditing, setIsEditing] = useState(forceEdit)
@@ -178,6 +185,12 @@ function SceneName({
             setIsEditing(false)
         }
     }, [isLoading, forceEdit])
+
+    const debouncedOnBlurSave = useDebouncedCallback((value: string) => {
+        if (onChange) {
+            onChange(value)
+        }
+    }, renameDebounceMs)
 
     // If onBlur is provided, we want to show a button that allows the user to edit the name
     // Otherwise, we want to show the name as a text
@@ -203,9 +216,9 @@ function SceneName({
                         )}
                         placeholder="Enter name"
                         onBlur={() => {
-                            // Save changes when leaving the field
-                            if (onChange && name !== initialName) {
-                                onChange(name || '')
+                            // Save changes when leaving the field (debounced)
+                            if (name !== initialName) {
+                                debouncedOnBlurSave(name || '')
                             }
                             // Exit edit mode if not forced
                             if (!forceEdit) {
@@ -263,6 +276,7 @@ type SceneDescriptionProps = {
     onChange?: (value: string) => void
     canEdit?: boolean
     forceEdit?: boolean
+    renameDebounceMs?: number
 }
 
 function SceneDescription({
@@ -272,6 +286,7 @@ function SceneDescription({
     onChange,
     canEdit = false,
     forceEdit = false,
+    renameDebounceMs = 100,
 }: SceneDescriptionProps): JSX.Element | null {
     const [description, setDescription] = useState(initialDescription)
     const [isEditing, setIsEditing] = useState(forceEdit)
@@ -293,6 +308,12 @@ function SceneDescription({
             setIsEditing(false)
         }
     }, [isLoading, forceEdit])
+
+    const debouncedOnBlurSave = useDebouncedCallback((value: string) => {
+        if (onChange) {
+            onChange(value)
+        }
+    }, renameDebounceMs)
 
     const Element =
         onChange && canEdit ? (
@@ -317,9 +338,9 @@ function SceneDescription({
                         markdown={markdown}
                         placeholder={emptyText}
                         onBlur={() => {
-                            // Save changes when leaving the field
-                            if (onChange && description !== initialDescription) {
-                                onChange(description || '')
+                            // Save changes when leaving the field (debounced)
+                            if (description !== initialDescription) {
+                                debouncedOnBlurSave(description || '')
                             }
                             // Exit edit mode if not forced
                             if (!forceEdit) {

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -309,7 +309,7 @@ function SceneDescription({
         }
     }, [isLoading, forceEdit])
 
-    const debouncedOnBlurSave = useDebouncedCallback((value: string) => {
+    const debouncedOnBlurSaveDescription = useDebouncedCallback((value: string) => {
         if (onChange) {
             onChange(value)
         }
@@ -340,7 +340,7 @@ function SceneDescription({
                         onBlur={() => {
                             // Save changes when leaving the field (debounced)
                             if (description !== initialDescription) {
-                                debouncedOnBlurSave(description || '')
+                                debouncedOnBlurSaveDescription(description || '')
                             }
                             // Exit edit mode if not forced
                             if (!forceEdit) {

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -556,6 +556,8 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 forceEdit={insightMode === ItemMode.Edit}
                 // Renaming insights is too fast, so we need to debounce it
                 renameDebounceMs={1000}
+                // Use onBlur-only saves to prevent autosave while typing
+                saveOnBlur={true}
             />
             <SceneDivider />
         </>


### PR DESCRIPTION
## Problem

Insights were saving the name/description too quickly onChange, making it annoying to edit them

## Changes

This removes the save for `onChange` and uses `onBlur` with debounce for both name and description in insights. It keeps the save on save too.

## How did you test this code?

Locally