### PR TITLE
chore: Change copy to make clear were not consolidating

### DIFF
--- a/frontend/src/scenes/settings/environment/EnvironmentRollbackModal.tsx
+++ b/frontend/src/scenes/settings/environment/EnvironmentRollbackModal.tsx
@@ -20,6 +20,13 @@ function ModalDescription(): JSX.Element {
                 moving environments back to a project-based approach, and we're offering a way to migrate off of the
                 beta.
             </p>
+            <p>
+                Please choose a primary environment and we will preserve the event data from this environment in this
+                existing project. We will also move everything <em>except</em> data from the other environments into
+                this project. But don't worry! We will create new projects for each of the other environments and all
+                your event data will be preserved.
+            </p>
+
             <p className="font-bold">You will not lose any data.</p>
         </div>
     )

--- a/frontend/src/scenes/settings/environment/EnvironmentRollbackModal.tsx
+++ b/frontend/src/scenes/settings/environment/EnvironmentRollbackModal.tsx
@@ -17,8 +17,8 @@ function ModalDescription(): JSX.Element {
             </p>
             <p>
                 You're seeing this because you're using multiple environments per project. As we rollback the beta we're
-                moving environments back to a project-based approach, and we're offering a way to consolidate your
-                environments.
+                moving environments back to a project-based approach, and we're offering a way to migrate off of the
+                beta.
             </p>
             <p className="font-bold">You will not lose any data.</p>
         </div>
@@ -109,7 +109,7 @@ function ModalFooter(): JSX.Element {
                     onClick={submitEnvironmentRollback}
                     disabled={!isReadyToSubmit}
                 >
-                    Separate environments
+                    Separate environments into projects
                 </LemonButton>
             </div>
         </div>


### PR DESCRIPTION
## Problem

- We have clashing statements in the environments rollback modal, one says `consolidate`, the other `separate` (opposites). So we need to clarify.
