### PR TITLE
feat(customers): Dashboard id in url and persisted in localStorage

### DIFF
--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -1,8 +1,9 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
+import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -19,6 +20,7 @@ export interface CustomerDashboard {
 
 export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>([
     path(['scenes', 'customerAnalytics', 'customerAnalyticsScene']),
+    tabAwareScene(),
     connect({
         actions: [
             newDashboardLogic({ initialTags: ['customer-analytics'] }),
@@ -59,10 +61,9 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
     reducers({
         selectedDashboardId: [
             null as number | null,
+            { persist: true },
             {
                 selectDashboard: (_, { dashboardId }) => dashboardId,
-                loadCustomerDashboardsSuccess: (_, { availableDashboards }) =>
-                    availableDashboards.length > 0 ? availableDashboards[0].id : null,
             },
         ],
     }),
@@ -94,7 +95,24 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
             }
         },
     })),
-    afterMount(({ actions }) => {
+    urlToAction(({ actions }) => ({
+        '/customer_analytics': (_, queryParams) => {
+            const id = queryParams?.dashboardId
+            if (id && !isNaN(id)) {
+                actions.selectDashboard(id)
+            }
+        },
+    })),
+    actionToUrl(() => ({
+        selectDashboard: ({ dashboardId }) => {
+            const params = dashboardId ? { dashboardId: dashboardId.toString() } : {}
+            return ['/customer_analytics', params]
+        },
+    })),
+    afterMount(({ actions, values }) => {
         actions.loadCustomerDashboards()
+        if (values.selectedDashboardId) {
+            actions.selectDashboard(values.selectedDashboardId)
+        }
     }),
 ])


### PR DESCRIPTION
## Problem
It wasn't possible to share the url to a specific dashboard in customer analytics. Additionally, it would always open the first insight in alphabetical order.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/38388
## Changes
- Persist last viewed dashboard id in localStorage and reopen it when accessing the page again
- Add dashboard id to url and read from it to open specific dashboards
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
