### PR TITLE
fix: limit blobby v2 batch upload concurrency in dev

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
@@ -3,6 +3,8 @@ import { Upload } from '@aws-sdk/lib-storage'
 import { randomBytes } from 'crypto'
 import { PassThrough } from 'stream'
 
+import { isDevEnv } from '~/utils/env-utils'
+
 import { logger } from '../../../../utils/logger'
 import { SessionBatchMetrics } from './metrics'
 import {
@@ -44,6 +46,8 @@ class S3SessionBatchFileWriter implements SessionBatchFileWriter {
                 Body: this.stream,
                 ContentType: 'application/octet-stream',
             },
+            // 1 for dev to reduce S3 throttling
+            queueSize: isDevEnv() ? 1 : undefined,
         })
 
         this.stream.on('error', (error) => {


### PR DESCRIPTION
in dev we regularly get stuck unable to upload from blobby v2
killing the plugin server
tearing down the local environment is the only fix

i tried a few changes of timeout and upload setting

it appears that this change resolves things on my machine 🤞