### PR TITLE
fix(flags): Make using hash overrides more robust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.16",
  "tokio",
+ "tokio-retry",
  "tower 0.4.13",
  "tower-http",
  "tracing",
@@ -7610,6 +7611,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use sqlx::{
     pool::PoolConnection,
     postgres::{PgPool, PgPoolOptions, PgRow},
-    Postgres,
+    Error as SqlxError, Postgres,
 };
 use thiserror::Error;
 use tokio::time::timeout;
@@ -90,5 +90,372 @@ impl Client for PgPool {
 
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
         Ok(self.acquire().await?)
+    }
+}
+
+/// Determines if a sqlx::Error represents a foreign key constraint violation
+pub fn is_foreign_key_constraint_error(error: &SqlxError) -> bool {
+    match error {
+        SqlxError::Database(db_error) => {
+            // Class 23 — Integrity Constraint Violation; 23503 = foreign_key_violation
+            // See: https://www.postgresql.org/docs/current/errcodes-appendix.html
+            if let Some(code) = db_error.code() {
+                code.as_ref() == "23503"
+            } else {
+                let msg = db_error.message().to_lowercase();
+                msg.contains("violates foreign key constraint")
+                    || msg.contains("foreign key constraint")
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Determines if a sqlx::Error represents a transient failure that should be retried
+pub fn is_transient_error(error: &SqlxError) -> bool {
+    match error {
+        // Connection/pool issues: usually transient.
+        SqlxError::Io(_)
+        | SqlxError::PoolTimedOut
+        | SqlxError::PoolClosed
+        // TLS/handshake can be transient (network/cert rollover).
+        | SqlxError::Tls(_) => true,
+
+        // Database-specific errors: prefer SQLSTATE when available.
+        SqlxError::Database(db_error) => {
+            if let Some(code) = db_error.code() {
+                let code = code.as_ref();
+
+                // See: PostgreSQL SQLSTATE appendix
+                // 08***  Connection Exception
+                // 53***  Insufficient Resources
+                // 57***  Operator Intervention
+                // 58***  System Error (often transient)
+                // 40001  Serialization Failure
+                // 40003  Statement Completion Unknown (retry if idempotent)
+                // 40P01  Deadlock Detected
+                code.starts_with("08")
+                    || code.starts_with("53")
+                    || code.starts_with("57")
+                    || code.starts_with("58")
+                    || code == "40001"
+                    || code == "40003"
+                    || code == "40P01"
+            } else {
+                // Last resort: message heuristics (less reliable than SQLSTATE).
+                let msg = db_error.message().to_lowercase();
+                msg.contains("connection")
+                    || msg.contains("timeout")
+                    || msg.contains("timed out")
+                    || msg.contains("temporary")
+                    || msg.contains("deadlock")
+                    || msg.contains("serialization")
+                    || msg.contains("disk full")
+                    || msg.contains("canceling statement due to")
+                    || msg.contains("terminating connection due to")
+                    || msg.contains("ssl")
+                    || msg.contains("tls")
+            }
+        }
+
+        // Protocol glitches may be transient.
+        SqlxError::Protocol(msg) => {
+            let m = msg.to_lowercase();
+            m.contains("connection") || m.contains("timeout") || m.contains("ssl") || m.contains("tls")
+        }
+
+        // Default: assume non-transient since we're not sure about the error type.
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::Error as SqlxError;
+
+    #[test]
+    fn test_is_transient_error_connection_errors() {
+        // Test that database connection errors trigger retries
+        let pool_timeout_error = SqlxError::PoolTimedOut;
+        assert!(is_transient_error(&pool_timeout_error));
+
+        let pool_closed_error = SqlxError::PoolClosed;
+        assert!(is_transient_error(&pool_closed_error));
+
+        let io_error = SqlxError::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused",
+        ));
+        assert!(is_transient_error(&io_error));
+
+        // Test TLS errors are considered transient
+        let tls_error = SqlxError::Tls(Box::new(std::io::Error::other("TLS handshake failed")));
+        assert!(is_transient_error(&tls_error));
+    }
+
+    #[test]
+    fn test_is_transient_error_protocol_errors() {
+        // Test Protocol errors with connection issues
+        let protocol_connection_error = SqlxError::Protocol("connection lost".to_string());
+        assert!(is_transient_error(&protocol_connection_error));
+
+        let protocol_timeout_error = SqlxError::Protocol("operation timeout".to_string());
+        assert!(is_transient_error(&protocol_timeout_error));
+
+        // Test that non-connection protocol errors don't trigger retries
+        let protocol_other_error = SqlxError::Protocol("invalid protocol version".to_string());
+        assert!(!is_transient_error(&protocol_other_error));
+    }
+
+    #[test]
+    fn test_is_transient_error_non_transient_errors() {
+        // Test that configuration errors don't trigger retries
+        let config_error =
+            SqlxError::Configuration(Box::new(std::io::Error::other("invalid connection string")));
+        assert!(!is_transient_error(&config_error));
+
+        let column_error = SqlxError::ColumnNotFound("missing_column".to_string());
+        assert!(!is_transient_error(&column_error));
+
+        let row_not_found = SqlxError::RowNotFound;
+        assert!(!is_transient_error(&row_not_found));
+
+        let worker_crashed = SqlxError::WorkerCrashed;
+        assert!(!is_transient_error(&worker_crashed));
+    }
+
+    #[test]
+    fn test_is_foreign_key_constraint_error_non_database_errors() {
+        // Test that non-database errors don't trigger foreign key detection
+        let config_error =
+            SqlxError::Configuration(Box::new(std::io::Error::other("invalid connection string")));
+        assert!(!is_foreign_key_constraint_error(&config_error));
+
+        let column_error = SqlxError::ColumnNotFound("missing_column".to_string());
+        assert!(!is_foreign_key_constraint_error(&column_error));
+
+        let row_not_found = SqlxError::RowNotFound;
+        assert!(!is_foreign_key_constraint_error(&row_not_found));
+    }
+
+    #[test]
+    fn test_is_foreign_key_constraint_error_protocol_errors() {
+        // Test that protocol errors don't trigger foreign key detection
+        let protocol_error = SqlxError::Protocol("some protocol error".to_string());
+        assert!(!is_foreign_key_constraint_error(&protocol_error));
+    }
+
+    // Mock database error implementation for comprehensive testing
+    use sqlx::error::{DatabaseError, ErrorKind};
+    use std::{borrow::Cow, error::Error as StdError, fmt};
+
+    #[derive(Debug)]
+    struct MockDbError {
+        msg: &'static str,
+        code: Option<&'static str>,
+        kind: ErrorKind,
+    }
+
+    impl fmt::Display for MockDbError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.msg)
+        }
+    }
+
+    impl StdError for MockDbError {}
+
+    impl DatabaseError for MockDbError {
+        fn message(&self) -> &str {
+            self.msg
+        }
+        fn kind(&self) -> ErrorKind {
+            // We can't clone ErrorKind, so we'll return a reasonable default
+            match self.kind {
+                ErrorKind::UniqueViolation => ErrorKind::UniqueViolation,
+                ErrorKind::ForeignKeyViolation => ErrorKind::ForeignKeyViolation,
+                ErrorKind::NotNullViolation => ErrorKind::NotNullViolation,
+                ErrorKind::CheckViolation => ErrorKind::CheckViolation,
+                _ => ErrorKind::Other,
+            }
+        }
+        // Optionally surface a SQLSTATE
+        fn code(&self) -> Option<Cow<'_, str>> {
+            self.code.map(Cow::from)
+        }
+
+        fn as_error(&self) -> &(dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn StdError + Send + Sync + 'static> {
+            self
+        }
+    }
+
+    // Convenience: build a sqlx::Error::Database
+    fn db_err(msg: &'static str, code: Option<&'static str>, kind: ErrorKind) -> SqlxError {
+        SqlxError::from(MockDbError { msg, code, kind })
+    }
+
+    #[test]
+    fn test_foreign_key_constraint_error_with_sqlstate() {
+        // Test FK constraint violation with SQLSTATE 23503
+        let fk_error = db_err(
+            "insert violates foreign key constraint \"fk_constraint\"",
+            Some("23503"),
+            ErrorKind::ForeignKeyViolation,
+        );
+        assert!(is_foreign_key_constraint_error(&fk_error));
+
+        // Test non-FK constraint violations don't match
+        let unique_error = db_err(
+            "duplicate key value violates unique constraint",
+            Some("23505"),
+            ErrorKind::UniqueViolation,
+        );
+        assert!(!is_foreign_key_constraint_error(&unique_error));
+    }
+
+    #[test]
+    fn test_foreign_key_constraint_error_message_fallback() {
+        // Test message fallback when no SQLSTATE code is available
+        let fk_error_no_code = db_err(
+            "insert violates foreign key constraint \"user_fk\"",
+            None,
+            ErrorKind::ForeignKeyViolation,
+        );
+        assert!(is_foreign_key_constraint_error(&fk_error_no_code));
+
+        // Test shorter message pattern
+        let fk_error_short = db_err(
+            "foreign key constraint violation",
+            None,
+            ErrorKind::ForeignKeyViolation,
+        );
+        assert!(is_foreign_key_constraint_error(&fk_error_short));
+
+        // Test case insensitivity
+        let fk_error_caps = db_err(
+            "INSERT VIOLATES FOREIGN KEY CONSTRAINT",
+            None,
+            ErrorKind::ForeignKeyViolation,
+        );
+        assert!(is_foreign_key_constraint_error(&fk_error_caps));
+
+        // Test non-FK messages don't match
+        let other_error = db_err("some other database error", None, ErrorKind::Other);
+        assert!(!is_foreign_key_constraint_error(&other_error));
+    }
+
+    #[test]
+    fn test_transient_error_sqlstate_classes() {
+        // 08*** Connection Exception
+        let conn_err = db_err(
+            "connection dropped unexpectedly",
+            Some("08006"),
+            ErrorKind::Other,
+        );
+        assert!(is_transient_error(&conn_err));
+
+        // 53*** Insufficient Resources
+        let disk_full_err = db_err(
+            "could not extend file: No space left on device",
+            Some("53100"),
+            ErrorKind::Other,
+        );
+        assert!(is_transient_error(&disk_full_err));
+
+        // 57*** Operator Intervention
+        let cancel_err = db_err(
+            "canceling statement due to statement timeout",
+            Some("57014"),
+            ErrorKind::Other,
+        );
+        assert!(is_transient_error(&cancel_err));
+
+        // 58*** System Error
+        let sys_err = db_err(
+            "could not read block: Input/output error",
+            Some("58030"),
+            ErrorKind::Other,
+        );
+        assert!(is_transient_error(&sys_err));
+
+        // 40001 Serialization Failure
+        let serialization_err = db_err(
+            "could not serialize access due to concurrent update",
+            Some("40001"),
+            ErrorKind::Other,
+        );
+        assert!(is_transient_error(&serialization_err));
+
+        // 40003 Statement Completion Unknown
+        let completion_unknown = db_err(
+            "statement completion unknown",
+            Some("40003"),
+            ErrorKind::Other,
+        );
+        assert!(is_transient_error(&completion_unknown));
+
+        // 40P01 Deadlock Detected
+        let deadlock_err = db_err("deadlock detected", Some("40P01"), ErrorKind::Other);
+        assert!(is_transient_error(&deadlock_err));
+    }
+
+    #[test]
+    fn test_transient_error_non_transient_sqlstates() {
+        // 23*** Integrity Constraint Violations (generally permanent)
+        let unique_violation = db_err(
+            "duplicate key value violates unique constraint",
+            Some("23505"),
+            ErrorKind::UniqueViolation,
+        );
+        assert!(!is_transient_error(&unique_violation));
+
+        // 42*** Syntax Error or Access Rule Violation (permanent)
+        let syntax_error = db_err(
+            "syntax error at or near \"SELECT\"",
+            Some("42601"),
+            ErrorKind::Other,
+        );
+        assert!(!is_transient_error(&syntax_error));
+
+        // 22*** Data Exception (usually permanent)
+        let data_exception = db_err(
+            "invalid input syntax for type integer",
+            Some("22P02"),
+            ErrorKind::Other,
+        );
+        assert!(!is_transient_error(&data_exception));
+    }
+
+    #[test]
+    fn test_transient_error_message_fallback() {
+        // Test message heuristics when no SQLSTATE is available
+        let connection_msg_err = db_err("connection to server was lost", None, ErrorKind::Other);
+        assert!(is_transient_error(&connection_msg_err));
+
+        let timeout_msg_err = db_err("operation timed out", None, ErrorKind::Other);
+        assert!(is_transient_error(&timeout_msg_err));
+
+        let ssl_msg_err = db_err(
+            "SSL connection has been closed unexpectedly",
+            None,
+            ErrorKind::Other,
+        );
+        assert!(is_transient_error(&ssl_msg_err));
+
+        // Test non-transient message
+        let permanent_msg_err = db_err("column does not exist", None, ErrorKind::Other);
+        assert!(!is_transient_error(&permanent_msg_err));
+
+        // Test that memory pressure errors are NOT retried to avoid amplifying load
+        let memory_err = db_err("out of memory", None, ErrorKind::Other);
+        assert!(!is_transient_error(&memory_err));
     }
 }

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -83,7 +83,7 @@ impl Client for PgPool {
             None => DATABASE_TIMEOUT_MILLISECS,
         };
 
