### PR TITLE
fix(myke): Fix gRPC size limit in behavioral cohorts workflow

### DIFF
--- a/posthog/management/commands/analyze_behavioral_cohorts.py
+++ b/posthog/management/commands/analyze_behavioral_cohorts.py
@@ -13,7 +13,7 @@ from posthog.clickhouse.client.execute import sync_execute
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.constants import MESSAGING_TASK_QUEUE
 from posthog.temporal.common.client import async_connect
-from posthog.temporal.messaging.behavioral_cohorts_workflow import BehavioralCohortsWorkflowInputs
+from posthog.temporal.messaging.behavioral_cohorts_workflow_coordinator import CoordinatorWorkflowInputs
 
 logger = structlog.get_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -59,13 +59,13 @@ class Command(BaseCommand):
             "--parallelism",
             type=int,
             default=10,
-            help="Number of parallel workers for processing (default: 10)",
+            help="Number of parallel child workflows to spawn (default: 10)",
         )
         parser.add_argument(
             "--conditions-page-size",
             type=int,
             default=1000,
-            help="Number of conditions to fetch per activity call (default: 1000, max recommended: 10000)",
+            help="Number of conditions to fetch per page when loading data (default: 1000)",
         )
         parser.add_argument(
             "--use-temporal",
@@ -89,7 +89,6 @@ class Command(BaseCommand):
         limit = options.get("limit")
         parallelism = options.get("parallelism", 10)
         conditions_page_size = options.get("conditions_page_size", 1000)
-        use_coordinator = options.get("use_coordinator", False)
         conditions_per_workflow = options.get("conditions_per_workflow", 5000)
         use_temporal = options.get("use_temporal", True)
 
@@ -111,7 +110,6 @@ class Command(BaseCommand):
                 limit=limit,
                 parallelism=parallelism,
                 conditions_page_size=conditions_page_size,
-                use_coordinator=use_coordinator,
                 conditions_per_workflow=conditions_per_workflow,
             )
 
@@ -131,7 +129,7 @@ class Command(BaseCommand):
                     f"Workflow completed: {result['total_memberships']} memberships from {result['conditions_processed']} conditions"
                 )
                 self.stdout.write(
-                    f"Processed in {result['batches_processed']} parallel batches (parallelism={parallelism})"
+                    f"Processed across {result.get('child_workflows', result.get('batches_processed', 0))} parallel child workflows"
                 )
                 self.stdout.write(f"Total time: {total_time_seconds} seconds")
 
@@ -187,6 +185,7 @@ class Command(BaseCommand):
         limit: int | None,
         parallelism: int,
         conditions_page_size: int,
+        conditions_per_workflow: int,
     ) -> dict[str, Any] | None:
         """Run the Temporal workflow for parallel processing."""
 
@@ -194,8 +193,8 @@ class Command(BaseCommand):
             # Connect to Temporal
             client = await async_connect()
 
