### PR TITLE
fix(auth): correctly label password logins in new device emails

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -208,7 +208,7 @@ class LoginSerializer(serializers.Serializer):
             short_user_agent = get_short_user_agent(request)
             ip_address = get_ip_address(request)
             login_from_new_device_notification.delay(
-                user.id, timezone.now(), short_user_agent, ip_address, "Email/password"
+                user.id, timezone.now(), short_user_agent, ip_address, "email_password"
             )
 
         report_user_logged_in(user, social_provider="")

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -485,7 +485,11 @@ def login_from_new_device_notification(
     geoip_properties = get_geoip_properties(ip_address)
     country = geoip_properties.get("$geoip_country_name", "Unknown")
     city = geoip_properties.get("$geoip_city_name", "Unknown")
-    login_method = SOCIAL_AUTH_PROVIDER_DISPLAY_NAMES.get(backend_name, "SSO")
+
+    if backend_name == "email_password":
+        login_method = "Email/password"
+    else:
+        login_method = SOCIAL_AUTH_PROVIDER_DISPLAY_NAMES.get(backend_name, "SSO")
 
     is_new_device = check_and_cache_login_device(user_id, country, short_user_agent)
     if not is_new_device:

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -730,3 +730,28 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         assert html_body
         assert "Canada" in html_body
         assert "Google OAuth" in html_body
+
+    @patch("posthog.tasks.email.check_and_cache_login_device")
+    def test_login_from_new_device_notification_email_password(
+        self, mock_check_device: MagicMock, MockEmailMessage: MagicMock
+    ) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        mock_check_device.return_value = True  # Simulate new device
+
+        login_from_new_device_notification(
+            user_id=self.user.id,
+            login_time=timezone.now(),
+            short_user_agent="Chrome 135.0.0 on Mac OS 15.3",
+            ip_address="24.114.32.12",  # random ip in Canada
+            backend_name="email_password",
+        )
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+        assert mocked_email_messages[0].subject == "A new device logged into your account"
+
+        # Check that location appears in email body
+        html_body = mocked_email_messages[0].html_body
+        assert html_body
+        assert "Canada" in html_body
+        assert "Email/password" in html_body


### PR DESCRIPTION
## Problem

When I logged in with my email and password, I received a notification email incorrectly stating the login method was `SSO`:

<img width="561" height="471" alt="image" src="https://github.com/user-attachments/assets/8de8e10c-ec7f-450f-a1c2-4a0d104f747a" />

## Changes

I thought about adding `email_password` to the `SOCIAL_AUTH_PROVIDER_DISPLAY_NAMES`, but then realized it doesn't really make sense, since it's not a social auth provider. 

I guess it could be renamed and then it would fit, but for now I just added a separate if-clause.

## How did you test this code?

I added another test for this specific case.