### PR TITLE
fix(msg): prevent child workflows from terminating when parent completes

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -374,7 +374,7 @@
                                                                                   FROM person AS where_optimization
                                                                                   WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
                                    GROUP BY person.id
-                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                                   HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))) AS persons
                                 WHERE ifNull(equals(persons.properties___name, 'test'), 0)
                                 ORDER BY persons.id ASC
                                 LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -398,7 +398,7 @@
                               FROM person_distinct_id_overrides
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
-                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                              HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -467,7 +467,7 @@
                                                                                   FROM person AS where_optimization
                                                                                   WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
                                    GROUP BY person.id
-                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+                                   HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))) AS persons
                                 WHERE ifNull(equals(persons.properties___name, 'test'), 0)
                                 ORDER BY persons.id ASC
                                 LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -491,7 +491,7 @@
                               FROM person_distinct_id_overrides
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
-                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                              HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
@@ -3,6 +3,7 @@ import datetime as dt
 import dataclasses
 from typing import Any, Optional
 
+import temporalio.common
 import temporalio.activity
 import temporalio.workflow
 from structlog.contextvars import bind_contextvars
@@ -143,8 +144,11 @@ class BehavioralCohortsCoordinatorWorkflow(PostHogWorkflow):
         conditions_per_workflow = math.ceil(total_conditions / inputs.parallelism)
         conditions_per_workflow = min(conditions_per_workflow, inputs.conditions_per_workflow)
 
-        # Step 3: Import the child workflow inputs
-        from posthog.temporal.messaging.behavioral_cohorts_workflow import BehavioralCohortsWorkflowInputs
+        # Step 3: Import the child workflow inputs and workflow class
+        from posthog.temporal.messaging.behavioral_cohorts_workflow import (
+            BehavioralCohortsWorkflow,
+            BehavioralCohortsWorkflowInputs,
+        )
 
         # Step 4: Launch child workflows - fire and forget
         workflows_scheduled = 0
@@ -170,11 +174,11 @@ class BehavioralCohortsCoordinatorWorkflow(PostHogWorkflow):
             # Start child workflow - fire and forget, don't wait for result
             # Set parent_close_policy to ABANDON so child workflows continue after parent completes
             await temporalio.workflow.start_child_workflow(
-                "behavioral-cohorts-analysis",
+                BehavioralCohortsWorkflow.run,
                 child_inputs,
                 id=child_id,
                 task_queue=MESSAGING_TASK_QUEUE,
-                parent_close_policy=temporalio.common.ParentClosePolicy.ABANDON,
+                parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
             )
             workflows_scheduled += 1
 

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
@@ -167,12 +167,14 @@ class BehavioralCohortsCoordinatorWorkflow(PostHogWorkflow):
                 conditions_page_size=min(1000, limit),  # Don't fetch more than we need
             )
 
-            # Start child workflow - fire and forget, don't wait for result
+            # Start child workflow (non-blocking)
+            # Set parent_close_policy to ABANDON so child workflows continue after parent completes
             await temporalio.workflow.start_child_workflow(
                 "behavioral-cohorts-analysis",
                 child_inputs,
                 id=child_id,
                 task_queue=MESSAGING_TASK_QUEUE,
+                parent_close_policy=temporalio.common.ParentClosePolicy.ABANDON,
             )
             workflows_scheduled += 1
 

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow_coordinator.py
@@ -167,7 +167,7 @@ class BehavioralCohortsCoordinatorWorkflow(PostHogWorkflow):
                 conditions_page_size=min(1000, limit),  # Don't fetch more than we need
             )
 
-            # Start child workflow (non-blocking)
+            # Start child workflow - fire and forget, don't wait for result
             # Set parent_close_policy to ABANDON so child workflows continue after parent completes
             await temporalio.workflow.start_child_workflow(
                 "behavioral-cohorts-analysis",


### PR DESCRIPTION
## Problem

we missed a setting which led to the behavior that when the parent workflow completes (schedules the child workflows) all child workflows are terminated.  

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- added setting so child workflows can run 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
