### PR TITLE
feat(msg): add max size for lazy loader cache

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -136,6 +136,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         LAZY_LOADER_DEFAULT_BUFFER_MS: 10,
         LAZY_LOADER_TTL_MS: 1000 * 60 * 10, // 10 minutes
         LAZY_LOADER_EVICTION_ENABLED: false,
+        LAZY_LOADER_MAX_SIZE: 10000, // Maximum entries per cache before LRU eviction
         CAPTURE_INTERNAL_URL: isProdEnv()
             ? 'http://capture.posthog.svc.cluster.local:3000/capture'
             : 'http://localhost:8010/capture',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -376,6 +376,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     LAZY_LOADER_DEFAULT_BUFFER_MS: number
     LAZY_LOADER_TTL_MS: number
     LAZY_LOADER_EVICTION_ENABLED: boolean
+    LAZY_LOADER_MAX_SIZE: number
     CAPTURE_INTERNAL_URL: string
 
     // local directory might be a volume mount or a directory on disk (e.g. in local dev)

--- a/plugin-server/src/utils/lazy-loader.ts
+++ b/plugin-server/src/utils/lazy-loader.ts
@@ -64,6 +64,8 @@ export type LazyLoaderOptions<T> = {
     bufferMs?: number
     /** TTL for cache entries - evicted after this time regardless of use */
     ttlMs?: number
+    /** Maximum number of entries in the cache - LRU eviction when exceeded */
+    maxSize?: number
 }
 
 type LazyLoaderMap<T> = Record<string, T | null | undefined>
@@ -80,6 +82,7 @@ export class LazyLoader<T> {
     private refreshBackgroundAgeMs?: number
     private refreshJitterMs: number
     private ttlMs: number
+    private maxSize: number
 
     private buffer:
         | {
@@ -100,6 +103,7 @@ export class LazyLoader<T> {
         this.refreshBackgroundAgeMs = this.options.refreshBackgroundAgeMs
         this.refreshJitterMs = this.options.refreshJitterMs ?? this.refreshAgeMs / 5
         this.ttlMs = this.options.ttlMs ?? defaultConfig.LAZY_LOADER_TTL_MS
+        this.maxSize = this.options.maxSize ?? defaultConfig.LAZY_LOADER_MAX_SIZE
 
         if (this.refreshBackgroundAgeMs && this.refreshBackgroundAgeMs > this.refreshAgeMs) {
             throw new Error('refreshBackgroundAgeMs must be smaller than refreshAgeMs')
@@ -148,6 +152,9 @@ export class LazyLoader<T> {
                 this.backgroundRefreshAfter[key] =
                     Date.now() + (valueOrNull === null ? this.refreshNullAgeMs : this.refreshBackgroundAgeMs) + jitter
             }
+        }
+        if (defaultConfig.LAZY_LOADER_EVICTION_ENABLED) {
+            this.evictLRU()
         }
         this.updateCacheSizeMetric()
     }
@@ -298,6 +305,34 @@ export class LazyLoader<T> {
             }
         }
 
+        for (const key of keysToEvict) {
+            delete this.cache[key]
+            delete this.lastUsed[key]
+            delete this.cacheUntil[key]
+            delete this.backgroundRefreshAfter[key]
+        }
+
+        if (keysToEvict.length > 0) {
+            this.updateCacheSizeMetric()
+        }
+    }
+
+    private evictLRU(): void {
+        const cacheSize = Object.keys(this.cache).length
+        if (cacheSize <= this.maxSize) {
+            return
+        }
+
+        // Sort keys by lastUsed time (oldest first)
+        const sortedKeys = Object.entries(this.lastUsed)
+            .filter(([key]) => key in this.cache)
+            .sort((a, b) => (a[1] ?? 0) - (b[1] ?? 0))
+
+        // Calculate how many to evict
+        const toEvict = cacheSize - this.maxSize
+        const keysToEvict = sortedKeys.slice(0, toEvict).map(([key]) => key)
+
+        // Evict the least recently used entries
         for (const key of keysToEvict) {
             delete this.cache[key]
             delete this.lastUsed[key]


### PR DESCRIPTION
## Problem

We need a max size for the lazy loader cache since we are running into growing memory issues. Currently cache sizes grow as big as 18k entries for some lazy loaders. 

We have a TTL eviction but that seems not to be enough.

  1. TTL (Time-To-Live) Eviction

  When: Every time loadViaCache() is called (on any cache access)
  What: Removes entries that haven't been accessed for longer than ttlMs (default: 1 minute right now)
  How:
  - Checks ALL entries in the cache
  - Compares now - lastUsed > ttlMs for each entry
  - Removes expired entries regardless of cache size

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

LRU (Least Recently Used) Eviction

When: Every time new values are added via setValues()
What: Keeps cache size under maxSize limit (default: 10,000 entries)
  How:
  - Only runs if cache size > maxSize
  - Sorts entries by lastUsed timestamp (oldest first)
  - Removes the least recently used entries until cache size ≤ maxSize

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests
- behind a flag

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
