### PR TITLE
fix(cohort): Connect to `cohortsModel` to make sure its mounted in `cohortEditLogic`

### DIFF
--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -293,7 +293,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     try {
                         const cohort = await api.cohorts.get(id)
                         breakpoint()
-                        cohortsModel.actions.updateCohort(cohort)
+                        cohortsModel.findMounted()?.actions.updateCohort(cohort)
                         actions.setCohort(cohort)
                         actions.checkIfFinishedCalculating(cohort)
                         return processCohort(cohort)
@@ -312,7 +312,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     try {
                         if (cohort.id !== 'new') {
                             cohort = await api.cohorts.update(cohort.id, cohortFormData as Partial<CohortType>)
-                            cohortsModel.actions.updateCohort(cohort)
+                            cohortsModel.findMounted()?.actions.updateCohort(cohort)
 
                             if (cohort.experiment_set && cohort.experiment_set.length > 0) {
                                 // someone edited an exposure cohort. Track what kind of updates were made
@@ -320,7 +320,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                             }
                         } else {
                             cohort = await api.cohorts.create(cohortFormData as Partial<CohortType>)
-                            cohortsModel.actions.cohortCreated(cohort)
+                            cohortsModel.findMounted()?.actions.cohortCreated(cohort)
                         }
                     } catch (error: any) {
                         breakpoint()
@@ -501,7 +501,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     count: cohort.count,
                 }
                 actions.setCohort({ ...values.cohort, ...calculationFields })
-                cohortsModel.actions.updateCohort(cohort)
+                cohortsModel.findMounted()?.actions.updateCohort(cohort)
                 personsLogic.findMounted({ syncWithUrl: true })?.actions.loadCohorts() // To ensure sync on person page
                 if (values.pollTimeout) {
                     clearTimeout(values.pollTimeout)

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -50,6 +50,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
     path(['scenes', 'cohorts', 'cohortLogicEdit']),
     connect(() => ({
         actions: [eventUsageLogic, ['reportExperimentExposureCohortEdited']],
+        logic: [cohortsModel],
     })),
 
     actions({
@@ -293,7 +294,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     try {
                         const cohort = await api.cohorts.get(id)
                         breakpoint()
-                        cohortsModel.findMounted()?.actions.updateCohort(cohort)
+                        cohortsModel.actions.updateCohort(cohort)
                         actions.setCohort(cohort)
                         actions.checkIfFinishedCalculating(cohort)
                         return processCohort(cohort)
@@ -312,7 +313,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     try {
                         if (cohort.id !== 'new') {
                             cohort = await api.cohorts.update(cohort.id, cohortFormData as Partial<CohortType>)
-                            cohortsModel.findMounted()?.actions.updateCohort(cohort)
+                            cohortsModel.actions.updateCohort(cohort)
 
                             if (cohort.experiment_set && cohort.experiment_set.length > 0) {
                                 // someone edited an exposure cohort. Track what kind of updates were made
@@ -320,7 +321,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                             }
                         } else {
                             cohort = await api.cohorts.create(cohortFormData as Partial<CohortType>)
-                            cohortsModel.findMounted()?.actions.cohortCreated(cohort)
+                            cohortsModel.actions.cohortCreated(cohort)
                         }
                     } catch (error: any) {
                         breakpoint()
@@ -473,7 +474,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
     })),
     listeners(({ actions, values }) => ({
         deleteCohort: () => {
-            cohortsModel.findMounted()?.actions.deleteCohort({ id: values.cohort.id, name: values.cohort.name })
+            cohortsModel.actions.deleteCohort({ id: values.cohort.id, name: values.cohort.name })
             router.actions.push(urls.cohorts())
         },
         submitCohortFailure: () => {
@@ -501,7 +502,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     count: cohort.count,
                 }
                 actions.setCohort({ ...values.cohort, ...calculationFields })
-                cohortsModel.findMounted()?.actions.updateCohort(cohort)
+                cohortsModel.actions.updateCohort(cohort)
                 personsLogic.findMounted({ syncWithUrl: true })?.actions.loadCohorts() // To ensure sync on person page
                 if (values.pollTimeout) {
                     clearTimeout(values.pollTimeout)


### PR DESCRIPTION
## Problem

I don't think this is happening to production because the latency is longer; I can reproduce in my local reliably: 


https://github.com/user-attachments/assets/b2003047-29d3-4981-b346-f0fffefca5e1

The problematic line is:

https://github.com/PostHog/posthog/blob/1bfc98c618cfa2a528994e759b70a53b70507463/frontend/src/scenes/cohorts/cohortEditLogic.ts#L296

I believe when this line is called, `cohortsModel` might not have been mounted yet. 

## Changes


https://github.com/user-attachments/assets/13641ae1-acc4-4f2e-8bdc-7323062d9d72



## How did you test this code?
Locally:
1) Create a notebook
2) Open the notebook on your side panel
3) Go to `/cohorts` and drag a cohort into the notebook
4) You should see that the notebook now has the cohort
5) Refresh the page, the cohort in the notebook should load accordingly

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
