### PR TITLE
feat: add dashboard access control migration

### DIFF
--- a/posthog/management/commands/run_rbac_migrations.py
+++ b/posthog/management/commands/run_rbac_migrations.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand
 import structlog
 
 from posthog.models.organization import Organization
+from posthog.rbac.migrations.rbac_dashboard_migration import rbac_dashboard_access_control_migration
 from posthog.rbac.migrations.rbac_feature_flag_migration import rbac_feature_flag_role_access_migration
 from posthog.rbac.migrations.rbac_team_migration import rbac_team_access_control_migration
 
@@ -110,8 +111,9 @@ class Command(BaseCommand):
 
             team_success = org_result["team_migration"]["success"]
             ff_success = org_result["feature_flag_migration"]["success"]
+            dashboard_success = org_result["dashboard_migration"]["success"]
 
-            if team_success and ff_success:
+            if team_success and ff_success and dashboard_success:
                 self.stdout.write(self.style.SUCCESS(f"Organization {org_id} ({org_name}): All migrations successful"))
             else:
                 self.stdout.write(self.style.WARNING(f"Organization {org_id} ({org_name}): Some migrations failed"))
@@ -124,12 +126,17 @@ class Command(BaseCommand):
                     error = org_result["feature_flag_migration"]["error"] or "Unknown error"
                     self.stdout.write(self.style.ERROR(f"  Feature flag migration failed: {error}"))
 
