### PR TITLE
feat(myke): adds heap dump functionality to hog-worker

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -1,7 +1,6 @@
 import { instrumented } from '~/common/tracing/tracing-utils'
 
 import { HealthCheckResult, Hub } from '../../types'
-import { initializeHeapDump } from '../../utils/heap-dump'
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { CyclotronJobQueue } from '../services/job-queue/job-queue'
@@ -32,12 +31,6 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
         }
 
         this.cyclotronJobQueue = new CyclotronJobQueue(hub, this.queue, (batch) => this.processBatch(batch))
-
-        // Initialize heap dump functionality
-        initializeHeapDump({
-            enabled: hub.HEAP_DUMP_ENABLED,
-            outputPath: hub.HEAP_DUMP_OUTPUT_PATH,
-        })
     }
 
     @instrumented('cdpConsumer.handleEachBatch.executeInvocations')

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -1,6 +1,7 @@
 import { instrumented } from '~/common/tracing/tracing-utils'
 
 import { HealthCheckResult, Hub } from '../../types'
+import { initializeHeapDump } from '../../utils/heap-dump'
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { CyclotronJobQueue } from '../services/job-queue/job-queue'
@@ -31,6 +32,12 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
         }
 
         this.cyclotronJobQueue = new CyclotronJobQueue(hub, this.queue, (batch) => this.processBatch(batch))
