### PR TITLE
fix(sql-editor): various scene/tab bugs

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -94,7 +94,7 @@ export function PanelLayoutPanel({
         panelWidth: computedPanelWidth,
         panelWillHide,
     } = useValues(panelLayoutLogic)
-    const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
+    const { closePanel } = useActions(panelLayoutLogic)
     const containerRef = useRef<HTMLDivElement | null>(null)
     const { mobileLayout: isMobileLayout } = useValues(navigation3000Logic)
     const { projectTreeMode } = useValues(projectTreeLogic({ key: PROJECT_TREE_KEY }))
@@ -164,8 +164,7 @@ export function PanelLayoutPanel({
 
                                 <ButtonPrimitive
                                     onClick={() => {
-                                        showLayoutPanel(false)
-                                        clearActivePanelIdentifier()
+                                        closePanel()
                                     }}
                                     tooltip="Close panel"
                                     iconOnly

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -819,7 +819,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
     listeners(({ actions, values, key }) => ({
         setActivePanelIdentifier: () => {
             // clear search term when changing panel
-            actions.clearSearch()
+            if (values.searchTerm !== '') {
+                actions.clearSearch()
+            }
             if (values.projectTreeMode !== 'tree') {
                 actions.setProjectTreeMode('tree')
             }

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -26,6 +26,7 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
         values: [navigation3000Logic, ['mobileLayout']],
     })),
     actions({
+        closePanel: true,
         showLayoutNavBar: (visible: boolean) => ({ visible }),
         showLayoutPanel: (visible: boolean) => ({ visible }),
         toggleLayoutPanelPinned: (pinned: boolean) => ({ pinned }),
@@ -148,6 +149,10 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
         ],
     }),
     listeners(({ actions, values, cache }) => ({
+        closePanel: () => {
+            actions.showLayoutPanel(false)
+            actions.clearActivePanelIdentifier()
+        },
         setPanelIsResizing: ({ isResizing }) => {
             // If we're not resizing and the panel is at or below the minimum width, hide it
             if (!isResizing && values.panelWidth <= PANEL_LAYOUT_MIN_WIDTH - 1) {

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -108,7 +108,7 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
     const variablesLogicProps: VariablesLogicProps = {
         key: dataVisualizationLogicProps.key,
         readOnly: false,
-        queryInput,
+        queryInput: queryInput ?? '',
         sourceQuery,
         setQuery: setSourceQuery,
         onUpdate: (query) => {

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -23,7 +23,6 @@ import { QueryHistoryModal } from './QueryHistoryModal'
 import { QueryPane } from './QueryPane'
 import { FixErrorButton } from './components/FixErrorButton'
 import { draftsLogic } from './draftsLogic'
-import { editorSizingLogic } from './editorSizingLogic'
 import { multitabEditorLogic } from './multitabEditorLogic'
 
 interface QueryWindowProps {
@@ -58,8 +57,6 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
     const { saveOrUpdateDraft } = useActions(draftsLogic)
     const { response } = useValues(dataNodeLogic)
     const { updatingDataWarehouseSavedQuery } = useValues(dataWarehouseViewsLogic)
-    const { sidebarWidth } = useValues(editorSizingLogic)
-    const { resetDefaultSidebarWidth } = useActions(editorSizingLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const [editingViewDisabledReason, EditingViewButtonIcon] = useMemo(() => {
         if (updatingDataWarehouseSavedQuery) {
@@ -78,34 +75,6 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
     }, [updatingDataWarehouseSavedQuery, changesToSave, response])
 
     const isMaterializedView = editingView?.is_materialized === true
-
-    const renderSidebarButton = (): JSX.Element => {
-        if (activePanelIdentifier !== 'Database') {
-            return (
-                <LemonButton
-                    onClick={() => setActivePanelIdentifier('Database')}
-                    className="rounded-none"
-                    icon={<IconSidebarClose />}
-                    type="tertiary"
-                    size="xsmall"
-                />
-            )
-        }
-
-        if (sidebarWidth === 0) {
-            return (
-                <LemonButton
-                    onClick={() => resetDefaultSidebarWidth()}
-                    className="rounded-none"
-                    icon={<IconSidebarClose />}
-                    type="tertiary"
-                    size="xsmall"
-                />
-            )
-        }
-
-        return <></>
-    }
 
     return (
         <div className="flex flex-1 flex-col h-full overflow-hidden">
@@ -128,7 +97,17 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                 </div>
             )}
             <div className="flex flex-row justify-start align-center w-full pl-2 pr-2 bg-white dark:bg-black border-b">
-                {renderSidebarButton()}
+                {activePanelIdentifier !== 'Database' ? (
+                    <LemonButton
+                        onClick={() => setActivePanelIdentifier('Database')}
+                        className="rounded-none"
+                        icon={<IconSidebarClose />}
+                        type="tertiary"
+                        size="xsmall"
+                    >
+                        Show database
+                    </LemonButton>
+                ) : null}
                 <RunButton />
                 <LemonDivider vertical />
                 {isDraft && featureFlags[FEATURE_FLAGS.EDITOR_DRAFTS] && (
@@ -142,7 +121,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                                     saveOrUpdateDraft(
                                         {
                                             kind: NodeKind.HogQLQuery,
-                                            query: queryInput,
+                                            query: queryInput ?? '',
                                         },
                                         editingView.id,
                                         currentDraft?.id || undefined,
@@ -152,7 +131,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                                     saveOrUpdateDraft(
                                         {
                                             kind: NodeKind.HogQLQuery,
-                                            query: queryInput,
+                                            query: queryInput ?? '',
                                         },
                                         undefined,
                                         currentDraft?.id || undefined,
@@ -175,7 +154,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                                             id: editingView.id,
                                             query: {
                                                 ...sourceQuery.source,
-                                                query: queryInput,
+                                                query: queryInput ?? '',
                                             },
                                             name: editingView.name,
                                             types: response && 'types' in response ? (response?.types ?? []) : [],
@@ -207,7 +186,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                                 size="xsmall"
                                 id="sql-editor-query-window-save-draft"
                                 onClick={() => {
-                                    saveDraft(activeTab, queryInput, editingView.id)
+                                    saveDraft(activeTab, queryInput ?? '', editingView.id)
                                 }}
                             >
                                 Save draft
@@ -219,7 +198,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                                     id: editingView.id,
                                     query: {
                                         ...sourceQuery.source,
-                                        query: queryInput,
+                                        query: queryInput ?? '',
                                     },
                                     types: response && 'types' in response ? (response?.types ?? []) : [],
                                     shouldRematerialize: isMaterializedView,
@@ -266,8 +245,8 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                 <FixErrorButton type="tertiary" size="xsmall" source="action-bar" />
             </div>
             <QueryPane
-                originalValue={originalQueryInput}
-                queryInput={suggestedQueryInput || queryInput}
+                originalValue={originalQueryInput ?? ''}
+                queryInput={(suggestedQueryInput || queryInput) ?? ''}
                 sourceQuery={sourceQuery.source}
                 promptError={null}
                 onRun={runQuery}
@@ -316,7 +295,7 @@ function RunButton(): JSX.Element {
             return ['var(--primary)', 'No changes to run']
         }
 
-        if (!metadata || isUsingIndices || queryInput.trim().length === 0) {
+        if (!metadata || isUsingIndices || queryInput?.trim().length === 0) {
             return ['var(--success)', 'New changes to run']
         }
 

--- a/frontend/src/scenes/data-warehouse/editor/components/FixErrorButton.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/components/FixErrorButton.tsx
@@ -70,7 +70,7 @@ export function FixErrorButton({ type, size, contentOverride, source }: FixError
             disabledReason={disabledReason}
             icon={icon}
             onClick={() => {
-                fixHogQLErrors(queryInput, queryError)
+                fixHogQLErrors(queryInput ?? '', queryError)
                 posthog.capture(`sql-editor-fix-error-click`, { source })
             }}
         >

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -126,7 +126,7 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
         panelExplicitlyClosed: [
             false,
             {
-                [panelLayoutLogic.actions.closePanel]: () => true,
+                [panelLayoutLogic.actionTypes.closePanel]: () => true,
             },
         ],
     })),

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -116,14 +116,20 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
         reportAIQueryPromptOpen: true,
         setWasPanelActive: (wasPanelActive: boolean) => ({ wasPanelActive }),
     }),
-    reducers({
+    reducers(() => ({
         wasPanelActive: [
             false,
             {
                 setWasPanelActive: (_, { wasPanelActive }) => wasPanelActive,
             },
         ],
-    }),
+        panelExplicitlyClosed: [
+            false,
+            {
+                [panelLayoutLogic.actions.closePanel]: () => true,
+            },
+        ],
+    })),
     listeners(() => ({
         reportAIQueryPrompted: () => {
             posthog.capture('ai_query_prompted')
@@ -514,11 +520,13 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             },
         ],
     })),
-    urlToAction(() => ({
+    urlToAction(({ values }) => ({
         [urls.sqlEditor()]: () => {
-            panelLayoutLogic.actions.showLayoutPanel(true)
-            panelLayoutLogic.actions.setActivePanelIdentifier('Database')
-            panelLayoutLogic.actions.toggleLayoutPanelPinned(true)
+            if (!values.panelExplicitlyClosed) {
+                panelLayoutLogic.actions.showLayoutPanel(true)
+                panelLayoutLogic.actions.setActivePanelIdentifier('Database')
+                panelLayoutLogic.actions.toggleLayoutPanelPinned(true)
+            }
         },
         '*': () => {
             if (router.values.location.pathname !== urls.sqlEditor()) {

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1044,7 +1044,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                 if (searchParams.open_draft || (hashParams.draft && values.queryInput === null)) {
                     const draftId = searchParams.open_draft || hashParams.draft
                     const draft = values.drafts.find((draft) => {
-                        return (draft.id = draftId)
+                        return draft.id === draftId
                     })
 
                     if (!draft) {

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -201,7 +201,6 @@ export const sceneLogic = kea<sceneLogicType>([
             tabId,
             params,
         }),
-        setLoadedSceneLogic: (logic: BuiltLogic) => ({ logic }),
         reloadBrowserDueToImportError: true,
 
         newTab: (href?: string | null) => ({ href }),
@@ -353,14 +352,6 @@ export const sceneLogic = kea<sceneLogicType>([
                     ...state,
                     [sceneId]: { ...exportedScene, lastTouch: new Date().valueOf() },
                 }),
-            },
-        ],
-        loadedSceneLogics: [
-            {} as Record<string, BuiltLogic>,
-            {
-                setLoadedSceneLogic: (state, { logic }) => {
-                    return { ...state, [logic.pathString]: logic }
-                },
             },
         ],
         loadingScene: [
@@ -683,7 +674,6 @@ export const sceneLogic = kea<sceneLogicType>([
                 const builtLogicProps = { tabId, ...exportedScene?.paramsToProps?.(params) }
                 const builtLogic = exportedScene?.logic(builtLogicProps)
                 cache.mountedTabLogic[tabId] = builtLogic.mount()
-                actions.setLoadedSceneLogic(builtLogic) // persist the logic for TURBO MODE
             }
         },
         openScene: ({ tabId, sceneId, sceneKey, params, method }) => {


### PR DESCRIPTION
## Changes

Fix some data warehouse scene/tab bugs [reported here](https://posthog.slack.com/archives/C08499A7REU/p1758534318876599):

- After closing the database panel and editing the query, the panel would reopen
- Anything purely numeric (e.g. "1") as the query would cause the page to crash on reload
- Fix backpace-related errors (going to "" in a view would reset the query, etc)
- Add a "Show database" label to the button that opens the panel if closed
- Removed something unused in sceneLogic

## How did you test this code?

Opened various views, insights and queries by clicking and by reloading the page with it open.

I'd still like to revisit the database panel opening/closing logic. This PR doesn't change anything there, just fixes a bug.