### PR TITLE
fix(insights): Switching to a new insight in an existing insight is not showing the new insight

### DIFF
--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -494,9 +494,11 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             if (q) {
                 const validQuery = typeof q === 'string' ? parseDraftQueryFromURL(q) : q
                 if (validQuery) {
-                    validatingQuery = true
                     if (initial) {
+                        validatingQuery = true
                         actions.upgradeQuery(validQuery)
+                    } else {
+                        queryFromUrl = typeof q === 'string' ? parseDraftQueryFromURL(q) : null
                     }
                 } else {
                     console.error('Invalid query', q)

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -433,7 +433,6 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             if (insightId === 'new') {
                 insightId = `new-${values.tabId}` as InsightShortId
             }
-            const currentInsightId = values.insightId
 
             const currentScene = sceneLogic.findMounted()?.values
 
@@ -498,8 +497,8 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     if (initial) {
                         validatingQuery = true
                         actions.upgradeQuery(validQuery)
-                    } else if (currentInsightId !== insightId) {
-                        queryFromUrl = typeof q === 'string' ? parseDraftQueryFromURL(q) : null
+                    } else if (method !== 'REPLACE') {
+                        queryFromUrl = validQuery
                     }
                 } else {
                     console.error('Invalid query', q)

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -433,6 +433,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             if (insightId === 'new') {
                 insightId = `new-${values.tabId}` as InsightShortId
             }
+            const currentInsightId = values.insightId
 
             const currentScene = sceneLogic.findMounted()?.values
 
@@ -497,7 +498,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     if (initial) {
                         validatingQuery = true
                         actions.upgradeQuery(validQuery)
-                    } else {
+                    } else if (currentInsightId !== insightId) {
                         queryFromUrl = typeof q === 'string' ? parseDraftQueryFromURL(q) : null
                     }
                 } else {


### PR DESCRIPTION
## Problem

When trying to view funnel in a paths insight, we get an empty screen: 


https://github.com/user-attachments/assets/75db7524-b237-4f0a-96eb-d3f47a2553fe

There are two issues:
1) `validatingQuery` should be set to `true` only when we are upgrading the query
2) We should update `queryFromUrl` to the latest query that is from the url `parseDraftQueryFromURL(q)`

## Changes


https://github.com/user-attachments/assets/39c4fa05-a3c8-4e0d-a20d-9499c65a877e



## How did you test this code?

1) Go to a paths insight
2) Click on one of the path card's triple dots icon
3) Select `View Funnel`
4) You should be redirected to a funnel insight 
