### PR TITLE
fix: don't double-count dropped events

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/transformEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/transformEventStep.ts
@@ -1,7 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { HogTransformerService, TransformationResult } from '../../../cdp/hog-transformations/hog-transformer.service'
-import { droppedEventCounter } from './metrics'
 
 export async function transformEventStep(
     event: PluginEvent,
@@ -10,9 +9,5 @@ export async function transformEventStep(
     if (!hogTransformer) {
         return { event, invocationResults: [] }
     }
-    const result = await hogTransformer.transformEventAndProduceMessages(event)
-    if (!result.event) {
-        droppedEventCounter.inc()
-    }
-    return result
+    return await hogTransformer.transformEventAndProduceMessages(event)
 }


### PR DESCRIPTION
## Problem

We double-count dropped events, first in the transformation step, then in the pipelines.

## Changes

Removes the call to count dropped messages from the transform step.

## How did you test this code?

Only changes metrics, will monitor on prod.
