### PR TITLE
chore: backend task not failing on vite

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,8 @@
                 "SKIP_SERVICE_VERSION_REQUIREMENTS": "1",
                 "PRINT_SQL": "1",
                 "BILLING_SERVICE_URL": "https://billing.dev.posthog.dev",
-                "CLOUD_DEPLOYMENT": "dev"
+                "CLOUD_DEPLOYMENT": "dev",
+                "POSTHOG_USE_VITE": "1"
             },
             "envFile": "${workspaceFolder}/.env",
             "console": "integratedTerminal",


### PR DESCRIPTION
## Problem

Locally, we moved the FE to use `vite`: BE would not be able to correctly load without setting the `POSTHOG_USE_VITE ` env variable.