-        let fut = timeout(Duration::from_secs(timeout_ms), query_results).await?;
+        let fut = timeout(Duration::from_millis(timeout_ms), query_results).await?;
 
         Ok(fut?)
     }

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -57,6 +57,7 @@ opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+tokio-retry = "0.3"
 
 [lints]
 workspace = true

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -19,9 +19,10 @@ impl DatabasePools {
             get_pool(&config.read_database_url, config.max_pg_connections)
                 .await
                 .map_err(|e| {
-                    FlagError::DatabaseError(format!(
-                        "Failed to create non-persons reader pool: {e}"
-                    ))
+                    FlagError::DatabaseError(
+                        e,
+                        Some("Failed to create non-persons reader pool".to_string()),
+                    )
                 })?,
         );
 
@@ -29,9 +30,10 @@ impl DatabasePools {
             get_pool(&config.write_database_url, config.max_pg_connections)
                 .await
                 .map_err(|e| {
-                    FlagError::DatabaseError(format!(
-                        "Failed to create flag matching writer pool: {e}"
-                    ))
+                    FlagError::DatabaseError(
+                        e,
+                        Some("Failed to create flag matching writer pool".to_string()),
+                    )
                 })?,
         );
 
@@ -44,7 +46,10 @@ impl DatabasePools {
                 )
                 .await
                 .map_err(|e| {
-                    FlagError::DatabaseError(format!("Failed to create persons reader pool: {e}"))
+                    FlagError::DatabaseError(
+                        e,
+                        Some("Failed to create persons reader pool".to_string()),
+                    )
                 })?,
             )
         } else {
@@ -59,7 +64,10 @@ impl DatabasePools {
                 )
                 .await
                 .map_err(|e| {
-                    FlagError::DatabaseError(format!("Failed to create persons writer pool: {e}"))
+                    FlagError::DatabaseError(
+                        e,
+                        Some("Failed to create persons writer pool".to_string()),
+                    )
                 })?,
             )
         } else {

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -218,7 +218,7 @@ impl FeatureFlagMatcher {
         feature_flags: FeatureFlagList,
         person_property_overrides: Option<HashMap<String, Value>>,
         group_property_overrides: Option<HashMap<String, HashMap<String, Value>>>,
-        hash_key_override: Option<String>,
+        hash_key_override: Option<String>,  // Aka $anon_distinct_id
         request_id: Uuid,
         flag_keys: Option<Vec<String>>,
     ) -> FlagsResponse {

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -5493,17 +5493,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_hash_key_override_error_marks_continuity_flags_as_errors() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-        let router = PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
-        );
-        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let context = TestContext::new(None).await;
+        let router = context.create_postgres_router();
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.persons_reader.clone(),
+            None,
+            None,
+        ));
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -5547,13 +5547,17 @@ mod tests {
 
         // Test the scenario where hash key override reading fails
         // This simulates the case where we have experience continuity flags but hash override reads fail
+        let overrides = crate::flags::flag_matching::FlagEvaluationOverrides {
+            person_property_overrides: None,
+            group_property_overrides: None,
+            hash_key_overrides: None, // hash_key_overrides (None simulates read failure)
+            hash_key_override_error: true, // hash_key_override_error (simulates the error occurred)
+        };
+
         let response = matcher
             .evaluate_flags_with_overrides(
                 flags,
-                None,
-                None,
-                None, // hash_key_overrides (None simulates read failure)
-                true, // hash_key_override_error (simulates the error occurred)
+                overrides,
                 Uuid::new_v4(),
                 None, // flag_keys
             )

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -5490,4 +5490,103 @@ mod tests {
             "Should match second condition (index 1)"
         );
     }
