### PR TITLE
feat: Add RBAC capabilities to our query runners

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -89,7 +89,7 @@ from posthog.queries.trends.trends import Trends
 from posthog.queries.util import get_earliest_timestamp
 from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
-from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+from posthog.rbac.user_access_control import UserAccessControlError, UserAccessControlSerializerMixin
 from posthog.schema_migrations.upgrade import upgrade
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 from posthog.settings import CAPTURE_TIME_TO_SEE_DATA, SITE_URL
@@ -1096,6 +1096,8 @@ When set, the specified dashboard's filters and date range override will be appl
                 else:
                     result = self.calculate_trends(request)
         except ExposedHogQLError as e:
+            raise ValidationError(str(e))
+        except UserAccessControlError as e:
             raise ValidationError(str(e))
         except Cohort.DoesNotExist as e:
             raise ValidationError(str(e))

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -52,6 +52,7 @@ from posthog.rate_limit import (
     ClickHouseSustainedRateThrottle,
     HogQLQueryThrottle,
 )
+from posthog.rbac.user_access_control import UserAccessControlError
 from posthog.schema_migrations.upgrade import upgrade
 
 from common.hogvm.python.utils import HogVMException
@@ -178,6 +179,8 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             return Response(result, status=response_status)
         except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
+        except UserAccessControlError as e:
+            raise ValidationError(str(e))
         except ResolutionError as e:
             raise ValidationError(str(e))
         except ConcurrencyLimitExceeded as c:

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -185,9 +185,12 @@ def process_query_model(
         else:
             raise ValidationError(f"Unsupported query kind: {query.__class__.__name__}")
     else:  # Query runner available - it will handle execution as well as caching
-        query_runner.apply_dashboard_filters(dashboard_filters)
-        query_runner.apply_variable_overrides(variables_override)
+        if dashboard_filters:
+            query_runner.apply_dashboard_filters(dashboard_filters)
+        if variables_override:
+            query_runner.apply_variable_overrides(variables_override)
         query_runner.is_query_service = is_query_service
+
         result = query_runner.run(
             execution_mode=execution_mode,
             user=user,

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -185,10 +185,8 @@ def process_query_model(
         else:
             raise ValidationError(f"Unsupported query kind: {query.__class__.__name__}")
     else:  # Query runner available - it will handle execution as well as caching
-        if dashboard_filters:
-            query_runner.apply_dashboard_filters(dashboard_filters)
-        if variables_override:
-            query_runner.apply_variable_overrides(variables_override)
+        query_runner.apply_dashboard_filters(dashboard_filters)
+        query_runner.apply_variable_overrides(variables_override)
         query_runner.is_query_service = is_query_service
         result = query_runner.run(
             execution_mode=execution_mode,

--- a/posthog/api/web_vitals.py
+++ b/posthog/api/web_vitals.py
@@ -1,12 +1,14 @@
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import exceptions, status, viewsets
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import TemporaryTokenAuthentication
 from posthog.hogql_queries.query_runner import ExecutionMode, get_query_runner
+from posthog.rbac.user_access_control import UserAccessControlError
 
 
 # This is a simple wrapper around a basic query, so that's why `scope_object = "query"`
@@ -78,7 +80,11 @@ class WebVitalsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             team=self.team,
         )
 
-        result = query_runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
+        try:
+            result = query_runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
+        except UserAccessControlError as e:
+            raise ValidationError(str(e))
+
         if result is None:
             return Response({"error": "Failed to calculate web vitals"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -207,8 +207,13 @@ def execute_process_query(
     except CHQueryErrorTooManySimultaneousQueries:
         raise
     except Exception as err:
+        from posthog.rbac.user_access_control import UserAccessControlError
+
         query_status.results = None  # Clear results in case they are faulty
-        if isinstance(err, APIException | ExposedHogQLError | ExposedCHQueryError) or is_staff_user:
+        if (
+            isinstance(err, APIException | ExposedHogQLError | ExposedCHQueryError | UserAccessControlError)
+            or is_staff_user
+        ):
             # We can only expose the error message if it's a known safe error OR if the user is PostHog staff
             query_status.error_message = str(err)
         logger.exception("Error processing query async", team_id=team_id, query_id=query_id, exc_info=True)

--- a/posthog/hogql_queries/query_cache_factory.py
+++ b/posthog/hogql_queries/query_cache_factory.py
@@ -1,11 +1,8 @@
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from posthog.hogql_queries.query_cache import DjangoCacheQueryCacheManager
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
 from posthog.models import Team
-
-if TYPE_CHECKING:
-    from posthog.models import User
 
 
 def get_query_cache_manager(
@@ -14,7 +11,6 @@ def get_query_cache_manager(
     cache_key: str,
     insight_id: Optional[int] = None,
     dashboard_id: Optional[int] = None,
-    user: Optional["User"] = None,
 ) -> QueryCacheManagerBase:
     return DjangoCacheQueryCacheManager(
         team_id=team.pk,

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1196,8 +1196,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     def _refresh_frequency(self) -> timedelta:
         return timedelta(minutes=1)
 
-    def apply_variable_overrides(self, variable_overrides: list[HogQLVariable]):
+    def apply_variable_overrides(self, variable_overrides: list[HogQLVariable] | None):
         """Irreversibly update self.query with provided variable overrides."""
+        if not variable_overrides:
+            return
+
         if not hasattr(self.query, "variables") or not self.query.kind == "HogQLQuery" or len(variable_overrides) == 0:
             return
 
@@ -1210,8 +1213,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             if self.query.variables.get(variable.variableId):
                 self.query.variables[variable.variableId] = variable
 
-    def apply_dashboard_filters(self, dashboard_filter: DashboardFilter):
+    def apply_dashboard_filters(self, dashboard_filter: DashboardFilter | None):
         """Irreversibly update self.query with provided dashboard filters."""
+        if not dashboard_filter:
+            return
+
         if not hasattr(self.query, "properties") or not hasattr(self.query, "dateRange"):
             capture_exception(
                 NotImplementedError(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -88,6 +88,7 @@ from posthog.hogql_queries.query_metadata import extract_query_metadata
 from posthog.hogql_queries.utils.event_usage import log_event_usage_from_query_metadata
 from posthog.models import Team, User
 from posthog.models.team import WeekStartDay
+from posthog.rbac.user_access_control import UserAccessControlError
 from posthog.schema_helpers import to_dict
 from posthog.utils import generate_cache_key, get_from_dict_or_attr, to_json
 
@@ -950,6 +951,25 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 if tags.scene:
                     posthoganalytics.tag("scene", tags.scene)
 
+            # Abort early if the user doesn't have access to the query runner
+            # We'll proceed as usual if there's no user connected to this request
+            if user is not None and not self.can_access_query_runner(user):
+                posthoganalytics.capture(
+                    distinct_id=user.distinct_id,
+                    event="query access control error",
+                    properties={
+                        "query_runner": self.__class__.__name__,
+                        "query_id": self.query_id,
+                        "insight_id": insight_id,
+                        "dashboard_id": dashboard_id,
+                        "execution_mode": execution_mode.value,
+                        "query_type": getattr(self.query, "kind", "Other"),
+                        "cache_key": cache_key,
+                    },
+                )
+
+                raise UserAccessControlError()
+
             trigger: str | None = get_query_tag_value("trigger")
 
             self.query_id = query_id or self.query_id
@@ -1079,11 +1099,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             if trigger:
                 fresh_response_dict["calculation_trigger"] = trigger
 
-            fresh_response = CachedResponse(**fresh_response_dict)
-
             # Don't cache debug queries with errors and export queries
-            has_error: Optional[list] = fresh_response_dict.get("error", None)
-            if (has_error is None or len(has_error) == 0) and self.limit_context != LimitContext.EXPORT:
+            errors: Optional[list] = fresh_response_dict.get("error", None)
+            has_error = errors is not None and len(errors) > 0
+            if not has_error and self.limit_context != LimitContext.EXPORT:
                 cache_manager.set_cache_data(
                     response=fresh_response_dict,
                     # This would be a possible place to decide to not ever keep this cache warm
@@ -1105,12 +1124,12 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     "query_type": getattr(self.query, "kind", "Other"),
                     "response_time_ms": round((perf_counter() - start_time) * 1000, 2),
                     "query_duration_ms": query_duration_ms,
-                    "has_error": has_error is not None and len(has_error) > 0,
+                    "has_error": has_error,
                 },
                 groups=(groups(self.team.organization, self.team)),
             )
 
-            return fresh_response
+            return CachedResponse(**fresh_response_dict)
 
     def get_api_queries_concurrency_limit(self):
         """
@@ -1184,6 +1203,28 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         interval = query_date_range.interval_name if query_date_range else "minute"
         mode = ThresholdMode.LAZY if lazy else ThresholdMode.DEFAULT
         return cache_target_age(interval, last_refresh=last_refresh, mode=mode)
+
+    def can_access_query_runner(self, user: User) -> bool:
+        """
+        Child query runners can override this to check if the user has access to the query runner
+        by using the user_access_control.check_access_level_for_resource method
+
+        Example
+        ```
+        from posthog.rbac.user_access_control import UserAccessControl
+
+        def can_access_query_runner(self, user: User) -> bool:
+            user_access_control = UserAccessControl(user=user, team=self.team)
+            return user_access_control.check_access_level_for_resource("revenue_analytics", "viewer")
+        ```
+
+        Args:
+            user: The user to check access for
+
+        Returns:
+            True if the user has access to the query runner, False otherwise
+        """
+        return True
 
     def _is_stale(self, last_refresh: Optional[datetime], lazy: bool = False) -> bool:
         query_date_range = getattr(self, "query_date_range", None)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1236,11 +1236,8 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     def _refresh_frequency(self) -> timedelta:
         return timedelta(minutes=1)
 
-    def apply_variable_overrides(self, variable_overrides: list[HogQLVariable] | None):
+    def apply_variable_overrides(self, variable_overrides: list[HogQLVariable]):
         """Irreversibly update self.query with provided variable overrides."""
-        if not variable_overrides:
-            return
-
         if not hasattr(self.query, "variables") or not self.query.kind == "HogQLQuery" or len(variable_overrides) == 0:
             return
 
@@ -1253,11 +1250,8 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             if self.query.variables.get(variable.variableId):
                 self.query.variables[variable.variableId] = variable
 
-    def apply_dashboard_filters(self, dashboard_filter: DashboardFilter | None):
+    def apply_dashboard_filters(self, dashboard_filter: DashboardFilter):
         """Irreversibly update self.query with provided dashboard filters."""
-        if not dashboard_filter:
-            return
-
         if not hasattr(self.query, "properties") or not hasattr(self.query, "dateRange"):
             capture_exception(
                 NotImplementedError(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -959,7 +959,6 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 cache_key=cache_key,
                 insight_id=insight_id,
                 dashboard_id=dashboard_id,
-                user=user,
             )
 
             if execution_mode == ExecutionMode.CALCULATE_ASYNC_ALWAYS:

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -29,6 +29,11 @@ except ImportError:
     pass
 
 
+class UserAccessControlError(Exception):
+    def __init__(self):
+        super().__init__("Access control failure")
+
+
 class AccessSource(Enum):
     """Enum for how a user got access to a resource"""
 

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -68,9 +68,9 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext[AR]):
         RevenueAnalyticsTopCustomersQuery,
     ]
 
-    def can_access_query_runner(self, user: User) -> bool:
+    def validate_query_runner_access(self, user: User) -> bool:
         user_access_control = UserAccessControl(user=user, team=self.team)
-        return user_access_control.check_access_level_for_resource("revenue_analytics", "viewer")
+        return user_access_control.assert_access_level_for_resource("revenue_analytics", "viewer")
 
     def where_property_exprs(self, join_from: RevenueAnalyticsBaseView) -> list[ast.Expr]:
         # Some filters are not namespaced and they should simply use the raw property

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -20,7 +20,9 @@ from posthog.hogql.property import property_to_expr
 
 from posthog.hogql_queries.query_runner import AR, QueryRunnerWithHogQLContext
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models import User
 from posthog.models.filters.mixins.utils import cached_property
+from posthog.rbac.user_access_control import UserAccessControl
 from posthog.warehouse.models import ExternalDataSchema
 from posthog.warehouse.types import ExternalDataSourceType
 
@@ -65,6 +67,10 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext[AR]):
         RevenueAnalyticsOverviewQuery,
         RevenueAnalyticsTopCustomersQuery,
     ]
+
+    def can_access_query_runner(self, user: User) -> bool:
+        user_access_control = UserAccessControl(user=user, team=self.team)
+        return user_access_control.check_access_level_for_resource("revenue_analytics", "viewer")
 
     def where_property_exprs(self, join_from: RevenueAnalyticsBaseView) -> list[ast.Expr]:
         # Some filters are not namespaced and they should simply use the raw property

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
@@ -328,7 +328,7 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
     def test_cannot_access_query_runner_without_view_access_control(self):
         """Test that the query runner cannot access the query runner without view access control"""
         AccessControl.objects.create(team=self.team, resource="revenue_analytics", access_level="none")
-        self.organization.available_product_features.append({"key": AvailableFeature.ADVANCED_PERMISSIONS})
+        self.organization.available_product_features.append({"key": AvailableFeature.ADVANCED_PERMISSIONS})  # type: ignore[union-attr]
         self.organization.save()
 
         runner = RevenueAnalyticsQueryRunnerImpl(team=self.team, query=self.query)

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_query_runner.py
@@ -4,10 +4,16 @@ from posthog.test.base import APIBaseTest
 
 from posthog.schema import IntervalType, RevenueAnalyticsGrossRevenueQuery
 
+from posthog.constants import AvailableFeature
 from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
 from posthog.warehouse.types import ExternalDataSourceType
 
 from products.revenue_analytics.backend.hogql_queries.revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
+
+try:
+    from ee.models.rbac.access_control import AccessControl
+except ImportError:
+    pass
 
 
 # This is required because we can't instantiate the base class directly
@@ -313,3 +319,17 @@ class TestRevenueAnalyticsQueryRunner(APIBaseTest):
 
         # Should return our small cache target age since it's the first time syncing
         self.assertDiff(RevenueAnalyticsQueryRunner.SMALL_CACHE_TARGET_AGE)
+
+    def test_can_access_query_runner_by_default(self):
+        """Test that the query runner can access the query runner"""
+        runner = RevenueAnalyticsQueryRunnerImpl(team=self.team, query=self.query)
+        self.assertTrue(runner.can_access_query_runner(self.user))
+
+    def test_cannot_access_query_runner_without_view_access_control(self):
+        """Test that the query runner cannot access the query runner without view access control"""
+        AccessControl.objects.create(team=self.team, resource="revenue_analytics", access_level="none")
+        self.organization.available_product_features.append({"key": AvailableFeature.ADVANCED_PERMISSIONS})
+        self.organization.save()
+
+        runner = RevenueAnalyticsQueryRunnerImpl(team=self.team, query=self.query)
+        self.assertFalse(runner.can_access_query_runner(self.user))


### PR DESCRIPTION
Pretty simple implementation raising a `UserAccessControlError` error when we detect we can't access a query runner. Each query runner can implement this as they wish by simply implementing the `can_access_query_runner(user)` method. I've implemented this for Revenue Analytics for reference purposes.

<img width="1222" height="299" alt="image" src="https://github.com/user-attachments/assets/42ba7a00-633c-45ad-b4e7-821fbfbe0d2e" />
