### PR TITLE
chore(rust): make several unit tests cheaper

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -1097,10 +1097,10 @@ mod tests {
 
         let tmp_checkpoint_dir = TempDir::new().unwrap();
 
-        // configure frequent checkpoints and long retention, cleanup interval
+        // configure moderate checkpoints with reasonable intervals
         let config = CheckpointConfig {
-            checkpoint_interval: Duration::from_millis(3),
-            cleanup_interval: Duration::from_secs(120),
+            checkpoint_interval: Duration::from_millis(50), // Submit frequent checkpoints during test run
+            cleanup_interval: Duration::from_secs(30),
             max_concurrent_checkpoints: 2,
             local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
             ..Default::default()
@@ -1110,11 +1110,16 @@ mod tests {
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
         manager.start();
 
-        tokio::time::sleep(Duration::from_millis(0)).await;
+        // Give the manager time to start checkpointing
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
         let mut hit_expected_cap = false;
         let mut never_above_zero = true;
+        let start = std::time::Instant::now();
+        let timeout = Duration::from_secs(3);
 
-        for _ in 0..1000000 {
+
+        while start.elapsed() < timeout {
             let inflight = manager.is_checkpointing.lock().await.len();
             if inflight == config.max_concurrent_checkpoints {
                 hit_expected_cap = true;
@@ -1125,9 +1130,13 @@ mod tests {
             if inflight == 0 {
                 never_above_zero = false;
             }
+
+            // Small sleep to prevent busy waiting
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        assert!(hit_expected_cap);
-        assert!(!never_above_zero);
+
+        assert!(hit_expected_cap, "Expected to hit the concurrent checkpoint cap of {}", config.max_concurrent_checkpoints);
+        assert!(!never_above_zero, "Expected to see some checkpointing activity");
 
         manager.stop().await;
 

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -1118,7 +1118,6 @@ mod tests {
         let start = std::time::Instant::now();
         let timeout = Duration::from_secs(3);
 
-
         while start.elapsed() < timeout {
             let inflight = manager.is_checkpointing.lock().await.len();
             if inflight == config.max_concurrent_checkpoints {
@@ -1135,8 +1134,15 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
-        assert!(hit_expected_cap, "Expected to hit the concurrent checkpoint cap of {}", config.max_concurrent_checkpoints);
-        assert!(!never_above_zero, "Expected to see some checkpointing activity");
+        assert!(
+            hit_expected_cap,
+            "Expected to hit the concurrent checkpoint cap of {}",
+            config.max_concurrent_checkpoints
+        );
+        assert!(
+            !never_above_zero,
+            "Expected to see some checkpointing activity"
+        );
 
         manager.stop().await;
 

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -443,8 +443,17 @@ impl CheckpointManager {
     }
 
     async fn cleanup_local_checkpoints(config: &CheckpointConfig) -> Result<()> {
+        info!(
+            checkpoint_base_dir = config.local_checkpoint_dir,
+            "Checkpoint cleaner: starting local checkpoint cleanup scan..."
+        );
+
         let checkpoint_base_dir = PathBuf::from(config.local_checkpoint_dir.clone());
         if !checkpoint_base_dir.exists() {
+            warn!(
+                checkpoint_base_dir = config.local_checkpoint_dir,
+                "Checkpoint cleaner: local checkpoint directory does not exist, skipping cleanup"
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
## Problem
Hit some trouble in my local after a reset that led me to make some tweaks to both of these unit tests.

## Changes
* Cheaper `capture` events suite (don't recreate the reqwest Client)
* Cheaper checkpoint manager cap test 

## How did you test this code?
Locally and in CI

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
