### PR TITLE
fix(msg): implement cdp input sanitization through messaging

### DIFF
--- a/products/messaging/frontend/Campaigns/hogflows/steps/StepFunction.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/steps/StepFunction.tsx
@@ -1,5 +1,7 @@
 import { useActions, useValues } from 'kea'
 
+import { sanitizeInputs } from 'scenes/hog-functions/configuration/hogFunctionConfigurationLogic'
+
 import { CyclotronJobInputType } from '~/types'
 
 import { campaignLogic } from '../../campaignLogic'
@@ -8,12 +10,17 @@ import { StepSchemaErrors } from './components/StepSchemaErrors'
 import { StepFunctionNode } from './hogFunctionStepLogic'
 
 export function StepFunctionConfiguration({ node }: { node: StepFunctionNode }): JSX.Element {
-    const { actionValidationErrorsById } = useValues(campaignLogic)
+    const { actionValidationErrorsById, hogFunctionTemplatesById } = useValues(campaignLogic)
     const { partialSetCampaignActionConfig } = useActions(campaignLogic)
 
     const templateId = node.data.config.template_id
     const validationResult = actionValidationErrorsById[node.id]
     const inputs = node.data.config.inputs as Record<string, CyclotronJobInputType>
+
+    const setInputs = (inputs: Record<string, CyclotronJobInputType>): void => {
+        const { inputs_schema } = hogFunctionTemplatesById[node.data.config.template_id]
+        partialSetCampaignActionConfig(node.id, { inputs: sanitizeInputs({ inputs_schema, inputs }) })
+    }
 
     return (
         <>
@@ -21,7 +28,7 @@ export function StepFunctionConfiguration({ node }: { node: StepFunctionNode }):
             <HogFlowFunctionConfiguration
                 templateId={templateId}
                 inputs={inputs}
-                setInputs={(inputs) => partialSetCampaignActionConfig(node.id, { inputs })}
+                setInputs={setInputs}
                 errors={validationResult?.errors}
             />
         </>


### PR DESCRIPTION
## Problem

Fields that need sanitization (secret and json fields) are currently broken through messaging.

## Changes

- Implement the same sanitization through the same function
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
