### PR TITLE
fix(flags): db routing bug

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1561,7 +1561,7 @@ impl FeatureFlagMatcher {
 
         if self
             .group_type_mapping_cache
-            .init(self.router.get_non_persons_reader().clone())
+            .init(self.router.get_persons_reader().clone())
             .await
             .is_err()
         {

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -292,7 +292,6 @@ mod tests {
             )
             .await;
 
-        println!("Flags: {:?}", result.flags);
 
         let legacy_response = LegacyFlagsResponse::from_response(result);
         assert!(!legacy_response.errors_while_computing_flags);
@@ -5195,7 +5194,6 @@ mod tests {
             )
             .await;
 
-        println!("Flags in result: {:?}", result.flags);
 
         assert!(!result.errors_while_computing_flags);
         // The flag should evaluate using DB properties for condition 1 (which has feature_access="full")

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -292,7 +292,6 @@ mod tests {
             )
             .await;
 
-
         let legacy_response = LegacyFlagsResponse::from_response(result);
         assert!(!legacy_response.errors_while_computing_flags);
         assert_eq!(
@@ -5193,7 +5192,6 @@ mod tests {
                 None,
             )
             .await;
-
 
         assert!(!result.errors_while_computing_flags);
         // The flag should evaluate using DB properties for condition 1 (which has feature_access="full")


### PR DESCRIPTION
## Problem

There was a database routing bug in some flags matching code that was routing group type mapping look ups to the non persons database.

These are being moved to the persons database

## Changes

- Changed the cache to get initialized with the persons reader rather than the non persons reader
- removed an accidental println from a previous commit

## How did you test this code?

Unit tests

