### PR TITLE
feat(sessions): Add dagster job for backfilling sessions v3

### DIFF
--- a/.dagster_home/workspace.yaml
+++ b/.dagster_home/workspace.yaml
@@ -12,6 +12,7 @@ load_from:
     #    - python_module: dags.locations.clickhouse
 
     # These dags are loaded in local dev
-    - python_module: dags.locations.max_ai
-    - python_module: dags.locations.web_analytics
     - python_module: dags.locations.experiments
+    - python_module: dags.locations.max_ai
+    - python_module: dags.locations.sessions
+    - python_module: dags.locations.web_analytics

--- a/dags/locations/sessions.py
+++ b/dags/locations/sessions.py
@@ -1,0 +1,7 @@
+import dagster
+
+from dags import sessions
+
+defs = dagster.Definitions(
+    assets=[sessions.sessions_v3_backfill],
+)

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -6,14 +6,12 @@ from dateutil.relativedelta import relativedelta
 from posthog.clickhouse.client import sync_execute
 from posthog.models.raw_sessions.sql_v3 import RAW_SESSION_TABLE_BACKFILL_SQL_V3
 
-# Define monthly partitions - adjust start_date as needed
 monthly_partitions = MonthlyPartitionsDefinition(
     start_date="2019-01-01"
 )  # this is a year before posthog was founded, so should be early enough even including data imports
 
 
 def partion_key_to_where_clause(partition_key: str) -> str:
-    """Convert a partition key (e.g., "2023-01-01") to a SQL WHERE clause for that month."""
     partition_start_date_incl = datetime.strptime(partition_key, "%Y-%m-%d")
     partition_end_date_excl = partition_start_date_incl + relativedelta(months=1)
 

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+from dagster import AssetExecutionContext, MonthlyPartitionsDefinition, asset
+from dateutil.relativedelta import relativedelta
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.raw_sessions.sql_v3 import RAW_SESSION_TABLE_BACKFILL_SQL_V3
+
+# Define monthly partitions - adjust start_date as needed
+monthly_partitions = MonthlyPartitionsDefinition(
+    start_date="2019-01-01"
+)  # this is a year before posthog was founded, so should be early enough even including data imports
+
+
+def partion_key_to_where_clause(partition_key: str) -> str:
+    """Convert a partition key (e.g., "2023-01-01") to a SQL WHERE clause for that month."""
+    partition_start_date_incl = datetime.strptime(partition_key, "%Y-%m-%d")
+    partition_end_date_excl = partition_start_date_incl + relativedelta(months=1)
+
+    start_incl = partition_start_date_incl.strftime("%Y-%m-%d")
+    end_excl = partition_end_date_excl.strftime("%Y-%m-%d")
+
+    return f"'{start_incl}' <= timestamp AND timestamp < '{end_excl}'"
+
+
+@asset(partitions_def=monthly_partitions, name="sessions_v3_backfill")
+def sessions_v3_backfill(context: AssetExecutionContext):
+    where_clause = partion_key_to_where_clause(context.partition_key)
+
+    # Generate the SQL using your existing function
+    backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause)
+
+    context.log.info(f"Running backfill for {context.partition_key} (where='{where_clause}')")
+
+    sync_execute(backfill_sql)
+
+    context.log.info(f"Successfully backfilled sessions_v3 for {context.partition_key}")
+
+    return f"Backfilled {context.partition_key}"


### PR DESCRIPTION
Merge https://github.com/PostHog/posthog/pull/38593 first

## Problem

We want to backfill this table for 3 reasons:
* to measure performance of this table on the production cluster
* to measure correctness of this table before switching customers onto it
* to have historical data when we switch customers onto it

I want to make a start on all of these

## Changes

Add a dagster asset to backfill this table (see referenced PR for the migration that adds it)

## How did you test this code?
The sessions table has good test coverage

I also ran this dagster job in a local dev setup

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
