### PR TITLE
feat(customers): Add more fields to info section in person feed

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -171,7 +171,6 @@ export const FEATURE_FLAGS = {
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith
     HOGQL_DASHBOARD_ASYNC: 'hogql-dashboard-async', // owner: @webjunkie
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-ingestion
-    PERSON_FEED_CANVAS: 'person-feed-canvas', // owner: #project-canvas
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: @neilkakkar #team-feature-success
     INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     SURVEYS_ADAPTIVE_LIMITS: 'surveys-adaptive-limits', // owner: #team-surveys

--- a/frontend/src/lib/logic/userPreferencesLogic.ts
+++ b/frontend/src/lib/logic/userPreferencesLogic.ts
@@ -21,10 +21,10 @@ export const userPreferencesLogic = kea<userPreferencesLogicType>([
         ],
         hideNullValues: [true, { persist: true }, { setHideNullValues: (_, { enabled }) => enabled }],
         pinnedPersonProperties: [
-            [],
+            [] as string[],
             { persist: true },
             {
-                pinPersonProperty: (state, { prop }) => [...state, prop],
+                pinPersonProperty: (state, { prop }) => (state.includes(prop) ? state : [...state, prop]),
                 unpinPersonProperty: (state, { prop }) => state.filter((p) => p !== prop),
             },
         ],

--- a/frontend/src/lib/logic/userPreferencesLogic.ts
+++ b/frontend/src/lib/logic/userPreferencesLogic.ts
@@ -8,6 +8,8 @@ export const userPreferencesLogic = kea<userPreferencesLogicType>([
     actions({
         setHidePostHogPropertiesInTable: (enabled: boolean) => ({ enabled }),
         setHideNullValues: (enabled: boolean) => ({ enabled }),
+        pinPersonProperty: (prop: string) => ({ prop }),
+        unpinPersonProperty: (prop: string) => ({ prop }),
     }),
     reducers(() => ({
         hidePostHogPropertiesInTable: [
@@ -18,5 +20,13 @@ export const userPreferencesLogic = kea<userPreferencesLogicType>([
             },
         ],
         hideNullValues: [true, { persist: true }, { setHideNullValues: (_, { enabled }) => enabled }],
+        pinnedPersonProperties: [
+            [],
+            { persist: true },
+            {
+                pinPersonProperty: (state, { prop }) => [...state, prop],
+                unpinPersonProperty: (state, { prop }) => state.filter((p) => p !== prop),
+            },
+        ],
     })),
 ])

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeMap.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeMap.tsx
@@ -13,10 +13,10 @@ import { NotebookNodeEmptyState } from './components/NotebookNodeEmptyState'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeMapAttributes>): JSX.Element | null => {
-    const { id } = attributes
+    const { id, distinctId } = attributes
     const { expanded } = useValues(notebookNodeLogic)
 
-    const logic = personLogic({ id })
+    const logic = personLogic({ id, distinctId })
     const { person, personLoading } = useValues(logic)
 
     if (personLoading) {
@@ -49,6 +49,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeMapAttributes>)
 
 type NotebookNodeMapAttributes = {
     id: string
+    distinctId: string
 }
 
 export const NotebookNodeMap = createPostHogWidgetNode<NotebookNodeMapAttributes>({
@@ -61,5 +62,6 @@ export const NotebookNodeMap = createPostHogWidgetNode<NotebookNodeMapAttributes
     startExpanded: true,
     attributes: {
         id: {},
+        distinctId: {},
     },
 })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -130,7 +130,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttribute
                                     {infoLoading ? (
                                         <LemonSkeleton className="h-4 w-24" />
                                     ) : info?.lastSeen ? (
-                                        <TZLabel time={info.lastSeen} />
+                                        <TZLabel time={info.lastSeen.toISOString()} />
                                     ) : (
                                         'unknown'
                                     )}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -21,9 +21,9 @@ import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttributes>): JSX.Element => {
-    const { id } = attributes
+    const { id, distinctId } = attributes
 
-    const logic = personLogic({ id })
+    const logic = personLogic({ distinctId, id })
     const { info, infoLoading, person, personLoading } = useValues(logic)
     const { setExpanded, setActions, insertAfter } = useActions(notebookNodeLogic)
     const { setTitlePlaceholder } = useActions(notebookNodeLogic)
@@ -130,7 +130,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttribute
                                     {infoLoading ? (
                                         <LemonSkeleton className="h-4 w-24" />
                                     ) : info?.lastSeen ? (
-                                        <TZLabel time={info.lastSeen.toISOString()} />
+                                        <TZLabel time={info.lastSeen} />
                                     ) : (
                                         'unknown'
                                     )}
@@ -165,7 +165,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttribute
 }
 
 type NotebookNodePersonAttributes = {
-    id: string
+    id: string | undefined
+    distinctId: string
 }
 
 export const NotebookNodePerson = createPostHogWidgetNode<NotebookNodePersonAttributes>({
@@ -174,15 +175,17 @@ export const NotebookNodePerson = createPostHogWidgetNode<NotebookNodePersonAttr
     Component,
     minHeight: '10rem',
     expandable: false,
-    href: (attrs) => urls.personByDistinctId(attrs.id),
+    href: (attrs) => urls.personByDistinctId(attrs.distinctId),
     resizeable: true,
     attributes: {
         id: {},
+        distinctId: {},
     },
+    // FIXME: pasteOptions is not really working. Maybe change to personByUUID
     pasteOptions: {
         find: urls.personByDistinctId('(.+)', false),
         getAttributes: async (match) => {
-            return { id: match[1] }
+            return { distinctId: match[1], id: undefined }
         },
     },
     serializedText: (attrs) => {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
@@ -9,6 +9,7 @@ import { personLogic } from 'scenes/persons/personLogic'
 import { PersonType } from '~/types'
 
 import { createPostHogWidgetNode } from '../NodeWrapper'
+import { notebookNodeLogic } from '../notebookNodeLogic'
 import { Session } from './Session'
 import { notebookNodePersonFeedLogic } from './notebookNodePersonFeedLogic'
 
@@ -41,11 +42,16 @@ const Feed = ({ person }: FeedProps): JSX.Element => {
     )
 }
 
-const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttributes>): JSX.Element => {
+const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttributes>): JSX.Element | null => {
     const { id } = attributes
+    const { expanded } = useValues(notebookNodeLogic)
 
     const logic = personLogic({ id })
     const { person, personLoading } = useValues(logic)
+
+    if (!expanded) {
+        return null
+    }
 
     if (personLoading) {
         return <FeedSkeleton />
@@ -65,7 +71,8 @@ export const NotebookNodePersonFeed = createPostHogWidgetNode<NotebookNodePerson
     titlePlaceholder: 'Feed',
     Component,
     resizeable: false,
-    expandable: false,
+    expandable: true,
+    startExpanded: true,
     attributes: {
         id: {},
     },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
@@ -43,10 +43,10 @@ const Feed = ({ person }: FeedProps): JSX.Element => {
 }
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttributes>): JSX.Element | null => {
-    const { id } = attributes
+    const { id, distinctId } = attributes
     const { expanded } = useValues(notebookNodeLogic)
 
-    const logic = personLogic({ id })
+    const logic = personLogic({ id, distinctId })
     const { person, personLoading } = useValues(logic)
 
     if (!expanded) {
@@ -64,6 +64,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttri
 
 type NotebookNodePersonFeedAttributes = {
     id: string
+    distinctId: string
 }
 
 export const NotebookNodePersonFeed = createPostHogWidgetNode<NotebookNodePersonFeedAttributes>({
@@ -75,5 +76,6 @@ export const NotebookNodePersonFeed = createPostHogWidgetNode<NotebookNodePerson
     startExpanded: true,
     attributes: {
         id: {},
+        distinctId: {},
     },
 })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeProperties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeProperties.tsx
@@ -1,10 +1,12 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
-import { LemonLabel, LemonSkeleton } from '@posthog/lemon-ui'
+import { IconPin, IconPinFilled } from '@posthog/icons'
+import { LemonButton, LemonLabel, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
 import { personLogic } from 'scenes/persons/personLogic'
 
@@ -20,6 +22,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePropertiesAttri
 
     const logic = personLogic({ id })
     const { person, personLoading } = useValues(logic)
+    const { pinnedPersonProperties } = useValues(userPreferencesLogic)
 
     if (personLoading) {
         return <LemonSkeleton className="h-6" />
@@ -27,28 +30,59 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePropertiesAttri
         return <NotFound object="person" />
     }
 
-    const numProperties = Object.keys(person.properties).length
-
     if (!expanded) {
         return null
     }
 
+    const pinnedProperties = Object.fromEntries(
+        Object.entries(person.properties).filter(([key, _]) => pinnedPersonProperties.includes(key))
+    )
+    const unpinnedProperties = Object.fromEntries(
+        Object.entries(person.properties).filter(([key, _]) => !pinnedPersonProperties.includes(key))
+    )
+    const numUnpinnedProperties = Object.keys(unpinnedProperties).length
+    const numPinnedProperties = Object.keys(unpinnedProperties).length
+
     return (
         <div className="py-2 px-4 text-xs">
-            {Object.entries(person.properties).map(([key, value], index) => {
-                const isLast = index === numProperties - 1
+            {Object.entries(pinnedProperties).map(([key, value], index) => {
+                const isLast = numUnpinnedProperties === numPinnedProperties && index === numPinnedProperties - 1
 
-                return (
-                    <div key={key} className="mb-1">
-                        <LemonLabel className="leading-4">
-                            <PropertyKeyInfo value={key} />
-                        </LemonLabel>
-                        <div className={`${!isLast && 'border-b border-primary pb-1'}`}>
-                            <PropertiesTable properties={value} rootKey={key} type={PropertyDefinitionType.Person} />
-                        </div>
-                    </div>
-                )
+                return <PropertyItem key={key} name={key} value={value} isLast={isLast} isPinned />
             })}
+            {Object.entries(unpinnedProperties).map(([key, value], index) => {
+                const isLast = index === numUnpinnedProperties - 1
+
+                return <PropertyItem key={key} name={key} value={value} isLast={isLast} />
+            })}
+        </div>
+    )
+}
+
+function PropertyItem({
+    name,
+    value,
+    isLast,
+    isPinned = false,
+}: {
+    name: string
+    value: any
+    isLast: boolean
+    isPinned?: boolean
+}): JSX.Element {
+    const { pinPersonProperty, unpinPersonProperty } = useActions(userPreferencesLogic)
+    const Icon = isPinned ? IconPinFilled : IconPin
+    const onClick = isPinned ? () => unpinPersonProperty(name) : () => pinPersonProperty(name)
+
+    return (
+        <div key={name} className="mb-1">
+            <LemonLabel className="flex justify-between leading-4">
+                <PropertyKeyInfo value={name} />
+                <LemonButton noPadding size="small" icon={<Icon />} onClick={onClick} />
+            </LemonLabel>
+            <div className={`${!isLast && 'border-b border-primary pb-1'}`}>
+                <PropertiesTable properties={value} rootKey={name} type={PropertyDefinitionType.Person} />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeProperties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeProperties.tsx
@@ -16,11 +16,11 @@ import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodePropertiesAttributes>): JSX.Element | null => {
-    const { id } = attributes
+    const { id, distinctId } = attributes
 
     const { expanded } = useValues(notebookNodeLogic)
 
-    const logic = personLogic({ id })
+    const logic = personLogic({ id, distinctId })
     const { person, personLoading } = useValues(logic)
     const { pinnedPersonProperties } = useValues(userPreferencesLogic)
 
@@ -89,6 +89,7 @@ function PropertyItem({
 
 type NotebookNodePropertiesAttributes = {
     id: string
+    distinctId: string
 }
 
 export const NotebookNodeProperties = createPostHogWidgetNode({
@@ -100,5 +101,6 @@ export const NotebookNodeProperties = createPostHogWidgetNode({
     startExpanded: true,
     attributes: {
         id: {},
+        distinctId: {},
     },
 })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeProperties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeProperties.tsx
@@ -41,7 +41,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePropertiesAttri
         Object.entries(person.properties).filter(([key, _]) => !pinnedPersonProperties.includes(key))
     )
     const numUnpinnedProperties = Object.keys(unpinnedProperties).length
-    const numPinnedProperties = Object.keys(unpinnedProperties).length
+    const numPinnedProperties = Object.keys(pinnedProperties).length
 
     return (
         <div className="py-2 px-4 text-xs">

--- a/frontend/src/scenes/persons/PersonFeedCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonFeedCanvas.tsx
@@ -14,8 +14,7 @@ const PersonFeedCanvas = ({ person }: PersonFeedCanvasProps): JSX.Element => {
     const { isCloudOrDev } = useValues(preflightLogic)
 
     const id = person.id
-
-    const personId = person.distinct_ids[0]
+    const distinctId = person.distinct_ids[0]
 
     return (
         <Notebook
@@ -31,24 +30,25 @@ const PersonFeedCanvas = ({ person }: PersonFeedCanvasProps): JSX.Element => {
                             height: null,
                             title: null,
                             nodeId: uuid(),
-                            id: personId,
+                            id,
+                            distinctId,
                             __init: null,
                             children: [
                                 {
                                     type: 'ph-person',
-                                    attrs: { id: personId, nodeId: uuid(), title: 'Info' },
+                                    attrs: { id, distinctId, nodeId: uuid(), title: 'Info' },
                                 },
                                 ...(isCloudOrDev
                                     ? [
                                           {
                                               type: 'ph-map',
-                                              attrs: { id: personId, nodeId: uuid() },
+                                              attrs: { id, distinctId, nodeId: uuid() },
                                           },
                                       ]
                                     : []),
                                 {
                                     type: 'ph-properties',
-                                    attrs: { id: personId, nodeId: uuid() },
+                                    attrs: { id, distinctId, nodeId: uuid() },
                                 },
                             ],
                         },

--- a/frontend/src/scenes/persons/personLogic.tsx
+++ b/frontend/src/scenes/persons/personLogic.tsx
@@ -10,18 +10,19 @@ import { PersonType } from '~/types'
 import type { personLogicType } from './personLogicType'
 
 export interface PersonLogicProps {
-    id: string
+    id: string | undefined
+    distinctId: string
 }
 
 export interface Info {
     sessionCount: number
     eventCount: number
-    lastSeen: Date | null
+    lastSeen: string | null
 }
 
 export const personLogic = kea<personLogicType>([
     props({} as PersonLogicProps),
-    key((props) => props.id),
+    key((props) => props.distinctId),
     path((key) => ['scenes', 'persons', 'personLogic', key]),
     actions({
         loadPerson: true,
@@ -32,7 +33,7 @@ export const personLogic = kea<personLogicType>([
             null as PersonType | null,
             {
                 loadPerson: async (): Promise<PersonType | null> => {
-                    const response = await api.persons.list({ distinct_id: props.id })
+                    const response = await api.persons.list({ distinct_id: props.distinctId })
                     const person = response.results[0]
                     return person
                 },

--- a/frontend/src/scenes/persons/personLogic.tsx
+++ b/frontend/src/scenes/persons/personLogic.tsx
@@ -41,7 +41,7 @@ export const personLogic = kea<personLogicType>([
         info: [
             null as Info | null,
             {
-                loadInfo: async (): Promise<any> => {
+                loadInfo: async (): Promise<Info | null> => {
                     if (!props.id) {
                         return null
                     }

--- a/frontend/src/scenes/persons/personLogic.tsx
+++ b/frontend/src/scenes/persons/personLogic.tsx
@@ -1,5 +1,5 @@
-import { actions, afterMount, kea, key, path, props } from 'kea'
-import { loaders } from 'kea-loaders'
+import { actions, kea, key, path, props } from 'kea'
+import { lazyLoaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -27,7 +27,7 @@ export const personLogic = kea<personLogicType>([
         loadPerson: true,
         loadInfo: true,
     }),
-    loaders(({ props }) => ({
+    lazyLoaders(({ props }) => ({
         person: [
             null as PersonType | null,
             {
@@ -80,8 +80,4 @@ export const personLogic = kea<personLogicType>([
             },
         ],
     })),
-    afterMount(({ actions }) => {
-        actions.loadPerson()
-        actions.loadInfo()
-    }),
 ])

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -348,11 +348,7 @@ export const personsLogic = kea<personsLogicType>([
             ],
         ],
         urlId: [() => [(_, props) => props.urlId], (urlId) => urlId],
-        feedEnabled: [
-            (s) => [s.featureFlags],
-            (featureFlags) =>
-                !!featureFlags[FEATURE_FLAGS.PERSON_FEED_CANVAS] || !!featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE],
-        ],
+        feedEnabled: [(s) => [s.featureFlags], (featureFlags) => !!featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]],
         primaryDistinctId: [
             (s) => [s.person],
             (person): string | null => {

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -348,7 +348,11 @@ export const personsLogic = kea<personsLogicType>([
             ],
         ],
         urlId: [() => [(_, props) => props.urlId], (urlId) => urlId],
-        feedEnabled: [(s) => [s.featureFlags], (featureFlags) => !!featureFlags[FEATURE_FLAGS.PERSON_FEED_CANVAS]],
+        feedEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags) =>
+                !!featureFlags[FEATURE_FLAGS.PERSON_FEED_CANVAS] || !!featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE],
+        ],
         primaryDistinctId: [
             (s) => [s.person],
             (person): string | null => {


### PR DESCRIPTION
## Problem
There is no way to pin the person properties you check the most.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/38538
## Changes
- Enables `feed` tab for `crm-iteration-one` flag
- Add a way to pin person properties, storing the preferences in localStorage
- Add a few more user information in `Info` panel
- Minor tweaks to feed nodes:
	- Make feed expandable/collapsible
	- Remove expanded state of person note, as it was showing props only 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
