### PR TITLE
fix(spinner): constrain height only for scene level overlays

### DIFF
--- a/frontend/src/lib/lemon-ui/Spinner/Spinner.tsx
+++ b/frontend/src/lib/lemon-ui/Spinner/Spinner.tsx
@@ -87,7 +87,7 @@ export function SpinnerOverlay({
             className={twJoin(
                 'SpinnerOverlay',
                 sceneLevel && 'SpinnerOverlay--scene-level',
-                'h-[calc(100vh-var(--scene-layout-header-height))]'
+                sceneLevel && 'h-[calc(100vh-var(--scene-layout-header-height))]'
             )}
             aria-hidden={!visible}
         >


### PR DESCRIPTION
## Problem

Spinners are out of place:

<img width="2378" height="1680" alt="image" src="https://github.com/user-attachments/assets/2c928007-2e68-465b-b114-44a559b0b460" />

## Changes

Set their height only if they're scene level spinners.

![2025-09-26 15 44 24](https://github.com/user-attachments/assets/d433473e-3aba-4b04-a9c5-f2840360ea7f)


## How did you test this code?

The gif above