### PR TITLE
feat(tasks): maintain tab parameter when navigating

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,6 +2350,10 @@ importers:
       react-dom:
         specifier: '*'
         version: 18.2.0(react@18.2.0)
+    devDependencies:
+      kea-test-utils:
+        specifier: '*'
+        version: 0.2.4(kea@3.1.7(react@18.2.0))
 
   products/user_interviews:
     dependencies:

--- a/products/tasks/frontend/TaskTracker.tsx
+++ b/products/tasks/frontend/TaskTracker.tsx
@@ -13,6 +13,7 @@ import { GitHubIntegrationSettings } from './components/GitHubIntegrationSetting
 import { KanbanView } from './components/KanbanView'
 import { TaskControlPanel } from './components/TaskControlPanel'
 import { tasksLogic } from './tasksLogic'
+import type { TaskTrackerTab } from './types'
 
 export const scene: SceneExport = {
     component: TaskTracker,
@@ -28,7 +29,7 @@ export function TaskTracker(): JSX.Element {
         return <NotFound object="Tasks" caption="This feature is not enabled for your project." />
     }
 
-    const tabs = [
+    const tabs: { key: TaskTrackerTab; label: string; content: React.ReactNode }[] = [
         {
             key: 'dashboard' as const,
             label: 'Dashboard',

--- a/products/tasks/frontend/tasksLogic.test.ts
+++ b/products/tasks/frontend/tasksLogic.test.ts
@@ -1,0 +1,57 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { tasksLogic } from './tasksLogic'
+
+jest.mock('lib/api')
+
+describe('tasksLogic', () => {
+    let logic: ReturnType<typeof tasksLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.spyOn(api.tasks, 'list').mockResolvedValue({ results: [] })
+        jest.spyOn(api, 'get').mockResolvedValue({ results: [] })
+        logic = tasksLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        jest.clearAllMocks()
+    })
+
+    describe('URL handling', () => {
+        it('handles tab switching', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab('kanban')
+            })
+                .toMatchValues({
+                    activeTab: 'kanban',
+                })
+                .toFinishAllListeners()
+
+            expect(router.values.searchParams).toEqual(
+                expect.objectContaining({
+                    tab: 'kanban',
+                })
+            )
+        })
+
+        it('handles invalid tab values by defaulting to dashboard', async () => {
+            await expectLogic(logic, () => {
+                router.actions.push('/tasks?tab=invalid')
+            })
+                .toMatchValues({
+                    activeTab: 'dashboard',
+                })
+                .toFinishAllListeners()
+
+            expect(router.values.searchParams.tab).toBeUndefined()
+        })
+    })
+})

--- a/products/tasks/frontend/types.ts
+++ b/products/tasks/frontend/types.ts
@@ -137,3 +137,5 @@ export interface WorkflowConfiguration {
     workflow: TaskWorkflow
     stages: WorkflowStage[]
 }
+
+export type TaskTrackerTab = 'dashboard' | 'backlog' | 'kanban' | 'settings'

--- a/products/tasks/package.json
+++ b/products/tasks/package.json
@@ -16,5 +16,8 @@
         "@dnd-kit/utilities": "*",
         "react-dom": "*",
         "@types/react-dom": "*"
+    },
+    "devDependencies": {
+        "kea-test-utils": "*"
     }
 }


### PR DESCRIPTION
## Problem

We weren't maintaining URL state when navigating tabs, which is annoying if you want to navigate back/forward in the browser between tabs.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Maintain tab state in URL, for example `?tab=dashboard`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
