### PR TITLE
chore(property-defs-rs): adds log for persons db pool creation

### DIFF
--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -3,7 +3,7 @@ use quick_cache::sync::Cache;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::collections::HashMap;
 use time::Duration;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{
     api::v1::query::Manager,
@@ -54,11 +54,12 @@ impl AppContext {
         let persons_options = PgPoolOptions::new().max_connections(config.max_pg_connections);
         let persons_pool: Option<PgPool> =
             if config.read_groups_from_persons_db && !config.database_persons_url.is_empty() {
-                Some(
-                    persons_options
-                        .connect(&config.database_persons_url)
-                        .await?,
-                )
+                info!("Creating persons DB connection pool (read_groups_from_persons_db=true)");
+                let pool = persons_options
+                    .connect(&config.database_persons_url)
+                    .await?;
+                info!("Successfully created persons DB connection pool");
+                Some(pool)
             } else {
                 None
             };


### PR DESCRIPTION
## Problem

We'd like to have observability in logs around creating the persons db pool, so taht we can audit this easily during migration

## Changes

Add a "creating" db log and a "successfully" created db log.

## How did you test this code?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
