### PR TITLE
fix(kafka-dedup): fall back to parent CapturedEvent for missing required dedup values

### DIFF
--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -238,7 +238,7 @@ impl MessageProcessor for DeduplicationProcessor {
                             raw_event.distinct_id =
                                 Some(serde_json::Value::String(extracted_distinct_id));
                         }
-                        if raw_event.token.is_none() && extracted_token.is_empty() {
+                        if raw_event.token.is_none() && !extracted_token.is_empty() {
                             raw_event.token = Some(extracted_token);
                         }
 

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -197,7 +197,13 @@ impl MessageProcessor for DeduplicationProcessor {
         // Parse the captured event and extract the raw event from it
         let raw_event = match serde_json::from_slice::<CapturedEvent>(payload) {
             Ok(captured_event) => {
+                // extract well-validated values from the CapturedEvent that
+                // may or may not be present in the wrapped RawEvent
                 let now = captured_event.now.clone();
+                let extracted_distinct_id = captured_event.distinct_id.clone();
+                let extracted_token = captured_event.token.clone();
+                let extracted_uuid = captured_event.uuid;
+
                 // The RawEvent is serialized in the data field
                 match serde_json::from_str::<RawEvent>(&captured_event.data) {
                     Ok(mut raw_event) => {
@@ -221,6 +227,21 @@ impl MessageProcessor for DeduplicationProcessor {
                                 // Timestamp exists and is valid, keep it
                             }
                         }
+
+                        // if RawEvent is missing any of the core values
+                        // extracted by capture into the CapturedEvent
+                        // wrapper, use those values for downstream analysis
+                        if raw_event.uuid.is_none() {
+                            raw_event.uuid = Some(extracted_uuid);
+                        }
+                        if raw_event.distinct_id.is_none() && !extracted_distinct_id.is_empty() {
+                            raw_event.distinct_id =
+                                Some(serde_json::Value::String(extracted_distinct_id));
+                        }
+                        if raw_event.token.is_none() && extracted_token.is_empty() {
+                            raw_event.token = Some(extracted_token);
+                        }
+
                         raw_event
                     }
                     Err(e) => {

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -198,7 +198,7 @@ impl KafkaDeduplicatorService {
                             } else {
                                 // Explicitly report unhealthy when a worker dies
                                 checkpoint_health_handle.report_status(health::ComponentStatus::Unhealthy).await;
-                                error!("Checkpoint manager is unhealthy - checkpont and/or cleanup loops died");
+                                error!("Checkpoint manager is unhealthy - checkpoint and/or cleanup loops died");
                             }
                         }
                     }
@@ -208,10 +208,10 @@ impl KafkaDeduplicatorService {
         }
 
         info!(
-            "Started checkpoint manager (export enabled = {:?}, checkpoint interval = {:?}, cleanup interval = {:?})",
+            "Started checkpoint manager (export enabled = {:?}, checkpoint interval = {:?}, checkpoint_cleanup interval = {:?})",
             self.checkpoint_manager.as_ref().unwrap().export_enabled(),
             self.config.checkpoint_interval(),
-            self.config.cleanup_interval(),
+            self.config.checkpoint_cleanup_interval(),
         );
 
         // Spawn task to report processor pool health


### PR DESCRIPTION
## Problem
`capture-rs` performs more extensive extraction and validation (multiple SDK-dependent fallback sources, etc.) for some of the required fields the `kafka-deduplicator` operates on, and places them in the `CapturedEvent` wrapper. The `RawEvent` does not always contain these fields, even if they were present on the payload

## Changes

Quick experiment to eval falling back to `CapturedEvent` when required fields (esp. `distinct_id` is missing on the `RawEvent`. Prereq to overhauling the parsing and processing layer to retain `CapturedEvent` through the pipeline

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog update
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
