### PR TITLE
fix: use crontab instead of relative scheduling

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -106,11 +106,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="warm team access caches",
     )
 
-    add_periodic_task_with_expiry(
-        sender,
-        60 * 60,  # hourly
+    sender.add_periodic_task(
+        crontab(hour="*", minute="0"),  # hourly
         enforce_max_replay_retention_period.s(),
-        "hourly enforce max replay retention period",
+        name="hourly enforce max replay retention period",
+        expires=30 * 60,  # half hour
     )
 
     # Update events table partitions twice a week


### PR DESCRIPTION
## Problem

It looks like our task schedule is reloaded very frequently (every 10 minutes or so) - this means the tasks that are scheduled to run relative to the starting time won't ever run if they run less than once per 10 minutes.

## Changes

Change the `enforce_max_replay_retention_period` task to use a crontab schedule so it runs at minute 0 of every hour, regardless of when the schedule was loaded.