### PR TITLE
fix: poll for notifications only when visible

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -11,7 +11,6 @@ import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
-import { usePageVisibilityCb } from 'lib/hooks/usePageVisibility'
 import { IconWithCount } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -53,21 +52,16 @@ export const SidePanelActivity = (): JSX.Element => {
 
     const { hasNotifications, notifications, importantChangesLoading, hasUnread } =
         useValues(sidePanelNotificationsLogic)
-    const { togglePolling, markAllAsRead, loadImportantChanges } = useActions(sidePanelNotificationsLogic)
+    const { markAllAsRead, loadImportantChanges } = useActions(sidePanelNotificationsLogic)
 
     const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-
-    usePageVisibilityCb((pageIsVisible) => {
-        togglePolling(pageIsVisible)
-    })
 
     useOnMountEffect(() => {
         loadImportantChanges(false)
 
         return () => {
             markAllAsRead()
-            togglePolling(false)
         }
     })
 

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, beforeUnmount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, afterMount, beforeUnmount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { lazyLoaders } from 'kea-loaders'
 import posthog, { JsonRecord } from 'posthog-js'
 
@@ -192,7 +192,14 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
         unreadCount: [(s) => [s.unread], (unread) => (unread || []).length],
         hasUnread: [(s) => [s.unreadCount], (unreadCount) => unreadCount > 0],
     }),
+    afterMount(({ cache, actions }) => {
+        cache.onVisibilityChange = () => {
+            actions.togglePolling(document.visibilityState === 'visible')
+        }
+        document.addEventListener('visibilitychange', cache.onVisibilityChange)
+    }),
     beforeUnmount(({ cache }) => {
         clearTimeout(cache.pollTimeout)
+        document.removeEventListener('visibilitychange', cache.onVisibilityChange)
     }),
 ])


### PR DESCRIPTION
<img width="308" height="581" alt="Screenshot 2025-09-22 at 20 46 03" src="https://github.com/user-attachments/assets/0bb75f04-4dc2-410a-b8ce-b7caf736bdc4" />

observed this API polling while the page was not visible
but it shouldn't do

let's alter how we detect if we should be polling
it might be keeping the page alive, stopping background tabs being inactive, and anyway it's unnecessary