### PR TITLE
fix(sql-editor): insight scene query setter

### DIFF
--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -54,9 +54,10 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
 
     const actuallyShowQueryEditor = insightMode === ItemMode.Edit && showQueryEditor
 
-    const setQuery = (query: Node, isSourceUpdate?: boolean): void => {
-        if (!isInsightVizNode(query) || isSourceUpdate) {
-            setInsightQuery(query)
+    const setQuery = (q: Node | ((q: Node) => Node), isSourceUpdate?: boolean): void => {
+        let node = typeof q === 'function' ? (query ? q(query) : null) : q
+        if (!isInsightVizNode(node) || isSourceUpdate) {
+            setInsightQuery(node)
         }
     }
 


### PR DESCRIPTION
## Problem

Some DW queries freeze dashboards.

## Changes

I traced a bad `setQuery` call to the modified lines. Hopefully parsing the argument here like this solves it. 

## How did you test this code?

Didn't test much, as I couldn't replicate this locally.