### PR TITLE
SUPPORT SUPERDAY: Adding a new button in SidePanelSupport to report bugs directly to GH

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
+import { IconFeatures, IconHelmet, IconMap, IconBug } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -411,6 +411,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
@abigailbramble 

## Problem

This change improves the user experience for developers and users who encounter bugs while using the application. Currently, users who find issues need to navigate away from the app to report bugs on GitHub, creating friction in the feedback process. By adding a direct "Report Bug" button in the SidePanelSupport component, we're making it easier for users to provide valuable feedback and report issues without leaving their current workflow.

## Changes

Added a new "Report Bug" button to the SidePanelSupport component
The button provides direct access to GitHub issues for bug reporting
Maintains consistent styling with existing support panel elements

## How did you test this code?

Didn't really test the code yet.

