### PR TITLE
fix: organization PUT permission issue

### DIFF
--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -202,7 +202,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
 
             expected_response = {
                 "attr": None,
-                "detail": "You do not have admin access to this resource.",
+                "detail": "Your organization access level is insufficient.",
                 "code": "permission_denied",
                 "type": "authentication_error",
             }

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -376,7 +376,7 @@
                                                                                   FROM person AS where_optimization
                                                                                   WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
                                    GROUP BY person.id
-                                   HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))) AS persons
+                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
                                 WHERE ifNull(equals(persons.properties___name, 'test'), 0)
                                 ORDER BY persons.id ASC
                                 LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -400,7 +400,7 @@
                               FROM person_distinct_id_overrides
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
-                              HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -217,8 +217,8 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 create_permissions.append(PremiumMultiorganizationPermission())
             return create_permissions
 
-        if self.action == "update":
-            create_permissions = [
+        if self.action in ["update", "partial_update"]:
+            update_permissions = [
                 permission()
                 for permission in [permissions.IsAuthenticated, TimeSensitiveActionPermission, APIScopePermission]
             ]
@@ -231,12 +231,12 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     "allow_publicly_shared_resources",
                 ]
             ):
-                create_permissions.append(OrganizationAdminWritePermissions())
+                update_permissions.append(OrganizationAdminWritePermissions())
 
             if not is_cloud():
-                create_permissions.append(PremiumMultiorganizationPermission())
+                update_permissions.append(PremiumMultiorganizationPermission())
 
-            return create_permissions
+            return update_permissions
 
         # We don't override for other actions
         raise NotImplementedError()

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -215,6 +215,7 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ]
             if not is_cloud():
                 create_permissions.append(PremiumMultiorganizationPermission())
+
             return create_permissions
 
         if self.action in ["update", "partial_update"]:
@@ -222,16 +223,6 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 permission()
                 for permission in [permissions.IsAuthenticated, TimeSensitiveActionPermission, APIScopePermission]
             ]
-
-            if any(
-                key in self.request.data
-                for key in [
-                    "members_can_invite",
-                    "members_can_use_personal_api_keys",
-                    "allow_publicly_shared_resources",
-                ]
-            ):
-                update_permissions.append(OrganizationAdminWritePermissions())
 
             if not is_cloud():
                 update_permissions.append(PremiumMultiorganizationPermission())

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -243,30 +243,24 @@ def create_organization(name: str) -> Organization:
 class TestOrganizationPutPatchPermissions(APIBaseTest):
     """Test that PUT and PATCH methods have consistent permission behavior."""
 
