### PR TITLE
feat(wip): dedupe async queries

### DIFF
--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -34,7 +34,6 @@ from posthog.schema import (
 from posthog.hogql.constants import LimitContext
 
 from posthog.api.services.query import process_query_dict
-from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.property_definition import PropertyDefinition, PropertyType
 from posthog.models.utils import UUIDT
@@ -1088,100 +1087,6 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         assert isinstance(updated_query, RetentionQuery)
         assert updated_query.version == 2
         assert updated_query.retentionFilter.meanRetentionCalculation == MeanRetentionCalculation.SIMPLE
-
-    def test_query_deduplication_prevents_duplicate_execution(self):
-        """Test that identical queries are deduplicated and only one execution occurs."""
-        from posthog.schema import HogQLQuery
-
-        with freeze_time("2020-01-10 12:00:00"):
-            _create_person(
-                properties={"email": "test@posthog.com"},
-                distinct_ids=["test-user"],
-                team=self.team,
-                immediate=True,
-            )
-            _create_event(
-                team=self.team,
-                event="test_event",
-                distinct_id="test-user",
-                properties={"value": 42},
-            )
-        flush_persons_and_events()
-
-        query = HogQLQuery(query="SELECT count() FROM events WHERE event = 'test_event'")
-        query_data = {"query": query.model_dump(), "refresh": ExecutionMode.CALCULATE_ASYNC_ALWAYS}
-
-        with freeze_time("2020-01-10 12:14:00"):
-            response1 = self.client.post(f"/api/environments/{self.team.id}/query/", query_data)
-            response2 = self.client.post(f"/api/environments/{self.team.id}/query/", query_data)
-            response3 = self.client.post(f"/api/environments/{self.team.id}/query/", query_data)
-
-        self.assertEqual(response1.status_code, 202)
-        self.assertEqual(response2.status_code, 202)
-        self.assertEqual(response3.status_code, 202)
-
-        response1_data = response1.json()
-        response2_data = response2.json()
-        response3_data = response3.json()
-
-        query_id1 = response1_data["query_status"]["id"]
-        query_id2 = response2_data["query_status"]["id"]
-        query_id3 = response3_data["query_status"]["id"]
-
-        self.assertEqual(query_id1, query_id2, "First and second queries should have same ID")
-        self.assertEqual(query_id2, query_id3, "Second and third queries should have same ID")
-
-        self.assertIsNotNone(query_id1)
-        self.assertNotEqual(query_id1, "unknown")
-
-    def test_query_deduplication_different_queries_not_deduplicated(self):
-        """Test that different queries are not deduplicated."""
-        from posthog.schema import HogQLQuery
-
-        with freeze_time("2020-01-10 12:00:00"):
-            _create_person(
-                properties={"email": "test@posthog.com"},
-                distinct_ids=["test-user"],
-                team=self.team,
-                immediate=True,
-            )
-            _create_event(
-                team=self.team,
-                event="test_event",
-                distinct_id="test-user",
-                properties={"value": 42},
-            )
-        flush_persons_and_events()
-
-        query1 = HogQLQuery(query="SELECT count() FROM events WHERE event = 'test_event'")
-        query2 = HogQLQuery(query="SELECT count() FROM events WHERE event = 'other_event'")
-        query3 = HogQLQuery(query="SELECT count() FROM events WHERE properties.value = 42")
-
-        with freeze_time("2020-01-10 12:14:00"):
-            response1 = self.client.post(
-                f"/api/environments/{self.team.id}/query/",
-                {"query": query1.model_dump(), "refresh": ExecutionMode.CALCULATE_ASYNC_ALWAYS},
-            )
-            response2 = self.client.post(
-                f"/api/environments/{self.team.id}/query/",
-                {"query": query2.model_dump(), "refresh": ExecutionMode.CALCULATE_ASYNC_ALWAYS},
-            )
-            response3 = self.client.post(
-                f"/api/environments/{self.team.id}/query/",
-                {"query": query3.model_dump(), "refresh": ExecutionMode.CALCULATE_ASYNC_ALWAYS},
-            )
-
-        self.assertEqual(response1.status_code, 202)
-        self.assertEqual(response2.status_code, 202)
-        self.assertEqual(response3.status_code, 202)
-
-        query_id1 = response1.json()["query_status"]["id"]
-        query_id2 = response2.json()["query_status"]["id"]
-        query_id3 = response3.json()["query_status"]["id"]
-
-        self.assertNotEqual(query_id1, query_id2, "Different queries should have different IDs")
-        self.assertNotEqual(query_id2, query_id3, "Different queries should have different IDs")
-        self.assertNotEqual(query_id1, query_id3, "Different queries should have different IDs")
 
 
 class TestQueryRetrieve(APIBaseTest):

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -50,7 +50,9 @@ class QueryRetrievalError(Exception):
 
 class QueryStatusManager:
     STATUS_TTL_SECONDS = 60 * 20  # 20 minutes
+    DEDUP_TTL_SECONDS = 60 * 60  # 20 minutes
     KEY_PREFIX_ASYNC_RESULTS = "query_async"
+    KEY_PREFIX_RUNNING_QUERIES = "running_queries"
 
     def __init__(self, query_id: str, team_id: int):
         self.redis_client = redis.get_client()
@@ -64,6 +66,10 @@ class QueryStatusManager:
     @property
     def clickhouse_query_status_key(self) -> str:
         return f"{self.KEY_PREFIX_ASYNC_RESULTS}:{self.team_id}:{self.query_id}:status"
+
+    @property
+    def running_queries_key(self) -> str:
+        return f"{self.KEY_PREFIX_RUNNING_QUERIES}:{self.team_id}"
 
     def store_query_status(self, query_status: QueryStatus):
         value = SafeJSONRenderer().render(query_status.model_dump(exclude={"clickhouse_query_progress"}))
@@ -140,6 +146,34 @@ class QueryStatusManager:
         logger.info("Deleting redis query key %s", self.results_key)
         self.redis_client.delete(self.results_key)
         self.redis_client.delete(self.clickhouse_query_status_key)
+
+    def get_running_query_by_cache_key(self, cache_key: str) -> Optional[str]:
+        """Get the query_id of a running query with the given cache_key, if any."""
+        try:
+            query_id = self.redis_client.hget(self.running_queries_key, cache_key)
+            return query_id.decode("utf-8") if query_id else None
+        except Exception as e:
+            logger.exception("Error getting running query", cache_key=cache_key, error=str(e))
+            return None
+
+    def register_cache_key_mapping(self, cache_key: str) -> None:
+        """Register this query as running with the given cache_key."""
+        try:
+            self.redis_client.hset(self.running_queries_key, cache_key, self.query_id)
+            self.redis_client.expire(self.running_queries_key, self.DEDUP_TTL_SECONDS)
+            logger.warning("Registered running query", cache_key=cache_key, query_id=self.query_id)
+        except Exception as e:
+            logger.exception(
+                "Error registering running query", cache_key=cache_key, query_id=self.query_id, error=str(e)
+            )
+
+    def unregister_cache_key_mapping(self, cache_key: str) -> None:
+        """Unregister a query that's no longer running."""
+        try:
+            self.redis_client.hdel(self.running_queries_key, cache_key)
+            logger.warning("Unregistered running query", cache_key=cache_key)
+        except Exception as e:
+            logger.exception("Error unregistering running query", cache_key=cache_key, error=str(e))
 
 
 def execute_process_query(
@@ -222,6 +256,15 @@ def execute_process_query(
     finally:
         query_status.end_time = datetime.datetime.now(datetime.UTC)
         manager.store_query_status(query_status)
+        try:
+            cache_key = None
+            if query_status.results:
+                cache_key = query_status.results.get("cache_key")
+
+            if cache_key:
+                manager.unregister_cache_key_mapping(cache_key)
+        except Exception as e:
+            logger.exception("Error cleaning up deduplication tracking", team_id=team_id, error=str(e))
 
 
 def enqueue_process_query_task(
@@ -232,6 +275,7 @@ def enqueue_process_query_task(
     insight_id: Optional[int] = None,
     dashboard_id: Optional[int] = None,
     query_id: Optional[str] = None,
+    cache_key: Optional[str] = None,
     # Attention: This is to pierce through the _manager_ cache, query runner will always refresh
     refresh_requested: bool = False,
     force: bool = False,
@@ -250,6 +294,20 @@ def enqueue_process_query_task(
         # If we've seen this query before return and don't resubmit it.
         return manager.get_query_status()
 
+    try:
+        if cache_key:
+            existing_query_id = manager.get_running_query_by_cache_key(cache_key)
+            if existing_query_id:
+                logger.warning(
+                    "Found duplicate running query",
+                    cache_key=cache_key,
+                    existing_query_id=existing_query_id,
+                    new_query_id=query_id,
+                )
+                return get_query_status(team.id, existing_query_id)
+    except Exception as e:
+        logger.exception("Error checking for duplicate query", team_id=team.id, error=str(e))
+
     # Immediately set status, so we don't have race with celery
     query_status = QueryStatus(
         id=query_id,
@@ -259,6 +317,12 @@ def enqueue_process_query_task(
         dashboard_id=dashboard_id,
     )
     manager.store_query_status(query_status)
+
+    if cache_key:
+        try:
+            manager.register_cache_key_mapping(cache_key)
+        except Exception as e:
+            logger.exception("Error registering running query for deduplication", team_id=team.id, error=str(e))
 
     task_signature = process_query_task.si(
         team.id, user_id, query_id, query_json, is_query_service, LimitContext.QUERY_ASYNC

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -848,6 +848,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             dashboard_id=cache_manager.dashboard_id,
             query_json=self.query.model_dump(),
             query_id=self.query_id or cache_manager.cache_key,  # Use cache key as query ID to avoid duplicates
+            cache_key=cache_manager.cache_key,
             refresh_requested=refresh_requested,
             is_query_service=self.is_query_service,
         )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

for our beloved CH cluster?

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

for async queries that are sent to Celery, first check if there's a running query with that cache_key

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

tests - which I need to add more of, and move the ones that are here around

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
