### PR TITLE
chore: move salesforce enrichment to billing schedule

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -129,7 +129,7 @@ async def create_salesforce_enrichment_schedule(client: Client):
             "salesforce-enrichment-async",
             SalesforceEnrichmentInputs(chunk_size=DEFAULT_CHUNK_SIZE),
             id="salesforce-enrichment-schedule",
-            task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+            task_queue=BILLING_TASK_QUEUE,
         ),
         spec=ScheduleSpec(
             calendars=[


### PR DESCRIPTION
After #38467, I was able to run the enrichment successfully by triggering it manually on the general purpose worker, as I'm waiting for the secrets to be added to the billing worker, which should be done later today.

In the meantime, preparing this to move the workflow to the billing queue in the schedule - it runs once a week over the weekend.

I've also set up a Slack alert + a subscription to make sure we won't miss this in the future when it's down.