### PR TITLE
feat(activity-logs): UI/UX enhancements

### DIFF
--- a/frontend/src/scenes/audit-logs/AdvancedActivityLogsList.tsx
+++ b/frontend/src/scenes/audit-logs/AdvancedActivityLogsList.tsx
@@ -4,16 +4,14 @@ import { SkeletonLog } from 'lib/components/ActivityLog/ActivityLog'
 import { describerFor } from 'lib/components/ActivityLog/activityLogLogic'
 import { humanize } from 'lib/components/ActivityLog/humanizeActivity'
 import { DetectiveHog } from 'lib/components/hedgehogs'
-import { PaginationControl, usePagination } from 'lib/lemon-ui/PaginationControl'
 
-import { AuditLogTableHeader, AuditLogTableRow } from './AuditLogTable'
+import { AuditLogTable } from './AuditLogTable'
 import { advancedActivityLogsLogic } from './advancedActivityLogsLogic'
 
 export function AdvancedActivityLogsList(): JSX.Element {
     const { advancedActivityLogs, advancedActivityLogsLoading, pagination } = useValues(advancedActivityLogsLogic)
 
     const humanizedLogs = advancedActivityLogs?.results ? humanize(advancedActivityLogs.results, describerFor) : []
-    const paginationState = usePagination(humanizedLogs, pagination)
 
     if (advancedActivityLogsLoading) {
         return <AdvancedActivityLogsListSkeleton />
@@ -23,22 +21,7 @@ export function AdvancedActivityLogsList(): JSX.Element {
         return <AdvancedActivityLogsEmptyState />
     }
 
-    return (
-        <div>
-            <div className="border border-border rounded-md bg-bg-light overflow-hidden">
-                <AuditLogTableHeader />
-                <div className="divide-y divide-border">
-                    {humanizedLogs.map((logItem, index) => (
-                        <AuditLogTableRow key={index} logItem={logItem} />
-                    ))}
-                </div>
-            </div>
-
-            <div className="flex justify-center mt-6">
-                <PaginationControl {...paginationState} data-attr="audit-logs-pagination" />
-            </div>
-        </div>
-    )
+    return <AuditLogTable logItems={humanizedLogs} pagination={pagination} />
 }
 
 const AdvancedActivityLogsListSkeleton = (): JSX.Element => (

--- a/frontend/src/scenes/audit-logs/AuditLogTable.tsx
+++ b/frontend/src/scenes/audit-logs/AuditLogTable.tsx
@@ -1,142 +1,158 @@
 import { useState } from 'react'
 
-import { IconCollapse, IconExpand } from '@posthog/icons'
 import { LemonTabs } from '@posthog/lemon-ui'
 
 import { HumanizedActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
 import { humanizeScope } from 'lib/components/ActivityLog/humanizeActivity'
 import MonacoDiffEditor from 'lib/components/MonacoDiffEditor'
 import { TZLabel } from 'lib/components/TZLabel'
+import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 
-export interface AuditLogTableRowProps {
-    logItem: HumanizedActivityLogItem
+export interface AuditLogTableProps {
+    logItems: HumanizedActivityLogItem[]
+    pagination?: PaginationManual
 }
 
-export function AuditLogTableHeader(): JSX.Element {
+const columns: LemonTableColumns<HumanizedActivityLogItem> = [
+    {
+        title: 'Description',
+        dataIndex: 'description',
+        key: 'description',
+        className: 'max-w-80',
+        render: (description) => (
+            <span className="[&_*]:inline whitespace-nowrap overflow-hidden text-ellipsis">
+                {typeof description === 'string' ? description : description || 'No description'}
+            </span>
+        ),
+        width: '40%',
+    },
+    {
+        title: 'User',
+        key: 'user',
+        render: (_, logItem) => (
+            <ProfilePicture
+                showName={true}
+                user={{
+                    first_name: logItem.isSystem ? 'PostHog' : logItem.name,
+                    email: logItem.email ?? undefined,
+                }}
+                type={logItem.isSystem ? 'system' : 'person'}
+                size="md"
+            />
+        ),
+        width: '20%',
+    },
+    {
+        title: 'Activity',
+        key: 'action',
+        render: (_, logItem) => <span className="capitalize">{logItem.unprocessed?.activity || 'Unknown'}</span>,
+        width: '20%',
+    },
+    {
+        title: 'Scope',
+        key: 'scope',
+        render: (_, logItem) => (
+            <span className="inline-block">
+                {logItem.unprocessed?.scope ? humanizeScope(logItem.unprocessed.scope, true) : 'Unknown'}
+            </span>
+        ),
+        width: '20%',
+    },
+    {
+        title: 'Time',
+        key: 'time',
+        render: (_, logItem) => <TZLabel time={logItem.created_at} />,
+        width: '10%',
+    },
+]
+
+export function AuditLogTable({ logItems, pagination }: AuditLogTableProps): JSX.Element {
+    const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+
+    const toggleRowExpansion = (_: HumanizedActivityLogItem, index: number): void => {
+        setExpandedRows((prev) => {
+            const newSet = new Set(prev)
+            if (newSet.has(index)) {
+                newSet.delete(index)
+            } else {
+                newSet.add(index)
+            }
+            return newSet
+        })
+    }
+
+    const isRowExpanded = (_: HumanizedActivityLogItem, index: number): boolean => {
+        return expandedRows.has(index)
+    }
+
     return (
-        <div className="grid grid-cols-12 gap-4 py-3 px-4 bg-accent-3000 border-b border-border font-semibold text-sm text-muted-alt">
-            <div className="col-span-4">Description</div>
-
-            <div className="col-span-2">User</div>
-
-            <div className="col-span-2">Action</div>
-
-            <div className="col-span-2">Scope</div>
-
-            <div className="col-span-1">Time</div>
-
-            <div className="col-span-1" />
-        </div>
+        <LemonTable
+            columns={columns}
+            dataSource={logItems}
+            expandable={{
+                expandedRowRender: (logItem) => <ExpandedRowContent logItem={logItem} />,
+                rowExpandable: () => true,
+                isRowExpanded: (logItem, index) => (isRowExpanded(logItem, index) ? 1 : 0),
+                onRowExpand: (logItem, index) => toggleRowExpansion(logItem, index),
+                onRowCollapse: (logItem, index) => toggleRowExpansion(logItem, index),
+            }}
+            onRow={(logItem, index) => ({
+                onClick: () => toggleRowExpansion(logItem, index),
+                style: { cursor: 'pointer' },
+            })}
+            pagination={pagination}
+            data-attr="audit-log-table"
+        />
     )
 }
 
-export function AuditLogTableRow({ logItem }: AuditLogTableRowProps): JSX.Element {
-    const [expanded, setExpanded] = useState(false)
+function ExpandedRowContent({ logItem }: { logItem: HumanizedActivityLogItem }): JSX.Element {
     const unprocessed = logItem.unprocessed
 
+    if (!unprocessed) {
+        return <div className="p-4 text-muted">No additional details available</div>
+    }
+
     return (
-        <div className="border-b border-border last:border-b-0">
-            <div
-                className="grid grid-cols-12 gap-4 py-3 px-4 hover:bg-accent-3000 items-center text-sm cursor-pointer"
-                onClick={() => setExpanded(!expanded)}
-                data-attr="audit-log-row"
-            >
-                <div className="col-span-4">
-                    <div className="truncate [&_*]:inline [&_*]:mr-1">
-                        {typeof logItem.description === 'string'
-                            ? logItem.description
-                            : logItem.description || 'No description'}
-                    </div>
-                </div>
-
-                <div className="col-span-2">
-                    <ProfilePicture
-                        showName={true}
-                        user={{
-                            first_name: logItem.isSystem ? 'PostHog' : logItem.name,
-                            email: logItem.email ?? undefined,
-                        }}
-                        type={logItem.isSystem ? 'system' : 'person'}
-                        size="md"
-                    />
-                </div>
-
-                <div className="col-span-2">
-                    <span className="capitalize">{unprocessed?.activity || 'Unknown'}</span>
-                </div>
-
-                <div className="col-span-2">
-                    <span className="inline-block px-2 py-1 bg-accent-3000 rounded">
-                        {unprocessed?.scope ? humanizeScope(unprocessed.scope, true) : 'Unknown'}
-                    </span>
-                </div>
-
-                <div className="col-span-1 text-muted text-xs">
-                    <TZLabel time={logItem.created_at} />
-                </div>
-
-                <div className="col-span-1 flex justify-end">
-                    <button
-                        className="text-muted-alt hover:text-default p-1 rounded hover:bg-accent-3000"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            setExpanded(!expanded)
-                        }}
-                        aria-label={expanded ? 'Collapse row' : 'Expand row'}
-                        data-attr="audit-log-expand-button"
-                    >
-                        {expanded ? <IconCollapse /> : <IconExpand />}
-                    </button>
-                </div>
-            </div>
-
-            {expanded && (
-                <div className="bg-surface-secondary border-t border-border">
-                    <div className="px-6 py-4">
-                        {unprocessed && (
-                            <>
-                                <div className="mb-6">
-                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                        <div className="space-y-3">
-                                            <div>
-                                                <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
-                                                    Description
-                                                </div>
-                                                <div className="text-sm text-default [&_div]:inline [&_div]:mr-1">
-                                                    {logItem.description}
-                                                </div>
-                                            </div>
-                                            {logItem.extendedDescription && (
-                                                <div>
-                                                    <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
-                                                        Extended Description
-                                                    </div>
-                                                    <div className="text-sm text-default [&_div]:inline [&_div]:mr-1">
-                                                        {logItem.extendedDescription}
-                                                    </div>
-                                                </div>
-                                            )}
-                                            {unprocessed.item_id && (
-                                                <div>
-                                                    <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
-                                                        Item ID
-                                                    </div>
-                                                    <div className="text-sm text-default">{unprocessed.item_id}</div>
-                                                </div>
-                                            )}
-                                        </div>
-                                    </div>
+        <div className="px-4 py-4">
+            <div className="mb-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-3">
+                        <div>
+                            <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
+                                Description
+                            </div>
+                            <div className="text-sm text-default [&_div]:inline [&_div]:mr-1">
+                                {logItem.description}
+                            </div>
+                        </div>
+                        {logItem.extendedDescription && (
+                            <div>
+                                <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
+                                    Extended Description
                                 </div>
-
-                                <div>
-                                    <ActivityDetailsSection logItem={logItem} />
+                                <div className="text-sm text-default [&_div]:inline [&_div]:mr-1">
+                                    {logItem.extendedDescription}
                                 </div>
-                            </>
+                            </div>
+                        )}
+                        {unprocessed.item_id && (
+                            <div>
+                                <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
+                                    Item ID
+                                </div>
+                                <div className="text-sm text-default">{unprocessed.item_id}</div>
+                            </div>
                         )}
                     </div>
                 </div>
-            )}
+            </div>
+
+            <div>
+                <ActivityDetailsSection logItem={logItem} />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/audit-logs/AuditLogTable.tsx
+++ b/frontend/src/scenes/audit-logs/AuditLogTable.tsx
@@ -43,7 +43,7 @@ export function AuditLogTableRow({ logItem }: AuditLogTableRowProps): JSX.Elemen
                 data-attr="audit-log-row"
             >
                 <div className="col-span-4">
-                    <div className="truncate [&_div]:inline [&_div]:mr-1">
+                    <div className="truncate [&_*]:inline [&_*]:mr-1">
                         {typeof logItem.description === 'string'
                             ? logItem.description
                             : logItem.description || 'No description'}

--- a/frontend/src/scenes/audit-logs/AuditLogTable.tsx
+++ b/frontend/src/scenes/audit-logs/AuditLogTable.tsx
@@ -24,7 +24,7 @@ export function AuditLogTableHeader(): JSX.Element {
 
             <div className="col-span-2">Scope</div>
 
-            <div className="col-span-1">Timestamp</div>
+            <div className="col-span-1">Time</div>
 
             <div className="col-span-1" />
         </div>

--- a/frontend/src/scenes/audit-logs/AuditLogTable.tsx
+++ b/frontend/src/scenes/audit-logs/AuditLogTable.tsx
@@ -116,43 +116,35 @@ function ExpandedRowContent({ logItem }: { logItem: HumanizedActivityLogItem }):
     }
 
     return (
-        <div className="px-4 py-4">
-            <div className="mb-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="space-y-3">
-                        <div>
-                            <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
-                                Description
-                            </div>
-                            <div className="text-sm text-default [&_div]:inline [&_div]:mr-1">
-                                {logItem.description}
-                            </div>
+        <div className="p-4 space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-3">
+                    <div>
+                        <div className="text-[11px] font-medium text-muted-alt uppercase tracking-wider mb-1">
+                            Description
                         </div>
-                        {logItem.extendedDescription && (
-                            <div>
-                                <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
-                                    Extended Description
-                                </div>
-                                <div className="text-sm text-default [&_div]:inline [&_div]:mr-1">
-                                    {logItem.extendedDescription}
-                                </div>
-                            </div>
-                        )}
-                        {unprocessed.item_id && (
-                            <div>
-                                <div className="text-xs font-medium text-muted-alt uppercase tracking-wider mb-1">
-                                    Item ID
-                                </div>
-                                <div className="text-sm text-default">{unprocessed.item_id}</div>
-                            </div>
-                        )}
+                        <div className="text-[13px] text-default">{logItem.description}</div>
                     </div>
+                    {logItem.extendedDescription && (
+                        <div>
+                            <div className="text-[11px] font-medium text-muted-alt uppercase tracking-wider mb-1">
+                                Extended Description
+                            </div>
+                            <div className="text-[13px] text-default">{logItem.extendedDescription}</div>
+                        </div>
+                    )}
+                    {unprocessed.item_id && (
+                        <div>
+                            <div className="text-[11px] font-medium text-muted-alt uppercase tracking-wider mb-1">
+                                Item ID
+                            </div>
+                            <div className="text-[13px] text-default">{unprocessed.item_id}</div>
+                        </div>
+                    )}
                 </div>
             </div>
 
-            <div>
-                <ActivityDetailsSection logItem={logItem} />
-            </div>
+            <ActivityDetailsSection logItem={logItem} />
         </div>
     )
 }
@@ -171,9 +163,9 @@ const ActivityDetailsSection = ({ logItem }: { logItem: HumanizedActivityLogItem
                 logItem.extendedDescription
                     ? {
                           key: 'extended description',
-                          label: 'Extended Description',
+                          label: 'Extended description',
                           tooltip: 'Some activities have a more detailed description that is not shown when collapsed.',
-                          content: <div className="[&_div]:inline [&_div]:mr-1">{logItem.extendedDescription}</div>,
+                          content: <div>{logItem.extendedDescription}</div>,
                       }
                     : false,
                 {

--- a/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
+++ b/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
@@ -80,7 +80,7 @@ export const BasicFiltersTab = (): JSX.Element => {
                 </div>
 
                 <div className="flex flex-col gap-1">
-                    <label className="block text-sm font-medium mb-1">Action</label>
+                    <label className="block text-sm font-medium mb-1">Activity</label>
                     <LemonInputSelect
                         mode="multiple"
                         displayMode="count"
@@ -93,7 +93,7 @@ export const BasicFiltersTab = (): JSX.Element => {
                                 label: humanizeActivity(a.value),
                             })) || []
                         }
-                        placeholder="All actions"
+                        placeholder="All activities"
                         allowCustomValues={false}
                         data-attr="audit-logs-action-filter"
                         size="small"
@@ -155,8 +155,8 @@ export const BasicFiltersTab = (): JSX.Element => {
 
                         <div className="flex flex-col gap-1">
                             <div className="flex items-center gap-1 mb-1">
-                                <label className="block text-sm font-medium">Is system action?</label>
-                                <Tooltip title="Actions performed automatically by PostHog's system, such as scheduled tasks, background processes, or automated workflows.">
+                                <label className="block text-sm font-medium">Is system activity?</label>
+                                <Tooltip title="Activities performed automatically by PostHog's system, such as scheduled tasks, background processes, or automated workflows.">
                                     <IconInfo className="w-4 h-4 text-muted-alt cursor-help" />
                                 </Tooltip>
                             </div>

--- a/frontend/src/scenes/audit-logs/DetailFilters.tsx
+++ b/frontend/src/scenes/audit-logs/DetailFilters.tsx
@@ -11,6 +11,8 @@ import {
     Tooltip,
 } from '@posthog/lemon-ui'
 
+import { midEllipsis } from 'lib/utils'
+
 import { ActiveDetailFilter, advancedActivityLogsLogic } from './advancedActivityLogsLogic'
 
 interface DetailFilterRowProps {
@@ -35,44 +37,73 @@ const DetailFilterRow = ({ filter }: DetailFilterRowProps): JSX.Element => {
             activeFilters.filter((f) => f.key !== filter.key && !f.isCustom).map((f) => f.fieldPath)
         )
 
-        const sections = new Map<string, { fields: Map<string, string>; scope: string }>()
-        const generalFields = new Set<string>()
+        // Group by field name instead of scope
+        const fieldGroups = new Map<string, { scopes: string[]; fullPaths: string[] }>()
 
         Object.entries(availableFilters.detail_fields).forEach(([scope, scopeData]) => {
-            const cleanScope = scope.replace(/([A-Z])/g, ' $1').trim() || 'General'
-
-            if (!sections.has(cleanScope)) {
-                sections.set(cleanScope, { fields: new Map(), scope })
-            }
-
             scopeData.fields.forEach((field) => {
                 const fieldValue = `${scope}::${field.name}`
-                if (!selectedFields.has(fieldValue) || fieldValue === filter.fieldPath) {
-                    sections.get(cleanScope)!.fields.set(field.name, fieldValue)
-                }
 
-                if (cleanScope === 'General') {
-                    generalFields.add(field.name)
+                if (!selectedFields.has(fieldValue) || fieldValue === filter.fieldPath) {
+                    if (!fieldGroups.has(field.name)) {
+                        fieldGroups.set(field.name, { scopes: [], fullPaths: [] })
+                    }
+
+                    const group = fieldGroups.get(field.name)!
+                    if (!group.scopes.includes(scope)) {
+                        group.scopes.push(scope)
+                        group.fullPaths.push(fieldValue)
+                    }
                 }
             })
         })
 
-        const fieldSections = Array.from(sections.entries())
-            .sort(([a], [b]) => (a === 'General' ? -1 : b === 'General' ? 1 : a.localeCompare(b)))
-            .map(([title, { fields }]) => {
-                const fieldOptions = Array.from(fields.entries())
-                    .filter(([fieldName]) => title === 'General' || !generalFields.has(fieldName))
-                    .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([fieldName, fieldValue]) => ({
-                        value: fieldValue,
-                        label: fieldName,
-                    }))
+        // Convert to options with composite display
+        const fieldOptions = Array.from(fieldGroups.entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([fieldName, group]) => {
+                // Get the last part of the field path after splitting by "."
+                const displayName = fieldName.split('.').pop() || fieldName
 
-                return { title, options: fieldOptions }
+                // Create tooltip with full path and scopes
+                const scopeNames = group.scopes.map((scope) => scope.replace(/([A-Z])/g, ' $1').trim()).join(', ')
+                const displayPath = fieldName.length > 50 ? midEllipsis(fieldName, 50) : fieldName
+
+                // For single scope, use direct field path; for multiple, use first one as primary
+                const primaryValue = group.fullPaths[0]
+
+                return {
+                    value: primaryValue,
+                    label: (
+                        <div className="flex flex-col">
+                            <div>{displayName}</div>
+                            <div className="text-xs text-muted">{displayPath}</div>
+                        </div>
+                    ),
+                    tooltip: (
+                        <div className="text-xs">
+                            <div>
+                                <strong>Full path:</strong>
+                                <br />
+                                {fieldName}
+                            </div>
+                            <br />
+                            <div>
+                                <strong>Available in:</strong>
+                                <br />
+                                {scopeNames}
+                            </div>
+                        </div>
+                    ),
+                }
             })
-            .filter((section) => section.options.length > 0)
 
-        return fieldSections
+        return [
+            {
+                title: 'Available Fields',
+                options: fieldOptions,
+            },
+        ]
     }, [availableFilters, filter.key, filter.fieldPath, activeFilters])
 
     const validateCustomFieldPath = (path: string): string | null => {
@@ -233,49 +264,86 @@ export const DetailFilters = (): JSX.Element => {
 
         const selectedFields = new Set(activeFilters.filter((f) => !f.isCustom).map((f) => f.fieldPath))
 
-        const sections = new Map<string, { fields: Map<string, string>; scope: string }>()
-        const generalFields = new Set<string>()
+        // Group by field name instead of scope
+        const fieldGroups = new Map<string, { scopes: string[]; fullPaths: string[] }>()
 
         Object.entries(availableFilters.detail_fields).forEach(([scope, scopeData]) => {
-            const cleanScope = scope.replace(/([A-Z])/g, ' $1').trim() || 'General'
-
-            if (!sections.has(cleanScope)) {
-                sections.set(cleanScope, { fields: new Map(), scope })
-            }
-
             scopeData.fields.forEach((field) => {
                 const fieldValue = `${scope}::${field.name}`
+
                 if (!selectedFields.has(fieldValue)) {
-                    sections.get(cleanScope)!.fields.set(field.name, fieldValue)
-                }
+                    if (!fieldGroups.has(field.name)) {
+                        fieldGroups.set(field.name, { scopes: [], fullPaths: [] })
+                    }
 
-                if (cleanScope === 'General') {
-                    generalFields.add(field.name)
+                    const group = fieldGroups.get(field.name)!
+                    if (!group.scopes.includes(scope)) {
+                        group.scopes.push(scope)
+                        group.fullPaths.push(fieldValue)
+                    }
                 }
             })
         })
 
-        const fieldSections = Array.from(sections.entries())
-            .sort(([a], [b]) => (a === 'General' ? -1 : b === 'General' ? 1 : a.localeCompare(b)))
-            .map(([title, { fields }]) => {
-                const fieldOptions = Array.from(fields.entries())
-                    .filter(([fieldName]) => title === 'General' || !generalFields.has(fieldName))
-                    .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([fieldName, fieldValue]) => ({
-                        value: fieldValue,
-                        label: fieldName,
-                    }))
+        // Convert to options with composite display
+        const fieldOptions = Array.from(fieldGroups.entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([fieldName, group]) => {
+                // Get the last part of the field path after splitting by "."
+                const displayName = fieldName.split('.').pop() || fieldName
 
-                return { title, options: fieldOptions }
+                // Create tooltip with full path and scopes
+                const scopeNames = group.scopes.map((scope) => scope.replace(/([A-Z])/g, ' $1').trim()).join(', ')
+                const displayPath = fieldName.length > 50 ? midEllipsis(fieldName, 50) : fieldName
+
+                // For single scope, use direct field path; for multiple, use first one as primary
+                const primaryValue = group.fullPaths[0]
+
+                return {
+                    value: primaryValue,
+                    label: (
+                        <div className="flex flex-col">
+                            <div>{displayName}</div>
+                            <div className="text-xs text-muted">{displayPath}</div>
+                        </div>
+                    ),
+                    tooltip: (
+                        <div className="text-xs">
+                            <div>
+                                <strong>Full path:</strong>
+                                <br />
+                                {fieldName}
+                            </div>
+                            <br />
+                            <div>
+                                <strong>Available in:</strong>
+                                <br />
+                                {scopeNames}
+                            </div>
+                        </div>
+                    ),
+                }
             })
-            .filter((section) => section.options.length > 0)
 
-        fieldSections.push({
+        const sections = [
+            {
+                title: 'Available Fields',
+                options: fieldOptions,
+            },
+        ]
+
+        sections.push({
             title: 'Custom',
-            options: [{ value: '__add_custom__', label: 'Custom field path...' }],
+            options: [
+                {
+                    value: '__add_custom__',
+                    label: <span>Custom field path...</span>,
+                    tooltip: <div>Enter a custom field path manually</div>,
+                },
+            ],
         })
 
-        return fieldSections
+        return sections
     }, [availableFilters, activeFilters])
 
     if (!availableFilters?.detail_fields || Object.keys(availableFilters.detail_fields).length === 0) {

--- a/frontend/src/scenes/audit-logs/ExportsList.tsx
+++ b/frontend/src/scenes/audit-logs/ExportsList.tsx
@@ -18,11 +18,6 @@ import { ExportedAsset, advancedActivityLogsLogic } from './advancedActivityLogs
 export function ExportsList(): JSX.Element {
     const { exports, exportsLoading } = useValues(advancedActivityLogsLogic)
 
-    if (exportsLoading) {
-        // You could add a skeleton here if desired
-        return <div>Loading exports...</div>
-    }
-
     if (!exports || exports.length === 0) {
         return <ExportsEmptyState />
     }
@@ -90,7 +85,7 @@ export function ExportsList(): JSX.Element {
             <LemonTable
                 dataSource={exports}
                 columns={columns}
-                loading={false}
+                loading={exportsLoading}
                 rowKey="id"
                 footer={
                     <div className="flex items-center justify-end mt-2 mr-2">

--- a/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
+++ b/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
@@ -37,7 +37,7 @@ export const getFilterSummary = (exportAsset: ExportedAsset): string => {
 
     const activeFilters: string[] = []
     if (filters.start_date || filters.end_date) {
-        activeFilters.push(`Date filter: 1`)
+        activeFilters.push(`Date: 1`)
     }
     if (filters.users && filters.users.length > 0) {
         activeFilters.push(`Users: ${filters.users.length}`)

--- a/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
+++ b/frontend/src/scenes/audit-logs/ExportsListHelpers.tsx
@@ -46,7 +46,7 @@ export const getFilterSummary = (exportAsset: ExportedAsset): string => {
         activeFilters.push(`Scopes: ${filters.scopes.length}`)
     }
     if (filters.activities && filters.activities.length > 0) {
-        activeFilters.push(`Actions: ${filters.activities.length}`)
+        activeFilters.push(`Activities: ${filters.activities.length}`)
     }
     if (filters.detail_filters && Object.keys(filters.detail_filters).length > 0) {
         activeFilters.push(`Detail filters: ${Object.keys(filters.detail_filters).length}`)
@@ -83,7 +83,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
 
         filterSections.push(
             <div key="dates">
-                <strong>Date Range:</strong>
+                <strong>Date range:</strong>
                 <br />
                 {filters.start_date && `From: ${formatDate(filters.start_date)}`}
                 {filters.start_date && filters.end_date && <br />}
@@ -117,7 +117,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
     if (filters.activities && filters.activities.length > 0) {
         filterSections.push(
             <div key="activities">
-                <strong>Actions ({filters.activities.length}):</strong>
+                <strong>Activities ({filters.activities.length}):</strong>
                 <br />
                 {filters.activities.slice(0, 5).join(', ')}
                 {filters.activities.length > 5 && `... and ${filters.activities.length - 5} more`}
@@ -136,7 +136,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
 
         filterSections.push(
             <div key="detail_filters">
-                <strong>Detail Filters ({detailFilterEntries.length}):</strong>
+                <strong>Detail filters ({detailFilterEntries.length}):</strong>
                 <br />
                 {detailFilterText.slice(0, 3).join(', ')}
                 {detailFilterText.length > 3 && `... and ${detailFilterText.length - 3} more`}
@@ -147,7 +147,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
     if (filters.was_impersonated !== undefined) {
         filterSections.push(
             <div key="was_impersonated">
-                <strong>Was Impersonated:</strong>
+                <strong>Was impersonated:</strong>
                 <br />
                 {filters.was_impersonated ? 'Yes' : 'No'}
             </div>
@@ -157,7 +157,7 @@ export const getFilterTooltip = (exportAsset: ExportedAsset): JSX.Element => {
     if (filters.is_system !== undefined) {
         filterSections.push(
             <div key="is_system">
-                <strong>Is System Action:</strong>
+                <strong>Is system activity:</strong>
                 <br />
                 {filters.is_system ? 'Yes' : 'No'}
             </div>

--- a/frontend/src/scenes/surveys/surveyActivityDescriber.tsx
+++ b/frontend/src/scenes/surveys/surveyActivityDescriber.tsx
@@ -276,12 +276,7 @@ const surveyActionsMapping: Record<
                 </>
             )
             if (afterFlag.filters?.groups?.length > 0) {
-                changes.push(
-                    <>
-                        set targeting conditions to:
-                        <pre>{JSON.stringify(afterFlag.filters, null, 2)}</pre>
-                    </>
-                )
+                changes.push(<>set new targeting conditions</>)
             }
         } else if (beforeFlag && !afterFlag) {
             changes.push(
@@ -312,24 +307,12 @@ const surveyActionsMapping: Record<
         const changes: Description[] = []
 
         if (!beforeFlag && afterFlag) {
-            changes.push(
-                <>
-                    added targeting flag filter with the following conditions:
-                    <pre>{JSON.stringify(afterFlag, null, 2)}</pre>
-                </>
-            )
+            changes.push(<>added a targeting flag filter</>)
         } else if (beforeFlag && !afterFlag) {
             changes.push(<>removed targeting flag filter</>)
         } else if (beforeFlag && afterFlag) {
             if (JSON.stringify(beforeFlag) !== JSON.stringify(afterFlag)) {
-                changes.push(
-                    <>
-                        changed targeting conditions from:
-                        <pre>{JSON.stringify(beforeFlag, null, 2)}</pre>
-                        to:
-                        <pre>{JSON.stringify(afterFlag, null, 2)}</pre>
-                    </>
-                )
+                changes.push(<>changed targeting conditions</>)
             }
         }
 


### PR DESCRIPTION
## Changes

  - Change how we present the fields in the detail filters dropdown
  - Restyle the table
  - Change Time column header
  - Null out the page when changing filters
  - Simplify survey logs to not render JSON dumps in the activity log describers
  - Change loading presentation on exports lists
  - Make all entries in the activity logs list as one-liners
  - Various little comments from this [thread](https://posthog.slack.com/archives/C0351B1DMUY/p1758544888647649)
  
  
<img width="1234" height="685" alt="image" src="https://github.com/user-attachments/assets/917d6c25-9e77-4261-aedb-3bca2586a941" />


<img width="1234" height="469" alt="image" src="https://github.com/user-attachments/assets/81f208d7-ff69-46ad-acd9-32a22a90c80c" />


