### PR TITLE
fix(experiments): Convert numpy types to native types in stats

### DIFF
--- a/products/experiments/stats/bayesian/utils.py
+++ b/products/experiments/stats/bayesian/utils.py
@@ -193,7 +193,8 @@ def credible_interval(posterior_mean: float, posterior_std: float, alpha: float 
     if posterior_std <= 0:
         raise StatisticError("Posterior standard deviation must be positive")
 
-    return tuple(norm.ppf([alpha / 2, 1 - alpha / 2], loc=posterior_mean, scale=posterior_std))
+    bounds = norm.ppf([alpha / 2, 1 - alpha / 2], loc=posterior_mean, scale=posterior_std)
+    return (float(bounds[0]), float(bounds[1]))
 
 
 def calculate_risk(posterior_mean: float, posterior_std: float) -> tuple[float, float]:

--- a/products/experiments/stats/frequentist/utils.py
+++ b/products/experiments/stats/frequentist/utils.py
@@ -154,11 +154,11 @@ def calculate_p_value(t_statistic: float, degrees_of_freedom: float, test_type: 
         P-value
     """
     if test_type == "two_sided":
-        return 2 * (1 - stats.t.cdf(abs(t_statistic), degrees_of_freedom))
+        return float(2 * (1 - stats.t.cdf(abs(t_statistic), degrees_of_freedom)))
     elif test_type == "greater":
-        return 1 - stats.t.cdf(t_statistic, degrees_of_freedom)
+        return float(1 - stats.t.cdf(t_statistic, degrees_of_freedom))
     elif test_type == "less":
-        return stats.t.cdf(t_statistic, degrees_of_freedom)
+        return float(stats.t.cdf(t_statistic, degrees_of_freedom))
     else:
         raise StatisticError(f"Unknown test type: {test_type}")
 
@@ -191,7 +191,7 @@ def calculate_confidence_interval(
     if test_type == "two_sided":
         t_critical = stats.t.ppf(1 - alpha / 2, degrees_of_freedom)
         margin = t_critical * standard_error
-        return (point_estimate - margin, point_estimate + margin)
+        return (float(point_estimate - margin), float(point_estimate + margin))
 
     else:
         raise StatisticError(f"Unknown test type: {test_type}")


### PR DESCRIPTION
## Problem
Experiment timeseries calculations fail when saving results to the database because stats functions return numpy types that can't be serialized.

```
dagster._core.definitions.events.Failure: Failed to compute timeseries: Object of type bool_ is not JSON serializable
```

## Changes
Convert numpy types to native Python types in the stats functions (which is what we're doing already in some stats methods).

## How did you test this code?
Locally, timeseries calculation now complete successfully.