### PR TITLE
feat(web-analytics): target specific host when doing partition swap

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -237,7 +237,7 @@ class ClickhouseCluster:
         """
         Execute the callable on a specific host by hostname.
 
-        This is useful when targeting an exact host, such as when working with non-replicated tables.
+        If the hostname does not exists, it will throw an error.
         """
         host_info = self.__find_host_by_name(hostname)
 
@@ -245,7 +245,6 @@ class ClickhouseCluster:
             return FuturesMap({host_info: executor.submit(self.__get_task_function(host_info, fn))})
 
     def __find_host_by_name(self, hostname: str) -> HostInfo:
-        """Find HostInfo by hostname."""
         for host_info in self.__hosts:
             if host_info.connection_info.host == hostname:
                 return host_info
@@ -499,6 +498,7 @@ class Retryable(Generic[T]):  # note: this class exists primarily to allow a rea
 
             def delay_fn(_):
                 return self.policy.delay
+
         else:
             delay_fn = self.policy.delay
 


### PR DESCRIPTION
## Problem

Another take on the investigations to fix https://github.com/PostHog/posthog/pull/38281 for web pre-aggregated v2 tables that are having replication issues.

This targets the get/replace partitions commands to the host that got them on the insert step. This guarantees that the replication will kick in and avoid forcing extra replication on staging tables like the other PR: https://github.com/PostHog/posthog/pull/38373

## Changes

- Include `map_specific_host` in cluster.py so we can target a specific host
- Change the swap/get partition logic to target the most recent change host with the partition.

## How did you test this code?

Integration tests and running those steps manually to fix the problem in production.
