### PR TITLE
fix(msg): fix incorrect success metric for filtered events

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -1232,14 +1232,16 @@ describe('HogTransformer', () => {
                     expect.objectContaining({
                         metric_name: 'filtering_failed',
                     }),
-                ])
+                ]),
+                'hog_function'
             )
             expect(queueLogsSpy).toHaveBeenCalledWith(
                 expect.arrayContaining([
                     expect.objectContaining({
                         message: expect.stringContaining('Global variable not found'),
                     }),
-                ])
+                ]),
+                'hog_function'
             )
 
             expect(result.event?.properties?.working_property).toBe('working')

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -1217,20 +1217,38 @@ describe('HogTransformer', () => {
                 workingFunction.id,
             ])
 
+            const queueAppMetricsSpy = jest.spyOn(hogTransformer['hogFunctionMonitoringService'], 'queueAppMetrics')
+            const queueLogsSpy = jest.spyOn(hogTransformer['hogFunctionMonitoringService'], 'queueLogs')
+
             const event = createPluginEvent({ event: 'test-event' }, teamId)
             const result = await hogTransformer.transformEventAndProduceMessages(event)
 
             // Verify one transformation was applied and the other was skipped
-            expect(result.event?.properties?.error_filter_property).toBeUndefined()
-            expect(result.invocationResults[0].error).toContain('Global variable not found')
             expect(result.event?.properties?.$transformations_skipped).toContain(
                 `${errorFunction.name} (${errorFunction.id})`
+            )
+            expect(queueAppMetricsSpy).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        metric_name: 'filtering_failed',
+                    }),
+                ])
+            )
+            expect(queueLogsSpy).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        message: expect.stringContaining('Global variable not found'),
+                    }),
+                ])
             )
 
             expect(result.event?.properties?.working_property).toBe('working')
             expect(result.event?.properties?.$transformations_succeeded).toContain(
                 `${workingFunction.name} (${workingFunction.id})`
             )
+
+            queueAppMetricsSpy.mockRestore()
+            queueLogsSpy.mockRestore()
         })
 
         it('should skip transformation when none of multiple filters match', async () => {

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -15,7 +15,7 @@ import { HogFunctionManagerService } from '../services/managers/hog-function-man
 import { HogFunctionMonitoringService } from '../services/monitoring/hog-function-monitoring.service'
 import { HogWatcherService, HogWatcherState } from '../services/monitoring/hog-watcher.service'
 import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '../utils/hog-function-filtering'
-import { createInvocation, createInvocationResult } from '../utils/invocation-utils'
+import { createInvocation } from '../utils/invocation-utils'
 import { cleanNullValues } from './transformation-functions'
 
 export const hogTransformationDroppedEvents = new Counter({
@@ -198,26 +198,11 @@ export class HogTransformerService {
                     })
 
                     // If filter didn't pass skip the actual transformation and add logs and errors from the filterResult
+                    this.hogFunctionMonitoringService.queueAppMetrics(filterResults.metrics, 'hog_function')
+                    this.hogFunctionMonitoringService.queueLogs(filterResults.logs, 'hog_function')
+
                     if (!filterResults.match) {
                         transformationsSkipped.push(transformationIdentifier)
-                        results.push(
-                            createInvocationResult(
-                                createInvocation(
-                                    {
-                                        ...globals,
-                                        inputs: {}, // Not needed as this is only for a valid return type
-                                    },
-                                    hogFunction
-                                ),
-                                {},
-                                {
-                                    metrics: filterResults.metrics,
-                                    logs: filterResults.logs,
-                                    error: filterResults.error,
-                                    finished: true,
-                                }
-                            )
-                        )
                         continue
                     }
                 }


### PR DESCRIPTION
## Problem

At the moment, every filtered event will incorrectly generate a success metric because we generically queue a success or failure metric for every result. Instead, let's queue the filter logs and metrics, but don't push an empty result.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

updated tests

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
