### PR TITLE
fix: refactor resource type selection in SharingModal

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -46,6 +46,23 @@ import { upgradeModalLogic } from '../UpgradeModal/upgradeModalLogic'
 import { SharePasswordsTable } from './SharePasswordsTable'
 import { sharingLogic } from './sharingLogic'
 
+function getResourceType(
+    dashboardId?: number,
+    insightShortId?: InsightShortId,
+    recordingId?: string
+): AccessControlResourceType {
+    if (dashboardId) {
+        return AccessControlResourceType.Dashboard
+    }
+    if (insightShortId) {
+        return AccessControlResourceType.Insight
+    }
+    if (recordingId) {
+        return AccessControlResourceType.SessionRecording
+    }
+    return AccessControlResourceType.Project
+}
+
 export const SHARING_MODAL_WIDTH = 600
 
 export interface SharingModalBaseProps {
@@ -152,13 +169,7 @@ export function SharingModalContent({
                             <LemonBanner type="warning">Public sharing is disabled for this organization.</LemonBanner>
                         ) : (
                             <AccessControlAction
-                                resourceType={
-                                    dashboardId
-                                        ? AccessControlResourceType.Dashboard
-                                        : insightShortId
-                                          ? AccessControlResourceType.Insight
-                                          : AccessControlResourceType.Project
-                                }
+                                resourceType={getResourceType(dashboardId, insightShortId, recordingId)}
                                 minAccessLevel={AccessControlLevel.Editor}
                                 userAccessLevel={userAccessLevel}
                             >


### PR DESCRIPTION
Add getResourceType helper to determine AccessControlResourceType based on dashboardId, insightShortId, or recordingId. Fixes for recordings as well which were missing.