### PR TITLE
fix(plugin-server): collect & propagate capturedPostHogEvents in cdp-…

### DIFF
--- a/plugin-server/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/hog_function.ts
@@ -29,6 +29,12 @@ export class HogFunctionHandler implements ActionHandler {
     ): Promise<ActionHandlerResult> {
         const functionResult = await this.executeHogFunction(invocation, action)
 
+        // Add all events to capture
+        result.capturedPostHogEvents = [
+            ...result.capturedPostHogEvents,
+            ...functionResult.capturedPostHogEvents
+        ]
+
         // Add all logs
         functionResult.logs.forEach((log: MinimalLogEntry) => {
             result.logs.push({

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -6,6 +6,7 @@ import { UUIDT } from '../../../utils/utils'
 import {
     CyclotronJobInvocationHogFlow,
     CyclotronJobInvocationResult,
+    HogFunctionCapturedEvent,
     HogFunctionFilterGlobals,
     HogFunctionInvocationGlobals,
     LogEntry,
@@ -123,6 +124,7 @@ export class HogFlowExecutorService {
         let result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow> | null = null
         const metrics: MinimalAppMetric[] = []
         const logs: MinimalLogEntry[] = []
+        const capturedPostHogEvents: HogFunctionCapturedEvent[] = []
 
         const earlyExitResult = await this.shouldExitEarly(invocation)
         if (earlyExitResult) {
@@ -151,6 +153,7 @@ export class HogFlowExecutorService {
                 }
             }
 
+            capturedPostHogEvents.push(...result.capturedPostHogEvents)
             logs.push(...result.logs)
             metrics.push(...result.metrics)
 
@@ -159,6 +162,7 @@ export class HogFlowExecutorService {
             }
         }
 
+        result.capturedPostHogEvents = capturedPostHogEvents
         result.logs = logs
         result.metrics = metrics
 


### PR DESCRIPTION
…cyclotron-worker-hogflow consumer

### Problem

This fixes an issue where `capturedPostHogEvents` were not being properly collected and propagated in the CDP cyclotron worker hogflow consumer. When hog functions executed within hogflows captured PostHog events, these events were being lost instead of being passed through to the result, preventing them from being processed correctly downstream.

<img width="469" height="437" alt="image" src="https://github.com/user-attachments/assets/4b05c1b0-7e04-42da-9953-8ad64ba2e461" />

### Changes

- Added event collection logic in `HogFunctionHandler` to merge `capturedPostHogEvents` from function results into the main result
- Added `capturedPostHogEvents` array initialization and collection in `HogFlowExecutorService` to properly aggregate events from all executed actions
- Added missing `HogFunctionCapturedEvent` import in the executor service

The changes ensure that captured events from hog functions are properly collected and included in the final invocation result.

### How did you test this code?

I tested the code manually by running hogflows with hog functions that capture PostHog events and verified that the events are now properly collected and propagated. I failed to write automated tests because the test environment stopped working, but the functionality was validated through manual testing of the event collection flow.

Fixes: #38325
