### PR TITLE
fix(data-warehouse): Fix some dashboards not loading properly and borking chrome windows

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -257,7 +257,11 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             ['loadData'],
         ],
     })),
-    propsChanged(({ actions, values, props }) => {
+    propsChanged(({ actions, values, props }, oldProps) => {
+        if (JSON.stringify(props) === JSON.stringify(oldProps)) {
+            return
+        }
+
         if (props.query && !objectsEqual(props.query, values.query)) {
             actions._setQuery(props.query)
         }


### PR DESCRIPTION
## Problem
- We're getting stuck in an infinite loop when loading some dashboards that use `DataVisualizationNodes`
- context: https://posthog.slack.com/archives/C02E3BKC78F/p1758645579269849

## Changes
- Check if the props change, if they dont, then dont bother doing anything
- This is broken because even though the `props.query` and `values.query` are semantically the same, one has default values set for missing objects, example below:

**`props.query` (without defaults)**
<img width="289" height="103" alt="image" src="https://github.com/user-attachments/assets/93fcc469-7a9f-4cdb-a515-12b9b19d155d" />

**`values.query` (with defaults):**
<img width="397" height="138" alt="image" src="https://github.com/user-attachments/assets/841b5861-c3da-472f-ac3c-5521679d9b13" />

