### PR TITLE
feat(experiments): add breakdown button to metric header.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -312,6 +312,7 @@ export const FEATURE_FLAGS = {
     RECORDINGS_PLAYER_EVENT_PROPERTY_EXPANSION: 'recordings-player-event-property-expansion', // owner: @pauldambra #team-replay
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     SEEKBAR_PREVIEW_SCRUBBING: 'seekbar-preview-scrubbing', // owner: @pauldambra #team-replay
+    EXPERIMENTS_BREAKDOWN_FILTER: 'experiments-breakdown-filter', // owner: @rodrigoi #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
@@ -555,6 +555,7 @@ export function DeltaChart({
     const metricTitlePanel = (
         <MetricHeader
             displayOrder={displayOrder}
+            experiment={experiment}
             metric={metric}
             metricType={metricType}
             isPrimaryMetric={!isSecondary}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -221,6 +221,7 @@ export function MetricRowGroup({
                         metric={metric}
                         metricType={metricType}
                         isPrimaryMetric={!isSecondary}
+                        experiment={experiment}
                         onDuplicateMetricClick={() => onDuplicateMetric?.()}
                     />
                 </td>
@@ -309,6 +310,7 @@ export function MetricRowGroup({
                         metric={metric}
                         metricType={metricType}
                         isPrimaryMetric={!isSecondary}
+                        experiment={experiment}
                         onDuplicateMetricClick={() => onDuplicateMetric?.()}
                     />
                 </td>

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonDialog, LemonDropdown, LemonTag } from '@posthog/lemo
 
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { METRIC_CONTEXTS, experimentMetricModalLogic } from 'scenes/experiments/Metrics/experimentMetricModalLogic'
 import { modalsLogic } from 'scenes/experiments/modalsLogic'
 import { urls } from 'scenes/urls'
@@ -93,6 +94,8 @@ export const MetricHeader = ({
     experiment: Experiment
     onDuplicateMetricClick: (metric: ExperimentMetric) => void
 }): JSX.Element => {
+    const showBreakdownFilter = useFeatureFlag('EXPERIMENTS_BREAKDOWN_FILTER')
+
     /**
      * This is a bit overkill, since primary and secondary metric dialogs are
      * identical.
@@ -210,20 +213,22 @@ export const MetricHeader = ({
                     )}
                 </div>
             </div>
-            <div className="flex justify-end items-end">
-                <AddBreakdownButton
-                    experiment={experiment}
-                    onChange={(breakdown) => {
-                        /**
-                         * TODO: Handle the breakdown selection
-                         * this is to please the eslint gods
-                         */
-                        if (breakdown) {
-                            return
-                        }
-                    }}
-                />
-            </div>
+            {showBreakdownFilter && (
+                <div className="flex justify-end items-end">
+                    <AddBreakdownButton
+                        experiment={experiment}
+                        onChange={(breakdown) => {
+                            /**
+                             * TODO: Handle the breakdown selection
+                             * this is to please the eslint gods
+                             */
+                            if (breakdown) {
+                                return
+                            }
+                        }}
+                    />
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -1,28 +1,87 @@
 import { useActions } from 'kea'
+import { useState } from 'react'
 
-import { IconCopy, IconPencil } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonTag } from '@posthog/lemon-ui'
+import { IconCopy, IconPencil, IconPlusSmall } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonDropdown, LemonTag } from '@posthog/lemon-ui'
 
+import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { METRIC_CONTEXTS, experimentMetricModalLogic } from 'scenes/experiments/Metrics/experimentMetricModalLogic'
 import { modalsLogic } from 'scenes/experiments/modalsLogic'
 import { urls } from 'scenes/urls'
 
-import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import type { EventsNode, ExperimentMetric } from '~/queries/schema/schema-general'
+import { NodeKind } from '~/queries/schema/schema-general'
+import type { Experiment } from '~/types'
 
 import { MetricTitle } from './MetricTitle'
 import { getMetricTag } from './utils'
+
+// Helper function to get the exposure event from experiment
+const getExposureEvent = (experiment: Experiment): string => {
+    return experiment.exposure_criteria?.exposure_config?.event || '$feature_flag_called'
+}
+
+// AddBreakdownButton component for event property breakdowns
+const AddBreakdownButton = ({
+    experiment,
+    onChange,
+}: {
+    experiment: Experiment
+    onChange: (breakdown: { type: string; property: any }) => void
+}): JSX.Element => {
+    const [dropdownOpen, setDropdownOpen] = useState(false)
+
+    // Create metadata source for the exposure event to filter properties
+    const exposureEvent = getExposureEvent(experiment)
+    const metadataSource: EventsNode = {
+        kind: NodeKind.EventsNode,
+        event: exposureEvent,
+    }
+
+    return (
+        <LemonDropdown
+            overlay={
+                <TaxonomicFilter
+                    onChange={(taxonomicGroup, value) => {
+                        onChange({ type: 'event', property: value })
+                        setDropdownOpen(false)
+                    }}
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.PersonProperties,
+                    ]}
+                    metadataSource={metadataSource}
+                />
+            }
+            visible={dropdownOpen}
+            onClickOutside={() => setDropdownOpen(false)}
+        >
+            <LemonButton
+                type="secondary"
+                size="xsmall"
+                icon={<IconPlusSmall />}
+                onClick={() => setDropdownOpen(!dropdownOpen)}
+            >
+                Add breakdown
+            </LemonButton>
+        </LemonDropdown>
+    )
+}
 
 export const MetricHeader = ({
     displayOrder,
     metric,
     metricType,
     isPrimaryMetric,
+    experiment,
     onDuplicateMetricClick,
 }: {
     displayOrder?: number
     metric: any
     metricType: any
     isPrimaryMetric: boolean
+    experiment: Experiment
     onDuplicateMetricClick: (metric: ExperimentMetric) => void
 }): JSX.Element => {
     /**
@@ -44,7 +103,7 @@ export const MetricHeader = ({
     const { openExperimentMetricModal } = useActions(experimentMetricModalLogic)
 
     return (
-        <div className="text-xs font-semibold">
+        <div className="text-xs font-semibold flex flex-col justify-between h-full">
             <div className="deprecated-space-y-1">
                 <div className="flex items-start justify-between gap-2 min-w-0">
                     <div className="text-xs font-semibold flex items-start min-w-0 flex-1">
@@ -141,6 +200,14 @@ export const MetricHeader = ({
                         </LemonTag>
                     )}
                 </div>
+            </div>
+            <div className="flex justify-end items-end">
+                <AddBreakdownButton
+                    experiment={experiment}
+                    onChange={(breakdown) => {
+                        // TODO: Handle the breakdown selection
+                    }}
+                />
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -29,8 +29,17 @@ const AddBreakdownButton = ({
 }: {
     experiment: Experiment
     onChange: (breakdown: { type: string; property: any }) => void
-}): JSX.Element => {
+}): JSX.Element | null => {
     const [dropdownOpen, setDropdownOpen] = useState(false)
+
+    /**
+     * bail if we don't have an experiment
+     * this could happen if the experiment has not been loaded yet
+     * or if we are in the legacy experiment view
+     */
+    if (!experiment) {
+        return null
+    }
 
     // Create metadata source for the exposure event to filter properties
     const exposureEvent = getExposureEvent(experiment)
@@ -43,7 +52,7 @@ const AddBreakdownButton = ({
         <LemonDropdown
             overlay={
                 <TaxonomicFilter
-                    onChange={(taxonomicGroup, value) => {
+                    onChange={(_, value) => {
                         onChange({ type: 'event', property: value })
                         setDropdownOpen(false)
                     }}
@@ -205,7 +214,13 @@ export const MetricHeader = ({
                 <AddBreakdownButton
                     experiment={experiment}
                     onChange={(breakdown) => {
-                        // TODO: Handle the breakdown selection
+                        /**
+                         * TODO: Handle the breakdown selection
+                         * this is to please the eslint gods
+                         */
+                        if (breakdown) {
+                            return
+                        }
                     }}
                 />
             </div>


### PR DESCRIPTION
## Problem

Include in the metric header an option to add an event property breakdown.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding a new `AddBreakdownButton` to the Metric header, as the first step of enabling this feature. Next step is to persist the breakdowns and display them on the UI.

| Add breakdown button |
| - |
| ![add breakdown](https://github.com/user-attachments/assets/d9b9681f-8f26-4cc0-a2a1-69c4fdf1f35c) |

> [!IMPORTANT]
> This is hidden behind the `experiments-breakdown-filter` that has to be disabled so no user is exposed to this.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/4737bc72-5cac-4978-902d-557b22023d4c)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
