### PR TITLE
fix(max): fixing validation of deep research workflows

### DIFF
--- a/ee/hogai/graph/deep_research/planner/test/test_nodes.py
+++ b/ee/hogai/graph/deep_research/planner/test/test_nodes.py
@@ -22,7 +22,6 @@ from posthog.schema import (
     MultiVisualizationMessage,
     PlanningMessage,
     PlanningStepStatus,
-    TaskExecutionItem,
     TaskExecutionStatus,
 )
 
@@ -33,7 +32,7 @@ from ee.hogai.graph.deep_research.planner.prompts import (
     WRITE_RESULT_FAILED_TOOL_RESULT,
     WRITE_RESULT_TOOL_RESULT,
 )
-from ee.hogai.graph.deep_research.types import DeepResearchState, DeepResearchTodo
+from ee.hogai.graph.deep_research.types import DeepResearchState, DeepResearchTask, DeepResearchTodo
 from ee.hogai.utils.types import InsightArtifact
 from ee.hogai.utils.types.base import TaskResult
 
@@ -510,7 +509,7 @@ class TestDeepResearchPlannerToolsNode(BaseTest):
     async def test_execute_tasks_tool(self):
         """Test execute_tasks tool execution returns tasks"""
         tasks = [
-            TaskExecutionItem(
+            DeepResearchTask(
                 id="1",
                 description="Test task",
                 prompt="Test prompt",
@@ -681,7 +680,7 @@ class TestDeepResearchPlannerToolsNode(BaseTest):
             (
                 "with_tasks",
                 [
-                    TaskExecutionItem(
+                    DeepResearchTask(
                         id="1",
                         description="Test",
                         prompt="Test prompt",

--- a/ee/hogai/graph/deep_research/test/test_integration.py
+++ b/ee/hogai/graph/deep_research/test/test_integration.py
@@ -19,7 +19,6 @@ from posthog.schema import (
     PlanningMessage,
     PlanningStep,
     PlanningStepStatus,
-    TaskExecutionItem,
     TaskExecutionStatus,
     VisualizationItem,
 )
@@ -32,7 +31,12 @@ from ee.hogai.graph.deep_research.onboarding.nodes import DeepResearchOnboarding
 from ee.hogai.graph.deep_research.planner.nodes import DeepResearchPlannerNode, DeepResearchPlannerToolsNode
 from ee.hogai.graph.deep_research.report.nodes import DeepResearchReportNode
 from ee.hogai.graph.deep_research.task_executor.nodes import DeepResearchTaskExecutorNode
-from ee.hogai.graph.deep_research.types import DeepResearchIntermediateResult, DeepResearchState, DeepResearchTodo
+from ee.hogai.graph.deep_research.types import (
+    DeepResearchIntermediateResult,
+    DeepResearchState,
+    DeepResearchTask,
+    DeepResearchTodo,
+)
 from ee.hogai.utils.types.base import TaskResult
 from ee.models.assistant import Conversation
 
@@ -56,7 +60,7 @@ class TestDeepResearchWorkflowIntegration(APIBaseTest):
         self,
         messages: list[Any] | None = None,
         todos: list[DeepResearchTodo] | None = None,
-        tasks: list[TaskExecutionItem] | None = None,
+        tasks: list[DeepResearchTask] | None = None,
         task_results: list[TaskResult] | None = None,
         intermediate_results: list[DeepResearchIntermediateResult] | None = None,
         current_run_notebooks: list[DeepResearchNotebook] | None = None,

--- a/ee/hogai/graph/deep_research/test/test_types.py
+++ b/ee/hogai/graph/deep_research/test/test_types.py
@@ -13,13 +13,13 @@ from posthog.schema import (
     DeepResearchType,
     HumanMessage,
     PlanningStepStatus,
-    TaskExecutionItem,
     TaskExecutionStatus,
 )
 
 from ee.hogai.graph.deep_research.types import (
     DeepResearchIntermediateResult,
     DeepResearchState,
+    DeepResearchTask,
     DeepResearchTodo,
     PartialDeepResearchState,
     _SharedDeepResearchState,
@@ -237,7 +237,7 @@ class TestDeepResearchStates(BaseTest):
         ]
 
         tasks = [
-            TaskExecutionItem(
+            DeepResearchTask(
                 id="task-1",
                 description="Execute analysis",
                 prompt="Analyze the data and generate insights",
@@ -271,7 +271,7 @@ class TestDeepResearchStates(BaseTest):
         )
 
         self.assertEqual(len(cast(list[DeepResearchTodo], state.todos)), 2)
-        self.assertEqual(len(cast(list[TaskExecutionItem], state.tasks)), 1)
+        self.assertEqual(len(cast(list[DeepResearchTask], state.tasks)), 1)
         self.assertEqual(len(state.task_results), 1)
         self.assertEqual(len(state.intermediate_results), 1)
         self.assertEqual(len(state.messages), 2)

--- a/ee/hogai/graph/deep_research/types.py
+++ b/ee/hogai/graph/deep_research/types.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import Annotated, Literal, Optional
 
 from langgraph.graph import END, START
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from posthog.schema import DeepResearchNotebook, PlanningStepStatus, TaskExecutionItem
 
@@ -42,9 +42,7 @@ class DeepResearchIntermediateResult(BaseModel):
 
 
 class _SharedDeepResearchState(BaseStateWithMessages, BaseStateWithTasks):
-    # Keepingtyping aligned with the base class so mypy remains happy, but coerce incoming
-    # dicts into the DeepResearchTask subtype for assistant-specific fields.
-    tasks: Annotated[Optional[list[TaskExecutionItem]], replace] = Field(default=None)
+    tasks: Annotated[Optional[list[DeepResearchTask]], replace] = Field(default=None)  # type: ignore[assignment]
     todos: Annotated[Optional[list[DeepResearchTodo]], replace] = Field(default=None)
     """
     The current TO-DO list.
@@ -65,18 +63,6 @@ class _SharedDeepResearchState(BaseStateWithMessages, BaseStateWithTasks):
     """
     Notebooks created in the current deep research run (reset on new run).
     """
-
-    @field_validator("tasks", mode="before")
-    @classmethod
-    def _ensure_deep_research_tasks(cls, value):
-        if value is None:
-            return value
-
-        coerced: list[DeepResearchTask] = []
-        for task in value:
-            coerced.append(DeepResearchTask.model_validate(task))
-
-        return coerced
 
 
 class DeepResearchState(_SharedDeepResearchState):


### PR DESCRIPTION
## Problem

Deep-research workflows were failing validation when `planner`-produced tasks were fed back into the state. 
The shared state model still expected `TaskExecutionItem` references, so the `task_type` field  triggered validation failures.

## Changes

* Introduced the tasks field type with a `mypy` ignore to handle the inheritance mismatch with the base class.
* Updated tests to use `DeepResearchTask`, aligning them with the runtime payload and the new validator.

## How did you test this code?

- [x] unit tests
- [x] manual runs