+
+    #[tokio::test]
+    async fn test_hash_key_override_error_marks_continuity_flags_as_errors() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let router = PostgresRouter::new(
+            reader.clone(),
+            writer.clone(),
+            reader.clone(),
+            writer.clone(),
+        );
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+
+        let team = insert_new_team_in_pg(reader.clone(), None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        let distinct_id = "user_distinct_id".to_string();
+        let mut matcher = FeatureFlagMatcher::new(
+            distinct_id,
+            team.id,
+            team.project_id,
+            router,
+            cohort_cache,
+            None,
+            None,
+        );
+
+        // Create flags: one with experience continuity enabled, one without
+        let flag_with_continuity = create_test_flag(
+            Some(1),
+            Some(team.id),
+            Some("Test Flag Continuity".to_string()),
+            Some("test-flag-continuity".to_string()),
+            None,
+            Some(false),
+            Some(true),
+            Some(true), // ensure_experience_continuity
+        );
+
+        let flag_without_continuity = create_test_flag(
+            Some(2),
+            Some(team.id),
+            Some("Test Flag Normal".to_string()),
+            Some("test-flag-normal".to_string()),
+            None,
+            Some(false),
+            Some(true),
+            Some(false), // ensure_experience_continuity
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_with_continuity, flag_without_continuity],
+        };
+
+        // Test the scenario where hash key override reading fails
+        // This simulates the case where we have experience continuity flags but hash override reads fail
+        let response = matcher
+            .evaluate_flags_with_overrides(
+                flags,
+                None,
+                None,
+                None, // hash_key_overrides (None simulates read failure)
+                true, // hash_key_override_error (simulates the error occurred)
+                Uuid::new_v4(),
+                None, // flag_keys
+            )
+            .await;
+
+        // Should have errors_while_computing_flags set to true
+        assert!(
+            response.errors_while_computing_flags,
+            "Should have errors_while_computing_flags=true when hash override reads fail"
+        );
+
+        // The flag with experience continuity should have an error response
+        let continuity_flag_response = response
+            .flags
+            .get("test-flag-continuity")
+            .expect("Continuity flag should be present");
+        assert!(
+            !continuity_flag_response.enabled,
+            "Flag with continuity should be disabled due to error"
+        );
+        assert_eq!(
+            continuity_flag_response.reason.code, "hash_key_override_error",
+            "Should have hash_key_override_error reason"
+        );
+
+        // The flag without experience continuity should NOT have an error (should be evaluated normally)
+        let normal_flag_response = response.flags.get("test-flag-normal");
+        // The normal flag might be evaluated normally, so we just check it's not affected by the hash override error
+        if let Some(normal_response) = normal_flag_response {
+            assert_ne!(
+                normal_response.reason.code, "hash_key_override_error",
+                "Normal flag should not have hash override error"
+            );
+        }
+    }
 }

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -37,7 +37,7 @@ pub async fn evaluate_feature_flags(
             context.feature_flags,
             context.person_property_overrides,
             context.group_property_overrides,
-            context.hash_key_override,
+            context.hash_key_override, // Aka $anon_distinct_id
             request_id,
             context.flag_keys,
         )

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -3,6 +3,7 @@ pub const FLAG_EVALUATION_ERROR_COUNTER: &str = "flags_flag_evaluation_error_tot
 pub const FLAG_CACHE_HIT_COUNTER: &str = "flags_flag_cache_hit_total";
 pub const FLAG_CACHE_ERRORS_COUNTER: &str = "flags_flag_cache_errors_total";
 pub const FLAG_HASH_KEY_WRITES_COUNTER: &str = "flags_flag_hash_key_writes_total";
