### PR TITLE
fix(ingestion): Issue with malformed transform properties

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -648,7 +648,7 @@ describe('HogTransformer', () => {
             expect(result.event?.properties).not.toHaveProperty('$transformations_failed')
         })
 
-        it('should preserve existing transformation results when adding new ones', async () => {
+        it('should ignore existing transformation results when adding new ones', async () => {
             const successTemplate: HogFunctionTemplate = {
                 free: true,
                 status: 'beta',
@@ -685,7 +685,7 @@ describe('HogTransformer', () => {
                     event: 'test',
                     properties: {
                         $transformations_succeeded: ['Previous Success (prev-id)'],
-                        $transformations_failed: ['Previous Failure (prev-id)'],
+                        $transformations_failed: {}, // malformed value
                     },
                 },
                 teamId
@@ -695,10 +695,9 @@ describe('HogTransformer', () => {
 
             // Verify new results are appended to existing ones
             expect(result?.event?.properties?.$transformations_succeeded).toEqual([
-                'Previous Success (prev-id)',
                 `Success Template (${successFunction.id})`,
             ])
-            expect(result?.event?.properties?.$transformations_failed).toEqual(['Previous Failure (prev-id)'])
+            expect(result?.event?.properties?.$transformations_failed).toEqual(undefined)
         })
 
         it('should track skipped transformations when filter does not match', async () => {
@@ -740,7 +739,6 @@ describe('HogTransformer', () => {
                     event: 'does-not-match-me',
                     properties: {
                         original: true,
-                        $transformations_skipped: ['Previous Skip (prev-id)'],
                     },
                 },
                 teamId
@@ -751,7 +749,6 @@ describe('HogTransformer', () => {
             // Verify transformation was skipped and tracked
             expect(result.event?.properties?.should_not_be_set).toBeUndefined()
             expect(result.event?.properties?.$transformations_skipped).toEqual([
-                'Previous Skip (prev-id)',
                 `${hogFunction.name} (${hogFunction.id})`,
             ])
             expect(result.event?.properties?.original).toBe(true)

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -146,6 +146,15 @@ export class HogTransformerService {
     }
 
     public transformEvent(event: PluginEvent, teamHogFunctions: HogFunctionType[]): Promise<TransformationResult> {
+        // Sanitize transform event properties
+        if (event.properties) {
+            for (const key of ['$transformations_failed', '$transformations_skipped', '$transformations_succeeded']) {
+                if (key in event.properties) {
+                    delete event.properties[key]
+                }
+            }
+        }
+
         return instrumentFn(`hogTransformer.transformEvent`, async () => {
             hogTransformationInvocations.inc()
             const results: CyclotronJobInvocationResult[] = []

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -149,9 +149,9 @@ export class HogTransformerService {
         return instrumentFn(`hogTransformer.transformEvent`, async () => {
             hogTransformationInvocations.inc()
             const results: CyclotronJobInvocationResult[] = []
-            const transformationsSucceeded: string[] = event.properties?.$transformations_succeeded || []
-            const transformationsFailed: string[] = event.properties?.$transformations_failed || []
-            const transformationsSkipped: string[] = event.properties?.$transformations_skipped || []
+            const transformationsSucceeded: string[] = []
+            const transformationsFailed: string[] = []
+            const transformationsSkipped: string[] = []
 
             const shouldRunHogWatcher = Math.random() < this.hub.CDP_HOG_WATCHER_SAMPLE_RATE
 


### PR DESCRIPTION
## Problem

We had dropped messages due to errors assuming the type of the property being referenced. We don't ever need to preserve these values and as $ props they are protected for our usage so we don't need to keep them.

## Changes

* Ensure the properties are removed before we start the transforms
* Fix tests

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
