### PR TITLE
feat(flags): add 5XX counter with team_id label

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -287,3 +287,33 @@ impl From<sqlx::Error> for FlagError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_5xx() {
+        // Test 5XX errors
+        assert!(FlagError::Internal("test".to_string()).is_5xx());
+        assert!(FlagError::CacheUpdateError.is_5xx());
+        assert!(FlagError::DatabaseUnavailable.is_5xx());
+        assert!(FlagError::RedisUnavailable.is_5xx());
+        assert!(FlagError::TimeoutError.is_5xx());
+        assert!(FlagError::ClientFacing(ClientFacingError::ServiceUnavailable).is_5xx());
+
+        // Test 4XX errors
+        assert!(
+            !FlagError::ClientFacing(ClientFacingError::BadRequest("test".to_string())).is_5xx()
+        );
+        assert!(
+            !FlagError::ClientFacing(ClientFacingError::Unauthorized("test".to_string())).is_5xx()
+        );
+        assert!(!FlagError::ClientFacing(ClientFacingError::RateLimited).is_5xx());
+        assert!(!FlagError::ClientFacing(ClientFacingError::BillingLimit).is_5xx());
+        assert!(!FlagError::MissingDistinctId.is_5xx());
+        assert!(!FlagError::NoTokenError.is_5xx());
+        assert!(!FlagError::TokenValidationError.is_5xx());
+        assert!(!FlagError::PersonNotFound.is_5xx());
+    }
+}

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -101,7 +101,7 @@ impl FlagError {
                 | CookielessManagerError::InvalidIdentifyCount(_),
             ) => StatusCode::INTERNAL_SERVER_ERROR,
             FlagError::CookielessError(_) => return false, // Other CookielessErrors are 4XX
-            _ => return false, // Everything else is 4XX
+            _ => return false,                             // Everything else is 4XX
         };
         status.is_server_error()
     }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -175,6 +175,7 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
     };
 
     // Track 5XX errors with team_id if available
