### PR TITLE
fix(messaging): fix grpc size limit for temporal workflow

### DIFF
--- a/posthog/temporal/messaging/__init__.py
+++ b/posthog/temporal/messaging/__init__.py
@@ -1,11 +1,11 @@
 from posthog.temporal.messaging.behavioral_cohorts_workflow import (
     BehavioralCohortsWorkflow,
-    get_unique_conditions_activity,
+    get_unique_conditions_page_activity,
     process_condition_batch_activity,
 )
 
 WORKFLOWS = [BehavioralCohortsWorkflow]
 ACTIVITIES = [
-    get_unique_conditions_activity,
+    get_unique_conditions_page_activity,
     process_condition_batch_activity,
 ]

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -28,6 +28,7 @@ class BehavioralCohortsWorkflowInputs:
     days: int = 30
     limit: Optional[int] = None
     parallelism: int = 10  # Number of parallel workers
+    conditions_batch_size: int = 5000  # Max conditions to return per activity call
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -66,12 +67,36 @@ class CohortMembershipResult:
     batch_number: int
 
 
+@dataclasses.dataclass
+class GetConditionsPageInputs:
+    """Inputs for fetching a page of conditions."""
+
+    team_id: Optional[int] = None
+    cohort_id: Optional[int] = None
+    condition: Optional[str] = None
+    days: int = 30
+    limit: Optional[int] = None
+    offset: int = 0
+    page_size: int = 10000
+
+
+@dataclasses.dataclass
+class ConditionsPageResult:
+    """Result from fetching a page of conditions."""
+
+    conditions: list[dict[str, Any]]
+    has_more: bool
+    total_fetched: int
+
+
 @temporalio.activity.defn
-async def get_unique_conditions_activity(inputs: BehavioralCohortsWorkflowInputs) -> list[dict[str, Any]]:
+async def get_unique_conditions_page_activity(inputs: GetConditionsPageInputs) -> ConditionsPageResult:
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
 
-    logger.info("Fetching unique conditions from ClickHouse")
+    logger.info(
+        f"Fetching unique conditions page from ClickHouse (offset={inputs.offset}, page_size={inputs.page_size})"
+    )
 
     # Basic validation for reasonable bounds
     if not isinstance(inputs.days, int) or inputs.days < 0 or inputs.days > 365:
