### PR TITLE
Experiment Holdouts: rollout percentage validation

### DIFF
--- a/ee/clickhouse/views/test/test_experiment_holdouts.py
+++ b/ee/clickhouse/views/test/test_experiment_holdouts.py
@@ -143,4 +143,22 @@ class TestExperimentHoldoutCRUD(APILicensedTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.json()["detail"], "Filters are required to create an holdout group")
+        self.assertEqual(response.json()["detail"], "Filters are required to create a holdout group")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_holdouts",
+            data={
+                "name": "Test",
+                "filters": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 101,
+                        "variant": "holdout",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "Holdout percentage cannot exceed 100%")

--- a/frontend/src/scenes/experiments/Holdouts.tsx
+++ b/frontend/src/scenes/experiments/Holdouts.tsx
@@ -48,8 +48,15 @@ export function Holdouts(): JSX.Element {
         if (!holdout.name) {
             return 'Name is required'
         }
-        if (holdout.filters?.[0]?.rollout_percentage === undefined) {
+        const percentage = holdout.filters?.[0]?.rollout_percentage
+        if (percentage === undefined) {
             return 'Rollout percentage is required'
+        }
+        if (percentage < 0) {
+            return 'Rollout percentage cannot be negative'
+        }
+        if (percentage > 100) {
+            return 'Rollout percentage cannot exceed 100%'
         }
     }
 


### PR DESCRIPTION
## Problem

This PR addresses [this bug](https://github.com/PostHog/posthog/issues/35004):  
Experiment Holdout groups allow for invalid percentages (e.g. greater than 100% or less than 0%)

## Changes

This PR adds validations in two places:
1.  On the Backend, when creating an experiment holdout
2. On the Frontend, preventing users to create a holdout when they entered an invalid percentage value by disabling the `Save` button (similarly to what is done when no name is specified for the Holdout to be created)

These changes were tested manually to check their behavior, see following screenshots

**Screenshot without FE validation**
<img width="460" height="117" alt="BE error" src="https://github.com/user-attachments/assets/3ddb1802-b74f-453e-a97f-1aab1b95f215" />

**Screenshot FE validation 1) percentage > 100**
<img width="558" height="158" alt="percentage gt 100" src="https://github.com/user-attachments/assets/2e6765eb-d42b-452f-bbf3-5ec4e4996518" />

**Screenshot FE validation 2) percentage < 0**
<img width="558" height="158" alt="percentage lt 0" src="https://github.com/user-attachments/assets/2c3d14a9-0cf7-43a6-ae6d-e9fb974e12ae" />

## How did you test this code?

As mentioned above, the changes were validated manually.

Additionally, the existing backend tests were extended with an additional case.

## Open questions

Should the validation also be implemented in the model?
So far, I didn't implement in the model as other validations (e.g. non-empty name) are not implemented in the model either. I assume this is by convention.