### PR TITLE
chore(flags): Use PostgeSQL's session-level statement_timeout

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -4,20 +4,27 @@ use anyhow::Result;
 use async_trait::async_trait;
 use sqlx::{
     pool::PoolConnection,
-    postgres::{PgPool, PgPoolOptions, PgRow},
+    postgres::{PgPool, PgPoolOptions},
     Error as SqlxError, Postgres,
 };
 use thiserror::Error;
-use tokio::time::timeout;
 
-const DATABASE_TIMEOUT_MILLISECS: u64 = 1000;
+// Default database timeouts - optimized for production low-latency flag evaluation
+pub const DEFAULT_TIMEOUTS: DatabaseTimeouts = DatabaseTimeouts {
+    statement_timeout: Duration::from_millis(300), // Aggressive for fast flag evaluation
+    lock_timeout: Duration::from_millis(100),      // Avoid blocking on locks
+    acquire_timeout: Duration::from_millis(200),   // Fail fast under load
+    idle_timeout: Duration::from_secs(300),        // Close idle connections after 5 minutes
+    max_lifetime: Duration::from_secs(1800),       // Force refresh every 30 minutes
+    idle_in_transaction_session_timeout: Duration::from_secs(15), // Kill leaked transactions
+};
 
 #[derive(Error, Debug)]
 pub enum CustomDatabaseError {
     #[error("Pg error: {0}")]
     Other(#[from] sqlx::Error),
 
-    #[error("Timeout error")]
+    #[error("Client timeout error")]
     Timeout(#[from] tokio::time::error::Elapsed),
 }
 
@@ -26,16 +33,16 @@ pub type PostgresWriter = Arc<dyn Client + Send + Sync>;
 
 /// A simple db wrapper
 /// Supports running any arbitrary query with a timeout.
+///
+/// ## Timeout Strategy
+/// - Session defaults optimized for fast flag evaluation reads (300ms statement, 100ms lock)
+/// - Use `begin_write_transaction()` for writes that need longer timeouts (2s statement, 500ms lock)
+/// - Pool acquire timeout is aggressive (200ms) for fail-fast behavior under load
+///
 /// TODO: Make sqlx prepared statements work with pgbouncer, potentially by setting pooling mode to session.
 #[async_trait]
 pub trait Client {
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError>;
-    async fn run_query(
-        &self,
-        query: String,
-        parameters: Vec<String>,
-        timeout_ms: Option<u64>,
-    ) -> Result<Vec<PgRow>, CustomDatabaseError>;
 
     fn get_pool_stats(&self) -> Option<PoolStats>;
 }
@@ -46,13 +53,72 @@ pub struct PoolStats {
     pub num_idle: usize,
 }
 
+#[derive(Debug, Clone)]
+pub struct DatabaseTimeouts {
+    pub statement_timeout: Duration,
+    pub lock_timeout: Duration,
+    pub acquire_timeout: Duration,
+    pub idle_timeout: Duration,
+    pub max_lifetime: Duration,
+    pub idle_in_transaction_session_timeout: Duration,
+}
+
 pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
+    get_pool_with_timeouts(url, max_connections, DEFAULT_TIMEOUTS).await
+}
+
+pub async fn get_pool_with_timeouts(
+    url: &str,
+    max_connections: u32,
+    timeouts: DatabaseTimeouts,
+) -> Result<PgPool, sqlx::Error> {
     PgPoolOptions::new()
         .max_connections(max_connections)
-        .acquire_timeout(Duration::from_secs(1))
+        .acquire_timeout(timeouts.acquire_timeout)
         .test_before_acquire(true)
-        .idle_timeout(Duration::from_secs(300)) // Close idle connections after 5 minutes
-        .max_lifetime(Duration::from_secs(1800)) // Force refresh every 30 minutes
+        .idle_timeout(timeouts.idle_timeout)
+        .max_lifetime(timeouts.max_lifetime)
+        // Set PostgreSQL session-level timeouts for all queries on this connection
+        .after_connect(move |conn, _meta| {
+            Box::pin(async move {
+                // Convert to i64 with checked conversion to avoid overflow issues
+                let stmt_ms: i64 = timeouts
+                    .statement_timeout
+                    .as_millis()
+                    .try_into()
+                    .expect("statement_timeout too large");
+                let lock_ms: i64 = timeouts
+                    .lock_timeout
+                    .as_millis()
+                    .try_into()
+                    .expect("lock_timeout too large");
+
+                // Set statement timeout (PostgreSQL SET commands don't accept bind parameters)
+                sqlx::query(&format!("SET statement_timeout = '{stmt_ms}ms'"))
+                    .execute(&mut *conn)
+                    .await?;
+
+                // Set lock timeout to prevent getting stuck behind long transactions
+                sqlx::query(&format!("SET lock_timeout = '{lock_ms}ms'"))
+                    .execute(&mut *conn)
+                    .await?;
+
+                // Safety net: kill idle transactions to prevent leaked transactions
+                // from holding locks forever (doesn't affect normal autocommit reads)
+                let idle_tx_secs: i64 = timeouts
+                    .idle_in_transaction_session_timeout
+                    .as_secs()
+                    .try_into()
+                    .expect("idle_in_transaction_session_timeout too large");
+                sqlx::query(&format!(
+                    "SET idle_in_transaction_session_timeout = '{idle_tx_secs}s'"
+                ))
+                .execute(&mut *conn)
+                .await?;
+
+                Ok(())
+            })
+        })
         .connect(url)
         .await
 }
@@ -66,30 +132,9 @@ impl Client for PgPool {
         })
     }
 
