### PR TITLE
fix(experiments): Prevent duplication when editing metrics

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -261,14 +261,35 @@ export function ExperimentView(): JSX.Element {
                             <ExperimentMetricModal
                                 experimentId={experimentId}
                                 onSave={(metric, context) => {
-                                    const newOrderingArray = appendMetricToOrderingArray(
-                                        experiment,
-                                        metric.uuid!, //at this point metrics should always have a uuid
-                                        context.type === 'secondary'
+                                    // Check if this is an edit (metric with same UUID already exists) or create
+                                    const existingMetricIndex = experiment[context.field].findIndex(
+                                        (m) => m.uuid === metric.uuid
                                     )
+                                    const isEdit = existingMetricIndex !== -1
+
+                                    let newMetrics
+                                    let newOrderingArray
+
+                                    if (isEdit) {
+                                        // Replace existing metric
+                                        newMetrics = experiment[context.field].map((m) =>
+                                            m.uuid === metric.uuid ? metric : m
+                                        )
+                                        // Keep existing ordering for edits
+                                        newOrderingArray = experiment[context.orderingField]
+                                    } else {
+                                        // Add new metric
+                                        newMetrics = [...experiment[context.field], metric]
+                                        // Add to ordering array for new metrics
+                                        newOrderingArray = appendMetricToOrderingArray(
+                                            experiment,
+                                            metric.uuid!,
+                                            context.type === 'secondary'
+                                        )
+                                    }
 
                                     setExperiment({
-                                        [context.field]: [...experiment[context.field], metric],
+                                        [context.field]: newMetrics,
                                         [context.orderingField]: newOrderingArray,
                                     })
 


### PR DESCRIPTION
## Problem
Editing an experiment metric is duplicating the metric instead of updating it in place.

## Changes
When editing, replace the existing metric instead of always appending.

## How did you test this code?
- A metric is no longer being duplicated on edits
- Adding a new metric is working correctly