### PR TITLE
fix: swap staging table schemas to match production destination tables

### DIFF
--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -117,6 +117,14 @@ def REPLACE_WEB_STATS_HOURLY_STAGING_SQL():
 
 
 # Hardcoded production column definitions to match exact table structure
+#
+# NOTE: These definitions exist because the production destination tables have a different
+# column order than what our WEB_STATS_COLUMNS/WEB_BOUNCES_COLUMNS generate. Specifically,
+# mat_metadata_loggedIn appears at the END of the production tables (due to migration via
+# ALTER TABLE ADD COLUMN), but our code generates it in the middle. For REPLACE PARTITION
+# to work, staging and destination tables must have identical column order and types.
+#
+# Production table schemas extracted from DESCRIBE TABLE commands:
 WEB_STATS_V2_PRODUCTION_COLUMNS = """
     entry_pathname String,
     end_pathname String,

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -119,8 +119,8 @@ def REPLACE_WEB_STATS_HOURLY_STAGING_SQL():
 def REPLACE_WEB_STATS_V2_STAGING_SQL():
     return TABLE_TEMPLATE(
         "web_pre_aggregated_stats_staging",
-        WEB_STATS_COLUMNS,
-        WEB_STATS_ORDER_BY_FUNC("period_bucket"),
+        WEB_BOUNCES_COLUMNS,
+        WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
         force_unique_zk_path=True,
         replace=True,
         on_cluster=False,
@@ -130,8 +130,8 @@ def REPLACE_WEB_STATS_V2_STAGING_SQL():
 def REPLACE_WEB_BOUNCES_V2_STAGING_SQL():
     return TABLE_TEMPLATE(
         "web_pre_aggregated_bounces_staging",
-        WEB_BOUNCES_COLUMNS,
-        WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
+        WEB_STATS_COLUMNS,
+        WEB_STATS_ORDER_BY_FUNC("period_bucket"),
         force_unique_zk_path=True,
         replace=True,
         on_cluster=False,

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -190,7 +190,7 @@ def REPLACE_WEB_STATS_V2_STAGING_SQL():
     return TABLE_TEMPLATE(
         "web_pre_aggregated_stats_staging",
         WEB_STATS_V2_PRODUCTION_COLUMNS,
-        WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
+        WEB_STATS_ORDER_BY_FUNC("period_bucket"),
         force_unique_zk_path=True,
         replace=True,
         on_cluster=False,

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -116,10 +116,72 @@ def REPLACE_WEB_STATS_HOURLY_STAGING_SQL():
     )
 
 
+# Hardcoded production column definitions to match exact table structure
+WEB_STATS_V2_PRODUCTION_COLUMNS = """
+    entry_pathname String,
+    end_pathname String,
+    browser String,
+    os String,
+    viewport_width Int64,
+    viewport_height Int64,
+    referring_domain String,
+    utm_source String,
+    utm_medium String,
+    utm_campaign String,
+    utm_term String,
+    utm_content String,
+    country_code String,
+    city_name String,
+    region_code String,
+    region_name String,
+    has_gclid Bool,
+    has_gad_source_paid_search Bool,
+    has_fbclid Bool,
+    mat_metadata_backend Nullable(String),
+    persons_uniq_state AggregateFunction(uniq, UUID),
+    sessions_uniq_state AggregateFunction(uniq, String),
+    pageviews_count_state AggregateFunction(sum, UInt64),
+    bounces_count_state AggregateFunction(sum, UInt64),
+    total_session_duration_state AggregateFunction(sum, Int64),
+    total_session_count_state AggregateFunction(sum, UInt64),
+    mat_metadata_loggedIn Nullable(Bool)
+"""
+
+WEB_BOUNCES_V2_PRODUCTION_COLUMNS = """
+    entry_pathname String,
+    end_pathname String,
+    browser String,
+    os String,
+    viewport_width Int64,
+    viewport_height Int64,
+    referring_domain String,
+    utm_source String,
+    utm_medium String,
+    utm_campaign String,
+    utm_term String,
+    utm_content String,
+    country_code String,
+    city_name String,
+    region_code String,
+    region_name String,
+    has_gclid Bool,
+    has_gad_source_paid_search Bool,
+    has_fbclid Bool,
+    mat_metadata_backend Nullable(String),
+    persons_uniq_state AggregateFunction(uniq, UUID),
+    sessions_uniq_state AggregateFunction(uniq, String),
+    pageviews_count_state AggregateFunction(sum, UInt64),
+    bounces_count_state AggregateFunction(sum, UInt64),
+    total_session_duration_state AggregateFunction(sum, Int64),
+    total_session_count_state AggregateFunction(sum, UInt64),
+    mat_metadata_loggedIn Nullable(Bool)
+"""
+
+
 def REPLACE_WEB_STATS_V2_STAGING_SQL():
     return TABLE_TEMPLATE(
         "web_pre_aggregated_stats_staging",
-        WEB_BOUNCES_COLUMNS,
+        WEB_STATS_V2_PRODUCTION_COLUMNS,
         WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
         force_unique_zk_path=True,
         replace=True,
@@ -130,8 +192,8 @@ def REPLACE_WEB_STATS_V2_STAGING_SQL():
 def REPLACE_WEB_BOUNCES_V2_STAGING_SQL():
     return TABLE_TEMPLATE(
         "web_pre_aggregated_bounces_staging",
-        WEB_STATS_COLUMNS,
-        WEB_STATS_ORDER_BY_FUNC("period_bucket"),
+        WEB_BOUNCES_V2_PRODUCTION_COLUMNS,
+        WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
         force_unique_zk_path=True,
         replace=True,
         on_cluster=False,


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/38281 changed the logic to recreate the staging tables, but for the `SWAP PARTITION` to work, the tables must have the exact format. This is a workaround for us to keep testing the options describe on that first PR.

This is not a problem for v1 because we don't do partition swaps there, but it is what we want to accomplish here.

## Changes

- Use the table format on PROD for recreating the tables.

## How did you test this code?

- Running many queries

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
