### PR TITLE
fix(insights): Fix disabled chart controls after discard overrides

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -399,10 +399,13 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
         isUsingPathsV1: [(s) => [s.featureFlags], (featureFlags) => !featureFlags[FEATURE_FLAGS.PATHS_V2]],
         isUsingPathsV2: [(s) => [s.featureFlags], (featureFlags) => featureFlags[FEATURE_FLAGS.PATHS_V2]],
         hasOverrides: [
-            () => [(_, props) => props],
-            (props) =>
-                (isObject(props.filtersOverride) && !isEmptyObject(props.filtersOverride)) ||
-                (isObject(props.variablesOverride) && !isEmptyObject(props.variablesOverride)),
+            () => [(_, props) => props.filtersOverride, (_, props) => props.variablesOverride],
+            (filtersOverride: DashboardFilter | null, variablesOverride: Record<string, HogQLVariable> | null) => {
+                return (
+                    (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
+                    (isObject(variablesOverride) && !isEmptyObject(variablesOverride))
+                )
+            },
         ],
         editingDisabledReason: [
             (s) => [s.hasOverrides],


### PR DESCRIPTION
## Problem

Discarding filters overrides for an insight does not enable the chart controls (date filters, etc).

## How did you test this code?

Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
