### PR TITLE
fix(sql-editor): bandaid for subscriptions

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
@@ -166,8 +166,6 @@ describe('seriesBreakdownLogic', () => {
             chartSettings: {
                 goalLines: undefined,
                 seriesBreakdownColumn: 'test_column',
-                xAxis: undefined,
-                yAxis: [],
             },
         })
     })


### PR DESCRIPTION
## Problem

Subscriptions are causing the `dataVisualizationLogic` to update in a loop.

## Changes

Swap them out for shared listeners. Avoid listening on the `_setQuery` action.

## How did you test this code?

Clicked around locally, opened, edited, changed the SQL, looked it on dashboards. Everything was fine.