### PR TITLE
feat: Add `role` claim to billing JWT

### DIFF
--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -329,6 +329,7 @@ class TestBillingAPI(APILicensedTest):
             "id": self.license.key.split("::")[0],
             "organization_id": str(self.organization.id),
             "organization_name": "Test",
+            "organization_role": "member",
         }
 
     @patch("ee.api.billing.requests.get")

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -47,6 +47,10 @@ def build_billing_token(license: License, organization: Organization, user: Opti
 
     if user:
         payload["distinct_id"] = str(user.distinct_id)
+        org_membership = user.organization_memberships.get(organization=organization)
+
+        if org_membership:
+            payload["organization_role"] = org_membership.get_level_display()
 
     encoded_jwt = jwt.encode(
         payload,


### PR DESCRIPTION
The `role` claim allows the billing service to authorize user actions based on the user role for that customer.

## Problem

The Billing service has no way to authorize actions based on the role of the user requesting the action.
This PR adds the `role` claim to the JWT we send to the Billing system so it can make decisions based
on it.
