### PR TITLE
feat(web-analytics): sytem sync partition replicas before swap

### DIFF
--- a/dags/web_preaggregated_utils.py
+++ b/dags/web_preaggregated_utils.py
@@ -99,6 +99,16 @@ def drop_partitions_for_date_range(
         current_date += timedelta(days=1)
 
 
+def sync_partitions_on_replicas(
+    context: dagster.AssetExecutionContext, cluster: ClickhouseCluster, target_table: str
+) -> None:
+    context.log.info(f"Syncing replicas for {target_table} on all hosts")
+    cluster.map_hosts_by_roles(
+        lambda client: client.execute(f"SYSTEM SYNC REPLICA {target_table} LIGHTWEIGHT"),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+    ).result()
+
+
 def swap_partitions_from_staging(
     context: dagster.AssetExecutionContext, cluster: ClickhouseCluster, target_table: str, staging_table: str
 ) -> None:


### PR DESCRIPTION
## Problem

We are sometimes missing the partition on some hosts when querying which partitions exist or running REPLACE PARTITION, which makes it a no-op. More context: https://posthog.slack.com/archives/C076R4753Q8/p1758227088193229

## Changes

- Run `SYSTEM SYNC REPLICA` after inserting but before swapping the partitions to consume the replication queue

## How did you test this code?

I can guarantee it ran the command on my local machine, and it did not explode my computer. If it works for our use case in prod I will add some integration tests :)
