### PR TITLE
fix(max-ai): Set subscription_level to free when not available

### DIFF
--- a/frontend/src/scenes/max/maxBillingContextLogic.tsx
+++ b/frontend/src/scenes/max/maxBillingContextLogic.tsx
@@ -207,7 +207,9 @@ export const billingToMaxContext = (
 
     return {
         has_active_subscription: billing.has_active_subscription || false,
-        subscription_level: billing.subscription_level as MaxBillingContextSubscriptionLevel,
+        subscription_level:
+            (billing.subscription_level as MaxBillingContextSubscriptionLevel) ||
+            MaxBillingContextSubscriptionLevel.FREE,
         billing_plan: billing.billing_plan || null,
         is_deactivated: billing.deactivated,
         products: maxProducts,


### PR DESCRIPTION
## Problem

When using Max AI in my local environment, it fails with an exception about the billing subscription_level.

## Changes

Defaults to FREE when subscription_level is undefined.

## How did you test this code?

Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
