### PR TITLE
fix(batch-exports): Improve Databricks connection error handling

### DIFF
--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest.mock import patch
 
 from products.batch_exports.backend.temporal.destinations.databricks_batch_export import (
     DatabricksClient,
@@ -177,18 +176,17 @@ async def test_get_copy_into_table_from_volume_query():
 
 async def test_connect_when_invalid_host():
     """Test that we raise an error when the host is invalid."""
-    with patch.object(DatabricksClient, "CONNECT_TIMEOUT", 0.5):
-        client = DatabricksClient(
-            server_hostname="invalid",
-            http_path="test",
-            client_id="test",
-            client_secret="test",
-            catalog="test",
-            schema="test",
-        )
-        with pytest.raises(
-            DatabricksConnectionError,
-            match="Timed out while trying to connect to Databricks. Please check that the server_hostname and http_path are valid.",
-        ):
-            async with client.connect():
-                pass
+    client = DatabricksClient(
+        server_hostname="invalid",
+        http_path="test",
+        client_id="test",
+        client_secret="test",
+        catalog="test",
+        schema="test",
+    )
+    with pytest.raises(
+        DatabricksConnectionError,
+        match="Failed to connect to Databricks. Please check that the server_hostname and http_path are valid.",
+    ):
+        async with client.connect():
+            pass


### PR DESCRIPTION
## Problem

If incorrect connection details are provided, the Databricks client will take a long time to return an error, due to a 5 min default timeout. 

## Changes

Improve error handling so that we return an error a lot sooner if invalid connection details are provided. We need to override the Databricks' `Config` class in order to customise the timeout.

I have also improved logging so any errors should be more obvious.

The tests have also been refactored slightly. 

## How did you test this code?

Automated tests.

