### PR TITLE
chore(plugin-server): rm broker comm warning log

### DIFF
--- a/plugin-server/src/kafka/kafka-client-metrics.ts
+++ b/plugin-server/src/kafka/kafka-client-metrics.ts
@@ -201,18 +201,6 @@ export function trackBrokerMetrics(
             })
         }
 
-        // communication errors
-        if (stats.txerrs > 0 || stats.rxerrs > 0) {
-            logger.warn('Broker communication errors', {
-                ...labels,
-                consumer_id: consumerId,
-                txerrs: stats.txerrs,
-                rxerrs: stats.rxerrs,
-                txretries: stats.txretries,
-                req_timeouts: stats.req_timeouts,
-            })
-        }
-
         // request timeouts
         if (stats.req_timeouts > 0) {
             logger.warn('Broker request timeouts', {


### PR DESCRIPTION
## Problem

A noisy kafka broker log that doesn't give signal is polluting plugin-server logs.

## Changes

Rms the log, as it gives no signal and just add noise.

## How did you test this code?