@@ -94,74 +119,57 @@ async def get_unique_conditions_activity(inputs: BehavioralCohortsWorkflowInputs
 
     where_clause = " AND ".join(where_clauses)
 
-    # Use pagination to get all results in batches of 10,000
-    all_conditions = []
-    page_size = 10000
-    offset = 0
-    total_fetched = 0
-
-    # If user specified a limit, respect it as the maximum total results
-    user_limit = inputs.limit
+    # Calculate effective limit for this page
+    if inputs.limit:
+        remaining = inputs.limit - inputs.offset
+        if remaining <= 0:
+            return ConditionsPageResult(conditions=[], has_more=False, total_fetched=0)
+        current_limit = min(inputs.page_size, remaining)
+    else:
+        current_limit = inputs.page_size
 
     try:
-        while True:
-            # Calculate current batch limit
-            if user_limit:
-                remaining = user_limit - total_fetched
-                if remaining <= 0:
-                    break
-                current_limit = min(page_size, remaining)
-            else:
-                current_limit = page_size
+        query = """
+            SELECT DISTINCT
+                team_id,
+                cohort_id,
+                condition
+            FROM behavioral_cohorts_matches
+            WHERE {where_clause}
+            ORDER BY team_id, cohort_id, condition
+            LIMIT {limit} OFFSET {offset}
+        """.format(where_clause=where_clause, limit=current_limit, offset=inputs.offset)
 
-            query = """
-                SELECT DISTINCT
-                    team_id,
-                    cohort_id,
-                    condition
-                FROM behavioral_cohorts_matches
-                WHERE {where_clause}
-                ORDER BY team_id, cohort_id, condition
-                LIMIT {limit} OFFSET {offset}
-            """.format(where_clause=where_clause, limit=current_limit, offset=offset)
+        with tags_context(
+            team_id=inputs.team_id,
+            feature=Feature.BEHAVIORAL_COHORTS,
+            cohort_id=inputs.cohort_id,
+            product=Product.MESSAGING,
+            query_type="get_unique_conditions_page",
+        ):
+            results = sync_execute(query, params, ch_user=ClickHouseUser.COHORTS, workload=Workload.OFFLINE)
 
-            with tags_context(
-                team_id=inputs.team_id,
-                feature=Feature.BEHAVIORAL_COHORTS,
-                cohort_id=inputs.cohort_id,
-                product=Product.MESSAGING,
-                query_type="get_unique_conditions",
-            ):
-                results = sync_execute(query, params, ch_user=ClickHouseUser.COHORTS, workload=Workload.OFFLINE)
+        conditions = [
+            {
+                "team_id": row[0],
+                "cohort_id": row[1],
+                "condition": row[2],
+            }
+            for row in results
+        ]
 
-            # If no results returned, we've reached the end
-            if not results:
-                break
+        # Check if there are more results
+        has_more = len(results) == current_limit
+        total_fetched = inputs.offset + len(conditions)
 
-            batch_conditions = [
-                {
-                    "team_id": row[0],
-                    "cohort_id": row[1],
-                    "condition": row[2],
-                }
-                for row in results
-            ]
+        logger.info(
+            f"Fetched page with {len(conditions)} conditions (offset={inputs.offset}, total={total_fetched}, has_more={has_more})"
+        )
 
-            all_conditions.extend(batch_conditions)
-            total_fetched += len(batch_conditions)
-            offset += current_limit
-
-            logger.info(f"Fetched batch of {len(batch_conditions)} conditions (total: {total_fetched})")
-
-            # If we got fewer results than requested, we've reached the end
-            if len(results) < current_limit:
-                break
-
-        logger.info(f"Found {len(all_conditions)} unique conditions across all pages")
-        return all_conditions
+        return ConditionsPageResult(conditions=conditions, has_more=has_more, total_fetched=total_fetched)
 
     except Exception as e:
-        logger.exception("Error fetching unique conditions", error=str(e))
+        logger.exception("Error fetching unique conditions page", error=str(e))
         raise
 
 
@@ -296,13 +304,40 @@ class BehavioralCohortsWorkflow(PostHogWorkflow):
         workflow_logger = temporalio.workflow.logger
         workflow_logger.info(f"Starting behavioral cohorts workflow with parallelism={inputs.parallelism}")
 
-        # Step 1: Get all unique conditions
-        conditions = await temporalio.workflow.execute_activity(
-            get_unique_conditions_activity,
-            inputs,
-            start_to_close_timeout=dt.timedelta(minutes=5),
-            retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
-        )
+        # Step 1: Get all unique conditions in pages to avoid message size limits
+        all_conditions = []
+        offset = 0
+        page_size = inputs.conditions_batch_size
+
+        while True:
+            page_inputs = GetConditionsPageInputs(
+                team_id=inputs.team_id,
+                cohort_id=inputs.cohort_id,
+                condition=inputs.condition,
+                days=inputs.days,
+                limit=inputs.limit,
+                offset=offset,
+                page_size=page_size,
+            )
+
+            page_result = await temporalio.workflow.execute_activity(
+                get_unique_conditions_page_activity,
+                page_inputs,
+                start_to_close_timeout=dt.timedelta(minutes=5),
+                retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
+            )
+
+            all_conditions.extend(page_result.conditions)
+            workflow_logger.info(
+                f"Fetched page with {len(page_result.conditions)} conditions (total: {len(all_conditions)})"
+            )
+
+            if not page_result.has_more:
+                break
+
+            offset += len(page_result.conditions)
+
+        conditions = all_conditions
 
         if not conditions:
             workflow_logger.warning("No conditions found matching the criteria")


### PR DESCRIPTION
## Problem

 The workflow was failing with a Temporal message size limit error when processing large numbers of conditions:

`  grpc: received message larger than max (5392122 vs. 4194304)`

  Root cause: The get_unique_conditions_activity was fetching and returning all unique conditions (34,959 in as a
  _**single activity result**_. While the activity internally paginated database queries, it accumulated all results and returned them in _**one response**_ that exceeded Temporal's 4MB message size limit.

## Changes

Split the activity to return paginated results. nstead of one activity call returning all conditions, the
  workflow now:
  1. Makes multiple activity calls, each returning up to 10,000
  conditions
  2. Accumulates the conditions in the workflow layer
  3. Processes them in parallel as before

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