-    async fn run_query(
-        &self,
-        query: String,
-        parameters: Vec<String>,
-        timeout_ms: Option<u64>,
-    ) -> Result<Vec<PgRow>, CustomDatabaseError> {
-        let built_query = sqlx::query(&query);
-        let built_query = parameters
-            .iter()
-            .fold(built_query, |acc, param| acc.bind(param));
-        let query_results = built_query.fetch_all(self);
-
-        let timeout_ms = match timeout_ms {
-            Some(ms) => ms,
-            None => DATABASE_TIMEOUT_MILLISECS,
-        };
-
-        let fut = timeout(Duration::from_millis(timeout_ms), query_results).await?;
-
-        Ok(fut?)
-    }
-
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
-        Ok(self.acquire().await?)
+        let conn = self.acquire().await?;
+        Ok(conn)
     }
 }
 
@@ -107,6 +152,39 @@ pub fn is_foreign_key_constraint_error(error: &SqlxError) -> bool {
                     || msg.contains("foreign key constraint")
             }
         }
+        _ => false,
+    }
+}
+
+/// Determines if a sqlx::Error represents a timeout-related failure
+pub fn is_timeout_error(error: &SqlxError) -> bool {
+    match error {
+        // Pool acquisition timed out
+        SqlxError::PoolTimedOut => true,
+
+        // IO-level timeout (network/socket)
+        SqlxError::Io(e) if e.kind() == std::io::ErrorKind::TimedOut => true,
+
+        // Protocol text sometimes includes "timeout"
+        SqlxError::Protocol(msg) => msg.to_lowercase().contains("timeout"),
+
+        // Database-reported timeouts/cancels
+        SqlxError::Database(db_error) => {
+            if let Some(code) = db_error.code() {
+                let code = code.as_ref();
+                // 57014: query_canceled (e.g., statement_timeout)
+                // 55P03: lock_not_available (e.g., lock_timeout)
+                // 25P03: idle_in_transaction_session_timeout
+                code == "57014" || code == "55P03" || code == "25P03"
+            } else {
+                // Fallback heuristic (less reliable than SQLSTATE)
+                let msg = db_error.message().to_lowercase();
+                msg.contains("timeout")
+                    || msg.contains("canceling")   // Postgres US spelling
+                    || msg.contains("cancelling") // just in case
+            }
+        }
+
         _ => false,
     }
 }
