### PR TITLE
chore(web-analytics): detach asset checks from pre-aggregated assets 

### DIFF
--- a/dags/locations/web_analytics.py
+++ b/dags/locations/web_analytics.py
@@ -26,9 +26,6 @@ defs = dagster.Definitions(
     asset_checks=[
         web_preaggregated_asset_checks.web_analytics_accuracy_check,
         web_preaggregated_asset_checks.web_analytics_team_selection_v2_has_data,
-        web_preaggregated_asset_checks.web_pre_aggregated_bounces_has_data,
-        web_preaggregated_asset_checks.web_pre_aggregated_stats_has_data,
-        web_preaggregated_asset_checks.web_analytics_v2_accuracy_check,
         web_preaggregated_asset_checks.stats_daily_has_data,
         web_preaggregated_asset_checks.stats_hourly_has_data,
         web_preaggregated_asset_checks.bounces_daily_has_data,
@@ -39,16 +36,12 @@ defs = dagster.Definitions(
     jobs=[
         web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_job,
         web_preaggregated_daily.web_pre_aggregate_daily_job,
-        web_preaggregated_asset_checks.web_analytics_data_quality_job,
-        web_preaggregated_asset_checks.web_analytics_v2_data_quality_job,
-        web_preaggregated_asset_checks.simple_data_checks_job,
         web_preaggregated.web_pre_aggregate_job,
     ],
     schedules=[
         web_preaggregated_daily.web_pre_aggregate_daily_schedule,
         web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_schedule,
         web_preaggregated_asset_checks.web_analytics_weekly_data_quality_schedule,
-        web_preaggregated_asset_checks.web_analytics_v2_weekly_data_quality_schedule,
         web_preaggregated.web_pre_aggregate_historical_schedule,
         web_preaggregated.web_pre_aggregate_current_day_schedule,
     ],

--- a/dags/locations/web_analytics.py
+++ b/dags/locations/web_analytics.py
@@ -26,12 +26,6 @@ defs = dagster.Definitions(
     asset_checks=[
         web_preaggregated_asset_checks.web_analytics_accuracy_check,
         web_preaggregated_asset_checks.web_analytics_team_selection_v2_has_data,
-        web_preaggregated_asset_checks.stats_daily_has_data,
-        web_preaggregated_asset_checks.stats_hourly_has_data,
-        web_preaggregated_asset_checks.bounces_daily_has_data,
-        web_preaggregated_asset_checks.bounces_hourly_has_data,
-        web_preaggregated_asset_checks.stats_export_chdb_queryable,
-        web_preaggregated_asset_checks.bounces_export_chdb_queryable,
     ],
     jobs=[
         web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_job,
@@ -41,7 +35,6 @@ defs = dagster.Definitions(
     schedules=[
         web_preaggregated_daily.web_pre_aggregate_daily_schedule,
         web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_schedule,
-        web_preaggregated_asset_checks.web_analytics_weekly_data_quality_schedule,
         web_preaggregated.web_pre_aggregate_historical_schedule,
         web_preaggregated.web_pre_aggregate_current_day_schedule,
     ],

--- a/dags/web_preaggregated_asset_checks.py
+++ b/dags/web_preaggregated_asset_checks.py
@@ -613,7 +613,6 @@ def web_analytics_team_selection_v2_has_data(context: AssetCheckExecutionContext
 
 
 @asset_check(
-    asset="web_pre_aggregated_bounces",
     name="web_pre_aggregated_bounces_has_data",
     description="Check if web_pre_aggregated_bounces table has data",
 )
@@ -622,7 +621,6 @@ def web_pre_aggregated_bounces_has_data(context: AssetCheckExecutionContext) -> 
 
 
 @asset_check(
-    asset="web_pre_aggregated_stats",
     name="web_pre_aggregated_stats_has_data",
     description="Check if web_pre_aggregated_stats table has data",
 )
@@ -631,13 +629,11 @@ def web_pre_aggregated_stats_has_data(context: AssetCheckExecutionContext) -> As
 
 
 @asset_check(
-    asset="web_pre_aggregated_bounces",
     name="web_analytics_v2_accuracy_check",
     description="Validates that v2 pre-aggregated web analytics data matches regular queries within tolerance",
     blocking=False,
 )
 def web_analytics_v2_accuracy_check(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    """Data quality check: validates v2 pre-aggregated tables match regular WebOverview queries within tolerance."""
     return run_accuracy_check_for_version(context, "web_analytics_v2_accuracy_check", "v2", use_v2_tables=True)
 
 

--- a/dags/web_preaggregated_asset_checks.py
+++ b/dags/web_preaggregated_asset_checks.py
@@ -612,31 +612,6 @@ def web_analytics_team_selection_v2_has_data(context: AssetCheckExecutionContext
         )
 
 
-@asset_check(
-    name="web_pre_aggregated_bounces_has_data",
-    description="Check if web_pre_aggregated_bounces table has data",
-)
-def web_pre_aggregated_bounces_has_data(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    return table_has_data("web_pre_aggregated_bounces", dagster_tags(context), context)
-
-
-@asset_check(
-    name="web_pre_aggregated_stats_has_data",
-    description="Check if web_pre_aggregated_stats table has data",
-)
-def web_pre_aggregated_stats_has_data(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    return table_has_data("web_pre_aggregated_stats", dagster_tags(context), context)
-
-
-@asset_check(
-    name="web_analytics_v2_accuracy_check",
-    description="Validates that v2 pre-aggregated web analytics data matches regular queries within tolerance",
-    blocking=False,
-)
-def web_analytics_v2_accuracy_check(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    return run_accuracy_check_for_version(context, "web_analytics_v2_accuracy_check", "v2", use_v2_tables=True)
-
-
 web_analytics_data_quality_job = dagster.define_asset_job(
     name="web_analytics_data_quality_job",
     selection=dagster.AssetSelection.checks_for_assets(
@@ -683,28 +658,6 @@ def web_analytics_weekly_data_quality_schedule(context: dagster.ScheduleEvaluati
             }
         },
         tags={"trigger": "weekly_schedule"},
-    )
-
-
-@dagster.schedule(
-    cron_schedule="0 3 * * 0",
-    job=web_analytics_v2_data_quality_job,
-    execution_timezone="UTC",
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-)
-def web_analytics_v2_weekly_data_quality_schedule(context: dagster.ScheduleEvaluationContext):
-    return dagster.RunRequest(
-        run_config={
-            "ops": {
-                "web_analytics_v2_accuracy_check": {
-                    "config": {
-                        "tolerance_pct": DEFAULT_TOLERANCE_PCT,
-                        "days_back": DEFAULT_DAYS_BACK,
-                    }
-                }
-            }
-        },
-        tags={"trigger": "weekly_schedule_v2"},
     )
 
 

--- a/dags/web_preaggregated_asset_checks.py
+++ b/dags/web_preaggregated_asset_checks.py
@@ -81,42 +81,6 @@ def table_has_data(
         )
 
 
-@asset_check(
-    asset="web_analytics_bounces_daily",
-    name="bounces_daily_has_data",
-    description="Check if web_bounces_daily table has data",
-)
-def bounces_daily_has_data(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    return table_has_data("web_bounces_daily", dagster_tags(context), context)
-
-
-@asset_check(
-    asset="web_analytics_stats_table_daily",
-    name="stats_daily_has_data",
-    description="Check if web_stats_daily table has data",
-)
-def stats_daily_has_data(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    return table_has_data("web_stats_daily", dagster_tags(context), context)
-
-
-@asset_check(
-    asset="web_analytics_bounces_hourly",
-    name="bounces_hourly_has_data",
-    description="Check if web_bounces_hourly table has data",
-)
-def bounces_hourly_has_data(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    return table_has_data("web_bounces_hourly", dagster_tags(context), context)
-
-
-@asset_check(
-    asset="web_analytics_stats_table_hourly",
-    name="stats_hourly_has_data",
-    description="Check if web_stats_hourly table has data",
-)
-def stats_hourly_has_data(context: AssetCheckExecutionContext) -> AssetCheckResult:
-    return table_has_data("web_stats_hourly", dagster_tags(context), context)
-
-
 def check_export_chdb_queryable(export_type: str, log_event_name: str) -> AssetCheckResult:
     try:
         export_filename = f"{export_type}_export"
@@ -243,26 +207,6 @@ def check_export_chdb_queryable(export_type: str, log_event_name: str) -> AssetC
             description=f"Error checking export with chdb: {str(e)}",
             metadata={"error": MetadataValue.text(str(e))},
         )
-
-
-@asset_check(asset="web_analytics_stats_export", name="stats_export_chdb_queryable")
-def stats_export_chdb_queryable() -> AssetCheckResult:
-    """
-    Check if the web_stats_daily export file can be queried with chdb and contains data.
-    """
-    return check_export_chdb_queryable("web_stats_daily", "stats_export_chdb_check")
-
-
-@asset_check(
-    asset="web_analytics_bounces_export",
-    name="bounces_export_chdb_queryable",
-    description="Check if bounces export file can be queried with chdb and has data",
-)
-def bounces_export_chdb_queryable() -> AssetCheckResult:
-    """
-    Check if the web_bounces_daily export file can be queried with chdb and contains data.
-    """
-    return check_export_chdb_queryable("web_bounces_daily", "bounces_export_chdb_check")
 
 
 def log_query_sql(
@@ -610,55 +554,6 @@ def web_analytics_team_selection_v2_has_data(context: AssetCheckExecutionContext
             description=f"Failed to check v2 team selection: {str(e)}",
             metadata={"error": MetadataValue.text(str(e))},
         )
-
-
-web_analytics_data_quality_job = dagster.define_asset_job(
-    name="web_analytics_data_quality_job",
-    selection=dagster.AssetSelection.checks_for_assets(
-        [
-            "web_analytics_bounces_hourly",
-            "web_analytics_stats_table_hourly",
-            "web_analytics_bounces_daily",
-            "web_analytics_stats_table_daily",
-        ]
-    ),
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-)
-
-
-web_analytics_v2_data_quality_job = dagster.define_asset_job(
-    name="web_analytics_v2_data_quality_job",
-    selection=dagster.AssetSelection.checks_for_assets(
-        [
-            "web_analytics_team_selection_v2",
-            "web_pre_aggregated_bounces",
-            "web_pre_aggregated_stats",
-        ]
-    ),
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-)
-
-
-@dagster.schedule(
-    cron_schedule="0 2 * * 0",
-    job=web_analytics_data_quality_job,
-    execution_timezone="UTC",
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
-)
-def web_analytics_weekly_data_quality_schedule(context: dagster.ScheduleEvaluationContext):
-    return dagster.RunRequest(
-        run_config={
-            "ops": {
-                "web_analytics_accuracy_check": {
-                    "config": {
-                        "tolerance_pct": DEFAULT_TOLERANCE_PCT,
-                        "days_back": DEFAULT_DAYS_BACK,
-                    }
-                }
-            }
-        },
-        tags={"trigger": "weekly_schedule"},
-    )
 
 
 simple_data_checks_job = dagster.define_asset_job(


### PR DESCRIPTION
## Problem

Those are not super useful anymore and are taking some time when backfilling. We added a logic to skip when running the backfill, but the Dagster orchestrator still takes some time (~20s each) to trigger them and schedule a k8s pod/job to run them before checking for the skip.

This should make the jobs on EU take half the time and on US will be 20% faster.

## Changes

- Detach them from the v2 assets. The plan later on is to have them on a scheduler only instead directly on the asset.

## How did you test this code?

Running it locally. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
