### PR TITLE
chore(flags): refactor test util for dual database cxns

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
+++ b/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
@@ -104,46 +104,21 @@ impl CohortCacheManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cohorts::cohort_models::Cohort;
-    use crate::team::team_models::Team;
-    use crate::utils::test_utils::{
-        insert_cohort_for_team_in_pg, insert_new_team_in_pg, setup_dual_pg_writers,
-        setup_pg_reader_client, setup_pg_writer_client,
-    };
-    use common_database::Client;
-    use common_types::TeamId;
-    use std::sync::Arc;
+    use crate::utils::test_utils::TestContext;
     use tokio::time::{sleep, Duration};
-
-    /// Helper function to setup a new team for testing.
-    async fn setup_test_team() -> Result<Team, anyhow::Error> {
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await?;
-        Ok(team)
-    }
-
-    /// Helper function to insert a cohort for a team.
-    async fn setup_test_cohort(
-        writer_client: Arc<dyn Client + Send + Sync>,
-        team_id: TeamId,
-        name: Option<String>,
-    ) -> Result<Cohort, anyhow::Error> {
-        let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});
-        insert_cohort_for_team_in_pg(writer_client, team_id, name, filters, false).await
-    }
 
     /// Tests that cache entries expire after the specified TTL.
     #[tokio::test]
     async fn test_cache_expiry() -> Result<(), anyhow::Error> {
-        let writer_client = setup_pg_writer_client(None).await;
-        let reader_client = setup_pg_reader_client(None).await;
+        let context = TestContext::new(None).await;
+        let team = context.insert_new_team(None).await?;
 
-        let team = setup_test_team().await?;
-        let _cohort = setup_test_cohort(writer_client.clone(), team.id, None).await?;
+        let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});
+        let _cohort = context.insert_cohort(team.id, None, filters, false).await?;
 
         // Initialize CohortCacheManager with a short TTL for testing
         let cohort_cache = CohortCacheManager::new(
-            reader_client.clone(),
+            context.non_persons_reader.clone(),
             Some(100),
             Some(1), // 1-second TTL
         );
@@ -168,23 +143,25 @@ mod tests {
     /// Tests that the cache correctly evicts least recently used entries based on the weigher.
     #[tokio::test]
     async fn test_cache_weigher() -> Result<(), anyhow::Error> {
-        let writer_client = setup_pg_writer_client(None).await;
-        let reader_client = setup_pg_reader_client(None).await;
+        let context = TestContext::new(None).await;
 
         // Define a smaller max_capacity for testing
         let max_capacity: u64 = 3;
 
-        let cohort_cache = CohortCacheManager::new(reader_client.clone(), Some(max_capacity), None);
+        let cohort_cache =
+            CohortCacheManager::new(context.non_persons_reader.clone(), Some(max_capacity), None);
 
         let mut inserted_project_ids = Vec::new();
 
         // Insert multiple teams and their cohorts
+        let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});
         for _ in 0..max_capacity {
-            let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-            let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await?;
+            let team = context.insert_new_team(None).await?;
             let project_id = team.project_id;
             inserted_project_ids.push(project_id);
-            setup_test_cohort(writer_client.clone(), team.id, None).await?;
+            context
+                .insert_cohort(team.id, None, filters.clone(), false)
+                .await?;
             cohort_cache.get_cohorts(project_id).await?;
         }
 
@@ -195,11 +172,12 @@ mod tests {
             "Cache size should be equal to max_capacity"
         );
 
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let new_team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await?;
+        let new_team = context.insert_new_team(None).await?;
         let new_project_id = new_team.project_id;
         let new_team_id = new_team.id;
-        setup_test_cohort(writer_client.clone(), new_team_id, None).await?;
+        context
+            .insert_cohort(new_team_id, None, filters, false)
+            .await?;
         cohort_cache.get_cohorts(new_project_id).await?;
 
         cohort_cache.cache.run_pending_tasks().await;
@@ -227,13 +205,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_cohorts() -> Result<(), anyhow::Error> {
-        let writer_client = setup_pg_writer_client(None).await;
-        let reader_client = setup_pg_reader_client(None).await;
-        let team = setup_test_team().await?;
+        let context = TestContext::new(None).await;
+        let team = context.insert_new_team(None).await?;
         let project_id = team.project_id;
         let team_id = team.id;
-        let _cohort = setup_test_cohort(writer_client.clone(), team_id, None).await?;
-        let cohort_cache = CohortCacheManager::new(reader_client.clone(), None, None);
+
+        let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});
+        let _cohort = context.insert_cohort(team_id, None, filters, false).await?;
+        let cohort_cache = CohortCacheManager::new(context.non_persons_reader.clone(), None, None);
 
         let cached_cohorts = cohort_cache.cache.get(&project_id).await;
         assert!(cached_cohorts.is_none(), "Cache should initially be empty");

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -400,8 +400,8 @@ mod tests {
         cohorts::cohort_models::{CohortPropertyType, CohortValues},
         properties::property_models::PropertyType,
         utils::test_utils::{
-            insert_cohort_for_team_in_pg, insert_new_team_in_pg, setup_pg_reader_client,
-            setup_pg_writer_client,
+            insert_cohort_for_team_in_pg, insert_new_team_in_pg, setup_dual_pg_writers,
+            setup_pg_reader_client, setup_pg_writer_client,
         },
     };
     use serde_json::json;
@@ -411,7 +411,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team");
 
@@ -486,7 +487,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team");
 

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -399,45 +399,40 @@ mod tests {
     use crate::{
         cohorts::cohort_models::{CohortPropertyType, CohortValues},
         properties::property_models::PropertyType,
-        utils::test_utils::{
-            insert_cohort_for_team_in_pg, insert_new_team_in_pg, setup_dual_pg_writers,
-            setup_pg_reader_client, setup_pg_writer_client,
-        },
+        utils::test_utils::TestContext,
     };
     use serde_json::json;
 
     #[tokio::test]
     async fn test_list_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
         // Insert multiple cohorts for the team
-        insert_cohort_for_team_in_pg(
-            writer.clone(),
-            team.id,
-            Some("Cohort 1".to_string()),
-            json!({"properties": {"type": "AND", "values": [{"type": "property", "values": [{"key": "age", "type": "person", "value": [30], "negation": false, "operator": "gt"}]}]}}),
-            false,
-        )
-        .await
-        .expect("Failed to insert cohort1");
+        context
+            .insert_cohort(
+                team.id,
+                Some("Cohort 1".to_string()),
+                json!({"properties": {"type": "AND", "values": [{"type": "property", "values": [{"key": "age", "type": "person", "value": [30], "negation": false, "operator": "gt"}]}]}}),
+                false,
+            )
+            .await
+            .expect("Failed to insert cohort1");
 
-        insert_cohort_for_team_in_pg(
-            writer.clone(),
-            team.id,
-            Some("Cohort 2".to_string()),
-            json!({"properties": {"type": "OR", "values": [{"type": "property", "values": [{"key": "country", "type": "person", "value": ["USA"], "negation": false, "operator": "exact"}]}]}}),
-            false,
-        )
-        .await
-        .expect("Failed to insert cohort2");
+        context
+            .insert_cohort(
+                team.id,
+                Some("Cohort 2".to_string()),
+                json!({"properties": {"type": "OR", "values": [{"type": "property", "values": [{"key": "country", "type": "person", "value": ["USA"], "negation": false, "operator": "exact"}]}]}}),
+                false,
+            )
+            .await
+            .expect("Failed to insert cohort2");
 
-        let cohorts = Cohort::list_from_pg(reader, team.project_id)
+        let cohorts = Cohort::list_from_pg(context.non_persons_reader, team.project_id)
             .await
             .expect("Failed to list cohorts");
 
@@ -484,28 +479,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_extract_dependencies() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
         // Insert a single cohort that is dependent on another cohort
-        let dependent_cohort = insert_cohort_for_team_in_pg(
-            writer.clone(),
-            team.id,
-            Some("Dependent Cohort".to_string()),
-            json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$browser", "type": "person", "value": ["Safari"], "negation": false, "operator": "exact"}]}]}}),
-            false,
-        )
-        .await
-        .expect("Failed to insert dependent_cohort");
+        let dependent_cohort = context
+            .insert_cohort(
+                team.id,
+                Some("Dependent Cohort".to_string()),
+                json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$browser", "type": "person", "value": ["Safari"], "negation": false, "operator": "exact"}]}]}}),
+                false,
+            )
+            .await
+            .expect("Failed to insert dependent_cohort");
 
         // Insert main cohort with a single dependency
-        let main_cohort = insert_cohort_for_team_in_pg(
-                writer.clone(),
+        let main_cohort = context
+            .insert_cohort(
                 team.id,
                 Some("Main Cohort".to_string()),
                 json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "id", "type": "cohort", "value": dependent_cohort.id, "negation": false}]}]}}),
