### PR TITLE
feat(err):  transformations in cymbal

### DIFF
--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -86,9 +86,9 @@ export function HogFunctionFilters({
         ],
     }
 
-    if (type === 'transformation') {
-        excludedProperties[TaxonomicFilterGroupType.Events] = ['$exception']
-    }
+    // if (type === 'transformation') {
+    //     excludedProperties[TaxonomicFilterGroupType.Events] = ['$exception']
+    // }
 
     const taxonomicGroupTypes = useMemo(() => {
         const types = [

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,4 +1,4 @@
 [env]
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,
 # but we use it at the workspace level here to allow use of sqlx macros across all crates
-SQLX_OFFLINE = "true"
+SQLX_OFFLINE = "false"

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,4 +1,4 @@
 [env]
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,
 # but we use it at the workspace level here to allow use of sqlx macros across all crates
-SQLX_OFFLINE = "false"
+SQLX_OFFLINE = "true"

--- a/rust/.sqlx/query-6c2d7e95b1f863b560ec921bc8000d5c4e8a87780cfee16ed0bb7f082190f22a.json
+++ b/rust/.sqlx/query-6c2d7e95b1f863b560ec921bc8000d5c4e8a87780cfee16ed0bb7f082190f22a.json
@@ -1,0 +1,140 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    id,\n                    template_id,\n                    sha,\n                    name,\n                    description,\n                    code,\n                    code_language,\n                    inputs_schema,\n                    bytecode,\n                    type,\n                    status,\n                    category,\n                    kind,\n                    free,\n                    icon_url,\n                    filters,\n                    masking,\n                    mapping_templates,\n                    mappings,\n                    created_at,\n                    updated_at\n                FROM posthog_hogfunctiontemplate\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "template_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "sha",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "code_language",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "inputs_schema",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 8,
+        "name": "bytecode",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "category",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "kind",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 13,
+        "name": "free",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "icon_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 15,
+        "name": "filters",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 16,
+        "name": "masking",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 17,
+        "name": "mapping_templates",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 18,
+        "name": "mappings",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 19,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6c2d7e95b1f863b560ec921bc8000d5c4e8a87780cfee16ed0bb7f082190f22a"
+}

--- a/rust/.sqlx/query-a559560872c93991b7c09b4736536b93e63b8866a9d972820a1f96318c2d7ed2.json
+++ b/rust/.sqlx/query-a559560872c93991b7c09b4736536b93e63b8866a9d972820a1f96318c2d7ed2.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out\n                FROM posthog_team\n                WHERE id = $1\n                LIMIT 1\n            ",
+  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out,\n                    person_display_name_properties\n                FROM posthog_team\n                WHERE id = $1\n                LIMIT 1\n            ",
   "describe": {
     "columns": [
       {
@@ -52,6 +52,11 @@
         "ordinal": 9,
         "name": "person_processing_opt_out",
         "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "person_display_name_properties",
+        "type_info": "VarcharArray"
       }
     ],
     "parameters": {
@@ -69,8 +74,9 @@
       false,
       false,
       false,
+      true,
       true
     ]
   },
-  "hash": "3afcf202ecf9f429c97848f17a0ca32edb60f3bce27bbc7f5038100ba582375c"
+  "hash": "a559560872c93991b7c09b4736536b93e63b8866a9d972820a1f96318c2d7ed2"
 }

--- a/rust/.sqlx/query-ab7f880102bab167d7ebd1bcad53b84a1688cb1aca2e5ddbbae5caeac0aade98.json
+++ b/rust/.sqlx/query-ab7f880102bab167d7ebd1bcad53b84a1688cb1aca2e5ddbbae5caeac0aade98.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    id,\n                    team_id,\n                    name,\n                    description,\n                    created_at,\n                    created_by_id,\n                    deleted,\n                    updated_at,\n                    enabled,\n                    type,\n                    kind,\n                    icon_url,\n                    hog,\n                    bytecode,\n                    transpiled,\n                    inputs_schema,\n                    inputs,\n                    encrypted_inputs,\n                    filters,\n                    mappings,\n                    masking,\n                    template_id,\n                    hog_function_template_id,\n                    execution_order\n                FROM posthog_hogfunction\n                WHERE team_id = $1 AND deleted = false AND enabled = true AND type = $2\n                ORDER BY execution_order, created_at ASC NULLS LAST -- in line with `sortHogFunctions` in plugin-server\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_by_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "kind",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "icon_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "hog",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "bytecode",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 14,
+        "name": "transpiled",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "inputs_schema",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 16,
+        "name": "inputs",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 17,
+        "name": "encrypted_inputs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "filters",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 19,
+        "name": "mappings",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 20,
+        "name": "masking",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 21,
+        "name": "template_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 22,
+        "name": "hog_function_template_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "execution_order",
+        "type_info": "Int2"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "ab7f880102bab167d7ebd1bcad53b84a1688cb1aca2e5ddbbae5caeac0aade98"
+}

--- a/rust/.sqlx/query-cbefaeb6d6b0d309471e3f7403c359e46b78afd2ca017adaaa5d1d4826b35dae.json
+++ b/rust/.sqlx/query-cbefaeb6d6b0d309471e3f7403c359e46b78afd2ca017adaaa5d1d4826b35dae.json
@@ -1,0 +1,142 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    id,\n                    template_id,\n                    sha,\n                    name,\n                    description,\n                    code,\n                    code_language,\n                    inputs_schema,\n                    bytecode,\n                    type,\n                    status,\n                    category,\n                    kind,\n                    free,\n                    icon_url,\n                    filters,\n                    masking,\n                    mapping_templates,\n                    mappings,\n                    created_at,\n                    updated_at\n                FROM posthog_hogfunctiontemplate\n                WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "template_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "sha",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "code_language",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "inputs_schema",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 8,
+        "name": "bytecode",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "category",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "kind",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 13,
+        "name": "free",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "icon_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 15,
+        "name": "filters",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 16,
+        "name": "masking",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 17,
+        "name": "mapping_templates",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 18,
+        "name": "mappings",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 19,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "cbefaeb6d6b0d309471e3f7403c359e46b78afd2ca017adaaa5d1d4826b35dae"
+}

--- a/rust/.sqlx/query-eefee4f8da63fa58479a7e76816a4d2320be2aae5af2cf1c5cbba906470eaff0.json
+++ b/rust/.sqlx/query-eefee4f8da63fa58479a7e76816a4d2320be2aae5af2cf1c5cbba906470eaff0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out\n                FROM posthog_team\n                WHERE api_token = $1\n                LIMIT 1\n            ",
+  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out,\n                    person_display_name_properties\n                FROM posthog_team\n                WHERE api_token = $1\n                LIMIT 1\n            ",
   "describe": {
     "columns": [
       {
@@ -52,6 +52,11 @@
         "ordinal": 9,
         "name": "person_processing_opt_out",
         "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "person_display_name_properties",
+        "type_info": "VarcharArray"
       }
     ],
     "parameters": {
@@ -69,8 +74,9 @@
       false,
       false,
       false,
+      true,
       true
     ]
   },
-  "hash": "3e4b5666fcbcac6f7c6401e6d36252be592559c8705a479a6ee9b1c5462fb597"
+  "hash": "eefee4f8da63fa58479a7e76816a4d2320be2aae5af2cf1c5cbba906470eaff0"
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
  "common-redis",
  "common-types",
  "envconfig",
+ "fernet",
  "health",
  "hogvm",
  "httpmock",

--- a/rust/common/hogvm/src/lib.rs
+++ b/rust/common/hogvm/src/lib.rs
@@ -43,3 +43,6 @@ pub use values::NumOp;
 
 // Errors
 pub use error::VmError;
+
+// Ops
+pub use ops::Operation;

--- a/rust/common/hogvm/src/program.rs
+++ b/rust/common/hogvm/src/program.rs
@@ -5,10 +5,11 @@ use serde_json::{Number, Value as JsonValue};
 use crate::VmError;
 
 // A top-level hog program - functionally the body of a "main" function, if hog had such a thing
+#[derive(Debug, Clone)]
 pub struct Program {
-    bytecode: Vec<JsonValue>,
-    version: u64,
-    program_start_offset: usize,
+    pub bytecode: Vec<JsonValue>,
+    pub version: u64,
+    pub program_start_offset: usize,
 }
 
 // A referenceable module, exporting a set of functions. Top level programs can jump into module code

