### PR TITLE
feat(capture): add event and uuid kafka headers

### DIFF
--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -189,6 +189,7 @@ mod tests {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
                 computed_timestamp: None,
+                event_name: "test_event".to_string(),
             },
         };
 
@@ -227,6 +228,7 @@ mod tests {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
                 computed_timestamp: None,
+                event_name: "test_event".to_string(),
             },
         };
 

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -242,6 +242,8 @@ impl KafkaSink {
         let event_key = event.key();
         let session_id = metadata.session_id.clone();
         let distinct_id = event.distinct_id.clone();
+        let uuid = event.uuid.to_string();
+        let event_name = metadata.event_name.clone();
 
         drop(event); // Events can be EXTREMELY memory hungry
 
@@ -320,6 +322,14 @@ impl KafkaSink {
                     .insert(Header {
                         key: "timestamp",
                         value: computed_timestamp.map(|ts| ts.to_string()).as_deref(),
+                    })
+                    .insert(Header {
+                        key: "event",
+                        value: Some(&event_name),
+                    })
+                    .insert(Header {
+                        key: "uuid",
+                        value: Some(&uuid),
                     }),
             ),
         }) {
@@ -501,6 +511,7 @@ mod tests {
             data_type: DataType::AnalyticsMain,
             session_id: None,
             computed_timestamp: None,
+            event_name: "test_event".to_string(),
         };
 
         let event = ProcessedEvent {

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -331,6 +331,7 @@ mod tests {
                 data_type: DataType::AnalyticsMain,
                 session_id: None,
                 computed_timestamp: None,
+                event_name: "test_event".to_string(),
             },
         }
     }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -458,6 +458,7 @@ pub fn process_single_event(
         data_type,
         session_id: None,
         computed_timestamp: Some(computed_timestamp),
+        event_name: event.event.clone(),
     };
 
     let event = CapturedEvent {
@@ -648,6 +649,7 @@ pub async fn process_replay_events<'a>(
         data_type: DataType::SnapshotMain,
         session_id: Some(session_id_str.to_string()),
         computed_timestamp: Some(computed_timestamp), // Use computed event timestamp
+        event_name: "$snapshot_items".to_string(),
     };
 
     let event = CapturedEvent {

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -420,6 +420,7 @@ pub struct ProcessedEventMetadata {
     pub data_type: DataType,
     pub session_id: Option<String>,
     pub computed_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub event_name: String,
 }
 
 #[cfg(test)]

--- a/rust/capture/tests/kafka_headers.rs
+++ b/rust/capture/tests/kafka_headers.rs
@@ -317,13 +317,11 @@ async fn it_adds_event_and_generated_uuid_headers() -> Result<()> {
     // Basic UUID format validation
     assert!(
         uuid_header.len() == 36,
-        "UUID should be 36 characters long, got: {}",
-        uuid_header
+        "UUID should be 36 characters long, got: {uuid_header}"
     );
     assert!(
         uuid_header.contains('-'),
-        "UUID should contain dashes, got: {}",
-        uuid_header
+        "UUID should contain dashes, got: {uuid_header}"
     );
 
     Ok(())

--- a/rust/capture/tests/kafka_headers.rs
+++ b/rust/capture/tests/kafka_headers.rs
@@ -202,3 +202,244 @@ async fn it_adds_timestamp_header_with_clock_skew_correction() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn it_adds_event_and_uuid_headers_to_kafka_messages() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+    let event_name = "test_event_with_headers";
+    let uuid = "550e8400-e29b-41d4-a716-446655440000"; // Test with explicit UUID
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    // Test with explicit event name and UUID
+    let event = json!({
+        "token": token,
+        "event": event_name,
+        "distinct_id": distinct_id,
+        "uuid": uuid
+    });
+
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Get both event data and headers from the same message
+    let (event_data, headers) = main_topic.next_message_with_headers()?;
+
+    // Check that the event was processed correctly
+    assert!(event_data.is_object(), "Event should be a JSON object");
+    let event_obj = event_data.as_object().unwrap();
+    assert_eq!(event_obj.get("token").unwrap().as_str().unwrap(), token);
+    assert_eq!(
+        event_obj.get("distinct_id").unwrap().as_str().unwrap(),
+        distinct_id
+    );
+
+    // Verify event header exists and matches
+    assert!(
+        headers.contains_key("event"),
+        "Missing 'event' header. Available headers: {:?}",
+        headers.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        headers.get("event").unwrap(),
+        event_name,
+        "Event header should match the event name"
+    );
+
+    // Verify uuid header exists and matches
+    assert!(
+        headers.contains_key("uuid"),
+        "Missing 'uuid' header. Available headers: {:?}",
+        headers.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        headers.get("uuid").unwrap(),
+        uuid,
+        "UUID header should match the provided UUID"
+    );
+
+    // Verify other expected headers are still present
+    assert_eq!(headers.get("token").unwrap(), &token);
+    assert_eq!(headers.get("distinct_id").unwrap(), &distinct_id);
+    assert!(headers.contains_key("timestamp"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_adds_event_and_generated_uuid_headers() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+    let event_name = "test_event_generated_uuid";
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    // Test without providing UUID - should generate one
+    let event = json!({
+        "token": token,
+        "event": event_name,
+        "distinct_id": distinct_id
+    });
+
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Get both event data and headers from the same message
+    let (event_data, headers) = main_topic.next_message_with_headers()?;
+
+    // Check that the event was processed correctly
+    assert!(event_data.is_object(), "Event should be a JSON object");
+    let event_obj = event_data.as_object().unwrap();
+    assert_eq!(event_obj.get("token").unwrap().as_str().unwrap(), token);
+
+    // Verify event header
+    assert_eq!(
+        headers.get("event").unwrap(),
+        event_name,
+        "Event header should match the event name"
+    );
+
+    // Verify uuid header exists and is a valid UUID
+    assert!(
+        headers.contains_key("uuid"),
+        "Missing 'uuid' header. Available headers: {:?}",
+        headers.keys().collect::<Vec<_>>()
+    );
+    
+    let uuid_header = headers.get("uuid").unwrap();
+    // Basic UUID format validation
+    assert!(
+        uuid_header.len() == 36,
+        "UUID should be 36 characters long, got: {}",
+        uuid_header
+    );
+    assert!(
+        uuid_header.contains('-'),
+        "UUID should contain dashes, got: {}",
+        uuid_header
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_adds_correct_headers_for_special_events() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    // Test with $identify event (special case from engage endpoint)
+    let event = json!({
+        "token": token,
+        "event": "$identify",
+        "distinct_id": distinct_id,
+        "$set": {"email": "test@example.com"}
+    });
+
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let (_, headers) = main_topic.next_message_with_headers()?;
+
+    // Verify the $identify event name is in the header
+    assert_eq!(
+        headers.get("event").unwrap(),
+        "$identify",
+        "Event header should be $identify"
+    );
+
+    // Test with $pageview event
+    let pageview_event = json!({
+        "token": token,
+        "event": "$pageview",
+        "distinct_id": distinct_id,
+        "properties": {"$current_url": "https://example.com"}
+    });
+
+    let res = server.capture_events(pageview_event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let (_, headers) = main_topic.next_message_with_headers()?;
+
+    assert_eq!(
+        headers.get("event").unwrap(),
+        "$pageview",
+        "Event header should be $pageview"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_adds_correct_headers_for_snapshot_events() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+    let session_id = "550e8400-e29b-41d4-a716-446655440001";
+    let window_id = random_string("window", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_recordings(&main_topic).await;
+
+    // Test with snapshot event
+    let event = json!([{
+        "token": token,
+        "event": "$snapshot",
+        "distinct_id": distinct_id,
+        "properties": {
+            "$session_id": session_id,
+            "$window_id": window_id,
+            "$snapshot_data": [{"type": 2, "data": {"source": 0}}]
+        }
+    }]);
+
+    let res = server.capture_recording(event.to_string(), None).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Get message from snapshot topic 
+    let (event_data, headers) = main_topic.next_message_with_headers()?;
+
+    // Check that the event was transformed correctly
+    assert!(event_data.is_object(), "Event should be a JSON object");
+    let event_obj = event_data.as_object().unwrap();
+    
+    // Check event data contains the expected fields
+    let data = serde_json::from_str::<serde_json::Value>(event_obj.get("data").unwrap().as_str().unwrap())?;
+    assert_eq!(
+        data.get("event").unwrap().as_str().unwrap(),
+        "$snapshot_items",
+        "Snapshot events should be transformed to $snapshot_items"
+    );
+
+    // Verify event header is set to $snapshot_items
+    assert_eq!(
+        headers.get("event").unwrap(),
+        "$snapshot_items",
+        "Event header should be $snapshot_items for snapshot events"
+    );
+
+    // Verify uuid header exists
+    assert!(
+        headers.contains_key("uuid"),
+        "Missing 'uuid' header. Available headers: {:?}",
+        headers.keys().collect::<Vec<_>>()
+    );
+
+    // Verify other headers
+    assert_eq!(headers.get("token").unwrap(), &token);
+    assert_eq!(headers.get("distinct_id").unwrap(), &distinct_id);
+    assert!(headers.contains_key("timestamp"));
+
+    Ok(())
+}

--- a/rust/capture/tests/kafka_headers.rs
+++ b/rust/capture/tests/kafka_headers.rs
@@ -312,7 +312,7 @@ async fn it_adds_event_and_generated_uuid_headers() -> Result<()> {
         "Missing 'uuid' header. Available headers: {:?}",
         headers.keys().collect::<Vec<_>>()
     );
-    
+
     let uuid_header = headers.get("uuid").unwrap();
     // Basic UUID format validation
     assert!(
@@ -407,15 +407,17 @@ async fn it_adds_correct_headers_for_snapshot_events() -> Result<()> {
     let res = server.capture_recording(event.to_string(), None).await;
     assert_eq!(StatusCode::OK, res.status());
 
-    // Get message from snapshot topic 
+    // Get message from snapshot topic
     let (event_data, headers) = main_topic.next_message_with_headers()?;
 
     // Check that the event was transformed correctly
     assert!(event_data.is_object(), "Event should be a JSON object");
     let event_obj = event_data.as_object().unwrap();
-    
+
     // Check event data contains the expected fields
-    let data = serde_json::from_str::<serde_json::Value>(event_obj.get("data").unwrap().as_str().unwrap())?;
+    let data = serde_json::from_str::<serde_json::Value>(
+        event_obj.get("data").unwrap().as_str().unwrap(),
+    )?;
     assert_eq!(
         data.get("event").unwrap().as_str().unwrap(),
         "$snapshot_items",


### PR DESCRIPTION
## Problem

We'd like to be able to access event names and uuids without parsing the whole Kafka message payloads to handle event restrictions, redirects and DLQ more efficiently.

## Changes

Adds `event` and `uuid` Kafka headers.

## How did you test this code?

Added unit and integration tests.