@@ -457,5 +535,144 @@ mod tests {
         // Test that memory pressure errors are NOT retried to avoid amplifying load
         let memory_err = db_err("out of memory", None, ErrorKind::Other);
         assert!(!is_transient_error(&memory_err));
+    }
+
+    #[test]
+    fn test_is_timeout_error_pool_timeout() {
+        assert!(is_timeout_error(&SqlxError::PoolTimedOut));
+    }
+
+    #[test]
+    fn test_is_timeout_error_io_timeout() {
+        let io_error = SqlxError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "connection timed out",
+        ));
+        assert!(is_timeout_error(&io_error));
+    }
+
+    #[test]
+    fn test_is_timeout_error_io_non_timeout() {
+        let io_error = SqlxError::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused",
+        ));
+        assert!(!is_timeout_error(&io_error));
+    }
+
+    #[test]
+    fn test_is_timeout_error_protocol_timeout() {
+        let protocol_error = SqlxError::Protocol("operation timeout".to_string());
+        assert!(is_timeout_error(&protocol_error));
+
+        let protocol_non_timeout = SqlxError::Protocol("invalid protocol".to_string());
+        assert!(!is_timeout_error(&protocol_non_timeout));
+    }
+
+    #[test]
+    fn test_is_timeout_error_database_with_timeout_codes() {
+        // Test various timeout-related SQLSTATE codes
+        assert!(is_timeout_error(&db_err(
+            "canceling statement due to statement timeout",
+            Some("57014"),
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "lock not available",
+            Some("55P03"),
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "terminating connection due to idle-in-transaction timeout",
+            Some("25P03"),
+            ErrorKind::Other
+        )));
+    }
+
+    #[test]
+    fn test_is_timeout_error_database_non_timeout_codes() {
+        // Test non-timeout SQLSTATE codes
+        assert!(!is_timeout_error(&db_err(
+            "duplicate key value violates unique constraint",
+            Some("23505"),
+            ErrorKind::UniqueViolation
+        )));
+        assert!(!is_timeout_error(&db_err(
+            "syntax error at or near",
+            Some("42601"),
+            ErrorKind::Other
+        )));
+    }
+
+    #[test]
+    fn test_is_timeout_error_database_message_fallback() {
+        // Test message heuristics when no SQLSTATE code is available
+        assert!(is_timeout_error(&db_err(
+            "operation timeout",
+            None,
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "canceling statement due to timeout",
+            None,
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "cancelling statement due to timeout",
+            None,
+            ErrorKind::Other
+        )));
+
+        // Non-timeout messages
+        assert!(!is_timeout_error(&db_err(
+            "column does not exist",
+            None,
+            ErrorKind::Other
+        )));
+        assert!(!is_timeout_error(&db_err(
+            "relation does not exist",
+            None,
+            ErrorKind::Other
+        )));
+    }
+
+    #[test]
+    fn test_custom_database_error_conversion_timeout() {
+        // Test that CustomDatabaseError::Timeout converts to the timeout error type
+        use tokio::time::{timeout, Duration};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let elapsed_error = rt.block_on(async {
+            timeout(
+                Duration::from_nanos(1),
+                tokio::time::sleep(Duration::from_secs(1)),
+            )
+            .await
+            .unwrap_err()
+        });
+
+        let timeout_error = CustomDatabaseError::Timeout(elapsed_error);
+        // This test just ensures conversion compiles - actual usage depends on consuming crate
+        assert!(matches!(timeout_error, CustomDatabaseError::Timeout(_)));
+    }
+
+    #[test]
+    fn test_custom_database_error_conversion_sqlx_timeout() {
+        // Test that sqlx timeout errors are detected by is_timeout_error
+        let sqlx_timeout = SqlxError::PoolTimedOut;
+        assert!(is_timeout_error(&sqlx_timeout));
+
+        let timeout_error = CustomDatabaseError::Other(sqlx_timeout);
+        assert!(matches!(timeout_error, CustomDatabaseError::Other(_)));
+    }
+
+    #[test]
+    fn test_custom_database_error_conversion_sqlx_non_timeout() {
+        // Test that non-timeout sqlx errors are not detected as timeouts
+        let sqlx_error = SqlxError::RowNotFound;
+        assert!(!is_timeout_error(&sqlx_error));
+
+        let other_error = CustomDatabaseError::Other(sqlx_error);
+        assert!(matches!(other_error, CustomDatabaseError::Other(_)));
     }
 }

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -327,7 +327,7 @@ impl MockRedisClient {
     }
 
     // Helper method to safely lock the calls mutex
