### PR TITLE
fix(data-warehouse): Fix bools and added exports

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1,6 +1,8 @@
+from posthog.hogql import ast
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
     DateTimeDatabaseField,
+    ExpressionField,
     IntegerDatabaseField,
     StringDatabaseField,
     StringJSONDatabaseField,
@@ -17,7 +19,8 @@ cohorts: PostgresTable = PostgresTable(
         "team_id": IntegerDatabaseField(name="team_id"),
         "name": StringDatabaseField(name="name"),
         "description": StringDatabaseField(name="description"),
-        "deleted": BooleanDatabaseField(name="deleted"),
+        "_deleted": BooleanDatabaseField(name="deleted", hidden=True),
+        "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
         "filters": StringJSONDatabaseField(name="filters"),
         "groups": StringJSONDatabaseField(name="groups"),
         "query": StringJSONDatabaseField(name="query"),
@@ -25,7 +28,10 @@ cohorts: PostgresTable = PostgresTable(
         "last_calculation": DateTimeDatabaseField(name="last_calculation"),
         "version": IntegerDatabaseField(name="version"),
         "count": IntegerDatabaseField(name="count"),
-        "is_static": BooleanDatabaseField(name="is_static"),
+        "_is_static": BooleanDatabaseField(name="is_static", hidden=True),
+        "is_static": ExpressionField(
+            name="is_static", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_is_static"])])
+        ),
     },
 )
 
@@ -38,7 +44,8 @@ dashboards: PostgresTable = PostgresTable(
         "name": StringDatabaseField(name="name"),
         "description": StringDatabaseField(name="description"),
         "created_at": DateTimeDatabaseField(name="created_at"),
-        "deleted": BooleanDatabaseField(name="deleted"),
+        "_deleted": BooleanDatabaseField(name="deleted", hidden=True),
+        "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
         "filters": StringJSONDatabaseField(name="filters"),
         "variables": StringJSONDatabaseField(name="variables"),
     },
@@ -56,8 +63,10 @@ insights: PostgresTable = PostgresTable(
         "filters": StringJSONDatabaseField(name="filters"),
         "query": StringJSONDatabaseField(name="query"),
         "query_metadata": StringJSONDatabaseField(name="query_metadata"),
-        "deleted": BooleanDatabaseField(name="deleted"),
-        "saved": BooleanDatabaseField(name="saved"),
+        "_deleted": BooleanDatabaseField(name="deleted", hidden=True),
+        "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
+        "_saved": BooleanDatabaseField(name="saved", hidden=True),
+        "saved": ExpressionField(name="saved", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_saved"])])),
         "created_at": DateTimeDatabaseField(name="created_at"),
         "updated_at": DateTimeDatabaseField(name="updated_at"),
     },
@@ -77,7 +86,10 @@ experiments: PostgresTable = PostgresTable(
         "parameters": StringJSONDatabaseField(name="parameters"),
         "start_date": DateTimeDatabaseField(name="start_date"),
         "end_date": DateTimeDatabaseField(name="end_date"),
-        "archived": BooleanDatabaseField(name="archived"),
+        "_archived": BooleanDatabaseField(name="archived", hidden=True),
+        "archived": ExpressionField(
+            name="archived", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_archived"])])
+        ),
         "feature_flag_id": IntegerDatabaseField(name="feature_flag_id"),
     },
 )
@@ -92,7 +104,8 @@ data_warehouse_sources: PostgresTable = PostgresTable(
         "prefix": StringDatabaseField(name="prefix"),
         "created_at": DateTimeDatabaseField(name="created_at"),
         "updated_at": DateTimeDatabaseField(name="updated_at"),
-        "deleted": BooleanDatabaseField(name="deleted"),
+        "_deleted": BooleanDatabaseField(name="deleted", hidden=True),
+        "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
         "deleted_at": DateTimeDatabaseField(name="deleted_at"),
     },
 )
@@ -108,7 +121,8 @@ feature_flags: PostgresTable = PostgresTable(
         "filters": StringJSONDatabaseField(name="filters"),
         "rollout_percentage": IntegerDatabaseField(name="rollout_percentage"),
         "created_at": DateTimeDatabaseField(name="created_at"),
-        "deleted": BooleanDatabaseField(name="deleted"),
+        "_deleted": BooleanDatabaseField(name="deleted", hidden=True),
+        "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
     },
 )
 
