### PR TITLE
feat: allow insight queries on NamedQuery

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -16583,7 +16583,14 @@
                     "type": "string"
                 },
                 "query": {
-                    "$ref": "#/definitions/HogQLQuery"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/HogQLQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/InsightQueryNode"
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -16597,6 +16604,9 @@
                 },
                 "filters_override": {
                     "$ref": "#/definitions/DashboardFilter"
+                },
+                "query_override": {
+                    "type": "object"
                 },
                 "refresh": {
                     "$ref": "#/definitions/RefreshType",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1521,7 +1521,7 @@ export type RefreshType =
 export interface NamedQueryRequest {
     name?: string
     description?: string
-    query?: HogQLQuery
+    query?: HogQLQuery | InsightQueryNode
     is_active?: boolean
 }
 
@@ -1545,6 +1545,7 @@ export interface NamedQueryRunRequest {
     filters_override?: DashboardFilter
     variables_override?: Record<string, Record<string, any>>
     variables_values?: Record<string, any>
+    query_override?: Record<string, any>
 }
 
 export interface QueryRequest {

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -2,7 +2,7 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useState } from 'react'
 
-import { IconInfo, IconPencil, IconShare, IconTrash, IconWarning } from '@posthog/icons'
+import { IconCode2, IconInfo, IconPencil, IconShare, IconTrash, IconWarning } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
@@ -43,6 +43,7 @@ import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { getInsightDefinitionUrl } from 'lib/utils/insightLinks'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
+import { queryEndpointLogic } from 'scenes/data-warehouse/editor/output-pane-tabs/queryEndpointLogic'
 import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
 import { insightCommandLogic } from 'scenes/insights/insightCommandLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -65,7 +66,7 @@ import {
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { tagsModel } from '~/models/tagsModel'
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, QuerySchema } from '~/queries/schema/schema-general'
 import { isDataTableNode, isDataVisualizationNode, isEventsQuery, isHogQLQuery } from '~/queries/utils'
 import {
     AccessControlLevel,
@@ -103,11 +104,12 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     )
 
     // insightDataLogic
-    const { query, queryChanged, showQueryEditor, showDebugPanel, hogQL, exportContext, hogQLVariables } = useValues(
-        insightDataLogic(insightProps)
-    )
+    const { query, queryChanged, showQueryEditor, showDebugPanel, hogQL, exportContext, hogQLVariables, insightQuery } =
+        useValues(insightDataLogic(insightProps))
     const { toggleQueryEditorPanel, toggleDebugPanel } = useActions(insightDataLogic(insightProps))
     const { createStaticCohort } = useActions(exportsLogic)
+
+    const { createQueryEndpoint } = useActions(queryEndpointLogic({ tabId: 'qe-insight' }))
 
     // other logics
     useMountedLogic(insightCommandLogic(insightProps))
@@ -409,6 +411,25 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 ]}
                             />
                         ) : null}
+
+                        <ButtonPrimitive
+                            onClick={() => {
+                                {
+                                    query &&
+                                        createQueryEndpoint({
+                                            name: (defaultInsightName || Math.random().toString(36).substring(2, 15))
+                                                .slice(0, 20)
+                                                .replace(/\s+/g, '-'),
+                                            description: insight.description,
+                                            query: insightQuery as QuerySchema,
+                                        })
+                                }
+                            }}
+                            menuItem
+                        >
+                            <IconCode2 />
+                            Create query endpoint
+                        </ButtonPrimitive>
 
                         {hogQL &&
                             !isHogQLQuery(query) &&

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -66,7 +66,7 @@ import {
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { tagsModel } from '~/models/tagsModel'
-import { NodeKind, QuerySchema } from '~/queries/schema/schema-general'
+import { HogQLQuery, InsightQueryNode, NodeKind } from '~/queries/schema/schema-general'
 import { isDataTableNode, isDataVisualizationNode, isEventsQuery, isHogQLQuery } from '~/queries/utils'
 import {
     AccessControlLevel,
@@ -421,7 +421,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                 .slice(0, 20)
                                                 .replace(/\s+/g, '-'),
                                             description: insight.description,
-                                            query: insightQuery as QuerySchema,
+                                            query: insightQuery as HogQLQuery | InsightQueryNode,
                                         })
                                 }
                             }}

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -31,12 +31,14 @@ import {
 } from 'lib/components/Sharing/templateLinkMessages'
 import { SubscriptionsModal } from 'lib/components/Subscriptions/SubscriptionsModal'
 import { TitleWithIcon } from 'lib/components/TitleWithIcon'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { isEmptyObject, isObject } from 'lib/utils'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