+pub const FLAG_HASH_KEY_RETRIES_COUNTER: &str = "flags_hash_key_retries_total";
 pub const TEAM_CACHE_HIT_COUNTER: &str = "flags_team_cache_hit_total";
 pub const TEAM_CACHE_ERRORS_COUNTER: &str = "flags_team_cache_errors_total";
 pub const DB_TEAM_READS_COUNTER: &str = "flags_db_team_reads_total";

--- a/rust/feature-flags/src/metrics/utils.rs
+++ b/rust/feature-flags/src/metrics/utils.rs
@@ -35,18 +35,21 @@ pub fn team_id_label_filter(
 
 pub fn parse_exception_for_prometheus_label(err: &FlagError) -> &'static str {
     match err {
-        FlagError::DatabaseError(msg) => {
-            if msg.contains("statement timeout") {
+        FlagError::DatabaseError(sqlx_error, context) => {
+            let error_msg = sqlx_error.to_string();
+            let context_msg = context.as_deref().unwrap_or("");
+
+            if error_msg.contains("statement timeout") {
                 "timeout"
-            } else if msg.contains("no more connections") {
+            } else if error_msg.contains("no more connections") {
                 "no_more_connections"
-            } else if msg.contains("Failed to fetch conditions") {
+            } else if context_msg.contains("Failed to fetch conditions") {
                 "flag_condition_retry"
-            } else if msg.contains("Failed to fetch group") {
+            } else if context_msg.contains("Failed to fetch group") {
                 "group_mapping_retry"
-            } else if msg.contains("Database healthcheck failed") {
+            } else if context_msg.contains("Database healthcheck failed") {
                 "healthcheck_failed"
-            } else if msg.contains("query_wait_timeout") {
+            } else if error_msg.contains("query_wait_timeout") {
                 "query_wait_timeout"
             } else {
                 "database_error"


### PR DESCRIPTION
When flags have experience continuity enabled, it's very important that we handle hash overrides in a robust manner.

## Problem

When processing a request to `/flags`, if any flag has experience continuity enabled, we have query for hash overrides. Sometimes, these queries fail. When they do, we evaluate the flags using the supplied `distinct_id` instead of the override. This can lead to an incorrect evaluation. This is especially bad for experiment flags where a user might end up in the wrong variant.

## Changes

This PR does two main things:

1. Uses `tokio-retry` in `get_feature_flag_hash_key_overrides` to retry the query to `posthog_featureflaghashkeyoverride`.
2. If getting hash key overrides still fails, we set `errors_computing_flags` to `true` and mark all flags with experience continuity as being in error (`enabled: false`, `variant: None`).

Hopefully, the retry logic reduces the number of failures we get. But if not, marking these flags as errors will cause PostHog Web to not overwrite the cached values it has for these flags (like it does for any flags with errors). This is better than storing a bad evaluation.

## How did you test this code?

Manually: I just tested that /flags still works correctly. Hard to test a failure in the specific query.
Unit Tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Follow-up discussion

We have other retry logic. I think we should refactor those to use `tokio-retry` to clean up our code, but want to hear from others on that. I would do that in a follow-up.