### PR TITLE
feat(kafka-dedup): checkpoint graceful shutdown, avoid potential race condition

### DIFF
--- a/rust/.vscode/settings.json
+++ b/rust/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+  "rust-analyzer.server.path": "/Users/elireisman/.cargo/bin/rust-analyzer",
+  "rust-analyzer.checkOnSave.command": "check",
+  "rust-analyzer.checkOnSave.extraArgs": ["--workspace"],
+  "rust-analyzer.cargo.buildScripts.enable": true,
+  "rust-analyzer.procMacro.enable": true,
+  "rust-analyzer.imports.granularity.group": "module",
+  "rust-analyzer.imports.prefix": "crate",
+  "rust-analyzer.completion.addCallParentheses": true,
+  "rust-analyzer.completion.addCallArgumentSnippets": true,
+  "rust-analyzer.diagnostics.enable": true,
+  "rust-analyzer.diagnostics.enableExperimental": true,
+  "rust-analyzer.lens.enable": true,
+  "rust-analyzer.hover.actions.enable": true,
+  "rust-analyzer.inlayHints.enable": true,
+  "rust-analyzer.inlayHints.parameterHints.enable": true,
+  "rust-analyzer.inlayHints.typeHints.enable": true,
+  "rust-analyzer.inlayHints.chainingHints.enable": true,
+  "rust-analyzer.workspace.symbol.search.scope": "workspace_and_dependencies",
+  "rust-analyzer.files.watcher": "notify",
+  "rust-analyzer.notifications.cargoTomlNotFound": "ignore",
+  "rust-analyzer.cargo.features": "all"
+}
+

--- a/rust/kafka-deduplicator/sporadic_flaky_test_kafka_dedup.txt
+++ b/rust/kafka-deduplicator/sporadic_flaky_test_kafka_dedup.txt
@@ -1,0 +1,34 @@
+running 2 tests
+test test_deduplication_with_different_events ... FAILED
+test test_basic_deduplication ... FAILED
+
+failures:
+
+---- test_deduplication_with_different_events stdout ----
+Creating Kafka admin client for broker: localhost:9092
+Creating 2 topics
+Sending create topics request to Kafka...
+Topic test_dedup_events_f32632f5-d74c-4d74-981a-674b04aec820 result: InvalidPartitions
+Topic test_dedup_events_output_3b85212f-d977-4db6-8af6-46d5adc472aa result: InvalidPartitions
+Creating producer for topic: test_dedup_events_f32632f5-d74c-4d74-981a-674b04aec820
+Producing 3 events to topic test_dedup_events_f32632f5-d74c-4d74-981a-674b04aec820
+Error: Failed to send message: KafkaError (Message production error: InvalidPartitions (Broker: Invalid number of partitions))
+
+---- test_basic_deduplication stdout ----
+Starting test_basic_deduplication
+Acquiring test mutex...
+Test mutex acquired
+Test topics: input=test_dedup_input_f0ee1e6c-3f96-4b8d-90d9-6c11d50b0ab3, output=test_dedup_output_1670aa82-4e57-45ea-b794-72996b940a29, group=test_group_08484950-962b-4ce8-9195-de872296f277
+Creating Kafka topics...
+Creating Kafka admin client for broker: localhost:9092
+Creating 2 topics
+Sending create topics request to Kafka...
+Topic test_dedup_input_f0ee1e6c-3f96-4b8d-90d9-6c11d50b0ab3 result: InvalidPartitions
+Topic test_dedup_output_1670aa82-4e57-45ea-b794-72996b940a29 result: InvalidPartitions
+Topics created successfully
+Creating Kafka Deduplicator service...
+Service initialized
+Producing 5 duplicate events for user_123...
+Creating producer for topic: test_dedup_input_f0ee1e6c-3f96-4b8d-90d9-6c11d50b0ab3
+Producing 5 events to topic test_dedup_input_f0ee1e6c-3f96-4b8d-90d9-6c11d50b0ab3
+Error: Failed to send message: KafkaError (Message production error: InvalidPartitions (Broker: Invalid number of partitions))

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -34,6 +34,10 @@ pub struct CheckpointConfig {
     /// Maximum number of concurrent checkpoints to perform
     pub max_concurrent_checkpoints: usize,
 
+    /// How often to attempt to check if a slot is available
+    /// when max_concurrent_checkpoints slots are occupied
+    pub checkpoint_gate_interval: Duration,
+
     /// Timeout for S3 operations
     pub s3_timeout: Duration,
 }
