### PR TITLE
fix(msg): add option to keep undefined ua's in filter bot transformation

### DIFF
--- a/plugin-server/src/cdp/templates/_transformations/bot-detection/bot-detection.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/bot-detection/bot-detection.template.test.ts
@@ -7,6 +7,7 @@ const DEFAULT_INPUTS = {
     userAgent: '$raw_user_agent',
     customBotPatterns: '',
     customIpPrefixes: '',
+    keepUndefinedUseragent: 'Yes',
 }
 
 describe('bot-detection.template', () => {
@@ -50,35 +51,47 @@ describe('bot-detection.template', () => {
         expect(response.execResult).toBeFalsy()
     })
 
-    it('should treat missing user agent as bot traffic', async () => {
-        mockGlobals = tester.createGlobals({
-            event: {
-                properties: {},
-            },
-        })
-
-        const response = await tester.invoke(DEFAULT_INPUTS, mockGlobals)
-
-        expect(response.finished).toBeTruthy()
-        expect(response.error).toBeFalsy()
-        expect(response.execResult).toBeFalsy()
-    })
-
-    it('should treat empty user agent as bot traffic', async () => {
-        mockGlobals = tester.createGlobals({
-            event: {
-                properties: {
-                    $raw_user_agent: '',
+    it.each([
+        ['Yes', true],
+        ['No', false],
+    ])(
+        'should treat missing user agent when keepUndefinedUseragent is %s',
+        async (keepUndefinedUseragent, shouldKeepEvent) => {
+            mockGlobals = tester.createGlobals({
+                event: {
+                    properties: {},
                 },
-            },
-        })
+            })
 
-        const response = await tester.invoke(DEFAULT_INPUTS, mockGlobals)
+            const response = await tester.invoke({ ...DEFAULT_INPUTS, keepUndefinedUseragent }, mockGlobals)
 
-        expect(response.finished).toBeTruthy()
-        expect(response.error).toBeFalsy()
-        expect(response.execResult).toBeFalsy()
-    })
+            expect(response.finished).toBeTruthy()
+            expect(response.error).toBeFalsy()
+            shouldKeepEvent ? expect(response.execResult).toBeTruthy() : expect(response.execResult).toBeFalsy()
+        }
+    )
+
+    it.each([
+        ['Yes', true],
+        ['No', false],
+    ])(
+        'should treat empty user agent when keepUndefinedUseragent is %s',
+        async (keepUndefinedUseragent, shouldKeepEvent) => {
+            mockGlobals = tester.createGlobals({
+                event: {
+                    properties: {
+                        $raw_user_agent: '',
+                    },
+                },
+            })
+
+            const response = await tester.invoke({ ...DEFAULT_INPUTS, keepUndefinedUseragent }, mockGlobals)
+
+            expect(response.finished).toBeTruthy()
+            expect(response.error).toBeFalsy()
+            shouldKeepEvent ? expect(response.execResult).toBeTruthy() : expect(response.execResult).toBeFalsy()
+        }
+    )
 
     it('should detect bot in case-insensitive manner', async () => {
         mockGlobals = tester.createGlobals({

--- a/plugin-server/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
@@ -66,8 +66,7 @@ let known_bot_filter_list := ['bot', 'crawler', 'spider', 'feedfetcher-google',
 let userAgentProperty := inputs.userAgent
 
 // Check if user agent property exists in event
-// We treat missing user agent as bot traffic
-if (empty(event.properties[userAgentProperty])) {
+if (empty(event.properties[userAgentProperty]) and inputs.keepUndefinedUseragent == 'No') {
     return null
 }
 
@@ -75,8 +74,7 @@ if (empty(event.properties[userAgentProperty])) {
 let user_agent := event.properties[userAgentProperty]
 
 // Check for empty string
-// We treat empty user agent as bot traffic
-if (user_agent == '') {
+if (user_agent == '' and inputs.keepUndefinedUseragent == 'No') {
     return null
 }
 
@@ -344,6 +342,20 @@ return event
             default: '',
             secret: false,
             required: false,
+        },
+        {
+            key: 'keepUndefinedUseragent',
+            type: 'choice',
+            label: 'Keep events where useragent is undefined?',
+            description:
+                'Some events such as server-side events may not have a useragent property, choose if you want to keep these events',
+            default: 'Yes',
+            secret: false,
+            required: false,
+            choices: [
+                { value: 'Yes', label: 'Yes' },
+                { value: 'No', label: 'No' },
+            ],
         },
     ],
 }

--- a/plugin-server/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
@@ -346,7 +346,7 @@ return event
         {
             key: 'keepUndefinedUseragent',
             type: 'choice',
-            label: 'Keep events where useragent is undefined?',
+            label: 'Keep events where the useragent is not set?',
             description:
                 'Some events such as server-side events may not have a useragent property, choose if you want to keep these events',
             default: 'Yes',


### PR DESCRIPTION
## Problem

context: https://posthog.slack.com/archives/C08JQTX5RRP/p1758552837282639?thread_ts=1758548894.924319&cid=C08JQTX5RRP

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

updated tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
