### PR TITLE
feat(kafka-deduplicator): support multiple histogram buckets; configure similarity scoring

### DIFF
--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use axum::{routing::get, Router};
 use futures::future::ready;
 use health::HealthRegistry;
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use opentelemetry::{KeyValue, Value};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::trace::{BatchConfig, RandomIdGenerator, Sampler, Tracer};
@@ -57,9 +57,17 @@ pub async fn index() -> &'static str {
 /// Using fewer buckets to reduce cardinality
 fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
     const BUCKETS: &[f64] = &[0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 100.0, 500.0, 5000.0];
+    // similarity scores are all in the range [0.0, 1.0] so we want
+    // granular bucket ranges for higher fidelity metrics
+    const SIMILARITY_BUCKETS: &[f64] = &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
 
     PrometheusBuilder::new()
         .set_buckets(BUCKETS)
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Suffix("similarity_score".to_string()),
+            SIMILARITY_BUCKETS,
+        )
         .unwrap()
         .install_recorder()
         .unwrap()

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -30,7 +30,7 @@ pub const TIMESTAMP_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM: &str =
 
 /// Histogram for properties similarity score in timestamp deduplication
 pub const TIMESTAMP_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM: &str =
-    "timestamp_dedup_properties_similarity";
+    "timestamp_dedup_properties_similarity_score";
 
 /// Counter for specific fields that differ in timestamp deduplication
 pub const TIMESTAMP_DEDUP_FIELD_DIFFERENCES_COUNTER: &str =
@@ -53,7 +53,8 @@ pub const UUID_DEDUP_DIFFERENT_FIELDS_HISTOGRAM: &str = "uuid_dedup_different_fi
 pub const UUID_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM: &str = "uuid_dedup_different_properties";
 
 /// Histogram for properties similarity score in UUID deduplication
-pub const UUID_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM: &str = "uuid_dedup_properties_similarity";
+pub const UUID_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM: &str =
+    "uuid_dedup_properties_similarity_score";
 
 /// Counter for specific fields that differ in UUID deduplication
 pub const UUID_DEDUP_FIELD_DIFFERENCES_COUNTER: &str = "uuid_dedup_field_differences_total";


### PR DESCRIPTION
## Problem
Prior to making decisions on deduping vs. SDK bug classifications, we need better aggregate data output from the deduplicator metrics. At the moment, our event similarity scoring operates in range `[0.0, 1.0]` but our default histogram buckets are configured globally, and are too wide to capture the detail we need.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
As requested by @jose-sequeira 

* Implement configurable bucket ranges in our `PrometheusBuilder` bootstrap
* Add a pattern with appropriately-granular buckets for similarity score histograms
* Ensure all similarity score histograms follow the same naming pattern matching the new config

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (will validate in dev deploy)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog updates

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
