### PR TITLE
feat(flags): emit metrics for latency with team id label

### DIFF
--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -46,8 +46,7 @@ pub fn setup_metrics_routes(router: Router) -> Router {
 
 pub fn setup_metrics_recorder() -> PrometheusHandle {
     const BUCKETS: &[f64] = &[
-        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0,
-        1000.0, 2000.0, 5000.0, 10000.0,
+        5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
     ];
 
     PrometheusBuilder::new()
@@ -114,6 +113,11 @@ fn apply_label_filter(labels: &[(String, String)]) -> Vec<(String, String)> {
 
 pub fn gauge(name: &'static str, lables: &[(String, String)], value: f64) {
     metrics::gauge!(name, lables).set(value);
+}
+
+pub fn histogram(name: &'static str, labels: &[(String, String)], value: f64) {
+    let filtered_labels = apply_label_filter(labels);
+    metrics::histogram!(name, &filtered_labels).record(value);
 }
 
 // A guard to record the time between creation and drop as a histogram entry

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -46,7 +46,7 @@ pub fn setup_metrics_routes(router: Router) -> Router {
 
 pub fn setup_metrics_recorder() -> PrometheusHandle {
     const BUCKETS: &[f64] = &[
-        5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
+        1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
     ];
 
     PrometheusBuilder::new()

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -18,6 +18,7 @@ pub const PROPERTY_CACHE_MISSES_COUNTER: &str = "flags_property_cache_misses_tot
 pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
 pub const FLAG_REQUESTS_COUNTER: &str = "flags_requests_total";
+pub const FLAG_REQUESTS_LATENCY: &str = "flags_requests_duration_ms";
 
 // Performance monitoring
 pub const DB_CONNECTION_POOL_ACTIVE_COUNTER: &str = "flags_db_connection_pool_active_total";


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We currently track request count for all team ids in the `flags_requests_total` but we don't know how long requests take for a specific team id.

https://github.com/PostHog/posthog/issues/38054

## Changes

- Add histogram metrics with a team id label. 
- Remove some of the extra timing buckets that we don't need. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
