### PR TITLE
fix(devex): fully revert exporter change, remove vite flags

### DIFF
--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -20,7 +20,6 @@
       <env name="SESSION_RECORDING_KAFKA_HOSTS" value="localhost" />
       <env name="SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES" value="20971520" />
       <env name="SKIP_SERVICE_VERSION_REQUIREMENTS" value="1" />
-      <env name="POSTHOG_USE_VITE" value="1" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
     <option name="WORKING_DIRECTORY" value="" />

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,8 +61,7 @@
                 "SKIP_SERVICE_VERSION_REQUIREMENTS": "1",
                 "PRINT_SQL": "1",
                 "BILLING_SERVICE_URL": "https://billing.dev.posthog.dev",
-                "CLOUD_DEPLOYMENT": "dev",
-                "POSTHOG_USE_VITE": "1"
+                "CLOUD_DEPLOYMENT": "dev"
             },
             "envFile": "${workspaceFolder}/.env",
             "console": "integratedTerminal",

--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -1,8 +1,6 @@
 procs:
     backend:
         shell: 'uv sync --active && bin/check_kafka_clickhouse_up && python manage.py migrate && ./bin/start-backend'
-        env:
-            POSTHOG_USE_VITE: '1'
 
     celery-worker:
         shell: 'uv sync --active && bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
@@ -16,8 +14,6 @@ procs:
 
     frontend:
         shell: './bin/start-frontend'
-        env:
-            POSTHOG_USE_VITE: '1'
 
     docker-compose:
         # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -1,8 +1,6 @@
 procs:
     backend:
         shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-backend'
-        env:
-            POSTHOG_USE_VITE: '1'
 
     celery-worker:
         shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
@@ -15,8 +13,6 @@ procs:
 
     frontend:
         shell: './bin/start-frontend'
-        env:
-            POSTHOG_USE_VITE: '1'
 
     temporal-worker-general-purpose:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue general-purpose-task-queue'

--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -8,8 +8,5 @@ set -e
 # In particular, DEBUG=1 enables a lot of Tailwind logging we don't need, so let's set 0 instead
 export DEBUG=0
 
-# Set Vite usage flag to prevent ESBUILD script injection
-export POSTHOG_USE_VITE=1
-
 pnpm --filter=@posthog/frontend... install
 bin/turbo --filter=@posthog/frontend start-vite

--- a/bin/start-frontend-vite
+++ b/bin/start-frontend-vite
@@ -8,8 +8,5 @@ set -e
 # In particular, DEBUG=1 enables a lot of Tailwind logging we don't need, so let's set 0 instead
 export DEBUG=0
 
-# Set Vite usage flag to prevent ESBUILD script injection
-export POSTHOG_USE_VITE=1
-
 pnpm --filter=@posthog/frontend... install
 bin/turbo --filter=@posthog/frontend start-vite

--- a/frontend/vite-html-plugin.ts
+++ b/frontend/vite-html-plugin.ts
@@ -2,9 +2,9 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from '
 import { dirname, resolve } from 'path'
 import type { Plugin } from 'vite'
 
-const distHtmlFiles = ['dist/index.html', 'dist/layout.html', 'dist/exporter.html']
+const distHtmlFiles = ['dist/index.html', 'dist/layout.html']
 
-const srcHtmlFiles = ['src/index.html', 'src/layout.html', 'src/exporter/index.html']
+const srcHtmlFiles = ['src/index.html', 'src/layout.html']
 
 function deleteHtmlFiles(): void {
     distHtmlFiles.forEach((file) => {
@@ -51,9 +51,7 @@ function generateHtmlFiles(): void {
 
     // Copy HTML files
     srcHtmlFiles.forEach((file) => {
-        const outputFile =
-            file === 'src/exporter/index.html' ? 'dist/exporter.html' : `dist/${file.replace('src/', '')}`
-        copyHtmlFile(file, outputFile)
+        copyHtmlFile(file, `dist/${file.replace('src/', '')}`)
     })
 }
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -330,7 +330,6 @@ def get_context_for_template(
     request: HttpRequest,
     context: Optional[dict] = None,
     team_for_public_context: Optional["Team"] = None,
-    template_name: Optional[str] = None,
 ) -> dict:
     if context is None:
         context = {}
@@ -346,23 +345,18 @@ def get_context_for_template(
     if settings.DEBUG and not settings.TEST:
         context["debug"] = True
         context["git_branch"] = get_git_branch()
-        # Add vite dev scripts for development only when explicitly using Vite
-        if not settings.E2E_TESTING and os.environ.get("POSTHOG_USE_VITE"):
-            # Choose the correct entry point based on template
-            entry_point = "src/index.tsx"
-            if template_name == "exporter.html":
-                entry_point = "src/exporter/index.tsx"
-            context["vite_dev_scripts"] = f"""
+        # Add vite dev scripts for development
+        context["vite_dev_scripts"] = """
         <script type="module">
             import RefreshRuntime from 'http://localhost:8234/@react-refresh'
             RefreshRuntime.injectIntoGlobalHook(window)
-            window.$RefreshReg$ = () => {{}}
+            window.$RefreshReg$ = () => {}
             window.$RefreshSig$ = () => (type) => type
             window.__vite_plugin_react_preamble_installed__ = true
         </script>
         <!-- Vite development server -->
         <script type="module" src="http://localhost:8234/@vite/client"></script>
-        <script type="module" src="http://localhost:8234/{entry_point}"></script>"""
+        <script type="module" src="http://localhost:8234/src/index.tsx"></script>"""
 
     context["js_posthog_ui_host"] = ""
 


### PR DESCRIPTION
## Problem
Vite local development (now default) seems broken!
This recent [half-revert](https://github.com/PostHog/posthog/pull/38453) of this [this PR](https://github.com/PostHog/posthog/pull/38323/files#diff-83e1564f93aa8bbe220b6e93a740cd80e32f6ab81a13346a2a6310ea41e69a8b) didn't seem to fix it...
The changes in that initial PR isn't the culprit after some testing... (although fully reverting it here for clarify)

## REAL Problem (i hope)
The problem seems to be a failure to re-add the `POSTHOG_USE_VITE` dev flags on re-initialization (or something), and removing the flags seems to have made all the problems go away... it needed to happen anyways so 🤷  

How I realized it had to do with `re-initialization` was that I'd let me computer go to sleep and on wake up, it would be broken.

## Changes
Fully revert [this PR](https://github.com/PostHog/posthog/pull/38323/files#diff-83e1564f93aa8bbe220b6e93a740cd80e32f6ab81a13346a2a6310ea41e69a8b) (which did fix exporter)
Fully remove all `POSTHOG_USE_VITE` dev flags

## How did you test this code?
I removed all deps in the repo, reinstalled deps, started stack, made some changes, tore down stack. ✅ 
I removed all deps in the repo, reinstalled deps, started stack, made some changes, let computer go to sleep, wake up ✅ 