### PR TITLE
fix(experiments): fix label charts being out of order

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -50,19 +50,14 @@ import {
  */
 function convertExperimentResultToFunnelSteps(
     result: CachedNewExperimentQueryResponse,
-    metric: ExperimentMetric,
-    experiment: Experiment
+    metric: ExperimentMetric
 ): FunnelStepWithNestedBreakdown[] {
-    const variants = experiment.parameters?.feature_flag_variants || []
-
     const allResults = [result.baseline, ...(result.variant_results || [])]
     const numSteps = (result.baseline.step_counts?.length || 0) + 1
     const funnelSteps: FunnelStepWithNestedBreakdown[] = []
 
     for (let stepIndex = 0; stepIndex < numSteps; stepIndex++) {
         const variantSteps: FunnelStep[] = allResults.map((variantResult, variantIndex) => {
-            const variantKey = variants[variantIndex]?.key || (variantIndex === 0 ? 'control' : `test_${variantIndex}`)
-
             let count: number
             if (stepIndex === 0) {
                 count = variantResult.number_of_samples
@@ -85,19 +80,13 @@ function convertExperimentResultToFunnelSteps(
             }
 
             return {
-                action_id: `step_${stepIndex}`,
                 name: stepName,
                 custom_name: null,
-                order: variantIndex,
                 count: count,
                 type: 'events' as EntityType,
-                average_conversion_time: null,
-                median_conversion_time: null,
-                converted_people_url: '',
-                dropped_people_url: null,
-                breakdown_value: variantKey,
-                breakdownIndex: variantIndex,
-            } as FunnelStep & { breakdownIndex: number }
+                breakdown_value: variantResult.key,
+                breakdown_index: variantIndex,
+            } as FunnelStep & { breakdown_index: number }
         })
 
         const baseStep = variantSteps[0]
@@ -105,7 +94,6 @@ function convertExperimentResultToFunnelSteps(
 
         funnelSteps.push({
             ...baseStep,
-            order: stepIndex,
             count: totalCount,
             nested_breakdown: variantSteps,
         })
@@ -252,7 +240,7 @@ export function ResultDetails({
             {isExperimentFunnelMetric(metric) &&
                 (useExperimentFunnelChart ? (
                     <FunnelChart
-                        steps={convertExperimentResultToFunnelSteps(result, metric, experiment)}
+                        steps={convertExperimentResultToFunnelSteps(result, metric)}
                         showPersonsModal={false}
                         disableBaseline={true}
                         inCardView={true}

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -88,7 +88,7 @@ function convertExperimentResultToFunnelSteps(
                 action_id: `step_${stepIndex}`,
                 name: stepName,
                 custom_name: null,
-                order: stepIndex,
+                order: variantIndex,
                 count: count,
                 type: 'events' as EntityType,
                 average_conversion_time: null,
@@ -105,6 +105,7 @@ function convertExperimentResultToFunnelSteps(
 
         funnelSteps.push({
             ...baseStep,
+            order: stepIndex,
             count: totalCount,
             nested_breakdown: variantSteps,
         })

--- a/frontend/src/scenes/experiments/charts/funnel/FunnelBarVertical.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelBarVertical.tsx
@@ -35,17 +35,14 @@ interface FunnelBarVerticalCSSProperties extends React.CSSProperties {
 }
 
 export function FunnelBarVertical({ inCardView = false }: ChartParams): JSX.Element {
-    const { visibleStepsWithConversionMetrics } = useFunnelChartData()
+    const { stepsWithConversionMetrics } = useFunnelChartData()
     const { vizRef, showTooltip, hideTooltip } = useFunnelTooltip()
 
     const { height: availableHeight } = useResizeObserver({ ref: vizRef })
     const [scrollbarHeightPx, setScrollbarHeightPx] = useState(0)
     const [stepLegendRowHeightPx, setStepLegendRowHeightPx] = useState(0)
 
-    const seriesCount = Math.max(
-        ...visibleStepsWithConversionMetrics.map((step) => step.nested_breakdown?.length || 1),
-        1
-    )
+    const seriesCount = Math.max(...stepsWithConversionMetrics.map((step) => step.nested_breakdown?.length || 1), 1)
     // Calculate base bar width based on series count
     const widthLimits = [
         { min: 60, width: 4 },
@@ -83,7 +80,7 @@ export function FunnelBarVertical({ inCardView = false }: ChartParams): JSX.Elem
 
     /** Average conversion time is only shown if it's known for at least one step. */
     // != is intentional to catch undefined too
-    const showTime = visibleStepsWithConversionMetrics.some((step) => step.average_conversion_time != null)
+    const showTime = stepsWithConversionMetrics.some((step) => step.average_conversion_time != null)
 
     const minimumBarHeightPx = 150
     const borderHeightPx = 1
@@ -105,7 +102,7 @@ export function FunnelBarVertical({ inCardView = false }: ChartParams): JSX.Elem
                         }
                     >
                         <colgroup>
-                            {visibleStepsWithConversionMetrics.map((_, i) => (
+                            {stepsWithConversionMetrics.map((_, i) => (
                                 <col key={i} width={0} />
                             ))}
                             <col width="100%" />
@@ -116,7 +113,7 @@ export function FunnelBarVertical({ inCardView = false }: ChartParams): JSX.Elem
                                 <td>
                                     <StepBarLabels />
                                 </td>
-                                {visibleStepsWithConversionMetrics.map((step, stepIndex) => (
+                                {stepsWithConversionMetrics.map((step, stepIndex) => (
                                     <td key={stepIndex}>
                                         <StepBars step={step} stepIndex={stepIndex} />
                                     </td>
@@ -124,7 +121,7 @@ export function FunnelBarVertical({ inCardView = false }: ChartParams): JSX.Elem
                             </tr>
                             <tr ref={stepLegendRowRef}>
                                 <td />
-                                {visibleStepsWithConversionMetrics.map((step, stepIndex) => (
+                                {stepsWithConversionMetrics.map((step, stepIndex) => (
                                     <td key={stepIndex}>
                                         <StepLegend step={step} stepIndex={stepIndex} showTime={showTime} />
                                     </td>

--- a/frontend/src/scenes/experiments/charts/funnel/FunnelChart.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelChart.tsx
@@ -27,7 +27,6 @@ export interface FunnelChartProps extends ChartParams {
 }
 
 export interface FunnelChartDataContext {
-    visibleStepsWithConversionMetrics: FunnelStepWithConversionMetrics[]
     stepsWithConversionMetrics: FunnelStepWithConversionMetrics[]
     steps: FunnelStepWithNestedBreakdown[]
     hasFunnelResults: boolean
@@ -69,7 +68,6 @@ export function FunnelChart({
 
     const contextValue: FunnelChartDataContext = useMemo(
         () => ({
-            visibleStepsWithConversionMetrics: processedData.visibleStepsWithConversionMetrics,
             stepsWithConversionMetrics: processedData.stepsWithConversionMetrics,
             steps: processedData.steps,
             hasFunnelResults: processedData.hasFunnelResults,

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import { useActions } from 'kea'
 import { useRef } from 'react'
 
+import { getSeriesColor } from 'lib/colors'
 import { percentage } from 'lib/utils'
 
 import { SessionData } from '~/queries/schema/schema-general'
@@ -9,7 +10,6 @@ import { FunnelStepWithConversionMetrics } from '~/types'
 
 import { useTooltip } from './FunnelBarVertical'
 import { useFunnelChartData } from './FunnelChart'
-import { getSeriesColor } from './funnelUtils'
 import { sampledSessionsModalLogic } from './sampledSessionsModalLogic'
 
 export interface StepBarProps {
@@ -28,7 +28,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
     const { experimentResult } = useFunnelChartData()
     const { openModal } = useActions(sampledSessionsModalLogic)
 
-    const seriesColor = getSeriesColor(step)
+    const seriesColor = getSeriesColor((step as any).breakdown_index)
 
     // Get sampled sessions from the experiment result
     // Find the variant result that matches this series

--- a/frontend/src/scenes/experiments/charts/funnel/funnelUtils.ts
+++ b/frontend/src/scenes/experiments/charts/funnel/funnelUtils.ts
@@ -1,4 +1,3 @@
-import { getSeriesColor as getSeriesColorFromLib } from 'lib/colors'
 import { FunnelLayout } from 'lib/constants'
 import { flattenedStepsByBreakdown, stepsWithConversionMetrics } from 'scenes/funnels/funnelUtils'
 
@@ -20,16 +19,6 @@ export interface ProcessedFunnelData {
     stepsWithConversionMetrics: FunnelStepWithConversionMetrics[]
     flattenedBreakdowns: FlattenedFunnelStepByBreakdown[]
     hasFunnelResults: boolean
-}
-
-/**
- * Get a consistent color for a funnel series using the same index-based approach as exposure charts.
- */
-export function getSeriesColor(series: FunnelStepWithConversionMetrics): string {
-    // Use the breakdownIndex if available (added by experiment conversion)
-    // This matches exactly what the exposure chart does with getSeriesColor(index)
-    const index = (series as any).breakdownIndex ?? 0
-    return getSeriesColorFromLib(index)
 }
 
 /**

--- a/frontend/src/scenes/experiments/charts/funnel/funnelUtils.ts
+++ b/frontend/src/scenes/experiments/charts/funnel/funnelUtils.ts
@@ -93,9 +93,8 @@ function getVisibleStepsWithConversionMetrics(
             ? [baseLineSteps.steps[stepIndex], ...(step?.nested_breakdown ?? [])]
             : step?.nested_breakdown
         )
-            ?.map((b, breakdownIndex) => ({
+            ?.map((b) => ({
                 ...b,
-                order: breakdownIndex,
             }))
             ?.filter((b) => isOnlySeries || !hiddenLegendBreakdowns?.includes(getVisibilityKey(b.breakdown_value))),
     }))


### PR DESCRIPTION
## Problem

Labels on the funnel chart could appear out of order, i.e wrong label on the bar.

## Changes

Related to how order is preserved in the "visible steps logic" ported from the original funnel chart. We don't need this logic, at least to begin with, so for now, just remove the logic completely.

## How did you test this code?

Tested locally