### PR TITLE
feat(customers): Add like/dislike buttons to customer analytics insights

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -37,6 +37,8 @@ export interface CardMetaProps extends Pick<React.HTMLAttributes<HTMLDivElement>
     detailsTooltip?: string
     topHeading?: JSX.Element | null
     samplingFactor?: number | null
+    /** Additional controls to show in the top controls area */
+    extraControls?: JSX.Element | null
 }
 
 export function CardMeta({
@@ -53,6 +55,7 @@ export function CardMeta({
     detailsTooltip,
     className,
     samplingFactor,
+    extraControls,
 }: CardMetaProps): JSX.Element {
     const { ref: primaryRef, width: primaryWidth } = useResizeObserver()
     const { ref: detailsRef, height: detailsHeight } = useResizeObserver()
@@ -84,6 +87,7 @@ export function CardMeta({
                             )}
                         </h5>
                         <div className="CardMeta__controls">
+                            {extraControls}
                             {showDetailsControls && setAreDetailsShown && (
                                 <Tooltip title={detailsTooltip}>
                                     <LemonButton

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -242,6 +242,7 @@ function InsightCardInternal(
                             moreButtons={moreButtons}
                             filtersOverride={filtersOverride}
                             variablesOverride={variablesOverride}
+                            placement={placement}
                         />
                         <div className="InsightCard__viz">
                             {BlockingEmptyState ? (


### PR DESCRIPTION
## Problem
I'm figuring out what kind of data is useful for folks. For that, I need a way to easily capture feedback whether what they're seeing is useful or not.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/38387
## Changes
- Pass `placement` prop all the way down to `InsightMeta` component
- Add `extraControls` prop in `CardMeta` to display the like/dislike buttons
- Render the buttons only when insight is presented in a dashboard in customer analytics (hence why we need to know the `placement`)
- The buttons will log like/dislike events with metadata about the liked/disliked insight and the user who performed the action
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

<img width="619" height="478" alt="image" src="https://github.com/user-attachments/assets/4317593b-0d5c-4129-b721-c3e9fe541b45" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
