### PR TITLE
feat(sessions): Add migration to add sessions v3

### DIFF
--- a/posthog/clickhouse/migrations/0148_sessions_v3.py
+++ b/posthog/clickhouse/migrations/0148_sessions_v3.py
@@ -8,7 +8,7 @@ from posthog.models.raw_sessions.sql_v3 import (
 
 operations = [
     run_sql_with_exceptions(WRITABLE_RAW_SESSIONS_TABLE_SQL_V3()),
-    run_sql_with_exceptions(DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3()),
+    run_sql_with_exceptions(DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3(), node_roles=[NodeRole.DATA, NodeRole.COORDINATOR]),
     run_sql_with_exceptions(RAW_SESSIONS_TABLE_SQL_V3()),
     run_sql_with_exceptions(RAW_SESSIONS_CREATE_OR_REPLACE_VIEW_SQL_V3()),
     # normally there would be SQL to add the MV here too, but at the moment we only want this table to backfill,

--- a/posthog/clickhouse/migrations/0148_sessions_v3.py
+++ b/posthog/clickhouse/migrations/0148_sessions_v3.py
@@ -1,0 +1,16 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sql_v3 import (
+    DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3,
+    RAW_SESSIONS_CREATE_OR_REPLACE_VIEW_SQL_V3,
+    RAW_SESSIONS_TABLE_SQL_V3,
+    WRITABLE_RAW_SESSIONS_TABLE_SQL_V3,
+)
+
+operations = [
+    run_sql_with_exceptions(WRITABLE_RAW_SESSIONS_TABLE_SQL_V3()),
+    run_sql_with_exceptions(DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3()),
+    run_sql_with_exceptions(RAW_SESSIONS_TABLE_SQL_V3()),
+    run_sql_with_exceptions(RAW_SESSIONS_CREATE_OR_REPLACE_VIEW_SQL_V3()),
+    # normally there would be SQL to add the MV here too, but at the moment we only want this table to backfill,
+    # so let's not increase the load on the cluster just yet
+]

--- a/posthog/clickhouse/migrations/0149_sessions_v3.py
+++ b/posthog/clickhouse/migrations/0149_sessions_v3.py
@@ -1,3 +1,4 @@
+from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.raw_sessions.sql_v3 import (
     DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3,

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2758,7 +2758,7 @@
           properties_group_feature_flags
       FROM posthog_test.sharded_events
       WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
-      AND TRUE
+      AND True
   )
   
   SELECT

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2553,6 +2553,7 @@
       -- this is fine since even if the distinct_id changes during a session
       distinct_id AggregateFunction(argMax, String, DateTime64(6, 'UTC')),
       person_id AggregateFunction(argMax, UUID, DateTime64(6, 'UTC')),
+      distinct_ids AggregateFunction(groupUniqArray, String),
   
       min_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
       max_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
@@ -2633,7 +2634,7 @@
       SELECT
           team_id,
           `$session_id`,
-          distinct_id,
+          distinct_id AS _distinct_id,
           person_id,
           timestamp,
           inserted_at,
@@ -2765,8 +2766,9 @@
      team_id,
       toUUID(`$session_id`) as session_id_v7,
   
-      initializeAggregation('argMaxState', distinct_id, timestamp) as distinct_id,
+      initializeAggregation('argMaxState', _distinct_id, timestamp) as distinct_id,
       initializeAggregation('argMaxState', person_id, timestamp) as person_id,
+      initializeAggregation('groupUniqArrayState', _distinct_id) as distinct_ids,
   
       timestamp AS min_timestamp,
       timestamp AS max_timestamp,
@@ -3601,6 +3603,7 @@
       -- this is fine since even if the distinct_id changes during a session
       distinct_id AggregateFunction(argMax, String, DateTime64(6, 'UTC')),
       person_id AggregateFunction(argMax, UUID, DateTime64(6, 'UTC')),
+      distinct_ids AggregateFunction(groupUniqArray, String),
   
       min_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
       max_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
@@ -4484,6 +4487,7 @@
       -- this is fine since even if the distinct_id changes during a session
       distinct_id AggregateFunction(argMax, String, DateTime64(6, 'UTC')),
       person_id AggregateFunction(argMax, UUID, DateTime64(6, 'UTC')),
+      distinct_ids AggregateFunction(groupUniqArray, String),
   
       min_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
       max_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
@@ -5721,6 +5725,7 @@
       -- this is fine since even if the distinct_id changes during a session
       distinct_id AggregateFunction(argMax, String, DateTime64(6, 'UTC')),
       person_id AggregateFunction(argMax, UUID, DateTime64(6, 'UTC')),
+      distinct_ids AggregateFunction(groupUniqArray, String),
   
       min_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
       max_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),

--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -542,3 +542,26 @@ class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
         assert not result[1]["has_f1_a"]
         assert not result[1]["has_f1_b"]
         assert result[1]["has_f1_c"]
+
+    def test_tracks_all_distinct_ids(self):
+        distinct_id_1 = create_distinct_id()
+        distinct_id_2 = create_distinct_id()
+        session_id = create_session_id()
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id=distinct_id_1,
+            properties={"$current_url": "/", "$session_id": session_id},
+            timestamp="2024-03-08",
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id=distinct_id_2,
+            properties={"$current_url": "/", "$session_id": session_id},
+            timestamp="2024-03-08",
+        )
+
+        result = self.select_by_session_id(session_id)
+
+        assert set(result[0]["distinct_ids"]) == {distinct_id_1, distinct_id_2}

