### PR TITLE
feat(kafka-deduplicator): add pprof profiling endpoint to health server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1892,6 +1892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2667,18 @@ checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3959,6 +3980,7 @@ dependencies = [
  "common-types",
  "dashmap 6.1.0",
  "envconfig",
+ "flate2",
  "futures",
  "health",
  "metrics",
@@ -3968,6 +3990,7 @@ dependencies = [
  "opentelemetry 0.22.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.22.1",
+ "pprof",
  "rdkafka",
  "rocksdb",
  "serde",
@@ -4552,6 +4575,17 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "no-std-compat"
@@ -5308,6 +5342,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "protobuf",
+ "protobuf-codegen-pure",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5447,6 +5503,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
 ]
 
 [[package]]
@@ -7219,6 +7300,17 @@ dependencies = [
  "wasmparser",
  "zip 2.2.0",
  "zstd",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a767859f6549c665011970874c3f541838b4835d5aaaa493d3ee383918be9f10"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -19,6 +19,7 @@ common-alloc = { path = "../common/alloc" }
 common-types = { path = "../common/types" }
 dashmap = "6.1"
 envconfig = { workspace = true }
+flate2 = { workspace = true }
 futures = { workspace = true }
 health = { path = "../common/health" }
 metrics = { workspace = true }
@@ -28,6 +29,7 @@ once_cell = "1.21"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
+pprof = { version = "0.13", features = ["protobuf-codec"] }
 rdkafka = { workspace = true }
 rocksdb = "0.24.0"
 serde = { workspace = true }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -144,6 +144,9 @@ pub struct Config {
 
     #[envconfig(from = "OTEL_LOG_LEVEL", default = "info")]
     pub otel_log_level: tracing::Level,
+
+    #[envconfig(default = "false")]
+    pub enable_pprof: bool,
 }
 
 impl Config {

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -20,7 +20,9 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-use kafka_deduplicator::{config::Config, service::KafkaDeduplicatorService};
+use kafka_deduplicator::{
+    config::Config, service::KafkaDeduplicatorService, utils::pprof::handle_profile,
+};
 
 common_alloc::used!();
 
@@ -105,6 +107,7 @@ fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
     let router = Router::new()
         .route("/", get(index))
         .route("/_readiness", get(index))
+        .route("/pprof/profile", get(handle_profile))
         .route(
             "/_liveness",
             get(move || async move {

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -107,7 +107,6 @@ fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
     let router = Router::new()
         .route("/", get(index))
         .route("/_readiness", get(index))
-        .route("/pprof/profile", get(handle_profile))
         .route(
             "/_liveness",
             get(move || async move {
@@ -127,6 +126,12 @@ fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
                 status
             }),
         );
+
+    let router = if config.enable_pprof {
+        router.route("/pprof/profile", get(handle_profile))
+    } else {
+        router
+    };
 
     // Don't install metrics unless asked to
     // Installing a global recorder when capture is used as a library (during tests etc)

--- a/rust/kafka-deduplicator/src/utils/mod.rs
+++ b/rust/kafka-deduplicator/src/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod pprof;
 pub mod timestamp;

--- a/rust/kafka-deduplicator/src/utils/pprof.rs
+++ b/rust/kafka-deduplicator/src/utils/pprof.rs
@@ -1,0 +1,70 @@
+use anyhow::{Context, Result};
+use axum::{
+    extract::Query,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use pprof::{protos::Message, ProfilerGuardBuilder};
+use serde::Deserialize;
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[derive(Deserialize)]
+pub struct ProfileQueryParams {
+    pub seconds: Option<u64>,
+}
+
+pub async fn handle_profile(
+    Query(params): Query<ProfileQueryParams>,
+) -> Result<Response, Response> {
+    let seconds = params.seconds.unwrap_or(10);
+
+    match generate_report(seconds).await {
+        Ok(body) => Ok((
+            StatusCode::OK,
+            [("Content-Type", "application/octet-stream")],
+            [(
+                "Content-Disposition",
+                "attachment; filename=\"profile.pb.gz\"",
+            )],
+            body,
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [("Content-Type", "text/plain")],
+            e.to_string(),
+        )
+            .into_response()),
+    }
+}
+
+async fn generate_report(seconds: u64) -> Result<Vec<u8>> {
+    let guard = ProfilerGuardBuilder::default()
+        .frequency(500)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()
+        .context("Failed to build profiler guard")?;
+
+    sleep(Duration::from_secs(seconds)).await;
+
+    let profile = guard
+        .report()
+        .build()
+        .context("Failed to build profiler report")?
+        .pprof()
+        .context("Failed to build profiler profile")?;
+
+    let mut body = Vec::new();
+    let mut encoder = GzEncoder::new(&mut body, Compression::default());
+    profile
+        .write_to_writer(&mut encoder)
+        .context("Failed to write profile to writer")?;
+    encoder
+        .finish()
+        .context("Failed to finish encoding profile")?;
+
+    Ok(body)
+}


### PR DESCRIPTION
## Problem
We'd like to be able to profile the `kafka-deduplicator` in production. Let's start with `pprof` as its lightweight and has nice tooling.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Feature flag to enable (deploy cfg PR to wire this up sold separately)
* Add `pprof` `GET` endpoint to health server with `seconds=N` query param
* Wire up basic profiling report as a reponse that you can analyze or visualize with [go tool](https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/) and friends

If this behaves, we can enable the [flamegraph generation feature](https://crates.io/crates/pprof/0.13.0) too ✨ 

_Note: Rust `pprof` supports CPU profiling, which will come in handy, but we'll need something else for allocation snapshots. Stay tuned..._

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI - can deploy test when I'm back next week if no one beats me to it

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog update 
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
