### PR TITLE
feat: enable flexible branching rules for rating questions

### DIFF
--- a/frontend/src/scenes/surveys/components/question-branching/QuestionBranchingInput.tsx
+++ b/frontend/src/scenes/surveys/components/question-branching/QuestionBranchingInput.tsx
@@ -75,7 +75,7 @@ export function QuestionBranchingInput({
         ...(hasResponseBasedBranching
             ? [
                   {
-                      label: 'Specific question based on answer',
+                      label: 'Custom branching based on answer',
                       value: SurveyQuestionBranchingType.ResponseBased,
                   },
               ]
@@ -140,38 +140,27 @@ function getResponseConfiguration(
     question: RatingSurveyQuestion | MultipleSurveyQuestion
 ): { value: string | number; label: string }[] {
     if (question.type === SurveyQuestionType.Rating) {
-        // Handle different rating scales with appropriate groupings
-        switch (question.scale) {
-            case 3:
-                return [
-                    { value: 'negative', label: '1 (Negative)' },
-                    { value: 'neutral', label: '2 (Neutral)' },
-                    { value: 'positive', label: '3 (Positive)' },
-                ]
-            case 5:
-                return [
-                    { value: 'negative', label: '1 to 2 (Negative)' },
-                    { value: 'neutral', label: '3 (Neutral)' },
-                    { value: 'positive', label: '4 to 5 (Positive)' },
-                ]
-            case 7:
-                return [
-                    { value: 'negative', label: '1 to 3 (Negative)' },
-                    { value: 'neutral', label: '4 (Neutral)' },
-                    { value: 'positive', label: '5 to 7 (Positive)' },
-                ]
-            case 10:
-                // NPS scale with standard categories
-                return [
-                    { value: 'detractors', label: `0 to 6 (${NPS_DETRACTOR_LABEL})` },
-                    { value: 'passives', label: `7 to 8 (${NPS_PASSIVE_LABEL})` },
-                    { value: 'promoters', label: `9 to 10 (${NPS_PROMOTER_LABEL})` },
-                ]
-            default:
-                return []
+        const maxRating = question.scale === 10 ? 10 : question.scale
+        const minRating = question.scale === 10 ? 0 : 1
+
+        const options = []
+        for (let i = minRating; i <= maxRating; i++) {
+            options.push({
+                value: i,
+                label: `${i}`,
+            })
         }
+
+        if (question.scale === 10) {
+            options.push(
+                { value: 'detractors', label: `0 to 6 (${NPS_DETRACTOR_LABEL})` },
+                { value: 'passives', label: `7 to 8 (${NPS_PASSIVE_LABEL})` },
+                { value: 'promoters', label: `9 to 10 (${NPS_PROMOTER_LABEL})` }
+            )
+        }
+
+        return options
     } else if (question.type === SurveyQuestionType.SingleChoice) {
-        // Map each choice to its index for branching
         return question.choices.map((choice, choiceIndex) => ({
             value: choiceIndex,
             label: `Option ${choiceIndex + 1} ("${truncate(choice, 15)}")`,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1537,15 +1537,18 @@ export const surveyLogic = kea<surveyLogicType>([
                     return SurveyQuestionBranchingType.NextQuestion
                 }
 
-                // If a value is mapped onto an integer, we're redirecting to a specific question
-                if (Number.isInteger(question.branching.responseValues[response])) {
-                    const nextQuestionIndex = question.branching.responseValues[response]
-                    return `${SurveyQuestionBranchingType.SpecificQuestion}:${nextQuestionIndex}`
+                const responseValue = question.branching.responseValues[response]
+
+                // If responseValue exists and is a number, it could be either:
+                // 1. A rating value (1, 2, 3, etc.) mapping to a question index
+                // 2. A choice index for SingleChoice questions mapping to a question index
+                if (typeof responseValue === 'number') {
+                    return `${SurveyQuestionBranchingType.SpecificQuestion}:${responseValue}`
                 }
 
-                // If any other value is present (practically only Confirmation message), return that value
-                if (question.branching?.responseValues?.[response]) {
-                    return question.branching.responseValues[response]
+                // If any other value is present (string values like "end", "next_question", etc.)
+                if (responseValue) {
+                    return responseValue
                 }
 
                 // No branching specified, default to Next question / Confirmation message


### PR DESCRIPTION
### changes

- **Frontend**: Modified `QuestionBranchingInput.tsx` to generate individual rating options (1,2,3,etc.) instead of fixed categories
- **Frontend**: Updated `surveyLogic.tsx` to handle numeric rating values in branching logic  
- **UI**: Changed "Specific question based on answer" to "Custom branching based on answer" for clarity

fixes: #38510


- For a 5-scale rating question, users can now set:
- Rating 1 → Go to Question 3
- Rating 2 → Go to Question 4  
- Rating 3 → End survey
- Rating 4 → Go to Question 5
- Rating 5 → Go to Question 6

### How did you test this code?

- Tested rating options generation for 3, 5, 7, and 10-scale questions
- Verified individual rating values (1,2,3,etc.) map to specific questions correctly
- Confirmed existing surveys still work with old categories
- Checked the new UI label displays properly