### PR TITLE
fix(msg): better error message for cohort filter issue

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionTestLogic.tsx
@@ -344,8 +344,12 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                     }
 
                     actions.setTestResult(res)
-                } catch (e) {
-                    lemonToast.error(`An unexpected server error occurred while testing the function. ${e}`)
+                } catch (e: any) {
+                    if (e?.data?.configuration?.filters?.non_field_errors) {
+                        lemonToast.error(`Testing failed: ${e.data.configuration.filters.non_field_errors}`)
+                        return
+                    }
+                    lemonToast.error(`An unexpected server error occurred while testing the function: ${e}`)
                 }
             },
         },

--- a/frontend/src/scenes/hog-functions/testing/hogFunctionTestingLogic.tsx
+++ b/frontend/src/scenes/hog-functions/testing/hogFunctionTestingLogic.tsx
@@ -196,11 +196,11 @@ export const hogFunctionTestingLogic = kea<hogFunctionTestingLogicType>([
                     } catch (e: any) {
                         if (e?.data?.configuration?.filters?.non_field_errors) {
                             lemonToast.error(`Testing failed: ${e.data.configuration.filters.non_field_errors}`)
-                            return
+                        } else {
+                            lemonToast.error(`An unexpected server error occurred while testing the function: ${e}`)
                         }
-                        lemonToast.error(`An unexpected server error occurred while testing the function: ${e}`)
+                        return [...values.retries]
                     }
-
                     actions.removeLoadingRetry(eventId)
                     return [...values.retries]
                 },

--- a/frontend/src/scenes/hog-functions/testing/hogFunctionTestingLogic.tsx
+++ b/frontend/src/scenes/hog-functions/testing/hogFunctionTestingLogic.tsx
@@ -193,8 +193,12 @@ export const hogFunctionTestingLogic = kea<hogFunctionTestingLogicType>([
                         }
 
                         return [...values.retries, retry]
-                    } catch (e) {
-                        lemonToast.error(`An unexpected server error occurred while testing the function. ${e}`)
+                    } catch (e: any) {
+                        if (e?.data?.configuration?.filters?.non_field_errors) {
+                            lemonToast.error(`Testing failed: ${e.data.configuration.filters.non_field_errors}`)
+                            return
+                        }
+                        lemonToast.error(`An unexpected server error occurred while testing the function: ${e}`)
                     }
 
                     actions.removeLoadingRetry(eventId)

--- a/frontend/src/scenes/hog-functions/testing/hogFunctionTestingLogic.tsx
+++ b/frontend/src/scenes/hog-functions/testing/hogFunctionTestingLogic.tsx
@@ -199,7 +199,6 @@ export const hogFunctionTestingLogic = kea<hogFunctionTestingLogicType>([
                         } else {
                             lemonToast.error(`An unexpected server error occurred while testing the function: ${e}`)
                         }
-                        return [...values.retries]
                     }
                     actions.removeLoadingRetry(eventId)
                     return [...values.retries]


### PR DESCRIPTION
## Problem

The cohort filter error will just toast `non-ok request`, which is pretty confusing.

## Changes

- Toast this error instead if possible
<img width="453" height="154" alt="2025-09-22 at 19 12 53" src="https://github.com/user-attachments/assets/cac6c9f1-d231-4731-a2c7-bdb206f78367" />
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