@@ -109,6 +111,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { toggleQueryEditorPanel, toggleDebugPanel } = useActions(insightDataLogic(insightProps))
     const { createStaticCohort } = useActions(exportsLogic)
 
+    const { featureFlags } = useValues(featureFlagLogic)
     const { createQueryEndpoint } = useActions(queryEndpointLogic({ tabId: 'qe-insight' }))
 
     // other logics
@@ -412,24 +415,28 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             />
                         ) : null}
 
-                        <ButtonPrimitive
-                            onClick={() => {
-                                {
-                                    query &&
-                                        createQueryEndpoint({
-                                            name: (defaultInsightName || Math.random().toString(36).substring(2, 15))
-                                                .slice(0, 20)
-                                                .replace(/\s+/g, '-'),
-                                            description: insight.description,
-                                            query: insightQuery as HogQLQuery | InsightQueryNode,
-                                        })
-                                }
-                            }}
-                            menuItem
-                        >
-                            <IconCode2 />
-                            Create query endpoint
-                        </ButtonPrimitive>
+                        {featureFlags[FEATURE_FLAGS.EMBEDDED_ANALYTICS] ? (
+                            <ButtonPrimitive
+                                onClick={() => {
+                                    {
+                                        query &&
+                                            createQueryEndpoint({
+                                                name: (
+                                                    defaultInsightName || Math.random().toString(36).substring(2, 15)
+                                                )
+                                                    .slice(0, 20)
+                                                    .replace(/\s+/g, '-'),
+                                                description: insight.description,
+                                                query: insightQuery as HogQLQuery | InsightQueryNode,
+                                            })
+                                    }
+                                }}
+                                menuItem
+                            >
+                                <IconCode2 />
+                                Create query endpoint
+                            </ButtonPrimitive>
+                        ) : null}
 
                         {hogQL &&
                             !isHogQLQuery(query) &&

--- a/posthog/api/test/test_named_query.py
+++ b/posthog/api/test/test_named_query.py
@@ -391,38 +391,21 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
                     "custom_name": "Page Views",
                     "math": "total",
                     "fixedProperties": [
-                        {
-                            "key": "$current_url",
-                            "operator": "icontains",
-                            "type": "event",
-                            "value": "posthog.com"
-                        }
-                    ]
+                        {"key": "$current_url", "operator": "icontains", "type": "event", "value": "posthog.com"}
+                    ],
                 },
-                {
-                    "kind": "EventsNode", 
-                    "event": "$autocapture",
-                    "custom_name": "Autocapture Events",
-                    "math": "dau"
-                }
+                {"kind": "EventsNode", "event": "$autocapture", "custom_name": "Autocapture Events", "math": "dau"},
             ],
-            "dateRange": {
-                "date_from": "2025-01-01",
-                "date_to": "2025-01-31",
-                "explicitDate": True
-            },
+            "dateRange": {"date_from": "2025-01-01", "date_to": "2025-01-31", "explicitDate": True},
             "interval": "week",
             "breakdownFilter": {
                 "breakdown": "$geoip_country_code",
                 "breakdown_type": "event",
                 "breakdown_limit": 10,
                 "breakdown_hide_other_aggregation": False,
-                "breakdown_normalize_url": True
+                "breakdown_normalize_url": True,
             },
