### PR TITLE
fix(experiments): Change default variant label

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -518,7 +518,7 @@ export const experimentLogic = kea<experimentLogicType>([
                                 feature_flag_variants: [
                                     ...updatedRolloutPercentageVariants,
                                     {
-                                        key: `test_group_${state.parameters.feature_flag_variants.length}`,
+                                        key: `test-${state.parameters.feature_flag_variants.length}`,
                                         rollout_percentage: newRolloutPercentages[newRolloutPercentages.length - 1],
                                     },
                                 ],


### PR DESCRIPTION
## Changes
Update default variant naming from `test_group_2` → `test-2`, which is less clunky and closer to how users typically label variants.

## How did you test this code?
|Before|After|
|----|----|
|<img width="331" height="259" alt="image" src="https://github.com/user-attachments/assets/24bb8218-35f6-41ed-bad2-547c6628a71f" />|<img width="333" height="260" alt="image" src="https://github.com/user-attachments/assets/048124d6-dc46-4d4c-87e2-4aafc37f806b" />|