### PR TITLE
refactor(experiments): metric modal save cleanup.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -261,36 +261,20 @@ export function ExperimentView(): JSX.Element {
                             <ExperimentMetricModal
                                 experimentId={experimentId}
                                 onSave={(metric, context) => {
-                                    // Check if this is an edit (metric with same UUID already exists) or create
-                                    const existingMetricIndex = experiment[context.field].findIndex(
-                                        (m) => m.uuid === metric.uuid
-                                    )
-                                    const isEdit = existingMetricIndex !== -1
-
-                                    let newMetrics
-                                    let newOrderingArray
-
-                                    if (isEdit) {
-                                        // Replace existing metric
-                                        newMetrics = experiment[context.field].map((m) =>
-                                            m.uuid === metric.uuid ? metric : m
-                                        )
-                                        // Keep existing ordering for edits
-                                        newOrderingArray = experiment[context.orderingField]
-                                    } else {
-                                        // Add new metric
-                                        newMetrics = [...experiment[context.field], metric]
-                                        // Add to ordering array for new metrics
-                                        newOrderingArray = appendMetricToOrderingArray(
-                                            experiment,
-                                            metric.uuid!,
-                                            context.type === 'secondary'
-                                        )
-                                    }
+                                    const metrics = experiment[context.field]
+                                    const isNew = !metrics.some(({ uuid }) => uuid === metric.uuid)
 
                                     setExperiment({
-                                        [context.field]: newMetrics,
-                                        [context.orderingField]: newOrderingArray,
+                                        [context.field]: isNew
+                                            ? [...metrics, metric]
+                                            : metrics.map((m) => (m.uuid === metric.uuid ? metric : m)),
+                                        ...(isNew && {
+                                            [context.orderingField]: appendMetricToOrderingArray(
+                                                experiment,
+                                                metric.uuid!,
+                                                context.type === 'secondary'
+                                            ),
+                                        }),
                                     })
 
                                     updateExperimentMetrics()
@@ -302,17 +286,15 @@ export function ExperimentView(): JSX.Element {
                                         return
                                     }
 
-                                    const newOrderingArray = removeMetricFromOrderingArray(
-                                        experiment,
-                                        metric.uuid,
-                                        context.type === 'secondary'
-                                    )
-
-                                    const newMetrics = experiment[context.field].filter((m) => m.uuid !== metric.uuid)
-
                                     setExperiment({
-                                        [context.field]: newMetrics,
-                                        [context.orderingField]: newOrderingArray,
+                                        [context.field]: experiment[context.field].filter(
+                                            (m) => m.uuid !== metric.uuid
+                                        ),
+                                        [context.orderingField]: removeMetricFromOrderingArray(
+                                            experiment,
+                                            metric.uuid,
+                                            context.type === 'secondary'
+                                        ),
                                     })
 
                                     updateExperimentMetrics()

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -29,12 +29,7 @@ import {
     ResultsQuery,
 } from '../components/ResultsBreakdown'
 import { experimentLogic } from '../experimentLogic'
-import {
-    appendMetricToOrderingArray,
-    isLegacyExperiment,
-    isLegacyExperimentQuery,
-    removeMetricFromOrderingArray,
-} from '../utils'
+import { isLegacyExperiment, isLegacyExperimentQuery, removeMetricFromOrderingArray } from '../utils'
 import { DistributionModal, DistributionTable } from './DistributionTable'
 import { ExperimentHeader } from './ExperimentHeader'
 import { ExposureCriteriaModal } from './ExposureCriteria'
@@ -269,11 +264,10 @@ export function ExperimentView(): JSX.Element {
                                             ? [...metrics, metric]
                                             : metrics.map((m) => (m.uuid === metric.uuid ? metric : m)),
                                         ...(isNew && {
-                                            [context.orderingField]: appendMetricToOrderingArray(
-                                                experiment,
-                                                metric.uuid!,
-                                                context.type === 'secondary'
-                                            ),
+                                            [context.orderingField]: [
+                                                ...(experiment[context.orderingField] ?? []),
+                                                metric.uuid,
+                                            ],
                                         }),
                                     })
 


### PR DESCRIPTION
## Problem

No problem at all. Well, TS was complaining of implicit `any` on `newMetrics` and `newOrderingArray`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The most significant changes are using `some` instead of `findIndex` and only setting the ordering array if creating a new metric. Otherwise, the structure is the same. For consistency, we applied the same rules to `onDelete`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/36eaf8e6-e96d-4a9a-b7bf-54101df2b13b)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
