### PR TITLE
feat(ma): leaving only ads_read scope

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -350,7 +350,7 @@ class OauthIntegration:
                 token_info_config_fields=["id", "name", "email"],
                 client_id=settings.META_ADS_APP_CLIENT_ID,
                 client_secret=settings.META_ADS_APP_CLIENT_SECRET,
-                scope="ads_read ads_management business_management read_insights",
+                scope="ads_read",
                 id_path="id",
                 name_path="name",
             )


### PR DESCRIPTION
## Problem

We don't need all the scopes and for each scope we need to send a request.

## Changes

Including only ads_read scope.

## How did you test this code?
Manually and got the scope accepted.
<img width="1132" height="166" alt="image" src="https://github.com/user-attachments/assets/18509884-c0c6-41ba-9f95-c58bfc4c4d68" />


Can be tested here https://developers.facebook.com/tools/explorer/?method=GET&path=act_{accountID}%2Finsights&version=v23.0
