### PR TITLE
fix(insight): Funnel step more options should open new tab with `targetBlank`

### DIFF
--- a/frontend/src/scenes/funnels/FunnelStepMore.tsx
+++ b/frontend/src/scenes/funnels/FunnelStepMore.tsx
@@ -57,25 +57,25 @@ export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element 
             overlay={
                 <>
                     {stepNumber > 1 && (
-                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.before)}>
+                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.before)} targetBlank>
                             Show user paths leading to step
                         </LemonButton>
                     )}
                     {stepNumber > 1 && (
-                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.between)}>
+                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.between)} targetBlank>
                             Show user paths between previous step and this step
                         </LemonButton>
                     )}
-                    <LemonButton fullWidth to={getPathUrl(FunnelPathType.after)}>
+                    <LemonButton fullWidth to={getPathUrl(FunnelPathType.after)} targetBlank>
                         Show user paths after step
                     </LemonButton>
                     {stepNumber > 1 && (
-                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.after, true)}>
+                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.after, true)} targetBlank>
                             Show user paths after dropoff
                         </LemonButton>
                     )}
                     {stepNumber > 1 && (
-                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.before, true)}>
+                        <LemonButton fullWidth to={getPathUrl(FunnelPathType.before, true)} targetBlank>
                             Show user paths before dropoff
                         </LemonButton>
                     )}


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/38741

For more context on why this bug is happening, you can check out https://github.com/PostHog/posthog/pull/38696#issuecomment-3339000930.

Take note that this PR does not fix the underlying issue, but since in this PR we will open a new tab instead, we avoid running into the issue. 

## Changes


https://github.com/user-attachments/assets/4c34174c-1ff5-4143-89f2-0f9c429f21f5



## How did you test this code?

Locally:
1) Create a funnel
2) Add multiple query steps
3) Go to the second step's triple dot and click on it
4) You should see a bunch of options, each option should have an external link icon
5) Click on one of them, a new internal tab should open.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