+    // If the team_id is not available, it means the error occurred before or during the team fetch
     if let Err(ref e) = result {
         if e.is_5xx() {
             let team_label = match team_id_for_metrics {

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -10,7 +10,6 @@ pub mod properties;
 pub mod session_recording;
 pub mod types;
 
-use common_metrics::{histogram, inc};
 pub use types::*;
 
 use crate::{
@@ -21,6 +20,13 @@ use crate::{
 use std::collections::HashMap;
 use tracing::{info, instrument, warn};
 
+#[cfg(test)]
+use crate::handler::test_metrics::{histogram, inc};
+
+// In production, use the real metrics functions
+#[cfg(not(test))]
+use common_metrics::{histogram, inc};
+
 /// Primary entry point for feature flag requests.
 /// 1) Parses and authenticates the request,
 /// 2) Fetches the team and feature flags,
@@ -29,12 +35,63 @@ use tracing::{info, instrument, warn};
 /// 5) Returns a [`FlagsResponse`] or an error.
 #[instrument(skip_all, fields(request_id = %context.request_id))]
 pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, FlagError> {
-    let mut team_id_for_metrics: Option<i32> = None;
+    let start_time = std::time::Instant::now();
+    let (result, metrics_data) = process_request_inner(context).await;
+    let total_duration = start_time.elapsed();
 
-    let team_id_ref = &mut team_id_for_metrics;
-    let result: Result<FlagsResponse, FlagError> = async move {
-        let start_time = std::time::Instant::now();
+    record_metrics(&result, metrics_data, total_duration);
 
+    result
+}
+
+struct MetricsData {
+    team_id: Option<i32>,
+    flags_disabled: Option<bool>,
+}
+
+fn record_metrics(
+    result: &Result<FlagsResponse, FlagError>,
+    data: MetricsData,
+    duration: std::time::Duration,
+) {
+    let team_id = data
+        .team_id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "not_available".to_string());
+
+    let flags_disabled = data
+        .flags_disabled
+        .map(|disabled| disabled.to_string())
+        .unwrap_or_else(|| "not_available".to_string());
+
+    let labels = [
+        ("flags_disabled".to_string(), flags_disabled),
+        ("team_id".to_string(), team_id.clone()),
+    ];
+
+    inc(FLAG_REQUESTS_COUNTER, &labels, 1);
+    histogram(FLAG_REQUESTS_LATENCY, &labels, duration.as_millis() as f64);
+
+    if let Err(ref e) = result {
+        if e.is_5xx() {
+            inc(
+                FLAG_REQUEST_FAULTS_COUNTER,
+                &[("team_id".to_string(), team_id)],
+                1,
+            );
+        }
+    }
+}
+
+async fn process_request_inner(
+    context: RequestContext,
+) -> (Result<FlagsResponse, FlagError>, MetricsData) {
+    let mut metrics_data = MetricsData {
+        team_id: None,
+        flags_disabled: None,
+    };
+
+    let result = async {
         let flag_service = FlagService::new(
             context.state.redis_reader.clone(),
             context.state.redis_writer.clone(),
@@ -57,8 +114,8 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
             .get_team_from_cache_or_pg(&verified_token)
             .await?;
 
-        let team_id = team.id;
-        *team_id_ref = Some(team_id);
+        metrics_data.team_id = Some(team.id);
+        metrics_data.flags_disabled = Some(request.is_flags_disabled());
 
         tracing::debug!(
             "Team fetched: team_id={}, project_id={}",
@@ -135,25 +192,6 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
         let response =
             config_response_builder::build_response(flags_response, &context, &team).await?;
 
-        let total_duration = start_time.elapsed();
-
-        // Record metrics
-        let labels = [
-            (
-                "flags_disabled".to_string(),
-                request.is_flags_disabled().to_string(),
-            ),
-            ("team_id".to_string(), team.id.to_string()),
-        ];
-
-        inc(FLAG_REQUESTS_COUNTER, &labels, 1);
-
-        histogram(
-            FLAG_REQUESTS_LATENCY,
-            &labels,
-            total_duration.as_millis() as f64,
-        );
-
         // Comprehensive request summary
         info!(
             request_id = %context.request_id,
@@ -163,8 +201,6 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
             flags_count = response.flags.len(),
             flags_disabled = request.is_flags_disabled(),
             quota_limited = response.quota_limited.is_some(),
-            duration_ms = total_duration.as_millis(),
-            slow_request = total_duration.as_millis() > 1000,
             "Request completed"
         );
 
@@ -172,24 +208,237 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
     }
     .await;
 
-    // Track 5XX errors with team_id if available
-    // If the team_id is not available, it means the error occurred before or during the team fetch
-    if let Err(ref e) = result {
-        if e.is_5xx() {
-            let team_label = match team_id_for_metrics {
-                Some(id) => id.to_string(),
-                None => "not_available".to_string(),
-            };
-            inc(
-                FLAG_REQUEST_FAULTS_COUNTER,
-                &[("team_id".to_string(), team_label)],
-                1,
-            );
-        }
-    }
-
-    result
+    (result, metrics_data)
 }
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod test_metrics {
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct RecordedMetric {
+        pub name: String,
+        pub labels: Vec<(String, String)>,
+        pub value: f64,
+        pub metric_type: MetricType,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum MetricType {
+        Counter,
+        Histogram,
+    }
+
+    // Thread-safe storage for captured metrics during tests
+    // Using thread_local with RefCell for test isolation
+    thread_local! {
+        static RECORDED_METRICS: std::cell::RefCell<Vec<RecordedMetric>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    pub fn inc(name: &str, labels: &[(String, String)], value: u64) {
+        let metric = RecordedMetric {
+            name: name.to_string(),
+            labels: labels.to_vec(),
+            value: value as f64,
+            metric_type: MetricType::Counter,
+        };
+        RECORDED_METRICS.with(|metrics| {
+            metrics.borrow_mut().push(metric);
+        });
+    }
+
+    pub fn histogram(name: &str, labels: &[(String, String)], value: f64) {
+        let metric = RecordedMetric {
+            name: name.to_string(),
+            labels: labels.to_vec(),
+            value,
+            metric_type: MetricType::Histogram,
+        };
+        RECORDED_METRICS.with(|metrics| {
+            metrics.borrow_mut().push(metric);
+        });
+    }
+
+    // Test helper functions
+    pub fn clear_recorded_metrics() {
+        RECORDED_METRICS.with(|metrics| {
+            metrics.borrow_mut().clear();
+        });
+    }
+
+    pub fn get_recorded_metrics() -> Vec<RecordedMetric> {
+        RECORDED_METRICS.with(|metrics| metrics.borrow().clone())
+    }
+}
+
+#[cfg(test)]
+mod metrics_tests {
+    use super::*;
+    use crate::api::errors::ClientFacingError;
+    use crate::handler::test_metrics::{clear_recorded_metrics, get_recorded_metrics, MetricType};
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_record_metrics_with_complete_data() {
+        clear_recorded_metrics();
+
+        let result = Ok(FlagsResponse::new(
+            false,
+            HashMap::new(),
+            None,
+            Uuid::new_v4(),
+        ));
+        let data = MetricsData {
+            team_id: Some(123),
+            flags_disabled: Some(false),
+        };
+
+        // Call the real record_metrics function - it will use our test metrics functions
+        record_metrics(&result, data, std::time::Duration::from_millis(100));
+
+        // Verify the metrics were recorded correctly
+        let metrics = get_recorded_metrics();
+        assert_eq!(
+            metrics.len(),
+            2,
+            "Should record 2 metrics (counter and histogram)"
+        );
+
+        // Check the counter metric
+        let counter = &metrics[0];
+        assert_eq!(counter.name, FLAG_REQUESTS_COUNTER);
+        assert_eq!(counter.metric_type, MetricType::Counter);
+        assert_eq!(counter.value, 1.0);
+        assert!(counter
+            .labels
+            .contains(&("team_id".to_string(), "123".to_string())));
+        assert!(counter
+            .labels
+            .contains(&("flags_disabled".to_string(), "false".to_string())));
+
+        // Check the histogram metric
+        let histogram = &metrics[1];
+        assert_eq!(histogram.name, FLAG_REQUESTS_LATENCY);
+        assert_eq!(histogram.metric_type, MetricType::Histogram);
+        assert_eq!(histogram.value, 100.0);
+    }
+
+    #[test]
+    fn test_record_metrics_with_missing_data() {
+        clear_recorded_metrics();
+
+        let result = Ok(FlagsResponse::new(
+            false,
+            HashMap::new(),
+            None,
+            Uuid::new_v4(),
+        ));
+        let data = MetricsData {
+            team_id: None,
+            flags_disabled: None,
+        };
+
+        record_metrics(&result, data, std::time::Duration::from_millis(50));
+
+        let metrics = get_recorded_metrics();
+        assert_eq!(metrics.len(), 2);
+
+        // Both metrics should use "not_available" for missing values
+        for metric in &metrics {
+            assert!(metric
+                .labels
+                .contains(&("team_id".to_string(), "not_available".to_string())));
+            assert!(metric
+                .labels
+                .contains(&("flags_disabled".to_string(), "not_available".to_string())));
+        }
+    }
+
+    #[test]
+    fn test_record_metrics_with_5xx_error() {
+        clear_recorded_metrics();
+
+        let result = Err(FlagError::Internal("test error".to_string()));
+        let data = MetricsData {
+            team_id: Some(456),
+            flags_disabled: Some(true),
+        };
+
+        record_metrics(&result, data, std::time::Duration::from_millis(200));
+
+        let metrics = get_recorded_metrics();
+        assert_eq!(
+            metrics.len(),
+            3,
+            "Should record 3 metrics (counter, histogram, and fault counter)"
+        );
+
+        // Check the fault counter is recorded
+        let fault_counter = metrics
+            .iter()
+            .find(|m| m.name == FLAG_REQUEST_FAULTS_COUNTER)
+            .expect("Should have fault counter");
+
+        assert_eq!(fault_counter.metric_type, MetricType::Counter);
+        assert_eq!(fault_counter.value, 1.0);
+        assert!(fault_counter
+            .labels
+            .contains(&("team_id".to_string(), "456".to_string())));
+    }
+
+    #[test]
+    fn test_record_metrics_with_5xx_error_no_team_id() {
+        clear_recorded_metrics();
+
+        let result = Err(FlagError::DatabaseUnavailable);
+        let data = MetricsData {
+            team_id: None,
+            flags_disabled: Some(false),
+        };
+
+        record_metrics(&result, data, std::time::Duration::from_millis(150));
+
+        let metrics = get_recorded_metrics();
+        assert_eq!(metrics.len(), 3); // counter, histogram, and fault counter
+
+        // Should record fault counter with "not_available"
+        let fault_counter = metrics
+            .iter()
+            .find(|m| m.name == FLAG_REQUEST_FAULTS_COUNTER)
+            .expect("Should have fault counter");
+
+        assert!(fault_counter
+            .labels
+            .contains(&("team_id".to_string(), "not_available".to_string())));
+    }
+
+    #[test]
+    fn test_record_metrics_with_4xx_error() {
+        clear_recorded_metrics();
+
+        let result = Err(FlagError::ClientFacing(ClientFacingError::BadRequest(
+            "bad".to_string(),
+        )));
+        let data = MetricsData {
+            team_id: Some(789),
+            flags_disabled: Some(false),
+        };
+
+        record_metrics(&result, data, std::time::Duration::from_millis(75));
+
+        let metrics = get_recorded_metrics();
+        assert_eq!(metrics.len(), 2); // Only counter and histogram, NO fault counter
+
+        // Verify no fault counter was recorded
+        let fault_counter = metrics
+            .iter()
+            .find(|m| m.name == FLAG_REQUEST_FAULTS_COUNTER);
+        assert!(
+            fault_counter.is_none(),
+            "Should NOT record fault counter for 4XX errors"
+        );
+    }
+}

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -16,7 +16,7 @@ pub use types::*;
 use crate::{
     api::{errors::FlagError, types::FlagsResponse},
     flags::flag_service::FlagService,
-    metrics::consts::{FLAG_REQUESTS_COUNTER, FLAG_REQUESTS_LATENCY},
+    metrics::consts::{FLAG_REQUESTS_COUNTER, FLAG_REQUESTS_LATENCY, FLAG_REQUEST_FAULTS_COUNTER},
 };
 use std::collections::HashMap;
 use tracing::{info, instrument, warn};
@@ -29,142 +29,167 @@ use tracing::{info, instrument, warn};
 /// 5) Returns a [`FlagsResponse`] or an error.
 #[instrument(skip_all, fields(request_id = %context.request_id))]
 pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, FlagError> {
-    async move {
-        let start_time = std::time::Instant::now();
+    let mut team_id_for_metrics: Option<i32> = None;
 
-        let flag_service = FlagService::new(
-            context.state.redis_reader.clone(),
-            context.state.redis_writer.clone(),
-            context.state.database_pools.non_persons_reader.clone(),
-        );
+    let result: Result<FlagsResponse, FlagError> = {
+        let team_id_ref = &mut team_id_for_metrics;
+        async move {
+            let start_time = std::time::Instant::now();
 
-        let (original_distinct_id, verified_token, request) =
-            authentication::parse_and_authenticate(&context, &flag_service).await?;
+            let flag_service = FlagService::new(
+                context.state.redis_reader.clone(),
+                context.state.redis_writer.clone(),
+                context.state.database_pools.non_persons_reader.clone(),
+            );
 
-        let distinct_id_for_logging = original_distinct_id
-            .clone()
-            .unwrap_or_else(|| "disabled".to_string());
+            let (original_distinct_id, verified_token, request) =
+                authentication::parse_and_authenticate(&context, &flag_service).await?;
 
-        tracing::debug!(
-            "Authentication completed for distinct_id: {}",
-            distinct_id_for_logging
-        );
+            let distinct_id_for_logging = original_distinct_id
+                .clone()
+                .unwrap_or_else(|| "disabled".to_string());
 
-        let team = flag_service
-            .get_team_from_cache_or_pg(&verified_token)
-            .await?;
+            tracing::debug!(
+                "Authentication completed for distinct_id: {}",
+                distinct_id_for_logging
+            );
 
-        tracing::debug!(
-            "Team fetched: team_id={}, project_id={}",
-            team.id,
-            team.project_id
-        );
+            let team = flag_service
+                .get_team_from_cache_or_pg(&verified_token)
+                .await?;
 
-        // Early exit if flags are disabled
-        let flags_response = if request.is_flags_disabled() {
-            FlagsResponse::new(false, HashMap::new(), None, context.request_id)
-        } else if let Some(quota_limited_response) =
-            billing::check_limits(&context, &verified_token).await?
-        {
-            warn!("Request quota limited");
-            quota_limited_response
-        } else {
-            let distinct_id = cookieless::handle_distinct_id(
-                &context,
-                &request,
-                &team,
-                original_distinct_id
-                    .expect("distinct_id should be present when flags are not disabled"),
-            )
-            .await?;
+            let team_id = team.id;
+            *team_id_ref = Some(team_id);
 
-            tracing::debug!("Distinct ID resolved: {}", distinct_id);
-
-            let (filtered_flags, had_flag_errors) = flags::fetch_and_filter(
-                &flag_service,
-                team.project_id,
-                &context.meta,
-                &context.headers,
-                None,
-                request.evaluation_environments.as_ref(),
-            )
-            .await?;
-
-            tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
-
-            let property_overrides = properties::prepare_overrides(&context, &request)?;
-
-            // Evaluate flags (this will return empty if is_flags_disabled is true)
-            let mut response = flags::evaluate_for_request(
-                &context.state,
+            tracing::debug!(
+                "Team fetched: team_id={}, project_id={}",
                 team.id,
-                team.project_id,
-                distinct_id.clone(),
-                filtered_flags.clone(),
-                property_overrides.person_properties,
-                property_overrides.group_properties,
-                property_overrides.groups,
-                property_overrides.hash_key,
-                context.request_id,
-                request.is_flags_disabled(),
-                request.flag_keys.clone(),
-            )
-            .await;
+                team.project_id
+            );
 
-            // Set error flag if there were deserialization errors
-            if had_flag_errors {
-                response.errors_while_computing_flags = true;
-            }
+            // Early exit if flags are disabled
+            let flags_response = if request.is_flags_disabled() {
+                FlagsResponse::new(false, HashMap::new(), None, context.request_id)
+            } else if let Some(quota_limited_response) =
+                billing::check_limits(&context, &verified_token).await?
+            {
+                warn!("Request quota limited");
+                quota_limited_response
+            } else {
+                let distinct_id = cookieless::handle_distinct_id(
+                    &context,
+                    &request,
+                    &team,
+                    original_distinct_id
+                        .expect("distinct_id should be present when flags are not disabled"),
+                )
+                .await?;
 
-            // Only record billing if flags are not disabled
-            if !request.is_flags_disabled() {
-                billing::record_usage(&context, &filtered_flags, team.id).await;
-            }
+                tracing::debug!("Distinct ID resolved: {}", distinct_id);
 
-            response
-        };
+                let (filtered_flags, had_flag_errors) = flags::fetch_and_filter(
+                    &flag_service,
+                    team.project_id,
+                    &context.meta,
+                    &context.headers,
+                    None,
+                    request.evaluation_environments.as_ref(),
+                )
+                .await?;
 
-        // build the rest of the FlagsResponse, since the caller may have passed in `&config=true` and may need additional fields
-        // beyond just feature flags
-        let response =
-            config_response_builder::build_response(flags_response, &context, &team).await?;
+                tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
 
-        let total_duration = start_time.elapsed();
+                let property_overrides = properties::prepare_overrides(&context, &request)?;
 
-        // Record metrics
-        let labels = [
-            (
-                "flags_disabled".to_string(),
-                request.is_flags_disabled().to_string(),
-            ),
-            ("team_id".to_string(), team.id.to_string()),
-        ];
+                // Evaluate flags (this will return empty if is_flags_disabled is true)
+                let mut response = flags::evaluate_for_request(
+                    &context.state,
+                    team.id,
+                    team.project_id,
+                    distinct_id.clone(),
+                    filtered_flags.clone(),
+                    property_overrides.person_properties,
+                    property_overrides.group_properties,
+                    property_overrides.groups,
+                    property_overrides.hash_key,
+                    context.request_id,
+                    request.is_flags_disabled(),
+                    request.flag_keys.clone(),
+                )
+                .await;
 
-        inc(FLAG_REQUESTS_COUNTER, &labels, 1);
+                // Set error flag if there were deserialization errors
+                if had_flag_errors {
+                    response.errors_while_computing_flags = true;
+                }
 
-        histogram(
-            FLAG_REQUESTS_LATENCY,
-            &labels,
-            total_duration.as_millis() as f64,
-        );
+                // Only record billing if flags are not disabled
+                if !request.is_flags_disabled() {
+                    billing::record_usage(&context, &filtered_flags, team.id).await;
+                }
 
-        // Comprehensive request summary
-        info!(
-            request_id = %context.request_id,
-            distinct_id = %distinct_id_for_logging,
-            team_id = team.id,
-            project_id = team.project_id,
-            flags_count = response.flags.len(),
-            flags_disabled = request.is_flags_disabled(),
-            quota_limited = response.quota_limited.is_some(),
-            duration_ms = total_duration.as_millis(),
-            slow_request = total_duration.as_millis() > 1000,
-            "Request completed"
-        );
+                response
+            };
 
-        Ok(response)
+            // build the rest of the FlagsResponse, since the caller may have passed in `&config=true` and may need additional fields
+            // beyond just feature flags
+            let response =
+                config_response_builder::build_response(flags_response, &context, &team).await?;
+
+            let total_duration = start_time.elapsed();
+
+            // Record metrics
+            let labels = [
+                (
+                    "flags_disabled".to_string(),
+                    request.is_flags_disabled().to_string(),
+                ),
+                ("team_id".to_string(), team.id.to_string()),
+            ];
+
+            inc(FLAG_REQUESTS_COUNTER, &labels, 1);
+
+            histogram(
+                FLAG_REQUESTS_LATENCY,
+                &labels,
+                total_duration.as_millis() as f64,
+            );
+
+            // Comprehensive request summary
+            info!(
+                request_id = %context.request_id,
+                distinct_id = %distinct_id_for_logging,
+                team_id = team.id,
+                project_id = team.project_id,
+                flags_count = response.flags.len(),
+                flags_disabled = request.is_flags_disabled(),
+                quota_limited = response.quota_limited.is_some(),
+                duration_ms = total_duration.as_millis(),
+                slow_request = total_duration.as_millis() > 1000,
+                "Request completed"
+            );
+
+            Ok(response)
+        }
+        .await
+    };
+
+    // Track 5XX errors with team_id if available
+    if let Err(ref e) = result {
+        if e.is_5xx() {
+            let team_label = match team_id_for_metrics {
+                Some(id) => id.to_string(),
+                None => "not_available".to_string(),
+            };
+            inc(
+                FLAG_REQUEST_FAULTS_COUNTER,
+                &[("team_id".to_string(), team_label)],
+                1,
+            );
+        }
     }
-    .await
+
+    result
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -31,148 +31,146 @@ use tracing::{info, instrument, warn};
 pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, FlagError> {
     let mut team_id_for_metrics: Option<i32> = None;
 
-    let result: Result<FlagsResponse, FlagError> = {
-        let team_id_ref = &mut team_id_for_metrics;
-        async move {
-            let start_time = std::time::Instant::now();
+    let team_id_ref = &mut team_id_for_metrics;
+    let result: Result<FlagsResponse, FlagError> = async move {
+        let start_time = std::time::Instant::now();
 
-            let flag_service = FlagService::new(
-                context.state.redis_reader.clone(),
-                context.state.redis_writer.clone(),
-                context.state.database_pools.non_persons_reader.clone(),
-            );
+        let flag_service = FlagService::new(
+            context.state.redis_reader.clone(),
+            context.state.redis_writer.clone(),
+            context.state.database_pools.non_persons_reader.clone(),
+        );
 
-            let (original_distinct_id, verified_token, request) =
-                authentication::parse_and_authenticate(&context, &flag_service).await?;
+        let (original_distinct_id, verified_token, request) =
+            authentication::parse_and_authenticate(&context, &flag_service).await?;
 
-            let distinct_id_for_logging = original_distinct_id
-                .clone()
-                .unwrap_or_else(|| "disabled".to_string());
+        let distinct_id_for_logging = original_distinct_id
+            .clone()
+            .unwrap_or_else(|| "disabled".to_string());
 
-            tracing::debug!(
-                "Authentication completed for distinct_id: {}",
-                distinct_id_for_logging
-            );
+        tracing::debug!(
+            "Authentication completed for distinct_id: {}",
+            distinct_id_for_logging
+        );
 
-            let team = flag_service
-                .get_team_from_cache_or_pg(&verified_token)
-                .await?;
+        let team = flag_service
+            .get_team_from_cache_or_pg(&verified_token)
+            .await?;
 
-            let team_id = team.id;
-            *team_id_ref = Some(team_id);
+        let team_id = team.id;
+        *team_id_ref = Some(team_id);
 
-            tracing::debug!(
-                "Team fetched: team_id={}, project_id={}",
+        tracing::debug!(
+            "Team fetched: team_id={}, project_id={}",
+            team.id,
+            team.project_id
+        );
+
+        // Early exit if flags are disabled
+        let flags_response = if request.is_flags_disabled() {
+            FlagsResponse::new(false, HashMap::new(), None, context.request_id)
+        } else if let Some(quota_limited_response) =
+            billing::check_limits(&context, &verified_token).await?
+        {
+            warn!("Request quota limited");
+            quota_limited_response
+        } else {
+            let distinct_id = cookieless::handle_distinct_id(
+                &context,
+                &request,
+                &team,
+                original_distinct_id
+                    .expect("distinct_id should be present when flags are not disabled"),
+            )
+            .await?;
+
+            tracing::debug!("Distinct ID resolved: {}", distinct_id);
+
+            let (filtered_flags, had_flag_errors) = flags::fetch_and_filter(
+                &flag_service,
+                team.project_id,
+                &context.meta,
+                &context.headers,
+                None,
+                request.evaluation_environments.as_ref(),
+            )
+            .await?;
+
+            tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
+
+            let property_overrides = properties::prepare_overrides(&context, &request)?;
+
+            // Evaluate flags (this will return empty if is_flags_disabled is true)
+            let mut response = flags::evaluate_for_request(
+                &context.state,
                 team.id,
-                team.project_id
-            );
+                team.project_id,
+                distinct_id.clone(),
+                filtered_flags.clone(),
+                property_overrides.person_properties,
+                property_overrides.group_properties,
+                property_overrides.groups,
+                property_overrides.hash_key,
+                context.request_id,
+                request.is_flags_disabled(),
+                request.flag_keys.clone(),
+            )
+            .await;
 
-            // Early exit if flags are disabled
-            let flags_response = if request.is_flags_disabled() {
-                FlagsResponse::new(false, HashMap::new(), None, context.request_id)
-            } else if let Some(quota_limited_response) =
-                billing::check_limits(&context, &verified_token).await?
-            {
-                warn!("Request quota limited");
-                quota_limited_response
-            } else {
-                let distinct_id = cookieless::handle_distinct_id(
-                    &context,
-                    &request,
-                    &team,
-                    original_distinct_id
-                        .expect("distinct_id should be present when flags are not disabled"),
-                )
-                .await?;
+            // Set error flag if there were deserialization errors
+            if had_flag_errors {
+                response.errors_while_computing_flags = true;
+            }
 
-                tracing::debug!("Distinct ID resolved: {}", distinct_id);
+            // Only record billing if flags are not disabled
+            if !request.is_flags_disabled() {
+                billing::record_usage(&context, &filtered_flags, team.id).await;
+            }
 
-                let (filtered_flags, had_flag_errors) = flags::fetch_and_filter(
-                    &flag_service,
-                    team.project_id,
-                    &context.meta,
-                    &context.headers,
-                    None,
-                    request.evaluation_environments.as_ref(),
-                )
-                .await?;
+            response
+        };
 
-                tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
+        // build the rest of the FlagsResponse, since the caller may have passed in `&config=true` and may need additional fields
+        // beyond just feature flags
+        let response =
+            config_response_builder::build_response(flags_response, &context, &team).await?;
 
-                let property_overrides = properties::prepare_overrides(&context, &request)?;
+        let total_duration = start_time.elapsed();
 
-                // Evaluate flags (this will return empty if is_flags_disabled is true)
-                let mut response = flags::evaluate_for_request(
-                    &context.state,
-                    team.id,
-                    team.project_id,
-                    distinct_id.clone(),
-                    filtered_flags.clone(),
-                    property_overrides.person_properties,
-                    property_overrides.group_properties,
-                    property_overrides.groups,
-                    property_overrides.hash_key,
-                    context.request_id,
-                    request.is_flags_disabled(),
-                    request.flag_keys.clone(),
-                )
-                .await;
+        // Record metrics
+        let labels = [
+            (
+                "flags_disabled".to_string(),
+                request.is_flags_disabled().to_string(),
+            ),
+            ("team_id".to_string(), team.id.to_string()),
+        ];
 
-                // Set error flag if there were deserialization errors
-                if had_flag_errors {
-                    response.errors_while_computing_flags = true;
-                }
+        inc(FLAG_REQUESTS_COUNTER, &labels, 1);
 
-                // Only record billing if flags are not disabled
-                if !request.is_flags_disabled() {
-                    billing::record_usage(&context, &filtered_flags, team.id).await;
-                }
+        histogram(
+            FLAG_REQUESTS_LATENCY,
+            &labels,
+            total_duration.as_millis() as f64,
+        );
 
-                response
-            };
+        // Comprehensive request summary
+        info!(
+            request_id = %context.request_id,
+            distinct_id = %distinct_id_for_logging,
+            team_id = team.id,
+            project_id = team.project_id,
+            flags_count = response.flags.len(),
+            flags_disabled = request.is_flags_disabled(),
+            quota_limited = response.quota_limited.is_some(),
+            duration_ms = total_duration.as_millis(),
+            slow_request = total_duration.as_millis() > 1000,
+            "Request completed"
+        );
 
-            // build the rest of the FlagsResponse, since the caller may have passed in `&config=true` and may need additional fields
-            // beyond just feature flags
-            let response =
-                config_response_builder::build_response(flags_response, &context, &team).await?;
-
-            let total_duration = start_time.elapsed();
-
-            // Record metrics
-            let labels = [
-                (
-                    "flags_disabled".to_string(),
-                    request.is_flags_disabled().to_string(),
-                ),
-                ("team_id".to_string(), team.id.to_string()),
-            ];
-
-            inc(FLAG_REQUESTS_COUNTER, &labels, 1);
-
-            histogram(
-                FLAG_REQUESTS_LATENCY,
-                &labels,
-                total_duration.as_millis() as f64,
-            );
-
-            // Comprehensive request summary
-            info!(
-                request_id = %context.request_id,
-                distinct_id = %distinct_id_for_logging,
-                team_id = team.id,
-                project_id = team.project_id,
-                flags_count = response.flags.len(),
-                flags_disabled = request.is_flags_disabled(),
-                quota_limited = response.quota_limited.is_some(),
-                duration_ms = total_duration.as_millis(),
-                slow_request = total_duration.as_millis() > 1000,
-                "Request completed"
-            );
-
-            Ok(response)
-        }
-        .await
-    };
+        Ok(response)
+    }
+    .await;
 
     // Track 5XX errors with team_id if available
     // If the team_id is not available, it means the error occurred before or during the team fetch

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -19,6 +19,7 @@ pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
 pub const FLAG_REQUESTS_COUNTER: &str = "flags_requests_total";
 pub const FLAG_REQUESTS_LATENCY: &str = "flags_requests_duration_ms";
+pub const FLAG_REQUEST_FAULTS_COUNTER: &str = "flags_request_faults_total";
 
 // Performance monitoring
 pub const DB_CONNECTION_POOL_ACTIVE_COUNTER: &str = "flags_db_connection_pool_active_total";


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We currently have metrics for latency and request count labeled with team_id, it would be nice to also have a 5XX count labeled with team_id.

https://github.com/PostHog/posthog/issues/38054

## Changes

- Add 5XX count with team_id
- Add a helper function in error.rs `is_5xx`
- Move 5XX, latency, and request counter metrics to a single helper method


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

- Unit test for error matching
- I will verify metrics are emitted in prod

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
