### PR TITLE
fix(insight): New insight shouldn't be able to add to notebook or export

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -261,7 +261,9 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                     <ScenePanelActionsSection>
                         {hasDashboardItemId && <SceneMetalyticsSummaryButton dataAttrKey={RESOURCE_TYPE} />}
 
-                        <SceneAddToNotebookDropdownMenu shortId={insight.short_id} dataAttrKey={RESOURCE_TYPE} />
+                        {insight.short_id && (
+                            <SceneAddToNotebookDropdownMenu shortId={insight.short_id} dataAttrKey={RESOURCE_TYPE} />
+                        )}
                         <SceneAddToDashboardButton
                             dashboard={
                                 hasDashboardItemId

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -338,7 +338,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             </ButtonPrimitive>
                         )}
 
-                        {exportContext ? (
+                        {exportContext && insight.short_id != null ? (
                             <SceneExportDropdownMenu
                                 dropdownMenuItems={[
                                     {


### PR DESCRIPTION
## Problem

There are two problems:
1) New insight has no `insight.short_id`, so it will add an empty insight that is not linked to anything to the notebook.
2) Export for PNG is not working for new insight; and i don't think its supposed to work? 



## Changes


https://github.com/user-attachments/assets/ae40f647-1d71-4809-8e5a-bda2d8ecc9cf

### Alternative
We can choose to still allow for exports, since only export for PNG is not working. 

## How did you test this code?

Locally:
1) Go to the new insight page
2) Click on the more option icon in the top right corner

You should not see `add to notebook` or `export`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
