### PR TITLE
fix: fix local 8010 on linux

### DIFF
--- a/bin/start-backend
+++ b/bin/start-backend
@@ -12,4 +12,8 @@ export CLICKHOUSE_APP_PASSWORD="apppass"
 # Suppress frozen modules warning since we only debug our code, not stdlib
 export PYDEVD_DISABLE_FILE_VALIDATION=1
 
-python ${DEBUG:+ -m debugpy --listen 127.0.0.1:5678} -m uvicorn --reload posthog.asgi:application --host 127.0.0.1 --log-level debug --reload-include "posthog/" --reload-include "ee/" --reload-include "products/"
+# Bind to Docker bridge gateway IP for container access while maintaining security
+DOCKER_GATEWAY_IP=$(docker network inspect bridge --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}' 2>/dev/null || echo "172.17.0.1")
+echo "🐳 Using Docker bridge gateway for host access: $DOCKER_GATEWAY_IP"
+
+python ${DEBUG:+ -m debugpy --listen 127.0.0.1:5678} -m uvicorn --reload posthog.asgi:application --host $DOCKER_GATEWAY_IP --log-level debug --reload-include "posthog/" --reload-include "ee/" --reload-include "products/"

--- a/bin/start-backend
+++ b/bin/start-backend
@@ -12,8 +12,17 @@ export CLICKHOUSE_APP_PASSWORD="apppass"
 # Suppress frozen modules warning since we only debug our code, not stdlib
 export PYDEVD_DISABLE_FILE_VALIDATION=1
 
-# Bind to Docker bridge gateway IP for container access while maintaining security
-DOCKER_GATEWAY_IP=$(docker network inspect bridge --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}' 2>/dev/null || echo "172.17.0.1")
-echo "🐳 Using Docker bridge gateway for host access: $DOCKER_GATEWAY_IP"
+# Cross-platform Docker host access
+# On macOS/Windows: Docker runs in a VM, use 127.0.0.1 for the host bind
+# On Linux: Use bridge gateway IP for container access while maintaining security
+if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "msys" ]]; then
+    HOST_BIND="127.0.0.1"
+    echo "🍎 macOS/Windows detected, using secure localhost binding"
+else
+    # Linux - containers cannot reach host's 127.0.0.1, use bridge gateway
+    DOCKER_GATEWAY_IP=$(docker network inspect bridge --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}' 2>/dev/null || echo "172.17.0.1")
+    HOST_BIND="$DOCKER_GATEWAY_IP"
+    echo "🐧 Linux detected, binding to Docker bridge gateway: $HOST_BIND"
+fi
 
-python ${DEBUG:+ -m debugpy --listen 127.0.0.1:5678} -m uvicorn --reload posthog.asgi:application --host $DOCKER_GATEWAY_IP --log-level debug --reload-include "posthog/" --reload-include "ee/" --reload-include "products/"
+python ${DEBUG:+ -m debugpy --listen 127.0.0.1:5678} -m uvicorn --reload posthog.asgi:application --host $HOST_BIND --log-level debug --reload-include "posthog/" --reload-include "ee/" --reload-include "products/"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
             file: docker-compose.base.yml
             service: proxy
         ports:
-            - 8010:8000
+            - 127.0.0.1:8010:8000
         extra_hosts:
             - 'web:host-gateway'
             - 'plugins:host-gateway'


### PR DESCRIPTION
## Problem
tom's security fix (binding to 127.0.0.1) worked on mac but broke port 8010 on linux because of how docker works differently on each platform. on mac, docker desktop runs in a vm that automatically handles host-gateway access to 127.0.0.1. on linux, docker runs natively with a bridge network and containers can't reach the host's 127.0.0.1.

https://github.com/PostHog/posthog/pull/38036

## Changes
the fix uses platform-specific binding - mac keeps the secure 127.0.0.1 binding since it works with docker desktop, while linux binds to the docker bridge gateway ip which is both secure and accessible from containers. this keeps tom's security improvement while making the proxy work on both platforms.

## How did you test this code?
Tested it on both linux and mac. There is no change for mac os. 