+                if not dashboard_success:
+                    error = org_result["dashboard_migration"]["error"] or "Unknown error"
+                    self.stdout.write(self.style.ERROR(f"  Dashboard migration failed: {error}"))
+
     def find_organizations_needing_migration(self, rollout_date) -> list[int]:
         """
         Find organizations that need RBAC migration based on the following criteria:
         - Has a team with access_control = True
         - Has an OrganizationResourceAccess row
         - Has a Role with feature flag access settings
+        - Has dashboards with restriction_level = 37 (ONLY_COLLABORATORS_CAN_EDIT)
         - Created after the rollout date
 
         Returns:
@@ -153,6 +160,18 @@ class Command(BaseCommand):
         )
         logger.info(f"Found {len(orgs_with_feature_flag_roles)} organizations with feature flag roles")
 
+        # Find organizations with dashboards that have restriction level 37
+        from posthog.models.dashboard import Dashboard
+
+        orgs_with_restricted_dashboards = (
+            Organization.objects.filter(
+                team__dashboard__restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            )
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        logger.info(f"Found {len(orgs_with_restricted_dashboards)} organizations with restricted dashboards")
+
         # Find organizations created after the rollout date
         orgs_after_rollout_date = Organization.objects.filter(created_at__date__gte=rollout_date).values_list(
             "id", flat=True
@@ -161,7 +180,10 @@ class Command(BaseCommand):
 
         # Combine all organization IDs
         needs_migration = (
-            set(orgs_with_team_access_control) | set(orgs_with_resource_access) | set(orgs_with_feature_flag_roles)
+            set(orgs_with_team_access_control)
+            | set(orgs_with_resource_access)
+            | set(orgs_with_feature_flag_roles)
+            | set(orgs_with_restricted_dashboards)
         )
         logger.info(f"Found {len(needs_migration)} total organizations that need migration")
 
@@ -191,6 +213,7 @@ class Command(BaseCommand):
                 "organization_id": org_id,
                 "team_migration": {"success": False, "error": None},
                 "feature_flag_migration": {"success": False, "error": None},
+                "dashboard_migration": {"success": False, "error": None},
             }
 
             # Verify organization exists
@@ -230,8 +253,24 @@ class Command(BaseCommand):
                     "Feature flag role access migration failed", organization_id=org_id, error=error_msg, exc_info=True
                 )
 
+            # Run dashboard access control migration
+            try:
+                rbac_dashboard_access_control_migration(org_id)
+                org_result["dashboard_migration"]["success"] = True
+                logger.info("Dashboard access control migration successful", organization_id=org_id)
+            except Exception as e:
+                error_msg = str(e)
+                org_result["dashboard_migration"]["error"] = error_msg
+                logger.error(
+                    "Dashboard access control migration failed", organization_id=org_id, error=error_msg, exc_info=True
+                )
+
             # Update summary counters
-            if org_result["team_migration"]["success"] and org_result["feature_flag_migration"]["success"]:
+            if (
+                org_result["team_migration"]["success"]
+                and org_result["feature_flag_migration"]["success"]
+                and org_result["dashboard_migration"]["success"]
+            ):
                 results["successful"] += 1
                 logger.info("All migrations successful for organization", organization_id=org_id)
             else:

--- a/posthog/rbac/migrations/rbac_dashboard_migration.py
+++ b/posthog/rbac/migrations/rbac_dashboard_migration.py
@@ -1,0 +1,145 @@
+from django.db import transaction
+
+import structlog
+
+from posthog.exceptions_capture import capture_exception
+from posthog.models.dashboard import Dashboard
+from posthog.models.organization import Organization, OrganizationMembership
+
+from ee.models.rbac.access_control import AccessControl
+
+logger = structlog.get_logger(__name__)
+
+
+def rbac_dashboard_access_control_migration(organization_id: int):
+    """
+    This migration converts legacy dashboard permissions to the new RBAC system.
+
+    It handles two cases:
+    1. Dashboards with restriction_level=37 (ONLY_COLLABORATORS_CAN_EDIT):
+       - Creates a default "view" access control entry
+       - Changes restriction_level to 21 (EVERYONE_IN_PROJECT_CAN_EDIT)
+    2. Dashboard privilege rows:
+       - Converts each DashboardPrivilege to an AccessControl entry with "edit" access
+       - Removes the original DashboardPrivilege entries
+    """
+    logger.info("Starting RBAC dashboard migrations", organization_id=organization_id)
+
+    try:
+        with transaction.atomic():
+            organization = Organization.objects.get(id=organization_id)
+
+            # Get dashboards that need migration (restriction level 37)
+            team_ids = organization.teams.values_list("id", flat=True)
+            restricted_dashboards = Dashboard.objects.filter(
+                team_id__in=team_ids, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            )
+
+            for dashboard in restricted_dashboards:
+                try:
+                    # Skip if access control already exists for this dashboard
+                    if AccessControl.objects.filter(
+                        team_id=dashboard.team_id,
+                        resource="dashboard",
+                        resource_id=str(dashboard.id),
+                    ).exists():
+                        logger.info(
+                            "Skipping dashboard - access control already exists",
+                            dashboard_id=dashboard.id,
+                            team_id=dashboard.team_id,
+                        )
+                        continue
+
+                    # Create default access control entry for the dashboard (view access for all)
+                    AccessControl.objects.create(
+                        team_id=dashboard.team_id,
+                        access_level="view",
+                        resource="dashboard",
+                        resource_id=str(dashboard.id),
+                    )
+
+                    logger.info(
+                        "Created default dashboard access control", dashboard_id=dashboard.id, team_id=dashboard.team_id
+                    )
+
+                    # Convert dashboard privileges to access control entries
+                    try:
+                        from ee.models import DashboardPrivilege
+
+                        dashboard_privileges = DashboardPrivilege.objects.filter(dashboard_id=dashboard.id)
+
+                        for privilege in dashboard_privileges:
+                            try:
+                                # Find the organization membership for this user
+                                org_membership = OrganizationMembership.objects.filter(
+                                    user=privilege.user, organization=organization
+                                ).first()
+
+                                if not org_membership:
+                                    logger.warning(
+                                        "No organization membership found for user",
+                                        user_id=privilege.user.id,
+                                        dashboard_id=dashboard.id,
+                                    )
+                                    continue
+
+                                # Create access control entry for the user with edit access
+                                AccessControl.objects.create(
+                                    team_id=dashboard.team_id,
+                                    access_level="edit",
+                                    resource="dashboard",
+                                    resource_id=str(dashboard.id),
+                                    organization_member=org_membership,
+                                )
+
+                                logger.info(
+                                    "Migrated dashboard privilege to access control",
+                                    dashboard_id=dashboard.id,
+                                    user_id=privilege.user.id,
+                                    team_id=dashboard.team_id,
+                                )
+
+                                # Remove the original privilege entry
+                                privilege.delete()
+
+                            except Exception as e:
+                                error_message = f"Failed to migrate dashboard privilege for user {privilege.user.id}"
+                                logger.exception(error_message, exc_info=e)
+                                capture_exception(
+                                    e,
+                                    additional_properties={
+                                        "dashboard_id": dashboard.id,
+                                        "user_id": privilege.user.id,
+                                        "organization_id": organization_id,
+                                    },
+                                )
+                                raise
+
+                    except ImportError:
+                        # DashboardPrivilege model not available, skip privilege migration
+                        logger.info("DashboardPrivilege model not available, skipping privilege migration")
+
+                    # Update restriction level to EVERYONE_IN_PROJECT_CAN_EDIT (21)
+                    dashboard.restriction_level = Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+                    dashboard.save(update_fields=["restriction_level"])
+
+                    logger.info(
+                        "Updated dashboard restriction level",
+                        dashboard_id=dashboard.id,
+                        new_restriction_level=dashboard.restriction_level,
+                    )
+
+                except Exception as e:
+                    error_message = f"Failed to migrate dashboard {dashboard.id}"
+                    logger.exception(error_message, exc_info=e)
+                    capture_exception(
+                        e, additional_properties={"dashboard_id": dashboard.id, "organization_id": organization_id}
+                    )
+                    raise
+
+        logger.info("Finished RBAC dashboard migrations", organization_id=organization_id)
+    except Exception as e:
+        error_message = f"Failed to complete RBAC dashboard migration for organization {organization_id}"
+        logger.exception(error_message, exc_info=e)
+        capture_exception(e, additional_properties={"organization_id": organization_id})
+        raise

--- a/posthog/rbac/migrations/test/test_rbac_dashboard_migration.py
+++ b/posthog/rbac/migrations/test/test_rbac_dashboard_migration.py
@@ -1,0 +1,299 @@
+import pytest
+from posthog.test.base import BaseTest
+
+from posthog.constants import AvailableFeature
+from posthog.models.dashboard import Dashboard
+from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.team.team import Team
+from posthog.models.user import User
+from posthog.rbac.migrations.rbac_dashboard_migration import rbac_dashboard_access_control_migration
+
+try:
+    from ee.models.dashboard_privilege import DashboardPrivilege
+    from ee.models.rbac.access_control import AccessControl
+except ImportError:
+    pass
+
+
+@pytest.mark.ee
+class TestRBACDashboardMigration(BaseTest):
+    def setUp(self):
+        super().setUp()
+        # Enable advanced permissions for the organization
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ADVANCED_PERMISSIONS,
+                "name": AvailableFeature.ADVANCED_PERMISSIONS,
+            },
+        ]
+        self.organization.save()
+
+        # Create additional users and team members
+        self.user2 = User.objects.create_and_join(self.organization, "user2@posthog.com", "password123")
+        self.user3 = User.objects.create_and_join(self.organization, "user3@posthog.com", "password123")
+
+        # Get organization memberships
+        self.user1_membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        self.user2_membership = OrganizationMembership.objects.get(user=self.user2, organization=self.organization)
+        self.user3_membership = OrganizationMembership.objects.get(user=self.user3, organization=self.organization)
+
+    def test_migrate_dashboard_with_restriction_level_37_no_privileges(self):
+        """Test migrating a dashboard with restriction level 37 but no existing privileges"""
+        # Create a dashboard with restriction level 37 (ONLY_COLLABORATORS_CAN_EDIT)
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Restricted Dashboard",
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
+        )
+
+        # Verify initial state
+        self.assertEqual(dashboard.restriction_level, Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT)
+        self.assertFalse(AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard.id)).exists())
+
+        # Run migration
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Reload dashboard from database
+        dashboard.refresh_from_db()
+
+        # Verify dashboard restriction level was updated
+        self.assertEqual(dashboard.restriction_level, Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+
+        # Verify default access control was created
+        access_controls = AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard.id))
+        self.assertEqual(access_controls.count(), 1)
+
+        default_ac = access_controls.first()
+        self.assertEqual(default_ac.access_level, "view")
+        self.assertEqual(default_ac.team_id, self.team.id)
+        self.assertIsNone(default_ac.organization_member)
+        self.assertIsNone(default_ac.role)
+
+    def test_migrate_dashboard_with_restriction_level_37_and_privileges(self):
+        """Test migrating a dashboard with restriction level 37 and existing dashboard privileges"""
+        # Create a dashboard with restriction level 37
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Restricted Dashboard with Privileges",
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
+        )
+
+        # Create dashboard privileges for users
+        DashboardPrivilege.objects.create(
+            dashboard=dashboard,
+            user=self.user2,
+            level=Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
+        DashboardPrivilege.objects.create(
+            dashboard=dashboard,
+            user=self.user3,
+            level=Dashboard.PrivilegeLevel.CAN_VIEW,
+        )
+
+        # Verify initial state
+        self.assertEqual(DashboardPrivilege.objects.filter(dashboard=dashboard).count(), 2)
+
+        # Run migration
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Reload dashboard from database
+        dashboard.refresh_from_db()
+
+        # Verify dashboard restriction level was updated
+        self.assertEqual(dashboard.restriction_level, Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+
+        # Verify access controls were created
+        access_controls = AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard.id))
+        self.assertEqual(access_controls.count(), 3)  # 1 default + 2 user privileges
+
+        # Verify default access control
+        default_ac = access_controls.filter(organization_member=None, role=None).first()
+        self.assertIsNotNone(default_ac)
+        self.assertEqual(default_ac.access_level, "view")
+
+        # Verify user-specific access controls
+        user2_ac = access_controls.filter(organization_member=self.user2_membership).first()
+        self.assertIsNotNone(user2_ac)
+        self.assertEqual(user2_ac.access_level, "edit")
+
+        user3_ac = access_controls.filter(organization_member=self.user3_membership).first()
+        self.assertIsNotNone(user3_ac)
+        self.assertEqual(user3_ac.access_level, "edit")  # All privileges become "edit"
+
+        # Verify original privileges were deleted
+        self.assertEqual(DashboardPrivilege.objects.filter(dashboard=dashboard).count(), 0)
+
+    def test_migrate_dashboard_with_restriction_level_21_ignored(self):
+        """Test that dashboards with restriction level 21 are ignored"""
+        # Create a dashboard with restriction level 21 (EVERYONE_IN_PROJECT_CAN_EDIT)
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Unrestricted Dashboard",
+            restriction_level=Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT,
+        )
+
+        # Run migration
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Reload dashboard from database
+        dashboard.refresh_from_db()
+
+        # Verify dashboard restriction level was not changed
+        self.assertEqual(dashboard.restriction_level, Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+
+        # Verify no access controls were created
+        self.assertFalse(AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard.id)).exists())
+
+    def test_migration_handles_user_without_organization_membership(self):
+        """Test that migration handles users without organization membership gracefully"""
+        # Create a dashboard with restriction level 37
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Dashboard with Invalid User",
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
+        )
+
+        # Create a user without organization membership
+        orphaned_user = User.objects.create(email="orphaned@example.com", password="password123")
+
+        # Create a dashboard privilege for the orphaned user
+        DashboardPrivilege.objects.create(
+            dashboard=dashboard,
+            user=orphaned_user,
+            level=Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
+
+        # Run migration (should not raise exception)
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Reload dashboard from database
+        dashboard.refresh_from_db()
+
+        # Verify dashboard was still migrated
+        self.assertEqual(dashboard.restriction_level, Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+
+        # Verify default access control was created
+        default_ac = AccessControl.objects.filter(
+            resource="dashboard", resource_id=str(dashboard.id), organization_member=None, role=None
+        ).first()
+        self.assertIsNotNone(default_ac)
+        self.assertEqual(default_ac.access_level, "view")
+
+        # Verify no access control was created for the orphaned user
+        self.assertFalse(
+            AccessControl.objects.filter(
+                resource="dashboard", resource_id=str(dashboard.id), organization_member__user=orphaned_user
+            ).exists()
+        )
+
+        # The original privilege should NOT be deleted since we couldn't find org membership
+        # This is correct behavior - we skip processing for orphaned users
+        orphaned_privilege_count = DashboardPrivilege.objects.filter(user=orphaned_user).count()
+        self.assertEqual(orphaned_privilege_count, 1)  # Should still exist
+
+    def test_migration_skips_dashboards_with_existing_access_control(self):
+        """Test that migration skips dashboards that already have access control entries"""
+        # Create a dashboard with restriction level 37
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Dashboard with Existing Access Control",
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
+        )
+
+        # Create existing access control
+        existing_ac = AccessControl.objects.create(
+            team_id=self.team.id,
+            access_level="admin",
+            resource="dashboard",
+            resource_id=str(dashboard.id),
+            organization_member=self.user1_membership,
+        )
+
+        # Create a dashboard privilege that should not be migrated
+        DashboardPrivilege.objects.create(
+            dashboard=dashboard,
+            user=self.user2,
+            level=Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
+
+        # Run migration
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Reload dashboard from database
+        dashboard.refresh_from_db()
+
+        # Verify dashboard restriction level was NOT updated
+        self.assertEqual(dashboard.restriction_level, Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT)
+
+        # Verify only the existing access control remains
+        access_controls = AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard.id))
+        self.assertEqual(access_controls.count(), 1)
+        self.assertEqual(access_controls.first().id, existing_ac.id)
+
+        # Verify dashboard privilege was not deleted
+        self.assertEqual(DashboardPrivilege.objects.filter(dashboard=dashboard).count(), 1)
+
+    def test_migration_handles_multiple_teams_in_organization(self):
+        """Test that migration works correctly with multiple teams in the organization"""
+        # Create another team in the same organization
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+
+        # Create dashboards in both teams
+        dashboard1 = Dashboard.objects.create(
+            team=self.team,
+            name="Team 1 Dashboard",
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
+        )
+        dashboard2 = Dashboard.objects.create(
+            team=team2,
+            name="Team 2 Dashboard",
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
+        )
+
+        # Run migration
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Verify both dashboards were migrated
+        dashboard1.refresh_from_db()
+        dashboard2.refresh_from_db()
+
+        self.assertEqual(dashboard1.restriction_level, Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+        self.assertEqual(dashboard2.restriction_level, Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+
+        # Verify access controls were created for both dashboards
+        self.assertTrue(AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard1.id)).exists())
+        self.assertTrue(AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard2.id)).exists())
+
+    def test_migration_handles_organization_not_found(self):
+        """Test that migration raises exception for non-existent organization"""
+        with self.assertRaises(Organization.DoesNotExist):
+            rbac_dashboard_access_control_migration(999999)
+
+    def test_migration_is_idempotent(self):
+        """Test that running the migration multiple times doesn't create duplicates"""
+        # Create a dashboard with restriction level 37
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Idempotent Test Dashboard",
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
+        )
+
+        # Run migration first time
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Verify state after first migration
+        dashboard.refresh_from_db()
+        self.assertEqual(dashboard.restriction_level, Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+        access_controls_count = AccessControl.objects.filter(
+            resource="dashboard", resource_id=str(dashboard.id)
+        ).count()
+        self.assertEqual(access_controls_count, 1)
+
+        # Run migration second time
+        rbac_dashboard_access_control_migration(self.organization.id)
+
+        # Verify no duplicates were created
+        final_access_controls_count = AccessControl.objects.filter(
+            resource="dashboard", resource_id=str(dashboard.id)
+        ).count()
+        self.assertEqual(final_access_controls_count, access_controls_count)

--- a/posthog/rbac/migrations/test/test_rbac_dashboard_migration.py
+++ b/posthog/rbac/migrations/test/test_rbac_dashboard_migration.py
@@ -64,6 +64,7 @@ class TestRBACDashboardMigration(BaseTest):
         self.assertEqual(access_controls.count(), 1)
 
         default_ac = access_controls.first()
+        assert default_ac is not None
         self.assertEqual(default_ac.access_level, "view")
         self.assertEqual(default_ac.team_id, self.team.id)
         self.assertIsNone(default_ac.organization_member)
@@ -108,16 +109,16 @@ class TestRBACDashboardMigration(BaseTest):
 
         # Verify default access control
         default_ac = access_controls.filter(organization_member=None, role=None).first()
-        self.assertIsNotNone(default_ac)
+        assert default_ac is not None
         self.assertEqual(default_ac.access_level, "view")
 
         # Verify user-specific access controls
         user2_ac = access_controls.filter(organization_member=self.user2_membership).first()
-        self.assertIsNotNone(user2_ac)
+        assert user2_ac is not None
         self.assertEqual(user2_ac.access_level, "edit")
 
         user3_ac = access_controls.filter(organization_member=self.user3_membership).first()
-        self.assertIsNotNone(user3_ac)
+        assert user3_ac is not None
         self.assertEqual(user3_ac.access_level, "edit")  # All privileges become "edit"
 
         # Verify original privileges were deleted
@@ -176,7 +177,7 @@ class TestRBACDashboardMigration(BaseTest):
         default_ac = AccessControl.objects.filter(
             resource="dashboard", resource_id=str(dashboard.id), organization_member=None, role=None
         ).first()
-        self.assertIsNotNone(default_ac)
+        assert default_ac is not None
         self.assertEqual(default_ac.access_level, "view")
 
         # Verify no access control was created for the orphaned user
@@ -228,7 +229,9 @@ class TestRBACDashboardMigration(BaseTest):
         # Verify only the existing access control remains
         access_controls = AccessControl.objects.filter(resource="dashboard", resource_id=str(dashboard.id))
         self.assertEqual(access_controls.count(), 1)
-        self.assertEqual(access_controls.first().id, existing_ac.id)
+        remaining_ac = access_controls.first()
+        assert remaining_ac is not None
+        self.assertEqual(remaining_ac.id, existing_ac.id)
 
         # Verify dashboard privilege was not deleted
         self.assertEqual(DashboardPrivilege.objects.filter(dashboard=dashboard).count(), 1)


### PR DESCRIPTION
## Changes

Adding the migration script for dashboard permissions. There are only a few hundred affected dashboards, and most have no dashboard privileges set.

Should be low risk because much of the UX is already broken so it will only be fixing it for orgs. 

After this is run I'll remove the old dashboard privilege code. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