@@ -178,6 +192,18 @@ teams: PostgresTable = PostgresTable(
         "test_account_filters": StringJSONDatabaseField(name="test_account_filters"),
         "created_at": DateTimeDatabaseField(name="created_at"),
         "updated_at": DateTimeDatabaseField(name="updated_at"),
+    },
+)
+
+exports: PostgresTable = PostgresTable(
+    name="exports",
+    postgres_table_name="posthog_exportedasset",
+    fields={
+        "id": IntegerDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "export_format": StringDatabaseField(name="export_format"),
+        "created_at": DateTimeDatabaseField(name="created_at"),
+        "export_context": StringJSONDatabaseField(name="export_context"),
     },
 )
 

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -214,6 +214,7 @@ class SystemTables(TableGroup):
         "cohorts": cohorts,
         "insights": insights,
         "experiments": experiments,
+        "exports": exports,
         "data_warehouse_sources": data_warehouse_sources,
         "feature_flags": feature_flags,
         "groups": groups,

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1939,7 +1939,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "filters": {
                   "chain": null,
@@ -2007,7 +2007,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "filters": {
                   "chain": null,
@@ -2087,7 +2087,7 @@
                   "name": "is_static",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               }
           },
           "id": "system.cohorts",
@@ -2175,7 +2175,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "saved": {
                   "chain": null,
@@ -2185,7 +2185,7 @@
                   "name": "saved",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "created_at": {
                   "chain": null,
@@ -2313,7 +2313,7 @@
                   "name": "archived",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "feature_flag_id": {
                   "chain": null,
@@ -2328,6 +2328,54 @@
           },
           "id": "system.experiments",
           "name": "system.experiments",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.exports": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "export_format": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "export_format",
+                  "id": null,
+                  "name": "export_format",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "export_context": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "export_context",
+                  "id": null,
+                  "name": "export_context",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              }
+          },
+          "id": "system.exports",
+          "name": "system.exports",
           "row_count": null,
           "type": "system"
       },
@@ -2391,7 +2439,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "deleted_at": {
                   "chain": null,
@@ -2479,7 +2527,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               }
           },
           "id": "system.feature_flags",
@@ -4339,7 +4387,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "filters": {
                   "chain": null,
@@ -4407,7 +4455,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "filters": {
                   "chain": null,
@@ -4487,7 +4535,7 @@
                   "name": "is_static",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               }
           },
           "id": "system.cohorts",
@@ -4575,7 +4623,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "saved": {
                   "chain": null,
@@ -4585,7 +4633,7 @@
                   "name": "saved",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "created_at": {
                   "chain": null,
@@ -4713,7 +4761,7 @@
                   "name": "archived",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "feature_flag_id": {
                   "chain": null,
@@ -4728,6 +4776,54 @@
           },
           "id": "system.experiments",
           "name": "system.experiments",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.exports": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "export_format": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "export_format",
+                  "id": null,
+                  "name": "export_format",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "export_context": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "export_context",
+                  "id": null,
+                  "name": "export_context",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              }
+          },
+          "id": "system.exports",
+          "name": "system.exports",
           "row_count": null,
           "type": "system"
       },
@@ -4791,7 +4887,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               },
               "deleted_at": {
                   "chain": null,
@@ -4879,7 +4975,7 @@
                   "name": "deleted",
                   "schema_valid": true,
                   "table": null,
-                  "type": "boolean"
+                  "type": "expression"
               }
           },
           "id": "system.feature_flags",

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -96,7 +96,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'query_log', 'system.dashboards', 'system.cohorts', 'system.insights', 'system.experiments', 'system.data_warehouse_sources', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.insight_variables', 'system.surveys', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'query_log', 'system.dashboards', 'system.cohorts', 'system.insights', 'system.experiments', 'system.exports', 'system.data_warehouse_sources', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.insight_variables', 'system.surveys', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.


### PR DESCRIPTION
## Problem
- Bools arent really a thing in clickhouse like they are in postgres, so all postgres bools get converted to ints which cause filtering on them to fail

## Changes
- Fix the above by using a `toInt()` cast around the field
- Also added the `exported assets` table