### PR TITLE
fix(survey): Allow user to create dynamic cohort through a survey

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -11,6 +11,7 @@ import { SceneCommonButtons } from 'lib/components/Scenes/SceneCommonButtons'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { IconCohort } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
@@ -53,8 +54,15 @@ const RESOURCE_TYPE = 'survey'
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const { survey, surveyLoading } = useValues(surveyLogic)
-    const { editingSurvey, updateSurvey, stopSurvey, resumeSurvey, duplicateSurvey, setIsDuplicateToProjectModalOpen } =
-        useActions(surveyLogic)
+    const {
+        editingSurvey,
+        updateSurvey,
+        stopSurvey,
+        resumeSurvey,
+        duplicateSurvey,
+        setIsDuplicateToProjectModalOpen,
+        createDynamicCohortForSurvey,
+    } = useActions(surveyLogic)
     const { deleteSurvey } = useActions(surveysLogic)
     const { isOnNewEmptyStateExperiment } = useValues(surveysLogic)
     const { currentOrganization } = useValues(organizationLogic)
@@ -103,6 +111,15 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                         </ScenePanelInfoSection>
                         <ScenePanelDivider />
                         <ScenePanelActionsSection>
+                            <ButtonPrimitive
+                                onClick={() => createDynamicCohortForSurvey()}
+                                disabledReasons={{
+                                    'New survey cannot create cohort': survey.id === 'new',
+                                }}
+                                menuItem
+                            >
+                                <IconCohort /> Create dynamic cohort
+                            </ButtonPrimitive>
                             <ButtonPrimitive
                                 menuItem
                                 variant="danger"

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1007,18 +1007,24 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
                 const toastId = `create-dynamic-cohort-for-survey${values.survey.id}-${Date.now()}`
                 lemonToast.info('Creating cohort...', { toastId, autoClose: false })
-                const cohortFormData = createDynamicCohortFormData(values.survey as Survey)
-                const cohort = await api.cohorts.create(cohortFormData as Partial<CohortType>)
-                lemonToast.dismiss(toastId)
-                lemonToast.success('Cohort created. Please wait up to a few minutes for it to be calculated', {
-                    toastId: `cohort-created-${cohort.id}`,
-                    button: {
-                        label: 'View cohort',
-                        action: () => {
-                            router.actions.push(urls.cohort(cohort.id))
+                try {
+                    const cohortFormData = createDynamicCohortFormData(values.survey as Survey)
+                    const cohort = await api.cohorts.create(cohortFormData as Partial<CohortType>)
+                    lemonToast.dismiss(toastId)
+                    lemonToast.success('Cohort created. Please wait up to a few minutes for it to be calculated', {
+                        toastId: `cohort-created-${cohort.id}`,
+                        button: {
+                            label: 'View cohort',
+                            action: () => {
+                                router.actions.push(urls.cohort(cohort.id))
+                            },
                         },
-                    },
-                })
+                    })
+                } catch (error: any) {
+                    lemonToast.dismiss(toastId)
+                    lemonToast.error('Failed to create cohort. Please try again.')
+                    console.error('Cohort creation failed:', error)
+                }
             },
         }
     }),

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -615,3 +615,44 @@ export function buildSurveyTimestampFilter(
     return `AND timestamp >= '${fromDate}'
     AND timestamp <= '${toDate}'`
 }
+
+export function createDynamicCohortFormData(survey: Survey): FormData {
+    const cohortName = `Cohort for ${survey.name}`
+
+    const cohortFormData = new FormData()
+
+    cohortFormData.append('name', cohortName)
+
+    const filters = JSON.stringify({
+        properties: {
+            type: 'OR',
+            values: [
+                {
+                    type: 'OR',
+                    values: [
+                        {
+                            type: 'behavioral',
+                            value: 'performed_event',
+                            negation: false,
+                            key: 'survey sent',
+                            event_type: 'events',
+                            event_filters: [
+                                {
+                                    key: '$survey_id',
+                                    value: [`${survey.id}`],
+                                    operator: 'exact',
+                                    type: 'event',
+                                },
+                            ],
+                            explicit_datetime: survey.created_at,
+                        },
+                    ],
+                },
+            ],
+        },
+    })
+
+    cohortFormData.append('filters', filters)
+
+    return cohortFormData
+}


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/38518

## Changes


https://github.com/user-attachments/assets/dbe6702a-577c-4739-94f4-6a4f64b7917f

### Alternative
We could create a static cohort too, but the issue is that it would be harder for them to update the cohort when new surveys are sent.

## How did you test this code?

1) Go to a survey with some results
2) Click on the three dots menu on the top left 
3) Select `Create dynamic cohort`
4) You should see the toast messages and be able to visit the newly created cohort 

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

Yes, hmmm do I have to update any docs for this feature? 