### PR TITLE
chore(web-analytics): use same zk path for v2 staging tables

### DIFF
--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -244,7 +244,7 @@ def REPLACE_WEB_STATS_V2_STAGING_SQL():
         "web_pre_aggregated_stats_staging",
         WEB_STATS_V2_PRODUCTION_COLUMNS,
         WEB_STATS_V2_PRODUCTION_ORDER_BY,
-        force_unique_zk_path=True,
+        force_unique_zk_path=False,
         replace=True,
         on_cluster=False,
     )
@@ -255,7 +255,7 @@ def REPLACE_WEB_BOUNCES_V2_STAGING_SQL():
         "web_pre_aggregated_bounces_staging",
         WEB_BOUNCES_V2_PRODUCTION_COLUMNS,
         WEB_BOUNCES_V2_PRODUCTION_ORDER_BY,
-        force_unique_zk_path=True,
+        force_unique_zk_path=False,
         replace=True,
         on_cluster=False,
     )


### PR DESCRIPTION
## Problem

This may be the cause that the `REPLACE PARTITION` is not really triggering, those are replicated tables, but they each have a ZK path as we run the create on each host. 

This is needed for v1 so we can run the `EXCHANGE TABLE` command, but we are ok with having those replicated on the v2.

## Changes

- Don't enforce a unique ZK path.

## How did you test this code?

- Didn't explode locally.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

No