-            "compareFilter": {
-                "compare": True,
-                "compare_to": "-1m"
-            },
+            "compareFilter": {"compare": True, "compare_to": "-1m"},
             "trendsFilter": {
                 "display": "ActionsLineGraph",
                 "showLegend": True,
@@ -445,33 +428,18 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
                 "yAxisScaleType": "linear",
                 "formula": "A + B",
                 "formulas": ["A", "B", "A + B"],
-                "goalLines": [
-                    {
-                        "value": 1000,
-                        "label": "Target"
-                    }
-                ],
+                "goalLines": [{"value": 1000, "label": "Target"}],
                 "hiddenLegendIndexes": [1],
             },
             "properties": [
-                {
-                    "key": "$browser",
-                    "operator": "in",
-                    "type": "event",
-                    "value": ["Chrome", "Firefox", "Safari"]
-                },
-                {
-                    "key": "email",
-                    "operator": "is_set",
-                    "type": "person",
-                    "value": None
-                }
+                {"key": "$browser", "operator": "in", "type": "event", "value": ["Chrome", "Firefox", "Safari"]},
+                {"key": "email", "operator": "is_set", "type": "person", "value": None},
             ],
             "filterTestAccounts": True,
             "samplingFactor": 0.1,
             "aggregation_group_type_index": 1,
             "dataColorTheme": 0.5,