--- a/rust/common/types/src/team.rs
+++ b/rust/common/types/src/team.rs
@@ -18,6 +18,7 @@ pub struct Team {
     pub updated_at: DateTime<Utc>,
     pub anonymize_ips: bool,
     pub person_processing_opt_out: Option<bool>,
+    pub person_display_name_properties: Option<Vec<String>>,
 }
 
 impl Team {
@@ -38,7 +39,8 @@ impl Team {
                     created_at,
                     updated_at,
                     anonymize_ips,
-                    person_processing_opt_out
+                    person_processing_opt_out,
+                    person_display_name_properties
                 FROM posthog_team
                 WHERE id = $1
                 LIMIT 1
@@ -66,7 +68,8 @@ impl Team {
                     created_at,
                     updated_at,
                     anonymize_ips,
-                    person_processing_opt_out
+                    person_processing_opt_out,
+                    person_display_name_properties
                 FROM posthog_team
                 WHERE api_token = $1
                 LIMIT 1

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -40,6 +40,7 @@ posthog-rs = { workspace = true }
 base64 = { workspace = true }
 regex = { workspace = true }
 once_cell = { workspace = true }
+fernet = { workspace = true }
 
 [dev-dependencies]
 httpmock = { workspace = true }

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -53,6 +53,8 @@ pub struct AppContext {
 
     pub filtered_teams: Vec<i32>,
     pub filter_mode: FilterMode,
+
+    pub encrypted_secrets_keys: Vec<String>,
 }
 
 impl AppContext {
@@ -192,6 +194,11 @@ impl AppContext {
             billing_limiter,
             filtered_teams,
             filter_mode,
+            encrypted_secrets_keys: config
+                .encryption_keys
+                .split(',')
+                .map(|s| s.to_string())
+                .collect(),
         })
     }
 }

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -139,6 +139,13 @@ pub struct Config {
 
     #[envconfig(default = "false")]
     pub auto_assignment_enabled: bool, // Comma seperated list of users to either filter in (process) or filter out (ignore)
+
+    #[envconfig(default = "http://localhost:8010")]
+    pub site_url: String, // Used for hog transformation input building
+
+    // Same test key as the plugin server
+    #[envconfig(default = "00beef0000beef0000beef0000beef00")]
+    pub encryption_keys: String, // comma separated list of fernet keys
 }
 
 impl Config {

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -158,6 +158,8 @@ pub enum EventError {
     FailedToDeserialize(Box<CapturedEvent>, String),
     #[error("Filtered by team id")]
     FilteredByTeamId,
+    #[error("Event dropped by transformation")]
+    DroppedByTransformation,
 }
 
 impl From<JsResolveErr> for ResolveError {

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -72,3 +72,4 @@ pub const GROUP_TYPE_MAPPING_TIME: &str = "cymbal_group_type_mapping_time";
 pub const TRANSFORMATION_TIME: &str = "cymbal_transformation_time";
 pub const TRANSFORMATION_OUTCOME: &str = "cymbal_transformation_outcome";
 pub const TRANSFORMATION_EVENTS_DROPPED: &str = "cymbal_transformation_events_dropped";
+pub const TRANSFORMATION_SECRETS_FAILED: &str = "cymbal_transformation_secrets_failed";

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -69,3 +69,6 @@ pub const ISSUE_PROCESSING_TIME: &str = "cymbal_issue_processing_time";
 pub const FRAME_BATCH_TIME: &str = "cymbal_frame_batch_time";
 pub const FINGERPRINT_BATCH_TIME: &str = "cymbal_fingerprint_batch_time";
 pub const GROUP_TYPE_MAPPING_TIME: &str = "cymbal_group_type_mapping_time";
+pub const TRANSFORMATION_TIME: &str = "cymbal_transformation_time";
+pub const TRANSFORMATION_OUTCOME: &str = "cymbal_transformation_outcome";
+pub const TRANSFORMATION_EVENTS_DROPPED: &str = "cymbal_transformation_events_dropped";

--- a/rust/cymbal/src/pipeline/errors.rs
+++ b/rust/cymbal/src/pipeline/errors.rs
@@ -82,5 +82,9 @@ pub async fn report_error(_context: Arc<AppContext>, error: EventError) {
             // Totally mundane
             counter!(DROPPED_EVENTS, "reason" => "filtered_by_team_id").increment(1);
         }
+        EventError::DroppedByTransformation => {
+            // Totally mundane
+            counter!(DROPPED_EVENTS, "reason" => "dropped_by_transformation").increment(1);
+        }
     }
 }

--- a/rust/cymbal/src/pipeline/mod.rs
+++ b/rust/cymbal/src/pipeline/mod.rs
@@ -36,6 +36,7 @@ pub mod geoip;
 pub mod group;
 pub mod person;
 pub mod prep;
+pub mod transformations;
 
 // We can receive either ClickhouseEvents or CaptureEvents
 #[derive(Debug, Clone, Deserialize)]

--- a/rust/cymbal/src/pipeline/prep.rs
+++ b/rust/cymbal/src/pipeline/prep.rs
@@ -16,7 +16,7 @@ use super::{
 // Adds team info, and folds set, set_once and ip address data into the event properties
 pub fn prepare_events(
     events: Vec<IncomingEvent>,
-    teams_lut: HashMap<String, Option<Team>>,
+    teams_lut: &HashMap<String, Option<Team>>,
 ) -> Result<Vec<PipelineResult>, PipelineFailure> {
     let mut buffer = Vec::with_capacity(events.len());
 

--- a/rust/cymbal/src/pipeline/transformations/mod.rs
+++ b/rust/cymbal/src/pipeline/transformations/mod.rs
@@ -1,0 +1,145 @@
+use std::{collections::HashMap, sync::Arc};
+
+use common_types::ClickHouseEvent;
+use hogvm::{ExecutionContext, Program, VmError};
+use serde_json::Value;
+
+use crate::{
+    app_context::AppContext,
+    error::{PipelineFailure, PipelineResult},
+    pipeline::transformations::transform::HogFunctionFilter,
+};
+
+pub mod transform;
+
+// We could, and probably should, cache these
+struct ExecutableHogFunction {
+    filter: Option<ExecutionContext>,
+    transform: ExecutionContext,
+}
+
+pub async fn apply_transformations(
+    events: Vec<PipelineResult>,
+    context: Arc<AppContext>,
+) -> Result<Vec<PipelineResult>, PipelineFailure> {
+    // First, convert the hog function list for each team into an execution context list for each team
+    let mut executable_lists = HashMap::new();
+    for (i, event) in events.iter().enumerate() {
+        let Ok(event) = event else {
+            continue;
+        };
+
+        if executable_lists.contains_key(&event.team_id) {
+            continue;
+        }
+
+        let functions = context
+            .team_manager
+            .function_manager
+            .get_functions(event.team_id)
+            .await
+            .map_err(|e| (i, e))?;
+
+        let mut executables = Vec::new();
+
+        // We don't need to sort these, the manager returns them in the right order
+        for function in functions {
+            let transform_bytecode = context
+                .team_manager
+                .function_manager
+                .get_function_bytecode(&function)
+                .await
+                .map_err(|e| (i, e))?;
+
+            let Some(Value::Array(transform_bytecode)) = transform_bytecode else {
+                context
+                    .team_manager
+                    .function_manager
+                    .disable_function(&function, "Bytecode not found or not an array")
+                    .await
+                    .map_err(|e| (i, e))?;
+                continue;
+            };
+
+            let transform_program = match Program::new(transform_bytecode) {
+                Ok(p) => p,
+                Err(e) => {
+                    context
+                        .team_manager
+                        .function_manager
+                        .disable_function(&function, &format!("Failed to create program: {}", e))
+                        .await
+                        .map_err(|e| (i, e))?;
+                    continue;
+                }
+            };
+
+            // Globals like inputs etc. Does not include the event itself, as that is overwritten each time.
+            let placeholder_globals = context
+                .team_manager
+                .function_manager
+                .get_function_globals(&function)
+                .await
+                .map_err(|e| (i, e))?;
+
+            let transform_context = ExecutionContext::with_defaults(transform_program)
+                .with_globals(placeholder_globals);
+
+            let Some(filters) = &function.filters else {
+                executables.push(ExecutableHogFunction {
+                    filter: None,
+                    transform: transform_context,
+                });
+                continue;
+            };
+
+            let Ok(filters) = serde_json::from_value::<HogFunctionFilter>(filters.clone()) else {
+                context
+                    .team_manager
+                    .function_manager
+                    .disable_function(&function, "Filter not valid")
+                    .await
+                    .map_err(|e| (i, e))?;
+                continue;
+            };
+
+            let Some(filter_bytecode) = filters.bytecode else {
+                executables.push(ExecutableHogFunction {
+                    filter: None,
+                    transform: transform_context,
+                });
+                continue;
+            };
+
+            let filter_program = match Program::new(filter_bytecode) {
+                Ok(p) => p,
+                Err(e) => {
+                    context
+                        .team_manager
+                        .function_manager
+                        .disable_function(&function, &format!("Filter bytecode error: {}", e))
+                        .await
+                        .map_err(|e| (i, e))?;
+                    continue;
+                }
+            };
+
+            let filter_context = ExecutionContext::with_defaults(filter_program); // Filters have no globals aside from the event
+
+            executables.push(ExecutableHogFunction {
+                filter: Some(filter_context),
+                transform: transform_context,
+            });
+        }
+
+        executable_lists.insert(event.team_id, executables);
+    }
+
+    Ok(events)
+}
+
+enum TransformationResult {
+    Success(Option<ClickHouseEvent>), // On success, return the transformed event (or None, if it was dropped)
+    FilterFailure(ClickHouseEvent, VmError), // On filter failure, return the original event and the error
+    TransformFailure(ClickHouseEvent, VmError), // On transformation failure, return the original event and the error
+}

--- a/rust/cymbal/src/pipeline/transformations/mod.rs
+++ b/rust/cymbal/src/pipeline/transformations/mod.rs
@@ -213,8 +213,6 @@ pub async fn apply_transformations(
 // Apply a set of transformations to an event. Each transformation results in a TransformationResult.
 fn execute_transformations(
     event: ClickHouseEvent,
-    // TODO - this has to be mutable, because we have to mutate the ExecutionContext's contained here to install the event globals before running the filter. This is better
-    // than cloning the ExecutableHogFunction for each event, but it's still pretty ugly. A better HogVM interface would let us handle the globals set more elegantly.
     executable_list: &[ExecutableHogFunction],
 ) -> TransformSetOutcome {
     let mut results = Vec::new();

--- a/rust/cymbal/src/pipeline/transformations/mod.rs
+++ b/rust/cymbal/src/pipeline/transformations/mod.rs
@@ -1,19 +1,29 @@
 use std::{collections::HashMap, sync::Arc};
 
+use chrono::{DateTime, Utc};
 use common_types::ClickHouseEvent;
 use hogvm::{ExecutionContext, Program, VmError};
+use metrics::counter;
 use serde_json::Value;
+use uuid::Uuid;
 
 use crate::{
     app_context::AppContext,
     error::{PipelineFailure, PipelineResult},
-    pipeline::transformations::transform::HogFunctionFilter,
+    metric_consts::TRANSFORMATION_EVENTS_DROPPED,
+    pipeline::transformations::types::{
+        HogFunctionFilter, TransformLog, TransformOutcome, TransformResult, TransformSetOutcome,
+    },
 };
 
 pub mod transform;
+pub mod types;
 
-// We could, and probably should, cache these
+// TODO - there's just ample room for optimization here, if anyone feels like picking it up. Ofc, take a look at the timing metrics first.
+
+// We could, and probably should, cache these, rather than caching the raw HogFunction's
 struct ExecutableHogFunction {
+    id: Uuid,
     filter: Option<ExecutionContext>,
     transform: ExecutionContext,
 }
@@ -36,7 +46,7 @@ pub async fn apply_transformations(
         let functions = context
             .team_manager
             .function_manager
-            .get_functions(event.team_id)
+            .get_functions(&context.pool, event.team_id)
             .await
             .map_err(|e| (i, e))?;
 
@@ -47,7 +57,7 @@ pub async fn apply_transformations(
             let transform_bytecode = context
                 .team_manager
                 .function_manager
-                .get_function_bytecode(&function)
+                .get_function_bytecode(&context.pool, &function)
                 .await
                 .map_err(|e| (i, e))?;
 
@@ -87,6 +97,7 @@ pub async fn apply_transformations(
 
             let Some(filters) = &function.filters else {
                 executables.push(ExecutableHogFunction {
+                    id: function.id,
                     filter: None,
                     transform: transform_context,
                 });
@@ -105,6 +116,7 @@ pub async fn apply_transformations(
 
             let Some(filter_bytecode) = filters.bytecode else {
                 executables.push(ExecutableHogFunction {
+                    id: function.id,
                     filter: None,
                     transform: transform_context,
                 });
@@ -127,6 +139,7 @@ pub async fn apply_transformations(
             let filter_context = ExecutionContext::with_defaults(filter_program); // Filters have no globals aside from the event
 
             executables.push(ExecutableHogFunction {
+                id: function.id,
                 filter: Some(filter_context),
                 transform: transform_context,
             });
@@ -135,11 +148,118 @@ pub async fn apply_transformations(
         executable_lists.insert(event.team_id, executables);
     }
 
+    // We collect these to feed back to the manager for disabling, reporting logs etc.
+    // This isn't implemented yet, need to coordinate with CDP, right now they're just used for reporting metrics.
+    let mut transform_results: HashMap<Uuid, Vec<TransformResult>> = HashMap::new();
+    // In the future, this will be an events.iter_mut(), and then we'll *event = outcome.final_event.unwrap_or(PipelineResult::Err(EventError::DroppedByTransformation)),
+    // but for now, as we're just collecting execution outcome data, we don't do that yet. This is also used to report app metrics and logs.
+    for event in events.iter() {
+        let Ok(event) = event else {
+            continue;
+        };
+
+        let Some(list) = executable_lists.get_mut(&event.team_id) else {
+            continue;
+        };
+
+        let outcome = execute_transformations(event.clone(), list);
+
+        if let None = outcome.final_event {
+            counter!(TRANSFORMATION_EVENTS_DROPPED).increment(1);
+        }
+
+        for res in outcome.results {
+            transform_results
+                .entry(res.function_id)
+                .or_default()
+                .push(res);
+        }
+    }
+
+    context
+        .team_manager
+        .function_manager
+        .process_execution_results(transform_results)
+        .await
+        .map_err(|e| (0, e))?; // TODO - not great here, but it's pretty hard to tie a failure here to a particular event, so :shrug:
+
     Ok(events)
 }
 
-enum TransformationResult {
-    Success(Option<ClickHouseEvent>), // On success, return the transformed event (or None, if it was dropped)
-    FilterFailure(ClickHouseEvent, VmError), // On filter failure, return the original event and the error
-    TransformFailure(ClickHouseEvent, VmError), // On transformation failure, return the original event and the error
+// Apply a set of transformations to an event. Each transformation results in a TransformationResult.
+fn execute_transformations(
+    event: ClickHouseEvent,
+    // TODO - this has to be mutable, because we have to mutate the ExecutionContext's contained here to install the event globals before running the filter. This is better
+    // than cloning the ExecutableHogFunction for each event, but it's still pretty ugly. A better HogVM interface would let us handle the globals set more elegantly.
+    function_list: &mut Vec<ExecutableHogFunction>,
+) -> TransformSetOutcome {
+    let mut results = Vec::new();
+
+    let mut final_event = Some(event);
+
+    for function in function_list.iter_mut() {
+        // If the last transform dropped the event, we can exit early.
+        let Some(current) = final_event.as_ref() else {
+            break;
+        };
+
+        // Should we apply this transformation?
+        let run_function = match function.test_filter(current) {
+            Ok(r) => r,
+            Err(e) => {
+                results.push(TransformResult {
+                    function_id: function.id,
+                    outcome: TransformOutcome::FilterFailure(e),
+                    logs: Vec::new(),
+                });
+                continue;
+            }
+        };
+
+        if !run_function {
+            results.push(TransformResult {
+                function_id: function.id,
+                outcome: TransformOutcome::Skipped,
+                logs: Vec::new(),
+            });
+            continue;
+        }
+
+        // Apply it, storing the outcome into our final_event if it succeeds
+        let result = match function.apply_transform(current) {
+            Ok((new, logs)) => {
+                final_event = new;
+                TransformResult {
+                    function_id: function.id,
+                    outcome: TransformOutcome::Success,
+                    logs,
+                }
+            }
+            Err((e, logs)) => TransformResult {
+                function_id: function.id,
+                outcome: TransformOutcome::TransformFailure(e),
+                logs,
+            },
+        };
+
+        results.push(result);
+    }
+
+    TransformSetOutcome {
+        results,
+        final_event,
+    }
+}
+
+impl ExecutableHogFunction {
+    pub fn test_filter(&mut self, event: &ClickHouseEvent) -> Result<bool, VmError> {
+        todo!()
+    }
+
+    pub fn apply_transform(
+        &mut self,
+        event: &ClickHouseEvent,
+    ) -> Result<(Option<ClickHouseEvent>, Vec<TransformLog>), (VmError, Vec<TransformLog>)> {
+        todo!()
+    }
 }

--- a/rust/cymbal/src/pipeline/transformations/transform.rs
+++ b/rust/cymbal/src/pipeline/transformations/transform.rs
@@ -180,7 +180,13 @@ impl HogFunctionManager {
         // TODO - for now, all this does is this - need to coord with CDP. This is called when we failed to start executing
         // a function /at all/, which indicates either a cymbal bug or an invalid function, rather than the function failing
         // during execution.
-        debug!("Function {} disabled due to {}", function.id, s.to_string());
+        debug!(
+            "Function {} ({:?}) for team {} disabled due to {}",
+            function.id,
+            function.name,
+            function.team_id,
+            s.to_string()
+        );
         Ok(())
     }
 

--- a/rust/cymbal/src/pipeline/transformations/transform.rs
+++ b/rust/cymbal/src/pipeline/transformations/transform.rs
@@ -66,7 +66,7 @@ impl HogFunctionManager {
             return Ok(functions.into_iter().map(|f| f.inner).collect());
         };
 
-        // TODO - we hardcode transoformations as the function type in a bunch of places. Really the cache should be keyed
+        // TODO - we hardcode transformations as the function type in a bunch of places. Really the cache should be keyed
         // on function type as well as team id.
         let fetched =
             HogFunction::fetch_for_team(e, team_id, HogFunctionType::Transformation).await?;

--- a/rust/cymbal/src/pipeline/transformations/transform.rs
+++ b/rust/cymbal/src/pipeline/transformations/transform.rs
@@ -1,0 +1,295 @@
+use std::{collections::HashMap, fmt::Debug, time::Duration};
+
+use chrono::{DateTime, Utc};
+use moka::sync::{Cache, CacheBuilder};
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::error::UnhandledError;
+
+// This entire module could be in `common`, and only isn't because nobody else needs it yet.
+
+// These are returned by the CDP api, rather than persisted in PG, for some reason. We have to hit the API to fetch the function
+// state, or else go to redis to get it ourselves.
+pub enum HogFunctionState {
+    Unknown,
+    Healthy,
+    Degraded,
+    Disabled,
+    ForcefullyDegraded,
+    ForcefullyDisabled,
+}
+
+pub enum HogFunctionType {
+    Destination,
+    SiteDestination,
+    InternalDestination,
+    SourceWebhook,
+    SiteApp,
+    Transformation,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HogFunctionFilter {
+    pub bytecode: Option<Vec<Value>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HogFunction {
+    pub id: Uuid,
+    pub team_id: i32,
+    pub name: Option<String>,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+    pub created_by_id: Option<i32>,
+    pub deleted: bool,
+    pub updated_at: DateTime<Utc>,
+    pub enabled: bool,
+    pub r#type: Option<String>, // Actually HogFunctionType, but stringified
+    pub kind: Option<String>,   // Unused
+    pub icon_url: Option<String>,
+    pub hog: String,             // Source code of function, either typescript or hog
+    pub bytecode: Option<Value>, // Hog bytecode
+    pub transpiled: Option<String>, // If it's a site app or site destination, this is the javascript code
+    pub inputs_schema: Option<Value>,
+    pub inputs: Option<Value>,                  // Fixed function inputs
+    pub encrypted_inputs: Option<Value>,        // Encrypted function inputs
+    pub filters: Option<Value>,                 // Filter bytecode for the function
+    pub mappings: Option<Value>, // Input mappings ?? TODO - figure out how these are used for transforms
+    pub masking: Option<Value>, // Input masking ?? TODO - figure out how these are used for transforms
+    pub template_id: Option<String>, // The id of the template this function is based on
+    pub hog_function_template_id: Option<Uuid>, // The ID of the specific template version for this function
+    pub execution_order: Option<i16>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HogFunctionTemplate {
+    pub id: Uuid,
+    pub template_id: String,
+    pub sha: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub code: String,
+    pub code_language: String, // "hog" or "javascript"
+    pub inputs_schema: Value,
+    pub bytecode: Option<Value>,
+    pub r#type: String,
+    pub status: String,
+    pub category: Value,
+    pub kind: Option<String>, // Deprecated
+    pub free: bool,
+    pub icon_url: Option<String>,
+    pub filters: Option<Value>,
+    pub masking: Option<Value>,
+    pub mapping_templates: Option<Value>,
+    pub mappings: Option<Value>, // Deprecated
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct HogFunctionManager {
+    function_cache: Cache<i32, Vec<CachedWeight<HogFunction>>>,
+    template_cache: Cache<Uuid, CachedWeight<HogFunctionTemplate>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HogFunctionManagerConfig {
+    pub function_cache_size: u64,
+    pub function_cache_ttl: Duration,
+    pub template_cache_size: u64,
+    pub template_cache_ttl: Duration,
+}
+
+impl HogFunctionManager {
+    pub fn new(config: HogFunctionManagerConfig) -> Self {
+        let function_cache = CacheBuilder::new(config.function_cache_size)
+            .time_to_live(config.function_cache_ttl)
+            .weigher(|_, v: &Vec<CachedWeight<HogFunction>>| {
+                v.iter().map(|f| f.weight as u32).sum() // CAST: if this is larger than 4GB worth of data, we're dead anyway
+            })
+            .build();
+        let template_cache = CacheBuilder::new(config.template_cache_size)
+            .time_to_live(config.template_cache_ttl)
+            .weigher(|_, v: &CachedWeight<HogFunctionTemplate>| v.weight as u32) // CAST: as above
+            .build();
+        HogFunctionManager {
+            function_cache,
+            template_cache,
+        }
+    }
+
+    pub async fn get_functions(&self, team_id: i32) -> Result<Vec<HogFunction>, UnhandledError> {
+        Ok(Vec::new())
+    }
+
+    pub async fn get_function_bytecode(
+        &self,
+        function: &HogFunction,
+    ) -> Result<Option<Value>, UnhandledError> {
+        Ok(None)
+    }
+
+    pub async fn get_function_globals(
+        &self,
+        function: &HogFunction,
+    ) -> Result<Value, UnhandledError> {
+        Ok(Value::Null)
+    }
+
+    pub async fn disable_function(
+        &self,
+        function: &HogFunction,
+        s: impl ToString,
+    ) -> Result<(), UnhandledError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedWeight<T>
+where
+    T: Clone + Debug,
+{
+    pub inner: T,
+    pub weight: usize,
+}
+
+impl CachedWeight<HogFunction> {
+    pub fn new(function: HogFunction) -> Self {
+        let weight = function.cache_weight();
+        CachedWeight {
+            inner: function,
+            weight,
+        }
+    }
+}
+
+impl CachedWeight<HogFunctionTemplate> {
+    pub fn new(template: HogFunctionTemplate) -> Self {
+        let weight = template.cache_weight();
+        CachedWeight {
+            inner: template,
+            weight,
+        }
+    }
+}
+
+impl HogFunction {
+    // Estimates the size in bytes of this function. Only includes non-fixed-size data (so nums, uuid's etc are excluded)
+    pub fn cache_weight(&self) -> usize {
+        // Rust introspection wen
+        1 + self.name.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.description.len()
+            + self.r#type.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.kind.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.icon_url.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.hog.len()
+            + self
+                .bytecode
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .transpiled
+                .as_ref()
+                .map(|s| s.len())
+                .unwrap_or_default()
+            + self
+                .inputs_schema
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .inputs
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .encrypted_inputs
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .filters
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .mappings
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .masking
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .template_id
+                .as_ref()
+                .map(|s| s.len())
+                .unwrap_or_default()
+    }
+}
+
+impl HogFunctionTemplate {
+    pub fn cache_weight(&self) -> usize {
+        1 + self.template_id.len()
+            + self.sha.len()
+            + self.name.len()
+            + self
+                .description
+                .as_ref()
+                .map(|s| s.len())
+                .unwrap_or_default()
+            + self.code.len()
+            + self.code_language.len()
+            + estimate_value_size(&self.inputs_schema)
+            + self
+                .bytecode
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self.r#type.len()
+            + self.status.len()
+            + estimate_value_size(&self.category)
+            + self.kind.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.icon_url.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self
+                .filters
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .masking
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .mapping_templates
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .mappings
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+    }
+}
+
+// In-memory estimated resident size of a json value, excluding pointers
+pub fn estimate_value_size(value: &Value) -> usize {
+    match value {
+        Value::Null => 0,
+        Value::Bool(_) => 1,
+        Value::Number(_) => 64 / 8, // Numbers are always 64 bits (i64, u64 or f64)
+        Value::String(s) => s.len(), // Size of the string, plus a pointer, len and capacity
+        Value::Array(arr) => arr.iter().map(estimate_value_size).sum(), // Size of the inners, plus a pointer, len and capacity
+        Value::Object(obj) => obj
+            .iter()
+            .map(|(k, v)| k.len() + estimate_value_size(v))
+            .sum(),
+    }
+}

--- a/rust/cymbal/src/pipeline/transformations/transform.rs
+++ b/rust/cymbal/src/pipeline/transformations/transform.rs
@@ -1,95 +1,28 @@
 use std::{collections::HashMap, fmt::Debug, time::Duration};
 
-use chrono::{DateTime, Utc};
+use metrics::counter;
 use moka::sync::{Cache, CacheBuilder};
-use serde::Deserialize;
+
 use serde_json::Value;
+use sqlx::Postgres;
+use tracing::debug;
 use uuid::Uuid;
 
-use crate::error::UnhandledError;
+use crate::{
+    error::UnhandledError,
+    metric_consts::TRANSFORMATION_OUTCOME,
+    pipeline::transformations::{
+        types::{HogFunction, HogFunctionTemplate, HogFunctionType, TransformOutcome},
+        TransformResult,
+    },
+};
 
 // This entire module could be in `common`, and only isn't because nobody else needs it yet.
 
-// These are returned by the CDP api, rather than persisted in PG, for some reason. We have to hit the API to fetch the function
-// state, or else go to redis to get it ourselves.
-pub enum HogFunctionState {
-    Unknown,
-    Healthy,
-    Degraded,
-    Disabled,
-    ForcefullyDegraded,
-    ForcefullyDisabled,
-}
-
-pub enum HogFunctionType {
-    Destination,
-    SiteDestination,
-    InternalDestination,
-    SourceWebhook,
-    SiteApp,
-    Transformation,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct HogFunctionFilter {
-    pub bytecode: Option<Vec<Value>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct HogFunction {
-    pub id: Uuid,
-    pub team_id: i32,
-    pub name: Option<String>,
-    pub description: String,
-    pub created_at: DateTime<Utc>,
-    pub created_by_id: Option<i32>,
-    pub deleted: bool,
-    pub updated_at: DateTime<Utc>,
-    pub enabled: bool,
-    pub r#type: Option<String>, // Actually HogFunctionType, but stringified
-    pub kind: Option<String>,   // Unused
-    pub icon_url: Option<String>,
-    pub hog: String,             // Source code of function, either typescript or hog
-    pub bytecode: Option<Value>, // Hog bytecode
-    pub transpiled: Option<String>, // If it's a site app or site destination, this is the javascript code
-    pub inputs_schema: Option<Value>,
-    pub inputs: Option<Value>,                  // Fixed function inputs
-    pub encrypted_inputs: Option<Value>,        // Encrypted function inputs
-    pub filters: Option<Value>,                 // Filter bytecode for the function
-    pub mappings: Option<Value>, // Input mappings ?? TODO - figure out how these are used for transforms
-    pub masking: Option<Value>, // Input masking ?? TODO - figure out how these are used for transforms
-    pub template_id: Option<String>, // The id of the template this function is based on
-    pub hog_function_template_id: Option<Uuid>, // The ID of the specific template version for this function
-    pub execution_order: Option<i16>,
-}
-
-#[derive(Debug, Clone)]
-pub struct HogFunctionTemplate {
-    pub id: Uuid,
-    pub template_id: String,
-    pub sha: String,
-    pub name: String,
-    pub description: Option<String>,
-    pub code: String,
-    pub code_language: String, // "hog" or "javascript"
-    pub inputs_schema: Value,
-    pub bytecode: Option<Value>,
-    pub r#type: String,
-    pub status: String,
-    pub category: Value,
-    pub kind: Option<String>, // Deprecated
-    pub free: bool,
-    pub icon_url: Option<String>,
-    pub filters: Option<Value>,
-    pub masking: Option<Value>,
-    pub mapping_templates: Option<Value>,
-    pub mappings: Option<Value>, // Deprecated
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-}
-
 pub struct HogFunctionManager {
     function_cache: Cache<i32, Vec<CachedWeight<HogFunction>>>,
+
+    // There are a small number of templates, we mostly use the cache here to re-fetch them occasionally
     template_cache: Cache<Uuid, CachedWeight<HogFunctionTemplate>>,
 }
 
@@ -119,22 +52,74 @@ impl HogFunctionManager {
         }
     }
 
-    pub async fn get_functions(&self, team_id: i32) -> Result<Vec<HogFunction>, UnhandledError> {
-        Ok(Vec::new())
+    pub async fn get_functions<'c, E>(
+        &self,
+        e: E,
+        team_id: i32,
+    ) -> Result<Vec<HogFunction>, UnhandledError>
+    where
+        E: sqlx::Executor<'c, Database = Postgres>,
+    {
+        if let Some(functions) = self.function_cache.get(&team_id) {
+            return Ok(functions.into_iter().map(|f| f.inner).collect());
+        };
+
+        // TODO - we hardcode transoformations as the function type in a bunch of places. Really the cache should be keyed
+        // on function type as well as team id.
+        let fetched =
+            HogFunction::fetch_for_team(e, team_id, HogFunctionType::Transformation).await?;
+        let cached: Vec<_> = fetched
+            .clone()
+            .into_iter()
+            .map(|f| CachedWeight::from(f))
+            .collect();
+        self.function_cache.insert(team_id, cached);
+        Ok(fetched)
     }
 
-    pub async fn get_function_bytecode(
+    pub async fn get_template<'c, E>(
         &self,
+        e: E,
+        template_id: Uuid,
+    ) -> Result<Option<HogFunctionTemplate>, UnhandledError>
+    where
+        E: sqlx::Executor<'c, Database = Postgres>,
+    {
+        if let Some(template) = self.template_cache.get(&template_id) {
+            return Ok(Some(template.inner));
+        };
+
+        let fetched = HogFunctionTemplate::fetch_by_id(e, template_id).await?;
+        let cached = CachedWeight::from(fetched.clone());
+        self.template_cache.insert(template_id, cached);
+        Ok(Some(fetched))
+    }
+
+    pub async fn get_function_bytecode<'c, E>(
+        &self,
+        e: E,
         function: &HogFunction,
-    ) -> Result<Option<Value>, UnhandledError> {
-        Ok(None)
+    ) -> Result<Option<Value>, UnhandledError>
+    where
+        E: sqlx::Executor<'c, Database = Postgres>,
+    {
+        if let Some(bc) = function.bytecode.clone() {
+            return Ok(Some(bc)); // If the functions got bytecode, just use that
+        }
+
+        // Otherwise, if it's got a template, use that
+        let Some(template_id) = function.hog_function_template_id else {
+            return Ok(None);
+        };
+        let template = self.get_template(e, template_id).await?;
+        Ok(template.and_then(|t| t.bytecode))
     }
 
     pub async fn get_function_globals(
         &self,
         function: &HogFunction,
     ) -> Result<Value, UnhandledError> {
-        Ok(Value::Null)
+        todo!();
     }
 
     pub async fn disable_function(
@@ -142,6 +127,31 @@ impl HogFunctionManager {
         function: &HogFunction,
         s: impl ToString,
     ) -> Result<(), UnhandledError> {
+        // TODO - for now, all this does is this - need to coord with CDP. This is called when we failed to start executing
+        // a function /at all/, which indicates either a cymbal bug or an invalid function, rather than the function failing
+        // during execution.
+        debug!("Function {} disabled due to {}", function.id, s.to_string());
+        Ok(())
+    }
+
+    pub async fn process_execution_results(
+        &self,
+        results: HashMap<Uuid, Vec<TransformResult>>,
+    ) -> Result<(), UnhandledError> {
+        for (_function_id, result_set) in results {
+            for result in result_set {
+                // TODO - emit logs + metrics to kafka (probably as a best-effort task), figure out how to handle e.g. function disableing
+                // (co-ord with CDP).
+                let label = match result.outcome {
+                    TransformOutcome::Skipped => "skipped",
+                    TransformOutcome::Success => "success",
+                    TransformOutcome::FilterFailure(_) => "filter failure",
+                    TransformOutcome::TransformFailure(_) => "transform failure",
+                };
+
+                counter!(TRANSFORMATION_OUTCOME, &[("outcome", label)]).increment(1);
+            }
+        }
         Ok(())
     }
 }
@@ -155,8 +165,8 @@ where
     pub weight: usize,
 }
 
-impl CachedWeight<HogFunction> {
-    pub fn new(function: HogFunction) -> Self {
+impl From<HogFunction> for CachedWeight<HogFunction> {
+    fn from(function: HogFunction) -> Self {
         let weight = function.cache_weight();
         CachedWeight {
             inner: function,
@@ -165,131 +175,12 @@ impl CachedWeight<HogFunction> {
     }
 }
 
-impl CachedWeight<HogFunctionTemplate> {
-    pub fn new(template: HogFunctionTemplate) -> Self {
+impl From<HogFunctionTemplate> for CachedWeight<HogFunctionTemplate> {
+    fn from(template: HogFunctionTemplate) -> Self {
         let weight = template.cache_weight();
         CachedWeight {
             inner: template,
             weight,
         }
-    }
-}
-
-impl HogFunction {
-    // Estimates the size in bytes of this function. Only includes non-fixed-size data (so nums, uuid's etc are excluded)
-    pub fn cache_weight(&self) -> usize {
-        // Rust introspection wen
-        1 + self.name.as_ref().map(|s| s.len()).unwrap_or_default()
-            + self.description.len()
-            + self.r#type.as_ref().map(|s| s.len()).unwrap_or_default()
-            + self.kind.as_ref().map(|s| s.len()).unwrap_or_default()
-            + self.icon_url.as_ref().map(|s| s.len()).unwrap_or_default()
-            + self.hog.len()
-            + self
-                .bytecode
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .transpiled
-                .as_ref()
-                .map(|s| s.len())
-                .unwrap_or_default()
-            + self
-                .inputs_schema
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .inputs
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .encrypted_inputs
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .filters
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .mappings
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .masking
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .template_id
-                .as_ref()
-                .map(|s| s.len())
-                .unwrap_or_default()
-    }
-}
-
-impl HogFunctionTemplate {
-    pub fn cache_weight(&self) -> usize {
-        1 + self.template_id.len()
-            + self.sha.len()
-            + self.name.len()
-            + self
-                .description
-                .as_ref()
-                .map(|s| s.len())
-                .unwrap_or_default()
-            + self.code.len()
-            + self.code_language.len()
-            + estimate_value_size(&self.inputs_schema)
-            + self
-                .bytecode
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self.r#type.len()
-            + self.status.len()
-            + estimate_value_size(&self.category)
-            + self.kind.as_ref().map(|s| s.len()).unwrap_or_default()
-            + self.icon_url.as_ref().map(|s| s.len()).unwrap_or_default()
-            + self
-                .filters
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .masking
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .mapping_templates
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-            + self
-                .mappings
-                .as_ref()
-                .map(estimate_value_size)
-                .unwrap_or_default()
-    }
-}
-
-// In-memory estimated resident size of a json value, excluding pointers
-pub fn estimate_value_size(value: &Value) -> usize {
-    match value {
-        Value::Null => 0,
-        Value::Bool(_) => 1,
-        Value::Number(_) => 64 / 8, // Numbers are always 64 bits (i64, u64 or f64)
-        Value::String(s) => s.len(), // Size of the string, plus a pointer, len and capacity
-        Value::Array(arr) => arr.iter().map(estimate_value_size).sum(), // Size of the inners, plus a pointer, len and capacity
-        Value::Object(obj) => obj
-            .iter()
-            .map(|(k, v)| k.len() + estimate_value_size(v))
-            .sum(),
     }
 }

--- a/rust/cymbal/src/pipeline/transformations/types.rs
+++ b/rust/cymbal/src/pipeline/transformations/types.rs
@@ -3,28 +3,32 @@ use std::{fmt::Display, str::FromStr};
 use chrono::{DateTime, Utc};
 use common_types::ClickHouseEvent;
 use hogvm::VmError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
 use sqlx::Postgres;
 use uuid::Uuid;
 
+#[derive(Debug, Clone)]
 pub struct TransformSetOutcome {
     pub results: Vec<TransformResult>,
     pub final_event: Option<ClickHouseEvent>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TransformResult {
     pub function_id: Uuid,
     pub outcome: TransformOutcome,
     pub logs: Vec<TransformLog>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TransformLog {
     pub message: String,
     pub level: String,
     pub timestamp: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone)]
 pub enum TransformOutcome {
     Skipped,                   // The function filter skipped this event
     Success,                   // The transform was applied successfully
@@ -112,9 +116,10 @@ pub struct HogFunctionTemplate {
 }
 
 // All the globals that get injected into the hogvm runtime before execution
-mod transform_globals {
+pub mod transform_globals {
     use std::collections::HashMap;
 
+    use common_types::{ClickHouseEvent, GroupType, Team};
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
@@ -154,7 +159,7 @@ mod transform_globals {
     pub struct Group {
         pub id: String,     // The distinct_id equivalent, not the group type DB PK
         pub r#type: String, // Human readable group type
-        pub index: i16,     // group index,
+        pub index: i32,     // group index,
         pub url: String,
         pub properties: HashMap<String, Value>, // TODO - we probably won't support this for now
     }
@@ -166,10 +171,254 @@ mod transform_globals {
         pub body: HashMap<String, Value>,
         pub string_body: String,
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransformInvocationGlobals {}
+    // Note - we want to serialize nulls here, I /think/
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct InvocationGlobals {
+        pub project: Project,
+        pub source: Option<Source>,
+        pub event: Event,
+        pub person: Option<Person>,
+        pub groups: HashMap<String, Group>,
+        pub request: Option<Request>, // CDP webhooks api specific, always a None here
+        pub unsubscribe_url: Option<String>, // For email actions, always None here
+        pub inputs: HashMap<String, Value>,
+    }
+
+    // Team-wide context that's stable across invocations
+    pub struct FunctionContext {
+        pub group_types: Vec<GroupType>,
+        pub team: Team,
+        pub site_url: String,
+        pub inputs: HashMap<String, Value>,
+    }
+
+    // These are pretty much just events, but with some extra parsing and stuff (properties are parsed etc)
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct FilterGlobals {
+        pub event: String,
+        pub uuid: String,
+        pub timestamp: String,
+        pub elements_chain: String,
+        pub elements_chain_href: String,
+        pub elements_chain_texts: Vec<String>,
+        pub elements_chain_ids: Vec<String>,
+        pub elements_chain_elements: Vec<String>,
+        pub properties: HashMap<String, Value>,
+        pub distinct_id: String,
+
+        pub person: Option<Person>,
+        #[serde(rename = "$group_0")]
+        pub group_0_id: Option<String>,
+        #[serde(rename = "$group_1")]
+        pub group_1_id: Option<String>,
+        #[serde(rename = "$group_2")]
+        pub group_2_id: Option<String>,
+        #[serde(rename = "$group_3")]
+        pub group_3_id: Option<String>,
+        #[serde(rename = "$group_4")]
+        pub group_4_id: Option<String>,
+
+        pub group_0: GroupProperties,
+        pub group_1: GroupProperties,
+        pub group_2: GroupProperties,
+        pub group_3: GroupProperties,
+        pub group_4: GroupProperties,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+    pub struct GroupProperties {
+        properties: HashMap<String, Value>,
+    }
+
+    impl FilterGlobals {
+        pub fn new(context: &FunctionContext, event: &ClickHouseEvent) -> Self {
+            let props = event
+                .properties
+                .as_ref()
+                .and_then(|p| serde_json::from_str::<HashMap<String, Value>>(p).ok())
+                .unwrap_or_default();
+
+            let group_ids = vec![
+                props.get("$group_0").and_then(|v| v.as_str()),
+                props.get("$group_1").and_then(|v| v.as_str()),
+                props.get("$group_2").and_then(|v| v.as_str()),
+                props.get("$group_3").and_then(|v| v.as_str()),
+                props.get("$group_4").and_then(|v| v.as_str()),
+            ];
+
+            Self {
+                event: event.event.clone(),
+                uuid: event.uuid.to_string(),
+                timestamp: event.timestamp.clone(),
+                elements_chain: String::new(),       // TODO
+                elements_chain_href: String::new(),  // TODO
+                elements_chain_texts: Vec::new(),    // TODO
+                elements_chain_ids: Vec::new(),      // TODO
+                elements_chain_elements: Vec::new(), // TODO
+                distinct_id: event.distinct_id.clone(),
+                person: Person::new(&context.site_url, &context.team, event),
+                group_0_id: group_ids[0].map(|s| s.to_string()),
+                group_1_id: group_ids[1].map(|s| s.to_string()),
+                group_2_id: group_ids[2].map(|s| s.to_string()),
+                group_3_id: group_ids[3].map(|s| s.to_string()),
+                group_4_id: group_ids[4].map(|s| s.to_string()),
+                group_0: Default::default(), // TODO
+                group_1: Default::default(), // TODO
+                group_2: Default::default(), // TODO
+                group_3: Default::default(), // TODO
+                group_4: Default::default(), // TODO
+                properties: props,
+            }
+        }
+    }
+
+    impl InvocationGlobals {
+        pub fn new(context: &FunctionContext, event: &ClickHouseEvent) -> Self {
+            Self {
+                project: Project {
+                    id: context.team.id,
+                    name: context.team.name.clone(),
+                    url: format!("{}/project/{}", context.site_url, context.team.id),
+                },
+                source: None,
+                event: Event::from(event),
+                person: Person::new(&context.site_url, &context.team, event),
+                groups: context
+                    .group_types
+                    .iter()
+                    .map(|gt| {
+                        (
+                            gt.group_type.clone(),
+                            (context.site_url.as_str(), event, gt).try_into().ok(),
+                        )
+                    })
+                    .filter_map(|(key, value)| value.map(|v| (key, v)))
+                    .collect(),
+                request: None,
+                unsubscribe_url: None,
+                inputs: context.inputs.clone(),
+            }
+        }
+    }
+
+    impl FunctionContext {
+        pub fn new(
+            site_url: &str,
+            group_types: &[GroupType],
+            team: &Team,
+            inputs: HashMap<String, Value>,
+        ) -> Self {
+            Self {
+                site_url: site_url.to_string(),
+                group_types: group_types.to_vec(),
+                team: team.clone(),
+                inputs,
+            }
+        }
+    }
+
+    impl From<&ClickHouseEvent> for Event {
+        fn from(event: &ClickHouseEvent) -> Self {
+            let props = event
+                .properties
+                .as_ref()
+                .and_then(|p| serde_json::from_str::<HashMap<String, Value>>(p).ok())
+                .unwrap_or_default();
+
+            let url = match props.get("$current_url") {
+                Some(Value::String(url)) => url.clone(),
+                _ => String::new(),
+            };
+
+            Self {
+                uuid: event.uuid.to_string(),
+                event: event.event.clone(),
+                distinct_id: event.distinct_id.clone(),
+                properties: props,
+                elements_chain: String::new(),
+                timestamp: event.timestamp.clone(),
+                url,
+            }
+        }
+    }
+
+    impl Person {
+        fn new(site_url: &str, team: &Team, event: &ClickHouseEvent) -> Option<Self> {
+            let Some(props) = event.person_properties.as_ref() else {
+                return None;
+            };
+
+            let Some(db_id) = event.person_id.as_ref() else {
+                return None;
+            };
+
+            let Ok(props) = serde_json::from_str::<HashMap<String, Value>>(props) else {
+                return None;
+            };
+
+            let mut name = None;
+            if let Some(name_keys) = team.person_display_name_properties.as_ref() {
+                for key in name_keys {
+                    if let Some(Value::String(value)) = props.get(key) {
+                        name = Some(value.clone());
+                        break;
+                    }
+                }
+            }
+
+            let name = name.unwrap_or_else(|| event.distinct_id.clone());
+
+            // TODO - this needs to be URI encoded
+            let url = format!(
+                "{site_url}/project/{}/persons/{}",
+                event.team_id, event.distinct_id
+            );
+
+            Some(Self {
+                id: db_id.clone(),
+                properties: props,
+                name,
+                url,
+            })
+        }
+    }
+
+    impl TryFrom<(&str, &ClickHouseEvent, &GroupType)> for Group {
+        type Error = ();
+        fn try_from(
+            (site_url, event, group_type): (&str, &ClickHouseEvent, &GroupType),
+        ) -> Result<Self, ()> {
+            let Some(props) = event.properties.as_ref() else {
+                return Err(());
+            };
+            let Ok(props) = serde_json::from_str::<HashMap<String, Value>>(props) else {
+                return Err(());
+            };
+
+            let group_id_key = format!("$group_{}", group_type.group_type_index);
+            let Some(Value::String(id)) = props.get(&group_id_key) else {
+                return Err(());
+            };
+
+            let id = id.clone();
+
+            // TODO - this needs to be URI encoded
+            let url = format!(
+                "{site_url}/project/{}/groups/{}/{}",
+                event.team_id, group_type.group_type_index, id
+            );
+
+            Ok(Self {
+                id,
+                r#type: group_type.group_type.clone(),
+                index: group_type.group_type_index,
+                url,
+                properties: HashMap::new(),
+            })
+        }
+    }
+}
 
 impl HogFunction {
     pub async fn fetch_for_team<'c, E>(

--- a/rust/cymbal/src/pipeline/transformations/types.rs
+++ b/rust/cymbal/src/pipeline/transformations/types.rs
@@ -1,0 +1,445 @@
+use std::{fmt::Display, str::FromStr};
+
+use chrono::{DateTime, Utc};
+use common_types::ClickHouseEvent;
+use hogvm::VmError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::Postgres;
+use uuid::Uuid;
+
+pub struct TransformSetOutcome {
+    pub results: Vec<TransformResult>,
+    pub final_event: Option<ClickHouseEvent>,
+}
+
+pub struct TransformResult {
+    pub function_id: Uuid,
+    pub outcome: TransformOutcome,
+    pub logs: Vec<TransformLog>,
+}
+
+pub struct TransformLog {
+    pub message: String,
+    pub level: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+pub enum TransformOutcome {
+    Skipped,                   // The function filter skipped this event
+    Success,                   // The transform was applied successfully
+    FilterFailure(VmError),    // The transforms filter failed for some reason
+    TransformFailure(VmError), // The transform function failed for some reason
+}
+
+// These are returned by the CDP api, rather than persisted in PG, for some reason. We have to hit the API to fetch the function
+// state, or else go to redis to get it ourselves.
+pub enum HogFunctionState {
+    Unknown,
+    Healthy,
+    Degraded,
+    Disabled,
+    ForcefullyDegraded,
+    ForcefullyDisabled,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum HogFunctionType {
+    Destination,
+    SiteDestination,
+    InternalDestination,
+    SourceWebhook,
+    SiteApp,
+    Transformation,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HogFunctionFilter {
+    pub bytecode: Option<Vec<Value>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HogFunction {
+    pub id: Uuid,
+    pub team_id: i32,
+    pub name: Option<String>,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+    pub created_by_id: Option<i32>,
+    pub deleted: bool,
+    pub updated_at: DateTime<Utc>,
+    pub enabled: bool,
+    pub r#type: Option<String>, // Actually HogFunctionType, but stringified
+    pub kind: Option<String>,   // Unused
+    pub icon_url: Option<String>,
+    pub hog: String,             // Source code of function, either typescript or hog
+    pub bytecode: Option<Value>, // Hog bytecode
+    pub transpiled: Option<String>, // If it's a site app or site destination, this is the javascript code
+    pub inputs_schema: Option<Value>,
+    pub inputs: Option<Value>,                  // Fixed function inputs
+    pub encrypted_inputs: Option<String>, // Encrypted function inputs (Actually JSON, but stringified as part of encryption)
+    pub filters: Option<Value>,           // Filter bytecode for the function
+    pub mappings: Option<Value>, // Input mappings ?? TODO - figure out how these are used for transforms
+    pub masking: Option<Value>, // Input masking ?? TODO - figure out how these are used for transforms
+    pub template_id: Option<String>, // The id of the template this function is based on
+    pub hog_function_template_id: Option<Uuid>, // The ID of the specific template version for this function
+    pub execution_order: Option<i16>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HogFunctionTemplate {
+    pub id: Uuid,
+    pub template_id: String,
+    pub sha: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub code: String,
+    pub code_language: String, // "hog" or "javascript"
+    pub inputs_schema: Value,
+    pub bytecode: Option<Value>,
+    pub r#type: String,
+    pub status: String,
+    pub category: Value,
+    pub kind: Option<String>, // Deprecated
+    pub free: bool,
+    pub icon_url: Option<String>,
+    pub filters: Option<Value>,
+    pub masking: Option<Value>,
+    pub mapping_templates: Option<Value>,
+    pub mappings: Option<Value>, // Deprecated
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// All the globals that get injected into the hogvm runtime before execution
+mod transform_globals {
+    use std::collections::HashMap;
+
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Project {
+        pub id: i32,
+        pub name: String,
+        pub url: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Source {
+        pub name: String,
+        pub url: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Event {
+        pub uuid: String,
+        pub event: String,
+        pub distinct_id: String,
+        pub properties: HashMap<String, Value>,
+        pub elements_chain: String,
+        pub timestamp: String,
+        pub url: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Person {
+        pub id: String,
+        pub properties: HashMap<String, Value>,
+        pub name: String,
+        pub url: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Group {
+        pub id: String,     // The distinct_id equivalent, not the group type DB PK
+        pub r#type: String, // Human readable group type
+        pub index: i16,     // group index,
+        pub url: String,
+        pub properties: HashMap<String, Value>, // TODO - we probably won't support this for now
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Request {
+        pub headers: HashMap<String, Option<String>>,
+        pub ip: Option<String>,
+        pub body: HashMap<String, Value>,
+        pub string_body: String,
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformInvocationGlobals {}
+
+impl HogFunction {
+    pub async fn fetch_for_team<'c, E>(
+        e: E,
+        team_id: i32,
+        r#type: HogFunctionType,
+    ) -> Result<Vec<Self>, sqlx::Error>
+    where
+        E: sqlx::Executor<'c, Database = Postgres>,
+    {
+        sqlx::query_as!(
+            HogFunction,
+            r#"
+                SELECT
+                    id,
+                    team_id,
+                    name,
+                    description,
+                    created_at,
+                    created_by_id,
+                    deleted,
+                    updated_at,
+                    enabled,
+                    type,
+                    kind,
+                    icon_url,
+                    hog,
+                    bytecode,
+                    transpiled,
+                    inputs_schema,
+                    inputs,
+                    encrypted_inputs,
+                    filters,
+                    mappings,
+                    masking,
+                    template_id,
+                    hog_function_template_id,
+                    execution_order
+                FROM posthog_hogfunction
+                WHERE team_id = $1 AND deleted = false AND enabled = true AND type = $2
+                ORDER BY execution_order, created_at ASC NULLS LAST -- in line with `sortHogFunctions` in plugin-server
+            "#,
+            team_id,
+            r#type.to_string(),
+        )
+        .fetch_all(e)
+        .await
+    }
+}
+
+impl HogFunctionTemplate {
+    pub async fn fetch_all<'c, E>(e: E) -> Result<Vec<Self>, sqlx::Error>
+    where
+        E: sqlx::Executor<'c, Database = Postgres>,
+    {
+        sqlx::query_as!(
+            Self,
+            r#"
+                SELECT
+                    id,
+                    template_id,
+                    sha,
+                    name,
+                    description,
+                    code,
+                    code_language,
+                    inputs_schema,
+                    bytecode,
+                    type,
+                    status,
+                    category,
+                    kind,
+                    free,
+                    icon_url,
+                    filters,
+                    masking,
+                    mapping_templates,
+                    mappings,
+                    created_at,
+                    updated_at
+                FROM posthog_hogfunctiontemplate
+            "#,
+        )
+        .fetch_all(e)
+        .await
+    }
+
+    pub async fn fetch_by_id<'c, E>(e: E, id: Uuid) -> Result<Self, sqlx::Error>
+    where
+        E: sqlx::Executor<'c, Database = Postgres>,
+    {
+        sqlx::query_as!(
+            Self,
+            r#"
+                SELECT
+                    id,
+                    template_id,
+                    sha,
+                    name,
+                    description,
+                    code,
+                    code_language,
+                    inputs_schema,
+                    bytecode,
+                    type,
+                    status,
+                    category,
+                    kind,
+                    free,
+                    icon_url,
+                    filters,
+                    masking,
+                    mapping_templates,
+                    mappings,
+                    created_at,
+                    updated_at
+                FROM posthog_hogfunctiontemplate
+                WHERE id = $1
+            "#,
+            id
+        )
+        .fetch_one(e)
+        .await
+    }
+}
+
+impl Display for HogFunctionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HogFunctionType::Destination => write!(f, "destination"),
+            HogFunctionType::SiteDestination => write!(f, "site_destination"),
+            HogFunctionType::InternalDestination => write!(f, "internal_destination"),
+            HogFunctionType::SourceWebhook => write!(f, "source_webhook"),
+            HogFunctionType::SiteApp => write!(f, "site_app"),
+            HogFunctionType::Transformation => write!(f, "transformation"),
+        }
+    }
+}
+
+impl FromStr for HogFunctionType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "destination" => Ok(HogFunctionType::Destination),
+            "site_destination" => Ok(HogFunctionType::SiteDestination),
+            "internal_destination" => Ok(HogFunctionType::InternalDestination),
+            "source_webhook" => Ok(HogFunctionType::SourceWebhook),
+            "site_app" => Ok(HogFunctionType::SiteApp),
+            "transformation" => Ok(HogFunctionType::Transformation),
+            _ => Err(()),
+        }
+    }
+}
+
+impl HogFunction {
+    // Estimates the size in bytes of this function. Only includes non-fixed-size data (so nums, uuid's etc are excluded)
+    pub fn cache_weight(&self) -> usize {
+        // Rust introspection wen
+        1 + self.name.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.description.len()
+            + self.r#type.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.kind.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.icon_url.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.hog.len()
+            + self
+                .bytecode
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .transpiled
+                .as_ref()
+                .map(|s| s.len())
+                .unwrap_or_default()
+            + self
+                .inputs_schema
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .inputs
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .encrypted_inputs
+                .as_ref()
+                .map(|s| s.len())
+                .unwrap_or_default()
+            + self
+                .filters
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .mappings
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .masking
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .template_id
+                .as_ref()
+                .map(|s| s.len())
+                .unwrap_or_default()
+    }
+}
+
+impl HogFunctionTemplate {
+    pub fn cache_weight(&self) -> usize {
+        1 + self.template_id.len()
+            + self.sha.len()
+            + self.name.len()
+            + self
+                .description
+                .as_ref()
+                .map(|s| s.len())
+                .unwrap_or_default()
+            + self.code.len()
+            + self.code_language.len()
+            + estimate_value_size(&self.inputs_schema)
+            + self
+                .bytecode
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self.r#type.len()
+            + self.status.len()
+            + estimate_value_size(&self.category)
+            + self.kind.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self.icon_url.as_ref().map(|s| s.len()).unwrap_or_default()
+            + self
+                .filters
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .masking
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .mapping_templates
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+            + self
+                .mappings
+                .as_ref()
+                .map(estimate_value_size)
+                .unwrap_or_default()
+    }
+}
+
+// In-memory estimated resident size of a json value, excluding pointers
+pub fn estimate_value_size(value: &Value) -> usize {
+    match value {
+        Value::Null => 0,
+        Value::Bool(_) => 1,
+        Value::Number(_) => 64 / 8, // Numbers are always 64 bits (i64, u64 or f64)
+        Value::String(s) => s.len(), // Size of the string, plus a pointer, len and capacity
+        Value::Array(arr) => arr.iter().map(estimate_value_size).sum(), // Size of the inners, plus a pointer, len and capacity
+        Value::Object(obj) => obj
+            .iter()
+            .map(|(k, v)| k.len() + estimate_value_size(v))
+            .sum(),
+    }
+}

--- a/rust/cymbal/src/teams.rs
+++ b/rust/cymbal/src/teams.rs
@@ -10,7 +10,10 @@ use crate::{
     error::{PipelineFailure, UnhandledError},
     fingerprinting::grouping_rules::GroupingRule,
     metric_consts::ANCILLARY_CACHE,
-    pipeline::IncomingEvent,
+    pipeline::{
+        transformations::transform::{HogFunctionManager, HogFunctionManagerConfig},
+        IncomingEvent,
+    },
     sanitize_string, WithIndices,
 };
 
@@ -19,6 +22,7 @@ pub struct TeamManager {
     pub assignment_rules: Cache<TeamId, Vec<AssignmentRule>>,
     pub grouping_rules: Cache<TeamId, Vec<GroupingRule>>,
     pub group_type_indices: Cache<TeamId, Vec<GroupType>>,
+    pub function_manager: HogFunctionManager,
 }
 
 impl TeamManager {
@@ -49,11 +53,14 @@ impl TeamManager {
             })
             .build();
 
+        let function_manager = HogFunctionManager::new(HogFunctionManagerConfig::default());
+
         Self {
             token_cache: cache,
             assignment_rules,
             grouping_rules,
             group_type_indices,
+            function_manager,
         }
     }
 


### PR DESCRIPTION
I've got pretty mixed feelings about this. This PR represents the groundwork, but there's a long tail of work needed to get this fully aligned with the CDP side. Without it being a major goal, I think we're better off either 1) merging it fully disabled, with the intention to pick it back up in the future, or 2) abandoning it altogether in favour of setting up a dedicated pipeline in the plugin server that can just take exception events from kafka, apply transformations, and then send them to clickhouse.