--- a/posthog/models/raw_sessions/sql_v3.py
+++ b/posthog/models/raw_sessions/sql_v3.py
@@ -73,6 +73,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     -- this is fine since even if the distinct_id changes during a session
     distinct_id AggregateFunction(argMax, String, DateTime64(6, 'UTC')),
     person_id AggregateFunction(argMax, UUID, DateTime64(6, 'UTC')),
+    distinct_ids AggregateFunction(groupUniqArray, String),
 
     min_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
     max_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
@@ -255,7 +256,7 @@ WITH parsed_events AS (
     SELECT
         team_id,
         `$session_id`,
-        distinct_id,
+        distinct_id AS _distinct_id,
         person_id,
         timestamp,
         inserted_at,
@@ -275,8 +276,9 @@ SELECT
    team_id,
     toUUID(`$session_id`) as session_id_v7,
 
-    initializeAggregation('argMaxState', distinct_id, timestamp) as distinct_id,
+    initializeAggregation('argMaxState', _distinct_id, timestamp) as distinct_id,
     initializeAggregation('argMaxState', person_id, timestamp) as person_id,
+    initializeAggregation('groupUniqArrayState', _distinct_id) as distinct_ids,
 
     timestamp AS min_timestamp,
     timestamp AS max_timestamp,
@@ -424,13 +426,14 @@ SELECT
 
     argMaxMerge(distinct_id) as distinct_id,
     argMaxMerge(person_id) as person_id,
+    groupUniqArrayMerge(distinct_ids) AS distinct_ids,
 
     min(min_timestamp) as min_timestamp,
     max(max_timestamp) as max_timestamp,
     max(max_inserted_at) as max_inserted_at,
 
     -- urls
-    arrayDistinct(arrayFlatten(groupArray(urls)) )AS urls,
+    arrayDistinct(arrayFlatten(groupArray(urls))) AS urls,
     argMinMerge(entry_url) as entry_url,
     argMaxMerge(end_url) as end_url,
     argMaxMerge(last_external_click_url) as last_external_click_url,

--- a/posthog/models/raw_sessions/sql_v3.py
+++ b/posthog/models/raw_sessions/sql_v3.py
@@ -345,8 +345,8 @@ FROM parsed_events
     )
 
 
-RAW_SESSIONS_TABLE_MV_SQL_V3 = (
-    lambda: """
+def RAW_SESSIONS_TABLE_MV_SQL_V3(where=True):
+    return """
 CREATE MATERIALIZED VIEW IF NOT EXISTS {table_name}
 TO {database}.{target_table}
 AS
@@ -355,9 +355,9 @@ AS
         table_name=f"{TABLE_BASE_NAME_V3}_mv",
         target_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         database=settings.CLICKHOUSE_DATABASE,
-        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(),
+        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(where),
     )
-)
+
 
 RAW_SESSION_TABLE_UPDATE_SQL_V3 = (
     lambda: """


### PR DESCRIPTION
## Problem

The sessions v3 table is a straightforward upgrade over sessions v2. 

This PR helps us meausre the performance characteristics in a production environment

## Changes

This PR adds a migration to add the underlying session v3 tables, so that they can be backfilled, but does not add the MV to ingestion, so it doesn't increase the write load on the cluster by itself.

(of course if the backfill is running, that will increase the load on the cluster, but we have control over that in dagster)


## How did you test this code?

The sessions v3 table has tests at the clickhouse and hogql level, from other PRs

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
