### PR TITLE
feat(activity-logs): Introduces UI<>Query params sync

### DIFF
--- a/frontend/src/lib/components/AnimatedCollapsible.tsx
+++ b/frontend/src/lib/components/AnimatedCollapsible.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef, useState } from 'react'
 
 export function AnimatedCollapsible({
     collapsed,
+    autoHeight,
     children,
 }: {
     collapsed: boolean
+    autoHeight?: boolean
     children?: JSX.Element | JSX.Element[]
 }): JSX.Element {
     const collapsibleSectionRef = useRef<HTMLHeadingElement>(null)
@@ -20,6 +22,28 @@ export function AnimatedCollapsible({
             setHeight(0)
         }
     }, [collapsed, children])
+
+    // Observe height changes in the content, if autoHeight is true
+    // Covers the case where the content is dynamically updated and the height needs to be updated
+    useEffect(() => {
+        if (!autoHeight) {
+            return
+        }
+
+        if (!collapsed && collapsibleSectionRef.current) {
+            const resizeObserver = new ResizeObserver((entries) => {
+                for (const entry of entries) {
+                    setHeight(entry.contentRect.height)
+                }
+            })
+
+            resizeObserver.observe(collapsibleSectionRef.current)
+
+            return () => {
+                resizeObserver.disconnect()
+            }
+        }
+    }, [collapsed, autoHeight])
 
     return (
         <div

--- a/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
+++ b/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 
 import { IconCollapse, IconExpand, IconInfo } from '@posthog/icons'
 import { LemonButton, LemonSelect, Tooltip } from '@posthog/lemon-ui'
@@ -15,9 +14,8 @@ import { DetailFilters } from './DetailFilters'
 import { advancedActivityLogsLogic } from './advancedActivityLogsLogic'
 
 export const BasicFiltersTab = (): JSX.Element => {
-    const { filters, availableFilters } = useValues(advancedActivityLogsLogic)
-    const { setFilters } = useActions(advancedActivityLogsLogic)
-    const [showAdvancedMode, setShowAdvancedMode] = useState(false)
+    const { filters, availableFilters, showMoreFilters } = useValues(advancedActivityLogsLogic)
+    const { setFilters, setShowMoreFilters } = useActions(advancedActivityLogsLogic)
 
     return (
         <div className="flex flex-col gap-4 pt-4">
@@ -102,8 +100,8 @@ export const BasicFiltersTab = (): JSX.Element => {
                 <div className="flex items-end justify-end mb-1">
                     <LemonButton
                         type="tertiary"
-                        icon={showAdvancedMode ? <IconCollapse /> : <IconExpand />}
-                        onClick={() => setShowAdvancedMode(!showAdvancedMode)}
+                        icon={showMoreFilters ? <IconCollapse /> : <IconExpand />}
+                        onClick={() => setShowMoreFilters(!showMoreFilters)}
                         data-attr="audit-logs-more-filters-toggle"
                         className="text-muted-alt hover:text-default"
                     >
@@ -112,7 +110,7 @@ export const BasicFiltersTab = (): JSX.Element => {
                 </div>
             </div>
 
-            <AnimatedCollapsible collapsed={!showAdvancedMode}>
+            <AnimatedCollapsible collapsed={!showMoreFilters} autoHeight>
                 <div className="border-t border-border mt-4 pt-4">
                     <div className="flex gap-4 flex-start flex-wrap pt-2">
                         <div className="flex flex-col gap-1">

--- a/frontend/src/scenes/audit-logs/DetailFilters.tsx
+++ b/frontend/src/scenes/audit-logs/DetailFilters.tsx
@@ -11,7 +11,7 @@ interface DetailFilterRowProps {
 }
 
 const DetailFilterRow = ({ filter }: DetailFilterRowProps): JSX.Element => {
-    const { availableFilters } = useValues(advancedActivityLogsLogic)
+    const { availableFilters, activeFilters } = useValues(advancedActivityLogsLogic)
     const { updateActiveFilter, removeActiveFilter } = useActions(advancedActivityLogsLogic)
 
     const [localValue, setLocalValue] = useState<string | string[]>(filter.value)
@@ -24,7 +24,6 @@ const DetailFilterRow = ({ filter }: DetailFilterRowProps): JSX.Element => {
             return []
         }
 
-        const { activeFilters } = advancedActivityLogsLogic.values
         const selectedFields = new Set(
             activeFilters.filter((f) => f.key !== filter.key && !f.isCustom).map((f) => f.fieldPath)
         )
@@ -67,7 +66,7 @@ const DetailFilterRow = ({ filter }: DetailFilterRowProps): JSX.Element => {
             .filter((section) => section.options.length > 0)
 
         return fieldSections
-    }, [availableFilters, filter.key, filter.fieldPath])
+    }, [availableFilters, filter.key, filter.fieldPath, activeFilters])
 
     const validateCustomFieldPath = (path: string): string | null => {
         if (!path || !path.trim()) {
@@ -90,7 +89,10 @@ const DetailFilterRow = ({ filter }: DetailFilterRowProps): JSX.Element => {
     }, [filter.fieldPath])
 
     const handleOperationChange = (operation: ActiveDetailFilter['operation']): void => {
-        const newValue = operation === 'in' && !Array.isArray(filter.value) ? [filter.value as string] : filter.value
+        let newValue = filter.value
+        if (operation === 'in' && !Array.isArray(filter.value)) {
+            newValue = filter.value && (filter.value as string).trim() ? [filter.value as string] : []
+        }
         setLocalValue(newValue)
         updateActiveFilter(filter.key, { operation, value: newValue })
     }

--- a/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
+++ b/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
@@ -2,7 +2,7 @@ import { LemonTag } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 
-import { ExportedAsset } from './advancedActivityLogsLogic'
+import { AdvancedActivityLogFilters, ExportedAsset } from './advancedActivityLogsLogic'
 
 export const getStatusTag = (exportAsset: ExportedAsset): JSX.Element => {
     if (exportAsset.exception) {
@@ -30,7 +30,7 @@ export const getHumanReadableFormat = (format: string): string => {
 }
 
 export const getFilterSummary = (exportAsset: ExportedAsset): string => {
-    const filters = exportAsset.export_context?.filters
+    const filters = exportAsset.export_context?.filters as AdvancedActivityLogFilters
     if (!filters) {
         return 'No filters'
     }
@@ -65,7 +65,7 @@ export const getFilterSummary = (exportAsset: ExportedAsset): string => {
 }
 
 export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
-    const filters = exportAsset.export_context?.filters
+    const filters = exportAsset.export_context?.filters as AdvancedActivityLogFilters
     if (!filters) {
         return <div>No filters applied</div>
     }

--- a/frontend/src/scenes/audit-logs/advancedActivityLogsLogic.tsx
+++ b/frontend/src/scenes/audit-logs/advancedActivityLogsLogic.tsx
@@ -1,5 +1,6 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { ActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
@@ -7,7 +8,7 @@ import { ADVANCED_ACTIVITY_PAGE_SIZE, FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { dateStringToDayJs } from 'lib/utils'
+import { dateStringToDayJs, objectClean } from 'lib/utils'
 
 import { ActivityScope } from '~/types'
 
@@ -34,6 +35,7 @@ export interface AdvancedActivityLogFilters {
     was_impersonated?: boolean
     is_system?: boolean
     item_ids?: string[]
+    page?: number
 }
 
 export interface DetailField {
@@ -50,8 +52,6 @@ export interface AvailableFilters {
         users: Array<{ label: string; value: string }>
         scopes: Array<{ value: string }>
         activities: Array<{ value: string }>
-        was_impersonated: Array<{ label: string; value: string }>
-        is_system: Array<{ label: string; value: string }>
     }
     detail_fields?: Record<string, ScopeFields>
 }
@@ -64,23 +64,10 @@ export interface ExportedAsset {
     filename: string | null
     expires_after: string
     exception: string | null
-    export_context?: {
-        path?: string
-        method?: string
-        filters?: {
-            start_date?: string | null
-            end_date?: string | null
-            users?: string[]
-            scopes?: string[]
-            activities?: string[]
-            detail_filters?: Record<string, DetailFilter>
-            was_impersonated?: boolean
-            is_system?: boolean
-            item_ids?: string[]
-        }
-    }
+    export_context?: any
 }
 
+// Constants
 const DEFAULT_FILTERS: AdvancedActivityLogFilters = {
     start_date: '-30d',
     users: [],
@@ -88,9 +75,10 @@ const DEFAULT_FILTERS: AdvancedActivityLogFilters = {
     activities: [],
     detail_filters: {},
     item_ids: [],
+    page: 1,
 }
 
-const DEFAULT_ACTIVE_FILTERS: ActiveDetailFilter[] = []
+const ADVANCED_FILTERS = ['was_impersonated', 'is_system', 'item_ids', 'detail_filters'] as const
 
 export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
     path(['scenes', 'audit-logs', 'advancedActivityLogsLogic']),
@@ -100,59 +88,49 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
 
     actions({
         setFilters: (filters: Partial<AdvancedActivityLogFilters>) => ({ filters }),
-        clearAllFilters: true,
         setPage: (page: number) => ({ page }),
-        exportLogs: (format: 'csv' | 'xlsx' | 'json') => ({ format }),
-        loadAvailableFilters: true,
-        loadExports: true,
+        clearAllFilters: true,
         setActiveTab: (tab: 'logs' | 'exports') => ({ tab }),
-        addActiveFilter: (fieldPath: string, isCustom: boolean) => ({ fieldPath, isCustom }),
+        setShowMoreFilters: (show: boolean) => ({ show }),
+
+        // Detail filters
+        addActiveFilter: (fieldPath: string, isCustom: boolean = false) => ({ fieldPath, isCustom }),
         updateActiveFilter: (key: string, updates: Partial<ActiveDetailFilter>) => ({ key, updates }),
         removeActiveFilter: (key: string) => ({ key }),
+        setActiveFilters: (activeFilters: ActiveDetailFilter[]) => ({ activeFilters }),
         syncFiltersToAPI: true,
+
+        // Export
+        exportLogs: (format: 'csv' | 'xlsx') => ({ format }),
     }),
 
     reducers({
         filters: [
             DEFAULT_FILTERS,
             {
-                setFilters: (state, { filters }) => ({ ...state, ...filters }),
+                setFilters: (state, { filters }) => objectClean({ ...state, ...filters }),
+                setPage: (state, { page }) => ({ ...state, page }),
                 clearAllFilters: () => DEFAULT_FILTERS,
             },
         ],
         activeFilters: [
-            DEFAULT_ACTIVE_FILTERS as ActiveDetailFilter[],
+            [] as ActiveDetailFilter[],
             {
-                addActiveFilter: (state, { fieldPath, isCustom }) => {
-                    const key = `filter_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
-                    return [
-                        ...state,
-                        {
-                            key,
-                            fieldPath: isCustom ? '' : fieldPath,
-                            operation: 'exact' as const,
-                            value: '',
-                            isCustom,
-                        },
-                    ]
-                },
-                updateActiveFilter: (state, { key, updates }) => {
-                    return state.map((filter) => (filter.key === key ? { ...filter, ...updates } : filter))
-                },
-                removeActiveFilter: (state, { key }) => {
-                    return state.filter((filter) => filter.key !== key)
-                },
-                clearAllFilters: () => DEFAULT_ACTIVE_FILTERS,
-            },
-        ],
-        currentPage: [
-            1,
-            {
-                setPage: (_, { page }) => page,
-                setFilters: () => 1,
-                addDetailFilter: () => 1,
-                updateDetailFilter: () => 1,
-                removeDetailFilter: () => 1,
+                addActiveFilter: (state, { fieldPath, isCustom }) => [
+                    ...state,
+                    {
+                        key: `filter_${Date.now()}`,
+                        fieldPath: isCustom ? '' : fieldPath,
+                        operation: 'exact' as const,
+                        value: '',
+                        isCustom,
+                    },
+                ],
+                updateActiveFilter: (state, { key, updates }) =>
+                    state.map((filter) => (filter.key === key ? { ...filter, ...updates } : filter)),
+                removeActiveFilter: (state, { key }) => state.filter((filter) => filter.key !== key),
+                setActiveFilters: (_, { activeFilters }) => activeFilters,
+                clearAllFilters: () => [],
             },
         ],
         activeTab: [
@@ -161,13 +139,31 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
                 setActiveTab: (_, { tab }) => tab,
             },
         ],
+        showMoreFilters: [
+            false,
+            {
+                setShowMoreFilters: (_, { show }) => show,
+                setFilters: (state, { filters }) => {
+                    const hasAdvancedFilters = ADVANCED_FILTERS.some((key) => {
+                        if (key === 'detail_filters') {
+                            return filters.detail_filters && Object.keys(filters.detail_filters).length > 0
+                        }
+                        const value = filters[key]
+                        return value !== undefined && value !== null && (Array.isArray(value) ? value.length > 0 : true)
+                    })
+                    return hasAdvancedFilters ? true : state
+                },
+            },
+        ],
     }),
 
     loaders(({ values }) => ({
         advancedActivityLogs: [
             { results: [], count: 0 } as CountedPaginatedResponse<ActivityLogItem>,
             {
-                loadAdvancedActivityLogs: async () => {
+                loadAdvancedActivityLogs: async (_, breakpoint) => {
+                    await breakpoint(300)
+
                     const params = new URLSearchParams()
 
                     if (values.filters.start_date) {
@@ -194,14 +190,12 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
                     if (values.filters.is_system !== undefined) {
                         params.append('is_system', values.filters.is_system.toString())
                     }
-
                     if (values.filters.detail_filters && Object.keys(values.filters.detail_filters).length > 0) {
                         params.append('detail_filters', JSON.stringify(values.filters.detail_filters))
                     }
 
-                    params.append('page', values.currentPage.toString())
+                    params.append('page', (values.filters.page || 1).toString())
                     params.append('page_size', ADVANCED_ACTIVITY_PAGE_SIZE.toString())
-                    params.append('include_organization_scoped', '1')
 
                     const response = await api.get(`api/projects/@current/advanced_activity_logs/?${params}`)
                     return response
@@ -227,7 +221,6 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
                 loadExports: async () => {
                     const params = new URLSearchParams()
                     params.append('context_path', '/advanced_activity_logs/')
-
                     const response = await api.get(`api/environments/@current/exports/?${params}`)
                     return response.results || []
                 },
@@ -235,7 +228,7 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
         ],
     })),
 
-    selectors(({ actions }) => ({
+    selectors({
         isFeatureFlagEnabled: [
             (s) => [s.featureFlags],
             (featureFlags: any): boolean => !!featureFlags[FEATURE_FLAGS.ADVANCED_ACTIVITY_LOGS],
@@ -259,31 +252,31 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
         ],
 
         pagination: [
-            (s) => [s.currentPage, s.advancedActivityLogs],
-            (
-                currentPage: number,
-                advancedActivityLogs: CountedPaginatedResponse<ActivityLogItem>
-            ): PaginationManual => ({
+            (s) => [s.filters, s.advancedActivityLogs],
+            (filters: AdvancedActivityLogFilters, advancedActivityLogs): PaginationManual => ({
                 controlled: true,
                 pageSize: ADVANCED_ACTIVITY_PAGE_SIZE,
-                currentPage,
+                currentPage: filters.page || 1,
                 entryCount: advancedActivityLogs.count || 0,
-                onBackward: () => actions.setPage(currentPage - 1),
-                onForward: () => actions.setPage(currentPage + 1),
+                onBackward: () => advancedActivityLogsLogic.actions.setPage((filters.page || 1) - 1),
+                onForward: () => advancedActivityLogsLogic.actions.setPage((filters.page || 1) + 1),
             }),
         ],
-    })),
+    }),
 
     listeners(({ actions, values }) => ({
-        setPage: () => {
-            actions.loadAdvancedActivityLogs()
+        setFilters: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadAdvancedActivityLogs({})
         },
-        setFilters: () => {
-            actions.loadAdvancedActivityLogs()
+        setPage: () => {
+            actions.loadAdvancedActivityLogs({})
         },
         clearAllFilters: () => {
-            actions.loadAdvancedActivityLogs()
+            actions.loadAdvancedActivityLogs({})
         },
+
+        // Detail filter management
         addActiveFilter: ({ fieldPath }) => {
             if (fieldPath === '__add_custom__') {
                 actions.addActiveFilter('', true)
@@ -297,22 +290,85 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
         removeActiveFilter: () => {
             actions.syncFiltersToAPI()
         },
+
         syncFiltersToAPI: () => {
             const detailFilters: Record<string, DetailFilter> = {}
             values.activeFilters.forEach((filter: ActiveDetailFilter) => {
-                if (filter.fieldPath && filter.fieldPath.trim()) {
-                    const fieldPath = filter.fieldPath.includes('::')
-                        ? filter.fieldPath.split('::')[1]
-                        : filter.fieldPath
+                if (filter.fieldPath?.trim()) {
+                    const hasValue = Array.isArray(filter.value)
+                        ? filter.value.some((v) => v?.trim())
+                        : filter.value?.trim()
 
-                    detailFilters[fieldPath] = {
-                        operation: filter.operation,
-                        value: filter.value,
+                    if (hasValue) {
+                        const fieldPath = filter.fieldPath.includes('::')
+                            ? filter.fieldPath.split('::')[1]
+                            : filter.fieldPath
+
+                        detailFilters[fieldPath] = {
+                            operation: filter.operation,
+                            value: filter.value,
+                        }
                     }
                 }
             })
             actions.setFilters({ detail_filters: detailFilters })
+
+            if (Object.keys(detailFilters).length > 0) {
+                actions.setShowMoreFilters(true)
+            }
         },
+
+        // Handle detail filters from URL
+        loadAvailableFiltersSuccess: () => {
+            const searchParams = router.values.searchParams
+            if (searchParams.detail_filters && values.availableFilters) {
+                try {
+                    const parsedDetailFilters = JSON.parse(searchParams.detail_filters)
+                    const activeFilters = Object.entries(parsedDetailFilters).map(([fieldPath, filter], index) => {
+                        let isCustom = true
+                        let fullFieldPath = fieldPath
+
+                        if (values.availableFilters?.detail_fields) {
+                            // Check General scope first, then other scopes
+                            const scopeEntries = Object.entries(values.availableFilters.detail_fields)
+                            const generalScope = scopeEntries.find(([scope]) => scope === 'General')
+                            const otherScopes = scopeEntries.filter(([scope]) => scope !== 'General')
+
+                            for (const scopeEntry of [generalScope, ...otherScopes].filter(Boolean)) {
+                                const [scope, scopeData] = scopeEntry as [string, ScopeFields]
+                                const fieldExists = scopeData.fields.some(
+                                    (field: DetailField) => field.name === fieldPath
+                                )
+                                if (fieldExists) {
+                                    isCustom = false
+                                    fullFieldPath = `${scope}::${fieldPath}`
+                                    break
+                                }
+                            }
+                        }
+
+                        // If not found in any scope, keep it as custom
+                        if (isCustom) {
+                            fullFieldPath = fieldPath
+                        }
+
+                        return {
+                            key: `url_filter_${index}_${Date.now()}`,
+                            fieldPath: fullFieldPath,
+                            operation: (filter as DetailFilter).operation,
+                            value: (filter as DetailFilter).value,
+                            isCustom,
+                        }
+                    })
+
+                    actions.setActiveFilters(activeFilters)
+                    actions.setShowMoreFilters(true)
+                } catch (e) {
+                    console.error('Failed to parse detail_filters from URL:', e)
+                }
+            }
+        },
+
         exportLogs: async ({ format }) => {
             try {
                 const startDate = values.filters.start_date
@@ -334,13 +390,12 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
                     item_ids: values.filters.item_ids,
                 }
 
-                await api.create(`api/projects/@current/advanced_activity_logs/export/`, {
+                await api.create('api/projects/@current/advanced_activity_logs/export/', {
                     format,
                     filters: filtersToExport,
                 })
 
                 lemonToast.success(`Export started! Your ${format.toUpperCase()} export is being prepared.`)
-
                 actions.loadExports()
                 actions.setActiveTab('exports')
             } catch (error) {
@@ -350,10 +405,86 @@ export const advancedActivityLogsLogic = kea<advancedActivityLogsLogicType>([
         },
     })),
 
+    actionToUrl(({ values }) => ({
+        setFilters: () => {
+            const params = objectClean({
+                ...router.values.searchParams,
+                start_date: values.filters.start_date,
+                end_date: values.filters.end_date,
+                users: values.filters.users?.length ? values.filters.users.join(',') : undefined,
+                scopes: values.filters.scopes?.length ? values.filters.scopes.join(',') : undefined,
+                activities: values.filters.activities?.length ? values.filters.activities.join(',') : undefined,
+                item_ids: values.filters.item_ids?.length ? values.filters.item_ids.join(',') : undefined,
+                was_impersonated: values.filters.was_impersonated?.toString(),
+                is_system: values.filters.is_system?.toString(),
+                detail_filters:
+                    values.filters.detail_filters && Object.keys(values.filters.detail_filters).length > 0
+                        ? JSON.stringify(values.filters.detail_filters)
+                        : undefined,
+                page: values.filters.page && values.filters.page > 1 ? values.filters.page : undefined,
+            })
+
+            return [router.values.location.pathname, params, router.values.hashParams, { replace: true }]
+        },
+    })),
+
+    urlToAction(({ actions }) => ({
+        '/advanced-activity-logs': (_, searchParams) => {
+            const urlFilters: Partial<AdvancedActivityLogFilters> = {}
+
+            if (searchParams.start_date) {
+                urlFilters.start_date = searchParams.start_date
+            }
+            if (searchParams.end_date) {
+                urlFilters.end_date = searchParams.end_date
+            }
+            if (searchParams.users) {
+                urlFilters.users = Array.isArray(searchParams.users)
+                    ? searchParams.users
+                    : searchParams.users?.split(',') || []
+            }
+            if (searchParams.scopes) {
+                urlFilters.scopes = (
+                    Array.isArray(searchParams.scopes) ? searchParams.scopes : searchParams.scopes?.split(',') || []
+                ) as ActivityScope[]
+            }
+            if (searchParams.activities) {
+                urlFilters.activities = Array.isArray(searchParams.activities)
+                    ? searchParams.activities
+                    : searchParams.activities?.split(',') || []
+            }
+            if (searchParams.item_ids) {
+                urlFilters.item_ids = Array.isArray(searchParams.item_ids)
+                    ? searchParams.item_ids
+                    : searchParams.item_ids?.split(',') || []
+            }
+            if (searchParams.was_impersonated !== undefined) {
+                urlFilters.was_impersonated =
+                    searchParams.was_impersonated === 'true' || searchParams.was_impersonated === true
+            }
+            if (searchParams.is_system !== undefined) {
+                urlFilters.is_system = searchParams.is_system === 'true' || searchParams.is_system === true
+            }
+            if (searchParams.detail_filters) {
+                try {
+                    urlFilters.detail_filters = JSON.parse(searchParams.detail_filters)
+                } catch (e) {
+                    console.error('Failed to parse detail_filters from URL:', e)
+                }
+            }
+            if (searchParams.page) {
+                urlFilters.page = parseInt(searchParams.page, 10)
+            }
+
+            if (Object.keys(urlFilters).length > 0) {
+                actions.setFilters(urlFilters)
+            }
+        },
+    })),
+
     events(({ actions, cache }) => ({
         afterMount: () => {
             actions.loadAvailableFilters()
-            actions.loadAdvancedActivityLogs()
             actions.loadExports()
 
             cache.exportPollingInterval = setInterval(() => {

--- a/posthog/api/advanced_activity_logs/field_discovery.py
+++ b/posthog/api/advanced_activity_logs/field_discovery.py
@@ -47,8 +47,6 @@ class AdvancedActivityLogFieldDiscovery:
             "users": self._get_available_users(queryset),
             "scopes": self._get_available_scopes(queryset),
             "activities": self._get_available_activities(queryset),
-            "was_impersonated": self._get_available_was_impersonated(queryset),
-            "is_system": self._get_available_is_system(queryset),
         }
 
     def _get_available_users(self, queryset: QuerySet) -> list[dict[str, str]]:
@@ -194,11 +192,3 @@ class AdvancedActivityLogFieldDiscovery:
                 field_types = ["any"]
             result.append(("General", field_name, field_types))
         return result
-
-    def _get_available_was_impersonated(self, queryset: QuerySet) -> list[dict[str, str]]:
-        was_impersonated_values = queryset.values_list("was_impersonated", flat=True).distinct()
-        return [{"value": str(value).lower(), "label": "Yes" if value else "No"} for value in was_impersonated_values]
-
-    def _get_available_is_system(self, queryset: QuerySet) -> list[dict[str, str]]:
-        is_system_values = queryset.values_list("is_system", flat=True).distinct()
-        return [{"value": str(value).lower(), "label": "Yes" if value else "No"} for value in is_system_values]


### PR DESCRIPTION
## Changes

- Introduces UI<>Query params sync for the filters on the activity log page.
- Example:
```
http://localhost:8010/project/6/advanced-activity-logs?start_date=-7d&was_impersonated=true&is_system=true&item_ids=8%2C878&detail_filters=%7B%22changes%5B%5D.after.add_authorized_domain%22%3A%7B%22operation%22%3A%22contains%22%2C%22value%22%3A%22contains%20this%3F%22%7D%2C%22some.random.value%22%3A%7B%22operation%22%3A%22contains%22%2C%22value%22%3A%22some%20value%22%7D%7D%20&users=019970a5-ba03-0000-29b0-a1cd84f482d2&scopes=OrganizationInvite%2COrganization&activities=created
```

## How did you test this code?

- Manually