-            "version": 2
+            "version": 2,
         }
 
         data = {
@@ -539,42 +507,15 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
         """Test executing a named query with TrendsQuery override containing key fields."""
         trends_query = {
             "kind": "TrendsQuery",
-            "series": [
-                {
-                    "kind": "EventsNode",
-                    "event": "$pageview",
-                    "math": "total"
-                }
-            ],
-            "dateRange": {
-                "date_from": "2025-01-01",
-                "date_to": "2025-01-20"
-            },
+            "series": [{"kind": "EventsNode", "event": "$pageview", "math": "total"}],
+            "dateRange": {"date_from": "2025-01-01", "date_to": "2025-01-20"},
             "interval": "week",
-            "breakdownFilter": {
-                "breakdown": "$browser",
-                "breakdown_type": "event",
-                "breakdown_limit": 5
-            },
-            "compareFilter": {
-                "compare": True,
-                "compare_to": "-1d"
-            },
-            "trendsFilter": {
-                "display": "ActionsLineGraph",
-                "showLegend": True,
-                "decimalPlaces": 1
-            },
-            "properties": [
-                {
-                    "key": "$current_url",
-                    "operator": "icontains",
-                    "type": "event",
-                    "value": "posthog.com"
-                }
-            ],
+            "breakdownFilter": {"breakdown": "$browser", "breakdown_type": "event", "breakdown_limit": 5},
+            "compareFilter": {"compare": True, "compare_to": "-1d"},
+            "trendsFilter": {"display": "ActionsLineGraph", "showLegend": True, "decimalPlaces": 1},
+            "properties": [{"key": "$current_url", "operator": "icontains", "type": "event", "value": "posthog.com"}],
             "filterTestAccounts": False,
-            "samplingFactor": 0.5
+            "samplingFactor": 0.5,
         }
 
         NamedQuery.objects.create(
@@ -589,28 +530,15 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             "query_override": {
                 "interval": "hour",
                 "series": [
-                    {
-                        "kind": "EventsNode",
-                        "event": "$pageview",
-                        "math": "total"
-                    },
-                    {
-                        "kind": "EventsNode",
-                        "event": "$autocapture",
-                        "math": "dau"
-                    }
+                    {"kind": "EventsNode", "event": "$pageview", "math": "total"},
+                    {"kind": "EventsNode", "event": "$autocapture", "math": "dau"},
                 ],
-                "dateRange": {
-                    "date_from": "2025-01-01",
-                    "date_to": "2025-01-02"
-                }
+                "dateRange": {"date_from": "2025-01-01", "date_to": "2025-01-02"},
             }
         }
 
         response = self.client.post(
-            f"/api/environments/{self.team.id}/named_query/trends_execution_test/run/",
-            override_payload,
-            format="json"
+            f"/api/environments/{self.team.id}/named_query/trends_execution_test/run/", override_payload, format="json"
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
@@ -624,3 +552,26 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             first_series_result = response_data["results"][0]
             self.assertEqual(first_series_result["interval"], "hour")
             self.assertEqual(len(first_series_result["data"]), 25)
+
+    def test_execute_hogql_query_with_override_validation_error(self):
+        """Test that executing a HogQL query with query_override raises a validation error."""
+        hogql_query = {"kind": "HogQLQuery", "query": "SELECT count(1) FROM events"}
+
+        NamedQuery.objects.create(
+            name="hogql_validation_test",
+            team=self.team,
+            query=hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Try to execute with query_override (should fail)
+        override_payload = {"query_override": {"query": "SELECT count(2) FROM events"}}
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/named_query/hogql_validation_test/run/", override_payload, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+        self.assertIn("Query override is not supported for HogQL queries", response_data["detail"])

--- a/posthog/api/test/test_named_query.py
+++ b/posthog/api/test/test_named_query.py
@@ -58,7 +58,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_update_named_query(self):
         """Test updating an existing named query."""
-        # Create initial query
         named_query = NamedQuery.objects.create(
             name="update_test",
             team=self.team,
@@ -67,7 +66,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             created_by=self.user,
         )
 
-        # Update it
         updated_data = {
             "description": "Updated description",
             "is_active": False,
@@ -106,8 +104,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_delete_named_query(self):
         """Test deleting a named query."""
-
-        # Create query to delete
         NamedQuery.objects.create(
             name="delete_test",
             team=self.team,
@@ -121,7 +117,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_execute_named_query(self):
         """Test executing a named query successfully."""
-        # Create a simple query
         NamedQuery.objects.create(
             name="execute_test",
             team=self.team,
@@ -141,7 +136,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_execute_inactive_query(self):
         """Test that inactive queries cannot be executed."""
-        # Create an inactive query
         NamedQuery.objects.create(
             name="inactive_test",
             team=self.team,
@@ -156,7 +150,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_invalid_query_name_validation(self):
         """Test validation of invalid query names."""
-        # Test invalid characters
         data = {
             "name": "invalid@name!",
             "query": self.sample_query,
@@ -168,14 +161,12 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_missing_required_fields(self):
         """Test validation when required fields are missing."""
-        # Missing name
         data: dict[str, Any] = {"query": self.sample_query}
 
         response = self.client.post(f"/api/environments/{self.team.id}/named_query/", data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        # Missing query
         data = {"name": "test_query"}
 
         response = self.client.post(f"/api/environments/{self.team.id}/named_query/", data, format="json")
@@ -184,7 +175,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_duplicate_name_in_team(self):
         """Test that duplicate names within the same team are not allowed."""
-        # Create first query
         NamedQuery.objects.create(
             name="duplicate_test",
             team=self.team,
@@ -192,7 +182,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             created_by=self.user,
         )
 
-        # Try to create another with same name
         data = {
             "name": "duplicate_test",
             "query": {"kind": "HogQLQuery", "query": "SELECT 2"},
@@ -204,11 +193,9 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_team_isolation(self):
         """Test that queries are properly isolated between teams."""
-        # Create another team and user
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         other_user = User.objects.create_and_join(self.organization, "other@test.com", None)
 
-        # Create query in other team
         NamedQuery.objects.create(
             name="other_team_query",
             team=other_team,
@@ -216,14 +203,12 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             created_by=other_user,
         )
 
-        # Try to access it from current team - should return 404
         response = self.client.get(f"/api/environments/{self.team.id}/named_query/other_team_query/run/")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_execute_query_with_invalid_sql(self):
         """Test error handling when executing query with invalid SQL."""
-        # Create query with invalid SQL
         NamedQuery.objects.create(
             name="invalid_sql_test",
             team=self.team,
@@ -239,7 +224,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_execute_query_with_variables(self):
         """Test executing a named query with variables."""
-        # Create an insight variable first
         variable = InsightVariable.objects.create(
             team=self.team,
             name="From Date",
@@ -248,7 +232,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             default_value="2025-01-01",
         )
 
-        # Create a query with variables
         query_with_variables = {
             "kind": "HogQLQuery",
             "query": "select * from events where toDate(timestamp) > {variables.from_date} limit 1",
@@ -265,7 +248,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             is_active=True,
         )
 
-        # Execute with variable values
         request_data = {"variables_values": {"from_date": "2025-09-18"}}
 
         response = self.client.post(
@@ -278,7 +260,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_list_filter_by_is_active(self):
         """Test filtering named queries by is_active status."""
-        # Create active and inactive queries
         NamedQuery.objects.create(
             name="active_query",
             team=self.team,
@@ -294,7 +275,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             is_active=False,
         )
 
-        # Test filtering for active queries
         response = self.client.get(f"/api/environments/{self.team.id}/named_query/?is_active=true")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -302,7 +282,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response_data["results"][0]["name"], "active_query")
         self.assertTrue(response_data["results"][0]["is_active"])
 
-        # Test filtering for inactive queries
         response = self.client.get(f"/api/environments/{self.team.id}/named_query/?is_active=false")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -312,10 +291,8 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_list_filter_by_created_by(self):
         """Test filtering named queries by created_by user."""
-        # Create another user
         other_user = User.objects.create_and_join(self.organization, "other@test.com", None)
 
-        # Create queries by different users
         NamedQuery.objects.create(
             name="query_by_user1",
             team=self.team,
@@ -345,10 +322,8 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_list_filter_combined(self):
         """Test filtering named queries by both is_active and created_by."""
-        # Create another user
         other_user = User.objects.create_and_join(self.organization, "other@test.com", None)
 
-        # Create queries with different combinations
         NamedQuery.objects.create(
             name="active_query_user1",
             team=self.team,
@@ -371,7 +346,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
             is_active=True,
         )
 
-        # Test combined filtering
         response = self.client.get(
             f"/api/environments/{self.team.id}/named_query/?is_active=true&created_by={self.user.id}"
         )
@@ -383,7 +357,6 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_list_no_filters(self):
         """Test listing all named queries without filters."""
-        # Create multiple queries
         NamedQuery.objects.create(
             name="query1",
             team=self.team,
@@ -406,3 +379,248 @@ class TestNamedQuery(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(response_data["results"]), 2)
         query_names = {q["name"] for q in response_data["results"]}
         self.assertEqual(query_names, {"query1", "query2"})
+
+    def test_create_named_query_with_comprehensive_trends_query(self):
+        """Test creating a named query with a comprehensive TrendsQuery containing many fields."""
+        comprehensive_trends_query = {
+            "kind": "TrendsQuery",
+            "series": [
+                {
+                    "kind": "EventsNode",
+                    "event": "$pageview",
+                    "custom_name": "Page Views",
+                    "math": "total",
+                    "fixedProperties": [
+                        {
+                            "key": "$current_url",
+                            "operator": "icontains",
+                            "type": "event",
+                            "value": "posthog.com"
+                        }
+                    ]
+                },
+                {
+                    "kind": "EventsNode", 
+                    "event": "$autocapture",
+                    "custom_name": "Autocapture Events",
+                    "math": "dau"
+                }
+            ],
+            "dateRange": {
+                "date_from": "2025-01-01",
+                "date_to": "2025-01-31",
+                "explicitDate": True
+            },
+            "interval": "week",
+            "breakdownFilter": {
+                "breakdown": "$geoip_country_code",
+                "breakdown_type": "event",
+                "breakdown_limit": 10,
+                "breakdown_hide_other_aggregation": False,
+                "breakdown_normalize_url": True
+            },
+            "compareFilter": {
+                "compare": True,
+                "compare_to": "-1m"
+            },
+            "trendsFilter": {
+                "display": "ActionsLineGraph",
+                "showLegend": True,
+                "showValuesOnSeries": True,
+                "showLabelsOnSeries": False,
+                "showPercentStackView": False,
+                "showMultipleYAxes": True,
+                "aggregationAxisFormat": "numeric",
+                "aggregationAxisPrefix": "$",
+                "aggregationAxisPostfix": " USD",
+                "decimalPlaces": 2,
+                "minDecimalPlaces": 1,
+                "confidenceLevel": 0.95,
+                "showConfidenceIntervals": True,
+                "showMovingAverage": False,
+                "movingAverageIntervals": 7,
+                "smoothingIntervals": 3,
+                "showTrendLines": True,
+                "showAlertThresholdLines": False,
+                "yAxisScaleType": "linear",
+                "formula": "A + B",
+                "formulas": ["A", "B", "A + B"],
+                "goalLines": [
+                    {
+                        "value": 1000,
+                        "label": "Target"
+                    }
+                ],
+                "hiddenLegendIndexes": [1],
+            },
+            "properties": [
+                {
+                    "key": "$browser",
+                    "operator": "in",
+                    "type": "event",
+                    "value": ["Chrome", "Firefox", "Safari"]
+                },
+                {
+                    "key": "email",
+                    "operator": "is_set",
+                    "type": "person",
+                    "value": None
+                }
+            ],
+            "filterTestAccounts": True,
+            "samplingFactor": 0.1,
+            "aggregation_group_type_index": 1,
+            "dataColorTheme": 0.5,
+            "version": 2
+        }
+
+        data = {
+            "name": "comprehensive_trends_test",
+            "description": "A comprehensive trends query with many fields populated",
+            "query": comprehensive_trends_query,
+        }
+
+        response = self.client.post(f"/api/environments/{self.team.id}/named_query/", data, format="json")
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code, response.json())
+        response_data = response.json()
+
+        # Verify all the key fields are preserved
+        self.assertEqual("comprehensive_trends_test", response_data["name"])
+        self.assertEqual("A comprehensive trends query with many fields populated", response_data["description"])
+        self.assertTrue(response_data["is_active"])
+
+        saved_query = response_data["query"]
+        self.assertEqual("TrendsQuery", saved_query["kind"])
+        self.assertEqual("week", saved_query["interval"])
+        self.assertEqual(2, len(saved_query["series"]))
+        self.assertEqual("$pageview", saved_query["series"][0]["event"])
+        self.assertEqual("Page Views", saved_query["series"][0]["custom_name"])
+
+        # Verify date range
+        self.assertEqual("2025-01-01", saved_query["dateRange"]["date_from"])
+        self.assertEqual("2025-01-31", saved_query["dateRange"]["date_to"])
+        self.assertTrue(saved_query["dateRange"]["explicitDate"])
+
+        self.assertEqual("$geoip_country_code", saved_query["breakdownFilter"]["breakdown"])
+        self.assertEqual("event", saved_query["breakdownFilter"]["breakdown_type"])
+        self.assertEqual(10, saved_query["breakdownFilter"]["breakdown_limit"])
+
+        self.assertTrue(saved_query["compareFilter"]["compare"])
+        self.assertEqual("-1m", saved_query["compareFilter"]["compare_to"])
+
+        trends_filter = saved_query["trendsFilter"]
+        self.assertEqual("ActionsLineGraph", trends_filter["display"])
+        self.assertTrue(trends_filter["showLegend"])
+        self.assertTrue(trends_filter["showValuesOnSeries"])
+        self.assertEqual("numeric", trends_filter["aggregationAxisFormat"])
+        self.assertEqual("$", trends_filter["aggregationAxisPrefix"])
+        self.assertEqual(" USD", trends_filter["aggregationAxisPostfix"])
+        self.assertEqual(2, trends_filter["decimalPlaces"])
+        self.assertEqual(0.95, trends_filter["confidenceLevel"])
+        self.assertEqual("A + B", trends_filter["formula"])
+        self.assertEqual(1, len(trends_filter["goalLines"]))
+        self.assertEqual(1000, trends_filter["goalLines"][0]["value"])
+
+        self.assertEqual(2, len(saved_query["properties"]))
+        self.assertEqual("$browser", saved_query["properties"][0]["key"])
+        self.assertEqual("in", saved_query["properties"][0]["operator"])
+        self.assertEqual(["Chrome", "Firefox", "Safari"], saved_query["properties"][0]["value"])
+
+        self.assertTrue(saved_query["filterTestAccounts"])
+        self.assertEqual(0.1, saved_query["samplingFactor"])
+        self.assertEqual(1, saved_query["aggregation_group_type_index"])
+
+        named_query = NamedQuery.objects.get(name="comprehensive_trends_test", team=self.team)
+        self.assertEqual(named_query.created_by, self.user)
+        self.assertEqual("TrendsQuery", named_query.query["kind"])
+
+    def test_execute_named_query_with_trends_query_override(self):
+        """Test executing a named query with TrendsQuery override containing key fields."""
+        trends_query = {
+            "kind": "TrendsQuery",
+            "series": [
+                {
+                    "kind": "EventsNode",
+                    "event": "$pageview",
+                    "math": "total"
+                }
+            ],
+            "dateRange": {
+                "date_from": "2025-01-01",
+                "date_to": "2025-01-20"
+            },
+            "interval": "week",
+            "breakdownFilter": {
+                "breakdown": "$browser",
+                "breakdown_type": "event",
+                "breakdown_limit": 5
+            },
+            "compareFilter": {
+                "compare": True,
+                "compare_to": "-1d"
+            },
+            "trendsFilter": {
+                "display": "ActionsLineGraph",
+                "showLegend": True,
+                "decimalPlaces": 1
+            },
+            "properties": [
+                {
+                    "key": "$current_url",
+                    "operator": "icontains",
+                    "type": "event",
+                    "value": "posthog.com"
+                }
+            ],
+            "filterTestAccounts": False,
+            "samplingFactor": 0.5
+        }
+
+        NamedQuery.objects.create(
+            name="trends_execution_test",
+            team=self.team,
+            query=trends_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        override_payload = {
+            "query_override": {
+                "interval": "hour",
+                "series": [
+                    {
+                        "kind": "EventsNode",
+                        "event": "$pageview",
+                        "math": "total"
+                    },
+                    {
+                        "kind": "EventsNode",
+                        "event": "$autocapture",
+                        "math": "dau"
+                    }
+                ],
+                "dateRange": {
+                    "date_from": "2025-01-01",
+                    "date_to": "2025-01-02"
+                }
+            }
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/named_query/trends_execution_test/run/",
+            override_payload,
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        response_data = response.json()
+
+        self.assertIn("results", response_data)
+        self.assertIsInstance(response_data["results"], list)
+
+        # TODO: make this more specific
+        if response_data["results"]:
+            first_series_result = response_data["results"][0]
+            self.assertEqual(first_series_result["interval"], "hour")
+            self.assertEqual(len(first_series_result["data"]), 25)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -9051,6 +9051,7 @@ class NamedQueryRunRequest(BaseModel):
         default=None, description="Client provided query ID. Can be used to retrieve the status or cancel the query."
     )
     filters_override: Optional[DashboardFilter] = None
+    query_override: Optional[dict[str, Any]] = None
     refresh: Optional[RefreshType] = Field(
         default=RefreshType.BLOCKING,
         description=(
@@ -11966,16 +11967,6 @@ class MaxRecordingUniversalFilters(BaseModel):
     )
 
 
-class NamedQueryRequest(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: Optional[str] = None
-    is_active: Optional[bool] = None
-    name: Optional[str] = None
-    query: Optional[HogQLQuery] = None
-
-
 class PropertyGroupFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -13854,6 +13845,18 @@ class MultiVisualizationMessage(BaseModel):
     id: Optional[str] = None
     type: Literal["ai/multi_viz"] = "ai/multi_viz"
     visualizations: list[VisualizationItem]
+
+
+class NamedQueryRequest(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+    name: Optional[str] = None
+    query: Optional[
+        Union[HogQLQuery, Union[TrendsQuery, FunnelsQuery, RetentionQuery, PathsQuery, StickinessQuery, LifecycleQuery]]
+    ] = None
 
 
 class WebVitalsQuery(BaseModel):


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Embedded Analytics is all cool and that, but we want to allow more than just the HogQLQuery. This is the first iteration to allowing super easy creation of Query Endpoints from Insights.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- unblocks the NamedQuery to be created from Trends/Funnels/Stickiness/Funnels/User Paths/Retention/Lifecycle
<img width="305" height="642" alt="image" src="https://github.com/user-attachments/assets/d00ce0f9-7c21-44a0-ac34-807c5b3a631a" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

✨ tests ✨ 

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
Nope!