### PR TITLE
fix: add max_table_size_to_drop = 0 to drop table migration

### DIFF
--- a/posthog/clickhouse/migrations/0146_drop_session_replay_events_v2_test_table.py
+++ b/posthog/clickhouse/migrations/0146_drop_session_replay_events_v2_test_table.py
@@ -5,7 +5,9 @@ from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 operations = [
     run_sql_with_exceptions("DROP TABLE IF EXISTS session_replay_events_v2_test_mv"),
     run_sql_with_exceptions("DROP TABLE IF EXISTS kafka_session_replay_events_v2_test"),
-    run_sql_with_exceptions("DROP TABLE IF EXISTS sharded_session_replay_events_v2_test"),
+    run_sql_with_exceptions(
+        "DROP TABLE IF EXISTS sharded_session_replay_events_v2_test SETTINGS max_table_size_to_drop = 0"
+    ),
     run_sql_with_exceptions("DROP TABLE IF EXISTS writable_session_replay_events_v2_test"),
     run_sql_with_exceptions(
         "DROP TABLE IF EXISTS session_replay_events_v2_test SETTINGS max_table_size_to_drop = 0",

--- a/posthog/clickhouse/migrations/0146_drop_session_replay_events_v2_test_table.py
+++ b/posthog/clickhouse/migrations/0146_drop_session_replay_events_v2_test_table.py
@@ -8,6 +8,7 @@ operations = [
     run_sql_with_exceptions("DROP TABLE IF EXISTS sharded_session_replay_events_v2_test"),
     run_sql_with_exceptions("DROP TABLE IF EXISTS writable_session_replay_events_v2_test"),
     run_sql_with_exceptions(
-        "DROP TABLE IF EXISTS session_replay_events_v2_test", node_roles=[NodeRole.DATA, NodeRole.COORDINATOR]
+        "DROP TABLE IF EXISTS session_replay_events_v2_test SETTINGS max_table_size_to_drop = 0",
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
     ),
 ]


### PR DESCRIPTION
fixes a broken migration that hangs right now because of drop table safeguards
https://clickhouse.com/docs/operations/server-configuration-parameters/settings#max_table_size_to_drop