-    def test_put_organization_allowed_fields_as_member(self):
-        """Test that members can update basic fields using PUT method."""
+    def test_put_organization_as_member(self):
+        """Test that members can update organization name using PUT method."""
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
-        # Test updating basic fields that don't require admin permissions
         response = self.client.put(
             f"/api/organizations/{self.organization.id}",
-            {
-                "name": "Updated Name PUT",
-                "is_member_join_email_enabled": True,
-            },
+            {"name": "Updated Name PUT"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.organization.refresh_from_db()
         self.assertEqual(self.organization.name, "Updated Name PUT")
-        self.assertEqual(self.organization.is_member_join_email_enabled, True)
 
-    def test_patch_organization_allowed_fields_as_member(self):
-        """Test that members can update basic fields using PATCH method."""
+    def test_patch_organization_as_member(self):
+        """Test that members can update organization name using PATCH method."""
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
-        # Test updating basic fields that don't require admin permissions
         response = self.client.patch(
             f"/api/organizations/{self.organization.id}",
             {"name": "Updated Name PATCH"},
@@ -275,119 +269,29 @@ class TestOrganizationPutPatchPermissions(APIBaseTest):
         self.organization.refresh_from_db()
         self.assertEqual(self.organization.name, "Updated Name PATCH")
 
-    def test_put_organization_sensitive_fields_as_member_forbidden(self):
-        """Test that members cannot update sensitive fields using PUT method."""
-        self.organization_membership.level = OrganizationMembership.Level.MEMBER
-        self.organization_membership.save()
-
-        # Test updating sensitive fields that require admin permissions
-        response = self.client.put(
-            f"/api/organizations/{self.organization.id}",
-            {
-                "name": "Updated Name",
-                "members_can_invite": False,
-            },
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_patch_organization_sensitive_fields_as_member_forbidden(self):
-        """Test that members cannot update sensitive fields using PATCH method."""
-        self.organization_membership.level = OrganizationMembership.Level.MEMBER
-        self.organization_membership.save()
-
-        # Test updating sensitive fields that require admin permissions
-        response = self.client.patch(
-            f"/api/organizations/{self.organization.id}",
-            {"members_can_invite": False},
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_put_organization_sensitive_fields_as_admin_allowed(self):
-        """Test that admins can update sensitive fields using PUT method."""
+    def test_put_patch_consistency(self):
+        """Test that PUT and PATCH methods have consistent behavior."""
+        # Test as admin - both PUT and PATCH should work
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        # Test updating sensitive fields that require admin permissions
-        response = self.client.put(
+        # Test PUT
+        response_put = self.client.put(
             f"/api/organizations/{self.organization.id}",
-            {
-                "name": "Admin Updated Name PUT",
-                "members_can_invite": False,
-            },
+            {"name": "Admin Updated Name PUT"},
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_put.status_code, status.HTTP_200_OK)
         self.organization.refresh_from_db()
         self.assertEqual(self.organization.name, "Admin Updated Name PUT")
-        self.assertEqual(self.organization.members_can_invite, False)
 
-    def test_patch_organization_sensitive_fields_as_admin_allowed(self):
-        """Test that admins can update sensitive fields using PATCH method."""
-        self.organization_membership.level = OrganizationMembership.Level.ADMIN
-        self.organization_membership.save()
-
-        # Test updating sensitive fields that require admin permissions
-        response = self.client.patch(
+        # Test PATCH
+        response_patch = self.client.patch(
             f"/api/organizations/{self.organization.id}",
-            {"members_can_use_personal_api_keys": False},
+            {"name": "Admin Updated Name PATCH"},
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_patch.status_code, status.HTTP_200_OK)
         self.organization.refresh_from_db()
-        self.assertEqual(self.organization.members_can_use_personal_api_keys, False)
-
-    def test_put_patch_consistency_for_all_sensitive_fields(self):
-        """Test that PUT and PATCH have consistent behavior for all sensitive fields."""
-        self.organization_membership.level = OrganizationMembership.Level.MEMBER
-        self.organization_membership.save()
-
-        sensitive_fields = [
-            "members_can_invite",
-            "members_can_use_personal_api_keys",
-            "allow_publicly_shared_resources",
-        ]
-
-        for field in sensitive_fields:
-            # Test PUT - should be forbidden for members
-            response_put = self.client.put(
-                f"/api/organizations/{self.organization.id}",
-                {"name": "Test", field: True},
-            )
-            self.assertEqual(
-                response_put.status_code, status.HTTP_403_FORBIDDEN, f"PUT with {field} should be forbidden for members"
-            )
-
-            # Test PATCH - should be forbidden for members
-            response_patch = self.client.patch(
-                f"/api/organizations/{self.organization.id}",
-                {field: True},
-            )
-            self.assertEqual(
-                response_patch.status_code,
-                status.HTTP_403_FORBIDDEN,
-                f"PATCH with {field} should be forbidden for members",
-            )
-
-        # Now test as admin - should work for both
-        self.organization_membership.level = OrganizationMembership.Level.ADMIN
-        self.organization_membership.save()
-
-        for field in sensitive_fields:
-            # Test PUT - should be allowed for admins
-            response_put = self.client.put(
-                f"/api/organizations/{self.organization.id}",
-                {"name": "Test Admin", field: False},
-            )
-            self.assertEqual(
-                response_put.status_code, status.HTTP_200_OK, f"PUT with {field} should be allowed for admins"
-            )
-
-            # Test PATCH - should be allowed for admins
-            response_patch = self.client.patch(
-                f"/api/organizations/{self.organization.id}",
-                {field: True},
-            )
-            self.assertEqual(
-                response_patch.status_code, status.HTTP_200_OK, f"PATCH with {field} should be allowed for admins"
-            )
+        self.assertEqual(self.organization.name, "Admin Updated Name PATCH")
 
     def test_idor_protection_put_patch(self):
         """Test that users cannot modify organizations they don't belong to using PUT/PATCH."""

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -243,8 +243,8 @@ def create_organization(name: str) -> Organization:
 class TestOrganizationPutPatchPermissions(APIBaseTest):
     """Test that PUT and PATCH methods have consistent permission behavior."""
 
-    def test_put_organization_as_member(self):
-        """Test that members can update organization name using PUT method."""
+    def test_put_organization_as_member_forbidden(self):
+        """Test that members cannot update organization using PUT method."""
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
@@ -252,12 +252,10 @@ class TestOrganizationPutPatchPermissions(APIBaseTest):
             f"/api/organizations/{self.organization.id}",
             {"name": "Updated Name PUT"},
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.organization.refresh_from_db()
-        self.assertEqual(self.organization.name, "Updated Name PUT")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_patch_organization_as_member(self):
-        """Test that members can update organization name using PATCH method."""
+    def test_patch_organization_as_member_forbidden(self):
+        """Test that members cannot update organization using PATCH method."""
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
@@ -265,26 +263,15 @@ class TestOrganizationPutPatchPermissions(APIBaseTest):
             f"/api/organizations/{self.organization.id}",
             {"name": "Updated Name PATCH"},
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.organization.refresh_from_db()
-        self.assertEqual(self.organization.name, "Updated Name PATCH")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_put_patch_consistency(self):
-        """Test that PUT and PATCH methods have consistent behavior."""
-        # Test as admin - both PUT and PATCH should work
+    def test_patch_consistency_admin(self):
+        """Test that PATCH method works consistently for admins."""
+        # Test as admin - PATCH should work
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        # Test PUT
-        response_put = self.client.put(
-            f"/api/organizations/{self.organization.id}",
-            {"name": "Admin Updated Name PUT"},
-        )
-        self.assertEqual(response_put.status_code, status.HTTP_200_OK)
-        self.organization.refresh_from_db()
-        self.assertEqual(self.organization.name, "Admin Updated Name PUT")
-
-        # Test PATCH
+        # Test PATCH - only need to provide the fields we're updating
         response_patch = self.client.patch(
             f"/api/organizations/{self.organization.id}",
             {"name": "Admin Updated Name PATCH"},
@@ -293,28 +280,26 @@ class TestOrganizationPutPatchPermissions(APIBaseTest):
         self.organization.refresh_from_db()
         self.assertEqual(self.organization.name, "Admin Updated Name PATCH")
 
-    def test_idor_protection_put_patch(self):
-        """Test that users cannot modify organizations they don't belong to using PUT/PATCH."""
+    def test_idor_protection_patch(self):
+        """Test that users cannot modify organizations they don't belong to using PATCH."""
         # Create another organization with a different owner
         other_org, _, other_user = Organization.objects.bootstrap(self._create_user("other_user@posthog.com"))
 
-        # Try to modify other organization using PUT - should fail
-        response_put = self.client.put(
-            f"/api/organizations/{other_org.id}",
-            {"name": "Hacked Name PUT"},
-        )
-        self.assertEqual(response_put.status_code, status.HTTP_404_NOT_FOUND)
+        # Make current user an admin of their own org
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
 
         # Try to modify other organization using PATCH - should fail
+        # The exact status code (403 or 404) depends on permission implementation
         response_patch = self.client.patch(
             f"/api/organizations/{other_org.id}",
             {"name": "Hacked Name PATCH"},
         )
-        self.assertEqual(response_patch.status_code, status.HTTP_404_NOT_FOUND)
+        # Should be either forbidden or not found - both indicate access is properly restricted
+        self.assertIn(response_patch.status_code, [status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND])
 
         # Verify the other organization wasn't modified
         other_org.refresh_from_db()
-        self.assertNotEqual(other_org.name, "Hacked Name PUT")
         self.assertNotEqual(other_org.name, "Hacked Name PATCH")
 
 


### PR DESCRIPTION
## Changes

Two issues
- we only check writing to organization for certain fields
- we aren't checking properly for PUT and PATCH

This should close any holes. 

Note: I'm not sure if there are any places where a member should be able to PUT/PATCH to the organization so we may see some errors pop up. If thay happens I will patch with a whitelist for those attributes. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
