### PR TITLE
fix(batch-exports): Fallback on invalid format spec

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -128,9 +128,10 @@ def get_allowed_template_variables(inputs: S3InsertInputs) -> dict[str, str]:
 
 def get_s3_key_prefix(inputs: S3InsertInputs) -> str:
     template_variables = get_allowed_template_variables(inputs)
+
     try:
         return inputs.prefix.format(**template_variables)
-    except KeyError as e:
+    except (KeyError, ValueError) as e:
         EXTERNAL_LOGGER.warning(
             f"The key prefix '{inputs.prefix}' will be used as-is since it contains invalid template variables: {str(e)}"
         )

--- a/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_s3_batch_export_workflow.py
@@ -1761,6 +1761,15 @@ base_inputs = {"bucket_name": "test", "region": "test", "team_id": 1}
         ),
         (
             S3InsertInputs(
+                prefix="invalid-format-spec-{data_interval_start:hour}",
+                data_interval_start="2023-01-01 00:00:00",
+                data_interval_end="2023-01-01 01:00:00",
+                **base_inputs,  # type: ignore
+            ),
+            "invalid-format-spec-{data_interval_start:hour}/2023-01-01 00:00:00-2023-01-01 01:00:00.jsonl",
+        ),
+        (
+            S3InsertInputs(
                 prefix="",
                 data_interval_start="2023-01-01 00:00:00",
                 data_interval_end="2023-01-01 01:00:00",


### PR DESCRIPTION
## Problem

Using invalid format specifiers in an S3 batch export prefix raises a `ValueError` instead of a `KeyError`. We are not handling this properly with our fallback code.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Treat `ValueError`s with the same fallback as `KeyError`s.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test covering the invalid format spec case.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
