### PR TITLE
fix(cohorts): deleting persons from static cohorts

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -31,7 +31,11 @@ from posthog.models.cohort.sql import (
     GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID,
     RECALCULATE_COHORT_BY_ID,
 )
-from posthog.models.person.sql import INSERT_PERSON_STATIC_COHORT, PERSON_STATIC_COHORT_TABLE
+from posthog.models.person.sql import (
+    DELETE_PERSON_FROM_STATIC_COHORT,
+    INSERT_PERSON_STATIC_COHORT,
+    PERSON_STATIC_COHORT_TABLE,
+)
 from posthog.models.property import Property, PropertyGroup
 from posthog.queries.person_distinct_id_query import get_team_distinct_ids_query
 from posthog.queries.util import PersonPropertiesMode
@@ -286,15 +290,20 @@ def insert_static_cohort(person_uuids: list[Optional[uuid.UUID]], cohort_id: int
 
 
 def remove_person_from_static_cohort(person_uuid: uuid.UUID, cohort_id: int, *, team_id: int):
-    """Remove a person from a static cohort in ClickHouse."""
+    """Remove a person from a static cohort in ClickHouse.
+
+    Uses DELETE FROM with mutations_sync=0 to avoid replica synchronization issues in production.
+    This is an exception to PostHog's usual pattern due to the table lacking an is_deleted and version columns.
+    """
     tag_queries(cohort_id=cohort_id, team_id=team_id, name="remove_person_from_static_cohort", feature=Feature.COHORT)
     sync_execute(
-        f"DELETE FROM {PERSON_STATIC_COHORT_TABLE} WHERE person_id = %(person_id)s AND cohort_id = %(cohort_id)s AND team_id = %(team_id)s",
+        DELETE_PERSON_FROM_STATIC_COHORT,
         {
             "person_id": str(person_uuid),
             "cohort_id": cohort_id,
             "team_id": team_id,
         },
+        settings={"mutations_sync": "0"},
     )
 
 

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -353,6 +353,8 @@ INSERT_PERSON_STATIC_COHORT = (
     f"INSERT INTO {PERSON_STATIC_COHORT_TABLE} (id, person_id, cohort_id, team_id, _timestamp) VALUES"
 )
 
+DELETE_PERSON_FROM_STATIC_COHORT = f"DELETE FROM {PERSON_STATIC_COHORT_TABLE} WHERE person_id = %(person_id)s AND cohort_id = %(cohort_id)s AND team_id = %(team_id)s"
+
 #
 # Copying demo data
 #


### PR DESCRIPTION
## Problem

The PR #38037 introduced a bug that when deleting a person from a static cohort, it would throw the following error: 
`DB::Exception: Mutation is not finished because some replicas are inactive right now:` 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #38650

## Changes

- `mutations_sync` = 0 when deleting the person from ClickHouse

## How did you test this code?

- Manual (not able to test if it will work in a Cluster)