-            # Create workflow inputs
-            inputs = BehavioralCohortsWorkflowInputs(
+            # Always use coordinator workflow for true parallelism and to avoid GRPC limits
+            inputs = CoordinatorWorkflowInputs(
                 team_id=team_id,
                 cohort_id=cohort_id,
                 condition=condition,
@@ -203,18 +202,18 @@ class Command(BaseCommand):
                 days=days,
                 limit=limit,
                 parallelism=parallelism,
-                conditions_page_size=conditions_page_size,
+                conditions_per_workflow=conditions_per_workflow,
             )
 
             # Generate unique workflow ID
-            workflow_id = f"behavioral-cohorts-{team_id or 'all'}-{cohort_id or 'all'}-{int(time.time())}"
+            workflow_id = f"behavioral-cohorts-coordinator-{team_id or 'all'}-{cohort_id or 'all'}-{int(time.time())}"
 
-            logger.info(f"Starting Temporal workflow: {workflow_id}")
+            logger.info(f"Starting Temporal coordinator workflow: {workflow_id}")
 
             try:
-                # Execute the workflow
+                # Execute the coordinator workflow
                 result = await client.execute_workflow(
-                    "behavioral-cohorts-analysis",
+                    "behavioral-cohorts-coordinator",
                     inputs,
                     id=workflow_id,
                     id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,

--- a/posthog/management/commands/analyze_behavioral_cohorts.py
+++ b/posthog/management/commands/analyze_behavioral_cohorts.py
@@ -89,6 +89,8 @@ class Command(BaseCommand):
         limit = options.get("limit")
         parallelism = options.get("parallelism", 10)
         conditions_page_size = options.get("conditions_page_size", 1000)
+        use_coordinator = options.get("use_coordinator", False)
+        conditions_per_workflow = options.get("conditions_per_workflow", 5000)
         use_temporal = options.get("use_temporal", True)
 
         logger.info(
@@ -109,6 +111,8 @@ class Command(BaseCommand):
                 limit=limit,
                 parallelism=parallelism,
                 conditions_page_size=conditions_page_size,
+                use_coordinator=use_coordinator,
+                conditions_per_workflow=conditions_per_workflow,
             )
 
             if result:

--- a/posthog/temporal/messaging/__init__.py
+++ b/posthog/temporal/messaging/__init__.py
@@ -3,9 +3,17 @@ from posthog.temporal.messaging.behavioral_cohorts_workflow import (
     get_unique_conditions_page_activity,
     process_condition_batch_activity,
 )
+from posthog.temporal.messaging.behavioral_cohorts_workflow_coordinator import (
+    BehavioralCohortsCoordinatorWorkflow,
+    get_conditions_count_activity,
+)
 
-WORKFLOWS = [BehavioralCohortsWorkflow]
+WORKFLOWS = [
+    BehavioralCohortsWorkflow,
+    BehavioralCohortsCoordinatorWorkflow,
+]
 ACTIVITIES = [
     get_unique_conditions_page_activity,
     process_condition_batch_activity,
+    get_conditions_count_activity,
 ]

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -310,7 +310,7 @@ class BehavioralCohortsWorkflow(PostHogWorkflow):
         page_size = inputs.conditions_page_size
 
         # Step 1: Fetch all conditions for this workflow's range
-        all_conditions = []
+        all_conditions: list[dict[str, Any]] = []
         conditions_limit = inputs.limit  # This workflow's assigned range
 
         workflow_logger.info(f"Fetching conditions starting at offset={offset}, limit={conditions_limit}")
@@ -358,7 +358,7 @@ class BehavioralCohortsWorkflow(PostHogWorkflow):
                 "batches_processed": 0,
             }
 
-        workflow_logger.info(f"Processing {len(all_conditions)} conditions with parallelism={inputs.parallelism}")
+        workflow_logger.info(f"Processing {len(all_conditions)} conditions sequentially")
 
         # Step 2: Process all conditions in a single activity (no internal parallelism needed)
         workflow_logger.info(f"Processing {len(all_conditions)} conditions sequentially")

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
@@ -144,7 +144,12 @@ class BehavioralCohortsCoordinatorWorkflow(PostHogWorkflow):
 
         workflow_logger.info(f"Coordinating {total_conditions} conditions across {inputs.parallelism} child workflows")
 
-        # Step 2: Calculate ranges for each child workflow
+        # Step 2: Calculate ranges for each child workflow (potential perf improvement later)
+        #  Each child workflow processes a fixed range regardless of actual data
+        #  distribution. If conditions are sparse in certain ranges, some child
+        # workflows may finish quickly while others take much longer, leading to
+        # inefficient resource utilization.
+
         conditions_per_workflow = math.ceil(total_conditions / inputs.parallelism)
         conditions_per_workflow = min(conditions_per_workflow, inputs.conditions_per_workflow)
 

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
@@ -169,7 +169,6 @@ class BehavioralCohortsCoordinatorWorkflow(PostHogWorkflow):
                 days=inputs.days,
                 limit=limit,
                 offset=offset,
-                parallelism=2,  # Internal parallelism within each child
                 conditions_page_size=min(1000, limit),  # Don't fetch more than we need
             )
 

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
@@ -1,0 +1,208 @@
+import math
+import asyncio
+import datetime as dt
+import dataclasses
+from typing import Any, Optional
+
+import temporalio.activity
+import temporalio.workflow
+from structlog.contextvars import bind_contextvars
+
+from posthog.clickhouse.client.connection import ClickHouseUser, Workload
+from posthog.clickhouse.client.execute import sync_execute
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.constants import MESSAGING_TASK_QUEUE
+from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclasses.dataclass
+class CoordinatorWorkflowInputs:
+    """Inputs for the coordinator workflow that spawns child workflows."""
+
+    team_id: Optional[int] = None
+    cohort_id: Optional[int] = None
+    condition: Optional[str] = None
+    min_matches: int = 3
+    days: int = 30
+    limit: Optional[int] = None
+    parallelism: int = 10  # Number of child workflows to spawn
+    conditions_per_workflow: int = 5000  # Max conditions per child workflow
+
+    @property
+    def properties_to_log(self) -> dict[str, Any]:
+        return {
+            "team_id": self.team_id,
+            "cohort_id": self.cohort_id,
+            "min_matches": self.min_matches,
+            "days": self.days,
+            "parallelism": self.parallelism,
+            "conditions_per_workflow": self.conditions_per_workflow,
+        }
+
+
+@dataclasses.dataclass
+class ConditionsCountResult:
+    """Result from counting total conditions."""
+
+    count: int
+
+
+@temporalio.activity.defn
+async def get_conditions_count_activity(inputs: CoordinatorWorkflowInputs) -> ConditionsCountResult:
+    """Get the total count of unique conditions."""
+    bind_contextvars(team_id=inputs.team_id)
+    logger = LOGGER.bind()
+
+    logger.info("Counting total unique conditions")
+
+    where_clauses = ["date >= now() - toIntervalDay(%(days)s)"]
+    params: dict[str, Any] = {"days": inputs.days}
+
+    if inputs.team_id:
+        where_clauses.append("team_id = %(team_id)s")
+        params["team_id"] = inputs.team_id
+    if inputs.cohort_id:
+        where_clauses.append("cohort_id = %(cohort_id)s")
+        params["cohort_id"] = inputs.cohort_id
+    if inputs.condition:
+        where_clauses.append("condition = %(condition)s")
+        params["condition"] = inputs.condition
+
+    where_clause = " AND ".join(where_clauses)
+
+    # Count query - much lighter than fetching all conditions
+    query = f"""
+        SELECT COUNT(DISTINCT (team_id, cohort_id, condition)) as count
+        FROM behavioral_cohorts_matches
+        WHERE {where_clause}
+    """
+
+    if inputs.limit:
+        # Apply limit to the subquery
+        query = f"""
+            SELECT COUNT(*) as count FROM (
+                SELECT DISTINCT team_id, cohort_id, condition
+                FROM behavioral_cohorts_matches
+                WHERE {where_clause}
+                LIMIT {inputs.limit}
+            )
+        """
+
+    try:
+        with tags_context(
+            team_id=inputs.team_id,
+            feature=Feature.BEHAVIORAL_COHORTS,
+            cohort_id=inputs.cohort_id,
+            product=Product.MESSAGING,
+            query_type="count_unique_conditions",
+        ):
+            results = sync_execute(query, params, ch_user=ClickHouseUser.COHORTS, workload=Workload.OFFLINE)
+
+        count = results[0][0] if results else 0
+        logger.info(f"Found {count} total unique conditions")
+        return ConditionsCountResult(count=count)
+
+    except Exception as e:
+        logger.exception("Error counting unique conditions", error=str(e))
+        raise
+
+
+@temporalio.workflow.defn(name="behavioral-cohorts-coordinator")
+class BehavioralCohortsCoordinatorWorkflow(PostHogWorkflow):
+    """Coordinator workflow that spawns multiple child workflows for true parallelism."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> CoordinatorWorkflowInputs:
+        """Parse inputs from the management command CLI."""
+        return CoordinatorWorkflowInputs()
+
+    @temporalio.workflow.run
+    async def run(self, inputs: CoordinatorWorkflowInputs) -> dict[str, Any]:
+        """Run the coordinator workflow that spawns child workflows."""
+        workflow_logger = temporalio.workflow.logger
+        workflow_logger.info(f"Starting coordinator with parallelism={inputs.parallelism}")
+
+        # Step 1: Get total count of conditions
+        count_result = await temporalio.workflow.execute_activity(
+            get_conditions_count_activity,
+            inputs,
+            start_to_close_timeout=dt.timedelta(minutes=1),
+            retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
+        )
+
+        total_conditions = count_result.count
+        if total_conditions == 0:
+            workflow_logger.warning("No conditions found")
+            return {
+                "total_memberships": 0,
+                "conditions_processed": 0,
+                "child_workflows": 0,
+            }
+
+        workflow_logger.info(f"Coordinating {total_conditions} conditions across {inputs.parallelism} child workflows")
+
+        # Step 2: Calculate ranges for each child workflow
+        conditions_per_workflow = math.ceil(total_conditions / inputs.parallelism)
+        conditions_per_workflow = min(conditions_per_workflow, inputs.conditions_per_workflow)
+
+        # Step 3: Import the child workflow inputs
+        from posthog.temporal.messaging.behavioral_cohorts_workflow import BehavioralCohortsWorkflowInputs
+
+        # Step 4: Launch child workflows in parallel
+        child_handles = []
+        for i in range(inputs.parallelism):
+            offset = i * conditions_per_workflow
+            limit = min(conditions_per_workflow, total_conditions - offset)
+
+            if limit <= 0:
+                break
+
+            child_id = f"{temporalio.workflow.info().workflow_id}-child-{i}"
+            child_inputs = BehavioralCohortsWorkflowInputs(
+                team_id=inputs.team_id,
+                cohort_id=inputs.cohort_id,
+                condition=inputs.condition,
+                min_matches=inputs.min_matches,
+                days=inputs.days,
+                limit=limit,
+                offset=offset,
+                parallelism=2,  # Internal parallelism within each child
+                conditions_page_size=min(1000, limit),  # Don't fetch more than we need
+            )
+
+            # Start child workflow (non-blocking)
+            handle = await temporalio.workflow.start_child_workflow(
+                "behavioral-cohorts-analysis",
+                child_inputs,
+                id=child_id,
+                task_queue=MESSAGING_TASK_QUEUE,
+            )
+            child_handles.append(handle)
+
+            workflow_logger.info(f"Started child workflow {i+1} for conditions {offset}-{offset+limit-1}")
+
+        # Step 5: Wait for all children and aggregate results
+        child_results = await asyncio.gather(*[handle.result() for handle in child_handles])
+
+        total_memberships = 0
+        total_conditions_processed = 0
+
+        for i, result in enumerate(child_results):
+            total_memberships += result["total_memberships"]
+            total_conditions_processed += result["conditions_processed"]
+            workflow_logger.info(
+                f"Child {i} contributed {result['total_memberships']} memberships from {result['conditions_processed']} conditions"
+            )
+
+        workflow_logger.info(
+            f"Coordinator completed: {total_memberships} memberships from {total_conditions_processed} conditions"
+        )
+
+        return {
+            "total_memberships": total_memberships,
+            "conditions_processed": total_conditions_processed,
+            "child_workflows": len(child_handles),
+        }


### PR DESCRIPTION
## Problem

The workflow was failing with GRPC Message too large error when processing 34,959+ conditions, exceeding Temporal's 4MB state persistence limit.

## Changes

```
   Initial Solution (Single Workflow + Activity Fan-out)

                      Single Workflow
                 (34,959 conditions in memory)
                           |
            Accumulates ALL conditions in workflow state
                      (5.4MB - TOO BIG!)
                           |
                ❌ GRPC Message too large error
                           |
                Split into parallel activity tasks
                           |
          ┌────────────────┼────────────────┐
          ▼                ▼                ▼
     Activity 1       Activity 2       Activity 10
     (3,495          (3,495           (3,495
     conditions)     conditions)      conditions)
          │               │                │
     Process &       Process &        Process &
     return          return           return
     125K            132K             98K
     memberships     memberships      memberships
          │               │                │
          └───────────────┼────────────────┘
                          ▼
                Single workflow aggregates
                  ❌ all cohort memberships result set = >4MB
                     GRPC error again!

  Problems:
  - Workflow state held all 34,959 conditions (5.4MB)
  - Activities returned full membership data (20MB+)
  - Multiple GRPC bottlenecks
 ```
```
  New Solution (Multi-Workflow Coordinator - Simplified)

                     Coordinator Workflow
                (Lightweight: only orchestrates)
                           |
              Gets count: 34,959 (just a number)
                           |
             Spawns 10 independent child workflows
                           |
          ┌────────────────┼────────────────┐
          ▼                ▼                ▼
     Child Workflow 1  Child Workflow 2  Child Workflow 10
     (Pod A - 1 CPU)   (Pod B - 1 CPU)   (Pod J - 1 CPU)
          │                │                │
     Loads 3,495       Loads 3,495       Loads 3,495
     conditions        conditions        conditions
     (<1MB state)      (<1MB state)      (<1MB state)
          │                │                │
     Single activity   Single activity   Single activity
     processes ALL     processes ALL     processes ALL
     conditions        conditions        conditions
     SEQUENTIALLY      SEQUENTIALLY      SEQUENTIALLY
          │                │                │
     Returns COUNT     Returns COUNT     Returns COUNT
     (125K - just #)   (132K - just #)   (98K - just #)
          │                │                │
          └─────────────────┼─────────────────┘
                            ▼
                 Coordinator sums counts
                    (tiny messages)
                            ▼
                ✅ Final: 1.2M memberships

  Key Improvements:
  1. No internal fan-out: Each child runs one activity sequentially
  (perfect for 1-core pods)
  2. Distributed state: Each child holds only ~3,500 conditions instead
  of all 34,959
```

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
