### PR TITLE
fix(messaging): fix coming soon destinations showing up + rename "actions" -> "dispatch"

### DIFF
--- a/products/messaging/frontend/Campaigns/CampaignWorkflow.tsx
+++ b/products/messaging/frontend/Campaigns/CampaignWorkflow.tsx
@@ -9,7 +9,7 @@ export function CampaignWorkflow(props: CampaignLogicProps): JSX.Element {
     const { originalCampaign, campaignLoading } = useValues(campaignLogic(props))
 
     return (
-        <div className="relative border rounded-md h-[calc(100vh-210px)]">
+        <div className="relative border rounded-md h-[calc(100vh-280px)]">
             <BindLogic logic={campaignLogic} props={props}>
                 {!originalCampaign && campaignLoading ? <SpinnerOverlay /> : <HogFlowEditor />}
             </BindLogic>

--- a/products/messaging/frontend/Campaigns/CampaignsTable.tsx
+++ b/products/messaging/frontend/Campaigns/CampaignsTable.tsx
@@ -96,7 +96,7 @@ export function CampaignsTable(): JSX.Element {
             },
         },
         {
-            title: 'Actions',
+            title: 'Dispatches',
             width: 0,
             render: (_, item) => {
                 return <CampaignActionsSummary campaign={item} />

--- a/products/messaging/frontend/Campaigns/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -213,7 +213,7 @@ function HogFunctionTemplatesChooser(): JSX.Element {
                         <LemonInput
                             placeholder="Search..."
                             value={filters.search ?? ''}
-                            onChange={(e) => setFilters({ search: e })}
+                            onChange={(e) => setFilters({ ...filters, search: e })}
                             autoFocus
                         />
 
@@ -250,7 +250,7 @@ function HogFunctionTemplatesChooser(): JSX.Element {
                 }
             >
                 <LemonButton fullWidth onClick={() => setPopoverOpen(!popoverOpen)}>
-                    More actions
+                    More
                 </LemonButton>
             </LemonDropdown>
         </div>
@@ -261,7 +261,7 @@ export function HogFlowEditorPanelBuild(): JSX.Element {
     return (
         <div className="flex overflow-y-auto flex-col gap-px p-2">
             <span className="flex gap-2 text-sm font-semibold mt-2 items-center">
-                Actions <LemonDivider className="flex-1" />
+                Dispatch <LemonDivider className="flex-1" />
             </span>
             {ACTION_NODES_TO_SHOW.map((node, index) => (
                 <HogFlowEditorToolbarNode key={`${node.type}-${index}`} action={node} />


### PR DESCRIPTION

## Problem

- We're overloading the term "Actions", so renaming to "Dispatch"/"Dispatches" for now
- Coming soon destinations are showing up in prod when searching, I think introduced with https://github.com/PostHog/posthog/pull/37749

## Changes


https://github.com/user-attachments/assets/3da565a4-fb25-4b1a-8436-218ee58f242c



## How did you test this code?

See above