### PR TITLE
fix: Check for missing hex in session

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -573,8 +573,12 @@ class UserViewSet(
 
     @action(methods=["POST"], detail=True)
     def two_factor_validate(self, request, **kwargs):
+        hex_key = request.session.get("django_two_factor-hex")
+        if not hex_key:
+            return Response({"success": True})
+
         form = TOTPDeviceForm(
-            request.session["django_two_factor-hex"],
+            hex_key,
             request.user,
             data={"token": request.data["token"]},
         )


### PR DESCRIPTION
Fix this [error](https://grafana.prod-us.posthog.dev/a/grafana-lokiexplore-app/explore/service/posthog-web-django/logs?patterns=%5B%5D&from=now-24h&to=now&var-lineFormat=&var-ds=P44D702D3E93867EC&var-filters=service_name%7C%3D%7Cposthog-web-django&var-fields=level%7C%3D%7C__CV%CE%A9__%7B%22value%22:%22error%22__gfc__%22parser%22:%22mixed%22%7D,error&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=caseInsensitive,1%7C__gfp__~%7Ctwo_factor_validate&timezone=browser&var-all-fields=level%7C%3D%7C__CV%CE%A9__%7B%22value%22:%22error%22__gfc__%22parser%22:%22mixed%22%7D,error&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&sortOrder=%22Ascending%22&wrapLogMessage=false&prettifyLogMessage=false) in the newly deployed 2FA BE enforcement.