### PR TITLE
feat(kafka-dedup): rebucket checkpoint file size and count histograms

### DIFF
--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -61,12 +61,40 @@ fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
     // granular bucket ranges for higher fidelity metrics
     const SIMILARITY_BUCKETS: &[f64] = &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
 
+    const CHECKPOINT_FILE_COUNT_BUCKETS: &[f64] = &[
+        1.0, 10.0, 50.0, 100.0, 200.0, 400.0, 600.0, 800.0, 1000.0, 1500.0,
+    ];
+    const CHECKPOINT_SIZE_BYTES_BUCKETS: &[f64] = &[
+        1.0,
+        10.0,
+        100.0,
+        1024.0,
+        10.0 * 1024.0,
+        100.0 * 1024.0,
+        1024.0 * 1024.0,
+        10.0 * 1024.0 * 1024.0,
+        100.0 * 1024.0 * 1024.0,
+        1024.0 * 1024.0 * 1024.0,
+        10.0 * 1024.0 * 1024.0 * 1024.0,
+        100.0 * 1024.0 * 1024.0 * 1024.0,
+    ];
+
     PrometheusBuilder::new()
         .set_buckets(BUCKETS)
         .unwrap()
         .set_buckets_for_metric(
             Matcher::Suffix("similarity_score".to_string()),
             SIMILARITY_BUCKETS,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Suffix("checkpoint_file_count".to_string()),
+            CHECKPOINT_FILE_COUNT_BUCKETS,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Suffix("checkpoint_size_bytes".to_string()),
+            CHECKPOINT_SIZE_BYTES_BUCKETS,
         )
         .unwrap()
         .install_recorder()


### PR DESCRIPTION
## Problem
In order to measure at the granularity we want in our dashboards, we need to override the default Prometheus bucketing set in the deduper config.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Create custom bucket patterns for checkpoint file count and byte size histograms
* Override with custom matchers in the Prometheus config

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, and Grafana

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
