### PR TITLE
feat(messaging): add ttl to lazy-loader

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -134,6 +134,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         HOG_HOOK_URL: '',
         CAPTURE_CONFIG_REDIS_HOST: null,
         LAZY_LOADER_DEFAULT_BUFFER_MS: 10,
+        LAZY_LOADER_TTL_MS: 1000 * 60 * 10, // 10 minutes
+        LAZY_LOADER_EVICTION_ENABLED: false,
         CAPTURE_INTERNAL_URL: isProdEnv()
             ? 'http://capture.posthog.svc.cluster.local:3000/capture'
             : 'http://localhost:8010/capture',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -374,6 +374,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
     CAPTURE_CONFIG_REDIS_HOST: string | null // Redis cluster to use to coordinate with capture (overflow, routing)
     LAZY_LOADER_DEFAULT_BUFFER_MS: number
+    LAZY_LOADER_TTL_MS: number
+    LAZY_LOADER_EVICTION_ENABLED: boolean
     CAPTURE_INTERNAL_URL: string
 
     // local directory might be a volume mount or a directory on disk (e.g. in local dev)

--- a/plugin-server/src/utils/lazy-loader.test.ts
+++ b/plugin-server/src/utils/lazy-loader.test.ts
@@ -1,3 +1,4 @@
+import { defaultConfig } from '../config/config'
 import { LazyLoader } from './lazy-loader'
 import { delay } from './utils'
 
@@ -337,6 +338,17 @@ describe('LazyLoader', () => {
     })
 
     describe('TTL eviction', () => {
+        let originalEvictionEnabled: boolean
+
+        beforeAll(() => {
+            originalEvictionEnabled = defaultConfig.LAZY_LOADER_EVICTION_ENABLED
+            ;(defaultConfig as any).LAZY_LOADER_EVICTION_ENABLED = true
+        })
+
+        afterAll(() => {
+            ;(defaultConfig as any).LAZY_LOADER_EVICTION_ENABLED = originalEvictionEnabled
+        })
+
         it('should evict entries based on last access time', async () => {
             const customLoader = new LazyLoader({
                 name: 'test',

--- a/plugin-server/src/utils/lazy-loader.test.ts
+++ b/plugin-server/src/utils/lazy-loader.test.ts
@@ -371,20 +371,20 @@ describe('LazyLoader', () => {
             expect(customLoader.getCache()).toEqual({ key2: 'value2', key3: 'value3' })
         })
 
-        it('should use default TTL of 5 minutes based on last access', async () => {
+        it('should use default TTL of 10 minutes based on last access', async () => {
             loader.mockResolvedValueOnce({ key1: 'value1' })
 
             await lazyLoader.get('key1')
             expect(lazyLoader.getCache()).toEqual({ key1: 'value1' })
 
-            // Fast forward 4 minutes - should still be cached
-            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 4)
+            // Fast forward 9 minutes - should still be cached
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 9)
             loader.mockResolvedValueOnce({ key2: 'value2' })
             await lazyLoader.get('key2')
             expect(lazyLoader.getCache()).toEqual({ key1: 'value1', key2: 'value2' })
 
-            // Fast forward past 5 minutes since key1 last access - key1 should be evicted
-            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 6)
+            // Fast forward past 10 minutes since key1 last access - key1 should be evicted
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 11)
             loader.mockResolvedValueOnce({ key3: 'value3' })
             await lazyLoader.get('key3')
             expect(lazyLoader.getCache()).toEqual({ key2: 'value2', key3: 'value3' })


### PR DESCRIPTION
## Problem

The LazyLoader has a potential memory leak. Cached entries were never evicted and would accumulate indefinitely until manually cleared. This could cause memory issues and leads to our pods hitting their max memory limit

https://grafana.prod-us.posthog.dev/d/cdp/cdp?var-partition=$__all&from=now-3h&to=now&timezone=utc&var-database=posthog-cyclotron-shard0-prod-us-east-1&var-queue=$__all&var-service=$__all&viewPanel=panel-84

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added TTL-based eviction with LRU behavior:

  - New ttlMs option (default: 10 minutes)
  - LRU eviction logic - entries evicted based on last access time, not creation time
  - Automatic cleanup - evictExpiredEntries() runs on each cache access
  - Preserved existing behavior - refresh mechanisms unchanged, no breaking changes

_**overall:**_

 - TTL > refresh age (10 min vs 5 min) prevents conflicts between refresh and eviction
  - Last-access based ensures frequently used entries stay cached

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
