### PR TITLE
fix(rust): fix redpanda docker-compose port cfg and misc. Rust workspace lints

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -155,7 +155,7 @@ services:
         restart: on-failure
         environment:
             KAFKA_CLUSTERS_0_NAME: local
-            KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+            KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: localhost:9092
             KAFKA_CLUSTERS_0_SCHEMAREGISTRY: http://kafka:8081
             DYNAMIC_CONFIG_ENABLED: 'true'
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -128,8 +128,7 @@ services:
         command:
             - redpanda
             - start
-            - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
-            - --advertise-kafka-addr internal://kafka:9092,external://localhost:19092
+            - --kafka-addr 0.0.0.0:9092
             - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
             - --advertise-pandaproxy-addr internal://kafka:8082,external://localhost:18082
             - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1439,7 +1439,6 @@ dependencies = [
  "dateparser",
  "envconfig",
  "flate2",
- "futures",
  "health",
  "jiff",
  "limiters",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -57,7 +57,6 @@ regex = { workspace = true }
 assert-json-diff = { workspace = true }
 anyhow = { workspace = true }
 axum-test-helper = { git = "https://github.com/posthog/axum-test-helper.git" }
-futures = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 rdkafka = { workspace = true }

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -296,7 +296,7 @@ impl MockRedisClient {
     }
 
     // Helper method to safely lock the calls mutex
-    fn lock_calls(&self) -> std::sync::MutexGuard<Vec<MockRedisCall>> {
+    fn lock_calls(&self) -> std::sync::MutexGuard<'_, Vec<MockRedisCall>> {
         match self.calls.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),


### PR DESCRIPTION
## Problem
Rust workspace tests in local dev are having trouble routing to the new `redpanda` Kafka container in docker compose. 

## Changes
* Updated `--kafka-addr` to sort out local routing issue
* Misc. small updates to Rust workspace tests (linter, warnings etc.)

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