-    fn lock_calls(&self) -> std::sync::MutexGuard<Vec<MockRedisCall>> {
+    fn lock_calls(&self) -> std::sync::MutexGuard<'_, Vec<MockRedisCall>> {
         match self.calls.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -91,7 +91,7 @@ impl FlagError {
             FlagError::RedisDataParsingError
             | FlagError::RedisUnavailable
             | FlagError::DatabaseUnavailable
-            | FlagError::TimeoutError => StatusCode::SERVICE_UNAVAILABLE,
+            | FlagError::TimeoutError(_) => StatusCode::SERVICE_UNAVAILABLE,
 
             FlagError::CookielessError(
                 CookielessManagerError::HashError(_)
@@ -319,7 +319,7 @@ mod tests {
         assert!(FlagError::CacheUpdateError.is_5xx());
         assert!(FlagError::DatabaseUnavailable.is_5xx());
         assert!(FlagError::RedisUnavailable.is_5xx());
-        assert!(FlagError::TimeoutError.is_5xx());
+        assert!(FlagError::TimeoutError(None).is_5xx());
         assert!(FlagError::ClientFacing(ClientFacingError::ServiceUnavailable).is_5xx());
 
         // Test 4XX errors

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -1971,7 +1971,7 @@ mod tests {
         assert!(!should_retry_on_error(&column_error));
 
         // Test that other error types don't trigger retries
-        let timeout_error_variant = FlagError::TimeoutError;
+        let timeout_error_variant = FlagError::TimeoutError(None);
         assert!(!should_retry_on_error(&timeout_error_variant));
 
         let missing_id_error = FlagError::MissingDistinctId;

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -10,14 +10,24 @@ use crate::{
 };
 use anyhow::Error;
 use axum::async_trait;
-use common_database::{get_pool, Client, CustomDatabaseError};
+use common_database::{get_pool_with_timeouts, Client, CustomDatabaseError, DatabaseTimeouts};
 use common_redis::{Client as RedisClientTrait, RedisClient};
 use common_types::{PersonId, TeamId};
 use rand::{distributions::Alphanumeric, Rng};
 use serde_json::{json, Value};
-use sqlx::{pool::PoolConnection, postgres::PgRow, Error as SqlxError, Postgres, Row};
-use std::sync::Arc;
+use sqlx::{pool::PoolConnection, Error as SqlxError, Postgres, Row};
+use std::{sync::Arc, time::Duration};
 use uuid::Uuid;
+
+// Test database timeouts - generous timeouts for test environment
+pub const TEST_TIMEOUTS: DatabaseTimeouts = DatabaseTimeouts {
+    statement_timeout: Duration::from_secs(5),
+    lock_timeout: Duration::from_secs(2),
+    acquire_timeout: Duration::from_secs(10),
+    idle_timeout: Duration::from_secs(300),  // 5 minutes
+    max_lifetime: Duration::from_secs(1800), // 30 minutes
+    idle_in_transaction_session_timeout: Duration::from_secs(30), // More generous for tests
+};
 
 pub fn random_string(prefix: &str, length: usize) -> String {
     let suffix: String = rand::thread_rng()
@@ -139,19 +149,29 @@ pub fn create_flag_from_json(json_value: Option<String>) -> Vec<FeatureFlag> {
 
 pub async fn setup_pg_reader_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+    let test_timeouts = TEST_TIMEOUTS;
     Arc::new(
-        get_pool(&config.read_database_url, config.max_pg_connections)
-            .await
-            .expect("Failed to create Postgres client"),
+        get_pool_with_timeouts(
+            &config.read_database_url,
+            config.max_pg_connections,
+            test_timeouts,
+        )
+        .await
+        .expect("Failed to create Postgres client"),
     )
 }
 
 pub async fn setup_pg_writer_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+    let test_timeouts = TEST_TIMEOUTS;
     Arc::new(
-        get_pool(&config.write_database_url, config.max_pg_connections)
-            .await
-            .expect("Failed to create Postgres client"),
+        get_pool_with_timeouts(
+            &config.write_database_url,
+            config.max_pg_connections,
+            test_timeouts,
+        )
+        .await
+        .expect("Failed to create Postgres client"),
     )
 }
 
@@ -161,29 +181,39 @@ pub async fn setup_dual_pg_readers(
     config: Option<&Config>,
 ) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+    let test_timeouts = TEST_TIMEOUTS;
 
     if config.is_persons_db_routing_enabled() {
         // Separate persons and non-persons databases
         let persons_reader = Arc::new(
-            get_pool(
+            get_pool_with_timeouts(
                 &config.get_persons_read_database_url(),
                 config.max_pg_connections,
+                test_timeouts.clone(),
             )
             .await
             .expect("Failed to create Postgres persons reader client"),
         );
         let non_persons_reader = Arc::new(
-            get_pool(&config.read_database_url, config.max_pg_connections)
-                .await
-                .expect("Failed to create Postgres client"),
+            get_pool_with_timeouts(
+                &config.read_database_url,
+                config.max_pg_connections,
+                test_timeouts,
+            )
+            .await
+            .expect("Failed to create Postgres client"),
         );
         (persons_reader, non_persons_reader)
     } else {
         // Same database for both
         let client = Arc::new(
-            get_pool(&config.read_database_url, config.max_pg_connections)
-                .await
-                .expect("Failed to create Postgres client"),
+            get_pool_with_timeouts(
+                &config.read_database_url,
+                config.max_pg_connections,
+                test_timeouts,
+            )
+            .await
+            .expect("Failed to create Postgres client"),
         );
         (client.clone(), client)
     }
@@ -195,29 +225,39 @@ pub async fn setup_dual_pg_writers(
     config: Option<&Config>,
 ) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+    let test_timeouts = TEST_TIMEOUTS;
 
     if config.is_persons_db_routing_enabled() {
         // Separate persons and non-persons databases
         let persons_writer = Arc::new(
-            get_pool(
+            get_pool_with_timeouts(
                 &config.get_persons_write_database_url(),
                 config.max_pg_connections,
+                test_timeouts.clone(),
             )
             .await
             .expect("Failed to create Postgres persons writer client"),
         );
         let non_persons_writer = Arc::new(
-            get_pool(&config.write_database_url, config.max_pg_connections)
-                .await
-                .expect("Failed to create Postgres client"),
+            get_pool_with_timeouts(
+                &config.write_database_url,
+                config.max_pg_connections,
+                test_timeouts,
+            )
+            .await
+            .expect("Failed to create Postgres client"),
         );
         (persons_writer, non_persons_writer)
     } else {
         // Same database for both
         let client = Arc::new(
-            get_pool(&config.write_database_url, config.max_pg_connections)
-                .await
-                .expect("Failed to create Postgres client"),
+            get_pool_with_timeouts(
+                &config.write_database_url,
+                config.max_pg_connections,
+                test_timeouts,
+            )
+            .await
+            .expect("Failed to create Postgres client"),
         );
         (client.clone(), client)
     }
@@ -227,16 +267,6 @@ pub struct MockPgClient;
 
 #[async_trait]
 impl Client for MockPgClient {
-    async fn run_query(
-        &self,
-        _query: String,
-        _parameters: Vec<String>,
-        _timeout_ms: Option<u64>,
-    ) -> Result<Vec<PgRow>, CustomDatabaseError> {
-        // Simulate a database connection failure
-        Err(CustomDatabaseError::Other(SqlxError::PoolTimedOut))
-    }
-
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
         // Simulate a database connection failure
         Err(CustomDatabaseError::Other(SqlxError::PoolTimedOut))
@@ -260,15 +290,15 @@ pub async fn insert_new_team_in_pg(
     const ORG_ID: &str = "019026a4be8000005bf3171d00629163";
 
     // Create new organization from scratch (in non-persons database)
-    non_persons_client.run_query(
-        r#"INSERT INTO posthog_organization
+    let mut conn = non_persons_client.get_connection().await?;
+    sqlx::query(r#"INSERT INTO posthog_organization
         (id, name, slug, created_at, updated_at, plugins_access_level, for_internal_metrics, is_member_join_email_enabled, enforce_2fa, is_hipaa, customer_id, available_product_features, personalization, setup_section_2_completed, domain_whitelist, members_can_use_personal_api_keys, allow_publicly_shared_resources)
         VALUES
         ($1::uuid, 'Test Organization', 'test-organization', '2024-06-17 14:40:49.298579+00:00', '2024-06-17 14:40:49.298593+00:00', 9, false, true, NULL, false, NULL, '{}', '{}', true, '{}', true, true)
-        ON CONFLICT DO NOTHING"#.to_string(),
-        vec![ORG_ID.to_string()],
-        Some(2000),
-    ).await?;
+        ON CONFLICT DO NOTHING"#)
+        .bind(ORG_ID)
+        .execute(&mut *conn)
+        .await?;
 
     // Create team model
     let id = match team_id {

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use common_database::get_pool;
+use common_database::get_pool_with_timeouts;
 use common_redis::MockRedisClient;
 use feature_flags::team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX};
 use limiters::redis::QUOTA_LIMITER_CACHE_KEY;
@@ -12,6 +12,7 @@ use tokio::sync::Notify;
 
 use feature_flags::config::Config;
 use feature_flags::server::serve;
+use feature_flags::utils::test_utils::TEST_TIMEOUTS;
 
 pub struct ServerHandle {
     pub addr: SocketAddr,
@@ -75,7 +76,12 @@ impl ServerHandle {
         tokio::spawn(async move {
             let redis_reader_client = Arc::new(mock_client);
             let redis_writer_client = redis_reader_client.clone();
-            let reader = match get_pool(&config.read_database_url, config.max_pg_connections).await
+            let reader = match get_pool_with_timeouts(
+                &config.read_database_url,
+                config.max_pg_connections,
+                TEST_TIMEOUTS,
+            )
+            .await
             {
                 Ok(client) => Arc::new(client),
                 Err(e) => {
@@ -83,7 +89,12 @@ impl ServerHandle {
                     return;
                 }
             };
-            let writer = match get_pool(&config.write_database_url, config.max_pg_connections).await
+            let writer = match get_pool_with_timeouts(
+                &config.write_database_url,
+                config.max_pg_connections,
+                TEST_TIMEOUTS,
+            )
+            .await
             {
                 Ok(client) => Arc::new(client),
                 Err(e) => {


### PR DESCRIPTION
## Problem

Our queries don't have any timeouts specified. By default that means a query can run as long as it takes. Without timeouts, slow queries can pile up and consume database connections, potentially bringing down the entire service.
 
During high loads, timeouts help by:

1. Preventing resource exhaustion - releasing database connections that would otherwise be tied up in slow/hung queries
2. Avoiding cascading failures - stopping the pile-up of requests that would eventually crash the system
3. Making failure observable - you get timeout errors instead of silent hangs, so you know there's a problem

## Changes

Ensure that we're using aggressive, but reasonable timeouts in production. @andyzzhao, would love your 👀 on the defaults I chose.

Also removed the `run_query` method on `Client` because it was only used by unit tests and caused a lot of confusion. Now, unit tests query the database the same way production code does, albeit with different timeouts.

Did not add `tokio::timeout` (aka a client timeout) this time around. We didn't have them before and adding them would change every call-site. I'd want to find an approach that is more centralized if we decide to add these. And we get most of the benefit from having PostgreSQL timeouts.

## How did you test this code?

Unit tests
Manual testing: Hit `/flags` service. Made sure writing to `posthog_featureflaghashkeyoverride` still works.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
