### PR TITLE
fix: use fixed ORDER BY on web staging tables

### DIFF
--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -183,12 +183,67 @@ WEB_BOUNCES_V2_PRODUCTION_COLUMNS = """
     mat_metadata_loggedIn Nullable(Bool)
 """
 
+# Production ORDER BY clauses extracted from production tables
+# These exclude nullable columns to avoid ClickHouse "Sorting key contains nullable columns" error
+WEB_STATS_V2_PRODUCTION_ORDER_BY = """(
+    team_id,
+    period_bucket,
+    host,
+    device_type,
+    pathname,
+    entry_pathname,
+    end_pathname,
+    browser,
+    os,
+    viewport_width,
+    viewport_height,
+    referring_domain,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_term,
+    utm_content,
+    country_code,
+    city_name,
+    region_code,
+    region_name,
+    has_gclid,
+    has_gad_source_paid_search,
+    has_fbclid
+)"""
+
+WEB_BOUNCES_V2_PRODUCTION_ORDER_BY = """(
+    team_id,
+    period_bucket,
+    host,
+    device_type,
+    entry_pathname,
+    end_pathname,
+    browser,
+    os,
+    viewport_width,
+    viewport_height,
+    referring_domain,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_term,
+    utm_content,
+    country_code,
+    city_name,
+    region_code,
+    region_name,
+    has_gclid,
+    has_gad_source_paid_search,
+    has_fbclid
+)"""
+
 
 def REPLACE_WEB_STATS_V2_STAGING_SQL():
     return TABLE_TEMPLATE(
         "web_pre_aggregated_stats_staging",
         WEB_STATS_V2_PRODUCTION_COLUMNS,
-        WEB_STATS_ORDER_BY_FUNC("period_bucket"),
+        WEB_STATS_V2_PRODUCTION_ORDER_BY,
         force_unique_zk_path=True,
         replace=True,
         on_cluster=False,
@@ -199,7 +254,7 @@ def REPLACE_WEB_BOUNCES_V2_STAGING_SQL():
     return TABLE_TEMPLATE(
         "web_pre_aggregated_bounces_staging",
         WEB_BOUNCES_V2_PRODUCTION_COLUMNS,
-        WEB_BOUNCES_ORDER_BY_FUNC("period_bucket"),
+        WEB_BOUNCES_V2_PRODUCTION_ORDER_BY,
         force_unique_zk_path=True,
         replace=True,
         on_cluster=False,


### PR DESCRIPTION
## Problem

We were building those from the list of props, but the new ones we've added are nullable, so they can't be on the sorting key. 

This is still linked to the saga of data consistency: https://github.com/PostHog/posthog/pull/38281

## Changes

Use a hardcoded list. This does not affect the existing tables as the migrations created them, just the staging ones that we're now recreating on each execution.

## How did you test this code?

Checked the query logs for the problem and updated the statement to wok.

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
