### PR TITLE
fix(max): speed up the query planner

### DIFF
--- a/ee/hogai/graph/query_planner/nodes.py
+++ b/ee/hogai/graph/query_planner/nodes.py
@@ -155,6 +155,7 @@ class QueryPlannerNode(TaxonomyReasoningNodeMixin, AssistantNode):
             reasoning={
                 "summary": "auto",  # Without this, there's no reasoning summaries! Only works with reasoning models
             },
+            include=["reasoning.encrypted_content"],
             team=self._team,
             user=self._user,
         ).bind_tools(


### PR DESCRIPTION
## Problem

I assumed that the include field is automatically attached, but @kappa90 was right and it's not. This has a 30-40% speed-up effect on subsequent generations.

## Changes

- Add missing `include` for encrypted reasoning.

## How did you test this code?

- Manual testing