+
+        // Initialize heap dump functionality
+        initializeHeapDump({
+            enabled: hub.HEAP_DUMP_ENABLED,
+            outputPath: hub.HEAP_DUMP_OUTPUT_PATH,
+        })
     }
 
     @instrumented('cdpConsumer.handleEachBatch.executeInvocations')

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -210,7 +210,8 @@ export function getDefaultConfig(): PluginsServerConfig {
 
         // Heap dump configuration
         HEAP_DUMP_ENABLED: false,
-        HEAP_DUMP_OUTPUT_PATH: '/tmp/heap-dumps',
+        HEAP_DUMP_S3_BUCKET: '', // Use OBJECT_STORAGE_BUCKET if not specified
+        HEAP_DUMP_S3_PREFIX: 'heap-dumps',
 
         CDP_FETCH_RETRIES: 3,
         CDP_FETCH_BACKOFF_BASE_MS: 1000,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -210,8 +210,10 @@ export function getDefaultConfig(): PluginsServerConfig {
 
         // Heap dump configuration
         HEAP_DUMP_ENABLED: false,
-        HEAP_DUMP_S3_BUCKET: '', // Use OBJECT_STORAGE_BUCKET if not specified
+        HEAP_DUMP_S3_BUCKET: '',
         HEAP_DUMP_S3_PREFIX: 'heap-dumps',
+        HEAP_DUMP_S3_ENDPOINT: '',
+        HEAP_DUMP_S3_REGION: '',
 
         CDP_FETCH_RETRIES: 3,
         CDP_FETCH_BACKOFF_BASE_MS: 1000,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -207,6 +207,11 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_CYCLOTRON_USE_BULK_COPY_JOB: isProdEnv() ? false : true,
         CDP_CYCLOTRON_COMPRESS_KAFKA_DATA: true,
         CDP_HOG_WATCHER_SAMPLE_RATE: 0, // default is off
+
+        // Heap dump configuration
+        HEAP_DUMP_ENABLED: false,
+        HEAP_DUMP_OUTPUT_PATH: '/tmp/heap-dumps',
+
         CDP_FETCH_RETRIES: 3,
         CDP_FETCH_BACKOFF_BASE_MS: 1000,
         CDP_FETCH_BACKOFF_MAX_MS: 30000,

--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -33,6 +33,7 @@ import { ServerCommands } from './utils/commands'
 import { closeHub, createHub } from './utils/db/hub'
 import { PostgresRouter } from './utils/db/postgres'
 import { isTestEnv } from './utils/env-utils'
+import { initializeHeapDump } from './utils/heap-dump'
 import { logger } from './utils/logger'
 import { NodeInstrumentation } from './utils/node-instrumentation'
 import { captureException, shutdown as posthogShutdown } from './utils/posthog'
@@ -81,6 +82,13 @@ export class PluginServer {
 
         const capabilities = getPluginServerCapabilities(this.config)
         const hub = (this.hub = await createHub(this.config, capabilities))
+
+        // Initialize heap dump functionality for all services
+        initializeHeapDump({
+            enabled: hub.HEAP_DUMP_ENABLED,
+            s3Bucket: hub.HEAP_DUMP_S3_BUCKET || hub.OBJECT_STORAGE_BUCKET,
+            s3Prefix: hub.HEAP_DUMP_S3_PREFIX,
+        })
 
         let _initPluginsPromise: Promise<void> | undefined
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -200,7 +200,8 @@ export type CdpConfig = {
 
     // Heap dump configuration
     HEAP_DUMP_ENABLED: boolean
-    HEAP_DUMP_OUTPUT_PATH: string
+    HEAP_DUMP_S3_BUCKET: string
+    HEAP_DUMP_S3_PREFIX: string
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
     CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
     CDP_FETCH_RETRIES: number
@@ -473,7 +474,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
 
     // Heap dump configuration
     HEAP_DUMP_ENABLED: boolean
-    HEAP_DUMP_OUTPUT_PATH: string
+    HEAP_DUMP_S3_BUCKET: string
+    HEAP_DUMP_S3_PREFIX: string
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -202,6 +202,8 @@ export type CdpConfig = {
     HEAP_DUMP_ENABLED: boolean
     HEAP_DUMP_S3_BUCKET: string
     HEAP_DUMP_S3_PREFIX: string
+    HEAP_DUMP_S3_ENDPOINT: string
+    HEAP_DUMP_S3_REGION: string
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
     CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
     CDP_FETCH_RETRIES: number
@@ -476,6 +478,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     HEAP_DUMP_ENABLED: boolean
     HEAP_DUMP_S3_BUCKET: string
     HEAP_DUMP_S3_PREFIX: string
+    HEAP_DUMP_S3_ENDPOINT: string
+    HEAP_DUMP_S3_REGION: string
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -197,6 +197,10 @@ export type CdpConfig = {
     CDP_REDIS_HOST: string
     CDP_REDIS_PORT: number
     CDP_REDIS_PASSWORD: string
+
+    // Heap dump configuration
+    HEAP_DUMP_ENABLED: boolean
+    HEAP_DUMP_OUTPUT_PATH: string
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
     CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
     CDP_FETCH_RETRIES: number
@@ -466,6 +470,10 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     SES_ACCESS_KEY_ID: string
     SES_SECRET_ACCESS_KEY: string
     SES_REGION: string
+
+    // Heap dump configuration
+    HEAP_DUMP_ENABLED: boolean
+    HEAP_DUMP_OUTPUT_PATH: string
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/utils/heap-dump.test.ts
+++ b/plugin-server/src/utils/heap-dump.test.ts
@@ -28,12 +28,10 @@ describe('heap-dump', () => {
         uploadedData = Buffer.alloc(0)
         s3Client = {} as jest.Mocked<S3Client>
 
-        // Test config
         config = {
             HEAP_DUMP_ENABLED: true,
             HEAP_DUMP_S3_BUCKET: 'test-heap-dumps',
             HEAP_DUMP_S3_PREFIX: 'heap-dumps',
-            HEAP_DUMP_S3_ENDPOINT: 'https://s3.us-east-1.amazonaws.com',
             HEAP_DUMP_S3_REGION: 'us-east-1',
         } as PluginsServerConfig
 
@@ -80,6 +78,12 @@ describe('heap-dump', () => {
         it('should not setup handler when bucket is not configured', () => {
             config.HEAP_DUMP_S3_BUCKET = ''
             initializeHeapDump(config, s3Client)
+            expect(processOnSpy).not.toHaveBeenCalled()
+        })
+
+        it('should not setup handler when region is not configured', () => {
+            config.HEAP_DUMP_S3_REGION = ''
+            initializeHeapDump(config, undefined)
             expect(processOnSpy).not.toHaveBeenCalled()
         })
 

--- a/plugin-server/src/utils/heap-dump.test.ts
+++ b/plugin-server/src/utils/heap-dump.test.ts
@@ -1,0 +1,142 @@
+import { S3Client } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
+import { Readable } from 'stream'
+
+import { PluginsServerConfig } from '../types'
+import { createHeapDump, initializeHeapDump } from './heap-dump'
+
+jest.mock('@aws-sdk/lib-storage')
+jest.mock('v8', () => ({
+    getHeapSnapshot: jest.fn(() => {
+        const mockSnapshot =
+            '{"snapshot":{"meta":{"node_fields":["type","name","id","self_size","edge_count","trace_node_id"],"node_types":[["hidden","array","string","object","code","closure","regexp","number","native","synthetic","concatenated string","sliced string","symbol","bigint"],"bigint"],"edge_fields":["type","name_or_index","to_node"],"edge_types":[["context","element","property","internal","hidden","shortcut","weak"]]},"node_count":1,"edge_count":0},"nodes":[0,0,0,0,0,0],"edges":[],"strings":[""]}'
+        return Readable.from([Buffer.from(mockSnapshot)])
+    }),
+}))
+
+jest.setTimeout(1000)
+
+describe('heap-dump', () => {
+    let s3Client: jest.Mocked<S3Client>
+    let config: PluginsServerConfig
+    let mockUpload: jest.Mock
+    let mockUploadDone: jest.Mock
+    let processOnSpy: jest.SpyInstance
+    let uploadedData: Buffer
+
+    beforeEach(() => {
+        uploadedData = Buffer.alloc(0)
+        s3Client = {} as jest.Mocked<S3Client>
+
+        // Test config
+        config = {
+            HEAP_DUMP_ENABLED: true,
+            HEAP_DUMP_S3_BUCKET: 'test-heap-dumps',
+            HEAP_DUMP_S3_PREFIX: 'heap-dumps',
+            HEAP_DUMP_S3_ENDPOINT: 'https://s3.us-east-1.amazonaws.com',
+            HEAP_DUMP_S3_REGION: 'us-east-1',
+        } as PluginsServerConfig
+
+        mockUpload = jest.fn().mockImplementation(({ params: { Body: stream } }) => {
+            const done = async () => {
+                return new Promise((resolve, reject) => {
+                    stream.on('data', (chunk: any) => {
+                        uploadedData = Buffer.concat([uploadedData, chunk])
+                    })
+                    stream.on('error', reject)
+                    stream.on('end', () => resolve({ Location: 'https://test-bucket.s3.amazonaws.com/test-key' }))
+                })
+            }
+
+            mockUploadDone = jest.fn().mockImplementation(done)
+            return { done: mockUploadDone }
+        })
+        jest.mocked(Upload).mockImplementation(mockUpload)
+
+        processOnSpy = jest.spyOn(process, 'on')
+        process.env.POD_NAME = 'test-pod'
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+        uploadedData = Buffer.alloc(0)
+        processOnSpy.mockRestore()
+        delete process.env.POD_NAME
+        process.removeAllListeners('SIGUSR2')
+    })
+
+    describe('initializeHeapDump', () => {
+        it('should not setup handler when disabled', () => {
+            config.HEAP_DUMP_ENABLED = false
+            initializeHeapDump(config, s3Client)
+            expect(processOnSpy).not.toHaveBeenCalled()
+        })
+
+        it('should not setup handler when S3 client is not provided', () => {
+            initializeHeapDump(config, undefined)
+            expect(processOnSpy).not.toHaveBeenCalled()
+        })
+
+        it('should not setup handler when bucket is not configured', () => {
+            config.HEAP_DUMP_S3_BUCKET = ''
+            initializeHeapDump(config, s3Client)
+            expect(processOnSpy).not.toHaveBeenCalled()
+        })
+
+        it('should setup SIGUSR2 signal handler when enabled', () => {
+            initializeHeapDump(config, s3Client)
+            expect(processOnSpy).toHaveBeenCalledWith('SIGUSR2', expect.any(Function))
+        })
+    })
+
+    describe('createHeapDump', () => {
+        it('should create heap dump and upload to S3', async () => {
+            await createHeapDump(s3Client, 'test-heap-dumps', 'heap-dumps')
+
+            expect(mockUpload).toHaveBeenCalledTimes(1)
+            expect(mockUpload).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    client: s3Client,
+                    params: expect.objectContaining({
+                        Bucket: 'test-heap-dumps',
+                        ContentType: 'application/octet-stream',
+                        Key: expect.stringMatching(
+                            /^heap-dumps\/\d{4}-\d{2}-\d{2}\/heapdump-test-pod-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.heapsnapshot$/
+                        ),
+                    }),
+                })
+            )
+            expect(mockUploadDone).toHaveBeenCalled()
+            expect(uploadedData.length).toBeGreaterThan(0)
+        })
+
+        it('should generate unique keys for each dump', async () => {
+            await createHeapDump(s3Client, 'test-heap-dumps', 'heap-dumps')
+            const firstKey = mockUpload.mock.calls[0][0].params.Key
+
+            // Small delay
+            await new Promise((resolve) => setTimeout(resolve, 1))
+
+            await createHeapDump(s3Client, 'test-heap-dumps', 'heap-dumps')
+            const secondKey = mockUpload.mock.calls[1][0].params.Key
+
+            expect(firstKey).not.toBe(secondKey)
+            expect(firstKey).toMatch(
+                /^heap-dumps\/\d{4}-\d{2}-\d{2}\/heapdump-test-pod-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.heapsnapshot$/
+            )
+            expect(secondKey).toMatch(
+                /^heap-dumps\/\d{4}-\d{2}-\d{2}\/heapdump-test-pod-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.heapsnapshot$/
+            )
+        })
+
+        it('should handle upload errors', async () => {
+            const testError = new Error('Upload failed')
+
+            mockUpload.mockImplementationOnce(() => ({
+                done: jest.fn().mockRejectedValue(testError),
+            }))
+
+            await expect(createHeapDump(s3Client, 'test-heap-dumps', 'heap-dumps')).rejects.toThrow(testError)
+        })
+    })
+})

--- a/plugin-server/src/utils/heap-dump.ts
+++ b/plugin-server/src/utils/heap-dump.ts
@@ -68,8 +68,8 @@ async function createHeapDump(): Promise<void> {
     }
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-    const workerId = process.env.WORKER_ID || 'unknown'
-    const filename = `heapdump-${workerId}-${process.pid}-${timestamp}.heapsnapshot`
+    const podName = process.env.POD_NAME || `pid-${process.pid}`
+    const filename = `heapdump-${podName}-${timestamp}.heapsnapshot`
 
     try {
         const startTime = Date.now()
@@ -96,7 +96,7 @@ async function createHeapDump(): Promise<void> {
                 Body: snapshot,
                 ContentType: 'application/octet-stream',
                 Metadata: {
-                    workerId,
+                    podName,
                     pid: process.pid.toString(),
                     timestamp: new Date().toISOString(),
                 },
@@ -116,7 +116,7 @@ async function createHeapDump(): Promise<void> {
             memoryBefore,
             memoryAfter,
             pid: process.pid,
-            workerId,
+            podName,
         })
     } catch (error) {
         logger.error('❌ Failed to stream heap dump to S3', {

--- a/plugin-server/src/utils/heap-dump.ts
+++ b/plugin-server/src/utils/heap-dump.ts
@@ -1,0 +1,140 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import * as v8 from 'v8'
+
+import { logger } from './logger'
+
+/**
+ * Simple heap dump utility based on signal handling
+ * Inspired by: https://medium.com/@amirilovic/how-to-find-production-memory-leaks-in-node-js-applications-a1b363b4884f
+ *
+ * Usage:
+ * - Send SIGUSR2 signal to the process: kill -USR2 <pid>
+ * - Heap dump will be written to the configured directory
+ */
+
+interface HeapDumpConfig {
+    enabled: boolean
+    outputPath: string
+}
+
+let isHeapDumpEnabled = false
+let heapDumpOutputPath = '/tmp/heap-dumps'
+
+export function initializeHeapDump(config: HeapDumpConfig): void {
+    if (!config.enabled) {
+        logger.debug('Heap dump functionality is disabled')
+        return
+    }
+
+    isHeapDumpEnabled = true
+    heapDumpOutputPath = config.outputPath
+
+    // Ensure output directory exists
+    try {
+        fs.mkdirSync(heapDumpOutputPath, { recursive: true })
+    } catch (error) {
+        logger.error('Failed to create heap dump directory', { error, path: heapDumpOutputPath })
+        return
+    }
+
+    // Set up signal handler for SIGUSR2
+    process.on('SIGUSR2', () => {
+        logger.info('📸 Received SIGUSR2 signal, creating heap dump...')
+        createHeapDump()
+    })
+
+    logger.info('📸 Heap dump initialized', {
+        outputPath: heapDumpOutputPath,
+        pid: process.pid,
+        instructions: `Send SIGUSR2 signal to create heap dump: kill -USR2 ${process.pid}`,
+    })
+}
+
+function createHeapDump(): void {
+    if (!isHeapDumpEnabled) {
+        logger.warn('Heap dump requested but functionality is disabled')
+        return
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const workerId = process.env.WORKER_ID || 'unknown'
+    const filename = `heapdump-${workerId}-${process.pid}-${timestamp}.heapsnapshot`
+    const filepath = path.join(heapDumpOutputPath, filename)
+
+    try {
+        const startTime = Date.now()
+        const memoryBefore = process.memoryUsage()
+
+        logger.info('📸 Starting heap dump creation', {
+            filename,
+            memoryUsage: memoryBefore,
+        })
+
+        // Create heap snapshot and write to file
+        const snapshot = v8.getHeapSnapshot()
+        const fileStream = fs.createWriteStream(filepath)
+
+        snapshot.pipe(fileStream)
+
+        snapshot.on('end', () => {
+            const duration = Date.now() - startTime
+            const stats = fs.statSync(filepath)
+            const memoryAfter = process.memoryUsage()
+
+            logger.info('✅ Heap dump created successfully', {
+                filename,
+                filepath,
+                size: stats.size,
+                duration: `${duration}ms`,
+                memoryBefore,
+                memoryAfter,
+                pid: process.pid,
+                workerId,
+            })
+        })
+
+        snapshot.on('error', (error) => {
+            logger.error('❌ Failed to create heap dump', {
+                error,
+                filename,
+                filepath,
+            })
+        })
+
+        fileStream.on('error', (error) => {
+            logger.error('❌ Failed to write heap dump to file', {
+                error,
+                filename,
+                filepath,
+            })
+        })
+    } catch (error) {
+        logger.error('❌ Unexpected error during heap dump creation', {
+            error,
+            filename,
+            filepath,
+        })
+    }
+}
+
+/**
+ * Get current heap dump configuration status
+ */
+export function getHeapDumpStatus(): {
+    enabled: boolean
+    outputPath: string
+    pid: number
+    workerId: string
+    instructions: string
+} {
+    return {
+        enabled: isHeapDumpEnabled,
+        outputPath: heapDumpOutputPath,
+        pid: process.pid,
+        workerId: process.env.WORKER_ID || 'unknown',
+        instructions: isHeapDumpEnabled
+            ? `Send SIGUSR2 signal to create heap dump: kill -USR2 ${process.pid}`
+            : 'Heap dumps are disabled',
+    }
+}

--- a/plugin-server/src/utils/heap-dump.ts
+++ b/plugin-server/src/utils/heap-dump.ts
@@ -45,7 +45,7 @@ export function initializeHeapDump(config: PluginsServerConfig, heapDumpS3Client
     }
 }
 
-async function createHeapDump(s3Client: S3Client, s3Bucket: string, s3Prefix: string): Promise<void> {
+export async function createHeapDump(s3Client: S3Client, s3Bucket: string, s3Prefix: string): Promise<void> {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
     const podName = process.env.POD_NAME || `pid-${process.pid}`
     const filename = `heapdump-${podName}-${timestamp}.heapsnapshot`
@@ -117,5 +117,6 @@ async function createHeapDump(s3Client: S3Client, s3Bucket: string, s3Prefix: st
             filename,
             bucket: s3Bucket,
         })
+        throw error
     }
 }


### PR DESCRIPTION
## Problem

We have a memory leak in our hog-worker and need a way to debug the heap. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

  - Created `src/utils/heap-dump.ts` - `SIGUSR2` signal handler that writes `.heapsnapshot` files to s3
  - Added config: `HEAP_DUMP_ENABLED` to flag it
  - Integrated into server.ts so all services have it

  Usage:
  1. Enable:` HEAP_DUMP_ENABLED=true` and define the bucket in env variables
  2. Exec into pod (through e.g. lens)
  3. get pid using ` ps aux | grep node` or `pgrep node`
  4. Trigger dump: kill -USR2 <pid> (can repeat multiple times)
  5. Download dumps from s3 analyze in Chrome DevTools 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
