### PR TITLE
fix(frontend): no $pageview if only the hash changes

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -378,7 +378,7 @@ export const sceneLogic = kea<sceneLogicType>([
             },
         ],
         lastSetScenePayload: [
-            null as Record<string, any> | null,
+            {} as Record<string, any>,
             {
                 setScene: (_, { sceneId, sceneKey, tabId, params }) => ({ sceneId, sceneKey, tabId, params }),
             },

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1,4 +1,5 @@
 import { arrayMove } from '@dnd-kit/sortable'
+import equal from 'fast-deep-equal'
 import {
     BuiltLogic,
     actions,
@@ -376,6 +377,12 @@ export const sceneLogic = kea<sceneLogicType>([
                 reloadBrowserDueToImportError: () => new Date().valueOf(),
             },
         ],
+        lastSetScenePayload: [
+            null as Record<string, any> | null,
+            {
+                setScene: (_, { sceneId, sceneKey, tabId, params }) => ({ sceneId, sceneKey, tabId, params }),
+            },
+        ],
     }),
     selectors({
         activeTab: [
@@ -642,8 +649,24 @@ export const sceneLogic = kea<sceneLogicType>([
                 router.actions.replace(pathname.replace(/(\/+)$/, ''), search, hash)
             }
         },
-        setScene: ({ tabId, sceneId, exportedScene, params, scrollToTop }, _, __, previousState) => {
-            posthog.capture('$pageview')
+        setScene: ({ tabId, sceneKey, sceneId, exportedScene, params, scrollToTop }, _, __, previousState) => {
+            const {
+                sceneId: lastSceneId,
+                sceneKey: lastSceneKey,
+                tabId: lastTabId,
+                params: lastParams,
+            } = selectors.lastSetScenePayload(previousState)
+
+            // Do not trigger a new pageview event when only the hashParams change
+            if (
+                lastSceneId !== sceneId ||
+                lastSceneKey !== sceneKey ||
+                lastTabId !== tabId ||
+                !equal(lastParams.params, params.params) ||
+                JSON.stringify(lastParams.searchParams) !== JSON.stringify(params.searchParams) // `equal` crashes here
+            ) {
+                posthog.capture('$pageview')
+            }
 
             // if we clicked on a link, scroll to top
             const previousScene = selectors.sceneId(previousState)


### PR DESCRIPTION
## Problem

The SQL editor is sending a new pageview event on every keystroke

## Changes

Stop sending pageview events when only the URL's hash changes.

## How did you test this code?

Local clicky-clicks. 