### PR TITLE
test(batch-exports): Speed up batch exports API tests

### DIFF
--- a/posthog/api/test/batch_exports/backfills/test_cancel.py
+++ b/posthog/api/test/batch_exports/backfills/test_cancel.py
@@ -8,8 +8,6 @@ from unittest.mock import patch
 
 from django.test.client import Client as HttpClient
 
-from posthog.api.test.batch_exports.conftest import start_test_worker
-from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import (
     backfill_batch_export_ok,
     cancel_batch_export_backfill_ok,
@@ -17,8 +15,6 @@ from posthog.api.test.batch_exports.operations import (
     get_batch_export_backfill_ok,
     list_batch_export_backfills_ok,
 )
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
 
 
 def wait_for_backfill_creation(client: HttpClient, team_id: int, batch_export_id: str):
@@ -37,7 +33,7 @@ def wait_for_backfill_creation(client: HttpClient, team_id: int, batch_export_id
 
 
 @pytest.mark.django_db(transaction=True)
-def test_cancelling_a_batch_export_backfill(client: HttpClient, temporal):
+def test_cancelling_a_batch_export_backfill(client: HttpClient, organization, team, user, temporal):
     """Test cancelling a BatchExportBackfill."""
     destination_data = {
         "type": "S3",
@@ -55,9 +51,6 @@ def test_cancelling_a_batch_export_backfill(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     with patch("products.batch_exports.backend.temporal.pipeline.producer.Producer.start") as mock_producer_start:
@@ -67,33 +60,31 @@ def test_cancelling_a_batch_export_backfill(client: HttpClient, temporal):
             return None
 
         mock_producer_start.side_effect = mock_sleep
+        batch_export = create_batch_export_ok(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+        batch_export_id = batch_export["id"]
 
-        with start_test_worker(temporal):
-            batch_export = create_batch_export_ok(
-                client,
-                team.pk,
-                batch_export_data,
-            )
-            batch_export_id = batch_export["id"]
+        start_at = "2023-10-23T00:00:00+00:00"
+        end_at = "2023-10-24T00:00:00+00:00"
+        # ensure there is data to backfill, otherwise validation will fail
+        _create_event(
+            team=team,
+            event="$pageview",
+            distinct_id="person_1",
+            timestamp=dt.datetime(2023, 10, 23, 0, 1, 0, tzinfo=dt.UTC),
+        )
+        backfill_batch_export_ok(client, team.pk, batch_export_id, start_at, end_at)
 
-            start_at = "2023-10-23T00:00:00+00:00"
-            end_at = "2023-10-24T00:00:00+00:00"
-            # ensure there is data to backfill, otherwise validation will fail
-            _create_event(
-                team=team,
-                event="$pageview",
-                distinct_id="person_1",
-                timestamp=dt.datetime(2023, 10, 23, 0, 1, 0, tzinfo=dt.UTC),
-            )
-            backfill_batch_export_ok(client, team.pk, batch_export_id, start_at, end_at)
+        # backfill model is created as part of a temporal activity, so we need to wait for it to be created
+        backfill_data = wait_for_backfill_creation(client, team.pk, batch_export_id)
+        assert backfill_data["status"] == "Running"
+        backfill_id = backfill_data["id"]
 
-            # backfill model is created as part of a temporal activity, so we need to wait for it to be created
-            backfill_data = wait_for_backfill_creation(client, team.pk, batch_export_id)
-            assert backfill_data["status"] == "Running"
-            backfill_id = backfill_data["id"]
+        data = cancel_batch_export_backfill_ok(client, team.pk, batch_export_id, backfill_id)
+        assert data["cancelled"] is True
 
-            data = cancel_batch_export_backfill_ok(client, team.pk, batch_export_id, backfill_id)
-            assert data["cancelled"] is True
-
-            backfill_data = get_batch_export_backfill_ok(client, team.pk, batch_export_id, backfill_id)
-            assert backfill_data["status"] == "Cancelled"
+        backfill_data = get_batch_export_backfill_ok(client, team.pk, batch_export_id, backfill_id)
+        assert backfill_data["status"] == "Cancelled"

--- a/posthog/api/test/batch_exports/backfills/test_create.py
+++ b/posthog/api/test/batch_exports/backfills/test_create.py
@@ -9,13 +9,8 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from posthog.api.test.batch_exports.conftest import start_test_worker
-from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import backfill_batch_export, create_batch_export_ok
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
 from posthog.models.person.util import create_person
-from posthog.temporal.common.client import sync_connect
 
 pytestmark = [
     pytest.mark.django_db,
@@ -24,7 +19,7 @@ pytestmark = [
 
 @pytest.mark.parametrize("legacy_endpoint", [False, True])
 @pytest.mark.parametrize("model", ["events", "persons"])
-def test_batch_export_backfill(client: HttpClient, model, legacy_endpoint: bool):
+def test_batch_export_backfill(client: HttpClient, organization, team, user, temporal, model, legacy_endpoint: bool):
     """Test a BatchExport can be backfilled.
 
     We should be able to create a Batch Export, then request that the Schedule
@@ -37,8 +32,6 @@ def test_batch_export_backfill(client: HttpClient, model, legacy_endpoint: bool)
     This test checks that both endpoints work as expected.
     We can remove the legacy endpoint once we're confident that nobody is using it.
     """
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -56,9 +49,6 @@ def test_batch_export_backfill(client: HttpClient, model, legacy_endpoint: bool)
         "model": model,
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     # ensure there is data to backfill, otherwise validation will fail
@@ -78,25 +68,22 @@ def test_batch_export_backfill(client: HttpClient, model, legacy_endpoint: bool)
             timestamp=dt.datetime(2021, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
         )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
 
-        response = backfill_batch_export(
-            client=client,
-            team_id=team.pk,
-            batch_export_id=batch_export_id,
-            start_at="2021-01-01T00:00:00+00:00",
-            end_at="2021-01-01T01:00:00+00:00",
-            legacy_endpoint=legacy_endpoint,
-        )
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = backfill_batch_export(
+        client=client,
+        team_id=team.pk,
+        batch_export_id=batch_export_id,
+        start_at="2021-01-01T00:00:00+00:00",
+        end_at="2021-01-01T01:00:00+00:00",
+        legacy_endpoint=legacy_endpoint,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
 
-def test_batch_export_backfill_with_non_isoformatted_dates(client: HttpClient):
+def test_batch_export_backfill_with_non_isoformatted_dates(client: HttpClient, organization, team, user, temporal):
     """Test a BatchExport backfill fails if we pass malformed dates."""
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -113,27 +100,21 @@ def test_batch_export_backfill_with_non_isoformatted_dates(client: HttpClient):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
 
-        batch_export_id = batch_export["id"]
+    batch_export_id = batch_export["id"]
 
-        response = backfill_batch_export(client, team.pk, batch_export_id, "not a date", "2021-01-01T01:00:00+00:00")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    response = backfill_batch_export(client, team.pk, batch_export_id, "not a date", "2021-01-01T01:00:00+00:00")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
-        response = backfill_batch_export(client, team.pk, batch_export_id, "2021-01-01T01:00:00+00:00", "not a date")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    response = backfill_batch_export(client, team.pk, batch_export_id, "2021-01-01T01:00:00+00:00", "not a date")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
-def test_batch_export_backfill_with_end_at_in_the_future(client: HttpClient):
+def test_batch_export_backfill_with_end_at_in_the_future(client: HttpClient, organization, team, user, temporal):
     """Test a BatchExport backfill fails if we pass malformed dates."""
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -150,32 +131,26 @@ def test_batch_export_backfill_with_end_at_in_the_future(client: HttpClient):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     test_time = dt.datetime.now(dt.UTC)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
 
-        batch_export_id = batch_export["id"]
+    batch_export_id = batch_export["id"]
 
-        with freeze_time(test_time):
-            response = backfill_batch_export(
-                client,
-                team.pk,
-                batch_export_id,
-                test_time.isoformat(),
-                (test_time + dt.timedelta(hours=1, seconds=1)).isoformat(),
-            )
-            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    with freeze_time(test_time):
+        response = backfill_batch_export(
+            client,
+            team.pk,
+            batch_export_id,
+            test_time.isoformat(),
+            (test_time + dt.timedelta(hours=1, seconds=1)).isoformat(),
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
-def test_batch_export_backfill_with_naive_bounds(client: HttpClient):
+def test_batch_export_backfill_with_naive_bounds(client: HttpClient, organization, team, user, temporal):
     """Test a BatchExport backfill fails if we naive dates."""
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -192,27 +167,21 @@ def test_batch_export_backfill_with_naive_bounds(client: HttpClient):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
 
-        batch_export_id = batch_export["id"]
+    batch_export_id = batch_export["id"]
 
-        response = backfill_batch_export(client, team.pk, batch_export_id, "2021-01-01T01:00:00", "2021-01-01T01:00:00")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    response = backfill_batch_export(client, team.pk, batch_export_id, "2021-01-01T01:00:00", "2021-01-01T01:00:00")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
-        response = backfill_batch_export(client, team.pk, batch_export_id, "2021-01-01T01:00:00", "2021-01-01T01:00:00")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    response = backfill_batch_export(client, team.pk, batch_export_id, "2021-01-01T01:00:00", "2021-01-01T01:00:00")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
-def test_batch_export_backfill_with_start_at_after_end_at(client: HttpClient):
+def test_batch_export_backfill_with_start_at_after_end_at(client: HttpClient, organization, team, user, temporal):
     """Test a BatchExport backfill fails if start_at is after end_at."""
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -229,38 +198,32 @@ def test_batch_export_backfill_with_start_at_after_end_at(client: HttpClient):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
 
-        batch_export_id = batch_export["id"]
+    batch_export_id = batch_export["id"]
 
-        response = backfill_batch_export(
-            client,
-            team.pk,
-            batch_export_id,
-            "2021-01-01T01:00:00+00:00",
-            "2021-01-01T01:00:00+00:00",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    response = backfill_batch_export(
+        client,
+        team.pk,
+        batch_export_id,
+        "2021-01-01T01:00:00+00:00",
+        "2021-01-01T01:00:00+00:00",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
-        response = backfill_batch_export(
-            client,
-            team.pk,
-            batch_export_id,
-            "2021-01-01T01:00:00+00:00",
-            "2020-01-01T01:00:00+00:00",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    response = backfill_batch_export(
+        client,
+        team.pk,
+        batch_export_id,
+        "2021-01-01T01:00:00+00:00",
+        "2020-01-01T01:00:00+00:00",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
-def test_cannot_trigger_backfill_for_another_organization(client: HttpClient):
-    temporal = sync_connect()
-
+def test_cannot_trigger_backfill_for_another_organization(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -277,35 +240,32 @@ def test_cannot_trigger_backfill_for_another_organization(client: HttpClient):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
+    from posthog.api.test.batch_exports.fixtures import create_organization
+    from posthog.api.test.test_team import create_team
+    from posthog.api.test.test_user import create_user
 
     other_organization = create_organization("Other Org")
     create_team(other_organization)
     other_user = create_user("other-test@user.com", "Other Test User", other_organization)
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    client.force_login(user)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
 
-        batch_export_id = batch_export["id"]
+    batch_export_id = batch_export["id"]
 
-        client.force_login(other_user)
-        response = backfill_batch_export(
-            client,
-            team.pk,
-            batch_export_id,
-            "2021-01-01T00:00:00+00:00",
-            "2021-01-01T01:00:00+00:00",
-        )
+    client.force_login(other_user)
+    response = backfill_batch_export(
+        client,
+        team.pk,
+        batch_export_id,
+        "2021-01-01T00:00:00+00:00",
+        "2021-01-01T01:00:00+00:00",
+    )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
 
-def test_backfill_is_partitioned_by_team_id(client: HttpClient):
-    temporal = sync_connect()
-
+def test_backfill_is_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -322,29 +282,27 @@ def test_backfill_is_partitioned_by_team_id(client: HttpClient):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
+    from posthog.api.test.test_team import create_team
+
     other_team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    client.force_login(user)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
 
-        batch_export_id = batch_export["id"]
+    batch_export_id = batch_export["id"]
 
-        response = backfill_batch_export(
-            client,
-            other_team.pk,
-            batch_export_id,
-            "2021-01-01T00:00:00+00:00",
-            "2021-01-01T01:00:00+00:00",
-        )
+    response = backfill_batch_export(
+        client,
+        other_team.pk,
+        batch_export_id,
+        "2021-01-01T00:00:00+00:00",
+        "2021-01-01T01:00:00+00:00",
+    )
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
 
 
-def test_batch_export_backfill_created_in_timezone(client: HttpClient):
+def test_batch_export_backfill_created_in_timezone(client: HttpClient, temporal, organization, user):
     """Test creating a BatchExportBackfill sets the right ID in UTC timezone.
 
     PostgreSQL stores datetime values in their UTC representation, converting the input
@@ -356,7 +314,6 @@ def test_batch_export_backfill_created_in_timezone(client: HttpClient):
     to do that later, but this test case is still valuable to ensure we are pulling and
     using the timezone stored in PostgreSQL correctly.
     """
-    temporal = sync_connect()
 
     destination_data = {
         "type": "S3",
@@ -374,9 +331,9 @@ def test_batch_export_backfill_created_in_timezone(client: HttpClient):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
+    from posthog.api.test.test_team import create_team
+
     team = create_team(organization, timezone="US/Eastern")
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     # ensure there is data to backfill, otherwise validation will fail
@@ -384,33 +341,32 @@ def test_batch_export_backfill_created_in_timezone(client: HttpClient):
         team=team, event="$pageview", distinct_id="person_1", timestamp=dt.datetime(2021, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
     )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
 
-        response = backfill_batch_export(
-            client,
-            team.pk,
-            batch_export_id,
-            "2021-01-01T00:00:00-05:00",
-            "2021-10-01T00:00:00-04:00",
-        )
+    response = backfill_batch_export(
+        client,
+        team.pk,
+        batch_export_id,
+        "2021-01-01T00:00:00-05:00",
+        "2021-10-01T00:00:00-04:00",
+    )
 
-        data = response.json()
+    data = response.json()
 
-        assert response.status_code == status.HTTP_200_OK, data
-        assert data["backfill_id"] == f"{batch_export_id}-Backfill-2021-01-01T05:00:00+00:00-2021-10-01T04:00:00+00:00"
+    assert response.status_code == status.HTTP_200_OK, data
+    assert data["backfill_id"] == f"{batch_export_id}-Backfill-2021-01-01T05:00:00+00:00-2021-10-01T04:00:00+00:00"
 
 
 @pytest.mark.parametrize("model", ["events", "persons"])
-def test_batch_export_backfill_when_start_at_is_before_earliest_backfill_start_at(client: HttpClient, model):
+def test_batch_export_backfill_when_start_at_is_before_earliest_backfill_start_at(
+    client: HttpClient, organization, team, user, temporal, model
+):
     """Test that a BatchExport backfill will use the earliest possible backfill start date if start_at is before this.
 
     For example if the timestamp of the earliest event is 2021-01-02T00:10:00+00:00, and the BatchExport is created with
     a start_at of 2021-01-01T00:00:00+00:00, then the backfill will use 2021-01-02T00:00:00+00:00 as the start_at date.
     """
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -428,9 +384,6 @@ def test_batch_export_backfill_when_start_at_is_before_earliest_backfill_start_a
         "model": model,
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     if model == "events":
@@ -449,29 +402,30 @@ def test_batch_export_backfill_when_start_at_is_before_earliest_backfill_start_a
             timestamp=dt.datetime(2021, 1, 2, 0, 10, 0, tzinfo=dt.UTC),
         )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
-        with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id) as mock_backfill_export:
-            response = backfill_batch_export(
-                client,
-                team.pk,
-                batch_export_id,
-                "2021-01-01T00:00:00+00:00",
-                "2021-01-03T00:00:00+00:00",
-            )
-            assert response.status_code == status.HTTP_200_OK, response.json()
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
+    with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id) as mock_backfill_export:
+        response = backfill_batch_export(
+            client,
+            team.pk,
+            batch_export_id,
+            "2021-01-01T00:00:00+00:00",
+            "2021-01-03T00:00:00+00:00",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
 
-            mock_backfill_export.assert_called_with(
-                ANY,  # temporal instance will be a different object
-                batch_export_id,
-                team.pk,
-                dt.datetime.fromisoformat("2021-01-02T00:00:00+00:00").astimezone(team.timezone_info),
-                dt.datetime.fromisoformat("2021-01-03T00:00:00+00:00").astimezone(team.timezone_info),
-            )
+        mock_backfill_export.assert_called_with(
+            ANY,  # temporal instance will be a different object
+            batch_export_id,
+            team.pk,
+            dt.datetime.fromisoformat("2021-01-02T00:00:00+00:00").astimezone(team.timezone_info),
+            dt.datetime.fromisoformat("2021-01-03T00:00:00+00:00").astimezone(team.timezone_info),
+        )
 
 
-def test_batch_export_backfill_when_backfill_end_at_is_before_earliest_event(client: HttpClient):
+def test_batch_export_backfill_when_backfill_end_at_is_before_earliest_event(
+    client: HttpClient, organization, team, user, temporal
+):
     """Test a BatchExport backfill fails if the end_at is before the earliest event.
 
     In this case, we know that the backfill range doesn't contain any data, so we can fail fast.
@@ -479,8 +433,6 @@ def test_batch_export_backfill_when_backfill_end_at_is_before_earliest_event(cli
     For example if the timestamp of the earliest event is 2021-01-03T00:10:00+00:00, and the BatchExport is created with a
     start_at of 2021-01-01T00:00:00+00:00 and an end_at of 2021-01-02T00:00:00+00:00, then the backfill will fail.
     """
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -497,37 +449,31 @@ def test_batch_export_backfill_when_backfill_end_at_is_before_earliest_event(cli
         "interval": "day",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     _create_event(
         team=team, event="$pageview", distinct_id="person_1", timestamp=dt.datetime(2021, 1, 3, 0, 10, 0, tzinfo=dt.UTC)
     )
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
-        with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id):
-            response = backfill_batch_export(
-                client,
-                team.pk,
-                batch_export_id,
-                "2021-01-01T00:00:00+00:00",
-                "2021-01-02T00:00:00+00:00",
-            )
-            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-            assert (
-                response.json()["detail"]
-                == "The provided backfill date range contains no data. The earliest possible backfill start date is 2021-01-03 00:00:00"
-            )
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
+    with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id):
+        response = backfill_batch_export(
+            client,
+            team.pk,
+            batch_export_id,
+            "2021-01-01T00:00:00+00:00",
+            "2021-01-02T00:00:00+00:00",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert (
+            response.json()["detail"]
+            == "The provided backfill date range contains no data. The earliest possible backfill start date is 2021-01-03 00:00:00"
+        )
 
 
 @pytest.mark.parametrize("model", ["events", "persons"])
-def test_batch_export_backfill_when_no_data_exists(client: HttpClient, model):
+def test_batch_export_backfill_when_no_data_exists(client: HttpClient, organization, team, user, temporal, model):
     """Test a BatchExport backfill fails if no data exists for the given model."""
-    temporal = sync_connect()
-
     destination_data = {
         "type": "S3",
         "config": {
@@ -545,21 +491,17 @@ def test_batch_export_backfill_when_no_data_exists(client: HttpClient, model):
         "model": model,
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
-        with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id):
-            response = backfill_batch_export(
-                client,
-                team.pk,
-                batch_export_id,
-                "2021-01-01T00:00:00+00:00",
-                "2021-01-02T00:00:00+00:00",
-            )
-            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-            assert response.json()["detail"] == "There is no data to backfill for this model."
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
+    with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id):
+        response = backfill_batch_export(
+            client,
+            team.pk,
+            batch_export_id,
+            "2021-01-01T00:00:00+00:00",
+            "2021-01-02T00:00:00+00:00",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["detail"] == "There is no data to backfill for this model."

--- a/posthog/api/test/batch_exports/backfills/test_list.py
+++ b/posthog/api/test/batch_exports/backfills/test_list.py
@@ -4,25 +4,15 @@ import pytest
 
 from django.test.client import Client as HttpClient
 
-from posthog.api.test.batch_exports.fixtures import (
-    create_backfill,
-    create_batch_export,
-    create_destination,
-    create_organization,
-)
+from posthog.api.test.batch_exports.fixtures import create_backfill, create_batch_export, create_destination
 from posthog.api.test.batch_exports.operations import list_batch_export_backfills_ok
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
 from posthog.batch_exports.models import BatchExportBackfill
 
 pytestmark = [pytest.mark.django_db]
 
 
-def test_list_batch_export_backfills(client: HttpClient):
+def test_list_batch_export_backfills(client: HttpClient, organization, team, user):
     """Test that we can list batch export backfills."""
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     destination = create_destination()
     batch_export = create_batch_export(team, destination)
     create_backfill(
@@ -47,14 +37,10 @@ def test_list_batch_export_backfills(client: HttpClient):
     assert len(response["results"]) == 2
 
 
-def test_cannot_list_batch_export_backfills_for_other_organizations(client: HttpClient):
+def test_cannot_list_batch_export_backfills_for_other_organizations(client: HttpClient, organization, team, user):
     """
     Should not be able to list batch export backfills for other organizations.
     """
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
-
     destination = create_destination()
     batch_export = create_batch_export(team, destination)
     create_backfill(
@@ -73,6 +59,10 @@ def test_cannot_list_batch_export_backfills_for_other_organizations(client: Http
         BatchExportBackfill.Status.COMPLETED,
         dt.datetime(2025, 1, 1, 1, 0, 0, tzinfo=dt.UTC),
     )
+
+    from posthog.api.test.batch_exports.fixtures import create_organization
+    from posthog.api.test.test_team import create_team
+    from posthog.api.test.test_user import create_user
 
     other_organization = create_organization("Other Test Org")
     other_team = create_team(other_organization)
@@ -89,15 +79,13 @@ def test_cannot_list_batch_export_backfills_for_other_organizations(client: Http
     assert len(response["results"]) == 0
 
 
-def test_list_is_partitioned_by_team(client: HttpClient):
+def test_list_is_partitioned_by_team(client: HttpClient, organization, team, user):
     """
     Should be able to list batch export backfills for a specific team.
     """
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    another_team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
+    from posthog.api.test.test_team import create_team
 
+    another_team = create_team(organization)
     destination = create_destination()
     batch_export = create_batch_export(team, destination)
     create_backfill(

--- a/posthog/api/test/batch_exports/backfills/test_read_only.py
+++ b/posthog/api/test/batch_exports/backfills/test_read_only.py
@@ -6,26 +6,16 @@ from django.test.client import Client as TestClient
 
 from rest_framework import status
 
-from posthog.api.test.batch_exports.fixtures import (
-    create_backfill,
-    create_batch_export,
-    create_destination,
-    create_organization,
-)
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
+from posthog.api.test.batch_exports.fixtures import create_backfill, create_batch_export, create_destination
 from posthog.batch_exports.models import BatchExportBackfill
 
 pytestmark = [pytest.mark.django_db]
 
 
-def test_cannot_delete_batch_export_backfill(client: TestClient):
+def test_cannot_delete_batch_export_backfill(client: TestClient, organization, team, user):
     """
     Should not be able to delete a batch export backfill.
     """
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     destination = create_destination()
     batch_export = create_batch_export(team, destination)
     backfill = create_backfill(
@@ -42,13 +32,10 @@ def test_cannot_delete_batch_export_backfill(client: TestClient):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_cannot_update_batch_export_backfill(client: TestClient):
+def test_cannot_update_batch_export_backfill(client: TestClient, organization, team, user):
     """
     Should not be able to update a batch export backfill.
     """
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     destination = create_destination()
     batch_export = create_batch_export(team, destination)
     backfill = create_backfill(

--- a/posthog/api/test/batch_exports/fixtures.py
+++ b/posthog/api/test/batch_exports/fixtures.py
@@ -1,6 +1,14 @@
 from posthog.api.test.test_organization import create_organization as create_organization_base
 from posthog.constants import AvailableFeature
-from posthog.models import BatchExport, BatchExportBackfill, BatchExportDestination, BatchExportRun, Organization
+from posthog.models import (
+    BatchExport,
+    BatchExportBackfill,
+    BatchExportDestination,
+    BatchExportRun,
+    Organization,
+    Team,
+    User,
+)
 
 
 def create_organization(name: str, has_data_pipelines_feature: bool = True) -> Organization:
@@ -11,6 +19,32 @@ def create_organization(name: str, has_data_pipelines_feature: bool = True) -> O
         ]
         organization.save()
     return organization
+
+
+def create_team(organization: Organization, name: str = "Test team", timezone: str = "UTC") -> Team:
+    """
+    This is a helper that just creates a team. It currently uses the orm, but we
+    could use either the api, or django admin to create, to get better parity
+    with real world scenarios.
+    """
+    return Team.objects.create(
+        organization=organization,
+        name=name,
+        ingested_event=True,
+        completed_snippet_onboarding=True,
+        is_demo=True,
+        timezone=timezone,
+        base_currency="USD",
+    )
+
+
+def create_user(email: str, password: str, organization: Organization):
+    """
+    Helper that just creates a user. It currently uses the orm, but we
+    could use either the api, or django admin to create, to get better parity
+    with real world scenarios.
+    """
+    return User.objects.create_and_join(organization, email, password)
 
 
 def create_destination() -> BatchExportDestination:

--- a/posthog/api/test/batch_exports/operations.py
+++ b/posthog/api/test/batch_exports/operations.py
@@ -1,12 +1,76 @@
+import time
 import asyncio
+import datetime as dt
+import threading
+from contextlib import contextmanager
 
 from django.test.client import Client as TestClient
 
 import temporalio.client
+import temporalio.worker
 from asgiref.sync import async_to_sync
 from rest_framework import status
+from temporalio.client import Client as TemporalClient
+from temporalio.worker import Worker
 
+from posthog import constants
 from posthog.models.utils import UUIDT
+
+from products.batch_exports.backend.temporal import ACTIVITIES, WORKFLOWS
+
+
+class ThreadedWorker(Worker):
+    """A Temporal Worker that can run in a separate thread.
+
+    Inteded to be used in sync tests that require a Temporal Worker.
+    """
+
+    @contextmanager
+    def run_in_thread(self):
+        """Run a Temporal Worker in a thread.
+
+        Don't use this outside of tests. Once PostHog is fully async we can get rid of this.
+        """
+        loop = asyncio.new_event_loop()
+        t = threading.Thread(target=self.run_using_loop, daemon=True, args=(loop,))
+        t.start()
+
+        try:
+            while not self.is_running:
+                time.sleep(0.1)
+            yield
+        finally:
+            self._shutdown_event.set()
+            # Give the worker a chance to shut down before exiting
+            max_wait = 10.0
+            while t.is_alive() and max_wait > 0:
+                time.sleep(0.1)
+                max_wait -= 0.1
+
+    def run_using_loop(self, loop):
+        """Setup an event loop to run the Worker.
+
+        Using async_to_sync(Worker.run) causes a deadlock.
+        """
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(super().run())
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+
+@contextmanager
+def start_test_worker(temporal: TemporalClient):
+    with ThreadedWorker(
+        client=temporal,
+        task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+        workflows=WORKFLOWS,
+        activities=ACTIVITIES,
+        workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        graceful_shutdown_timeout=dt.timedelta(seconds=5),
+    ).run_in_thread():
+        yield
 
 
 def create_batch_export(client: TestClient, team_id: int, batch_export_data: dict | str):

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -10,56 +10,17 @@ from django.test.client import Client as HttpClient
 from asgiref.sync import async_to_sync
 from rest_framework import status
 
-from posthog.api.test.batch_exports.conftest import cleanup_temporal_schedules, describe_schedule, start_test_worker
+from posthog.api.test.batch_exports.conftest import describe_schedule
 from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import create_batch_export
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 from posthog.batch_exports.models import BatchExport
-from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.codec import EncryptionCodec
 
 pytestmark = [
     pytest.mark.django_db,
 ]
-
-
-@pytest.fixture
-def organization():
-    return create_organization("Test Org")
-
-
-@pytest.fixture
-def team(organization):
-    return create_team(organization)
-
-
-@pytest.fixture
-def user(organization):
-    return create_user("test@user.com", "Test User", organization)
-
-
-@pytest.fixture(scope="module")
-def temporal():
-    """Return a TemporalClient instance."""
-    client = sync_connect()
-    yield client
-
-
-@pytest.fixture(scope="module", autouse=True)
-def temporal_worker(temporal):
-    """Use a module scoped fixture to start a Temporal Worker.
-
-    This saves a lot of time, as waiting for the worker to stop takes a while.
-    """
-    with start_test_worker(temporal):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    client = sync_connect()
-    cleanup_temporal_schedules(client)
 
 
 @pytest.mark.parametrize("interval", ["hour", "day", "every 5 minutes"])

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -10,12 +10,13 @@ from django.test.client import Client as HttpClient
 from asgiref.sync import async_to_sync
 from rest_framework import status
 
-from posthog.api.test.batch_exports.conftest import describe_schedule, start_test_worker
+from posthog.api.test.batch_exports.conftest import cleanup_temporal_schedules, describe_schedule, start_test_worker
 from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import create_batch_export
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 from posthog.batch_exports.models import BatchExport
+from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.codec import EncryptionCodec
 
 pytestmark = [
@@ -23,8 +24,46 @@ pytestmark = [
 ]
 
 
+@pytest.fixture
+def organization():
+    return create_organization("Test Org")
+
+
+@pytest.fixture
+def team(organization):
+    return create_team(organization)
+
+
+@pytest.fixture
+def user(organization):
+    return create_user("test@user.com", "Test User", organization)
+
+
+@pytest.fixture(scope="module")
+def temporal():
+    """Return a TemporalClient instance."""
+    client = sync_connect()
+    yield client
+
+
+@pytest.fixture(scope="module", autouse=True)
+def temporal_worker(temporal):
+    """Use a module scoped fixture to start a Temporal Worker.
+
+    This saves a lot of time, as waiting for the worker to stop takes a while.
+    """
+    with start_test_worker(temporal):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    client = sync_connect()
+    cleanup_temporal_schedules(client)
+
+
 @pytest.mark.parametrize("interval", ["hour", "day", "every 5 minutes"])
-def test_create_batch_export_with_interval_schedule(client: HttpClient, interval, temporal):
+def test_create_batch_export_with_interval_schedule(client: HttpClient, interval, temporal, organization, team, user):
     """Test creating a BatchExport.
 
     When creating a BatchExport, we should create a corresponding Schedule in
@@ -51,89 +90,85 @@ def test_create_batch_export_with_interval_schedule(client: HttpClient, interval
         "interval": interval,
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        with mock.patch(
-            "posthog.batch_exports.http.posthoganalytics.feature_enabled",
-            return_value=True,
-        ) as feature_enabled:
-            response = create_batch_export(
-                client,
-                team.pk,
-                batch_export_data,
-            )
+    with mock.patch(
+        "posthog.batch_exports.http.posthoganalytics.feature_enabled",
+        return_value=True,
+    ) as feature_enabled:
+        response = create_batch_export(
+            client,
+            team.pk,
+            batch_export_data,
+        )
 
-        if interval == "every 5 minutes":
-            feature_enabled.assert_called_once_with(
-                "high-frequency-batch-exports",
-                str(team.uuid),
-                groups={"organization": str(team.organization.id)},
-                group_properties={
-                    "organization": {
-                        "id": str(team.organization.id),
-                        "created_at": team.organization.created_at,
-                    }
-                },
-                send_feature_flag_events=False,
-            )
+    if interval == "every 5 minutes":
+        feature_enabled.assert_called_once_with(
+            "high-frequency-batch-exports",
+            str(team.uuid),
+            groups={"organization": str(team.organization.id)},
+            group_properties={
+                "organization": {
+                    "id": str(team.organization.id),
+                    "created_at": team.organization.created_at,
+                }
+            },
+            send_feature_flag_events=False,
+        )
 
-        assert response.status_code == status.HTTP_201_CREATED, response.json()
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
 
-        data = response.json()
+    data = response.json()
 
-        # We should not get the aws_access_key_id or aws_secret_access_key back, so
-        # remove that from the data we expect.
-        batch_export_data["destination"]["config"].pop("aws_access_key_id")
-        batch_export_data["destination"]["config"].pop("aws_secret_access_key")
-        assert data["destination"] == batch_export_data["destination"]
+    # We should not get the aws_access_key_id or aws_secret_access_key back, so
+    # remove that from the data we expect.
+    batch_export_data["destination"]["config"].pop("aws_access_key_id")
+    batch_export_data["destination"]["config"].pop("aws_secret_access_key")
+    assert data["destination"] == batch_export_data["destination"]
 
-        # We should match on top level fields.
-        assert {"name": data["name"], "interval": data["interval"]} == {
-            "name": "my-production-s3-bucket-destination",
-            "interval": interval,
-        }
+    # We should match on top level fields.
+    assert {"name": data["name"], "interval": data["interval"]} == {
+        "name": "my-production-s3-bucket-destination",
+        "interval": interval,
+    }
 
-        # validate the underlying temporal schedule has been created
-        codec = EncryptionCodec(settings=settings)
-        schedule = describe_schedule(temporal, data["id"])
+    # validate the underlying temporal schedule has been created
+    codec = EncryptionCodec(settings=settings)
+    schedule = describe_schedule(temporal, data["id"])
 
-        batch_export = BatchExport.objects.get(id=data["id"])
-        assert schedule.schedule.spec.intervals[0].every == batch_export.interval_time_delta
-        assert schedule.schedule.spec.jitter == batch_export.jitter
+    batch_export = BatchExport.objects.get(id=data["id"])
+    assert schedule.schedule.spec.intervals[0].every == batch_export.interval_time_delta
+    assert schedule.schedule.spec.jitter == batch_export.jitter
 
-        decoded_payload = async_to_sync(codec.decode)(schedule.schedule.action.args)
-        args = json.loads(decoded_payload[0].data)
+    decoded_payload = async_to_sync(codec.decode)(schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
 
-        # Common inputs
-        assert args["team_id"] == team.pk
-        assert args["batch_export_id"] == data["id"]
-        assert args["interval"] == interval
+    # Common inputs
+    assert args["team_id"] == team.pk
+    assert args["batch_export_id"] == data["id"]
+    assert args["interval"] == interval
 
-        if interval == "hour":
-            assert batch_export.jitter == dt.timedelta(minutes=15)
-        elif interval == "day":
-            assert batch_export.jitter == dt.timedelta(hours=1)
-        elif interval == "every 5 minutes":
-            assert batch_export.jitter == dt.timedelta(minutes=1)
+    if interval == "hour":
+        assert batch_export.jitter == dt.timedelta(minutes=15)
+    elif interval == "day":
+        assert batch_export.jitter == dt.timedelta(hours=1)
+    elif interval == "every 5 minutes":
+        assert batch_export.jitter == dt.timedelta(minutes=1)
 
-        # S3 specific inputs
-        assert args["bucket_name"] == "my-production-s3-bucket"
-        assert args["region"] == "us-east-1"
-        assert args["prefix"] == "posthog-events/"
-        assert args["aws_access_key_id"] == "abc123"
-        assert args["aws_secret_access_key"] == "secret"
-        assert args["use_virtual_style_addressing"]
+    # S3 specific inputs
+    assert args["bucket_name"] == "my-production-s3-bucket"
+    assert args["region"] == "us-east-1"
+    assert args["prefix"] == "posthog-events/"
+    assert args["aws_access_key_id"] == "abc123"
+    assert args["aws_secret_access_key"] == "secret"
+    assert args["use_virtual_style_addressing"]
 
 
 @pytest.mark.parametrize(
     "timezone",
     ["US/Pacific", "UTC", "Europe/Berlin", "Asia/Tokyo", "Pacific/Marquesas", "Asia/Katmandu"],
 )
-def test_create_batch_export_with_different_team_timezones(client: HttpClient, timezone: str, temporal):
+def test_create_batch_export_with_different_team_timezones(client: HttpClient, timezone: str, temporal, organization):
     """Test creating a BatchExport.
 
     When creating a BatchExport, we should create a corresponding Schedule in
@@ -158,30 +193,28 @@ def test_create_batch_export_with_different_team_timezones(client: HttpClient, t
         "interval": "day",
     }
 
-    organization = create_organization("Test Org")
     team = create_team(organization, timezone=timezone)
     user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        assert response.status_code == status.HTTP_201_CREATED, response.json()
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
 
-        data = response.json()
-        schedule = describe_schedule(temporal, data["id"])
-        intervals = schedule.schedule.spec.intervals
+    data = response.json()
+    schedule = describe_schedule(temporal, data["id"])
+    intervals = schedule.schedule.spec.intervals
 
-        assert len(intervals) == 1
-        assert schedule.schedule.spec.intervals[0].every == dt.timedelta(days=1)
-        assert schedule.schedule.spec.time_zone_name == timezone
+    assert len(intervals) == 1
+    assert schedule.schedule.spec.intervals[0].every == dt.timedelta(days=1)
+    assert schedule.schedule.spec.time_zone_name == timezone
 
 
-def test_cannot_create_a_batch_export_for_another_organization(client: HttpClient, temporal):
+def test_cannot_create_a_batch_export_for_another_organization(client: HttpClient, temporal, organization, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -199,25 +232,24 @@ def test_cannot_create_a_batch_export_for_another_organization(client: HttpClien
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
     create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
     another_organization = create_organization("Another Test Org")
     another_team = create_team(another_organization)
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        response = create_batch_export(
-            client,
-            another_team.pk,
-            batch_export_data,
-        )
+    client.force_login(user)
+    response = create_batch_export(
+        client,
+        another_team.pk,
+        batch_export_data,
+    )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
 
-def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(client: HttpClient, temporal):
+def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(
+    client: HttpClient, temporal, organization, team, user
+):
     destination_data = {
         "type": "S3",
         "config": {
@@ -235,34 +267,29 @@ def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(cli
         "interval": "every 5 minutes",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
-
-    with start_test_worker(temporal):
-        client.force_login(user)
-        with mock.patch(
-            "posthog.batch_exports.http.posthoganalytics.feature_enabled",
-            return_value=False,
-        ) as feature_enabled:
-            response = create_batch_export(
-                client,
-                team.pk,
-                batch_export_data,
-            )
-            assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
-            feature_enabled.assert_called_once_with(
-                "high-frequency-batch-exports",
-                str(team.uuid),
-                groups={"organization": str(team.organization.id)},
-                group_properties={
-                    "organization": {
-                        "id": str(team.organization.id),
-                        "created_at": team.organization.created_at,
-                    }
-                },
-                send_feature_flag_events=False,
-            )
+    client.force_login(user)
+    with mock.patch(
+        "posthog.batch_exports.http.posthoganalytics.feature_enabled",
+        return_value=False,
+    ) as feature_enabled:
+        response = create_batch_export(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+        feature_enabled.assert_called_once_with(
+            "high-frequency-batch-exports",
+            str(team.uuid),
+            groups={"organization": str(team.organization.id)},
+            group_properties={
+                "organization": {
+                    "id": str(team.organization.id),
+                    "created_at": team.organization.created_at,
+                }
+            },
+            send_feature_flag_events=False,
+        )
 
 
 TEST_HOGQL_QUERY = """
@@ -277,7 +304,7 @@ FROM events
 """
 
 
-def test_create_batch_export_with_custom_schema(client: HttpClient, temporal):
+def test_create_batch_export_with_custom_schema(client: HttpClient, temporal, organization, team, user):
     """Test creating a BatchExport with a custom schema expressed as a HogQL Query.
 
     When creating a BatchExport, we should create a corresponding Schedule in
@@ -304,57 +331,53 @@ def test_create_batch_export_with_custom_schema(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        assert response.status_code == status.HTTP_201_CREATED, response.json()
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
 
-        data = response.json()
-        expected_hogql_query = " ".join(TEST_HOGQL_QUERY.split())  # Don't care about whitespace
-        assert data["schema"]["hogql_query"] == expected_hogql_query
+    data = response.json()
+    expected_hogql_query = " ".join(TEST_HOGQL_QUERY.split())  # Don't care about whitespace
+    assert data["schema"]["hogql_query"] == expected_hogql_query
 
-        codec = EncryptionCodec(settings=settings)
-        schedule = describe_schedule(temporal, data["id"])
+    codec = EncryptionCodec(settings=settings)
+    schedule = describe_schedule(temporal, data["id"])
 
-        batch_export = BatchExport.objects.get(id=data["id"])
+    batch_export = BatchExport.objects.get(id=data["id"])
 
-        decoded_payload = async_to_sync(codec.decode)(schedule.schedule.action.args)
-        args = json.loads(decoded_payload[0].data)
+    decoded_payload = async_to_sync(codec.decode)(schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
 
-        expected_fields = [
-            {"expression": "events.event", "alias": "event"},
-            {"expression": "events.team_id", "alias": "my_team"},
-            {"expression": "events.properties", "alias": "properties"},
-            {
-                "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')",
-                "alias": "browser",
-            },
-            {
-                "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '')",
-                "alias": "custom",
-            },
-            {"alias": "person_id", "expression": "events.person_id"},
-        ]
-        expected_schema = {
-            "fields": expected_fields,
-            "values": {
-                "hogql_val_0": "$browser",
-                "hogql_val_1": "custom",
-            },
-            "hogql_query": expected_hogql_query,
-        }
+    expected_fields = [
+        {"expression": "events.event", "alias": "event"},
+        {"expression": "events.team_id", "alias": "my_team"},
+        {"expression": "events.properties", "alias": "properties"},
+        {
+            "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')",
+            "alias": "browser",
+        },
+        {
+            "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '')",
+            "alias": "custom",
+        },
+        {"alias": "person_id", "expression": "events.person_id"},
+    ]
+    expected_schema = {
+        "fields": expected_fields,
+        "values": {
+            "hogql_val_0": "$browser",
+            "hogql_val_1": "custom",
+        },
+        "hogql_query": expected_hogql_query,
+    }
 
-        assert batch_export.schema == expected_schema
-        assert args["batch_export_model"] == {"filters": None, "name": "events", "schema": expected_schema}
+    assert batch_export.schema == expected_schema
+    assert args["batch_export_model"] == {"filters": None, "name": "events", "schema": expected_schema}
 
 
 @pytest.mark.parametrize(
@@ -367,7 +390,9 @@ def test_create_batch_export_with_custom_schema(client: HttpClient, temporal):
         "SELECT event FROM events UNION ALL SELECT event FROM events",
     ],
 )
-def test_create_batch_export_fails_with_invalid_query(client: HttpClient, invalid_query, temporal):
+def test_create_batch_export_fails_with_invalid_query(
+    client: HttpClient, invalid_query, temporal, organization, team, user
+):
     """Test creating a BatchExport should fail with an invalid query."""
 
     destination_data = {
@@ -388,19 +413,15 @@ def test_create_batch_export_fails_with_invalid_query(client: HttpClient, invali
         "hogql_query": invalid_query,
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
 @pytest.mark.parametrize(
@@ -431,7 +452,7 @@ def test_create_batch_export_fails_with_invalid_query(client: HttpClient, invali
     ],
 )
 def test_create_snowflake_batch_export_validates_credentials(
-    client: HttpClient, auth_type, credentials, expected_status, temporal
+    client: HttpClient, auth_type, credentials, expected_status, temporal, organization, team, user
 ):
     """Test creating a BatchExport with Snowflake destination validates credentials based on auth type."""
 
@@ -455,25 +476,21 @@ def test_create_snowflake_batch_export_validates_credentials(
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        assert response.status_code == expected_status
+    assert response.status_code == expected_status
 
-        if expected_status == status.HTTP_400_BAD_REQUEST:
-            if auth_type == "password":
-                assert "Password is required if authentication type is password" in response.json()["detail"]
-            else:
-                assert "Private key is required if authentication type is key pair" in response.json()["detail"]
+    if expected_status == status.HTTP_400_BAD_REQUEST:
+        if auth_type == "password":
+            assert "Password is required if authentication type is password" in response.json()["detail"]
+        else:
+            assert "Private key is required if authentication type is key pair" in response.json()["detail"]
 
 
 @pytest.mark.parametrize(
@@ -527,7 +544,7 @@ def test_create_snowflake_batch_export_validates_credentials(
     ],
 )
 def test_create_s3_batch_export_validates_file_format_and_compression(
-    client: HttpClient, file_format, compression, expected_error_message, temporal
+    client: HttpClient, file_format, compression, expected_error_message, temporal, organization, team, user
 ):
     """Test creating a BatchExport with S3 destination validates file format and compression."""
 
@@ -550,23 +567,19 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        if expected_error_message is None:
-            assert response.status_code == status.HTTP_201_CREATED
-        else:
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            assert response.json()["detail"] == expected_error_message
+    if expected_error_message is None:
+        assert response.status_code == status.HTTP_201_CREATED
+    else:
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == expected_error_message
 
 
 @pytest.mark.parametrize(
@@ -625,7 +638,9 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
         ),
     ],
 )
-def test_create_batch_export_with_invalid_config(client: HttpClient, temporal, type, config, expected_error_message):
+def test_create_batch_export_with_invalid_config(
+    client: HttpClient, temporal, type, config, expected_error_message, organization, team, user
+):
     """Test creating a BatchExport with an invalid configuration returns an error."""
 
     destination_data = {
@@ -639,17 +654,13 @@ def test_create_batch_export_with_invalid_config(client: HttpClient, temporal, t
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert expected_error_message in response.json()["detail"]
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert expected_error_message in response.json()["detail"]

--- a/posthog/api/test/batch_exports/test_delete.py
+++ b/posthog/api/test/batch_exports/test_delete.py
@@ -11,7 +11,6 @@ from asgiref.sync import async_to_sync
 from rest_framework import status
 from temporalio.service import RPCError
 
-from posthog.api.test.batch_exports.conftest import start_test_worker
 from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import (
     backfill_batch_export_ok,
@@ -30,7 +29,7 @@ pytestmark = [
 ]
 
 
-def test_delete_batch_export(client: HttpClient, temporal):
+def test_delete_batch_export(client: HttpClient, temporal, organization, team, user):
     """Test deleting a BatchExport."""
     destination_data = {
         "type": "S3",
@@ -48,19 +47,15 @@ def test_delete_batch_export(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
 
-        delete_batch_export_ok(client, team.pk, batch_export_id)
+    delete_batch_export_ok(client, team.pk, batch_export_id)
 
-        response = get_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+    response = get_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
     with pytest.raises(RPCError):
         describe_schedule(temporal, batch_export_id)
@@ -92,7 +87,7 @@ async def wait_for_workflow_in_status(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_delete_batch_export_cancels_backfills(client: HttpClient, temporal):
+def test_delete_batch_export_cancels_backfills(client: HttpClient, temporal, organization, team, user):
     """Test deleting a BatchExport cancels ongoing BatchExportBackfill."""
     destination_data = {
         "type": "S3",
@@ -110,48 +105,44 @@ def test_delete_batch_export_cancels_backfills(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
 
-        start_at = "2023-10-23T00:00:00+00:00"
-        end_at = "2023-10-24T00:00:00+00:00"
+    start_at = "2023-10-23T00:00:00+00:00"
+    end_at = "2023-10-24T00:00:00+00:00"
 
-        # ensure there is data to backfill, otherwise validation will fail
-        _create_event(
-            team=team,
-            event="$pageview",
-            distinct_id="person_1",
-            timestamp=dt.datetime(2023, 10, 23, 0, 0, 0, tzinfo=dt.UTC),
-        )
-        batch_export_backfill = backfill_batch_export_ok(client, team.pk, batch_export_id, start_at, end_at)
+    # ensure there is data to backfill, otherwise validation will fail
+    _create_event(
+        team=team,
+        event="$pageview",
+        distinct_id="person_1",
+        timestamp=dt.datetime(2023, 10, 23, 0, 0, 0, tzinfo=dt.UTC),
+    )
+    batch_export_backfill = backfill_batch_export_ok(client, team.pk, batch_export_id, start_at, end_at)
 
-        # In order for the backfill to be cancelable, it needs to be running and requesting backfills.
-        # We check this by waiting for executions scheduled by our BatchExport id to pop up.
-        _ = wait_for_workflow_executions(temporal, query=f'TemporalScheduledById="{batch_export_id}"')
+    # In order for the backfill to be cancelable, it needs to be running and requesting backfills.
+    # We check this by waiting for executions scheduled by our BatchExport id to pop up.
+    _ = wait_for_workflow_executions(temporal, query=f'TemporalScheduledById="{batch_export_id}"')
 
-        delete_batch_export_ok(client, team.pk, batch_export_id)
+    delete_batch_export_ok(client, team.pk, batch_export_id)
 
-        response = get_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+    response = get_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
-        workflow = wait_for_workflow_in_status(
-            temporal,
-            workflow_id=batch_export_backfill["backfill_id"],
-            status=temporalio.client.WorkflowExecutionStatus.CANCELED,
-        )
-        assert workflow.status == temporalio.client.WorkflowExecutionStatus.CANCELED
+    workflow = wait_for_workflow_in_status(
+        temporal,
+        workflow_id=batch_export_backfill["backfill_id"],
+        status=temporalio.client.WorkflowExecutionStatus.CANCELED,
+    )
+    assert workflow.status == temporalio.client.WorkflowExecutionStatus.CANCELED
 
     with pytest.raises(RPCError):
         describe_schedule(temporal, batch_export_id)
 
 
-def test_cannot_delete_export_of_other_organizations(client: HttpClient, temporal):
+def test_cannot_delete_export_of_other_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -167,31 +158,26 @@ def test_cannot_delete_export_of_other_organizations(client: HttpClient, tempora
         "destination": destination_data,
         "interval": "hour",
     }
-
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
     another_organization = create_organization("Another Org")
     create_team(another_organization)
     another_user = create_user("another-test@user.com", "Another Test User", another_organization)
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
+    client.force_login(user)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
 
-        client.force_login(another_user)
-        response = delete_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+    client.force_login(another_user)
+    response = delete_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
-        # Make sure we can still get the export with the right user
-        client.force_login(user)
-        response = get_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == status.HTTP_200_OK
+    # Make sure we can still get the export with the right user
+    client.force_login(user)
+    response = get_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == status.HTTP_200_OK
 
 
-def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal):
+def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -208,27 +194,23 @@ def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
     another_team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
+    client.force_login(user)
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
 
-        # Try to delete with the other team
-        response = delete_batch_export(client, another_team.pk, batch_export_id)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+    # Try to delete with the other team
+    response = delete_batch_export(client, another_team.pk, batch_export_id)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
-        # Make sure we can still get the export with the right user
-        response = get_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == status.HTTP_200_OK
+    # Make sure we can still get the export with the right user
+    response = get_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db(transaction=True)
-def test_delete_batch_export_even_without_underlying_schedule(client: HttpClient, temporal):
+def test_delete_batch_export_even_without_underlying_schedule(client: HttpClient, temporal, organization, team, user):
     """Test deleting a BatchExport completes even if underlying Schedule was already deleted."""
     destination_data = {
         "type": "S3",
@@ -246,25 +228,21 @@ def test_delete_batch_export_even_without_underlying_schedule(client: HttpClient
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
-        batch_export_id = batch_export["id"]
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export_id = batch_export["id"]
 
-        handle = temporal.get_schedule_handle(batch_export_id)
-        async_to_sync(handle.delete)()
+    handle = temporal.get_schedule_handle(batch_export_id)
+    async_to_sync(handle.delete)()
 
-        with pytest.raises(RPCError):
-            describe_schedule(temporal, batch_export_id)
+    with pytest.raises(RPCError):
+        describe_schedule(temporal, batch_export_id)
 
-        delete_batch_export_ok(client, team.pk, batch_export_id)
+    delete_batch_export_ok(client, team.pk, batch_export_id)
 
-        response = get_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+    response = get_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
     with pytest.raises(RPCError):
         describe_schedule(temporal, batch_export_id)

--- a/posthog/api/test/batch_exports/test_get.py
+++ b/posthog/api/test/batch_exports/test_get.py
@@ -4,7 +4,6 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from posthog.api.test.batch_exports.conftest import start_test_worker
 from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import create_batch_export_ok, get_batch_export
 from posthog.api.test.test_team import create_team
@@ -15,7 +14,7 @@ pytestmark = [
 ]
 
 
-def test_can_get_exports_for_your_organizations(client: HttpClient, temporal):
+def test_can_get_exports_for_your_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -33,32 +32,28 @@ def test_can_get_exports_for_your_organizations(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        response = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        response = get_batch_export(client, team.pk, response["id"])
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = get_batch_export(client, team.pk, response["id"])
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-        batch_export = response.json()
+    batch_export = response.json()
 
-        # Check that the destination config is returned, except for aws_access_key_id and aws_secret_access_key.
-        assert batch_export["destination"]["config"] == {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        }
+    # Check that the destination config is returned, except for aws_access_key_id and aws_secret_access_key.
+    assert batch_export["destination"]["config"] == {
+        "bucket_name": "my-production-s3-bucket",
+        "region": "us-east-1",
+        "prefix": "posthog-events/",
+    }
 
 
-def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal):
+def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -75,28 +70,23 @@ def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal
         "destination": destination_data,
         "interval": "hour",
     }
-
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
     another_organization = create_organization("Another Org")
     another_user = create_user("another-test@user.com", "Another Test User", another_organization)
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        response = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    client.force_login(user)
+    response = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        client.force_login(another_user)
-        response = get_batch_export(client, team.pk, response["id"])
-        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+    client.force_login(another_user)
+    response = get_batch_export(client, team.pk, response["id"])
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
 
-def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal):
+def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, organization, team, user):
     """
     You shouldn't be able to fetch a BatchExport by id, via a team that it
     doesn't belong to.
@@ -118,28 +108,24 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
     another_team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        response = get_batch_export(client, another_team.pk, batch_export["id"])
-        assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    response = get_batch_export(client, another_team.pk, batch_export["id"])
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
 
-        # And switch the teams around for good measure.
-        batch_export = create_batch_export_ok(
-            client,
-            another_team.pk,
-            batch_export_data,
-        )
+    # And switch the teams around for good measure.
+    batch_export = create_batch_export_ok(
+        client,
+        another_team.pk,
+        batch_export_data,
+    )
 
-        response = get_batch_export(client, team.pk, batch_export["id"])
-        assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    response = get_batch_export(client, team.pk, batch_export["id"])
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()

--- a/posthog/api/test/batch_exports/test_list.py
+++ b/posthog/api/test/batch_exports/test_list.py
@@ -16,13 +16,10 @@ pytestmark = [
 ]
 
 
-def test_list_batch_exports(client: HttpClient):
+def test_list_batch_exports(client: HttpClient, organization, team, user):
     """
     Should be able to list batch exports.
     """
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     destination_data = {
@@ -58,14 +55,10 @@ def test_list_batch_exports(client: HttpClient):
     assert len(response["results"]) == 0
 
 
-def test_cannot_list_batch_exports_for_other_organizations(client: HttpClient):
+def test_cannot_list_batch_exports_for_other_organizations(client: HttpClient, organization, team, user):
     """
     Should not be able to list batch exports for other teams.
     """
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
-
     other_organization = create_organization("Other Test Org")
     other_team = create_team(other_organization)
     other_user = create_user("another-test@user.com", "Another Test User", other_organization)
@@ -100,14 +93,11 @@ def test_cannot_list_batch_exports_for_other_organizations(client: HttpClient):
     assert len(response["results"]) == 0
 
 
-def test_list_is_partitioned_by_team(client: HttpClient):
+def test_list_is_partitioned_by_team(client: HttpClient, organization, team, user):
     """
     Should be able to list batch exports for a specific team.
     """
-    organization = create_organization("Test Org")
-    team = create_team(organization)
     another_team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
     destination_data = {
         "type": "S3",

--- a/posthog/api/test/batch_exports/test_pause.py
+++ b/posthog/api/test/batch_exports/test_pause.py
@@ -7,8 +7,6 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from posthog.api.test.batch_exports.conftest import start_test_worker
-from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import (
     create_batch_export_ok,
     get_batch_export_ok,
@@ -17,8 +15,6 @@ from posthog.api.test.batch_exports.operations import (
     unpause_batch_export,
     unpause_batch_export_ok,
 )
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
 from posthog.batch_exports.service import batch_export_delete_schedule
 from posthog.temporal.common.schedule import describe_schedule
 
@@ -27,7 +23,7 @@ pytestmark = [
 ]
 
 
-def test_pause_and_unpause_batch_export(client: HttpClient, temporal):
+def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organization, team, user):
     """Test pausing and unpausing a BatchExport."""
 
     destination_data = {
@@ -47,41 +43,38 @@ def test_pause_and_unpause_batch_export(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    assert batch_export["paused"] is False
+    schedule_desc = describe_schedule(temporal, batch_export["id"])
+    assert schedule_desc.schedule.state.paused is False
 
-        assert batch_export["paused"] is False
-        schedule_desc = describe_schedule(temporal, batch_export["id"])
-        assert schedule_desc.schedule.state.paused is False
+    batch_export_id = batch_export["id"]
 
-        batch_export_id = batch_export["id"]
+    pause_batch_export_ok(client, team.pk, batch_export_id)
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
 
-        pause_batch_export_ok(client, team.pk, batch_export_id)
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
+    assert data["paused"] is True
+    schedule_desc = describe_schedule(temporal, data["id"])
+    assert schedule_desc.schedule.state.paused is True
 
-        assert data["paused"] is True
-        schedule_desc = describe_schedule(temporal, data["id"])
-        assert schedule_desc.schedule.state.paused is True
+    unpause_batch_export_ok(client, team.pk, batch_export_id)
 
-        unpause_batch_export_ok(client, team.pk, batch_export_id)
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
 
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-
-        assert data["paused"] is False
-        schedule_desc = describe_schedule(temporal, data["id"])
-        assert schedule_desc.schedule.state.paused is False
+    assert data["paused"] is False
+    schedule_desc = describe_schedule(temporal, data["id"])
+    assert schedule_desc.schedule.state.paused is False
 
 
-def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(client: HttpClient, temporal):
+def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
+    client: HttpClient, temporal, organization, team, user
+):
     destination_data = {
         "type": "S3",
         "config": {
@@ -99,53 +92,51 @@ def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(client: H
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
+    from posthog.api.test.batch_exports.fixtures import create_organization
+    from posthog.api.test.test_team import create_team
+    from posthog.api.test.test_user import create_user
 
     other_organization = create_organization("Other Test Org")
     create_team(other_organization)
     other_user = create_user("another-test@user.com", "Another Test User", other_organization)
+    client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    batch_export_id = batch_export["id"]
 
-        batch_export_id = batch_export["id"]
+    client.force_login(other_user)
+    response = pause_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == 403, response.json()
 
-        client.force_login(other_user)
-        response = pause_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == 403, response.json()
+    # Make sure it's still running
+    client.force_login(user)
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
+    assert data["paused"] is False
 
-        # Make sure it's still running
-        client.force_login(user)
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-        assert data["paused"] is False
+    schedule_desc = describe_schedule(temporal, data["id"])
+    assert schedule_desc.schedule.state.paused is False
 
-        schedule_desc = describe_schedule(temporal, data["id"])
-        assert schedule_desc.schedule.state.paused is False
+    # Now pause it for real, as the correct user
+    pause_batch_export_ok(client, team.pk, batch_export_id)
 
-        # Now pause it for real, as the correct user
-        pause_batch_export_ok(client, team.pk, batch_export_id)
+    # Now check we can't unpause it as the other user.
+    client.force_login(other_user)
+    response = unpause_batch_export(client, team.pk, batch_export_id)
+    assert response.status_code == 403, response.json()
 
-        # Now check we can't unpause it as the other user.
-        client.force_login(other_user)
-        response = unpause_batch_export(client, team.pk, batch_export_id)
-        assert response.status_code == 403, response.json()
-
-        # Make sure it's still paused
-        client.force_login(user)
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-        assert data["paused"] is True
-        schedule_desc = describe_schedule(temporal, data["id"])
-        assert schedule_desc.schedule.state.paused is True
+    # Make sure it's still paused
+    client.force_login(user)
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
+    assert data["paused"] is True
+    schedule_desc = describe_schedule(temporal, data["id"])
+    assert schedule_desc.schedule.state.paused is True
 
 
-def test_pause_and_unpause_are_partitioned_by_team_id(client: HttpClient, temporal):
+def test_pause_and_unpause_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -163,47 +154,44 @@ def test_pause_and_unpause_are_partitioned_by_team_id(client: HttpClient, tempor
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
+    from posthog.api.test.test_team import create_team
+
     other_team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    batch_export_id = batch_export["id"]
 
-        batch_export_id = batch_export["id"]
+    # True pausing using the other team
+    response = pause_batch_export(client, other_team.pk, batch_export_id)
+    assert response.status_code == 404, response.json()
 
-        # True pausing using the other team
-        response = pause_batch_export(client, other_team.pk, batch_export_id)
-        assert response.status_code == 404, response.json()
+    # Make sure it's still running
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
+    assert data["paused"] is False
 
-        # Make sure it's still running
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-        assert data["paused"] is False
+    schedule_desc = describe_schedule(temporal, data["id"])
+    assert schedule_desc.schedule.state.paused is False
 
-        schedule_desc = describe_schedule(temporal, data["id"])
-        assert schedule_desc.schedule.state.paused is False
+    # Now pause it for real, as the correct team
+    pause_batch_export_ok(client, team.pk, batch_export_id)
 
-        # Now pause it for real, as the correct team
-        pause_batch_export_ok(client, team.pk, batch_export_id)
+    # Now check we can't unpause it as the other team.
+    response = unpause_batch_export(client, other_team.pk, batch_export_id)
+    assert response.status_code == 404, response.json()
 
-        # Now check we can't unpause it as the other team.
-        response = unpause_batch_export(client, other_team.pk, batch_export_id)
-        assert response.status_code == 404, response.json()
-
-        # Make sure it's still paused
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-        assert data["paused"] is True
-        schedule_desc = describe_schedule(temporal, data["id"])
-        assert schedule_desc.schedule.state.paused is True
+    # Make sure it's still paused
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
+    assert data["paused"] is True
+    schedule_desc = describe_schedule(temporal, data["id"])
+    assert schedule_desc.schedule.state.paused is True
 
 
-def test_pause_batch_export_that_is_already_paused(client: HttpClient, temporal):
+def test_pause_batch_export_that_is_already_paused(client: HttpClient, temporal, organization, team, user):
     """Test pausing a BatchExport that is already paused doesn't actually do anything."""
 
     destination_data = {
@@ -223,41 +211,36 @@ def test_pause_batch_export_that_is_already_paused(client: HttpClient, temporal)
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    assert batch_export["paused"] is False
+    schedule_desc = describe_schedule(temporal, batch_export["id"])
+    assert schedule_desc.schedule.state.paused is False
 
-        assert batch_export["paused"] is False
-        schedule_desc = describe_schedule(temporal, batch_export["id"])
-        assert schedule_desc.schedule.state.paused is False
+    batch_export_id = batch_export["id"]
 
-        batch_export_id = batch_export["id"]
+    pause_batch_export_ok(client, team.pk, batch_export_id)
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
 
-        pause_batch_export_ok(client, team.pk, batch_export_id)
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
+    last_updated_at = data["last_updated_at"]
 
-        last_updated_at = data["last_updated_at"]
+    assert last_updated_at > batch_export["last_updated_at"]
+    assert data["paused"] is True
+    schedule_desc = describe_schedule(temporal, data["id"])
+    assert schedule_desc.schedule.state.paused is True
 
-        assert last_updated_at > batch_export["last_updated_at"]
-        assert data["paused"] is True
-        schedule_desc = describe_schedule(temporal, data["id"])
-        assert schedule_desc.schedule.state.paused is True
+    pause_batch_export_ok(client, team.pk, batch_export_id)
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
 
-        pause_batch_export_ok(client, team.pk, batch_export_id)
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-
-        assert last_updated_at == data["last_updated_at"]
+    assert last_updated_at == data["last_updated_at"]
 
 
-def test_unpause_batch_export_that_is_already_unpaused(client: HttpClient, temporal):
+def test_unpause_batch_export_that_is_already_unpaused(client: HttpClient, temporal, organization, team, user):
     """Test unpausing a BatchExport that is already unpaused doesn't actually do anything."""
 
     destination_data = {
@@ -277,32 +260,27 @@ def test_unpause_batch_export_that_is_already_unpaused(client: HttpClient, tempo
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    assert batch_export["paused"] is False
+    schedule_desc = describe_schedule(temporal, batch_export["id"])
+    assert schedule_desc.schedule.state.paused is False
 
-        assert batch_export["paused"] is False
-        schedule_desc = describe_schedule(temporal, batch_export["id"])
-        assert schedule_desc.schedule.state.paused is False
+    batch_export_id = batch_export["id"]
+    last_updated_at = batch_export["last_updated_at"]
 
-        batch_export_id = batch_export["id"]
-        last_updated_at = batch_export["last_updated_at"]
+    unpause_batch_export_ok(client, team.pk, batch_export_id)
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
 
-        unpause_batch_export_ok(client, team.pk, batch_export_id)
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-
-        assert last_updated_at == data["last_updated_at"]
+    assert last_updated_at == data["last_updated_at"]
 
 
-def test_pause_non_existent_batch_export(client: HttpClient, temporal):
+def test_pause_non_existent_batch_export(client: HttpClient, temporal, organization, team, user):
     """Test pausing a BatchExport that doesn't exist."""
 
     destination_data = {
@@ -322,30 +300,25 @@ def test_pause_non_existent_batch_export(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    assert batch_export["paused"] is False
+    schedule_desc = describe_schedule(temporal, batch_export["id"])
+    assert schedule_desc.schedule.state.paused is False
 
-        assert batch_export["paused"] is False
-        schedule_desc = describe_schedule(temporal, batch_export["id"])
-        assert schedule_desc.schedule.state.paused is False
+    batch_export_delete_schedule(temporal, batch_export["id"])
 
-        batch_export_delete_schedule(temporal, batch_export["id"])
-
-        batch_export_id = batch_export["id"]
-        resp = pause_batch_export(client, team.pk, batch_export_id)
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    batch_export_id = batch_export["id"]
+    resp = pause_batch_export(client, team.pk, batch_export_id)
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal):
+def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal, organization, team, user):
     """Test unpausing a BatchExport can trigger a backfill."""
 
     destination_data = {
@@ -365,36 +338,31 @@ def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    assert batch_export["paused"] is False
+    schedule_desc = describe_schedule(temporal, batch_export["id"])
+    assert schedule_desc.schedule.state.paused is False
+    batch_export_id = batch_export["id"]
 
-        assert batch_export["paused"] is False
-        schedule_desc = describe_schedule(temporal, batch_export["id"])
-        assert schedule_desc.schedule.state.paused is False
-        batch_export_id = batch_export["id"]
+    pause_batch_export_ok(client, team.pk, batch_export_id)
 
-        pause_batch_export_ok(client, team.pk, batch_export_id)
+    with patch("posthog.batch_exports.service.backfill_export") as mock_backfill:
+        unpause_batch_export_ok(client, team.pk, batch_export_id, backfill=True)
 
-        with patch("posthog.batch_exports.service.backfill_export") as mock_backfill:
-            unpause_batch_export_ok(client, team.pk, batch_export_id, backfill=True)
-
-        data = get_batch_export_ok(client, team.pk, batch_export_id)
-        assert batch_export["last_updated_at"] < data["last_updated_at"]
-        start_at = dt.datetime.strptime(data["last_paused_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.UTC)
-        end_at = dt.datetime.strptime(data["last_updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.UTC)
-        mock_backfill.assert_called_once_with(
-            ANY,
-            batch_export["id"],
-            team.pk,
-            start_at,
-            end_at,
-        )
+    data = get_batch_export_ok(client, team.pk, batch_export_id)
+    assert batch_export["last_updated_at"] < data["last_updated_at"]
+    start_at = dt.datetime.strptime(data["last_paused_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.UTC)
+    end_at = dt.datetime.strptime(data["last_updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.UTC)
+    mock_backfill.assert_called_once_with(
+        ANY,
+        batch_export["id"],
+        team.pk,
+        start_at,
+        end_at,
+    )

--- a/posthog/api/test/batch_exports/test_runs.py
+++ b/posthog/api/test/batch_exports/test_runs.py
@@ -9,8 +9,7 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from posthog.api.test.batch_exports.conftest import start_test_worker
-from posthog.api.test.batch_exports.fixtures import create_organization
+from posthog.api.test.batch_exports.fixtures import create_organization, create_team, create_user
 from posthog.api.test.batch_exports.operations import (
     backfill_batch_export_ok,
     cancel_batch_export_run_ok,
@@ -20,15 +19,13 @@ from posthog.api.test.batch_exports.operations import (
     get_batch_export_runs_ok,
     wait_for_workflow_executions,
 )
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
 
 pytestmark = [
     pytest.mark.django_db,
 ]
 
 
-def test_can_get_export_runs_for_your_organizations(client: HttpClient, temporal):
+def test_can_get_export_runs_for_your_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -46,23 +43,18 @@ def test_can_get_export_runs_for_your_organizations(client: HttpClient, temporal
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
+    response = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        response = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
-
-        response = get_batch_export_runs(client, team.pk, response["id"])
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = get_batch_export_runs(client, team.pk, response["id"])
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
 
-def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal):
+def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -79,28 +71,22 @@ def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal
         "destination": destination_data,
         "interval": "hour",
     }
-
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
 
     another_organization = create_organization("Another Org")
     another_user = create_user("another-test@user.com", "Another Test User", another_organization)
+    client.force_login(user)
+    response = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        response = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
-
-        client.force_login(another_user)
-        response = get_batch_export_runs(client, team.pk, response["id"])
-        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+    client.force_login(another_user)
+    response = get_batch_export_runs(client, team.pk, response["id"])
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
 
-def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal):
+def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, organization, team, user):
     """
     You shouldn't be able to fetch a BatchExport by id, via a team that it
     doesn't belong to.
@@ -122,35 +108,30 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
     another_team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-    with start_test_worker(temporal):
-        client.force_login(user)
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = get_batch_export(client, another_team.pk, batch_export["id"])
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
 
-        response = get_batch_export(client, another_team.pk, batch_export["id"])
-        assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    # And switch the teams around for good measure.
+    batch_export = create_batch_export_ok(
+        client,
+        another_team.pk,
+        batch_export_data,
+    )
 
-        # And switch the teams around for good measure.
-        batch_export = create_batch_export_ok(
-            client,
-            another_team.pk,
-            batch_export_data,
-        )
-
-        response = get_batch_export(client, team.pk, batch_export["id"])
-        assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    response = get_batch_export(client, team.pk, batch_export["id"])
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
 
 
 @pytest.mark.django_db(transaction=True)
-def test_cancelling_a_batch_export_run(client: HttpClient, temporal):
+def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organization, team, user):
     """Test cancelling a BatchExportRun."""
     destination_data = {
         "type": "S3",
@@ -168,9 +149,6 @@ def test_cancelling_a_batch_export_run(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     with patch("products.batch_exports.backend.temporal.pipeline.producer.Producer.start") as mock_producer_start:
@@ -181,40 +159,39 @@ def test_cancelling_a_batch_export_run(client: HttpClient, temporal):
 
         mock_producer_start.side_effect = mock_sleep
 
-        with start_test_worker(temporal):
-            batch_export = create_batch_export_ok(
-                client,
-                team.pk,
-                batch_export_data,
-            )
-            batch_export_id = batch_export["id"]
+        batch_export = create_batch_export_ok(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+        batch_export_id = batch_export["id"]
 
-            start_at = "2023-10-23T00:00:00+00:00"
-            end_at = "2023-10-24T00:00:00+00:00"
-            # ensure there is data to backfill, otherwise validation will fail
-            _create_event(
-                team=team,
-                event="$pageview",
-                distinct_id="person_1",
-                timestamp=dt.datetime(2023, 10, 23, 0, 1, 0, tzinfo=dt.UTC),
-            )
-            backfill_batch_export_ok(client, team.pk, batch_export_id, start_at, end_at)
+        start_at = "2023-10-23T00:00:00+00:00"
+        end_at = "2023-10-24T00:00:00+00:00"
+        # ensure there is data to backfill, otherwise validation will fail
+        _create_event(
+            team=team,
+            event="$pageview",
+            distinct_id="person_1",
+            timestamp=dt.datetime(2023, 10, 23, 0, 1, 0, tzinfo=dt.UTC),
+        )
+        backfill_batch_export_ok(client, team.pk, batch_export_id, start_at, end_at)
 
-            # In order for a run to be cancelable we need a running workflow execution
-            _ = wait_for_workflow_executions(temporal, query=f'TemporalScheduledById="{batch_export_id}"')
+        # In order for a run to be cancelable we need a running workflow execution
+        _ = wait_for_workflow_executions(temporal, query=f'TemporalScheduledById="{batch_export_id}"')
 
-            data = get_batch_export_runs_ok(client, team.pk, batch_export_id)
-            assert len(data["results"]) == 1
-            run = data["results"][0]
-            assert run["status"] == "Running"
+        data = get_batch_export_runs_ok(client, team.pk, batch_export_id)
+        assert len(data["results"]) == 1
+        run = data["results"][0]
+        assert run["status"] == "Running"
 
-            data = cancel_batch_export_run_ok(client, team.pk, batch_export_id, run["id"])
-            assert data["cancelled"] is True
+        data = cancel_batch_export_run_ok(client, team.pk, batch_export_id, run["id"])
+        assert data["cancelled"] is True
 
-            data = get_batch_export_runs_ok(client, team.pk, batch_export_id)
-            assert len(data["results"]) == 1
-            run = data["results"][0]
-            assert run["status"] == "Cancelled"
+        data = get_batch_export_runs_ok(client, team.pk, batch_export_id)
+        assert len(data["results"]) == 1
+        run = data["results"][0]
+        assert run["status"] == "Cancelled"
 
 
 # TODO - add a test to ensure we can't cancel a completed run?

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -10,16 +10,13 @@ from django.test.client import Client as HttpClient
 from asgiref.sync import async_to_sync
 from rest_framework import status
 
-from posthog.api.test.batch_exports.conftest import describe_schedule, start_test_worker
-from posthog.api.test.batch_exports.fixtures import create_organization
+from posthog.api.test.batch_exports.conftest import describe_schedule
 from posthog.api.test.batch_exports.operations import (
     create_batch_export_ok,
     get_batch_export_ok,
     patch_batch_export,
     put_batch_export,
 )
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
 from posthog.batch_exports.service import sync_batch_export
 from posthog.models import BatchExport, BatchExportDestination
 from posthog.temporal.common.codec import EncryptionCodec
@@ -29,7 +26,7 @@ pytestmark = [
 ]
 
 
-def test_can_put_config(client: HttpClient, temporal):
+def test_can_put_config(client: HttpClient, temporal, organization, team, user):
     destination_data: dict[str, t.Any] = {
         "type": "S3",
         "config": {
@@ -49,58 +46,54 @@ def test_can_put_config(client: HttpClient, temporal):
         "end_at": "2023-07-20T00:00:00+00:00",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        # If we try to update without all fields, it should fail with a 400 error
-        new_batch_export_data: dict[str, t.Any] = {
-            "name": "my-production-s3-bucket-destination",
-            "interval": "hour",
-        }
-        response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+    # If we try to update without all fields, it should fail with a 400 error
+    new_batch_export_data: dict[str, t.Any] = {
+        "name": "my-production-s3-bucket-destination",
+        "interval": "hour",
+    }
+    response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-        old_schedule = describe_schedule(temporal, batch_export["id"])
+    old_schedule = describe_schedule(temporal, batch_export["id"])
 
-        # We should be able to update if we specify all fields
-        new_destination_data = {**destination_data}
-        new_destination_data["config"]["bucket_name"] = "my-new-production-s3-bucket"
-        new_destination_data["config"]["aws_secret_access_key"] = "new-secret"
-        new_batch_export_data_2: dict[str, t.Any] = {
-            "name": "my-production-s3-bucket-destination",
-            "destination": new_destination_data,
-            "interval": "day",
-            "start_at": "2022-07-19 00:00:00",
-        }
+    # We should be able to update if we specify all fields
+    new_destination_data = {**destination_data}
+    new_destination_data["config"]["bucket_name"] = "my-new-production-s3-bucket"
+    new_destination_data["config"]["aws_secret_access_key"] = "new-secret"
+    new_batch_export_data_2: dict[str, t.Any] = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": new_destination_data,
+        "interval": "day",
+        "start_at": "2022-07-19 00:00:00",
+    }
 
-        response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data_2)
-        assert response.status_code == status.HTTP_200_OK
+    response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data_2)
+    assert response.status_code == status.HTTP_200_OK
 
-        # get the batch export and validate e.g. that interval has been updated to day
-        batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-        assert batch_export["interval"] == "day"
+    # get the batch export and validate e.g. that interval has been updated to day
+    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
+    assert batch_export["interval"] == "day"
 
-        # validate the underlying temporal schedule has been updated
-        codec = EncryptionCodec(settings=settings)
-        new_schedule = describe_schedule(temporal, batch_export["id"])
-        assert old_schedule.schedule.spec.intervals[0].every != new_schedule.schedule.spec.intervals[0].every
-        assert new_schedule.schedule.spec.intervals[0].every == dt.timedelta(days=1)
-        assert new_schedule.schedule.spec.start_at == dt.datetime(2022, 7, 19, 0, 0, 0, tzinfo=dt.UTC)
-        assert new_schedule.schedule.spec.end_at == dt.datetime(2023, 7, 20, 0, 0, 0, tzinfo=dt.UTC)
+    # validate the underlying temporal schedule has been updated
+    codec = EncryptionCodec(settings=settings)
+    new_schedule = describe_schedule(temporal, batch_export["id"])
+    assert old_schedule.schedule.spec.intervals[0].every != new_schedule.schedule.spec.intervals[0].every
+    assert new_schedule.schedule.spec.intervals[0].every == dt.timedelta(days=1)
+    assert new_schedule.schedule.spec.start_at == dt.datetime(2022, 7, 19, 0, 0, 0, tzinfo=dt.UTC)
+    assert new_schedule.schedule.spec.end_at == dt.datetime(2023, 7, 20, 0, 0, 0, tzinfo=dt.UTC)
 
-        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
-        args = json.loads(decoded_payload[0].data)
-        assert args["bucket_name"] == "my-new-production-s3-bucket"
-        assert args["aws_secret_access_key"] == "new-secret"
+    decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
+    assert args["bucket_name"] == "my-new-production-s3-bucket"
+    assert args["aws_secret_access_key"] == "new-secret"
 
 
 @pytest.mark.parametrize("interval", ["hour", "day"])
@@ -108,7 +101,7 @@ def test_can_put_config(client: HttpClient, temporal):
     "timezone",
     ["US/Pacific", "UTC", "Europe/Berlin", "Asia/Tokyo", "Pacific/Marquesas", "Asia/Katmandu"],
 )
-def test_can_patch_config(client: HttpClient, interval, timezone, temporal):
+def test_can_patch_config(client: HttpClient, interval, timezone, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -126,57 +119,57 @@ def test_can_patch_config(client: HttpClient, interval, timezone, temporal):
         "interval": interval,
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization, timezone=timezone)
-    user = create_user("test@user.com", "Test User", organization)
+    # Update team timezone for this test
+    team.timezone = timezone
+    team.save()
+
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
-        old_schedule = describe_schedule(temporal, batch_export["id"])
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
+    old_schedule = describe_schedule(temporal, batch_export["id"])
 
-        # We should be able to update the destination config, excluding the aws
-        # credentials. The existing values should be preserved.
-        new_destination_data = {
-            "type": "S3",
-            "config": {
-                "bucket_name": "my-new-production-s3-bucket",
-                "region": "us-east-1",
-                "prefix": "posthog-events/",
-            },
-        }
+    # We should be able to update the destination config, excluding the aws
+    # credentials. The existing values should be preserved.
+    new_destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-new-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+        },
+    }
 
-        new_batch_export_data = {
-            "name": "my-production-s3-bucket-destination",
-            "destination": new_destination_data,
-        }
+    new_batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": new_destination_data,
+    }
 
-        response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-        # get the batch export and validate e.g. that bucket_name and interval
-        # has been preserved.
-        batch_export_data = get_batch_export_ok(client, team.pk, batch_export["id"])
-        assert batch_export_data["interval"] == interval
-        assert batch_export_data["destination"]["config"]["bucket_name"] == "my-new-production-s3-bucket"
+    # get the batch export and validate e.g. that bucket_name and interval
+    # has been preserved.
+    batch_export_data = get_batch_export_ok(client, team.pk, batch_export["id"])
+    assert batch_export_data["interval"] == interval
+    assert batch_export_data["destination"]["config"]["bucket_name"] == "my-new-production-s3-bucket"
 
-        # validate the underlying temporal schedule has been updated
-        codec = EncryptionCodec(settings=settings)
-        new_schedule = describe_schedule(temporal, batch_export["id"])
-        assert old_schedule.schedule.spec.intervals[0].every == new_schedule.schedule.spec.intervals[0].every
-        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
-        args = json.loads(decoded_payload[0].data)
-        assert args["bucket_name"] == "my-new-production-s3-bucket"
-        assert new_schedule.schedule.spec.time_zone_name == old_schedule.schedule.spec.time_zone_name == timezone
+    # validate the underlying temporal schedule has been updated
+    codec = EncryptionCodec(settings=settings)
+    new_schedule = describe_schedule(temporal, batch_export["id"])
+    assert old_schedule.schedule.spec.intervals[0].every == new_schedule.schedule.spec.intervals[0].every
+    decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
+    assert args["bucket_name"] == "my-new-production-s3-bucket"
+    assert new_schedule.schedule.spec.time_zone_name == old_schedule.schedule.spec.time_zone_name == timezone
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("interval", ["hour", "day"])
-def test_can_patch_config_with_invalid_old_values(client: HttpClient, interval, temporal):
+def test_can_patch_config_with_invalid_old_values(client: HttpClient, interval, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -194,9 +187,6 @@ def test_can_patch_config_with_invalid_old_values(client: HttpClient, interval, 
         "interval": interval,
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
     # Create a BatchExport straight in the database/temporal to avoid going through the API
@@ -209,42 +199,41 @@ def test_can_patch_config_with_invalid_old_values(client: HttpClient, interval, 
     destination.save()
     batch_export.save()
 
-    with start_test_worker(temporal):
-        # We should be able to update the destination config, even if there is an invalid config
-        # in the existing keys.
-        new_destination_data = {
-            "type": "S3",
-            "config": {
-                "bucket_name": "my-new-production-s3-bucket",
-                "region": "us-east-1",
-                "prefix": "posthog-events/",
-            },
-        }
+    # We should be able to update the destination config, even if there is an invalid config
+    # in the existing keys.
+    new_destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-new-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+        },
+    }
 
-        new_batch_export_data = {
-            "name": "my-production-s3-bucket-destination",
-            "destination": new_destination_data,
-        }
+    new_batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": new_destination_data,
+    }
 
-        response = patch_batch_export(client, team.pk, batch_export.id, new_batch_export_data)
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = patch_batch_export(client, team.pk, batch_export.id, new_batch_export_data)
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-        # get the batch export and validate e.g. that bucket_name and interval
-        # has been preserved.
-        batch_export_data = get_batch_export_ok(client, team.pk, batch_export.id)
-        assert batch_export_data["interval"] == interval
-        assert batch_export_data["destination"]["config"]["bucket_name"] == "my-new-production-s3-bucket"
+    # get the batch export and validate e.g. that bucket_name and interval
+    # has been preserved.
+    batch_export_data = get_batch_export_ok(client, team.pk, batch_export.id)
+    assert batch_export_data["interval"] == interval
+    assert batch_export_data["destination"]["config"]["bucket_name"] == "my-new-production-s3-bucket"
 
-        # validate the underlying temporal schedule has been updated
-        codec = EncryptionCodec(settings=settings)
-        new_schedule = describe_schedule(temporal, batch_export_data["id"])
-        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
-        args = json.loads(decoded_payload[0].data)
-        assert args["bucket_name"] == "my-new-production-s3-bucket"
-        assert args.get("invalid_key", None) is None
+    # validate the underlying temporal schedule has been updated
+    codec = EncryptionCodec(settings=settings)
+    new_schedule = describe_schedule(temporal, batch_export_data["id"])
+    decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
+    assert args["bucket_name"] == "my-new-production-s3-bucket"
+    assert args.get("invalid_key", None) is None
 
 
-def test_can_patch_hogql_query(client: HttpClient, temporal):
+def test_can_patch_hogql_query(client: HttpClient, temporal, organization, team, user):
     """Test we can patch a schema with a HogQL query."""
     destination_data = {
         "type": "S3",
@@ -263,31 +252,57 @@ def test_can_patch_hogql_query(client: HttpClient, temporal):
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
-        old_schedule = describe_schedule(temporal, batch_export["id"])
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
+    old_schedule = describe_schedule(temporal, batch_export["id"])
 
-        new_batch_export_data = {
-            "name": "my-production-s3-bucket-destination",
-            "hogql_query": "select toString(uuid) as uuid, 'test' as test, toInt(1+1) as n from events",
-        }
+    new_batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "hogql_query": "select toString(uuid) as uuid, 'test' as test, toInt(1+1) as n from events",
+    }
 
-        response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-        response_data: dict[str, t.Any] = get_batch_export_ok(client, team.pk, batch_export["id"])
-        assert response_data["interval"] == "hour"
-        assert response_data["destination"]["config"]["bucket_name"] == "my-production-s3-bucket"
-        assert response_data["schema"] == {
+    response_data: dict[str, t.Any] = get_batch_export_ok(client, team.pk, batch_export["id"])
+    assert response_data["interval"] == "hour"
+    assert response_data["destination"]["config"]["bucket_name"] == "my-production-s3-bucket"
+    assert response_data["schema"] == {
+        "fields": [
+            {
+                "alias": "uuid",
+                "expression": "toString(events.uuid)",
+            },
+            {
+                "alias": "test",
+                "expression": "%(hogql_val_0)s",
+            },
+            {
+                "alias": "n",
+                "expression": "accurateCastOrNull(plus(1, 1), %(hogql_val_1)s)",
+            },
+        ],
+        "values": {"hogql_val_0": "test", "hogql_val_1": "Int64"},
+        "hogql_query": "SELECT toString(uuid) AS uuid, 'test' AS test, toInt(plus(1, 1)) AS n FROM events",
+    }
+
+    # validate the underlying temporal schedule has been updated
+    codec = EncryptionCodec(settings=settings)
+    new_schedule = describe_schedule(temporal, batch_export["id"])
+    assert old_schedule.schedule.spec.intervals[0].every == new_schedule.schedule.spec.intervals[0].every
+    decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
+    assert args["bucket_name"] == "my-production-s3-bucket"
+    assert args["interval"] == "hour"
+    assert args["batch_export_model"] == {
+        "name": "events",
+        "filters": None,
+        "schema": {
             "fields": [
                 {
                     "alias": "uuid",
@@ -304,41 +319,11 @@ def test_can_patch_hogql_query(client: HttpClient, temporal):
             ],
             "values": {"hogql_val_0": "test", "hogql_val_1": "Int64"},
             "hogql_query": "SELECT toString(uuid) AS uuid, 'test' AS test, toInt(plus(1, 1)) AS n FROM events",
-        }
-
-        # validate the underlying temporal schedule has been updated
-        codec = EncryptionCodec(settings=settings)
-        new_schedule = describe_schedule(temporal, batch_export["id"])
-        assert old_schedule.schedule.spec.intervals[0].every == new_schedule.schedule.spec.intervals[0].every
-        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
-        args = json.loads(decoded_payload[0].data)
-        assert args["bucket_name"] == "my-production-s3-bucket"
-        assert args["interval"] == "hour"
-        assert args["batch_export_model"] == {
-            "name": "events",
-            "filters": None,
-            "schema": {
-                "fields": [
-                    {
-                        "alias": "uuid",
-                        "expression": "toString(events.uuid)",
-                    },
-                    {
-                        "alias": "test",
-                        "expression": "%(hogql_val_0)s",
-                    },
-                    {
-                        "alias": "n",
-                        "expression": "accurateCastOrNull(plus(1, 1), %(hogql_val_1)s)",
-                    },
-                ],
-                "values": {"hogql_val_0": "test", "hogql_val_1": "Int64"},
-                "hogql_query": "SELECT toString(uuid) AS uuid, 'test' AS test, toInt(plus(1, 1)) AS n FROM events",
-            },
-        }
+        },
+    }
 
 
-def test_patch_returns_error_on_unsupported_hogql_query(client: HttpClient, temporal):
+def test_patch_returns_error_on_unsupported_hogql_query(client: HttpClient, temporal, organization, team, user):
     destination_data = {
         "type": "S3",
         "config": {
@@ -358,28 +343,24 @@ def test_patch_returns_error_on_unsupported_hogql_query(client: HttpClient, temp
         "end_at": "2023-07-20 00:00:00",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        new_batch_export_data = {
-            "name": "my-production-s3-bucket-destination",
-            # toInt32 is not a supported HogQL function
-            "hogql_query": "select toInt32(1+1) as n from events",
-        }
-        response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+    new_batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        # toInt32 is not a supported HogQL function
+        "hogql_query": "select toInt32(1+1) as n from events",
+    }
+    response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_can_patch_snowflake_batch_export_credentials(client: HttpClient, temporal):
+def test_can_patch_snowflake_batch_export_credentials(client: HttpClient, temporal, organization, team, user):
     """Test we can switch Snowflake authentication types while preserving credentials."""
     destination_data = {
         "type": "Snowflake",
@@ -401,65 +382,63 @@ def test_can_patch_snowflake_batch_export_credentials(client: HttpClient, tempor
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        # Test switching to key pair auth type
-        new_destination_data = {
-            "type": "Snowflake",
-            "config": {
-                "authentication_type": "keypair",
-                "private_key": "SECRET_KEY",
-            },
-        }
+    # Test switching to key pair auth type
+    new_destination_data = {
+        "type": "Snowflake",
+        "config": {
+            "authentication_type": "keypair",
+            "private_key": "SECRET_KEY",
+        },
+    }
 
-        new_batch_export_data = {
-            "destination": new_destination_data,
-        }
+    new_batch_export_data = {
+        "destination": new_destination_data,
+    }
 
-        response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-        # Verify the auth type switch worked and other fields were preserved
-        batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-        assert batch_export["destination"]["type"] == "Snowflake"
-        assert batch_export["destination"]["config"]["account"] == "my-account"
-        assert batch_export["destination"]["config"]["authentication_type"] == "keypair"
-        assert "private_key" not in batch_export["destination"]["config"]  # Private key should be hidden in response
+    # Verify the auth type switch worked and other fields were preserved
+    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
+    assert batch_export["destination"]["type"] == "Snowflake"
+    assert batch_export["destination"]["config"]["account"] == "my-account"
+    assert batch_export["destination"]["config"]["authentication_type"] == "keypair"
+    assert "private_key" not in batch_export["destination"]["config"]  # Private key should be hidden in response
 
-        # Test switching back to password auth type without providing password (should keep original)
-        new_destination_data = {
-            "type": "Snowflake",
-            "config": {
-                "authentication_type": "password",
-            },
-        }
+    # Test switching back to password auth type without providing password (should keep original)
+    new_destination_data = {
+        "type": "Snowflake",
+        "config": {
+            "authentication_type": "password",
+        },
+    }
 
-        new_batch_export_data = {
-            "destination": new_destination_data,
-        }
+    new_batch_export_data = {
+        "destination": new_destination_data,
+    }
 
-        response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-        assert response.status_code == status.HTTP_200_OK, response.json()
+    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-        # Verify switched back to password auth and kept original password
-        batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-        assert batch_export["destination"]["type"] == "Snowflake"
-        assert batch_export["destination"]["config"]["account"] == "my-account"
-        assert batch_export["destination"]["config"]["authentication_type"] == "password"
-        assert "password" not in batch_export["destination"]["config"]  # Password should be hidden in response
+    # Verify switched back to password auth and kept original password
+    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
+    assert batch_export["destination"]["type"] == "Snowflake"
+    assert batch_export["destination"]["config"]["account"] == "my-account"
+    assert batch_export["destination"]["config"]["authentication_type"] == "password"
+    assert "password" not in batch_export["destination"]["config"]  # Password should be hidden in response
 
 
-def test_switching_snowflake_auth_type_to_keypair_requires_private_key(client: HttpClient, temporal):
+def test_switching_snowflake_auth_type_to_keypair_requires_private_key(
+    client: HttpClient, temporal, organization, team, user
+):
     """Test that switching to keypair authentication requires a private key to be provided."""
     destination_data = {
         "type": "Snowflake",
@@ -481,35 +460,31 @@ def test_switching_snowflake_auth_type_to_keypair_requires_private_key(client: H
         "interval": "hour",
     }
 
-    organization = create_organization("Test Org")
-    team = create_team(organization)
-    user = create_user("test@user.com", "Test User", organization)
     client.force_login(user)
 
-    with start_test_worker(temporal):
-        batch_export = create_batch_export_ok(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
-        # Test switching to keypair auth type without providing a private key
-        new_destination_data = {
-            "type": "Snowflake",
-            "config": {
-                "authentication_type": "keypair",
-            },
-        }
+    # Test switching to keypair auth type without providing a private key
+    new_destination_data = {
+        "type": "Snowflake",
+        "config": {
+            "authentication_type": "keypair",
+        },
+    }
 
-        new_batch_export_data = {
-            "destination": new_destination_data,
-        }
+    new_batch_export_data = {
+        "destination": new_destination_data,
+    }
 
-        response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Private key is required if authentication type is key pair" in response.json()["detail"]
+    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Private key is required if authentication type is key pair" in response.json()["detail"]
 
-        # Verify the auth type was not changed
-        batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-        assert batch_export["destination"]["type"] == "Snowflake"
-        assert batch_export["destination"]["config"]["authentication_type"] == "password"
+    # Verify the auth type was not changed
+    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
+    assert batch_export["destination"]["type"] == "Snowflake"
+    assert batch_export["destination"]["config"]["authentication_type"] == "password"


### PR DESCRIPTION
## Problem

Our API tests for batch exports are very slow (many take over 10s), which can be pretty frustrating.

## Changes

Upon closer inspection, most of the duration of the tests is due to us starting and stopping a temporal test worker, which we need to start in a separate thread and ensure it stops (otherwise we can run into other errors when pytest needs to stop).

Rather than start and stop a worker for each test, we [create a module-scoped fixture](https://github.com/PostHog/posthog/pull/38318/files#diff-18ee624eceadd2893bd69d908a40c973d000fa60ecd59fc53b7f9e8d7ae9bd3fR56-R63) to do this, so we only need to do it once per test module.

I have also refactored the creation of orgs, teams and users into a fixture to avoid some repetition.

This reduces the test duration by more than 3X:

Before:
```
117 passed in 598.57s (0:09:58)
```

After:
```
117 passed in 162.54s (0:02:42)
```

**NOTE: the diffs look large but most is indentation diffs caused by removing the `start_test_worker` context manager. Diffs best viewed using the 'Hide whitespace' setting 😉**

## How did you test this code?

This is test code.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
