### PR TITLE
fix(plugin-server): stop retries for properties size violations

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-property-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-service.ts
@@ -1,8 +1,9 @@
 import { InternalPerson } from '../../../types'
-import { promiseRetry } from '../../../utils/retries'
+import { defaultRetryConfig, promiseRetry } from '../../../utils/retries'
 import { PersonContext } from './person-context'
 import { PersonCreateService } from './person-create-service'
 import { applyEventPropertyUpdates, computeEventPropertyUpdates } from './person-update'
+import { PersonPropertiesSizeViolationError } from './repositories/person-repository'
 
 /**
  * Service responsible for handling person property updates and person creation.
@@ -20,6 +21,14 @@ export class PersonPropertyService {
         // - the person might have been merged between start of processing and now
         // we simply and stupidly start from scratch
         return await promiseRetry(() => this.updateProperties(), 'update_person')
+        return await promiseRetry(
+            () => this.updateProperties(),
+            'update_person',
+            deafultRetryConfig.MAX_RETRIES_DEFAULT,
+            defaultRetryConfig.RETRY_INTERVAL_DEFAULT,
+            undefined,
+            [PersonPropertiesSizeViolationError]
+        )
     }
 
     async updateProperties(): Promise<[InternalPerson, Promise<void>]> {

--- a/plugin-server/src/worker/ingestion/persons/person-property-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-service.ts
@@ -20,7 +20,6 @@ export class PersonPropertyService {
         // - another thread created the person during a race
         // - the person might have been merged between start of processing and now
         // we simply and stupidly start from scratch
-        return await promiseRetry(() => this.updateProperties(), 'update_person')
         return await promiseRetry(
             () => this.updateProperties(),
             'update_person',

--- a/plugin-server/src/worker/ingestion/persons/person-property-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-service.ts
@@ -23,7 +23,7 @@ export class PersonPropertyService {
         return await promiseRetry(
             () => this.updateProperties(),
             'update_person',
-            deafultRetryConfig.MAX_RETRIES_DEFAULT,
+            defaultRetryConfig.MAX_RETRIES_DEFAULT,
             defaultRetryConfig.RETRY_INTERVAL_DEFAULT,
             undefined,
             [PersonPropertiesSizeViolationError]

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -22,6 +22,7 @@ export class PersonPropertiesSizeViolationError extends Error {
         super(message)
         this.name = 'PersonPropertiesSizeViolationError'
     }
+    readonly isRetriable = false
 }
 
 export interface PersonRepository {


### PR DESCRIPTION
## Problem

We were retrying attempts to create/update person records that violated the person properties size constraint. These won't ever succeed, so we shouldn't retry.

## Changes

- tell the promiseRetry() that wraps updatePerson to not retry if we get a Person Properties Size Violation Error
- set the isRetriable property as false on the Size violation error

## How did you test this code?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
