### PR TITLE
fix: event type collapse initial state

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -335,9 +335,9 @@ const TreeNode = React.memo(function TraceNode({
     const usage = node.displayUsage
     const item = node.event
 
-    const { eventTypeFilters } = useValues(llmAnalyticsTraceLogic)
+    const { eventTypeExpanded } = useValues(llmAnalyticsTraceLogic)
     const eventType = getEventType(item)
-    const isCollapsedDueToFilter = eventTypeFilters[eventType] === false
+    const isCollapsedDueToFilter = !eventTypeExpanded(eventType)
 
     const children = [
         isLLMTraceEvent(item) && item.properties.$ai_is_error && (
@@ -778,8 +778,8 @@ function EventTypeTag({ event, size }: { event: LLMTrace | LLMTraceEvent; size?:
 
 function EventTypeFilters(): JSX.Element {
     const { availableEventTypes } = useValues(llmAnalyticsTraceDataLogic)
-    const { eventTypeFilters } = useValues(llmAnalyticsTraceLogic)
-    const { toggleEventTypeFilter } = useActions(llmAnalyticsTraceLogic)
+    const { eventTypeExpanded } = useValues(llmAnalyticsTraceLogic)
+    const { toggleEventTypeExpanded } = useActions(llmAnalyticsTraceLogic)
 
     if (availableEventTypes.length === 0) {
         return <></>
@@ -792,8 +792,8 @@ function EventTypeFilters(): JSX.Element {
                 {availableEventTypes.map((eventType: string) => (
                     <LemonCheckbox
                         key={eventType}
-                        checked={eventTypeFilters[eventType] ?? true}
-                        onChange={() => toggleEventTypeFilter(eventType)}
+                        checked={eventTypeExpanded(eventType)}
+                        onChange={() => toggleEventTypeExpanded(eventType)}
                         label={<span className="capitalize text-xs">{eventType}s</span>}
                         size="small"
                     />

--- a/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
@@ -64,7 +64,7 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
         hideAllMessages: (type: 'input' | 'output') => ({ type }),
         applySearchResults: (inputMatches: boolean[], outputMatches: boolean[]) => ({ inputMatches, outputMatches }),
         setDisplayOption: (displayOption: DisplayOption) => ({ displayOption }),
-        toggleEventTypeFilter: (eventType: string) => ({ eventType }),
+        toggleEventTypeExpanded: (eventType: string) => ({ eventType }),
     }),
 
     reducers({
@@ -142,13 +142,13 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
                 setDisplayOption: (_, { displayOption }) => displayOption,
             },
         ],
-        eventTypeFilters: [
+        eventTypeExpandedMap: [
             {} as Record<string, boolean>,
             persistConfig,
             {
-                toggleEventTypeFilter: (state, { eventType }) => ({
+                toggleEventTypeExpanded: (state, { eventType }) => ({
                     ...state,
-                    [eventType]: !state[eventType],
+                    [eventType]: !(state[eventType] ?? true),
                 }),
             },
         ],
@@ -202,6 +202,13 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
                     },
                 ]
             },
+        ],
+        eventTypeExpanded: [
+            (s) => [s.eventTypeExpandedMap],
+            (eventTypeExpandedMap) =>
+                (eventType: string): boolean => {
+                    return eventTypeExpandedMap[eventType] ?? true
+                },
         ],
     }),
 


### PR DESCRIPTION
First time setting the expansion state required a double click due to incorrect handling of undefined value. This fixes it and ensures all logic is in the logic file.