@@ -48,9 +52,10 @@ impl Default for CheckpointConfig {
             s3_key_prefix: "deduplication-checkpoints".to_string(),
             full_upload_interval: 0, // TODO: always full checkpoints until we impl incremental
             aws_region: "us-east-1".to_string(),
-            max_local_checkpoints: 10, // number of most-recent local checkpoints to retain per partition
-            max_checkpoint_retention_hours: 72, // no local checkpoint is stored longer than this
-            max_concurrent_checkpoints: 3, // max number of concurrent checkpoint jobs to run
+            max_local_checkpoints: 10,
+            max_checkpoint_retention_hours: 72,
+            max_concurrent_checkpoints: 3,
+            checkpoint_gate_interval: Duration::from_millis(200),
             s3_timeout: Duration::from_secs(300), // 5 minutes
         }
     }

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -38,6 +38,9 @@ pub struct CheckpointConfig {
     /// when max_concurrent_checkpoints slots are occupied
     pub checkpoint_gate_interval: Duration,
 
+    /// Timeout for checkpoint worker graceful shutdown (applied in CheckpointManager::stop)
+    pub checkpoint_worker_shutdown_timeout: Duration,
+
     /// Timeout for S3 operations
     pub s3_timeout: Duration,
 }
@@ -56,6 +59,7 @@ impl Default for CheckpointConfig {
             max_checkpoint_retention_hours: 72,
             max_concurrent_checkpoints: 3,
             checkpoint_gate_interval: Duration::from_millis(200),
+            checkpoint_worker_shutdown_timeout: Duration::from_secs(10),
             s3_timeout: Duration::from_secs(300), // 5 minutes
         }
     }

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -150,11 +150,11 @@ impl CheckpointManager {
 
                         // Attempt to checkpoint each partitions' backing store in
                         // the candidate list. If the store is no longer owned by
-                        // the StoreManager, the receiver will bail out and continue
-                        // to loop. If the gating lock (is_checkpointing) is at max
-                        // capacity or an attempt for the given partition is already
-                        // in-flight, we block at this iter of 'inner loop until the
-                        // attempt can proceed or the manager's token is cancelled
+                        // the StoreManager, or a checkpoint is already in-flight
+                        // for the given partition, we skip it and continue. If the
+                        // gating lock (is_checkpointing) is at max capacity, we block
+                        // at this iteration of 'inner loop until the another attempt
+                        // completes and a new slot opens up
                         'inner: for partition in candidates {
                             let partition_tag = partition.to_string();
 

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -651,10 +651,10 @@ mod tests {
 
     fn create_test_event() -> RawEvent {
         RawEvent {
-            uuid: None,
+            uuid: Some(uuid::Uuid::now_v7()),
             event: "test_event".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("test_token".to_string()),
+            distinct_id: Some(serde_json::Value::String(uuid::Uuid::now_v7().to_string())),
+            token: Some(uuid::Uuid::now_v7().to_string()),
             properties: HashMap::new(),
             ..Default::default()
         }
@@ -951,8 +951,8 @@ mod tests {
     async fn test_cleaner_task_retention_time() {
         // Add some test stores
         let store_manager = create_test_store_manager();
-        let store1 = create_test_store("flush_all_with_stores", 0);
-        let store2 = create_test_store("flush_all_with_stores", 1);
+        let store1 = create_test_store("cleaner_task_retention_time", 0);
+        let store2 = create_test_store("cleaner_task_retention_time", 1);
 
         // Add events to the stores
         let event = create_test_event();
@@ -962,11 +962,11 @@ mod tests {
         // add dedup stores to manager
         let stores = store_manager.stores();
         stores.insert(
-            Partition::new("flush_all_with_stores".to_string(), 0),
+            Partition::new("cleaner_task_retention_time".to_string(), 0),
             store1,
         );
         stores.insert(
-            Partition::new("flush_all_with_stores".to_string(), 1),
+            Partition::new("cleaner_task_retention_time".to_string(), 1),
             store2,
         );
 
@@ -1016,8 +1016,8 @@ mod tests {
     async fn test_cleaner_task_partition_count() {
         // Add some test stores
         let store_manager = create_test_store_manager();
-        let store1 = create_test_store("flush_all_with_stores", 0);
-        let store2 = create_test_store("flush_all_with_stores", 1);
+        let store1 = create_test_store("cleaner_task_partition_count", 0);
+        let store2 = create_test_store("cleaner_task_partition_count", 1);
 
         // Add events to the stores
         let event = create_test_event();
@@ -1027,11 +1027,11 @@ mod tests {
         // add dedup stores to manager
         let stores = store_manager.stores();
         stores.insert(
-            Partition::new("flush_all_with_stores".to_string(), 0),
+            Partition::new("cleaner_task_partition_count".to_string(), 0),
             store1,
         );
         stores.insert(
-            Partition::new("flush_all_with_stores".to_string(), 1),
+            Partition::new("cleaner_task_partition_count".to_string(), 1),
             store2,
         );
 

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -425,13 +425,14 @@ impl CheckpointManager {
         partition: &Partition,
         is_checkpointing: &Arc<Mutex<HashSet<Partition>>>,
     ) -> CheckpointStatus {
-        let is_checkpointing_guard = is_checkpointing.lock().await;
+        let mut is_checkpointing_guard = is_checkpointing.lock().await;
 
         if is_checkpointing_guard.contains(partition) {
             return CheckpointStatus::InProgress;
         }
 
         if is_checkpointing_guard.len() < config.max_concurrent_checkpoints {
+            is_checkpointing_guard.insert(partition.clone());
             return CheckpointStatus::Ready;
         }
 

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -98,6 +98,9 @@ pub struct Config {
     #[envconfig(default = "3")]
     pub max_concurrent_checkpoints: usize,
 
+    #[envconfig(default = "200")]
+    pub checkpoint_gate_interval_millis: u64,
+
     #[envconfig(default = "/tmp/checkpoints")]
     pub local_checkpoint_dir: String,
 
@@ -263,6 +266,10 @@ impl Config {
     /// Get cleanup interval as Duration
     pub fn cleanup_interval(&self) -> Duration {
         Duration::from_secs(self.cleanup_interval_secs)
+    }
+
+    pub fn checkpoint_gate_interval(&self) -> Duration {
+        Duration::from_millis(self.checkpoint_gate_interval_millis)
     }
 
     /// Get S3 timeout as Duration

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -101,6 +101,12 @@ pub struct Config {
     #[envconfig(default = "200")]
     pub checkpoint_gate_interval_millis: u64,
 
+    #[envconfig(default = "10")]
+    pub checkpoint_worker_shutdown_timeout_secs: u64,
+
+    #[envconfig(default = "5")]
+    pub max_local_checkpoints: usize,
+
     #[envconfig(default = "/tmp/checkpoints")]
     pub local_checkpoint_dir: String,
 
@@ -116,9 +122,6 @@ pub struct Config {
 
     #[envconfig(default = "us-east-1")]
     pub aws_region: String,
-
-    #[envconfig(default = "5")]
-    pub max_local_checkpoints: usize,
 
     #[envconfig(default = "300")] // 5 minutes in seconds
     pub s3_timeout_secs: u64,
@@ -270,6 +273,14 @@ impl Config {
 
     pub fn checkpoint_gate_interval(&self) -> Duration {
         Duration::from_millis(self.checkpoint_gate_interval_millis)
+    }
+
+    pub fn checkpoint_worker_shutdown_timeout(&self) -> Duration {
+        Duration::from_secs(self.checkpoint_worker_shutdown_timeout_secs)
+    }
+
+    pub fn max_local_checkpoints(&self) -> usize {
+        self.max_local_checkpoints
     }
 
     /// Get S3 timeout as Duration

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -86,3 +86,8 @@ pub const CHECKPOINT_CLEANER_DIRS_FOUND: &str = "checkpoint_cleaner_dirs_found";
 
 /// Counter for the number of checkpoint directories deleted
 pub const CHECKPOINT_CLEANER_DELETE_ATTEMPTS: &str = "checkpoint_cleaner_delete_attempts";
+
+/// Counts number of times a StoreManager lookup by partition
+/// finds no associated DeduplicationStore, meaning ownership
+/// has changed across a rebalance or other event asynchronously
+pub const CHECKPOINT_STORE_NOT_FOUND_COUNTER: &str = "checkpoint_store_not_found";

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -85,6 +85,7 @@ impl KafkaDeduplicatorService {
             max_checkpoint_retention_hours: config.max_checkpoint_retention_hours,
             max_concurrent_checkpoints: config.max_concurrent_checkpoints,
             checkpoint_gate_interval: config.checkpoint_gate_interval(),
+            checkpoint_worker_shutdown_timeout: config.checkpoint_worker_shutdown_timeout(),
             s3_timeout: config.s3_timeout(),
         };
 

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -84,6 +84,7 @@ impl KafkaDeduplicatorService {
             max_local_checkpoints: config.max_local_checkpoints,
             max_checkpoint_retention_hours: config.max_checkpoint_retention_hours,
             max_concurrent_checkpoints: config.max_concurrent_checkpoints,
+            checkpoint_gate_interval: config.checkpoint_gate_interval(),
             s3_timeout: config.s3_timeout(),
         };
 


### PR DESCRIPTION
## Problem
The current checkpoint manager has no graceful shutdown period to give in-flight async checkpoint attempts a chance to finish before hard cancellation.

In addition, the  async checkpoint submission loop gates on several locks to ensure only a capped number of unique-per-partition attempts can be active at once. This avoids some cloning of manager-owned locking structures, but it's opaque, not testable, and introduces the chance for a race condition.

## Changes
* Implement graceful shutdown for checkpoint manager's in-flight worker threads
* Simplify worker-attempt locking and eliminate race conditions
* Unit tests for concurrent task attempt gating
* Update all the things to reflect the API changes involved (test suites, etc.)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog update (PoC service, not live)


<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