@@ -514,7 +507,7 @@ mod tests {
             .await
             .expect("Failed to insert main_cohort");
 
-        let cohorts = Cohort::list_from_pg(reader.clone(), team.project_id)
+        let cohorts = Cohort::list_from_pg(context.non_persons_reader.clone(), team.project_id)
             .await
             .expect("Failed to fetch cohorts");
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -219,8 +219,8 @@ impl Config {
             write_database_url: "postgres://posthog:posthog@localhost:5432/test_posthog"
                 .to_string(),
             read_database_url: "postgres://posthog:posthog@localhost:5432/test_posthog".to_string(),
-            persons_write_database_url: "".to_string(),
-            persons_read_database_url: "".to_string(),
+            persons_write_database_url: "postgres://posthog:posthog@localhost:5434/posthog_persons".to_string(),
+            persons_read_database_url: "postgres://posthog:posthog@localhost:5434/posthog_persons".to_string(),
             max_concurrency: 1000,
             max_pg_connections: 10,
             acquire_timeout_secs: 5,

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -219,8 +219,8 @@ impl Config {
             write_database_url: "postgres://posthog:posthog@localhost:5432/test_posthog"
                 .to_string(),
             read_database_url: "postgres://posthog:posthog@localhost:5432/test_posthog".to_string(),
-            persons_write_database_url: "postgres://posthog:posthog@localhost:5434/posthog_persons".to_string(),
-            persons_read_database_url: "postgres://posthog:posthog@localhost:5434/posthog_persons".to_string(),
+            persons_write_database_url: "".to_string(),
+            persons_read_database_url: "".to_string(),
             max_concurrency: 1000,
             max_pg_connections: 10,
             acquire_timeout_secs: 5,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -179,8 +179,8 @@ mod tests {
     use super::*;
     use crate::utils::test_utils::{
         insert_flag_for_team_in_pg, insert_flags_for_team_in_redis, insert_new_team_in_pg,
-        insert_new_team_in_redis, setup_invalid_pg_client, setup_pg_reader_client,
-        setup_redis_client,
+        insert_new_team_in_redis, setup_dual_pg_writers, setup_invalid_pg_client,
+        setup_pg_reader_client, setup_redis_client,
     };
     use rand::Rng;
 
@@ -233,7 +233,8 @@ mod tests {
     async fn test_fetch_flags_from_pg() {
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team");
 
@@ -291,7 +292,8 @@ mod tests {
     async fn test_fetch_multiple_flags_from_pg() {
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team");
 

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -178,9 +178,8 @@ impl FeatureFlagList {
 mod tests {
     use super::*;
     use crate::utils::test_utils::{
-        insert_flag_for_team_in_pg, insert_flags_for_team_in_redis, insert_new_team_in_pg,
-        insert_new_team_in_redis, setup_dual_pg_writers, setup_invalid_pg_client,
-        setup_pg_reader_client, setup_redis_client,
+        insert_flags_for_team_in_redis, insert_new_team_in_redis, setup_invalid_pg_client,
+        setup_redis_client, TestContext,
     };
     use rand::Rng;
 
@@ -231,20 +230,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_flags_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
-        insert_flag_for_team_in_pg(reader.clone(), team.id, None)
+        context
+            .insert_flag(team.id, None)
             .await
             .expect("Failed to insert flag");
 
-        let (flags_from_pg, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from pg");
+        let (flags_from_pg, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from pg");
 
         assert_eq!(flags_from_pg.flags.len(), 1);
         let flag = flags_from_pg.flags.first().expect("Flags should be in pg");
@@ -256,20 +256,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_empty_team_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
+        let context = TestContext::new(None).await;
 
-        let (FeatureFlagList { flags }, _) = FeatureFlagList::from_pg(reader.clone(), 1234)
-            .await
-            .expect("Failed to fetch flags from pg");
+        let (FeatureFlagList { flags }, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), 1234)
+                .await
+                .expect("Failed to fetch flags from pg");
 
         assert_eq!(flags.len(), 0);
     }
 
     #[tokio::test]
     async fn test_fetch_nonexistent_team_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
+        let context = TestContext::new(None).await;
 
-        match FeatureFlagList::from_pg(reader.clone(), -1).await {
+        match FeatureFlagList::from_pg(context.non_persons_reader.clone(), -1).await {
             Ok((flags, _)) => assert_eq!(flags.flags.len(), 0),
             Err(err) => panic!("Expected empty result, got error: {err:?}"),
         }
@@ -290,10 +291,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_multiple_flags_from_pg() {
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
@@ -327,17 +327,20 @@ mod tests {
         };
 
         // Insert multiple flags for the team
-        insert_flag_for_team_in_pg(reader.clone(), team.id, Some(flag1))
+        context
+            .insert_flag(team.id, Some(flag1))
             .await
             .expect("Failed to insert flags");
 
-        insert_flag_for_team_in_pg(reader.clone(), team.id, Some(flag2))
+        context
+            .insert_flag(team.id, Some(flag2))
             .await
             .expect("Failed to insert flags");
 
-        let (flags_from_pg, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from pg");
+        let (flags_from_pg, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from pg");
 
         assert_eq!(flags_from_pg.flags.len(), 2);
         for flag in &flags_from_pg.flags {

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -947,7 +947,8 @@ mod tests {
         let distinct_id = "user2".to_string();
 
         // Insert person
-        context.insert_person(team.id, distinct_id.clone(), None)
+        context
+            .insert_person(team.id, distinct_id.clone(), None)
             .await
             .unwrap();
 
@@ -985,9 +986,7 @@ mod tests {
         };
 
         // Insert the feature flag into the database
-        context.insert_flag(team.id, Some(flag_row))
-            .await
-            .unwrap();
+        context.insert_flag(team.id, Some(flag_row)).await.unwrap();
 
         // Set hash key override
         let router = context.create_postgres_router();
@@ -1002,10 +1001,10 @@ mod tests {
         .unwrap();
 
         // Retrieve hash key overrides
-        let overrides =
-            context.get_feature_flag_hash_key_overrides(team.id, vec![distinct_id.clone()])
-                .await
-                .unwrap();
+        let overrides = context
+            .get_feature_flag_hash_key_overrides(team.id, vec![distinct_id.clone()])
+            .await
+            .unwrap();
 
         assert_eq!(
             overrides.get("test_flag"),
@@ -1017,37 +1016,42 @@ mod tests {
     #[tokio::test]
     async fn test_set_feature_flag_hash_key_overrides_with_multiple_persons() {
         let context = TestContext::new(None).await;
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
         // Create 3 persons
-        let person1_id = context.insert_person(
-            team.id,
-            "batch_user1".to_string(),
-            Some(json!({"email": "user1@example.com"})),
-        )
-        .await
-        .expect("Failed to insert person1");
+        let person1_id = context
+            .insert_person(
+                team.id,
+                "batch_user1".to_string(),
+                Some(json!({"email": "user1@example.com"})),
+            )
+            .await
+            .expect("Failed to insert person1");
 
-        let _person2_id = context.insert_person(
-            team.id,
-            "batch_user2".to_string(),
-            Some(json!({"email": "user2@example.com"})),
-        )
-        .await
-        .expect("Failed to insert person2");
+        let _person2_id = context
+            .insert_person(
+                team.id,
+                "batch_user2".to_string(),
+                Some(json!({"email": "user2@example.com"})),
+            )
+            .await
+            .expect("Failed to insert person2");
 
-        let _person3_id = context.insert_person(
-            team.id,
-            "batch_user3".to_string(),
-            Some(json!({"email": "user3@example.com"})),
-        )
-        .await
-        .expect("Failed to insert person3");
+        let _person3_id = context
+            .insert_person(
+                team.id,
+                "batch_user3".to_string(),
+                Some(json!({"email": "user3@example.com"})),
+            )
+            .await
+            .expect("Failed to insert person3");
 
         // Add additional distinct_id for person1 to test multiple distinct_ids per person
-        let mut conn = context.get_persons_connection()
+        let mut conn = context
+            .get_persons_connection()
             .await
             .expect("Failed to get connection");
         let mut transaction = conn.begin().await.expect("Failed to begin transaction");
@@ -1082,7 +1086,8 @@ mod tests {
                 version: Some(1),
                 evaluation_runtime: None,
             };
-            context.insert_flag(team.id, Some(flag_row))
+            context
+                .insert_flag(team.id, Some(flag_row))
                 .await
                 .unwrap_or_else(|_| panic!("Failed to insert flag {i}"));
         }
@@ -1112,12 +1117,10 @@ mod tests {
         // Verify all combinations were created correctly
         // Should create overrides for all distinct_ids
         for distinct_id in &distinct_ids {
-            let overrides = context.get_feature_flag_hash_key_overrides(
-                team.id,
-                vec![distinct_id.clone()],
-            )
-            .await
-            .unwrap_or_else(|_| panic!("Failed to get overrides for {distinct_id}"));
+            let overrides = context
+                .get_feature_flag_hash_key_overrides(team.id, vec![distinct_id.clone()])
+                .await
+                .unwrap_or_else(|_| panic!("Failed to get overrides for {distinct_id}"));
 
             assert_eq!(
                 overrides.len(),
@@ -1137,7 +1140,8 @@ mod tests {
 
         // Verify the actual count in the database
         // batch_user1 and batch_user1_alt map to same person, so 3 persons * 4 flags = 12 overrides
-        let mut conn = context.get_persons_connection()
+        let mut conn = context
+            .get_persons_connection()
             .await
             .expect("Failed to get connection");
         let count: i64 = sqlx::query_scalar(
@@ -1159,26 +1163,29 @@ mod tests {
     #[tokio::test]
     async fn test_set_feature_flag_hash_key_overrides_with_with_existing_overrides() {
         let context = TestContext::new(None).await;
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
         // Create 2 persons
-        let person1_id = context.insert_person(
-            team.id,
-            "existing_user1".to_string(),
-            Some(json!({"email": "existing1@example.com"})),
-        )
-        .await
-        .expect("Failed to insert person1");
+        let person1_id = context
+            .insert_person(
+                team.id,
+                "existing_user1".to_string(),
+                Some(json!({"email": "existing1@example.com"})),
+            )
+            .await
+            .expect("Failed to insert person1");
 
-        let _person2_id = context.insert_person(
-            team.id,
-            "existing_user2".to_string(),
-            Some(json!({"email": "existing2@example.com"})),
-        )
-        .await
-        .expect("Failed to insert person2");
+        let _person2_id = context
+            .insert_person(
+                team.id,
+                "existing_user2".to_string(),
+                Some(json!({"email": "existing2@example.com"})),
+            )
+            .await
+            .expect("Failed to insert person2");
 
         // Create 3 flags
         for i in 1..=3 {
@@ -1194,13 +1201,15 @@ mod tests {
                 version: Some(1),
                 evaluation_runtime: None,
             };
-            context.insert_flag(team.id, Some(flag_row))
+            context
+                .insert_flag(team.id, Some(flag_row))
                 .await
                 .unwrap_or_else(|_| panic!("Failed to insert flag {i}"));
         }
 
         // Manually insert some existing overrides
-        let mut conn = context.get_persons_connection()
+        let mut conn = context
+            .get_persons_connection()
             .await
             .expect("Failed to get connection");
         let mut transaction = conn.begin().await.expect("Failed to begin transaction");
@@ -1241,12 +1250,10 @@ mod tests {
         assert!(result, "Should have written new overrides");
 
         // Verify existing overrides are preserved
-        let overrides1 = context.get_feature_flag_hash_key_overrides(
-            team.id,
-            vec!["existing_user1".to_string()],
-        )
-        .await
-        .expect("Failed to get overrides");
+        let overrides1 = context
+            .get_feature_flag_hash_key_overrides(team.id, vec!["existing_user1".to_string()])
+            .await
+            .expect("Failed to get overrides");
 
         assert_eq!(
             overrides1.get("existing_flag_1"),
@@ -1265,7 +1272,8 @@ mod tests {
         );
 
         // Verify the count - should have 6 total (2 existing + 4 new)
-        let mut conn = context.get_persons_connection()
+        let mut conn = context
+            .get_persons_connection()
             .await
             .expect("Failed to get connection");
         let count: i64 = sqlx::query_scalar(
@@ -1285,18 +1293,20 @@ mod tests {
     #[tokio::test]
     async fn test_set_overrides_filters_inactive_and_deleted_flags() {
         let context = TestContext::new(None).await;
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
         // Create a person
-        context.insert_person(
-            team.id,
-            "filter_test_user".to_string(),
-            Some(json!({"email": "filter@example.com"})),
-        )
-        .await
-        .expect("Failed to insert person");
+        context
+            .insert_person(
+                team.id,
+                "filter_test_user".to_string(),
+                Some(json!({"email": "filter@example.com"})),
+            )
+            .await
+            .expect("Failed to insert person");
 
         // Create various flags with different states
         let active_flag = FeatureFlagRow {
@@ -1351,16 +1361,20 @@ mod tests {
             evaluation_runtime: None,
         };
 
-        context.insert_flag(team.id, Some(active_flag))
+        context
+            .insert_flag(team.id, Some(active_flag))
             .await
             .expect("Failed to insert active flag");
-        context.insert_flag(team.id, Some(inactive_flag))
+        context
+            .insert_flag(team.id, Some(inactive_flag))
             .await
             .expect("Failed to insert inactive flag");
-        context.insert_flag(team.id, Some(deleted_flag))
+        context
+            .insert_flag(team.id, Some(deleted_flag))
             .await
             .expect("Failed to insert deleted flag");
-        context.insert_flag(team.id, Some(no_continuity_flag))
+        context
+            .insert_flag(team.id, Some(no_continuity_flag))
             .await
             .expect("Failed to insert no continuity flag");
 
@@ -1379,12 +1393,10 @@ mod tests {
         assert!(result, "Should have written override for active flag");
 
         // Verify only the active flag with experience continuity got an override
-        let overrides = context.get_feature_flag_hash_key_overrides(
-            team.id,
-            vec!["filter_test_user".to_string()],
-        )
-        .await
-        .expect("Failed to get overrides");
+        let overrides = context
+            .get_feature_flag_hash_key_overrides(team.id, vec!["filter_test_user".to_string()])
+            .await
+            .expect("Failed to get overrides");
 
         assert_eq!(overrides.len(), 1, "Should have exactly 1 override");
         assert_eq!(
@@ -1411,18 +1423,20 @@ mod tests {
     #[tokio::test]
     async fn test_should_write_hash_key_override() {
         let context = TestContext::new(None).await;
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
         // Create a person
-        context.insert_person(
-            team.id,
-            "should_write_user".to_string(),
-            Some(json!({"email": "should_write@example.com"})),
-        )
-        .await
-        .expect("Failed to insert person");
+        context
+            .insert_person(
+                team.id,
+                "should_write_user".to_string(),
+                Some(json!({"email": "should_write@example.com"})),
+            )
+            .await
+            .expect("Failed to insert person");
 
         // Create a flag with experience continuity
         let flag_row = FeatureFlagRow {
@@ -1437,7 +1451,8 @@ mod tests {
             version: Some(1),
             evaluation_runtime: None,
         };
-        context.insert_flag(team.id, Some(flag_row))
+        context
+            .insert_flag(team.id, Some(flag_row))
             .await
             .expect("Failed to insert flag");
 
@@ -1502,7 +1517,8 @@ mod tests {
     #[tokio::test]
     async fn test_set_overrides_with_no_persons() {
         let context = TestContext::new(None).await;
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 
@@ -1519,7 +1535,8 @@ mod tests {
             version: Some(1),
             evaluation_runtime: None,
         };
-        context.insert_flag(team.id, Some(flag_row))
+        context
+            .insert_flag(team.id, Some(flag_row))
             .await
             .expect("Failed to insert flag");
 
@@ -1541,7 +1558,8 @@ mod tests {
         assert!(!result, "Should return false when no persons found");
 
         // Verify no overrides were created
-        let mut conn = context.get_persons_connection()
+        let mut conn = context
+            .get_persons_connection()
             .await
             .expect("Failed to get connection");
         let count: i64 = sqlx::query_scalar(

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -156,10 +156,10 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             p.id as person_id,
             p.properties as person_properties
         FROM posthog_persondistinctid ppd
-        INNER JOIN posthog_person p 
-            ON p.id = ppd.person_id 
+        INNER JOIN posthog_person p
+            ON p.id = ppd.person_id
             AND p.team_id = ppd.team_id
-        WHERE ppd.distinct_id = $1 
+        WHERE ppd.distinct_id = $1
             AND ppd.team_id = $2
     "#;
 
@@ -198,7 +198,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         if !static_cohort_ids.is_empty() {
             let cohort_query = r#"
                     WITH cohort_membership AS (
-                        SELECT c.cohort_id, 
+                        SELECT c.cohort_id,
                                CASE WHEN pc.cohort_id IS NOT NULL THEN true ELSE false END AS is_member
                         FROM unnest($1::integer[]) AS c(cohort_id)
                         LEFT JOIN posthog_cohortpeople AS pc
@@ -282,7 +282,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     // Only fetch group property data if we have group types to look up
     if !group_type_indexes.is_empty() {
         let group_query = r#"
-            SELECT 
+            SELECT
                 group_type_index,
                 group_key,
                 group_properties
@@ -460,8 +460,8 @@ pub async fn get_feature_flag_hash_key_overrides(
     conn_timer.fin();
 
     let person_and_distinct_id_query = r#"
-            SELECT person_id, distinct_id 
-            FROM posthog_persondistinctid 
+            SELECT person_id, distinct_id
+            FROM posthog_persondistinctid
             WHERE team_id = $1 AND distinct_id = ANY($2)
         "#;
 
@@ -478,8 +478,8 @@ pub async fn get_feature_flag_hash_key_overrides(
 
     // Get hash key overrides
     let hash_key_override_query = r#"
-            SELECT feature_flag_key, hash_key, person_id 
-            FROM posthog_featureflaghashkeyoverride 
+            SELECT feature_flag_key, hash_key, person_id
+            FROM posthog_featureflaghashkeyoverride
             WHERE team_id = $1 AND person_id = ANY($2)
         "#;
 
@@ -543,26 +543,26 @@ pub async fn set_feature_flag_hash_key_overrides(
 
         // Query 1: Get all person data - person_ids + existing overrides + validation (person pool)
         let person_data_query = r#"
-            SELECT DISTINCT 
-                p.person_id, 
+            SELECT DISTINCT
+                p.person_id,
                 p.distinct_id,
                 existing.feature_flag_key
             FROM posthog_persondistinctid p
-            LEFT JOIN posthog_featureflaghashkeyoverride existing 
+            LEFT JOIN posthog_featureflaghashkeyoverride existing
                 ON existing.person_id = p.person_id AND existing.team_id = p.team_id
-            WHERE p.team_id = $1 
+            WHERE p.team_id = $1
                 AND p.distinct_id = ANY($2)
                 AND EXISTS (SELECT 1 FROM posthog_person WHERE id = p.person_id AND team_id = p.team_id)
         "#;
 
         // Query 2: Get all active feature flags with experience continuity (non-person pool)
         let flags_query = r#"
-            SELECT flag.key 
+            SELECT flag.key
             FROM posthog_featureflag flag
             JOIN posthog_team team ON flag.team_id = team.id
-            WHERE team.project_id = $1 
-                AND flag.ensure_experience_continuity = TRUE 
-                AND flag.active = TRUE 
+            WHERE team.project_id = $1
+                AND flag.ensure_experience_continuity = TRUE
+                AND flag.active = TRUE
                 AND flag.deleted = FALSE
         "#;
 
@@ -761,7 +761,7 @@ pub async fn should_write_hash_key_override(
 
     // Query 1: Get person_ids and existing overrides from person pool in one shot
     let person_data_query = r#"
-        SELECT DISTINCT 
+        SELECT DISTINCT
             p.person_id,
             existing.feature_flag_key
         FROM posthog_persondistinctid p
@@ -775,8 +775,8 @@ pub async fn should_write_hash_key_override(
         SELECT key FROM posthog_featureflag flag
         JOIN posthog_team team ON flag.team_id = team.id
         WHERE team.project_id = $1
-            AND flag.ensure_experience_continuity = TRUE 
-            AND flag.active = TRUE 
+            AND flag.ensure_experience_continuity = TRUE
+            AND flag.active = TRUE
             AND flag.deleted = FALSE
     "#;
 
@@ -937,7 +937,7 @@ mod tests {
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
         utils::test_utils::{
             create_test_flag, insert_flag_for_team_in_pg, insert_new_team_in_pg,
-            insert_person_for_team_in_pg, setup_pg_reader_client, setup_pg_writer_client,
+            insert_person_for_team_in_pg, setup_dual_pg_writers,
         },
     };
 
@@ -945,13 +945,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_feature_flag_hash_key_overrides_success() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
         let distinct_id = "user2".to_string();
 
         // Insert person
-        insert_person_for_team_in_pg(reader.clone(), team.id, distinct_id.clone(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, distinct_id.clone(), None)
             .await
             .unwrap();
 
@@ -989,16 +988,16 @@ mod tests {
         };
 
         // Insert the feature flag into the database
-        insert_flag_for_team_in_pg(writer.clone(), team.id, Some(flag_row))
+        insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(flag_row))
             .await
             .unwrap();
 
         // Set hash key override
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         set_feature_flag_hash_key_overrides(
             &router,
@@ -1012,7 +1011,7 @@ mod tests {
 
         // Retrieve hash key overrides
         let overrides =
-            get_feature_flag_hash_key_overrides(reader.clone(), team.id, vec![distinct_id.clone()])
+            get_feature_flag_hash_key_overrides(persons_writer.clone(), team.id, vec![distinct_id.clone()])
                 .await
                 .unwrap();
 
@@ -1025,15 +1024,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_feature_flag_hash_key_overrides_with_multiple_persons() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
             .await
             .expect("Failed to insert team");
 
         // Create 3 persons
         let person1_id = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "batch_user1".to_string(),
             Some(json!({"email": "user1@example.com"})),
@@ -1042,7 +1040,7 @@ mod tests {
         .expect("Failed to insert person1");
 
         let _person2_id = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "batch_user2".to_string(),
             Some(json!({"email": "user2@example.com"})),
@@ -1051,7 +1049,7 @@ mod tests {
         .expect("Failed to insert person2");
 
         let _person3_id = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "batch_user3".to_string(),
             Some(json!({"email": "user3@example.com"})),
@@ -1060,7 +1058,7 @@ mod tests {
         .expect("Failed to insert person3");
 
         // Add additional distinct_id for person1 to test multiple distinct_ids per person
-        let mut conn = writer
+        let mut conn = persons_writer.clone()
             .get_connection()
             .await
             .expect("Failed to get connection");
@@ -1096,7 +1094,7 @@ mod tests {
                 version: Some(1),
                 evaluation_runtime: None,
             };
-            insert_flag_for_team_in_pg(writer.clone(), team.id, Some(flag_row))
+            insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(flag_row))
                 .await
                 .unwrap_or_else(|_| panic!("Failed to insert flag {i}"));
         }
@@ -1111,10 +1109,10 @@ mod tests {
         let hash_key = "batch_hash_key".to_string();
 
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         let result = set_feature_flag_hash_key_overrides(
             &router,
@@ -1132,7 +1130,7 @@ mod tests {
         // Should create overrides for all distinct_ids
         for distinct_id in &distinct_ids {
             let overrides = get_feature_flag_hash_key_overrides(
-                reader.clone(),
+                persons_writer.clone(),
                 team.id,
                 vec![distinct_id.clone()],
             )
@@ -1157,12 +1155,12 @@ mod tests {
 
         // Verify the actual count in the database
         // batch_user1 and batch_user1_alt map to same person, so 3 persons * 4 flags = 12 overrides
-        let mut conn = reader
+        let mut conn = persons_writer.clone()
             .get_connection()
             .await
             .expect("Failed to get connection");
         let count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM posthog_featureflaghashkeyoverride 
+            "SELECT COUNT(*) FROM posthog_featureflaghashkeyoverride
              WHERE team_id = $1 AND hash_key = $2",
         )
         .bind(team.id)
@@ -1179,15 +1177,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_feature_flag_hash_key_overrides_with_with_existing_overrides() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
             .await
             .expect("Failed to insert team");
 
         // Create 2 persons
         let person1_id = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "existing_user1".to_string(),
             Some(json!({"email": "existing1@example.com"})),
@@ -1196,7 +1193,7 @@ mod tests {
         .expect("Failed to insert person1");
 
         let _person2_id = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "existing_user2".to_string(),
             Some(json!({"email": "existing2@example.com"})),
@@ -1218,13 +1215,13 @@ mod tests {
                 version: Some(1),
                 evaluation_runtime: None,
             };
-            insert_flag_for_team_in_pg(writer.clone(), team.id, Some(flag_row))
+            insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(flag_row))
                 .await
                 .unwrap_or_else(|_| panic!("Failed to insert flag {i}"));
         }
 
         // Manually insert some existing overrides
-        let mut conn = writer
+        let mut conn = non_persons_writer.clone()
             .get_connection()
             .await
             .expect("Failed to get connection");
@@ -1253,10 +1250,10 @@ mod tests {
         let new_hash = "new_batch_hash".to_string();
 
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         let result = set_feature_flag_hash_key_overrides(
             &router,
@@ -1272,7 +1269,7 @@ mod tests {
 
         // Verify existing overrides are preserved
         let overrides1 = get_feature_flag_hash_key_overrides(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             vec!["existing_user1".to_string()],
         )
@@ -1296,7 +1293,7 @@ mod tests {
         );
 
         // Verify the count - should have 6 total (2 existing + 4 new)
-        let mut conn = reader
+        let mut conn = persons_writer.clone()
             .get_connection()
             .await
             .expect("Failed to get connection");
@@ -1316,15 +1313,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_overrides_filters_inactive_and_deleted_flags() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
             .await
             .expect("Failed to insert team");
 
         // Create a person
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "filter_test_user".to_string(),
             Some(json!({"email": "filter@example.com"})),
@@ -1385,25 +1381,25 @@ mod tests {
             evaluation_runtime: None,
         };
 
-        insert_flag_for_team_in_pg(writer.clone(), team.id, Some(active_flag))
+        insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(active_flag))
             .await
             .expect("Failed to insert active flag");
-        insert_flag_for_team_in_pg(writer.clone(), team.id, Some(inactive_flag))
+        insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(inactive_flag))
             .await
             .expect("Failed to insert inactive flag");
-        insert_flag_for_team_in_pg(writer.clone(), team.id, Some(deleted_flag))
+        insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(deleted_flag))
             .await
             .expect("Failed to insert deleted flag");
-        insert_flag_for_team_in_pg(writer.clone(), team.id, Some(no_continuity_flag))
+        insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(no_continuity_flag))
             .await
             .expect("Failed to insert no continuity flag");
 
         // Set overrides
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         let result = set_feature_flag_hash_key_overrides(
             &router,
@@ -1419,7 +1415,7 @@ mod tests {
 
         // Verify only the active flag with experience continuity got an override
         let overrides = get_feature_flag_hash_key_overrides(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             vec!["filter_test_user".to_string()],
         )
@@ -1450,15 +1446,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_should_write_hash_key_override() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
             .await
             .expect("Failed to insert team");
 
         // Create a person
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "should_write_user".to_string(),
             Some(json!({"email": "should_write@example.com"})),
@@ -1479,16 +1474,16 @@ mod tests {
             version: Some(1),
             evaluation_runtime: None,
         };
-        insert_flag_for_team_in_pg(writer.clone(), team.id, Some(flag_row))
+        insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(flag_row))
             .await
             .expect("Failed to insert flag");
 
         // Test 1: Should return true when no overrides exist
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         let should_write = should_write_hash_key_override(
             &router,
@@ -1504,10 +1499,10 @@ mod tests {
 
         // Now set an override
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         set_feature_flag_hash_key_overrides(
             &router,
@@ -1521,10 +1516,10 @@ mod tests {
 
         // Test 2: Should return false when override exists
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         let should_write = should_write_hash_key_override(
             &router,
@@ -1543,10 +1538,10 @@ mod tests {
 
         // Test 3: Should return false for non-existent person
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         let should_write = should_write_hash_key_override(
             &router,
@@ -1563,9 +1558,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_overrides_with_no_persons() {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
             .await
             .expect("Failed to insert team");
 
@@ -1582,16 +1576,16 @@ mod tests {
             version: Some(1),
             evaluation_runtime: None,
         };
-        insert_flag_for_team_in_pg(writer.clone(), team.id, Some(flag_row))
+        insert_flag_for_team_in_pg(non_persons_writer.clone(), team.id, Some(flag_row))
             .await
             .expect("Failed to insert flag");
 
         // Try to set overrides for non-existent distinct_ids
         let router = crate::database::PostgresRouter::new(
-            reader.clone(),
-            writer.clone(),
-            reader.clone(),
-            writer.clone(),
+            persons_writer.clone(),
+            persons_writer.clone(),
+            non_persons_writer.clone(),
+            non_persons_writer.clone(),
         );
         let result = set_feature_flag_hash_key_overrides(
             &router,
@@ -1609,7 +1603,7 @@ mod tests {
         assert!(!result, "Should return false when no persons found");
 
         // Verify no overrides were created
-        let mut conn = reader
+        let mut conn = persons_writer.clone()
             .get_connection()
             .await
             .expect("Failed to get connection");

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -98,7 +98,7 @@ mod tests {
     use super::*;
     use crate::utils::test_utils::{
         insert_flag_for_team_in_pg, insert_flags_for_team_in_redis, insert_new_team_in_pg,
-        setup_pg_reader_client, setup_redis_client,
+        setup_dual_pg_writers, setup_pg_reader_client, setup_redis_client,
     };
 
     #[test]
@@ -401,7 +401,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -497,7 +498,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -639,7 +641,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -730,7 +733,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -834,7 +838,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -934,7 +939,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
 
         // Test malformed JSON in Redis
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -961,7 +967,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1035,7 +1042,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1112,7 +1120,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1207,7 +1216,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1313,7 +1323,8 @@ mod tests {
         let redis_client = setup_redis_client(None).await;
         let reader = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team in pg");
 

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -97,8 +97,7 @@ mod tests {
 
     use super::*;
     use crate::utils::test_utils::{
-        insert_flag_for_team_in_pg, insert_flags_for_team_in_redis, insert_new_team_in_pg,
-        setup_dual_pg_writers, setup_pg_reader_client, setup_redis_client,
+        insert_flags_for_team_in_redis, setup_redis_client, TestContext,
     };
 
     #[test]
@@ -399,10 +398,9 @@ mod tests {
     #[tokio::test]
     async fn test_multivariate_flag_parsing() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -454,24 +452,24 @@ mod tests {
         .expect("Failed to insert flag in Redis");
 
         // Insert into Postgres
-        insert_flag_for_team_in_pg(
-            reader.clone(),
-            team.id,
-            Some(FeatureFlagRow {
-                id: 1,
-                team_id: team.id,
-                name: Some("Multivariate Flag".to_string()),
-                key: "multivariate_flag".to_string(),
-                filters: multivariate_flag["filters"].clone(),
-                deleted: false,
-                active: true,
-                ensure_experience_continuity: Some(false),
-                version: Some(1),
-                evaluation_runtime: Some("all".to_string()),
-            }),
-        )
-        .await
-        .expect("Failed to insert flag in Postgres");
+        context
+            .insert_flag(
+                team.id,
+                Some(FeatureFlagRow {
+                    id: 1,
+                    team_id: team.id,
+                    name: Some("Multivariate Flag".to_string()),
+                    key: "multivariate_flag".to_string(),
+                    filters: multivariate_flag["filters"].clone(),
+                    deleted: false,
+                    active: true,
+                    ensure_experience_continuity: Some(false),
+                    version: Some(1),
+                    evaluation_runtime: Some("all".to_string()),
+                }),
+            )
+            .await
+            .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
@@ -484,9 +482,10 @@ mod tests {
         assert_eq!(redis_flag.get_variants().len(), 3);
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag");
@@ -496,10 +495,9 @@ mod tests {
     #[tokio::test]
     async fn test_multivariate_flag_with_payloads() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -555,24 +553,24 @@ mod tests {
         .expect("Failed to insert flag in Redis");
 
         // Insert into Postgres
-        insert_flag_for_team_in_pg(
-            reader.clone(),
-            team.id,
-            Some(FeatureFlagRow {
-                id: 1,
-                team_id: team.id,
-                name: Some("Multivariate Flag with Payloads".to_string()),
-                key: "multivariate_flag_with_payloads".to_string(),
-                filters: multivariate_flag_with_payloads["filters"].clone(),
-                deleted: false,
-                active: true,
-                ensure_experience_continuity: Some(false),
-                version: Some(1),
-                evaluation_runtime: Some("all".to_string()),
-            }),
-        )
-        .await
-        .expect("Failed to insert flag in Postgres");
+        context
+            .insert_flag(
+                team.id,
+                Some(FeatureFlagRow {
+                    id: 1,
+                    team_id: team.id,
+                    name: Some("Multivariate Flag with Payloads".to_string()),
+                    key: "multivariate_flag_with_payloads".to_string(),
+                    filters: multivariate_flag_with_payloads["filters"].clone(),
+                    deleted: false,
+                    active: true,
+                    ensure_experience_continuity: Some(false),
+                    version: Some(1),
+                    evaluation_runtime: Some("all".to_string()),
+                }),
+            )
+            .await
+            .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
@@ -584,9 +582,10 @@ mod tests {
         assert_eq!(redis_flag.key, "multivariate_flag_with_payloads");
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag_with_payloads");
@@ -639,10 +638,9 @@ mod tests {
     #[tokio::test]
     async fn test_flag_with_super_groups() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -687,24 +685,24 @@ mod tests {
         .expect("Failed to insert flag in Redis");
 
         // Insert into Postgres
-        insert_flag_for_team_in_pg(
-            reader.clone(),
-            team.id,
-            Some(FeatureFlagRow {
-                id: 1,
-                team_id: team.id,
-                name: Some("Flag with Super Groups".to_string()),
-                key: "flag_with_super_groups".to_string(),
-                filters: flag_with_super_groups["filters"].clone(),
-                deleted: false,
-                active: true,
-                ensure_experience_continuity: Some(false),
-                version: Some(1),
-                evaluation_runtime: Some("all".to_string()),
-            }),
-        )
-        .await
-        .expect("Failed to insert flag in Postgres");
+        context
+            .insert_flag(
+                team.id,
+                Some(FeatureFlagRow {
+                    id: 1,
+                    team_id: team.id,
+                    name: Some("Flag with Super Groups".to_string()),
+                    key: "flag_with_super_groups".to_string(),
+                    filters: flag_with_super_groups["filters"].clone(),
+                    deleted: false,
+                    active: true,
+                    ensure_experience_continuity: Some(false),
+                    version: Some(1),
+                    evaluation_runtime: Some("all".to_string()),
+                }),
+            )
+            .await
+            .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
@@ -718,9 +716,10 @@ mod tests {
         assert_eq!(redis_flag.filters.super_groups.as_ref().unwrap().len(), 1);
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "flag_with_super_groups");
@@ -731,10 +730,9 @@ mod tests {
     #[tokio::test]
     async fn test_flags_with_different_property_types() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -786,24 +784,24 @@ mod tests {
         .expect("Failed to insert flag in Redis");
 
         // Insert into Postgres
-        insert_flag_for_team_in_pg(
-            reader.clone(),
-            team.id,
-            Some(FeatureFlagRow {
-                id: 1,
-                team_id: team.id,
-                name: Some("Flag with Different Properties".to_string()),
-                key: "flag_with_different_properties".to_string(),
-                filters: flag_with_different_properties["filters"].clone(),
-                deleted: false,
-                active: true,
-                ensure_experience_continuity: Some(false),
-                version: Some(1),
-                evaluation_runtime: Some("all".to_string()),
-            }),
-        )
-        .await
-        .expect("Failed to insert flag in Postgres");
+        context
+            .insert_flag(
+                team.id,
+                Some(FeatureFlagRow {
+                    id: 1,
+                    team_id: team.id,
+                    name: Some("Flag with Different Properties".to_string()),
+                    key: "flag_with_different_properties".to_string(),
+                    filters: flag_with_different_properties["filters"].clone(),
+                    deleted: false,
+                    active: true,
+                    ensure_experience_continuity: Some(false),
+                    version: Some(1),
+                    evaluation_runtime: Some("all".to_string()),
+                }),
+            )
+            .await
+            .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
@@ -820,9 +818,10 @@ mod tests {
         assert_eq!(redis_properties[2].prop_type, PropertyType::Cohort);
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
         let pg_flag = &pg_flags.flags[0];
         assert_eq!(pg_flag.key, "flag_with_different_properties");
@@ -836,10 +835,9 @@ mod tests {
     #[tokio::test]
     async fn test_deleted_and_inactive_flags() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -874,43 +872,43 @@ mod tests {
         .expect("Failed to insert flags in Redis");
 
         // Insert into Postgres
-        insert_flag_for_team_in_pg(
-            reader.clone(),
-            team.id,
-            Some(FeatureFlagRow {
-                id: 0,
-                team_id: team.id,
-                name: Some("Deleted Flag".to_string()),
-                key: "deleted_flag".to_string(),
-                filters: deleted_flag["filters"].clone(),
-                deleted: true,
-                active: true,
-                ensure_experience_continuity: Some(false),
-                version: Some(1),
-                evaluation_runtime: Some("all".to_string()),
-            }),
-        )
-        .await
-        .expect("Failed to insert deleted flag in Postgres");
+        context
+            .insert_flag(
+                team.id,
+                Some(FeatureFlagRow {
+                    id: 0,
+                    team_id: team.id,
+                    name: Some("Deleted Flag".to_string()),
+                    key: "deleted_flag".to_string(),
+                    filters: deleted_flag["filters"].clone(),
+                    deleted: true,
+                    active: true,
+                    ensure_experience_continuity: Some(false),
+                    version: Some(1),
+                    evaluation_runtime: Some("all".to_string()),
+                }),
+            )
+            .await
+            .expect("Failed to insert deleted flag in Postgres");
 
-        insert_flag_for_team_in_pg(
-            reader.clone(),
-            team.id,
-            Some(FeatureFlagRow {
-                id: 0,
-                team_id: team.id,
-                name: Some("Inactive Flag".to_string()),
-                key: "inactive_flag".to_string(),
-                filters: inactive_flag["filters"].clone(),
-                deleted: false,
-                active: false,
-                ensure_experience_continuity: Some(false),
-                version: Some(1),
-                evaluation_runtime: Some("all".to_string()),
-            }),
-        )
-        .await
-        .expect("Failed to insert inactive flag in Postgres");
+        context
+            .insert_flag(
+                team.id,
+                Some(FeatureFlagRow {
+                    id: 0,
+                    team_id: team.id,
+                    name: Some("Inactive Flag".to_string()),
+                    key: "inactive_flag".to_string(),
+                    filters: inactive_flag["filters"].clone(),
+                    deleted: false,
+                    active: false,
+                    ensure_experience_continuity: Some(false),
+                    version: Some(1),
+                    evaluation_runtime: Some("all".to_string()),
+                }),
+            )
+            .await
+            .expect("Failed to insert inactive flag in Postgres");
 
         // Fetch and verify from Redis
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
@@ -925,9 +923,10 @@ mod tests {
             .any(|f| f.key == "inactive_flag" && !f.active));
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 0);
         assert!(!pg_flags.flags.iter().any(|f| f.deleted)); // no deleted flags
         assert!(!pg_flags.flags.iter().any(|f| f.active)); // no inactive flags
@@ -936,11 +935,11 @@ mod tests {
     #[tokio::test]
     async fn test_error_handling() {
         let redis_client = setup_redis_client(Some("redis://localhost:6379/".to_string())).await;
-        let reader = setup_pg_reader_client(None).await;
+        let context = TestContext::new(None).await;
 
         // Test malformed JSON in Redis
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -957,7 +956,7 @@ mod tests {
 
         // Test database query error (using a non-existent table)
         let result = sqlx::query("SELECT * FROM non_existent_table")
-            .fetch_all(&mut *reader.get_connection().await.unwrap())
+            .fetch_all(&mut *context.non_persons_reader.get_connection().await.unwrap())
             .await;
         assert!(result.is_err());
     }
@@ -965,10 +964,9 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_access() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -991,29 +989,29 @@ mod tests {
         .await
         .expect("Failed to insert flag in Redis");
 
-        insert_flag_for_team_in_pg(
-            reader.clone(),
-            team.id,
-            Some(FeatureFlagRow {
-                id: 0,
-                team_id: team.id,
-                name: Some("Concurrent Flag".to_string()),
-                key: "concurrent_flag".to_string(),
-                filters: flag["filters"].clone(),
-                deleted: false,
-                active: true,
-                ensure_experience_continuity: Some(false),
-                version: Some(1),
-                evaluation_runtime: Some("all".to_string()),
-            }),
-        )
-        .await
-        .expect("Failed to insert flag in Postgres");
+        context
+            .insert_flag(
+                team.id,
+                Some(FeatureFlagRow {
+                    id: 0,
+                    team_id: team.id,
+                    name: Some("Concurrent Flag".to_string()),
+                    key: "concurrent_flag".to_string(),
+                    filters: flag["filters"].clone(),
+                    deleted: false,
+                    active: true,
+                    ensure_experience_continuity: Some(false),
+                    version: Some(1),
+                    evaluation_runtime: Some("all".to_string()),
+                }),
+            )
+            .await
+            .expect("Failed to insert flag in Postgres");
 
         let mut handles = vec![];
         for _ in 0..10 {
             let redis_client = redis_client.clone();
-            let reader = reader.clone();
+            let reader = context.non_persons_reader.clone();
             let project_id = team.project_id;
 
             let handle = task::spawn(async move {
@@ -1040,10 +1038,9 @@ mod tests {
     #[ignore]
     async fn test_performance() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1073,24 +1070,24 @@ mod tests {
         .expect("Failed to insert flags in Redis");
 
         for flag in flags {
-            insert_flag_for_team_in_pg(
-                reader.clone(),
-                team.id,
-                Some(FeatureFlagRow {
-                    id: 0,
-                    team_id: team.id,
-                    name: Some(flag["name"].as_str().unwrap().to_string()),
-                    key: flag["key"].as_str().unwrap().to_string(),
-                    filters: flag["filters"].clone(),
-                    deleted: false,
-                    active: true,
-                    ensure_experience_continuity: Some(false),
-                    version: Some(1),
-                    evaluation_runtime: Some("all".to_string()),
-                }),
-            )
-            .await
-            .expect("Failed to insert flag in Postgres");
+            context
+                .insert_flag(
+                    team.id,
+                    Some(FeatureFlagRow {
+                        id: 0,
+                        team_id: team.id,
+                        name: Some(flag["name"].as_str().unwrap().to_string()),
+                        key: flag["key"].as_str().unwrap().to_string(),
+                        filters: flag["filters"].clone(),
+                        deleted: false,
+                        active: true,
+                        ensure_experience_continuity: Some(false),
+                        version: Some(1),
+                        evaluation_runtime: Some("all".to_string()),
+                    }),
+                )
+                .await
+                .expect("Failed to insert flag in Postgres");
         }
 
         let start = Instant::now();
@@ -1100,7 +1097,7 @@ mod tests {
         let redis_duration = start.elapsed();
 
         let start = Instant::now();
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(context.non_persons_reader, team.project_id)
             .await
             .expect("Failed to fetch flags from Postgres");
         let pg_duration = start.elapsed();
@@ -1118,10 +1115,9 @@ mod tests {
     #[tokio::test]
     async fn test_edge_cases() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1166,33 +1162,34 @@ mod tests {
         .expect("Failed to insert edge case flags in Redis");
 
         for flag in edge_case_flags.as_array().unwrap() {
-            insert_flag_for_team_in_pg(
-                reader.clone(),
-                team.id,
-                Some(FeatureFlagRow {
-                    id: 0,
-                    team_id: team.id,
-                    name: flag["name"].as_str().map(|s| s.to_string()),
-                    key: flag["key"].as_str().unwrap().to_string(),
-                    filters: flag["filters"].clone(),
-                    deleted: false,
-                    active: true,
-                    ensure_experience_continuity: Some(false),
-                    version: Some(1),
-                    evaluation_runtime: Some("all".to_string()),
-                }),
-            )
-            .await
-            .expect("Failed to insert edge case flag in Postgres");
+            context
+                .insert_flag(
+                    team.id,
+                    Some(FeatureFlagRow {
+                        id: 0,
+                        team_id: team.id,
+                        name: flag["name"].as_str().map(|s| s.to_string()),
+                        key: flag["key"].as_str().unwrap().to_string(),
+                        filters: flag["filters"].clone(),
+                        deleted: false,
+                        active: true,
+                        ensure_experience_continuity: Some(false),
+                        version: Some(1),
+                        evaluation_runtime: Some("all".to_string()),
+                    }),
+                )
+                .await
+                .expect("Failed to insert edge case flag in Postgres");
         }
 
         // Fetch and verify edge case flags
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
         assert_eq!(redis_flags.flags.len(), 3);
         assert_eq!(pg_flags.flags.len(), 3);
 
@@ -1214,10 +1211,9 @@ mod tests {
     #[tokio::test]
     async fn test_consistent_behavior_from_both_clients() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1253,33 +1249,34 @@ mod tests {
         .expect("Failed to insert flags in Redis");
 
         for flag in flags.as_array().unwrap() {
-            insert_flag_for_team_in_pg(
-                reader.clone(),
-                team.id,
-                Some(FeatureFlagRow {
-                    id: 0,
-                    team_id: team.id,
-                    name: flag["name"].as_str().map(|s| s.to_string()),
-                    key: flag["key"].as_str().unwrap().to_string(),
-                    filters: flag["filters"].clone(),
-                    deleted: false,
-                    active: true,
-                    ensure_experience_continuity: Some(false),
-                    version: Some(1),
-                    evaluation_runtime: Some("all".to_string()),
-                }),
-            )
-            .await
-            .expect("Failed to insert flag in Postgres");
+            context
+                .insert_flag(
+                    team.id,
+                    Some(FeatureFlagRow {
+                        id: 0,
+                        team_id: team.id,
+                        name: flag["name"].as_str().map(|s| s.to_string()),
+                        key: flag["key"].as_str().unwrap().to_string(),
+                        filters: flag["filters"].clone(),
+                        deleted: false,
+                        active: true,
+                        ensure_experience_continuity: Some(false),
+                        version: Some(1),
+                        evaluation_runtime: Some("all".to_string()),
+                    }),
+                )
+                .await
+                .expect("Failed to insert flag in Postgres");
         }
 
         // Fetch flags from both sources
         let mut redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let (mut pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (mut pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
 
         // Sort flags by key to ensure consistent order
         redis_flags.flags.sort_by(|a, b| a.key.cmp(&b.key));
@@ -1321,10 +1318,9 @@ mod tests {
     #[tokio::test]
     async fn test_rollout_percentage_edge_cases() {
         let redis_client = setup_redis_client(None).await;
-        let reader = setup_pg_reader_client(None).await;
-
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -1372,33 +1368,34 @@ mod tests {
         .expect("Failed to insert flags in Redis");
 
         for flag in flags.as_array().unwrap() {
-            insert_flag_for_team_in_pg(
-                reader.clone(),
-                team.id,
-                Some(FeatureFlagRow {
-                    id: 0,
-                    team_id: team.id,
-                    name: flag["name"].as_str().map(|s| s.to_string()),
-                    key: flag["key"].as_str().unwrap().to_string(),
-                    filters: flag["filters"].clone(),
-                    deleted: false,
-                    active: true,
-                    ensure_experience_continuity: Some(false),
-                    version: Some(1),
-                    evaluation_runtime: Some("all".to_string()),
-                }),
-            )
-            .await
-            .expect("Failed to insert flag in Postgres");
+            context
+                .insert_flag(
+                    team.id,
+                    Some(FeatureFlagRow {
+                        id: 0,
+                        team_id: team.id,
+                        name: flag["name"].as_str().map(|s| s.to_string()),
+                        key: flag["key"].as_str().unwrap().to_string(),
+                        filters: flag["filters"].clone(),
+                        deleted: false,
+                        active: true,
+                        ensure_experience_continuity: Some(false),
+                        version: Some(1),
+                        evaluation_runtime: Some("all".to_string()),
+                    }),
+                )
+                .await
+                .expect("Failed to insert flag in Postgres");
         }
 
         // Fetch flags from both sources
         let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let (pg_flags, _) = FeatureFlagList::from_pg(reader.clone(), team.project_id)
-            .await
-            .expect("Failed to fetch flags from Postgres");
+        let (pg_flags, _) =
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+                .await
+                .expect("Failed to fetch flags from Postgres");
 
         // Verify rollout percentages
         for flags in &[redis_flags, pg_flags] {

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -26,7 +26,8 @@ mod tests {
         utils::test_utils::{
             add_person_to_cohort, create_group_in_pg, create_test_flag,
             get_person_id_by_distinct_id, insert_cohort_for_team_in_pg, insert_new_team_in_pg,
-            insert_person_for_team_in_pg, setup_pg_reader_client, setup_pg_writer_client,
+            insert_person_for_team_in_pg, setup_dual_pg_writers, setup_pg_reader_client,
+            setup_pg_writer_client,
         },
     };
 
@@ -36,18 +37,19 @@ mod tests {
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
             .await
             .expect("Failed to insert team in pg");
 
         let distinct_id = "user_distinct_id".to_string();
-        insert_person_for_team_in_pg(reader.clone(), team.id, distinct_id.clone(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, distinct_id.clone(), None)
             .await
             .expect("Failed to insert person");
 
         let not_matching_distinct_id = "not_matching_distinct_id".to_string();
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer,
             team.id,
             not_matching_distinct_id.clone(),
             Some(json!({ "email": "a@x.com"})),
@@ -164,7 +166,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             None,
@@ -231,7 +234,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             None,
@@ -327,7 +331,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let leaf_flag = create_test_flag_with_property(
             23,
@@ -447,7 +452,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let leaf_flag = create_test_flag(
             Some(2),
@@ -615,9 +621,10 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
         let _person_id = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user_distinct_id".to_string(),
             Some(json!({ "email": "email-in-db@example.com", "is-cool": true })),
@@ -739,7 +746,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let leaf_flag = create_test_flag_with_property(
             23,
@@ -896,7 +904,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let leaf_flag = create_test_flag(
             Some(3),
@@ -1084,7 +1093,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag_with_variants(team.id);
 
@@ -1279,7 +1289,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             None,
@@ -1365,7 +1376,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
         let flag = Arc::new(create_test_flag(
             None,
             Some(team.id),
@@ -1429,7 +1441,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             None,
@@ -1471,7 +1484,7 @@ mod tests {
         );
 
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"email": "user@example@domain.com", "age": 30})),
@@ -1680,10 +1693,11 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a person without properties
-        insert_person_for_team_in_pg(reader.clone(), team.id, "test_user".to_string(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, "test_user".to_string(), None)
             .await
             .unwrap();
 
@@ -1741,11 +1755,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a person with malformed properties
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"age": "not_a_number"})),
@@ -1858,7 +1873,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             Some(1),
@@ -1904,7 +1920,7 @@ mod tests {
         );
 
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"email": "user2@example.com", "age": 35})),
@@ -1942,11 +1958,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a cohort with complex conditions
         let cohort_row = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             None,
             json!({
@@ -2031,7 +2048,7 @@ mod tests {
 
         // Test case 1: Should match - posthog.com email (AND condition)
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user_1".to_string(),
             Some(json!({
@@ -2044,7 +2061,7 @@ mod tests {
 
         // Test case 2: Should match - fuziontech@gmail.com (AND condition)
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user_2".to_string(),
             Some(json!({
@@ -2057,7 +2074,7 @@ mod tests {
 
         // Test case 3: Should match - specific distinct_id (AND condition)
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "D_9eluZIT3gqjO9dJqo1aDeqTbAG4yLwXFhN0bz_Vfc".to_string(),
             Some(json!({
@@ -2070,7 +2087,7 @@ mod tests {
 
         // Test case 4: Should match - neil@posthog.com (OR condition)
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user_4".to_string(),
             Some(json!({
@@ -2083,7 +2100,7 @@ mod tests {
 
         // Test case 5: Should match - @leads.io email (OR condition with regex)
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user_5".to_string(),
             Some(json!({
@@ -2096,7 +2113,7 @@ mod tests {
 
         // Test case 6: Should NOT match - random email
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user_6".to_string(),
             Some(json!({
@@ -2183,7 +2200,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             Some(1),
@@ -2245,7 +2263,7 @@ mod tests {
         );
 
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_id".to_string(),
             Some(json!({"email": "test@posthog.com", "is_enabled": true})),
@@ -2253,11 +2271,11 @@ mod tests {
         .await
         .unwrap();
 
-        insert_person_for_team_in_pg(reader.clone(), team.id, "lil_id".to_string(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, "lil_id".to_string(), None)
             .await
             .unwrap();
 
-        insert_person_for_team_in_pg(reader.clone(), team.id, "another_id".to_string(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, "another_id".to_string(), None)
             .await
             .unwrap();
 
@@ -2329,10 +2347,11 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_id".to_string(),
             Some(json!({"email": "test@posthog.com", "is_enabled": "true"})),
@@ -2432,10 +2451,11 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_id".to_string(),
             Some(json!({"email": "test@posthog.com", "is_enabled": true})),
@@ -2443,11 +2463,11 @@ mod tests {
         .await
         .unwrap();
 
-        insert_person_for_team_in_pg(reader.clone(), team.id, "another_id".to_string(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, "another_id".to_string(), None)
             .await
             .unwrap();
 
-        insert_person_for_team_in_pg(reader.clone(), team.id, "lil_id".to_string(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, "lil_id".to_string(), None)
             .await
             .unwrap();
 
@@ -2592,11 +2612,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a cohort with the condition that matches the test user's properties
         let cohort_row = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             None,
             json!({
@@ -2621,7 +2642,7 @@ mod tests {
 
         // Insert a person with properties that match the cohort condition
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"$browser_version": 126})),
@@ -2690,11 +2711,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a cohort with a condition that does not match the test user's properties
         let cohort_row = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             None,
             json!({
@@ -2719,7 +2741,7 @@ mod tests {
 
         // Insert a person with properties that do not match the cohort condition
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"$browser_version": 126})),
@@ -2788,11 +2810,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a cohort with a condition that matches the test user's properties
         let cohort_row = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             None,
             json!({
@@ -2817,7 +2840,7 @@ mod tests {
 
         // Insert a person with properties that match the cohort condition
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"$browser_version": 126})),
@@ -2882,11 +2905,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a base cohort
         let base_cohort_row = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             None,
             json!({
@@ -2936,7 +2960,7 @@ mod tests {
 
         // Insert a person with properties that match the base cohort condition
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"$browser_version": 126})),
@@ -3005,11 +3029,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a cohort with a condition that does not match the test user's properties
         let cohort_row = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             None,
             json!({
@@ -3034,7 +3059,7 @@ mod tests {
 
         // Insert a person with properties that do not match the cohort condition
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "test_user".to_string(),
             Some(json!({"$browser_version": 125})),
@@ -3104,11 +3129,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a static cohort
         let cohort = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             Some("Static Cohort".to_string()),
             json!({}), // Static cohorts don't have property filters
@@ -3120,7 +3146,7 @@ mod tests {
         // Insert a person
         let distinct_id = "static_user".to_string();
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "static@user.com"})),
@@ -3129,12 +3155,12 @@ mod tests {
         .unwrap();
 
         // Retrieve the person's ID
-        let person_id = get_person_id_by_distinct_id(reader.clone(), team.id, &distinct_id)
+        let person_id = get_person_id_by_distinct_id(persons_writer.clone(), team.id, &distinct_id)
             .await
             .unwrap();
 
         // Associate the person with the static cohort
-        add_person_to_cohort(reader.clone(), person_id, cohort.id)
+        add_person_to_cohort(persons_writer.clone(), person_id, cohort.id)
             .await
             .unwrap();
 
@@ -3202,11 +3228,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a static cohort
         let cohort = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             Some("Another Static Cohort".to_string()),
             json!({}), // Static cohorts don't have property filters
@@ -3218,7 +3245,7 @@ mod tests {
         // Insert a person
         let distinct_id = "non_static_user".to_string();
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "nonstatic@user.com"})),
@@ -3287,11 +3314,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a static cohort
         let cohort = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             Some("Static Cohort NotIn".to_string()),
             json!({}), // Static cohorts don't have property filters
@@ -3303,7 +3331,7 @@ mod tests {
         // Insert a person
         let distinct_id = "not_in_static_user".to_string();
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "notinstatic@user.com"})),
@@ -3377,11 +3405,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a static cohort
         let cohort = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             Some("Static Cohort NotIn User In".to_string()),
             json!({}), // Static cohorts don't have property filters
@@ -3393,7 +3422,7 @@ mod tests {
         // Insert a person
         let distinct_id = "in_not_in_static_user".to_string();
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "innotinstatic@user.com"})),
@@ -3402,12 +3431,12 @@ mod tests {
         .unwrap();
 
         // Retrieve the person's ID
-        let person_id = get_person_id_by_distinct_id(reader.clone(), team.id, &distinct_id)
+        let person_id = get_person_id_by_distinct_id(persons_writer.clone(), team.id, &distinct_id)
             .await
             .unwrap();
 
         // Associate the person with the static cohort
-        add_person_to_cohort(reader.clone(), person_id, cohort.id)
+        add_person_to_cohort(persons_writer.clone(), person_id, cohort.id)
             .await
             .unwrap();
 
@@ -3470,12 +3499,13 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
         let distinct_id = "user3".to_string();
 
         // Insert person
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "user3@example.com"})),
@@ -3579,11 +3609,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
         let distinct_id = "user4".to_string();
 
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "user4@example.com"})),
@@ -3665,11 +3696,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
         let distinct_id = "user5".to_string();
 
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "user5@example.com"})),
@@ -3808,12 +3840,13 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
         let distinct_id = "test_user".to_string();
 
         // Insert a person with properties that will match our condition
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "test@example.com"})),
@@ -3960,11 +3993,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // example_id is outside 70% holdout
         let _person1 = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "example_id".to_string(),
             Some(json!({"$some_prop": 5})),
@@ -3974,7 +4008,7 @@ mod tests {
 
         // example_id2 is within 70% holdout
         let _person2 = insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "example_id2".to_string(),
             Some(json!({"$some_prop": 5})),
@@ -4198,7 +4232,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = FeatureFlag {
             id: 1,
@@ -4332,11 +4367,12 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         // Insert a static cohort
         let cohort = insert_cohort_for_team_in_pg(
-            reader.clone(),
+            non_persons_writer.clone(),
             team.id,
             Some("Static Cohort".to_string()),
             json!({}), // Static cohorts don't have property filters
@@ -4348,7 +4384,7 @@ mod tests {
         // Insert a person
         let distinct_id = "static_user".to_string();
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({"email": "static@user.com"})),
@@ -4357,10 +4393,10 @@ mod tests {
         .unwrap();
 
         // Get person ID and add to cohort
-        let person_id = get_person_id_by_distinct_id(reader.clone(), team.id, &distinct_id)
+        let person_id = get_person_id_by_distinct_id(persons_writer.clone(), team.id, &distinct_id)
             .await
             .unwrap();
-        add_person_to_cohort(reader.clone(), person_id, cohort.id)
+        add_person_to_cohort(persons_writer.clone(), person_id, cohort.id)
             .await
             .unwrap();
 
@@ -4428,7 +4464,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             None,
@@ -4502,7 +4539,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             None,
@@ -4654,7 +4692,8 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let flag = create_test_flag(
             None,
@@ -4729,7 +4768,7 @@ mod tests {
 
         // Test case 1: User with super condition property set to true
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "super_user".to_string(),
             Some(json!({
@@ -4742,7 +4781,7 @@ mod tests {
 
         // Test case 2: User with matching email but no super condition
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "posthog_user".to_string(),
             Some(json!({
@@ -4755,7 +4794,7 @@ mod tests {
 
         // Test case 3: User with neither super condition nor matching email
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "regular_user".to_string(),
             Some(json!({
@@ -4861,12 +4900,13 @@ mod tests {
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
             .await
             .expect("Failed to insert team in pg");
 
         let distinct_id = "user_distinct_id".to_string();
-        insert_person_for_team_in_pg(reader.clone(), team.id, distinct_id.clone(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, distinct_id.clone(), None)
             .await
             .expect("Failed to insert person");
 
@@ -4929,13 +4969,14 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let distinct_id = "test_user".to_string();
 
         // Insert person with specific properties in DB that would match condition 1
         insert_person_for_team_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             distinct_id.clone(),
             Some(json!({
@@ -5187,18 +5228,19 @@ mod tests {
         let reader = setup_pg_reader_client(None).await;
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
 
         let distinct_id = "test_user".to_string();
 
         // Insert person (required for group flag evaluation)
-        insert_person_for_team_in_pg(reader.clone(), team.id, distinct_id.clone(), None)
+        insert_person_for_team_in_pg(persons_writer.clone(), team.id, distinct_id.clone(), None)
             .await
             .expect("Failed to insert person");
 
         // Create a group with specific properties in DB that would match condition 1
         create_group_in_pg(
-            reader.clone(),
+            persons_writer.clone(),
             team.id,
             "organization",
             "test_org_123",
@@ -5516,7 +5558,8 @@ mod tests {
         let writer = setup_pg_writer_client(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
 
-        let team = insert_new_team_in_pg(reader.clone(), None)
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
             .await
             .expect("Failed to insert team");
 

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -9,7 +9,6 @@ mod tests {
     use crate::{
         api::types::{FlagValue, LegacyFlagsResponse},
         cohorts::cohort_cache_manager::CohortCacheManager,
-        database::postgres_router::PostgresRouter,
         flags::{
             flag_group_type_mapping::GroupTypeMappingCache,
             flag_match_reason::FeatureFlagMatchReason,
@@ -293,12 +292,6 @@ mod tests {
             )
             .await;
 
-        // Debug logging for test_group_property_overrides
-        println!("test_group_property_overrides result: {:?}", result);
-        println!(
-            "Errors while computing: {}",
-            result.errors_while_computing_flags
-        );
         println!("Flags: {:?}", result.flags);
 
         let legacy_response = LegacyFlagsResponse::from_response(result);
@@ -5200,12 +5193,6 @@ mod tests {
             )
             .await;
 
-        // Debug logging to see what's in the result
-        println!("Test result: {:?}", result);
-        println!(
-            "Errors while computing: {}",
-            result.errors_while_computing_flags
-        );
         println!("Flags in result: {:?}", result.flags);
 
         assert!(!result.errors_while_computing_flags);

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -29,25 +29,32 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_properties_from_pg_to_match() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
 
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
         let distinct_id = "user_distinct_id".to_string();
-        context.insert_person(team.id, distinct_id.clone(), None)
+        context
+            .insert_person(team.id, distinct_id.clone(), None)
             .await
             .expect("Failed to insert person");
 
         let not_matching_distinct_id = "not_matching_distinct_id".to_string();
-        context.insert_person(
-            team.id,
-            not_matching_distinct_id.clone(),
-            Some(json!({ "email": "a@x.com"})),
-        )
-        .await
-        .expect("Failed to insert person");
+        context
+            .insert_person(
+                team.id,
+                not_matching_distinct_id.clone(),
+                Some(json!({ "email": "a@x.com"})),
+            )
+            .await
+            .expect("Failed to insert person");
 
         let flag: FeatureFlag = serde_json::from_value(json!(
             {
@@ -141,7 +148,11 @@ mod tests {
     #[tokio::test]
     async fn test_person_property_overrides() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -202,7 +213,11 @@ mod tests {
     #[tokio::test]
     async fn test_group_property_overrides() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -235,7 +250,10 @@ mod tests {
         );
 
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
-        group_type_mapping_cache.init(context.persons_reader.clone()).await.unwrap();
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
 
         let group_types_to_indexes = [("organization".to_string(), 1)].into_iter().collect();
         let indexes_to_types = [(1, "organization".to_string())].into_iter().collect();
@@ -277,7 +295,10 @@ mod tests {
 
         // Debug logging for test_group_property_overrides
         println!("test_group_property_overrides result: {:?}", result);
-        println!("Errors while computing: {}", result.errors_while_computing_flags);
+        println!(
+            "Errors while computing: {}",
+            result.errors_while_computing_flags
+        );
         println!("Flags: {:?}", result.flags);
 
         let legacy_response = LegacyFlagsResponse::from_response(result);
@@ -297,7 +318,11 @@ mod tests {
     #[tokio::test]
     async fn test_flags_that_depends_on_other_boolean_flag() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let leaf_flag = create_test_flag_with_property(
@@ -411,7 +436,11 @@ mod tests {
     #[tokio::test]
     async fn test_flags_that_depends_on_other_multivariate_flag_variant_match() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let leaf_flag = create_test_flag(
@@ -573,15 +602,20 @@ mod tests {
     #[tokio::test]
     async fn test_flags_with_deep_dependency_tree_only_calls_db_once_total() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
-        let _person_id = context.insert_person(
-            team.id,
-            "test_user_distinct_id".to_string(),
-            Some(json!({ "email": "email-in-db@example.com", "is-cool": true })),
-        )
-        .await
-        .unwrap();
+        let _person_id = context
+            .insert_person(
+                team.id,
+                "test_user_distinct_id".to_string(),
+                Some(json!({ "email": "email-in-db@example.com", "is-cool": true })),
+            )
+            .await
+            .unwrap();
 
         let leaf_flag = create_test_flag_with_property(
             23,
@@ -690,7 +724,11 @@ mod tests {
     async fn test_flags_with_dependency_cycle_and_missing_dependency_still_evaluates_independent_flags(
     ) {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let leaf_flag = create_test_flag_with_property(
@@ -841,7 +879,11 @@ mod tests {
     #[tokio::test]
     async fn test_flags_that_depends_on_other_multivariate_flag_boolean_match() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let leaf_flag = create_test_flag(
@@ -989,7 +1031,11 @@ mod tests {
     async fn test_get_matching_variant_with_cache() {
         let flag = create_test_flag_with_variants(1);
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(1);
         let group_types_to_indexes = [("group_type_1".to_string(), 1)].into_iter().collect();
         let indexes_to_types = [(1, "group_type_1".to_string())].into_iter().collect();
@@ -1017,13 +1063,20 @@ mod tests {
     #[tokio::test]
     async fn test_get_matching_variant_with_db() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag_with_variants(team.id);
 
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
-        group_type_mapping_cache.init(context.persons_reader.clone()).await.unwrap();
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
 
         let router = context.create_postgres_router();
         let matcher = FeatureFlagMatcher::new(
@@ -1044,7 +1097,11 @@ mod tests {
     #[tokio::test]
     async fn test_is_condition_match_empty_properties() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let flag = create_test_flag(
             Some(1),
             None,
@@ -1092,7 +1149,11 @@ mod tests {
     #[tokio::test]
     async fn test_is_condition_match_flag_value_operator() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let flag = create_test_flag(
             Some(2),
             None,
@@ -1194,7 +1255,11 @@ mod tests {
     #[tokio::test]
     async fn test_overrides_avoid_db_lookups() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -1274,7 +1339,11 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_flag_evaluation() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
         let flag = Arc::new(create_test_flag(
             None,
@@ -1330,7 +1399,11 @@ mod tests {
     #[tokio::test]
     async fn test_property_operators() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -1372,13 +1445,14 @@ mod tests {
             None,
         );
 
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"email": "user@example@domain.com", "age": 30})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"email": "user@example@domain.com", "age": 30})),
+            )
+            .await
+            .unwrap();
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -1404,7 +1478,11 @@ mod tests {
     #[tokio::test]
     async fn test_empty_hashed_identifier() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let flag = create_test_flag(
             Some(1),
             None,
@@ -1447,7 +1525,11 @@ mod tests {
     #[tokio::test]
     async fn test_rollout_percentage() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let mut flag = create_test_flag(
             Some(1),
             None,
@@ -1495,7 +1577,11 @@ mod tests {
     #[tokio::test]
     async fn test_uneven_variant_distribution() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let mut flag = create_test_flag_with_variants(1);
 
         // Adjust variant rollout percentages to be uneven
@@ -1556,11 +1642,16 @@ mod tests {
     #[tokio::test]
     async fn test_missing_properties_in_db() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a person without properties
-        context.insert_person( team.id, "test_user".to_string(), None)
+        context
+            .insert_person(team.id, "test_user".to_string(), None)
             .await
             .unwrap();
 
@@ -1611,17 +1702,22 @@ mod tests {
     #[tokio::test]
     async fn test_malformed_property_data() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a person with malformed properties
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"age": "not_a_number"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"age": "not_a_number"})),
+            )
+            .await
+            .unwrap();
 
         let flag = create_test_flag(
             None,
@@ -1671,7 +1767,11 @@ mod tests {
     #[tokio::test]
     async fn test_evaluation_reasons() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let flag = create_test_flag(
             Some(1),
             None,
@@ -1715,7 +1815,11 @@ mod tests {
     #[tokio::test]
     async fn test_complex_conditions() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -1761,13 +1865,14 @@ mod tests {
             Some(false),
         );
 
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"email": "user2@example.com", "age": 35})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"email": "user2@example.com", "age": 35})),
+            )
+            .await
+            .unwrap();
 
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
@@ -1792,164 +1897,175 @@ mod tests {
     #[tokio::test]
     async fn test_complex_cohort_conditions() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a cohort with complex conditions
-        let cohort_row = context.insert_cohort(
-            team.id,
-            None,
-            json!({
-                "properties": {
-                    "type": "OR",
-                    "values": [
-                        {
-                            "type": "AND",
-                            "values": [{
-                                "key": "email",
-                                "type": "person",
-                                "value": "@posthog\\.com$",
-                                "negation": false,
-                                "operator": "regex"
-                            }]
-                        },
-                        {
-                            "type": "AND",
-                            "values": [{
-                                "key": "email",
-                                "type": "person",
-                                "value": ["fuziontech@gmail.com"],
-                                "operator": "exact"
-                            }]
-                        },
-                        {
-                            "type": "AND",
-                            "values": [{
-                                "key": "distinct_id",
-                                "type": "person",
-                                "value": ["D_9eluZIT3gqjO9dJqo1aDeqTbAG4yLwXFhN0bz_Vfc"],
-                                "operator": "exact"
-                            }]
-                        },
-                        {
-                            "type": "OR",
-                            "values": [{
-                                "key": "email",
-                                "type": "person",
-                                "value": ["neil@posthog.com"],
-                                "negation": false,
-                                "operator": "exact"
-                            }]
-                        },
-                        {
-                            "type": "OR",
-                            "values": [{
-                                "key": "email",
-                                "type": "person",
-                                "value": ["corywatilo@gmail.com"],
-                                "negation": false,
-                                "operator": "exact"
-                            }]
-                        },
-                        {
-                            "type": "OR",
-                            "values": [{
-                                "key": "email",
-                                "type": "person",
-                                "value": "@leads\\.io$",
-                                "negation": false,
-                                "operator": "regex"
-                            }]
-                        },
-                        {
-                            "type": "OR",
-                            "values": [{
-                                "key": "email",
-                                "type": "person",
-                                "value": "@desertcart\\.io$",
-                                "negation": false,
-                                "operator": "regex"
-                            }]
-                        }
-                    ]
-                }
-            }),
-            false,
-        )
-        .await
-        .unwrap();
+        let cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
+                        "type": "OR",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [{
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": "@posthog\\.com$",
+                                    "negation": false,
+                                    "operator": "regex"
+                                }]
+                            },
+                            {
+                                "type": "AND",
+                                "values": [{
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["fuziontech@gmail.com"],
+                                    "operator": "exact"
+                                }]
+                            },
+                            {
+                                "type": "AND",
+                                "values": [{
+                                    "key": "distinct_id",
+                                    "type": "person",
+                                    "value": ["D_9eluZIT3gqjO9dJqo1aDeqTbAG4yLwXFhN0bz_Vfc"],
+                                    "operator": "exact"
+                                }]
+                            },
+                            {
+                                "type": "OR",
+                                "values": [{
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["neil@posthog.com"],
+                                    "negation": false,
+                                    "operator": "exact"
+                                }]
+                            },
+                            {
+                                "type": "OR",
+                                "values": [{
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["corywatilo@gmail.com"],
+                                    "negation": false,
+                                    "operator": "exact"
+                                }]
+                            },
+                            {
+                                "type": "OR",
+                                "values": [{
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": "@leads\\.io$",
+                                    "negation": false,
+                                    "operator": "regex"
+                                }]
+                            },
+                            {
+                                "type": "OR",
+                                "values": [{
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": "@desertcart\\.io$",
+                                    "negation": false,
+                                    "operator": "regex"
+                                }]
+                            }
+                        ]
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
 
         // Test case 1: Should match - posthog.com email (AND condition)
-        context.insert_person(
-            team.id,
-            "test_user_1".to_string(),
-            Some(json!({
-                "email": "test@posthog.com",
-                "distinct_id": "test_user_1"
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user_1".to_string(),
+                Some(json!({
+                    "email": "test@posthog.com",
+                    "distinct_id": "test_user_1"
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test case 2: Should match - fuziontech@gmail.com (AND condition)
-        context.insert_person(
-            team.id,
-            "test_user_2".to_string(),
-            Some(json!({
-                "email": "fuziontech@gmail.com",
-                "distinct_id": "test_user_2"
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user_2".to_string(),
+                Some(json!({
+                    "email": "fuziontech@gmail.com",
+                    "distinct_id": "test_user_2"
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test case 3: Should match - specific distinct_id (AND condition)
-        context.insert_person(
-            team.id,
-            "D_9eluZIT3gqjO9dJqo1aDeqTbAG4yLwXFhN0bz_Vfc".to_string(),
-            Some(json!({
-                "email": "other@example.com",
-                "distinct_id": "D_9eluZIT3gqjO9dJqo1aDeqTbAG4yLwXFhN0bz_Vfc"
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "D_9eluZIT3gqjO9dJqo1aDeqTbAG4yLwXFhN0bz_Vfc".to_string(),
+                Some(json!({
+                    "email": "other@example.com",
+                    "distinct_id": "D_9eluZIT3gqjO9dJqo1aDeqTbAG4yLwXFhN0bz_Vfc"
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test case 4: Should match - neil@posthog.com (OR condition)
-        context.insert_person(
-            team.id,
-            "test_user_4".to_string(),
-            Some(json!({
-                "email": "neil@posthog.com",
-                "distinct_id": "test_user_4"
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user_4".to_string(),
+                Some(json!({
+                    "email": "neil@posthog.com",
+                    "distinct_id": "test_user_4"
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test case 5: Should match - @leads.io email (OR condition with regex)
-        context.insert_person(
-            team.id,
-            "test_user_5".to_string(),
-            Some(json!({
-                "email": "test@leads.io",
-                "distinct_id": "test_user_5"
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user_5".to_string(),
+                Some(json!({
+                    "email": "test@leads.io",
+                    "distinct_id": "test_user_5"
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test case 6: Should NOT match - random email
-        context.insert_person(
-            team.id,
-            "test_user_6".to_string(),
-            Some(json!({
-                "email": "random@example.com",
-                "distinct_id": "test_user_6"
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user_6".to_string(),
+                Some(json!({
+                    "email": "random@example.com",
+                    "distinct_id": "test_user_6"
+                })),
+            )
+            .await
+            .unwrap();
 
         // Create a feature flag using this cohort and verify matches
         let flag = create_test_flag(
@@ -2020,7 +2136,11 @@ mod tests {
     #[tokio::test]
     async fn test_super_condition_matches_boolean() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -2082,19 +2202,22 @@ mod tests {
             None,
         );
 
-        context.insert_person(
-            team.id,
-            "test_id".to_string(),
-            Some(json!({"email": "test@posthog.com", "is_enabled": true})),
-        )
-        .await
-        .unwrap();
-
-        context.insert_person( team.id, "lil_id".to_string(), None)
+        context
+            .insert_person(
+                team.id,
+                "test_id".to_string(),
+                Some(json!({"email": "test@posthog.com", "is_enabled": true})),
+            )
             .await
             .unwrap();
 
-        context.insert_person( team.id, "another_id".to_string(), None)
+        context
+            .insert_person(team.id, "lil_id".to_string(), None)
+            .await
+            .unwrap();
+
+        context
+            .insert_person(team.id, "another_id".to_string(), None)
             .await
             .unwrap();
 
@@ -2159,16 +2282,21 @@ mod tests {
     #[tokio::test]
     async fn test_super_condition_matches_string() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
-        context.insert_person(
-            team.id,
-            "test_id".to_string(),
-            Some(json!({"email": "test@posthog.com", "is_enabled": "true"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_id".to_string(),
+                Some(json!({"email": "test@posthog.com", "is_enabled": "true"})),
+            )
+            .await
+            .unwrap();
 
         let flag = create_test_flag(
             Some(1),
@@ -2255,22 +2383,29 @@ mod tests {
     #[tokio::test]
     async fn test_super_condition_matches_and_false() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
-        context.insert_person(
-            team.id,
-            "test_id".to_string(),
-            Some(json!({"email": "test@posthog.com", "is_enabled": true})),
-        )
-        .await
-        .unwrap();
-
-        context.insert_person( team.id, "another_id".to_string(), None)
+        context
+            .insert_person(
+                team.id,
+                "test_id".to_string(),
+                Some(json!({"email": "test@posthog.com", "is_enabled": true})),
+            )
             .await
             .unwrap();
 
-        context.insert_person( team.id, "lil_id".to_string(), None)
+        context
+            .insert_person(team.id, "another_id".to_string(), None)
+            .await
+            .unwrap();
+
+        context
+            .insert_person(team.id, "lil_id".to_string(), None)
             .await
             .unwrap();
 
@@ -2408,41 +2543,47 @@ mod tests {
     #[tokio::test]
     async fn test_basic_cohort_matching() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a cohort with the condition that matches the test user's properties
-        let cohort_row = context.insert_cohort(
-            team.id,
-            None,
-            json!({
-                "properties": {
-                    "type": "OR",
-                    "values": [{
+        let cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
                         "type": "OR",
                         "values": [{
-                            "key": "$browser_version",
-                            "type": "person",
-                            "value": "125",
-                            "negation": false,
-                            "operator": "gt"
+                            "type": "OR",
+                            "values": [{
+                                "key": "$browser_version",
+                                "type": "person",
+                                "value": "125",
+                                "negation": false,
+                                "operator": "gt"
+                            }]
                         }]
-                    }]
-                }
-            }),
-            false,
-        )
-        .await
-        .unwrap();
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
 
         // Insert a person with properties that match the cohort condition
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"$browser_version": 126})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"$browser_version": 126})),
+            )
+            .await
+            .unwrap();
 
         // Define a flag with a cohort filter
         let flag = create_test_flag(
@@ -2498,41 +2639,47 @@ mod tests {
     #[tokio::test]
     async fn test_not_in_cohort_matching() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a cohort with a condition that does not match the test user's properties
-        let cohort_row = context.insert_cohort(
-            team.id,
-            None,
-            json!({
-                "properties": {
-                    "type": "OR",
-                    "values": [{
+        let cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
                         "type": "OR",
                         "values": [{
-                            "key": "$browser_version",
-                            "type": "person",
-                            "value": "130",
-                            "negation": false,
-                            "operator": "gt"
+                            "type": "OR",
+                            "values": [{
+                                "key": "$browser_version",
+                                "type": "person",
+                                "value": "130",
+                                "negation": false,
+                                "operator": "gt"
+                            }]
                         }]
-                    }]
-                }
-            }),
-            false,
-        )
-        .await
-        .unwrap();
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
 
         // Insert a person with properties that do not match the cohort condition
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"$browser_version": 126})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"$browser_version": 126})),
+            )
+            .await
+            .unwrap();
 
         // Define a flag with a NotIn cohort filter
         let flag = create_test_flag(
@@ -2588,41 +2735,47 @@ mod tests {
     #[tokio::test]
     async fn test_not_in_cohort_matching_user_in_cohort() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a cohort with a condition that matches the test user's properties
-        let cohort_row = context.insert_cohort(
-            team.id,
-            None,
-            json!({
-                "properties": {
-                    "type": "OR",
-                    "values": [{
+        let cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
                         "type": "OR",
                         "values": [{
-                            "key": "$browser_version",
-                            "type": "person",
-                            "value": "125",
-                            "negation": false,
-                            "operator": "gt"
+                            "type": "OR",
+                            "values": [{
+                                "key": "$browser_version",
+                                "type": "person",
+                                "value": "125",
+                                "negation": false,
+                                "operator": "gt"
+                            }]
                         }]
-                    }]
-                }
-            }),
-            false,
-        )
-        .await
-        .unwrap();
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
 
         // Insert a person with properties that match the cohort condition
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"$browser_version": 126})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"$browser_version": 126})),
+            )
+            .await
+            .unwrap();
 
         // Define a flag with a NotIn cohort filter
         let flag = create_test_flag(
@@ -2674,65 +2827,72 @@ mod tests {
     #[tokio::test]
     async fn test_cohort_dependent_on_another_cohort() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a base cohort
-        let base_cohort_row = context.insert_cohort(
-            team.id,
-            None,
-            json!({
-                "properties": {
-                    "type": "OR",
-                    "values": [{
+        let base_cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
                         "type": "OR",
                         "values": [{
-                            "key": "$browser_version",
-                            "type": "person",
-                            "value": "125",
-                            "negation": false,
-                            "operator": "gt"
+                            "type": "OR",
+                            "values": [{
+                                "key": "$browser_version",
+                                "type": "person",
+                                "value": "125",
+                                "negation": false,
+                                "operator": "gt"
+                            }]
                         }]
-                    }]
-                }
-            }),
-            false,
-        )
-        .await
-        .unwrap();
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
 
         // Insert a dependent cohort that includes the base cohort
-        let dependent_cohort_row = context.insert_cohort(
-            team.id,
-            None,
-            json!({
-                "properties": {
-                    "type": "OR",
-                    "values": [{
+        let dependent_cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
                         "type": "OR",
                         "values": [{
-                            "key": "id",
-                            "type": "cohort",
-                            "value": base_cohort_row.id,
-                            "negation": false,
-                            "operator": "in"
+                            "type": "OR",
+                            "values": [{
+                                "key": "id",
+                                "type": "cohort",
+                                "value": base_cohort_row.id,
+                                "negation": false,
+                                "operator": "in"
+                            }]
                         }]
-                    }]
-                }
-            }),
-            false,
-        )
-        .await
-        .unwrap();
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
 
         // Insert a person with properties that match the base cohort condition
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"$browser_version": 126})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"$browser_version": 126})),
+            )
+            .await
+            .unwrap();
 
         // Define a flag with a cohort filter that depends on another cohort
         let flag = create_test_flag(
@@ -2788,41 +2948,47 @@ mod tests {
     #[tokio::test]
     async fn test_in_cohort_matching_user_not_in_cohort() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a cohort with a condition that does not match the test user's properties
-        let cohort_row = context.insert_cohort(
-            team.id,
-            None,
-            json!({
-                "properties": {
-                    "type": "OR",
-                    "values": [{
+        let cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
                         "type": "OR",
                         "values": [{
-                            "key": "$browser_version",
-                            "type": "person",
-                            "value": "130",
-                            "negation": false,
-                            "operator": "gt"
+                            "type": "OR",
+                            "values": [{
+                                "key": "$browser_version",
+                                "type": "person",
+                                "value": "130",
+                                "negation": false,
+                                "operator": "gt"
+                            }]
                         }]
-                    }]
-                }
-            }),
-            false,
-        )
-        .await
-        .unwrap();
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
 
         // Insert a person with properties that do not match the cohort condition
-        context.insert_person(
-            team.id,
-            "test_user".to_string(),
-            Some(json!({"$browser_version": 125})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "test_user".to_string(),
+                Some(json!({"$browser_version": 125})),
+            )
+            .await
+            .unwrap();
 
         // Define a flag with an In cohort filter
         let flag = create_test_flag(
@@ -2879,36 +3045,44 @@ mod tests {
     #[tokio::test]
     async fn test_static_cohort_matching_user_in_cohort() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a static cohort
-        let cohort = context.insert_cohort(
-            team.id,
-            Some("Static Cohort".to_string()),
-            json!({}), // Static cohorts don't have property filters
-            true,      // is_static = true
-        )
-        .await
-        .unwrap();
+        let cohort = context
+            .insert_cohort(
+                team.id,
+                Some("Static Cohort".to_string()),
+                json!({}), // Static cohorts don't have property filters
+                true,      // is_static = true
+            )
+            .await
+            .unwrap();
 
         // Insert a person
         let distinct_id = "static_user".to_string();
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "static@user.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "static@user.com"})),
+            )
+            .await
+            .unwrap();
 
         // Retrieve the person's ID
-        let person_id = context.get_person_id_by_distinct_id(team.id, &distinct_id)
+        let person_id = context
+            .get_person_id_by_distinct_id(team.id, &distinct_id)
             .await
             .unwrap();
 
         // Associate the person with the static cohort
-        context.add_person_to_cohort(cohort.id, person_id)
+        context
+            .add_person_to_cohort(cohort.id, person_id)
             .await
             .unwrap();
 
@@ -2969,28 +3143,34 @@ mod tests {
     #[tokio::test]
     async fn test_static_cohort_matching_user_not_in_cohort() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a static cohort
-        let cohort = context.insert_cohort(
-            team.id,
-            Some("Another Static Cohort".to_string()),
-            json!({}), // Static cohorts don't have property filters
-            true,
-        )
-        .await
-        .unwrap();
+        let cohort = context
+            .insert_cohort(
+                team.id,
+                Some("Another Static Cohort".to_string()),
+                json!({}), // Static cohorts don't have property filters
+                true,
+            )
+            .await
+            .unwrap();
 
         // Insert a person
         let distinct_id = "non_static_user".to_string();
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "nonstatic@user.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "nonstatic@user.com"})),
+            )
+            .await
+            .unwrap();
 
         // Note: Do NOT associate the person with the static cohort
 
@@ -3046,28 +3226,34 @@ mod tests {
     #[tokio::test]
     async fn test_static_cohort_not_in_matching_user_not_in_cohort() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a static cohort
-        let cohort = context.insert_cohort(
-            team.id,
-            Some("Static Cohort NotIn".to_string()),
-            json!({}), // Static cohorts don't have property filters
-            true,      // is_static = true
-        )
-        .await
-        .unwrap();
+        let cohort = context
+            .insert_cohort(
+                team.id,
+                Some("Static Cohort NotIn".to_string()),
+                json!({}), // Static cohorts don't have property filters
+                true,      // is_static = true
+            )
+            .await
+            .unwrap();
 
         // Insert a person
         let distinct_id = "not_in_static_user".to_string();
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "notinstatic@user.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "notinstatic@user.com"})),
+            )
+            .await
+            .unwrap();
 
         // No association with the static cohort
 
@@ -3128,36 +3314,44 @@ mod tests {
     #[tokio::test]
     async fn test_static_cohort_not_in_matching_user_in_cohort() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a static cohort
-        let cohort = context.insert_cohort(
-            team.id,
-            Some("Static Cohort NotIn User In".to_string()),
-            json!({}), // Static cohorts don't have property filters
-            true,      // is_static = true
-        )
-        .await
-        .unwrap();
+        let cohort = context
+            .insert_cohort(
+                team.id,
+                Some("Static Cohort NotIn User In".to_string()),
+                json!({}), // Static cohorts don't have property filters
+                true,      // is_static = true
+            )
+            .await
+            .unwrap();
 
         // Insert a person
         let distinct_id = "in_not_in_static_user".to_string();
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "innotinstatic@user.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "innotinstatic@user.com"})),
+            )
+            .await
+            .unwrap();
 
         // Retrieve the person's ID
-        let person_id = context.get_person_id_by_distinct_id(team.id, &distinct_id)
+        let person_id = context
+            .get_person_id_by_distinct_id(team.id, &distinct_id)
             .await
             .unwrap();
 
         // Associate the person with the static cohort
-        context.add_person_to_cohort(cohort.id, person_id)
+        context
+            .add_person_to_cohort(cohort.id, person_id)
             .await
             .unwrap();
 
@@ -3213,21 +3407,29 @@ mod tests {
     #[tokio::test]
     async fn test_evaluate_feature_flags_with_experience_continuity() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
         let distinct_id = "user3".to_string();
 
         // Insert person
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "user3@example.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "user3@example.com"})),
+            )
+            .await
+            .unwrap();
 
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
-        group_type_mapping_cache.init(context.persons_reader.clone()).await.unwrap();
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
 
         // Create flag with experience continuity
         let flag = create_test_flag(
@@ -3310,20 +3512,28 @@ mod tests {
     #[tokio::test]
     async fn test_evaluate_feature_flags_with_continuity_missing_override() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
         let distinct_id = "user4".to_string();
 
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "user4@example.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "user4@example.com"})),
+            )
+            .await
+            .unwrap();
 
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
-        group_type_mapping_cache.init(context.persons_reader.clone()).await.unwrap();
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
 
         // Create flag with experience continuity
         let flag = create_test_flag(
@@ -3389,20 +3599,28 @@ mod tests {
     #[tokio::test]
     async fn test_evaluate_all_feature_flags_mixed_continuity() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
         let distinct_id = "user5".to_string();
 
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "user5@example.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "user5@example.com"})),
+            )
+            .await
+            .unwrap();
 
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
-        group_type_mapping_cache.init(context.persons_reader.clone()).await.unwrap();
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
 
         // Create flag with continuity
         let flag_continuity = create_test_flag(
@@ -3520,18 +3738,23 @@ mod tests {
     #[tokio::test]
     async fn test_variant_override_in_condition() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
         let distinct_id = "test_user".to_string();
 
         // Insert a person with properties that will match our condition
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "test@example.com"})),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "test@example.com"})),
+            )
+            .await
+            .unwrap();
 
         // Create a flag with multiple variants and a condition with a variant override
         let flag = create_test_flag(
@@ -3665,26 +3888,32 @@ mod tests {
     #[tokio::test]
     async fn test_feature_flag_with_holdout_filter() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // example_id is outside 70% holdout
-        let _person1 = context.insert_person(
-            team.id,
-            "example_id".to_string(),
-            Some(json!({"$some_prop": 5})),
-        )
-        .await
-        .unwrap();
+        let _person1 = context
+            .insert_person(
+                team.id,
+                "example_id".to_string(),
+                Some(json!({"$some_prop": 5})),
+            )
+            .await
+            .unwrap();
 
         // example_id2 is within 70% holdout
-        let _person2 = context.insert_person(
-            team.id,
-            "example_id2".to_string(),
-            Some(json!({"$some_prop": 5})),
-        )
-        .await
-        .unwrap();
+        let _person2 = context
+            .insert_person(
+                team.id,
+                "example_id2".to_string(),
+                Some(json!({"$some_prop": 5})),
+            )
+            .await
+            .unwrap();
 
         let multivariate_json = MultivariateFlagOptions {
             variants: vec![
@@ -3890,7 +4119,11 @@ mod tests {
     async fn test_variants() {
         // Ported from posthog/test/test_feature_flag.py test_variants
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = FeatureFlag {
@@ -4008,34 +4241,42 @@ mod tests {
     #[tokio::test]
     async fn test_static_cohort_evaluation_skips_dependency_graph() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         // Insert a static cohort
-        let cohort = context.insert_cohort(
-            team.id,
-            Some("Static Cohort".to_string()),
-            json!({}), // Static cohorts don't have property filters
-            true,      // is_static = true
-        )
-        .await
-        .unwrap();
+        let cohort = context
+            .insert_cohort(
+                team.id,
+                Some("Static Cohort".to_string()),
+                json!({}), // Static cohorts don't have property filters
+                true,      // is_static = true
+            )
+            .await
+            .unwrap();
 
         // Insert a person
         let distinct_id = "static_user".to_string();
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({"email": "static@user.com"})),
-        )
-        .await
-        .unwrap();
-
-        // Get person ID and add to cohort
-        let person_id = context.get_person_id_by_distinct_id(team.id, &distinct_id)
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "static@user.com"})),
+            )
             .await
             .unwrap();
-        context.add_person_to_cohort(cohort.id, person_id)
+
+        // Get person ID and add to cohort
+        let person_id = context
+            .get_person_id_by_distinct_id(team.id, &distinct_id)
+            .await
+            .unwrap();
+        context
+            .add_person_to_cohort(cohort.id, person_id)
             .await
             .unwrap();
 
@@ -4096,7 +4337,11 @@ mod tests {
     #[tokio::test]
     async fn test_no_person_id_with_overrides() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -4164,7 +4409,11 @@ mod tests {
     #[tokio::test]
     async fn test_numeric_group_keys() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -4191,7 +4440,10 @@ mod tests {
 
         // Set up group type mapping cache
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
-        group_type_mapping_cache.init(context.persons_reader.clone()).await.unwrap();
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
 
         // Test with numeric group key
         let groups_numeric = HashMap::from([("organization".to_string(), json!(123))]);
@@ -4295,7 +4547,11 @@ mod tests {
     #[tokio::test]
     async fn test_complex_super_condition_matching() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let flag = create_test_flag(
@@ -4370,39 +4626,42 @@ mod tests {
         );
 
         // Test case 1: User with super condition property set to true
-        context.insert_person(
-            team.id,
-            "super_user".to_string(),
-            Some(json!({
-                "email": "random@example.com",
-                "$feature_enrollment/artificial-hog": true
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "super_user".to_string(),
+                Some(json!({
+                    "email": "random@example.com",
+                    "$feature_enrollment/artificial-hog": true
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test case 2: User with matching email but no super condition
-        context.insert_person(
-            team.id,
-            "posthog_user".to_string(),
-            Some(json!({
-                "email": "test@posthog.com",
-                "$feature_enrollment/artificial-hog": false
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "posthog_user".to_string(),
+                Some(json!({
+                    "email": "test@posthog.com",
+                    "$feature_enrollment/artificial-hog": false
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test case 3: User with neither super condition nor matching email
-        context.insert_person(
-            team.id,
-            "regular_user".to_string(),
-            Some(json!({
-                "email": "regular@example.com"
-            })),
-        )
-        .await
-        .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "regular_user".to_string(),
+                Some(json!({
+                    "email": "regular@example.com"
+                })),
+            )
+            .await
+            .unwrap();
 
         // Test super condition user
         let router = context.create_postgres_router();
@@ -4482,14 +4741,20 @@ mod tests {
     #[tokio::test]
     async fn test_filters_with_distinct_id_exact() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
 
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
         let distinct_id = "user_distinct_id".to_string();
-        context.insert_person( team.id, distinct_id.clone(), None)
+        context
+            .insert_person(team.id, distinct_id.clone(), None)
             .await
             .expect("Failed to insert person");
 
@@ -4545,24 +4810,29 @@ mod tests {
     #[tokio::test]
     async fn test_partial_property_overrides_fallback_behavior() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let distinct_id = "test_user".to_string();
 
         // Insert person with specific properties in DB that would match condition 1
-        context.insert_person(
-            team.id,
-            distinct_id.clone(),
-            Some(json!({
-                "app_version": "1.3.6",
-                "focus": "all-of-the-above",
-                "os": "iOS",
-                "email": "test@example.com"
-            })),
-        )
-        .await
-        .expect("Failed to insert person");
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({
+                    "app_version": "1.3.6",
+                    "focus": "all-of-the-above",
+                    "os": "iOS",
+                    "email": "test@example.com"
+                })),
+            )
+            .await
+            .expect("Failed to insert person");
 
         // Create a flag with two conditions similar to the user's example
         let flag = create_test_flag(
@@ -4781,30 +5051,36 @@ mod tests {
     #[tokio::test]
     async fn test_partial_group_property_overrides_fallback_behavior() {
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
         let team = context.insert_new_team(None).await.unwrap();
 
         let distinct_id = "test_user".to_string();
 
         // Insert person (required for group flag evaluation)
-        context.insert_person(team.id, distinct_id.clone(), None)
+        context
+            .insert_person(team.id, distinct_id.clone(), None)
             .await
             .expect("Failed to insert person");
 
         // Create a group with specific properties in DB that would match condition 1
-        context.create_group(
-            team.id,
-            "organization",
-            "test_org_123",
-            json!({
-                "plan": "enterprise",
-                "region": "us-east-1",
-                "feature_access": "full",
-                "billing_email": "billing@testorg.com"
-            }),
-        )
-        .await
-        .expect("Failed to create group");
+        context
+            .create_group(
+                team.id,
+                "organization",
+                "test_org_123",
+                json!({
+                    "plan": "enterprise",
+                    "region": "us-east-1",
+                    "feature_access": "full",
+                    "billing_email": "billing@testorg.com"
+                }),
+            )
+            .await
+            .expect("Failed to create group");
 
         // Create a group flag with two conditions similar to the person property test
         let flag = create_test_flag(
@@ -4872,7 +5148,10 @@ mod tests {
 
         // Set up group type mappings
         let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
-        group_type_mapping_cache.init(context.persons_reader.clone()).await.unwrap();
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
 
         let group_types_to_indexes = [("organization".to_string(), 1)].into_iter().collect();
         let indexes_to_types = [(1, "organization".to_string())].into_iter().collect();
@@ -4923,7 +5202,10 @@ mod tests {
 
         // Debug logging to see what's in the result
         println!("Test result: {:?}", result);
-        println!("Errors while computing: {}", result.errors_while_computing_flags);
+        println!(
+            "Errors while computing: {}",
+            result.errors_while_computing_flags
+        );
         println!("Flags in result: {:?}", result.flags);
 
         assert!(!result.errors_while_computing_flags);
@@ -5095,9 +5377,14 @@ mod tests {
         // Unlike decide, we don't sort conditions with variant overrides to the top.
         // This test ensures that the order is maintained regardless of the presence of a variant override.
         let context = TestContext::new(None).await;
-        let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
 
-        let team = context.insert_new_team(None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team");
 

--- a/rust/feature-flags/src/handler/error_tracking.rs
+++ b/rust/feature-flags/src/handler/error_tracking.rs
@@ -36,44 +36,39 @@ pub async fn get_suppression_rules(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_utils::{
-        insert_new_team_in_pg, insert_suppression_rule_in_pg, setup_dual_pg_writers,
-        setup_pg_reader_client,
-    };
+    use crate::utils::test_utils::{insert_suppression_rule_in_pg, TestContext};
     use serde_json::json;
 
     #[tokio::test]
     async fn test_get_suppression_rules_empty() {
-        let client = setup_pg_reader_client(None).await;
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+        let context = TestContext::new(None).await;
+        let team = context.insert_new_team(None).await.unwrap();
+
+        let result = get_suppression_rules(context.non_persons_reader, &team)
             .await
             .unwrap();
-
-        let result = get_suppression_rules(client, &team).await.unwrap();
 
         assert!(result.is_empty());
     }
 
     #[tokio::test]
     async fn test_get_suppression_rules_with_data() {
-        let client = setup_pg_reader_client(None).await;
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
-            .await
-            .unwrap();
+        let context = TestContext::new(None).await;
+        let team = context.insert_new_team(None).await.unwrap();
 
         let filter1 = json!({"errorType": "TypeError", "message": "Cannot read property"});
         let filter2 = json!({"stackTrace": {"contains": "node_modules"}});
 
-        insert_suppression_rule_in_pg(client.clone(), team.id, filter1.clone())
+        insert_suppression_rule_in_pg(context.non_persons_writer.clone(), team.id, filter1.clone())
             .await
             .unwrap();
-        insert_suppression_rule_in_pg(client.clone(), team.id, filter2.clone())
+        insert_suppression_rule_in_pg(context.non_persons_writer.clone(), team.id, filter2.clone())
             .await
             .unwrap();
 
-        let result = get_suppression_rules(client, &team).await.unwrap();
+        let result = get_suppression_rules(context.non_persons_reader, &team)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(result.contains(&filter1));
@@ -82,26 +77,31 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_suppression_rules_filters_by_team() {
-        let client = setup_pg_reader_client(None).await;
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team1 = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
-            .await
-            .unwrap();
-        let team2 = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
-            .await
-            .unwrap();
+        let context = TestContext::new(None).await;
+        let team1 = context.insert_new_team(None).await.unwrap();
+        let team2 = context.insert_new_team(None).await.unwrap();
 
         let filter1 = json!({"errorType": "TypeError"});
         let filter2 = json!({"errorType": "ReferenceError"});
 
-        insert_suppression_rule_in_pg(client.clone(), team1.id, filter1.clone())
-            .await
-            .unwrap();
-        insert_suppression_rule_in_pg(client.clone(), team2.id, filter2.clone())
-            .await
-            .unwrap();
+        insert_suppression_rule_in_pg(
+            context.non_persons_writer.clone(),
+            team1.id,
+            filter1.clone(),
+        )
+        .await
+        .unwrap();
+        insert_suppression_rule_in_pg(
+            context.non_persons_writer.clone(),
+            team2.id,
+            filter2.clone(),
+        )
+        .await
+        .unwrap();
 
-        let result = get_suppression_rules(client, &team1).await.unwrap();
+        let result = get_suppression_rules(context.non_persons_reader, &team1)
+            .await
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], filter1);

--- a/rust/feature-flags/src/handler/error_tracking.rs
+++ b/rust/feature-flags/src/handler/error_tracking.rs
@@ -46,7 +46,9 @@ mod tests {
     async fn test_get_suppression_rules_empty() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         let result = get_suppression_rules(client, &team).await.unwrap();
 
@@ -57,7 +59,9 @@ mod tests {
     async fn test_get_suppression_rules_with_data() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         let filter1 = json!({"errorType": "TypeError", "message": "Cannot read property"});
         let filter2 = json!({"stackTrace": {"contains": "node_modules"}});
@@ -80,8 +84,12 @@ mod tests {
     async fn test_get_suppression_rules_filters_by_team() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team1 = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
-        let team2 = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team1 = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
+            .await
+            .unwrap();
+        let team2 = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         let filter1 = json!({"errorType": "TypeError"});
         let filter2 = json!({"errorType": "ReferenceError"});

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -20,8 +20,8 @@ use crate::{
     },
     properties::property_models::{OperatorType, PropertyFilter, PropertyType},
     utils::test_utils::{
-        insert_flags_for_team_in_redis, insert_new_team_in_pg, insert_person_for_team_in_pg,
-        setup_dual_pg_writers, setup_pg_reader_client, setup_pg_writer_client, setup_redis_client,
+        insert_flags_for_team_in_redis, setup_pg_reader_client, setup_pg_writer_client,
+        setup_redis_client, TestContext,
     },
 };
 use axum::http::HeaderMap;
@@ -132,10 +132,8 @@ async fn test_evaluate_feature_flags() {
     let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
     let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer, None)
-        .await
-        .expect("Failed to insert team in pg");
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.expect("Failed to insert team in pg");
     let flag = FeatureFlag {
         name: Some("Test Flag".to_string()),
         id: 1,
@@ -208,16 +206,11 @@ async fn test_evaluate_feature_flags() {
 #[tokio::test]
 async fn test_evaluate_feature_flags_with_errors() {
     // Set up test dependencies
-    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
-    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
-    let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+    let context = TestContext::new(None).await;
+    let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+    let team = context.insert_new_team(None).await.expect("Failed to insert team in pg");
 
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer, None)
-        .await
-        .expect("Failed to insert team in pg");
-
-    insert_person_for_team_in_pg(persons_writer, team.id, "user123".to_string(), None)
+    context.insert_person(team.id, "user123".to_string(), None)
         .await
         .expect("Failed to insert person");
 
@@ -262,10 +255,10 @@ async fn test_evaluate_feature_flags_with_errors() {
         project_id: team.project_id,
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
-        persons_reader: reader.clone(),
-        persons_writer: writer.clone(),
-        non_persons_reader: reader.clone(),
-        non_persons_writer: writer,
+        persons_reader: context.persons_reader.clone(),
+        persons_writer: context.persons_writer.clone(),
+        non_persons_reader: context.non_persons_reader.clone(),
+        non_persons_writer: context.non_persons_writer.clone(),
         cohort_cache,
         person_property_overrides: Some(HashMap::new()),
         group_property_overrides: None,
@@ -593,13 +586,11 @@ async fn test_evaluate_feature_flags_multiple_flags() {
     let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
 
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer, None)
-        .await
-        .expect("Failed to insert team in pg");
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.expect("Failed to insert team in pg");
 
     let distinct_id = "user_distinct_id".to_string();
-    insert_person_for_team_in_pg(persons_writer, team.id, distinct_id.clone(), None)
+    context.insert_person(team.id, distinct_id.clone(), None)
         .await
         .expect("Failed to insert person");
 
@@ -694,10 +685,10 @@ async fn test_evaluate_feature_flags_details() {
     let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
     let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer, None).await.unwrap();
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.unwrap();
     let distinct_id = "user123".to_string();
-    insert_person_for_team_in_pg(persons_writer, team.id, distinct_id.clone(), None)
+    context.insert_person(team.id, distinct_id.clone(), None)
         .await
         .expect("Failed to insert person");
 
@@ -854,11 +845,9 @@ fn test_flag_error_request_decoding() {
 
 #[tokio::test]
 async fn test_evaluate_feature_flags_with_overrides() {
-    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
-    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
-    let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+    let context = TestContext::new(None).await;
+    let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+    let team = context.insert_new_team(None).await.unwrap();
 
     let flag = FeatureFlag {
         name: Some("Test Flag".to_string()),
@@ -906,10 +895,10 @@ async fn test_evaluate_feature_flags_with_overrides() {
         project_id: team.project_id,
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
-        persons_reader: reader.clone(),
-        persons_writer: writer.clone(),
-        non_persons_reader: reader.clone(),
-        non_persons_writer: writer,
+        persons_reader: context.persons_reader.clone(),
+        persons_writer: context.persons_writer.clone(),
+        non_persons_reader: context.non_persons_reader.clone(),
+        non_persons_writer: context.non_persons_writer.clone(),
         cohort_cache,
         person_property_overrides: None,
         group_property_overrides: Some(group_property_overrides),
@@ -951,13 +940,11 @@ async fn test_evaluate_feature_flags_with_overrides() {
 async fn test_long_distinct_id() {
     // distinct_id is CHAR(400)
     let long_id = "a".repeat(400);
-    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
-    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
-    let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer, None).await.unwrap();
+    let context = TestContext::new(None).await;
+    let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+    let team = context.insert_new_team(None).await.unwrap();
     let distinct_id = long_id.to_string();
-    insert_person_for_team_in_pg(persons_writer, team.id, distinct_id.clone(), None)
+    context.insert_person(team.id, distinct_id.clone(), None)
         .await
         .expect("Failed to insert person");
     let flag = FeatureFlag {
@@ -991,10 +978,10 @@ async fn test_long_distinct_id() {
         project_id: team.project_id,
         distinct_id: long_id,
         feature_flags: feature_flag_list,
-        persons_reader: reader.clone(),
-        persons_writer: writer.clone(),
-        non_persons_reader: reader.clone(),
-        non_persons_writer: writer,
+        persons_reader: context.persons_reader.clone(),
+        persons_writer: context.persons_writer.clone(),
+        non_persons_reader: context.non_persons_reader.clone(),
+        non_persons_writer: context.non_persons_writer.clone(),
         cohort_cache,
         person_property_overrides: None,
         group_property_overrides: None,
@@ -1133,8 +1120,8 @@ async fn test_fetch_and_filter_flags() {
         redis_writer_client.clone(),
         reader.clone(),
     );
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.unwrap();
 
     // Create a mix of survey and non-survey flags
     let flags = vec![

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -133,7 +133,10 @@ async fn test_evaluate_feature_flags() {
     let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
     let context = TestContext::new(None).await;
-    let team = context.insert_new_team(None).await.expect("Failed to insert team in pg");
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team in pg");
     let flag = FeatureFlag {
         name: Some("Test Flag".to_string()),
         id: 1,
@@ -207,10 +210,18 @@ async fn test_evaluate_feature_flags() {
 async fn test_evaluate_feature_flags_with_errors() {
     // Set up test dependencies
     let context = TestContext::new(None).await;
-    let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
-    let team = context.insert_new_team(None).await.expect("Failed to insert team in pg");
+    let cohort_cache = Arc::new(CohortCacheManager::new(
+        context.non_persons_reader.clone(),
+        None,
+        None,
+    ));
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team in pg");
 
-    context.insert_person(team.id, "user123".to_string(), None)
+    context
+        .insert_person(team.id, "user123".to_string(), None)
         .await
         .expect("Failed to insert person");
 
@@ -587,10 +598,14 @@ async fn test_evaluate_feature_flags_multiple_flags() {
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
 
     let context = TestContext::new(None).await;
-    let team = context.insert_new_team(None).await.expect("Failed to insert team in pg");
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team in pg");
 
     let distinct_id = "user_distinct_id".to_string();
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .expect("Failed to insert person");
 
@@ -688,7 +703,8 @@ async fn test_evaluate_feature_flags_details() {
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await.unwrap();
     let distinct_id = "user123".to_string();
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .expect("Failed to insert person");
 
@@ -846,7 +862,11 @@ fn test_flag_error_request_decoding() {
 #[tokio::test]
 async fn test_evaluate_feature_flags_with_overrides() {
     let context = TestContext::new(None).await;
-    let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+    let cohort_cache = Arc::new(CohortCacheManager::new(
+        context.non_persons_reader.clone(),
+        None,
+        None,
+    ));
     let team = context.insert_new_team(None).await.unwrap();
 
     let flag = FeatureFlag {
@@ -941,10 +961,15 @@ async fn test_long_distinct_id() {
     // distinct_id is CHAR(400)
     let long_id = "a".repeat(400);
     let context = TestContext::new(None).await;
-    let cohort_cache = Arc::new(CohortCacheManager::new(context.non_persons_reader.clone(), None, None));
+    let cohort_cache = Arc::new(CohortCacheManager::new(
+        context.non_persons_reader.clone(),
+        None,
+        None,
+    ));
     let team = context.insert_new_team(None).await.unwrap();
     let distinct_id = long_id.to_string();
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .expect("Failed to insert person");
     let flag = FeatureFlag {

--- a/rust/feature-flags/src/site_apps/mod.rs
+++ b/rust/feature-flags/src/site_apps/mod.rs
@@ -92,7 +92,9 @@ mod tests {
     use common_database::PostgresWriter;
 
     use super::*;
-    use crate::utils::test_utils::{insert_new_team_in_pg, setup_dual_pg_writers, setup_pg_reader_client};
+    use crate::utils::test_utils::{
+        insert_new_team_in_pg, setup_dual_pg_writers, setup_pg_reader_client,
+    };
 
     async fn insert_plugin_in_pg(
         client: PostgresWriter,
@@ -169,7 +171,9 @@ mod tests {
     async fn test_get_decide_site_apps_returns_empty_for_team_with_no_apps() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         let result = get_decide_site_apps(client, team.id).await.unwrap();
 
@@ -180,7 +184,9 @@ mod tests {
     async fn test_get_decide_site_apps_returns_apps_for_team() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -221,7 +227,9 @@ mod tests {
     async fn test_get_decide_site_apps_ignores_disabled_configs() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -257,7 +265,9 @@ mod tests {
     async fn test_get_decide_site_apps_ignores_non_transpiled_files() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -293,7 +303,9 @@ mod tests {
     async fn test_get_decide_site_apps_ignores_non_site_files() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -329,7 +341,9 @@ mod tests {
     async fn test_get_decide_site_apps_returns_multiple_apps() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         // Insert first plugin
         let plugin_id_1 = insert_plugin_in_pg(
@@ -397,7 +411,9 @@ mod tests {
     async fn test_get_decide_site_apps_url_format() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -444,8 +460,12 @@ mod tests {
     async fn test_get_decide_site_apps_filters_by_team() {
         let client = setup_pg_reader_client(None).await;
         let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-        let team1 = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
-        let team2 = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
+        let team1 = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None)
+            .await
+            .unwrap();
+        let team2 = insert_new_team_in_pg(persons_writer, non_persons_writer, None)
+            .await
+            .unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(

--- a/rust/feature-flags/src/site_apps/mod.rs
+++ b/rust/feature-flags/src/site_apps/mod.rs
@@ -92,7 +92,7 @@ mod tests {
     use common_database::PostgresWriter;
 
     use super::*;
-    use crate::utils::test_utils::{insert_new_team_in_pg, setup_pg_reader_client};
+    use crate::utils::test_utils::{insert_new_team_in_pg, setup_dual_pg_writers, setup_pg_reader_client};
 
     async fn insert_plugin_in_pg(
         client: PostgresWriter,
@@ -168,7 +168,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_returns_empty_for_team_with_no_apps() {
         let client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         let result = get_decide_site_apps(client, team.id).await.unwrap();
 
@@ -178,7 +179,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_returns_apps_for_team() {
         let client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -218,7 +220,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_ignores_disabled_configs() {
         let client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -253,7 +256,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_ignores_non_transpiled_files() {
         let client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -288,7 +292,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_ignores_non_site_files() {
         let client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -323,7 +328,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_returns_multiple_apps() {
         let client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         // Insert first plugin
         let plugin_id_1 = insert_plugin_in_pg(
@@ -390,7 +396,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_url_format() {
         let client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(
@@ -436,8 +443,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_decide_site_apps_filters_by_team() {
         let client = setup_pg_reader_client(None).await;
-        let team1 = insert_new_team_in_pg(client.clone(), None).await.unwrap();
-        let team2 = insert_new_team_in_pg(client.clone(), None).await.unwrap();
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
+        let team1 = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer.clone(), None).await.unwrap();
+        let team2 = insert_new_team_in_pg(persons_writer, non_persons_writer, None).await.unwrap();
 
         // Insert plugin
         let plugin_id = insert_plugin_in_pg(

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -136,8 +136,7 @@ mod tests {
 
     use super::*;
     use crate::utils::test_utils::{
-        insert_new_team_in_pg, insert_new_team_in_redis, random_string, setup_dual_pg_writers,
-        setup_pg_reader_client, setup_redis_client,
+        insert_new_team_in_redis, random_string, setup_redis_client, TestContext,
     };
 
     #[tokio::test]
@@ -253,16 +252,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_team_from_pg() {
-        let (persons_client, non_persons_client) = setup_dual_pg_writers(None).await;
-        let client = setup_pg_reader_client(None).await;
-
-        let team = insert_new_team_in_pg(persons_client, non_persons_client, None)
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
         let target_token = team.api_token;
 
-        let team_from_pg = Team::from_pg(client.clone(), target_token.as_str())
+        let team_from_pg = Team::from_pg(context.non_persons_reader.clone(), target_token.as_str())
             .await
             .expect("Failed to fetch team from pg");
 
@@ -276,10 +274,10 @@ mod tests {
         // TODO: Figure out a way such that `run_database_migrations` is called only once, and already called
         // before running these tests.
 
-        let client = setup_pg_reader_client(None).await;
+        let context = TestContext::new(None).await;
         let target_token = "xxxx".to_string();
 
-        match Team::from_pg(client.clone(), target_token.as_str()).await {
+        match Team::from_pg(context.non_persons_reader.clone(), target_token.as_str()).await {
             Err(FlagError::RowNotFound) => (),
             _ => panic!("Expected RowNotFound"),
         };
@@ -287,16 +285,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_team_with_null_array_elements_from_pg() {
-        let client = setup_pg_reader_client(None).await;
+        let context = TestContext::new(None).await;
 
         // Insert a team with NULL elements in the array
-        let (persons_client, non_persons_client) = setup_dual_pg_writers(None).await;
-        let team = insert_new_team_in_pg(persons_client, non_persons_client, None)
+        let team = context
+            .insert_new_team(None)
             .await
             .expect("Failed to insert team in pg");
 
         // Manually update the team to have NULL elements in session_recording_event_trigger_config
-        let mut conn = client
+        let mut conn = context
+            .non_persons_reader
             .get_connection()
             .await
             .expect("Failed to get connection");
@@ -317,7 +316,7 @@ mod tests {
         .expect("Failed to update team with NULL array elements");
 
         // Now fetch the team and verify it deserializes correctly
-        let team_from_pg = Team::from_pg(client.clone(), &team.api_token)
+        let team_from_pg = Team::from_pg(context.non_persons_reader.clone(), &team.api_token)
             .await
             .expect("Failed to fetch team with NULL array elements from pg");
 

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -136,8 +136,8 @@ mod tests {
 
     use super::*;
     use crate::utils::test_utils::{
-        insert_new_team_in_pg, insert_new_team_in_redis, random_string, setup_pg_reader_client,
-        setup_redis_client,
+        insert_new_team_in_pg, insert_new_team_in_redis, random_string, setup_dual_pg_writers,
+        setup_pg_reader_client, setup_redis_client,
     };
 
     #[tokio::test]
@@ -253,9 +253,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_team_from_pg() {
+        let (persons_client, non_persons_client) = setup_dual_pg_writers(None).await;
         let client = setup_pg_reader_client(None).await;
 
-        let team = insert_new_team_in_pg(client.clone(), None)
+        let team = insert_new_team_in_pg(persons_client, non_persons_client, None)
             .await
             .expect("Failed to insert team in pg");
 
@@ -289,7 +290,8 @@ mod tests {
         let client = setup_pg_reader_client(None).await;
 
         // Insert a team with NULL elements in the array
-        let team = insert_new_team_in_pg(client.clone(), None)
+        let (persons_client, non_persons_client) = setup_dual_pg_writers(None).await;
+        let team = insert_new_team_in_pg(persons_client, non_persons_client, None)
             .await
             .expect("Failed to insert team in pg");
 

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -808,19 +808,15 @@ impl TestContext {
         cohort_id: CohortId,
         person_id: PersonId,
     ) -> Result<(), Error> {
-        add_person_to_cohort(
-            self.persons_writer.clone(),
-            person_id,
-            cohort_id,
-        )
-        .await
+        add_person_to_cohort(self.persons_writer.clone(), person_id, cohort_id).await
     }
 
     pub async fn get_feature_flag_hash_key_overrides(
         &self,
         team_id: i32,
         distinct_ids: Vec<String>,
-    ) -> Result<std::collections::HashMap<String, String>, super::super::api::errors::FlagError> {
+    ) -> Result<std::collections::HashMap<String, String>, super::super::api::errors::FlagError>
+    {
         super::super::flags::flag_matching_utils::get_feature_flag_hash_key_overrides(
             self.persons_reader.clone(),
             team_id,
@@ -829,11 +825,15 @@ impl TestContext {
         .await
     }
 
-    pub async fn get_persons_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
+    pub async fn get_persons_connection(
+        &self,
+    ) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
         self.persons_writer.get_connection().await
     }
 
-    pub async fn get_non_persons_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
+    pub async fn get_non_persons_connection(
+        &self,
+    ) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
         self.non_persons_writer.get_connection().await
     }
 
@@ -859,12 +859,7 @@ impl TestContext {
         team_id: i32,
         filters: serde_json::Value,
     ) -> Result<uuid::Uuid, Error> {
-        insert_suppression_rule_in_pg(
-            self.non_persons_writer.clone(),
-            team_id,
-            filters,
-        )
-        .await
+        insert_suppression_rule_in_pg(self.non_persons_writer.clone(), team_id, filters).await
     }
 
     pub async fn update_team_autocapture_exceptions(
@@ -872,12 +867,7 @@ impl TestContext {
         team_id: i32,
         enabled: bool,
     ) -> Result<(), Error> {
-        update_team_autocapture_exceptions(
-            self.non_persons_writer.clone(),
-            team_id,
-            enabled,
-        )
-        .await
+        update_team_autocapture_exceptions(self.non_persons_writer.clone(), team_id, enabled).await
     }
 
     pub async fn get_person_id_by_distinct_id(
@@ -885,11 +875,6 @@ impl TestContext {
         team_id: i32,
         distinct_id: &str,
     ) -> Result<PersonId, Error> {
-        get_person_id_by_distinct_id(
-            self.persons_reader.clone(),
-            team_id,
-            distinct_id,
-        )
-        .await
+        get_person_id_by_distinct_id(self.persons_reader.clone(), team_id, distinct_id).await
     }
 }

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -731,7 +731,6 @@ pub struct TestContext {
 }
 
 impl TestContext {
-    /// Create a new TestContext with the given configuration
     pub async fn new(config: Option<&Config>) -> Self {
         let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
 
@@ -746,7 +745,6 @@ impl TestContext {
         }
     }
 
-    /// Create a PostgresRouter instance from this context
     pub fn create_postgres_router(&self) -> crate::database::PostgresRouter {
         crate::database::PostgresRouter::new(
             self.persons_reader.clone(),
@@ -756,7 +754,6 @@ impl TestContext {
         )
     }
 
-    /// Insert a new team into the database
     pub async fn insert_new_team(&self, team_id: Option<i32>) -> Result<Team, Error> {
         insert_new_team_in_pg(
             self.persons_writer.clone(),
@@ -766,7 +763,6 @@ impl TestContext {
         .await
     }
 
-    /// Insert a feature flag for a team
     pub async fn insert_flag(
         &self,
         team_id: i32,
@@ -775,7 +771,6 @@ impl TestContext {
         insert_flag_for_team_in_pg(self.non_persons_writer.clone(), team_id, flag).await
     }
 
-    /// Insert a person for a team
     pub async fn insert_person(
         &self,
         team_id: i32,
@@ -791,7 +786,6 @@ impl TestContext {
         .await
     }
 
-    /// Insert a cohort for a team
     pub async fn insert_cohort(
         &self,
         team_id: i32,
@@ -809,7 +803,6 @@ impl TestContext {
         .await
     }
 
-    /// Insert a static cohort membership
     pub async fn add_person_to_cohort(
         &self,
         cohort_id: CohortId,
@@ -823,7 +816,6 @@ impl TestContext {
         .await
     }
 
-    /// Get hash key overrides for feature flags
     pub async fn get_feature_flag_hash_key_overrides(
         &self,
         team_id: i32,
@@ -837,17 +829,14 @@ impl TestContext {
         .await
     }
 
-    /// Get a connection to the persons database (for direct SQL operations)
     pub async fn get_persons_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
         self.persons_writer.get_connection().await
     }
 
-    /// Get a connection to the non-persons database (for direct SQL operations)
     pub async fn get_non_persons_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
         self.non_persons_writer.get_connection().await
     }
 
-    /// Create a group for a team
     pub async fn create_group(
         &self,
         team_id: i32,
@@ -865,7 +854,6 @@ impl TestContext {
         .await
     }
 
-    /// Insert a suppression rule for error tracking
     pub async fn insert_suppression_rule(
         &self,
         team_id: i32,
@@ -879,7 +867,6 @@ impl TestContext {
         .await
     }
 
-    /// Update autocapture exceptions setting for a team
     pub async fn update_team_autocapture_exceptions(
         &self,
         team_id: i32,
@@ -893,7 +880,6 @@ impl TestContext {
         .await
     }
 
-    /// Get person ID by distinct ID
     pub async fn get_person_id_by_distinct_id(
         &self,
         team_id: i32,

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -155,6 +155,74 @@ pub async fn setup_pg_writer_client(config: Option<&Config>) -> Arc<dyn Client +
     )
 }
 
+/// Setup dual database clients for tests that need to work with both persons and non-persons databases.
+/// If persons DB routing is not enabled, returns the same client twice.
+pub async fn setup_dual_pg_readers(
+    config: Option<&Config>,
+) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
+    let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+
+    if config.is_persons_db_routing_enabled() {
+        // Separate persons and non-persons databases
+        let persons_reader = Arc::new(
+            get_pool(
+                &config.get_persons_read_database_url(),
+                config.max_pg_connections,
+            )
+            .await
+            .expect("Failed to create Postgres persons reader client"),
+        );
+        let non_persons_reader = Arc::new(
+            get_pool(&config.read_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
+        );
+        (persons_reader, non_persons_reader)
+    } else {
+        // Same database for both
+        let client = Arc::new(
+            get_pool(&config.read_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
+        );
+        (client.clone(), client)
+    }
+}
+
+/// Setup dual database writers for tests that need to write to both persons and non-persons databases.
+/// If persons DB routing is not enabled, returns the same client twice.
+pub async fn setup_dual_pg_writers(
+    config: Option<&Config>,
+) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
+    let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+
+    if config.is_persons_db_routing_enabled() {
+        // Separate persons and non-persons databases
+        let persons_writer = Arc::new(
+            get_pool(
+                &config.get_persons_write_database_url(),
+                config.max_pg_connections,
+            )
+            .await
+            .expect("Failed to create Postgres persons writer client"),
+        );
+        let non_persons_writer = Arc::new(
+            get_pool(&config.write_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
+        );
+        (persons_writer, non_persons_writer)
+    } else {
+        // Same database for both
+        let client = Arc::new(
+            get_pool(&config.write_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
+        );
+        (client.clone(), client)
+    }
+}
+
 pub struct MockPgClient;
 
 #[async_trait]
@@ -185,13 +253,14 @@ pub async fn setup_invalid_pg_client() -> Arc<dyn Client + Send + Sync> {
 }
 
 pub async fn insert_new_team_in_pg(
-    client: Arc<dyn Client + Send + Sync>,
+    persons_client: Arc<dyn Client + Send + Sync>,
+    non_persons_client: Arc<dyn Client + Send + Sync>,
     team_id: Option<i32>,
 ) -> Result<Team, Error> {
     const ORG_ID: &str = "019026a4be8000005bf3171d00629163";
 
-    // Create new organization from scratch
-    client.run_query(
+    // Create new organization from scratch (in non-persons database)
+    non_persons_client.run_query(
         r#"INSERT INTO posthog_organization
         (id, name, slug, created_at, updated_at, plugins_access_level, for_internal_metrics, is_member_join_email_enabled, enforce_2fa, is_hipaa, customer_id, available_product_features, personalization, setup_section_2_completed, domain_whitelist, members_can_use_personal_api_keys, allow_publicly_shared_resources)
         VALUES
@@ -218,9 +287,9 @@ pub async fn insert_new_team_in_pg(
     };
     let uuid = Uuid::now_v7();
 
-    let mut conn = client.get_connection().await?;
+    let mut non_persons_conn = non_persons_client.get_connection().await?;
 
-    // Insert a project for the team
+    // Insert a project for the team (in non-persons database)
     let res = sqlx::query(
         r#"INSERT INTO posthog_project
         (id, organization_id, name, created_at) VALUES
@@ -229,19 +298,20 @@ pub async fn insert_new_team_in_pg(
     .bind(team.project_id)
     .bind(ORG_ID)
     .bind(&team.name)
-    .execute(&mut *conn)
+    .execute(&mut *non_persons_conn)
     .await?;
     assert_eq!(res.rows_affected(), 1);
 
-    // Insert a team with the correct team-project relationship
+    // Insert a team with the correct team-project relationship (in non-persons database)
     let res = sqlx::query(
         r#"INSERT INTO posthog_team
         (id, uuid, organization_id, project_id, api_token, name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical, cookieless_server_hash_mode, base_currency, session_recording_retention_period, web_analytics_pre_aggregated_tables_enabled) VALUES
         ($1, $2, $3::uuid, $4, $5, $6, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]', $7, 'USD', '30d', false)"#
-    ).bind(team.id).bind(uuid).bind(ORG_ID).bind(team.project_id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode).execute(&mut *conn).await?;
+    ).bind(team.id).bind(uuid).bind(ORG_ID).bind(team.project_id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode).execute(&mut *non_persons_conn).await?;
     assert_eq!(res.rows_affected(), 1);
 
-    // Insert group type mappings
+    // Insert group type mappings (in persons database)
+    let mut persons_conn = persons_client.get_connection().await?;
     let group_types = vec![
         ("project", 0),
         ("organization", 1),
@@ -261,7 +331,7 @@ pub async fn insert_new_team_in_pg(
         .bind(group_type_index)
         .bind(team.id)
         .bind(team.project_id)
-        .execute(&mut *conn)
+        .execute(&mut *persons_conn)
         .await?;
         assert_eq!(res.rows_affected(), 1);
     }
@@ -648,4 +718,134 @@ pub fn create_test_flag_that_depends_on_flag(
             negation: None,
         },
     )
+}
+
+/// Test context that encapsulates all database connections needed for testing
+/// This struct manages the proper routing of database operations to the correct
+/// database (persons vs non-persons) based on the configuration
+pub struct TestContext {
+    pub persons_reader: Arc<dyn Client + Send + Sync>,
+    pub persons_writer: Arc<dyn Client + Send + Sync>,
+    pub non_persons_reader: Arc<dyn Client + Send + Sync>,
+    pub non_persons_writer: Arc<dyn Client + Send + Sync>,
+}
+
+impl TestContext {
+    /// Create a new TestContext with the given configuration
+    pub async fn new(config: Option<&Config>) -> Self {
+        let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+
+        let (persons_reader, non_persons_reader) = setup_dual_pg_readers(Some(config)).await;
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(Some(config)).await;
+
+        Self {
+            persons_reader,
+            persons_writer,
+            non_persons_reader,
+            non_persons_writer,
+        }
+    }
+
+    /// Create a PostgresRouter instance from this context
+    pub fn create_postgres_router(&self) -> crate::database::PostgresRouter {
+        crate::database::PostgresRouter::new(
+            self.persons_reader.clone(),
+            self.persons_writer.clone(),
+            self.non_persons_reader.clone(),
+            self.non_persons_writer.clone(),
+        )
+    }
+
+    /// Insert a new team into the database
+    pub async fn insert_new_team(&self, team_id: Option<i32>) -> Result<Team, Error> {
+        insert_new_team_in_pg(
+            self.persons_writer.clone(),
+            self.non_persons_writer.clone(),
+            team_id,
+        )
+        .await
+    }
+
+    /// Insert a feature flag for a team
+    pub async fn insert_flag(
+        &self,
+        team_id: i32,
+        flag: Option<FeatureFlagRow>,
+    ) -> Result<FeatureFlagRow, Error> {
+        insert_flag_for_team_in_pg(self.non_persons_writer.clone(), team_id, flag).await
+    }
+
+    /// Insert a person for a team
+    pub async fn insert_person(
+        &self,
+        team_id: i32,
+        distinct_id: String,
+        properties: Option<Value>,
+    ) -> Result<PersonId, Error> {
+        insert_person_for_team_in_pg(
+            self.persons_writer.clone(),
+            team_id,
+            distinct_id,
+            properties,
+        )
+        .await
+    }
+
+    /// Insert a cohort for a team
+    pub async fn insert_cohort(
+        &self,
+        team_id: i32,
+        name: Option<String>,
+        filters: serde_json::Value,
+        is_static: bool,
+    ) -> Result<Cohort, Error> {
+        insert_cohort_for_team_in_pg(
+            self.non_persons_writer.clone(),
+            team_id,
+            name,
+            filters,
+            is_static,
+        )
+        .await
+    }
+
+    /// Insert a static cohort membership
+    pub async fn add_person_to_cohort(
+        &self,
+        cohort_id: CohortId,
+        person_id: PersonId,
+        team_id: i32,
+    ) -> Result<(), Error> {
+        add_person_to_cohort(
+            self.non_persons_writer.clone(),
+            person_id,
+            cohort_id,
+            team_id,
+        )
+        .await
+    }
+
+    /// Get hash key overrides for feature flags
+    pub async fn get_feature_flag_hash_key_overrides(
+        &self,
+        team_id: i32,
+        distinct_ids: Vec<String>,
+    ) -> Result<Vec<(String, String)>, Error> {
+        super::super::flags::flag_matching_utils::get_feature_flag_hash_key_overrides(
+            self.persons_reader.clone(),
+            team_id,
+            distinct_ids,
+        )
+        .await
+    }
+
+    /// Get a connection to the persons database (for direct SQL operations)
+    pub async fn get_persons_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
+        self.persons_writer.get_connection().await
+    }
+
+    /// Get a connection to the non-persons database (for direct SQL operations)
+    pub async fn get_non_persons_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
+        self.non_persons_writer.get_connection().await
+    }
 }

--- a/rust/feature-flags/tests/test_experience_continuity.rs
+++ b/rust/feature-flags/tests/test_experience_continuity.rs
@@ -17,7 +17,10 @@ async fn test_experience_continuity_matches_python() -> Result<()> {
 
     // Insert a new team
     let context = TestContext::new(None).await;
-    let team = context.insert_new_team(None).await.expect("Failed to insert team");
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team");
 
     // Create a flag with experience continuity (50% rollout like the real experience-flag)
     let flag_row = FeatureFlagRow {
@@ -38,12 +41,13 @@ async fn test_experience_continuity_matches_python() -> Result<()> {
 
     // Create a person with false_eval_user (this ID evaluates to false for 50% rollout)
     let user_id = "false_eval_user";
-    context.insert_person(
-        team.id,
-        user_id.to_string(),
-        Some(json!({"email": "false_eval_user@example.com", "name": "Test User"})),
-    )
-    .await?;
+    context
+        .insert_person(
+            team.id,
+            user_id.to_string(),
+            Some(json!({"email": "false_eval_user@example.com", "name": "Test User"})),
+        )
+        .await?;
 
     // Start test server
     let config = DEFAULT_TEST_CONFIG.clone();
@@ -137,7 +141,10 @@ async fn test_experience_continuity_with_merge() -> Result<()> {
     // Test that merged persons also maintain overrides without $anon_distinct_id
 
     let context = TestContext::new(None).await;
-    let team = context.insert_new_team(None).await.expect("Failed to insert team");
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team");
 
     // Create flag
     let flag_row = FeatureFlagRow {
@@ -158,12 +165,13 @@ async fn test_experience_continuity_with_merge() -> Result<()> {
 
     // Create initial person with an ID that evaluates to false
     let initial_id = "false_eval_initial";
-    let person_id = context.insert_person(
-        team.id,
-        initial_id.to_string(),
-        Some(json!({"email": "initial@example.com"})),
-    )
-    .await?;
+    let person_id = context
+        .insert_person(
+            team.id,
+            initial_id.to_string(),
+            Some(json!({"email": "initial@example.com"})),
+        )
+        .await?;
 
     // Start server
     let config = DEFAULT_TEST_CONFIG.clone();

--- a/rust/feature-flags/tests/test_experience_continuity.rs
+++ b/rust/feature-flags/tests/test_experience_continuity.rs
@@ -6,10 +6,7 @@ pub mod common;
 use crate::common::ServerHandle;
 use feature_flags::config::DEFAULT_TEST_CONFIG;
 use feature_flags::flags::flag_models::FeatureFlagRow;
-use feature_flags::utils::test_utils::{
-    insert_flag_for_team_in_pg, insert_new_team_in_pg, insert_person_for_team_in_pg,
-    setup_dual_pg_writers, setup_pg_reader_client, setup_pg_writer_client,
-};
+use feature_flags::utils::test_utils::TestContext;
 
 #[tokio::test]
 async fn test_experience_continuity_matches_python() -> Result<()> {
@@ -18,14 +15,9 @@ async fn test_experience_continuity_matches_python() -> Result<()> {
     // 3. Set hash key override via $anon_distinct_id
     // 4. Call WITHOUT $anon_distinct_id - should maintain the override
 
-    let pg_reader = setup_pg_reader_client(None).await;
-    let pg_writer = setup_pg_writer_client(None).await;
-
     // Insert a new team
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer, None)
-        .await
-        .expect("Failed to insert team");
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.expect("Failed to insert team");
 
     // Create a flag with experience continuity (50% rollout like the real experience-flag)
     let flag_row = FeatureFlagRow {
@@ -42,12 +34,11 @@ async fn test_experience_continuity_matches_python() -> Result<()> {
         version: Some(1),
         evaluation_runtime: None,
     };
-    insert_flag_for_team_in_pg(pg_writer.clone(), team.id, Some(flag_row)).await?;
+    context.insert_flag(team.id, Some(flag_row)).await?;
 
     // Create a person with false_eval_user (this ID evaluates to false for 50% rollout)
     let user_id = "false_eval_user";
-    insert_person_for_team_in_pg(
-        persons_writer.clone(),
+    context.insert_person(
         team.id,
         user_id.to_string(),
         Some(json!({"email": "false_eval_user@example.com", "name": "Test User"})),
@@ -145,13 +136,8 @@ async fn test_experience_continuity_matches_python() -> Result<()> {
 async fn test_experience_continuity_with_merge() -> Result<()> {
     // Test that merged persons also maintain overrides without $anon_distinct_id
 
-    let pg_reader = setup_pg_reader_client(None).await;
-    let pg_writer = setup_pg_writer_client(None).await;
-
-    let (persons_writer, non_persons_writer) = setup_dual_pg_writers(None).await;
-    let team = insert_new_team_in_pg(persons_writer.clone(), non_persons_writer, None)
-        .await
-        .expect("Failed to insert team");
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.expect("Failed to insert team");
 
     // Create flag
     let flag_row = FeatureFlagRow {
@@ -168,12 +154,11 @@ async fn test_experience_continuity_with_merge() -> Result<()> {
         version: Some(1),
         evaluation_runtime: None,
     };
-    insert_flag_for_team_in_pg(pg_writer.clone(), team.id, Some(flag_row)).await?;
+    context.insert_flag(team.id, Some(flag_row)).await?;
 
     // Create initial person with an ID that evaluates to false
     let initial_id = "false_eval_initial";
-    let person_id = insert_person_for_team_in_pg(
-        persons_writer,
+    let person_id = context.insert_person(
         team.id,
         initial_id.to_string(),
         Some(json!({"email": "initial@example.com"})),
@@ -268,7 +253,7 @@ async fn test_experience_continuity_with_merge() -> Result<()> {
 
     // Step 5: Simulate a person merge (this would normally happen via $identify event)
     // Use an ID that would naturally evaluate to false to prove the override is working
-    let mut conn = pg_writer.get_connection().await?;
+    let mut conn = context.get_persons_connection().await?;
     sqlx::query(
         "INSERT INTO posthog_persondistinctid (team_id, person_id, distinct_id, version)
          VALUES ($1, $2, $3, 0)",

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -24,7 +24,6 @@ async fn it_handles_get_requests_with_minimal_response() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -73,7 +72,6 @@ async fn it_gets_legacy_response_for_v1_or_invalid_version(
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -145,7 +143,6 @@ async fn it_gets_v2_response_by_default_when_no_params() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -234,7 +231,6 @@ async fn it_get_new_response_when_version_is_2_or_more(#[case] version: &str) ->
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -319,7 +315,6 @@ async fn it_rejects_invalid_headers_flag_request() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -359,7 +354,6 @@ async fn it_rejects_invalid_headers_flag_request() -> Result<()> {
 async fn it_accepts_empty_distinct_id() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
     let distinct_id = "user_distinct_id".to_string();
@@ -483,7 +477,6 @@ async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
 
     // Set up Redis and PostgreSQL clients
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -535,7 +528,6 @@ async fn it_handles_disable_flags_without_distinct_id() -> Result<()> {
 
     // Set up Redis and PostgreSQL clients
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -652,7 +644,6 @@ async fn it_handles_multivariate_flags() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -744,7 +735,6 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
     let context = TestContext::new(None).await;
@@ -846,7 +836,6 @@ async fn it_matches_flags_to_a_request_with_group_property_overrides() -> Result
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(Some(team.id)).await.unwrap();
@@ -956,7 +945,6 @@ async fn test_feature_flags_with_json_payloads() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let distinct_id = "example_id".to_string();
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
 
     // Insert a new team into Redis and retrieve the team details
     let team = insert_new_team_in_redis(redis_client.clone())
@@ -1044,7 +1032,6 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let distinct_id = "example_id".to_string();
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team_id = rand::thread_rng().gen_range(1..10_000_000);
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(Some(team_id)).await.unwrap();
@@ -1216,7 +1203,6 @@ async fn it_handles_not_contains_property_filter() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -1292,7 +1278,6 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
     let context = TestContext::new(None).await;
@@ -1444,7 +1429,6 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let distinct_id = "example_id".to_string();
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await?;
     context
@@ -1588,7 +1572,6 @@ async fn test_super_condition_with_complex_request() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let distinct_id = "test_user".to_string();
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(redis_client.clone()).await?;
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await?;
@@ -1698,7 +1681,6 @@ async fn test_super_condition_with_complex_request() -> Result<()> {
 async fn test_flag_matches_with_no_person_profile() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -1827,7 +1809,6 @@ async fn it_only_includes_config_fields_when_requested() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -1899,7 +1880,6 @@ async fn test_config_basic_fields() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -1969,7 +1949,6 @@ async fn test_config_analytics_enabled() -> Result<()> {
 
     let distinct_id = "user_distinct_id".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -2009,7 +1988,6 @@ async fn test_config_analytics_enabled_by_default() -> Result<()> {
 
     let distinct_id = "user_distinct_id".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -2048,7 +2026,6 @@ async fn test_config_analytics_disabled_debug_mode() -> Result<()> {
 
     let distinct_id = "user_distinct_id".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -2084,7 +2061,6 @@ async fn test_config_capture_performance_combinations() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
 
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
@@ -2122,7 +2098,6 @@ async fn test_config_autocapture_exceptions() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -2159,7 +2134,6 @@ async fn test_config_optional_team_features() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -2204,7 +2178,6 @@ async fn test_config_site_apps_empty_by_default() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -2241,7 +2214,6 @@ async fn test_config_included_in_legacy_response() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -2343,7 +2315,7 @@ async fn test_config_site_apps_with_actual_plugins() -> Result<()> {
     // Insert a plugin
     let mut conn = pg_client.get_connection().await.unwrap();
     let plugin_id: i32 = sqlx::query_scalar(
-        r#"INSERT INTO posthog_plugin 
+        r#"INSERT INTO posthog_plugin
            (name, description, url, config_schema, tag, source, plugin_type, is_global, is_preinstalled, is_stateless, capabilities, from_json, from_web, organization_id, updated_at, created_at)
            VALUES ($1, 'Test Site App', $2, '[]', '', '', 'source', false, false, false, '{}', false, false, $3::uuid, NOW(), NOW())
            RETURNING id"#,
@@ -2358,7 +2330,7 @@ async fn test_config_site_apps_with_actual_plugins() -> Result<()> {
     // Insert plugin source file (site.ts with TRANSPILED status)
     let source_uuid = uuid::Uuid::new_v4().to_string();
     sqlx::query(
-        r#"INSERT INTO posthog_pluginsourcefile 
+        r#"INSERT INTO posthog_pluginsourcefile
            (id, plugin_id, filename, source, transpiled, status, updated_at)
            VALUES ($1::uuid, $2, 'site.ts', 'function test(){}', 'function test(){}', 'TRANSPILED', NOW())"#,
     )
@@ -2370,7 +2342,7 @@ async fn test_config_site_apps_with_actual_plugins() -> Result<()> {
 
     // Insert plugin config to connect the plugin to the team
     sqlx::query(
-        r#"INSERT INTO posthog_pluginconfig 
+        r#"INSERT INTO posthog_pluginconfig
            (plugin_id, team_id, enabled, "order", config, web_token, updated_at, created_at)
            VALUES ($1, $2, true, 1, '{}', 'test_site_app_token', NOW(), NOW())"#,
     )
@@ -2422,7 +2394,6 @@ async fn test_config_session_recording_with_rrweb_script() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -2493,7 +2464,6 @@ async fn test_config_session_recording_team_not_allowed_for_script() -> Result<(
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -2607,7 +2577,7 @@ async fn test_config_comprehensive_enterprise_team() -> Result<()> {
     // Add a site app plugin
     let mut conn = pg_client.get_connection().await.unwrap();
     let plugin_id: i32 = sqlx::query_scalar(
-        r#"INSERT INTO posthog_plugin 
+        r#"INSERT INTO posthog_plugin
            (name, description, url, config_schema, tag, source, plugin_type, is_global, is_preinstalled, is_stateless, capabilities, from_json, from_web, organization_id, updated_at, created_at)
            VALUES ($1, 'Enterprise Site App', $2, '[]', '', '', 'source', false, false, false, '{}', false, false, $3::uuid, NOW(), NOW())
            RETURNING id"#,
@@ -2621,7 +2591,7 @@ async fn test_config_comprehensive_enterprise_team() -> Result<()> {
 
     let source_uuid = uuid::Uuid::new_v4().to_string();
     sqlx::query(
-        r#"INSERT INTO posthog_pluginsourcefile 
+        r#"INSERT INTO posthog_pluginsourcefile
            (id, plugin_id, filename, source, transpiled, status, updated_at)
            VALUES ($1::uuid, $2, 'site.ts', 'function enterpriseFeature(){}', 'function enterpriseFeature(){}', 'TRANSPILED', NOW())"#,
     )
@@ -2632,7 +2602,7 @@ async fn test_config_comprehensive_enterprise_team() -> Result<()> {
     .unwrap();
 
     sqlx::query(
-        r#"INSERT INTO posthog_pluginconfig 
+        r#"INSERT INTO posthog_pluginconfig
            (plugin_id, team_id, enabled, "order", config, web_token, updated_at, created_at)
            VALUES ($1, $2, true, 1, '{}', 'enterprise_site_app_token', NOW(), NOW())"#,
     )
@@ -2736,7 +2706,6 @@ async fn test_config_comprehensive_minimal_team() -> Result<()> {
 
     let distinct_id = "minimal_user".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -2840,7 +2809,6 @@ async fn test_config_mixed_feature_combinations() -> Result<()> {
 
     let distinct_id = "mixed_user".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -2949,7 +2917,6 @@ async fn test_config_team_exclusions_and_overrides() -> Result<()> {
 
     let distinct_id = "exclusion_test_user".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -3036,7 +3003,6 @@ async fn test_config_legacy_vs_v2_consistency() -> Result<()> {
     let distinct_id = "consistency_user".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -3127,7 +3093,6 @@ async fn test_config_error_tracking_with_suppression_rules() -> Result<()> {
     let distinct_id = "error_tracking_user".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -3209,7 +3174,6 @@ async fn test_config_error_tracking_disabled() -> Result<()> {
     let distinct_id = "error_tracking_disabled_user".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -3259,7 +3223,6 @@ async fn test_disable_flags_returns_empty_response() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -3331,7 +3294,6 @@ async fn test_disable_flags_returns_empty_response_v2() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -3402,7 +3364,6 @@ async fn test_disable_flags_false_still_returns_flags() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -3475,7 +3436,6 @@ async fn test_disable_flags_with_config_still_returns_config_data() -> Result<()
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -3564,7 +3524,6 @@ async fn test_disable_flags_with_config_v2_still_returns_config_data() -> Result
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -3652,7 +3611,6 @@ async fn test_disable_flags_without_config_param_has_minimal_response() -> Resul
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -3729,7 +3687,6 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let distinct_id = "user_with_numeric_group".to_string();
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team_id = rand::thread_rng().gen_range(1..10_000_000);
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(Some(team_id)).await.unwrap();
@@ -3903,7 +3860,6 @@ async fn test_super_condition_property_overrides_bug_fix() -> Result<()> {
     let distinct_id = "super_condition_user".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -4096,7 +4052,6 @@ async fn test_property_override_bug_real_scenario() -> Result<()> {
     let distinct_id = "test_real_bug".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -4234,7 +4189,6 @@ async fn test_super_condition_with_cohort_filters() -> Result<()> {
     let distinct_id = "super_condition_cohort_user".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -4418,7 +4372,6 @@ async fn test_returns_empty_flags_when_no_active_flags_configured() -> Result<()
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -4559,7 +4512,6 @@ async fn test_group_key_property_matching() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(Some(team.id)).await.unwrap();
@@ -4735,7 +4687,7 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
     // Create the cohort in the database
     let mut conn = pg_client.get_connection().await.unwrap();
     let cohort_id: i32 = sqlx::query_scalar(
-        r#"INSERT INTO posthog_cohort 
+        r#"INSERT INTO posthog_cohort
            (name, description, team_id, deleted, filters, is_calculating, created_by_id, created_at, is_static, last_calculation, errors_calculating, groups, version)
            VALUES ($1, $2, $3, false, $4, false, NULL, NOW(), false, NOW(), 0, '[]', NULL)
            RETURNING id"#,
@@ -4901,7 +4853,6 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -5134,7 +5085,6 @@ async fn test_flag_keys_to_evaluate_parameter() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -5261,7 +5211,6 @@ async fn it_handles_empty_query_parameters() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -5312,7 +5261,6 @@ async fn it_handles_boolean_query_params_as_truthy() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token;
 
@@ -5453,7 +5401,7 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
     });
 
     let cohort_128293_id: i32 = sqlx::query_scalar(
-        r#"INSERT INTO posthog_cohort 
+        r#"INSERT INTO posthog_cohort
            (name, description, team_id, deleted, filters, is_calculating, created_by_id, created_at, is_static, last_calculation, errors_calculating, groups, version)
            VALUES ($1, $2, $3, false, $4, false, NULL, NOW(), false, NOW(), 0, '[]', NULL)
            RETURNING id"#,
@@ -5505,7 +5453,7 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
     });
 
     let cohort_128397_id: i32 = sqlx::query_scalar(
-        r#"INSERT INTO posthog_cohort 
+        r#"INSERT INTO posthog_cohort
            (name, description, team_id, deleted, filters, is_calculating, created_by_id, created_at, is_static, last_calculation, errors_calculating, groups, version)
            VALUES ($1, $2, $3, false, $4, false, NULL, NOW(), false, NOW(), 0, '[]', NULL)
            RETURNING id"#,
@@ -5677,7 +5625,6 @@ async fn test_empty_distinct_id_flag_matching() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -5989,7 +5936,7 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
     });
 
     let excluded_cohort_id: i32 = sqlx::query_scalar(
-        r#"INSERT INTO posthog_cohort 
+        r#"INSERT INTO posthog_cohort
            (name, description, team_id, deleted, filters, is_calculating, created_by_id, created_at, is_static, last_calculation, errors_calculating, groups, version)
            VALUES ($1, $2, $3, false, $4, false, NULL, NOW(), false, NOW(), 0, '[]', NULL)
            RETURNING id"#,
@@ -6027,7 +5974,7 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
     });
 
     let main_cohort_id: i32 = sqlx::query_scalar(
-        r#"INSERT INTO posthog_cohort 
+        r#"INSERT INTO posthog_cohort
            (name, description, team_id, deleted, filters, is_calculating, created_by_id, created_at, is_static, last_calculation, errors_calculating, groups, version)
            VALUES ($1, $2, $3, false, $4, false, NULL, NOW(), false, NOW(), 0, '[]', NULL)
            RETURNING id"#,
@@ -6188,7 +6135,6 @@ async fn test_date_string_property_matching_with_is_date_after() -> Result<()> {
     let distinct_id = "test_user_123".to_string();
 
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(redis_client.clone())
         .await
         .unwrap();

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -13,8 +13,8 @@ use crate::common::*;
 
 use feature_flags::config::{FlexBool, TeamIdCollection, DEFAULT_TEST_CONFIG};
 use feature_flags::utils::test_utils::{
-    insert_flags_for_team_in_redis, insert_new_team_in_redis,
-    setup_pg_reader_client, setup_redis_client, TestContext,
+    insert_flags_for_team_in_redis, insert_new_team_in_redis, setup_pg_reader_client,
+    setup_redis_client, TestContext,
 };
 
 pub mod common;
@@ -79,7 +79,10 @@ async fn it_gets_legacy_response_for_v1_or_invalid_version(
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     // Insert a specific flag for the team
     let flag_json = json!([{
@@ -149,7 +152,8 @@ async fn it_gets_v2_response_by_default_when_no_params() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -237,7 +241,8 @@ async fn it_get_new_response_when_version_is_2_or_more(#[case] version: &str) ->
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -321,7 +326,8 @@ async fn it_rejects_invalid_headers_flag_request() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -359,7 +365,10 @@ async fn it_accepts_empty_distinct_id() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
     let server = ServerHandle::for_config(config).await;
 
     let payload = json!({
@@ -649,7 +658,10 @@ async fn it_handles_multivariate_flags() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let flag_json = json!([{
         "id": 1,
@@ -737,7 +749,10 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
     let token = team.api_token;
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
     let flag_json = json!([{
         "id": 1,
         "key": "property-flag",
@@ -952,12 +967,13 @@ async fn test_feature_flags_with_json_payloads() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({"email": "tim@posthog.com"})),
-    )
-    .await?;
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({"email": "tim@posthog.com"})),
+        )
+        .await?;
 
     let flag_json = json!([{
         "id": 1,
@@ -1035,27 +1051,26 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
 
     // need this for the test to work, since we look up the dinstinct_id <-> person_id in from the DB at the beginning
     // of the flag evaluation process
-    context.insert_person(team.id, distinct_id.clone(), None).await?;
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await?;
 
     let token = team.api_token;
 
     // Create a group of type "organization" (group_type_index 1) with group_key "foo" and specific properties
-    context.create_group(
-        team.id,
-        "organization",
-        "foo",
-        json!({"email": "posthog@example.com"}),
-    )
-    .await?;
+    context
+        .create_group(
+            team.id,
+            "organization",
+            "foo",
+            json!({"email": "posthog@example.com"}),
+        )
+        .await?;
 
     // Create a group of type "project" (group_type_index 0) with group_key "bar" and specific properties
-    context.create_group(
-        team.id,
-        "project",
-        "bar",
-        json!({"name": "Project Bar"}),
-    )
-    .await?;
+    context
+        .create_group(team.id, "project", "bar", json!({"name": "Project Bar"}))
+        .await?;
 
     // Define feature flags
     let flags_json = json!([
@@ -1207,7 +1222,10 @@ async fn it_handles_not_contains_property_filter() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let flag_json = json!([{
         "id": 1,
@@ -1279,7 +1297,10 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
     let token = team.api_token;
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let flag_json = json!([
         {
@@ -1426,22 +1447,24 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
     let pg_client = setup_pg_reader_client(None).await;
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await?;
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
     let token = team.api_token;
 
     // Create a group with matching name
-    context.create_group(
-        team.id,
-        "organization",
-        "0183ccf3-5efd-0000-1541-bbd96d7d6b7f",
-        json!({
-            "name": "RaquelMSmith",
-            "created_at": "2023-10-16T16:00:00Z"
-        }),
-    )
-    .await?;
+    context
+        .create_group(
+            team.id,
+            "organization",
+            "0183ccf3-5efd-0000-1541-bbd96d7d6b7f",
+            json!({
+                "name": "RaquelMSmith",
+                "created_at": "2023-10-16T16:00:00Z"
+            }),
+        )
+        .await?;
 
     let flag_json = json!([{
         "id": 1,
@@ -1525,16 +1548,17 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
     );
 
     // Test with non-matching name but matching date
-    context.create_group(
-        team.id,
-        "organization",
-        "other_organization",
-        json!({
-            "name": "Other Org",
-            "created_at": "2023-10-16T16:00:00Z"
-        }),
-    )
-    .await?;
+    context
+        .create_group(
+            team.id,
+            "organization",
+            "other_organization",
+            json!({
+                "name": "Other Org",
+                "created_at": "2023-10-16T16:00:00Z"
+            }),
+        )
+        .await?;
 
     let payload = json!({
         "token": token,
@@ -1571,18 +1595,19 @@ async fn test_super_condition_with_complex_request() -> Result<()> {
     let token = team.api_token;
 
     // Insert person with just their stored properties from the DB
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({
-            "$feature_enrollment/artificial-hog": true,
-            "$feature_enrollment/error-tracking": true,
-            "$feature_enrollment/llm-observability": false,
-            "$feature_enrollment/messaging-product": true,
-            "email": "gtarasov.work@gmail.com"
-        })),
-    )
-    .await?;
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "$feature_enrollment/artificial-hog": true,
+                "$feature_enrollment/error-tracking": true,
+                "$feature_enrollment/llm-observability": false,
+                "$feature_enrollment/messaging-product": true,
+                "email": "gtarasov.work@gmail.com"
+            })),
+        )
+        .await?;
 
     // Create the same flag as in production
     let flag_json = json!([{
@@ -1808,7 +1833,10 @@ async fn it_only_includes_config_fields_when_requested() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let flag_json = json!([{
         "id": 1,
@@ -1877,7 +1905,10 @@ async fn test_config_basic_fields() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let flag_json = json!([{
         "id": 1,
@@ -1944,7 +1975,10 @@ async fn test_config_analytics_enabled() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1981,7 +2015,10 @@ async fn test_config_analytics_enabled_by_default() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2017,7 +2054,10 @@ async fn test_config_analytics_disabled_debug_mode() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2051,7 +2091,10 @@ async fn test_config_capture_performance_combinations() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2085,7 +2128,10 @@ async fn test_config_autocapture_exceptions() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2119,7 +2165,10 @@ async fn test_config_optional_team_features() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2161,7 +2210,10 @@ async fn test_config_site_apps_empty_by_default() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2195,7 +2247,10 @@ async fn test_config_included_in_legacy_response() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let flag_json = json!([{
         "id": 1,
@@ -2280,7 +2335,8 @@ async fn test_config_site_apps_with_actual_plugins() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -2391,7 +2447,8 @@ async fn test_config_session_recording_with_rrweb_script() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -2461,7 +2518,8 @@ async fn test_config_session_recording_team_not_allowed_for_script() -> Result<(
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -2541,7 +2599,10 @@ async fn test_config_comprehensive_enterprise_team() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     // Add a site app plugin
     let mut conn = pg_client.get_connection().await.unwrap();
@@ -2708,7 +2769,10 @@ async fn test_config_comprehensive_minimal_team() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2811,7 +2875,10 @@ async fn test_config_mixed_feature_combinations() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2916,7 +2983,10 @@ async fn test_config_team_exclusions_and_overrides() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2991,7 +3061,10 @@ async fn test_config_legacy_vs_v2_consistency() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3077,17 +3150,29 @@ async fn test_config_error_tracking_with_suppression_rules() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     // Enable autocapture exceptions in the database too
-    context.update_team_autocapture_exceptions(team.id, true).await.unwrap();
+    context
+        .update_team_autocapture_exceptions(team.id, true)
+        .await
+        .unwrap();
 
     // Insert some suppression rules
     let filter1 = json!({"errorType": "TypeError", "message": "Cannot read property"});
     let filter2 = json!({"stackTrace": {"contains": "node_modules"}});
 
-    context.insert_suppression_rule(team.id, filter1.clone()).await.unwrap();
-    context.insert_suppression_rule(team.id, filter2.clone()).await.unwrap();
+    context
+        .insert_suppression_rule(team.id, filter1.clone())
+        .await
+        .unwrap();
+    context
+        .insert_suppression_rule(team.id, filter2.clone())
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3130,10 +3215,14 @@ async fn test_config_error_tracking_disabled() -> Result<()> {
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
-    context.insert_person(team.id, distinct_id.clone(), None).await.unwrap();
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await
+        .unwrap();
 
     // Explicitly disable autocapture exceptions for the team
-    context.update_team_autocapture_exceptions(team.id, false)
+    context
+        .update_team_autocapture_exceptions(team.id, false)
         .await
         .unwrap();
 
@@ -3177,7 +3266,8 @@ async fn test_disable_flags_returns_empty_response() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -3248,7 +3338,8 @@ async fn test_disable_flags_returns_empty_response_v2() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -3318,7 +3409,8 @@ async fn test_disable_flags_false_still_returns_flags() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -3390,7 +3482,8 @@ async fn test_disable_flags_with_config_still_returns_config_data() -> Result<()
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -3478,7 +3571,8 @@ async fn test_disable_flags_with_config_v2_still_returns_config_data() -> Result
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -3565,7 +3659,8 @@ async fn test_disable_flags_without_config_param_has_minimal_response() -> Resul
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -3637,22 +3732,23 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
     let pg_client = setup_pg_reader_client(None).await;
     let team_id = rand::thread_rng().gen_range(1..10_000_000);
     let context = TestContext::new(None).await;
-    let team = context.insert_new_team(Some(team_id))
-        .await
-        .unwrap();
+    let team = context.insert_new_team(Some(team_id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None).await?;
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
+        .await?;
 
     let token = team.api_token;
 
     // Create a group with a numeric group_key (as a string in DB, but represents a number)
-    context.create_group(
-        team.id,
-        "organization",
-        "123",
-        json!({"name": "Organization 123", "size": "large"}),
-    )
-    .await?;
+    context
+        .create_group(
+            team.id,
+            "organization",
+            "123",
+            json!({"name": "Organization 123", "size": "large"}),
+        )
+        .await?;
 
     // Define a group-based flag with simple rollout (no property filters)
     let flags_json = json!([
@@ -3815,16 +3911,17 @@ async fn test_super_condition_property_overrides_bug_fix() -> Result<()> {
     context.insert_new_team(Some(team.id)).await.unwrap();
 
     // Insert person with the super condition property set to true in the database
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({
-            "$feature_enrollment/discussions": true,  // DB has it as true
-            "email": "user@example.com"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "$feature_enrollment/discussions": true,  // DB has it as true
+                "email": "user@example.com"
+            })),
+        )
+        .await
+        .unwrap();
 
     // Create a flag with a super condition that checks the enrollment property
     let flag_json = json!([{
@@ -3938,16 +4035,17 @@ async fn test_super_condition_property_overrides_bug_fix() -> Result<()> {
 
     // Test the reverse: override to true when DB has false
     // First update DB to have false
-    context.insert_person(
-        team.id,
-        "another_user".to_string(),
-        Some(json!({
-            "$feature_enrollment/discussions": false,  // DB has it as false
-            "email": "another@example.com"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            "another_user".to_string(),
+            Some(json!({
+                "$feature_enrollment/discussions": false,  // DB has it as false
+                "email": "another@example.com"
+            })),
+        )
+        .await
+        .unwrap();
 
     let payload_reverse_override = json!({
         "token": token,
@@ -4006,17 +4104,18 @@ async fn test_property_override_bug_real_scenario() -> Result<()> {
     context.insert_new_team(Some(team.id)).await.unwrap();
 
     // Insert person with TWO properties in the database
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({
-            "plan": "premium",  // Flag will check this property
-            "$feature_enrollment/discussions": true,  // We'll override this property
-            "email": "user@example.com"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "plan": "premium",  // Flag will check this property
+                "$feature_enrollment/discussions": true,  // We'll override this property
+                "email": "user@example.com"
+            })),
+        )
+        .await
+        .unwrap();
 
     // Create two flags:
     // 1. Flag that checks "plan" property (should be true with DB value)
@@ -4143,16 +4242,17 @@ async fn test_super_condition_with_cohort_filters() -> Result<()> {
     context.insert_new_team(Some(team.id)).await.unwrap();
 
     // Insert person with the super condition property
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({
-            "$feature_enrollment/discussions": false,  // Super condition property in DB
-            "email": "user@example.com"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "$feature_enrollment/discussions": false,  // Super condition property in DB
+                "email": "user@example.com"
+            })),
+        )
+        .await
+        .unwrap();
 
     // Create a flag that matches your production example:
     // - Has a super condition that checks "$feature_enrollment/discussions"
@@ -4325,7 +4425,8 @@ async fn test_returns_empty_flags_when_no_active_flags_configured() -> Result<()
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -4593,13 +4694,14 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
     context.insert_new_team(Some(team.id)).await.unwrap();
 
     // Insert person with the target email that should match the cohort
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({"email": "test.user@example.com"})),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({"email": "test.user@example.com"})),
+        )
+        .await
+        .unwrap();
 
     // Create the cohort with the specified filters:
     // OR condition with AND group that checks:
@@ -4712,13 +4814,14 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
 
     // Test with excluded.user@example.com - should NOT match cohort due to negation condition
     let excluded_distinct_id = "excluded.user".to_string();
-    context.insert_person(
-        team.id,
-        excluded_distinct_id.clone(),
-        Some(json!({"email": "excluded.user@example.com"})),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            excluded_distinct_id.clone(),
+            Some(json!({"email": "excluded.user@example.com"})),
+        )
+        .await
+        .unwrap();
 
     let payload_excluded = json!({
         "token": token,
@@ -4749,13 +4852,14 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
 
     // Test with non-example.com email - should NOT match cohort due to regex condition
     let non_example_distinct_id = "other.user".to_string();
-    context.insert_person(
-        team.id,
-        non_example_distinct_id.clone(),
-        Some(json!({"email": "other.user@other.com"})),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            non_example_distinct_id.clone(),
+            Some(json!({"email": "other.user@other.com"})),
+        )
+        .await
+        .unwrap();
 
     let payload_non_example = json!({
         "token": token,
@@ -4804,7 +4908,8 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -5036,7 +5141,8 @@ async fn test_flag_keys_to_evaluate_parameter() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -5162,7 +5268,8 @@ async fn it_handles_empty_query_parameters() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -5212,7 +5319,8 @@ async fn it_handles_boolean_query_params_as_truthy() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    context.insert_person(team.id, distinct_id.clone(), None)
+    context
+        .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
 
@@ -5294,23 +5402,24 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
     context.insert_new_team(Some(team.id)).await.unwrap();
 
     // Insert person with production-like data - should match via days_since_paid_plan_start condition
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({
-            "name": "Test User",
-            "email": "test@example.com",
-            "org_id": "test-org-123", // Not in the allowed org list
-            "user_id": "test-user-456",
-            "days_since_paid_plan_start": 77, // < 365, should match this condition
-            "created_at_timestamp": 1747758893, // Set, would match this condition
-            "upgraded_at_timestamp": 1749058908, // Has upgrade timestamp - fails the not_regex condition in cohort 128293
-            "paid_plan_start_date": "2025-06-04",
-            "trial_start_date": "2025-05-20"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "name": "Test User",
+                "email": "test@example.com",
+                "org_id": "test-org-123", // Not in the allowed org list
+                "user_id": "test-user-456",
+                "days_since_paid_plan_start": 77, // < 365, should match this condition
+                "created_at_timestamp": 1747758893, // Set, would match this condition
+                "upgraded_at_timestamp": 1749058908, // Has upgrade timestamp - fails the not_regex condition in cohort 128293
+                "paid_plan_start_date": "2025-06-04",
+                "trial_start_date": "2025-05-20"
+            })),
+        )
+        .await
+        .unwrap();
 
     let mut conn = pg_client.get_connection().await.unwrap();
 
@@ -5475,18 +5584,19 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
 
     // Test with user who SHOULD match - has low days_since_paid_plan_start and no upgraded_at_timestamp
     let matching_distinct_id = "matching_user".to_string();
-    context.insert_person(
-        team.id,
-        matching_distinct_id.clone(),
-        Some(json!({
-            "days_since_paid_plan_start": 200, // < 365, matches this condition
-            "created_at_timestamp": 1747758893,
-            "org_id": "12345" // Not in special list, but should match via days condition
-            // No upgraded_at_timestamp - this allows them to match base cohort 128293
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            matching_distinct_id.clone(),
+            Some(json!({
+                "days_since_paid_plan_start": 200, // < 365, matches this condition
+                "created_at_timestamp": 1747758893,
+                "org_id": "12345" // Not in special list, but should match via days condition
+                // No upgraded_at_timestamp - this allows them to match base cohort 128293
+            })),
+        )
+        .await
+        .unwrap();
 
     let matching_payload = json!({
         "token": token,
@@ -5518,18 +5628,19 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
 
     // Test with user who should NOT match the cohort - high days_since_paid_plan_start and has upgraded_at_timestamp
     let failing_distinct_id = "failing_user".to_string();
-    context.insert_person(
-        team.id,
-        failing_distinct_id.clone(),
-        Some(json!({
-            "days_since_paid_plan_start": "500", // > 365, fails the lt condition
-            "created_at_timestamp": "2024-01-01T00:00:00Z",
-            "upgraded_at_timestamp": "2024-02-01T00:00:00Z", // has upgrade timestamp, fails the not_regex condition
-            "org_id": "99999" // not in the specific org_id list
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            failing_distinct_id.clone(),
+            Some(json!({
+                "days_since_paid_plan_start": "500", // > 365, fails the lt condition
+                "created_at_timestamp": "2024-01-01T00:00:00Z",
+                "upgraded_at_timestamp": "2024-02-01T00:00:00Z", // has upgrade timestamp, fails the not_regex condition
+                "org_id": "99999" // not in the specific org_id list
+            })),
+        )
+        .await
+        .unwrap();
 
     let failing_payload = json!({
         "token": token,
@@ -5847,15 +5958,16 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
     context.insert_new_team(Some(team.id)).await.unwrap();
 
     // Insert person with email matching our target pattern
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({
-            "email": "engineer@posthog.com"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "email": "engineer@posthog.com"
+            })),
+        )
+        .await
+        .unwrap();
 
     let mut conn = pg_client.get_connection().await.unwrap();
 
@@ -5988,15 +6100,16 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
     // Test 2: User with admin@posthog.com should NOT match
     // (matches @posthog.com regex BUT is in admin cohort)
     let admin_distinct_id = "admin_user".to_string();
-    context.insert_person(
-        team.id,
-        admin_distinct_id.clone(),
-        Some(json!({
-            "email": "admin@posthog.com"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            admin_distinct_id.clone(),
+            Some(json!({
+                "email": "admin@posthog.com"
+            })),
+        )
+        .await
+        .unwrap();
 
     let admin_payload = json!({
         "token": token,
@@ -6026,15 +6139,16 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
     // Test 3: User without @posthog.com should NOT match
     // (doesn't match regex, regardless of admin status)
     let external_distinct_id = "external_user".to_string();
-    context.insert_person(
-        team.id,
-        external_distinct_id.clone(),
-        Some(json!({
-            "email": "user@example.com"
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            external_distinct_id.clone(),
+            Some(json!({
+                "email": "user@example.com"
+            })),
+        )
+        .await
+        .unwrap();
 
     let external_payload = json!({
         "token": token,
@@ -6084,17 +6198,18 @@ async fn test_date_string_property_matching_with_is_date_after() -> Result<()> {
     context.insert_new_team(Some(team.id)).await.unwrap();
 
     // Insert person with last_active_date as a string date
-    context.insert_person(
-        team.id,
-        distinct_id.clone(),
-        Some(json!({
-            "user_id": "test_123",
-            "last_active_date": "2024-03-15T19:17:07.083Z",
-            "segment": null  // This ensures the segment filter won't match
-        })),
-    )
-    .await
-    .unwrap();
+    context
+        .insert_person(
+            team.id,
+            distinct_id.clone(),
+            Some(json!({
+                "user_id": "test_123",
+                "last_active_date": "2024-03-15T19:17:07.083Z",
+                "segment": null  // This ensures the segment filter won't match
+            })),
+        )
+        .await
+        .unwrap();
 
     // Insert flag with filter configuration
     let flag_json = json!([{


### PR DESCRIPTION
## Problem

We'd like the feature flag test helpers to be able to connect to both the persons and non-persons databases during setup/interaction with postgres for unit tests.

There should be a single spot in code that defines which databases the helpers will connect to. Future updates to any shuffling around of database connections/resources should be a one line change instead of a 2500 line change.

## Changes

- Refactored test_utils to include a TestContext struct. This struct exposes the different database interaction helpers as methods, and manages the choice of which database to connect to for the caller.
- update unit tests to use the new TestContext struct

## How did you test this code?

It's all unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
