### PR TITLE
fix(myke): query to aggregate for behavioral cohorts

### DIFF
--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -208,13 +208,19 @@ async def process_condition_batch_activity(inputs: ProcessConditionBatchInputs) 
             query = """
                 SELECT
                     person_id
-                FROM behavioral_cohorts_matches
-                WHERE
-                    team_id = %(team_id)s
-                    AND cohort_id = %(cohort_id)s
-                    AND condition = %(condition)s
-                    AND date >= now() - toIntervalDay(%(days)s)
-                    AND matches >= %(min_matches)s
+                FROM (
+                    SELECT
+                        person_id,
+                        SUM(matches) as total_matches
+                    FROM behavioral_cohorts_matches
+                    WHERE
+                        team_id = %(team_id)s
+                        AND cohort_id = %(cohort_id)s
+                        AND condition = %(condition)s
+                        AND date >= now() - toIntervalDay(%(days)s)
+                    GROUP BY person_id
+                    HAVING total_matches >= %(min_matches)s
+                )
                 LIMIT 100000
             """
 


### PR DESCRIPTION
## Problem

  The behavioral_cohorts_matches table uses AggregatingMergeTree which aggregates data during merges, but this happens on a best-effort basis. This means multiple non-aggregated rows can exist for the same person_id, team_id, cohort_id, and condition combination for a given timespan.

When filtering by matches >= X directly without aggregation, we were missing valid results because:
  - Individual rows might have matches < X
  - But the sum of all rows for that person would be >= X

For example, a person might have 3 rows with 2 matches each (total 6), but filtering for matches >= 5 would return nothing since no individual row meets the criteria.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

 Modified the query to:
  1. First aggregate matches by person_id using
  SUM(matches) for that given timespan
  2. Then apply the min_matches filter using HAVING clause on the aggregated total

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
