### PR TITLE
fix(myke): add pagiantion for unique conditions query

### DIFF
--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -94,41 +94,71 @@ async def get_unique_conditions_activity(inputs: BehavioralCohortsWorkflowInputs
 
     where_clause = " AND ".join(where_clauses)
 
-    # Add LIMIT clause if specified
-    limit_clause = f"LIMIT {int(inputs.limit)}" if inputs.limit else ""
+    # Use pagination to get all results in batches of 10,000
+    all_conditions = []
+    page_size = 10000
+    offset = 0
+    total_fetched = 0
 
-    query = f"""
-        SELECT DISTINCT
-            team_id,
-            cohort_id,
-            condition
-        FROM behavioral_cohorts_matches
-        WHERE {where_clause}
-        ORDER BY team_id, cohort_id, condition
-        {limit_clause}
-    """
+    # If user specified a limit, respect it as the maximum total results
+    user_limit = inputs.limit
 
     try:
-        with tags_context(
-            team_id=inputs.team_id,
-            feature=Feature.BEHAVIORAL_COHORTS,
-            cohort_id=inputs.cohort_id,
-            product=Product.MESSAGING,
-            query_type="get_unique_conditions",
-        ):
-            results = sync_execute(query, params, ch_user=ClickHouseUser.COHORTS, workload=Workload.OFFLINE)
+        while True:
+            # Calculate current batch limit
+            if user_limit:
+                remaining = user_limit - total_fetched
+                if remaining <= 0:
+                    break
+                current_limit = min(page_size, remaining)
+            else:
+                current_limit = page_size
 
-        conditions = [
-            {
-                "team_id": row[0],
-                "cohort_id": row[1],
-                "condition": row[2],
-            }
-            for row in results
-        ]
+            query = f"""
+                SELECT DISTINCT
+                    team_id,
+                    cohort_id,
+                    condition
+                FROM behavioral_cohorts_matches
+                WHERE {where_clause}
+                ORDER BY team_id, cohort_id, condition
+                LIMIT {current_limit} OFFSET {offset}
+            """
 
-        logger.info(f"Found {len(conditions)} unique conditions")
-        return conditions
+            with tags_context(
+                team_id=inputs.team_id,
+                feature=Feature.BEHAVIORAL_COHORTS,
+                cohort_id=inputs.cohort_id,
+                product=Product.MESSAGING,
+                query_type="get_unique_conditions",
+            ):
+                results = sync_execute(query, params, ch_user=ClickHouseUser.COHORTS, workload=Workload.OFFLINE)
+
+            # If no results returned, we've reached the end
+            if not results:
+                break
+
+            batch_conditions = [
+                {
+                    "team_id": row[0],
+                    "cohort_id": row[1],
+                    "condition": row[2],
+                }
+                for row in results
+            ]
+
+            all_conditions.extend(batch_conditions)
+            total_fetched += len(batch_conditions)
+            offset += current_limit
+
+            logger.info(f"Fetched batch of {len(batch_conditions)} conditions (total: {total_fetched})")
+
+            # If we got fewer results than requested, we've reached the end
+            if len(results) < current_limit:
+                break
+
+        logger.info(f"Found {len(all_conditions)} unique conditions across all pages")
+        return all_conditions
 
     except Exception as e:
         logger.exception("Error fetching unique conditions", error=str(e))

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -122,10 +122,8 @@ async def get_unique_conditions_activity(inputs: BehavioralCohortsWorkflowInputs
                 FROM behavioral_cohorts_matches
                 WHERE {where_clause}
                 ORDER BY team_id, cohort_id, condition
-                LIMIT %(limit)s OFFSET %(offset)s
-            """.format(where_clause=where_clause)
-            
-            query_params = {**params, "limit": current_limit, "offset": offset}
+                LIMIT {limit} OFFSET {offset}
+            """.format(where_clause=where_clause, limit=current_limit, offset=offset)
 
             with tags_context(
                 team_id=inputs.team_id,

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -114,7 +114,7 @@ async def get_unique_conditions_activity(inputs: BehavioralCohortsWorkflowInputs
             else:
                 current_limit = page_size
 
-            query = f"""
+            query = """
                 SELECT DISTINCT
                     team_id,
                     cohort_id,
@@ -122,8 +122,10 @@ async def get_unique_conditions_activity(inputs: BehavioralCohortsWorkflowInputs
                 FROM behavioral_cohorts_matches
                 WHERE {where_clause}
                 ORDER BY team_id, cohort_id, condition
-                LIMIT {current_limit} OFFSET {offset}
-            """
+                LIMIT %(limit)s OFFSET %(offset)s
+            """.format(where_clause=where_clause)
+            
+            query_params = {**params, "limit": current_limit, "offset": offset}
 
             with tags_context(
                 team_id=inputs.team_id,


### PR DESCRIPTION
## Problem

due to the activity result is too large for temporal's grpc message limit.
grpc: received message larger than max (5392892 vs. 4194304)
result set is 34,964 unique conditions which creates a message of ~5.4MB, but temporal's default max message size is 4MB

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add pagination to get full result set

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
