### PR TITLE
fix(ux): max scene height

### DIFF
--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -165,7 +165,7 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel }: MaxIns
                     // pb-7 below is intentionally specific - it's chosen so that the bottom-most chat's title
                     // is at the same viewport height as the QuestionInput text that appear after going into a thread.
                     // This makes the transition from one view into another just that bit smoother visually.
-                    <div className="@container/max-welcome relative flex flex-col gap-4 px-4 pb-7 grow">
+                    <div className="@container/max-welcome relative flex flex-col gap-4 px-4 pb-7 grow min-h-[calc(100vh-var(--scene-layout-header-height))]">
                         <div className="flex-1 items-center justify-center flex flex-col gap-3">
                             <Intro />
                             <SidebarQuestionInputWithSuggestions />


### PR DESCRIPTION
## Problem
Recent Navigation/SceneLayout dom structure changes broke Max's scene from being full height

## Changes
Add screen min-height (minus header height) to max scene

## How did you test this code?
![2025-09-22 12 22 26](https://github.com/user-attachments/assets/84fc7b72-437f-4da6-abfe-bdef6f744bc3)
