### PR TITLE
fix(dashboard): Returning entity display is not in the right data structure for retention insight

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -307,13 +307,17 @@ function RetentionSummary({ query }: { query: RetentionQuery }): JSX.Element {
             and came back to perform
             <EntityDisplay
                 entity={
-                    {
-                        ...query.retentionFilter.returningEntity,
-                        kind:
-                            query.retentionFilter.returningEntity?.type === 'actions'
-                                ? NodeKind.ActionsNode
-                                : NodeKind.EventsNode,
-                    } as AnyEntityNode
+                    query.retentionFilter.returningEntity?.type === 'actions'
+                        ? {
+                              kind: NodeKind.ActionsNode,
+                              name: query.retentionFilter.returningEntity.name,
+                              id: query.retentionFilter.returningEntity.id as number,
+                          }
+                        : {
+                              kind: NodeKind.EventsNode,
+                              name: query.retentionFilter.returningEntity?.name,
+                              event: query.retentionFilter.returningEntity?.id as string,
+                          }
                 }
             />
             in any of the next periods


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/37279

## Changes

<img width="868" height="505" alt="Screenshot 2025-09-29 at 4 35 24 PM" src="https://github.com/user-attachments/assets/b9546a13-378f-4ef9-9994-3b9431a2c1df" />


## How did you test this code?

Locally:
1) Create a retention insight that both events are not page view 
2) Create a dashboard
3) Add the retention insight to the dashboard
4) Click on `show detail` for the retention insight

You should see the correct names for both events.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
