### PR TITLE
fix(max): add default node name to all nodes

### DIFF
--- a/ee/hogai/graph/base.py
+++ b/ee/hogai/graph/base.py
@@ -1,6 +1,6 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from typing import Any, Generic, Literal, Union, cast
+from typing import Any, Generic, Literal, Union
 from uuid import UUID
 
 from langchain_core.runnables import RunnableConfig
@@ -38,13 +38,9 @@ class BaseAssistantNode(Generic[StateType, PartialStateType], AssistantContextMi
         self._user = user
 
     @property
-    def node_name(self) -> MaxNodeName | None:
-        """
-        The identifier for this node in the graph.
-        """
-        if not self.config:
-            return None
-        return cast(MaxNodeName, self.config.get("metadata", {}).get("langgraph_node"))
+    @abstractmethod
+    def node_name(self) -> MaxNodeName:
+        raise NotImplementedError
 
     async def __call__(self, state: StateType, config: RunnableConfig) -> PartialStateType | None:
         """

--- a/ee/hogai/graph/billing/nodes.py
+++ b/ee/hogai/graph/billing/nodes.py
@@ -11,6 +11,8 @@ from posthog.clickhouse.client import sync_execute
 from ee.hogai.graph.base import AssistantNode
 from ee.hogai.graph.billing.prompts import BILLING_CONTEXT_PROMPT
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 # sync with frontend/src/scenes/billing/constants.ts
 USAGE_TYPES = [
@@ -32,6 +34,10 @@ USAGE_TYPES = [
 
 class BillingNode(AssistantNode):
     _teams_map: dict[int, str] = {}
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.BILLING
 
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         billing_context = self._get_billing_context(config)

--- a/ee/hogai/graph/deep_research/notebook/nodes.py
+++ b/ee/hogai/graph/deep_research/notebook/nodes.py
@@ -5,10 +5,15 @@ from posthog.schema import DeepResearchNotebook, DeepResearchType, HumanMessage
 
 from ee.hogai.graph.deep_research.base.nodes import DeepResearchNode
 from ee.hogai.graph.deep_research.notebook.prompts import DEEP_RESEARCH_NOTEBOOK_PLANNING_PROMPT
-from ee.hogai.graph.deep_research.types import DeepResearchState, PartialDeepResearchState
+from ee.hogai.graph.deep_research.types import DeepResearchNodeName, DeepResearchState, PartialDeepResearchState
+from ee.hogai.utils.types.composed import MaxNodeName
 
 
 class DeepResearchNotebookPlanningNode(DeepResearchNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return DeepResearchNodeName.NOTEBOOK_PLANNING
+
     async def arun(self, state: DeepResearchState, config: RunnableConfig) -> PartialDeepResearchState:
         # We use instructions with the OpenAI Responses API
         instructions = DEEP_RESEARCH_NOTEBOOK_PLANNING_PROMPT.format(

--- a/ee/hogai/graph/deep_research/onboarding/nodes.py
+++ b/ee/hogai/graph/deep_research/onboarding/nodes.py
@@ -9,11 +9,16 @@ from posthog.schema import AssistantMessage, HumanMessage
 
 from ee.hogai.graph.deep_research.base.nodes import DeepResearchNode
 from ee.hogai.graph.deep_research.onboarding.prompts import DEEP_RESEARCH_ONBOARDING_PROMPT
-from ee.hogai.graph.deep_research.types import DeepResearchState, PartialDeepResearchState
+from ee.hogai.graph.deep_research.types import DeepResearchNodeName, DeepResearchState, PartialDeepResearchState
 from ee.hogai.utils.helpers import extract_content_from_ai_message
+from ee.hogai.utils.types.composed import MaxNodeName
 
 
 class DeepResearchOnboardingNode(DeepResearchNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return DeepResearchNodeName.NOTEBOOK_PLANNING
+
     def should_run_onboarding_at_start(self, state: DeepResearchState) -> Literal["onboarding", "planning", "continue"]:
         if not state.messages:
             return "onboarding"

--- a/ee/hogai/graph/deep_research/planner/nodes.py
+++ b/ee/hogai/graph/deep_research/planner/nodes.py
@@ -41,6 +41,7 @@ from ee.hogai.graph.deep_research.planner.prompts import (
 )
 from ee.hogai.graph.deep_research.types import (
     DeepResearchIntermediateResult,
+    DeepResearchNodeName,
     DeepResearchState,
     DeepResearchTask,
     DeepResearchTodo,
@@ -50,6 +51,7 @@ from ee.hogai.notebook.notebook_serializer import NotebookSerializer
 from ee.hogai.utils.helpers import extract_content_from_ai_message
 from ee.hogai.utils.types import WithCommentary
 from ee.hogai.utils.types.base import BaseState, BaseStateWithMessages, InsightArtifact, TaskArtifact
+from ee.hogai.utils.types.composed import MaxNodeName
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +99,10 @@ class finalize_research(WithCommentary):
 
 
 class DeepResearchPlannerNode(DeepResearchNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return DeepResearchNodeName.PLANNER
+
     async def arun(self, state: DeepResearchState, config: RunnableConfig) -> PartialDeepResearchState:
         # We use instructions with the OpenAI Responses API
         instructions = DEEP_RESEARCH_PLANNER_PROMPT.format(
@@ -187,6 +193,10 @@ class DeepResearchPlannerNode(DeepResearchNode):
 
 
 class DeepResearchPlannerToolsNode(DeepResearchNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return DeepResearchNodeName.PLANNER_TOOLS
+
     async def get_reasoning_message(
         self, input: BaseState, default_message: Optional[str] = None
     ) -> ReasoningMessage | None:

--- a/ee/hogai/graph/deep_research/report/nodes.py
+++ b/ee/hogai/graph/deep_research/report/nodes.py
@@ -22,12 +22,14 @@ from ee.hogai.graph.deep_research.base.nodes import DeepResearchNode
 from ee.hogai.graph.deep_research.report.prompts import DEEP_RESEARCH_REPORT_PROMPT, FINAL_REPORT_USER_PROMPT
 from ee.hogai.graph.deep_research.types import (
     DeepResearchIntermediateResult,
+    DeepResearchNodeName,
     DeepResearchState,
     PartialDeepResearchState,
 )
 from ee.hogai.graph.query_executor.query_executor import AssistantQueryExecutor
 from ee.hogai.notebook.notebook_serializer import NotebookContext
 from ee.hogai.utils.types.base import InsightArtifact, TaskArtifact
+from ee.hogai.utils.types.composed import MaxNodeName
 
 
 class FormattedInsight(BaseModel):
@@ -48,6 +50,10 @@ class DeepResearchReportNode(DeepResearchNode):
     2. Formats insight artifacts using the query executor
     3. Generates a final markdown report with embedded insight references
     """
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return DeepResearchNodeName.REPORT
 
     async def arun(self, state: DeepResearchState, config: RunnableConfig) -> PartialDeepResearchState:
         # Collect all artifacts from task results

--- a/ee/hogai/graph/deep_research/task_executor/nodes.py
+++ b/ee/hogai/graph/deep_research/task_executor/nodes.py
@@ -6,11 +6,12 @@ from langchain_core.runnables import RunnableConfig
 from posthog.schema import AssistantMessage, AssistantToolCallMessage, TaskExecutionItem, TaskExecutionMessage
 
 from ee.hogai.graph.deep_research.task_executor.prompts import EXECUTE_TASKS_TOOL_RESULT
-from ee.hogai.graph.deep_research.types import DeepResearchState, PartialDeepResearchState
+from ee.hogai.graph.deep_research.types import DeepResearchNodeName, DeepResearchState, PartialDeepResearchState
 from ee.hogai.graph.parallel_task_execution.mixins import WithInsightCreationTaskExecution
 from ee.hogai.graph.parallel_task_execution.nodes import BaseTaskExecutorNode, TaskExecutionInputTuple
 from ee.hogai.utils.helpers import find_last_message_of_type
 from ee.hogai.utils.types.base import TaskResult
+from ee.hogai.utils.types.composed import MaxNodeName
 
 logger = structlog.get_logger(__name__)
 
@@ -21,6 +22,10 @@ class DeepResearchTaskExecutorNode(
     """
     Core task execution node that handles parallel task execution
     """
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return DeepResearchNodeName.TASK_EXECUTOR
 
     tool_call_id: str
 

--- a/ee/hogai/graph/funnels/nodes.py
+++ b/ee/hogai/graph/funnels/nodes.py
@@ -4,6 +4,8 @@ from langchain_core.runnables import RunnableConfig
 from posthog.schema import AssistantFunnelsQuery
 
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from ..schema_generator.nodes import SchemaGeneratorNode, SchemaGeneratorToolsNode
 from ..schema_generator.utils import SchemaGeneratorOutput
@@ -19,6 +21,10 @@ class FunnelGeneratorNode(SchemaGeneratorNode[AssistantFunnelsQuery]):
     OUTPUT_MODEL = FunnelsSchemaGeneratorOutput
     OUTPUT_SCHEMA = FUNNEL_SCHEMA
 
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.FUNNEL_GENERATOR
+
     async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         prompt = ChatPromptTemplate.from_messages(
             [
@@ -30,4 +36,6 @@ class FunnelGeneratorNode(SchemaGeneratorNode[AssistantFunnelsQuery]):
 
 
 class FunnelGeneratorToolsNode(SchemaGeneratorToolsNode):
-    pass
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.FUNNEL_GENERATOR_TOOLS

--- a/ee/hogai/graph/inkeep_docs/nodes.py
+++ b/ee/hogai/graph/inkeep_docs/nodes.py
@@ -17,6 +17,8 @@ from posthog.schema import AssistantMessage, AssistantToolCallMessage
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.state import PartialAssistantState
 from ee.hogai.utils.types import AssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from ..root.nodes import RootNode
 from .prompts import INKEEP_DATA_CONTINUATION_PHRASE, INKEEP_DOCS_SYSTEM_PROMPT
@@ -24,6 +26,10 @@ from .prompts import INKEEP_DATA_CONTINUATION_PHRASE, INKEEP_DOCS_SYSTEM_PROMPT
 
 class InkeepDocsNode(RootNode):  # Inheriting from RootNode to use the same message construction
     """Node for searching PostHog documentation using Inkeep."""
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.INKEEP_DOCS
 
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         """Process the state and return documentation search results."""

--- a/ee/hogai/graph/insights/nodes.py
+++ b/ee/hogai/graph/insights/nodes.py
@@ -25,6 +25,8 @@ from ee.hogai.graph.base import AssistantNode
 from ee.hogai.graph.query_executor.query_executor import AssistantQueryExecutor, SupportedQueryTypes
 from ee.hogai.graph.root.nodes import MAX_SUPPORTED_QUERY_KIND_TO_MODEL
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from .prompts import (
     EMPTY_DATABASE_ERROR_MESSAGE,
@@ -111,6 +113,10 @@ class InsightSearchNode(AssistantNode):
     MAX_SERIES_TO_PROCESS = 3
 
     REASONING_MESSAGE = "Searching for insights"
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.INSIGHTS_SEARCH
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ee/hogai/graph/parallel_task_execution/test/test_nodes.py
+++ b/ee/hogai/graph/parallel_task_execution/test/test_nodes.py
@@ -10,8 +10,10 @@ from pydantic import ConfigDict
 
 from posthog.schema import ReasoningMessage, TaskExecutionItem, TaskExecutionMessage, TaskExecutionStatus
 
+from ee.hogai.graph.deep_research.types import DeepResearchNodeName
 from ee.hogai.graph.parallel_task_execution.nodes import BaseTaskExecutorNode, TaskExecutionInputTuple
 from ee.hogai.utils.types.base import BaseStateWithTasks, TaskArtifact, TaskResult
+from ee.hogai.utils.types.composed import MaxNodeName
 
 
 class MockTestState(BaseStateWithTasks):
@@ -34,6 +36,10 @@ class TaskExecutorNodeImplementation(BaseTaskExecutorNode[MockTestState, MockPar
         super().__init__(team, user)
         self.input_tuples_called = False
         self.final_state_called = False
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return DeepResearchNodeName.TASK_EXECUTOR
 
     async def arun(self, state: MockTestState, config: RunnableConfig) -> MockPartialTestState:
         """Forward to the base _arun method."""

--- a/ee/hogai/graph/query_executor/nodes.py
+++ b/ee/hogai/graph/query_executor/nodes.py
@@ -17,6 +17,7 @@ from posthog.exceptions_capture import capture_exception
 
 from ee.hogai.graph.base import AssistantNode
 from ee.hogai.utils.types import AssistantNodeName, AssistantState, PartialAssistantState
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from .prompts import (
     FALLBACK_EXAMPLE_PROMPT,
@@ -33,7 +34,9 @@ from .query_executor import AssistantQueryExecutor
 
 
 class QueryExecutorNode(AssistantNode):
-    name = AssistantNodeName.QUERY_EXECUTOR
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.QUERY_EXECUTOR
 
     async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
         viz_message = state.messages[-1]

--- a/ee/hogai/graph/query_planner/nodes.py
+++ b/ee/hogai/graph/query_planner/nodes.py
@@ -32,6 +32,8 @@ from ee.hogai.graph.shared_prompts import CORE_MEMORY_PROMPT
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import dereference_schema, format_events_yaml
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from .prompts import (
     ACTIONS_EXPLANATION_PROMPT,
@@ -56,6 +58,10 @@ from .toolkit import (
 
 
 class QueryPlannerNode(TaxonomyReasoningNodeMixin, AssistantNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.QUERY_PLANNER
+
     def _get_dynamic_entity_tools(self):
         """Create dynamic Pydantic models with correct entity types for this team."""
         # Create Literal type with actual entity names
@@ -241,6 +247,10 @@ class QueryPlannerToolsNode(AssistantNode, ABC):
     the agent will terminate the conversation and return a message to the root node
     to request additional information.
     """
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.QUERY_PLANNER_TOOLS
 
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         toolkit = TaxonomyAgentToolkit(self._team)

--- a/ee/hogai/graph/rag/nodes.py
+++ b/ee/hogai/graph/rag/nodes.py
@@ -20,6 +20,8 @@ from posthog.models import Action
 from ee.hogai.graph.base import AssistantNode
 from ee.hogai.utils.embeddings import embed_search_query, get_azure_embeddings_client
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 NEXT_RAG_NODES = ["trends", "funnel", "retention", "sql", "end"]
 NextRagNode = Literal["trends", "funnel", "retention", "sql", "end"]
@@ -29,6 +31,10 @@ class InsightRagContextNode(AssistantNode):
     """
     Injects the RAG context of product analytics insights: actions and events.
     """
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.INSIGHT_RAG_CONTEXT
 
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
         plan = state.root_tool_insight_plan

--- a/ee/hogai/graph/retention/nodes.py
+++ b/ee/hogai/graph/retention/nodes.py
@@ -4,6 +4,8 @@ from langchain_core.runnables import RunnableConfig
 from posthog.schema import AssistantRetentionQuery
 
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from ..schema_generator.nodes import SchemaGeneratorNode, SchemaGeneratorToolsNode
 from ..schema_generator.utils import SchemaGeneratorOutput
@@ -19,6 +21,10 @@ class RetentionGeneratorNode(SchemaGeneratorNode[AssistantRetentionQuery]):
     OUTPUT_MODEL = RetentionSchemaGeneratorOutput
     OUTPUT_SCHEMA = RETENTION_SCHEMA
 
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.RETENTION_GENERATOR
+
     async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         prompt = ChatPromptTemplate.from_messages(
             [
@@ -30,4 +36,6 @@ class RetentionGeneratorNode(SchemaGeneratorNode[AssistantRetentionQuery]):
 
 
 class RetentionGeneratorToolsNode(SchemaGeneratorToolsNode):
-    pass
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.RETENTION_GENERATOR_TOOLS

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -49,7 +49,8 @@ from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL
 from ee.hogai.utils.helpers import find_last_ui_context
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
-from ee.hogai.utils.types.base import BaseState, BaseStateWithMessages
+from ee.hogai.utils.types.base import AssistantNodeName, BaseState, BaseStateWithMessages
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from .prompts import (
     ROOT_BILLING_CONTEXT_ERROR_PROMPT,
@@ -302,6 +303,10 @@ class RootNode(RootNodeUIContextMixin):
     Determines the maximum number of tool calls allowed in a single generation.
     """
     CONVERSATION_WINDOW_SIZE = 64000
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.ROOT
 
     async def get_reasoning_message(
         self, input: BaseState, default_message: Optional[str] = None
@@ -643,6 +648,10 @@ class RootNode(RootNodeUIContextMixin):
 
 
 class RootNodeTools(AssistantNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.ROOT_TOOLS
+
     async def get_reasoning_message(
         self, input: BaseState, default_message: Optional[str] = None
     ) -> ReasoningMessage | None:

--- a/ee/hogai/graph/schema_generator/test/test_nodes.py
+++ b/ee/hogai/graph/schema_generator/test/test_nodes.py
@@ -17,7 +17,8 @@ from ee.hogai.graph.schema_generator.nodes import RETRIES_ALLOWED, SchemaGenerat
 from ee.hogai.graph.schema_generator.parsers import PydanticOutputParserException
 from ee.hogai.graph.schema_generator.utils import SchemaGeneratorOutput
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
-from ee.hogai.utils.types.base import IntermediateStep
+from ee.hogai.utils.types.base import AssistantNodeName, IntermediateStep
+from ee.hogai.utils.types.composed import MaxNodeName
 
 DummySchema = SchemaGeneratorOutput[AssistantTrendsQuery]
 
@@ -26,6 +27,10 @@ class DummyGeneratorNode(SchemaGeneratorNode[AssistantTrendsQuery]):
     INSIGHT_NAME = "Test"
     OUTPUT_MODEL = SchemaGeneratorOutput[AssistantTrendsQuery]
     OUTPUT_SCHEMA = {}
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.TRENDS_GENERATOR
 
     async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         prompt = ChatPromptTemplate.from_messages(
@@ -520,9 +525,15 @@ class TestSchemaGeneratorNode(BaseTest):
             self.assertEqual(len(new_state.intermediate_steps or []), 1)
 
 
+class MockSchemaGeneratorToolsNode(SchemaGeneratorToolsNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.TRENDS_GENERATOR_TOOLS
+
+
 class TestSchemaGeneratorToolsNode(BaseTest):
     async def test_tools_node(self):
-        node = SchemaGeneratorToolsNode(self.team, self.user)
+        node = MockSchemaGeneratorToolsNode(self.team, self.user)
         action = AgentAction(tool="fix", tool_input="validationerror", log="pydanticexception")
         state = await node.arun(AssistantState(messages=[], intermediate_steps=[(action, None)]), {})
         state = cast(PartialAssistantState, state)

--- a/ee/hogai/graph/session_summaries/nodes.py
+++ b/ee/hogai/graph/session_summaries/nodes.py
@@ -46,11 +46,17 @@ from ee.hogai.session_summaries.session_group.summary_notebooks import (
 from ee.hogai.session_summaries.utils import logging_session_ids
 from ee.hogai.utils.state import prepare_reasoning_progress_message
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 
 class SessionSummarizationNode(AssistantNode):
     logger = structlog.get_logger(__name__)
     REASONING_MESSAGE = "Summarizing session recordings"
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.SESSION_SUMMARIZATION
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ee/hogai/graph/sql/nodes.py
+++ b/ee/hogai/graph/sql/nodes.py
@@ -5,6 +5,8 @@ from posthog.schema import AssistantHogQLQuery
 from posthog.hogql.context import HogQLContext
 
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from ..schema_generator.nodes import SchemaGeneratorNode, SchemaGeneratorToolsNode
 from .mixins import HogQLGeneratorMixin, SQLSchemaGeneratorOutput
@@ -19,10 +21,16 @@ class SQLGeneratorNode(HogQLGeneratorMixin, SchemaGeneratorNode[AssistantHogQLQu
 
     hogql_context: HogQLContext
 
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.SQL_GENERATOR
+
     async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         prompt = await self._construct_system_prompt()
         return await super()._run_with_prompt(state, prompt, config=config)
 
 
 class SQLGeneratorToolsNode(SchemaGeneratorToolsNode):
-    pass
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.SQL_GENERATOR_TOOLS

--- a/ee/hogai/graph/taxonomy/nodes.py
+++ b/ee/hogai/graph/taxonomy/nodes.py
@@ -19,6 +19,7 @@ from posthog.models.group_type_mapping import GroupTypeMapping
 
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import format_events_yaml
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from ..base import BaseAssistantNode
 from ..mixins import StateClassMixin, TaxonomyReasoningNodeMixin
@@ -31,7 +32,7 @@ from .prompts import (
 )
 from .toolkit import TaxonomyAgentToolkit
 from .tools import TaxonomyTool
-from .types import EntityType, TaxonomyAgentState
+from .types import EntityType, TaxonomyAgentState, TaxonomyNodeName
 
 TaxonomyStateType = TypeVar("TaxonomyStateType", bound=TaxonomyAgentState)
 TaxonomyPartialStateType = TypeVar("TaxonomyPartialStateType", bound=TaxonomyAgentState)
@@ -51,6 +52,10 @@ class TaxonomyAgentNode(
         super().__init__(team, user)
         self._toolkit = toolkit_class(team=team)
         self._state_class, self._partial_state_class = self._get_state_class(TaxonomyAgentNode)
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return TaxonomyNodeName.LOOP_NODE
 
     @cached_property
     def _team_group_types(self) -> list[str]:
@@ -153,6 +158,10 @@ class TaxonomyAgentToolsNode(
         super().__init__(team, user)
         self._toolkit = toolkit_class(team=team)
         self._state_class, self._partial_state_class = self._get_state_class(TaxonomyAgentToolsNode)
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return TaxonomyNodeName.TOOLS_NODE
 
     def run(self, state: TaxonomyStateType, config: RunnableConfig) -> TaxonomyPartialStateType:
         intermediate_steps = state.intermediate_steps or []

--- a/ee/hogai/graph/title_generator/nodes.py
+++ b/ee/hogai/graph/title_generator/nodes.py
@@ -9,10 +9,16 @@ from ee.hogai.graph.title_generator.prompts import TITLE_GENERATION_PROMPT
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import find_last_message_of_type
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 from ee.models.assistant import Conversation
 
 
 class TitleGeneratorNode(AssistantNode):
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.TITLE_GENERATOR
+
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
         human_message = find_last_message_of_type(state.messages, HumanMessage)
         if not human_message:

--- a/ee/hogai/graph/trends/nodes.py
+++ b/ee/hogai/graph/trends/nodes.py
@@ -4,6 +4,8 @@ from langchain_core.runnables import RunnableConfig
 from posthog.schema import AssistantTrendsQuery
 
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from ..schema_generator.nodes import SchemaGeneratorNode, SchemaGeneratorToolsNode
 from ..schema_generator.utils import SchemaGeneratorOutput
@@ -19,6 +21,10 @@ class TrendsGeneratorNode(SchemaGeneratorNode[AssistantTrendsQuery]):
     OUTPUT_MODEL = TrendsSchemaGeneratorOutput
     OUTPUT_SCHEMA = TRENDS_SCHEMA
 
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.TRENDS_GENERATOR
+
     async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         prompt = ChatPromptTemplate.from_messages(
             [
@@ -30,4 +36,6 @@ class TrendsGeneratorNode(SchemaGeneratorNode[AssistantTrendsQuery]):
 
 
 class TrendsGeneratorToolsNode(SchemaGeneratorToolsNode):
-    pass
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.TRENDS_GENERATOR_TOOLS

--- a/ee/hogai/utils/test/test_assistant_node.py
+++ b/ee/hogai/utils/test/test_assistant_node.py
@@ -4,6 +4,8 @@ from langchain_core.runnables import RunnableConfig
 
 from ee.hogai.graph.base import AssistantNode
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 from ee.models.assistant import CoreMemory
 
 
@@ -14,6 +16,10 @@ class TestAssistantNode(BaseTest):
         class Node(AssistantNode):
             def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
                 raise NotImplementedError
+
+            @property
+            def node_name(self) -> MaxNodeName:
+                return AssistantNodeName.ROOT
 
         self.node = Node(self.team, self.user)
 

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -336,6 +336,10 @@ class AssistantNodeName(StrEnum):
     TITLE_GENERATOR = "title_generator"
     INSIGHTS_SEARCH = "insights_search"
     SESSION_SUMMARIZATION = "session_summarization"
+    HOGQL_GENERATOR = "hogql_generator"
+    HOGQL_GENERATOR_TOOLS = "hogql_generator_tools"
+    SESSION_REPLAY_FILTER = "session_replay_filter"
+    SESSION_REPLAY_FILTER_OPTIONS_TOOLS = "session_replay_filter_options_tools"
 
 
 class AssistantMode(StrEnum):

--- a/products/data_warehouse/backend/max_tools.py
+++ b/products/data_warehouse/backend/max_tools.py
@@ -24,6 +24,8 @@ from ee.hogai.graph.taxonomy.toolkit import TaxonomyAgentToolkit
 from ee.hogai.graph.taxonomy.tools import base_final_answer
 from ee.hogai.graph.taxonomy.types import TaxonomyAgentState
 from ee.hogai.tool import MaxTool
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 
 class HogQLGeneratorArgs(BaseModel):
@@ -63,6 +65,10 @@ class HogQLGeneratorNode(
     def __init__(self, team: Team, user: User, toolkit_class: HogQLGeneratorToolkit):
         super().__init__(team, user, toolkit_class=toolkit_class)
 
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.HOGQL_GENERATOR
+
     def _get_system_prompt(self) -> ChatPromptTemplate:
         """Get default system prompts. Override in subclasses for custom prompts."""
 
@@ -100,6 +106,10 @@ class HogQLGeneratorNode(
 class HogQLGeneratorToolsNode(TaxonomyAgentToolsNode[TaxonomyAgentState, TaxonomyAgentState[FinalAnswerArgs]]):
     def __init__(self, team: Team, user: User, toolkit_class: HogQLGeneratorToolkit):
         super().__init__(team, user, toolkit_class=toolkit_class)
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.HOGQL_GENERATOR_TOOLS
 
 
 class HogQLGeneratorGraph(TaxonomyAgent[TaxonomyAgentState, TaxonomyAgentState[FinalAnswerArgs]]):

--- a/products/replay/backend/max_tools.py
+++ b/products/replay/backend/max_tools.py
@@ -15,6 +15,8 @@ from ee.hogai.graph.taxonomy.toolkit import TaxonomyAgentToolkit
 from ee.hogai.graph.taxonomy.tools import base_final_answer
 from ee.hogai.graph.taxonomy.types import TaxonomyAgentState
 from ee.hogai.tool import MaxTool
+from ee.hogai.utils.types.base import AssistantNodeName
+from ee.hogai.utils.types.composed import MaxNodeName
 
 from .prompts import (
     DATE_FIELDS_PROMPT,
@@ -53,6 +55,10 @@ class SessionReplayFilterNode(TaxonomyAgentNode[TaxonomyAgentState, TaxonomyAgen
     def __init__(self, team: Team, user: User, toolkit_class: type[SessionReplayFilterOptionsToolkit]):
         super().__init__(team, user, toolkit_class=toolkit_class)
 
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.SESSION_REPLAY_FILTER
+
     def _get_system_prompt(self) -> ChatPromptTemplate:
         """Get default system prompts. Override in subclasses for custom prompts."""
         all_messages = [
@@ -73,6 +79,10 @@ class SessionReplayFilterOptionsToolsNode(
 
     def __init__(self, team: Team, user: User, toolkit_class: type[SessionReplayFilterOptionsToolkit]):
         super().__init__(team, user, toolkit_class=toolkit_class)
+
+    @property
+    def node_name(self) -> MaxNodeName:
+        return AssistantNodeName.SESSION_REPLAY_FILTER_OPTIONS_TOOLS
 
 
 class SessionReplayFilterOptionsGraph(


### PR DESCRIPTION
## Problem
We (I) merged a change to how streaming works, which would use the `node_name` found within the `RunnableConfig`. That `node_name` doesn't exist if we run a node outside of a graph. 

## Changes
- Force all nodes to implement a `node_name` property

## How did you test this code?
Locally + tests
