### PR TITLE
feat(experiment): improve flag persistence field

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -304,6 +304,7 @@ export const FEATURE_FLAGS = {
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     ADVANCED_ACTIVITY_LOGS: 'advanced-activity-logs', // owner: @yasen-posthog #team-platform-features
     SIMPLIFIED_PRELAUNCH_CHECKLIST: 'simplified-prelaunch-checklist', // owner: @jurajmajerik #team-experiments
+    EXPERIMENT_FORM_PERSISTENCE_FIELD: 'experiment-form-persistence-field', // owner: @jurajmajerik #team-experiments multivariate
     HOW_TO_READ_METRICS_EXPLANATION: 'how-to-read-metrics-explanation', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_TIMESERIES: 'experiment-timeseries', // owner: @jurajmajerik #team-experiments
     DASHBOARD_TILE_OVERRIDES: 'dashboard-tile-overrides', // owner: @gesh #team-product-analytics

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -157,7 +157,7 @@ const ExperimentFormFields = (): JSX.Element => {
                     <SceneSection
                         title="Experiment type"
                         description="Select your experiment setup, this cannot be changed once saved."
-                        className={cn('gap-y-0 mt-6')}
+                        className={cn('mt-6')}
                     >
                         <LemonRadio
                             value={experiment.type}
@@ -196,7 +196,7 @@ const ExperimentFormFields = (): JSX.Element => {
                     <SceneSection
                         title="Participant type"
                         description="Determines on what level you want to aggregate metrics. You can change this later, but flag values for users will change so you need to reset the experiment for accurate results."
-                        className={cn('gap-y-0 mt-6')}
+                        className={cn('mt-6')}
                     >
                         <LemonRadio
                             value={

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form, Group } from 'kea-forms'
 import { useState } from 'react'
 
-import { IconPlusSmall, IconToggle, IconTrash } from '@posthog/icons'
+import { IconInfo, IconLock, IconPlusSmall, IconToggle, IconTrash, IconX } from '@posthog/icons'
 import {
     LemonBanner,
     LemonCheckbox,
@@ -16,12 +16,14 @@ import {
 
 import { ExperimentVariantNumber } from 'lib/components/SeriesGlyph'
 import { MAX_EXPERIMENT_VARIANTS } from 'lib/constants'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { GroupsAccessStatus, groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -45,6 +47,7 @@ const ExperimentFormFields = (): JSX.Element => {
         useActions(experimentLogic)
     const { webExperimentsAvailable, unavailableFeatureFlagKeys } = useValues(experimentsLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
+    const { featureFlags } = useValues(enabledFeaturesLogic)
 
     const { reportExperimentFeatureFlagModalOpened, reportExperimentFeatureFlagSelected } = useActions(eventUsageLogic)
 
@@ -341,31 +344,116 @@ const ExperimentFormFields = (): JSX.Element => {
                     </SceneSection>
                     <SceneDivider />
                     <div className={cn('mt-6 pb-2 max-w-150 mt-0 pb-0')}>
-                        <LemonField name="parameters.ensure_experience_continuity">
-                            {({ value, onChange }) => (
-                                <label className="border rounded p-4 group" htmlFor="continuity-checkbox">
-                                    <LemonCheckbox
-                                        id="continuity-checkbox"
-                                        label="Persist flag across authentication steps"
-                                        onChange={() => onChange(!value)}
-                                        fullWidth
-                                        checked={value}
-                                    />
-                                    <div className="text-secondary text-sm pl-6">
-                                        If your feature flag is evaluated for anonymous users, use this option to ensure
-                                        the flag value remains consistent after the user logs in. Depending on your
-                                        setup, this option may not always be appropriate. Note that this feature
-                                        requires creating profiles for anonymous users.{' '}
-                                        <Link
-                                            to="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
-                                            target="_blank"
+                        {featureFlags[FEATURE_FLAGS.EXPERIMENT_FORM_PERSISTENCE_FIELD] === 'test' ? (
+                            <SceneSection
+                                title={
+                                    <span className="flex items-center gap-2">
+                                        Variant persistence
+                                        <Tooltip
+                                            title={
+                                                <span>
+                                                    Only relevant if your experiment targets users transitioning from
+                                                    anonymous to logged-in. Persistence requires PostHog servers to
+                                                    perform the check and is incompatible with server-side local
+                                                    evaluation. Learn more in the{' '}
+                                                    <Link
+                                                        to="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
+                                                        target="_blank"
+                                                        className="text-white underline"
+                                                    >
+                                                        documentation
+                                                    </Link>
+                                                    .
+                                                </span>
+                                            }
                                         >
-                                            Learn more
-                                        </Link>
-                                    </div>
-                                </label>
-                            )}
-                        </LemonField>
+                                            <IconInfo className="text-secondary text-lg" />
+                                        </Tooltip>
+                                    </span>
+                                }
+                                description="Choose how experiment variants are handled when users authenticate"
+                            >
+                                <LemonField name="parameters.ensure_experience_continuity">
+                                    {({ value, onChange }) => {
+                                        const currentValue = value ?? false
+                                        return (
+                                            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 max-w-160">
+                                                {[
+                                                    {
+                                                        value: false,
+                                                        icon: <IconX />,
+                                                        title: 'Disabled (default)',
+                                                        description: 'Users may see different variants after login.',
+                                                    },
+                                                    {
+                                                        value: true,
+                                                        icon: <IconLock />,
+                                                        title: 'Persist across authentication',
+                                                        description:
+                                                            'Same variant before and after login. Incompatible with server-side flag evaluation.',
+                                                    },
+                                                ].map((option) => (
+                                                    <div
+                                                        key={option.value.toString()}
+                                                        className={`border rounded-lg p-4 cursor-pointer transition-all hover:border-primary-light ${
+                                                            currentValue === option.value
+                                                                ? 'border-primary bg-primary-highlight'
+                                                                : 'border-border'
+                                                        }`}
+                                                        onClick={() => onChange(option.value)}
+                                                    >
+                                                        <div className="flex items-start gap-3">
+                                                            <div className="text-lg text-muted">{option.icon}</div>
+                                                            <div className="flex-1">
+                                                                <div className="font-medium text-sm">
+                                                                    {option.title}
+                                                                </div>
+                                                                <div className="text-xs text-muted mt-1">
+                                                                    {option.description}
+                                                                </div>
+                                                            </div>
+                                                            <input
+                                                                type="radio"
+                                                                name="persistence-mode"
+                                                                checked={currentValue === option.value}
+                                                                onChange={() => onChange(option.value)}
+                                                                className="cursor-pointer"
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )
+                                    }}
+                                </LemonField>
+                            </SceneSection>
+                        ) : (
+                            <LemonField name="parameters.ensure_experience_continuity">
+                                {({ value, onChange }) => (
+                                    <label className="border rounded p-4 group" htmlFor="continuity-checkbox">
+                                        <LemonCheckbox
+                                            id="continuity-checkbox"
+                                            label="Persist flag across authentication steps"
+                                            onChange={() => onChange(!value)}
+                                            fullWidth
+                                            checked={value}
+                                        />
+                                        <div className="text-secondary text-sm pl-6">
+                                            If your feature flag is evaluated for anonymous users, use this option to
+                                            ensure the flag value remains consistent after the user logs in. Depending
+                                            on your setup, this option may not always be appropriate. Note that this
+                                            feature requires creating profiles for anonymous users.{' '}
+                                            <Link
+                                                to="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
+                                                target="_blank"
+                                            >
+                                                Learn more
+                                            </Link>
+                                        </div>
+                                    </label>
+                                )}
+                            </LemonField>
+                        )}
                     </div>
                 </>
             )}

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -392,31 +392,29 @@ const ExperimentFormFields = (): JSX.Element => {
                                                         description:
                                                             'Same variant before and after login. Incompatible with server-side flag evaluation.',
                                                     },
-                                                ].map((option) => (
+                                                ].map(({ value, icon, title, description }) => (
                                                     <div
-                                                        key={option.value.toString()}
+                                                        key={value.toString()}
                                                         className={`border rounded-lg p-4 cursor-pointer transition-all hover:border-primary-light ${
-                                                            currentValue === option.value
+                                                            currentValue === value
                                                                 ? 'border-primary bg-primary-highlight'
                                                                 : 'border-border'
                                                         }`}
-                                                        onClick={() => onChange(option.value)}
+                                                        onClick={() => onChange(value)}
                                                     >
                                                         <div className="flex items-start gap-3">
-                                                            <div className="text-lg text-muted">{option.icon}</div>
+                                                            <div className="text-lg text-muted">{icon}</div>
                                                             <div className="flex-1">
-                                                                <div className="font-medium text-sm">
-                                                                    {option.title}
-                                                                </div>
+                                                                <div className="font-medium text-sm">{title}</div>
                                                                 <div className="text-xs text-muted mt-1">
-                                                                    {option.description}
+                                                                    {description}
                                                                 </div>
                                                             </div>
                                                             <input
                                                                 type="radio"
                                                                 name="persistence-mode"
-                                                                checked={currentValue === option.value}
-                                                                onChange={() => onChange(option.value)}
+                                                                checked={currentValue === value}
+                                                                onChange={() => onChange(value)}
                                                                 className="cursor-pointer"
                                                             />
                                                         </div>


### PR DESCRIPTION
## Problem
The `Persist flag across authentication steps` field in the experiment form is verbose and might create friction for most users who don't need this feature.

## Changes
Added a new radio button UI with cleaner "variant persistence" copy and a tooltip. Releasing this as an experiment to track impact on the `Experiment created` event: https://us.posthog.com/project/2/experiments/168558

## How did you test this code?
|`control`|`test`|
|----|----|
|<img width="630" height="220" alt="image" src="https://github.com/user-attachments/assets/4f1aa5e9-d745-41b8-a7ed-17bcc59bb67c" />|<img width="630" height="252" alt="image" src="https://github.com/user-attachments/assets/8173b4ab-c57c-4140-9015-d0cd1164812b" />|