### PR TITLE
feat(tasks): base image for sandbox

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -1,0 +1,73 @@
+name: Tasks Sandbox Container Image CD
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+    workflow_dispatch:
+
+jobs:
+    changes:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        if: github.repository == 'PostHog/posthog'
+        name: Determine if sandbox image needs to be built
+        outputs:
+            sandbox_image: ${{ steps.filter.outputs.sandbox_image }}
+        steps:
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
+              id: filter
+              with:
+                  filters: |
+                      sandbox_image:
+                        - 'products/tasks/backend/sandbox/images/**'
+
+    sandbox_base_build:
+        needs: changes
+        name: Build and push Tasks Sandbox container image
+        if: |
+            github.repository == 'PostHog/posthog' && (
+                needs.changes.outputs.sandbox_image == 'true' ||
+                github.event_name == 'workflow_dispatch' ||
+                contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
+            )
+        runs-on: depot-ubuntu-latest
+        permissions:
+            id-token: write # allow issuing OIDC tokens for this workflow run
+            contents: read # allow at least reading the repo contents, add other permissions if necessary
+            packages: write # allow push to ghcr.io
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              with:
+                  fetch-depth: 2
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
+
+            - name: Login to ghcr.io
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+                  logout: false
+
+            - name: Build and push container image
+              id: build
+              uses: depot/build-push-action@2583627a84956d07561420dcc1d0eb1f2af3fac0 # v1
+              with:
+                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+                  buildx-fallback: false # the fallback is so slow it's better to just fail
+                  push: true
+                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-base:master,ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) }}
+                  platforms: linux/arm64,linux/amd64
+                  build-args: COMMIT_HASH=${{ github.sha }}

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -13,6 +13,8 @@ jobs:
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine if sandbox image needs to be built
+        permissions:
+            contents: read
         outputs:
             sandbox_image: ${{ steps.filter.outputs.sandbox_image }}
         steps:

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -376,7 +376,7 @@
                                                                                   FROM person AS where_optimization
                                                                                   WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
                                    GROUP BY person.id
-                                   HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))) AS persons
+                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
                                 WHERE ifNull(equals(persons.properties___name, 'test'), 0)
                                 ORDER BY persons.id ASC
                                 LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -400,7 +400,7 @@
                               FROM person_distinct_id_overrides
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
-                              HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -1,0 +1,87 @@
+# Dockerfile for the base sandbox image.
+
+FROM ubuntu:24.04
+
+# Set environment variables to prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Install system packages (expanded for coding environments)
+RUN apt-get update && \
+    apt-get install -y \
+    # Core tools
+    curl \
+    wget \
+    git \
+    vim \
+    nano \
+    tree \
+    htop \
+    unzip \
+    zip \
+    jq \
+    # Build tools
+    build-essential \
+    pkg-config \
+    # Languages and runtimes
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-dev \
+    # Databases
+    sqlite3 \
+    postgresql-client \
+    mysql-client \
+    redis-tools \
+    # System libraries often needed by Python packages
+    libssl-dev \
+    libffi-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    # Other useful tools
+    ca-certificates \
+    gnupg \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20.x
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install additional language package managers
+RUN npm install -g yarn pnpm typescript ts-node nodemon
+
+
+###
+# Claude Code SDK
+###
+
+RUN python3 -m venv /opt/claude-env
+
+RUN /opt/claude-env/bin/pip install --upgrade pip
+
+RUN /opt/claude-env/bin/pip install claude-code-sdk
+
+RUN npm install -g @anthropic-ai/claude-code
+
+# This is required for the Claude Code SDK to allow --dangerously-skip-permissions as the root user
+ENV IS_SANDBOX=1
+
+ENV PATH="/opt/claude-env/bin:$PATH"
+ENV PYTHONPATH="/tmp/workspace:$PYTHONPATH"
+
+WORKDIR /tmp/workspace
+
+RUN python3 --version && \
+    node --version && \
+    npm --version && \
+    /opt/claude-env/bin/python -c 'import claude_code_sdk; print("Claude Code SDK installed successfully")'
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Problem

We want to build a base image to extend on a per-team basis for running user code for tasks. We'll pull this from whatever platform we decide on for running our sandboxes.

## Changes

- Adds base dockerfile
- Adds CI workflow to build and publish the image on changes. Publishes to github container registry for now, we might move that somewhere else later depending on what we deploy