### PR TITLE
fix(insight): `View funnel` should normalise url in user paths insight

### DIFF
--- a/frontend/src/scenes/paths-v2/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths-v2/pathsDataLogic.ts
@@ -136,6 +136,7 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                 const name = currentItemCard.name.includes('http')
                     ? '$pageview'
                     : currentItemCard.name.replace(/(^[0-9]+_)/, '')
+                const url = new URL(currentItemCard.name.replace(/(^[0-9]+_)/, ''))
                 events.push({
                     id: name,
                     name: name,
@@ -147,7 +148,7 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                                 key: '$current_url',
                                 operator: PropertyOperator.Exact,
                                 type: PropertyFilterType.Event,
-                                value: currentItemCard.name.replace(/(^[0-9]+_)/, ''),
+                                value: url.href,
                             },
                         ],
                     }),

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -136,6 +136,7 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                 const name = currentItemCard.name.includes('http')
                     ? '$pageview'
                     : currentItemCard.name.replace(/(^[0-9]+_)/, '')
+                const url = new URL(currentItemCard.name.replace(/(^[0-9]+_)/, ''))
                 events.push({
                     id: name,
                     name: name,
@@ -147,7 +148,7 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                                 key: '$current_url',
                                 operator: PropertyOperator.Exact,
                                 type: PropertyFilterType.Event,
-                                value: currentItemCard.name.replace(/(^[0-9]+_)/, ''),
+                                value: url.href,
                             },
                         ],
                     }),


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/37393

I'm not 100% sure why this is happening, but i suspect its because for a URI with an authority but no path, it should be normalised to have a path of "/".

I think `url.href` is the easiest way to guarantee that, although we could also create a URL and check that it doesn't have a path. 

The reason why we are seeing the `/` at the end for some of the cards is because its using the `href`:

https://github.com/PostHog/posthog/blob/9057148ff9007088c30c547a507d674b0df5d17e/frontend/src/scenes/paths/pathUtils.ts#L103

## Changes


https://github.com/user-attachments/assets/25f7e669-7d1b-44e3-9cbe-d386d335b86a



## How did you test this code?

Firstly, create a user paths insight that has multiple steps.

Look for a path card that has one of the following characteristics:
1) The URI looks like eg: `http://localhost:3000/` or `https://posthog.com/` 
2) It has a previous path card that looks like the URL mentioned in 1)

Finally, go the triple dot of the path card and click on `View Funnel`. An insight should be opened( you might have to refresh, its an bug is being fixed in other PRs), and you should check the urls that it included the `/` behind. 
