### PR TITLE
chore(flags): Revert "chore(flags): Use PostgeSQL's session-level statement_timeout…

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -4,27 +4,20 @@ use anyhow::Result;
 use async_trait::async_trait;
 use sqlx::{
     pool::PoolConnection,
-    postgres::{PgPool, PgPoolOptions},
+    postgres::{PgPool, PgPoolOptions, PgRow},
     Error as SqlxError, Postgres,
 };
 use thiserror::Error;
+use tokio::time::timeout;
 
-// Default database timeouts - optimized for production low-latency flag evaluation
-pub const DEFAULT_TIMEOUTS: DatabaseTimeouts = DatabaseTimeouts {
-    statement_timeout: Duration::from_millis(300), // Aggressive for fast flag evaluation
-    lock_timeout: Duration::from_millis(100),      // Avoid blocking on locks
-    acquire_timeout: Duration::from_millis(200),   // Fail fast under load
-    idle_timeout: Duration::from_secs(300),        // Close idle connections after 5 minutes
-    max_lifetime: Duration::from_secs(1800),       // Force refresh every 30 minutes
-    idle_in_transaction_session_timeout: Duration::from_secs(15), // Kill leaked transactions
-};
+const DATABASE_TIMEOUT_MILLISECS: u64 = 1000;
 
 #[derive(Error, Debug)]
 pub enum CustomDatabaseError {
     #[error("Pg error: {0}")]
     Other(#[from] sqlx::Error),
 
-    #[error("Client timeout error")]
+    #[error("Timeout error")]
     Timeout(#[from] tokio::time::error::Elapsed),
 }
 
@@ -33,16 +26,16 @@ pub type PostgresWriter = Arc<dyn Client + Send + Sync>;
 
 /// A simple db wrapper
 /// Supports running any arbitrary query with a timeout.
-///
-/// ## Timeout Strategy
-/// - Session defaults optimized for fast flag evaluation reads (300ms statement, 100ms lock)
-/// - Use `begin_write_transaction()` for writes that need longer timeouts (2s statement, 500ms lock)
-/// - Pool acquire timeout is aggressive (200ms) for fail-fast behavior under load
-///
 /// TODO: Make sqlx prepared statements work with pgbouncer, potentially by setting pooling mode to session.
 #[async_trait]
 pub trait Client {
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError>;
+    async fn run_query(
+        &self,
+        query: String,
+        parameters: Vec<String>,
+        timeout_ms: Option<u64>,
+    ) -> Result<Vec<PgRow>, CustomDatabaseError>;
 
     fn get_pool_stats(&self) -> Option<PoolStats>;
 }
@@ -53,72 +46,13 @@ pub struct PoolStats {
     pub num_idle: usize,
 }
 
-#[derive(Debug, Clone)]
-pub struct DatabaseTimeouts {
-    pub statement_timeout: Duration,
-    pub lock_timeout: Duration,
-    pub acquire_timeout: Duration,
-    pub idle_timeout: Duration,
-    pub max_lifetime: Duration,
-    pub idle_in_transaction_session_timeout: Duration,
-}
-
 pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
-    get_pool_with_timeouts(url, max_connections, DEFAULT_TIMEOUTS).await
-}
-
-pub async fn get_pool_with_timeouts(
-    url: &str,
-    max_connections: u32,
-    timeouts: DatabaseTimeouts,
-) -> Result<PgPool, sqlx::Error> {
     PgPoolOptions::new()
         .max_connections(max_connections)
-        .acquire_timeout(timeouts.acquire_timeout)
+        .acquire_timeout(Duration::from_secs(1))
         .test_before_acquire(true)
-        .idle_timeout(timeouts.idle_timeout)
-        .max_lifetime(timeouts.max_lifetime)
-        // Set PostgreSQL session-level timeouts for all queries on this connection
-        .after_connect(move |conn, _meta| {
-            Box::pin(async move {
-                // Convert to i64 with checked conversion to avoid overflow issues
-                let stmt_ms: i64 = timeouts
-                    .statement_timeout
-                    .as_millis()
-                    .try_into()
-                    .expect("statement_timeout too large");
-                let lock_ms: i64 = timeouts
-                    .lock_timeout
-                    .as_millis()
-                    .try_into()
-                    .expect("lock_timeout too large");
-
-                // Set statement timeout (PostgreSQL SET commands don't accept bind parameters)
-                sqlx::query(&format!("SET statement_timeout = '{stmt_ms}ms'"))
-                    .execute(&mut *conn)
-                    .await?;
-
-                // Set lock timeout to prevent getting stuck behind long transactions
-                sqlx::query(&format!("SET lock_timeout = '{lock_ms}ms'"))
-                    .execute(&mut *conn)
-                    .await?;
-
-                // Safety net: kill idle transactions to prevent leaked transactions
-                // from holding locks forever (doesn't affect normal autocommit reads)
-                let idle_tx_secs: i64 = timeouts
-                    .idle_in_transaction_session_timeout
-                    .as_secs()
-                    .try_into()
-                    .expect("idle_in_transaction_session_timeout too large");
-                sqlx::query(&format!(
-                    "SET idle_in_transaction_session_timeout = '{idle_tx_secs}s'"
-                ))
-                .execute(&mut *conn)
-                .await?;
-
-                Ok(())
-            })
-        })
+        .idle_timeout(Duration::from_secs(300)) // Close idle connections after 5 minutes
+        .max_lifetime(Duration::from_secs(1800)) // Force refresh every 30 minutes
         .connect(url)
         .await
 }
@@ -132,9 +66,30 @@ impl Client for PgPool {
         })
     }
 
+    async fn run_query(
+        &self,
+        query: String,
+        parameters: Vec<String>,
+        timeout_ms: Option<u64>,
+    ) -> Result<Vec<PgRow>, CustomDatabaseError> {
+        let built_query = sqlx::query(&query);
+        let built_query = parameters
+            .iter()
+            .fold(built_query, |acc, param| acc.bind(param));
+        let query_results = built_query.fetch_all(self);
+
+        let timeout_ms = match timeout_ms {
+            Some(ms) => ms,
+            None => DATABASE_TIMEOUT_MILLISECS,
+        };
+
+        let fut = timeout(Duration::from_millis(timeout_ms), query_results).await?;
+
+        Ok(fut?)
+    }
+
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
-        let conn = self.acquire().await?;
-        Ok(conn)
+        Ok(self.acquire().await?)
     }
 }
 
@@ -153,84 +108,6 @@ pub fn is_foreign_key_constraint_error(error: &SqlxError) -> bool {
             }
         }
         _ => false,
-    }
-}
-
-/// Determines if a sqlx::Error represents a timeout-related failure
-pub fn is_timeout_error(error: &SqlxError) -> bool {
-    match error {
-        // Pool acquisition timed out
-        SqlxError::PoolTimedOut => true,
-
-        // IO-level timeout (network/socket)
-        SqlxError::Io(e) if e.kind() == std::io::ErrorKind::TimedOut => true,
-
-        // Protocol text sometimes includes "timeout"
-        SqlxError::Protocol(msg) => msg.to_lowercase().contains("timeout"),
-
-        // Database-reported timeouts/cancels
-        SqlxError::Database(db_error) => {
-            if let Some(code) = db_error.code() {
-                let code = code.as_ref();
-                // 57014: query_canceled (e.g., statement_timeout)
-                // 55P03: lock_not_available (e.g., lock_timeout)
-                // 25P03: idle_in_transaction_session_timeout
-                code == "57014" || code == "55P03" || code == "25P03"
-            } else {
-                // Fallback heuristic (less reliable than SQLSTATE)
-                let msg = db_error.message().to_lowercase();
-                msg.contains("timeout")
-                    || msg.contains("canceling")   // Postgres US spelling
-                    || msg.contains("cancelling") // just in case
-            }
-        }
-
-        _ => false,
-    }
-}
-
-/// Extract the specific type of timeout from a sqlx::Error
-pub fn extract_timeout_type(error: &SqlxError) -> Option<&'static str> {
-    match error {
-        // Pool acquisition timed out
-        SqlxError::PoolTimedOut => Some("pool_timeout"),
-
-        // IO-level timeout (network/socket)
-        SqlxError::Io(e) if e.kind() == std::io::ErrorKind::TimedOut => Some("io_timeout"),
-
-        // Protocol text sometimes includes "timeout"
-        SqlxError::Protocol(msg) if msg.to_lowercase().contains("timeout") => {
-            Some("protocol_timeout")
-        }
-
-        // Database-reported timeouts/cancels
-        SqlxError::Database(db_error) => {
-            if let Some(code) = db_error.code() {
-                let code = code.as_ref();
-                match code {
-                    // 57014: query_canceled (e.g., statement_timeout)
-                    "57014" => Some("query_canceled"),
-                    // 55P03: lock_not_available (e.g., lock_timeout)
-                    "55P03" => Some("lock_not_available"),
-                    // 25P03: idle_in_transaction_session_timeout
-                    "25P03" => Some("idle_in_transaction_timeout"),
-                    _ => None,
-                }
-            } else {
-                // Fallback heuristic (less reliable than SQLSTATE)
-                // Check more specific patterns first
-                let msg = db_error.message().to_lowercase();
-                if msg.contains("canceling") || msg.contains("cancelling") {
-                    Some("query_canceled")
-                } else if msg.contains("timeout") {
-                    Some("database_timeout")
-                } else {
-                    None
-                }
-            }
-        }
-
-        _ => None,
     }
 }
 
@@ -580,282 +457,5 @@ mod tests {
         // Test that memory pressure errors are NOT retried to avoid amplifying load
         let memory_err = db_err("out of memory", None, ErrorKind::Other);
         assert!(!is_transient_error(&memory_err));
-    }
-
-    #[test]
-    fn test_is_timeout_error_pool_timeout() {
-        assert!(is_timeout_error(&SqlxError::PoolTimedOut));
-    }
-
-    #[test]
-    fn test_is_timeout_error_io_timeout() {
-        let io_error = SqlxError::Io(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            "connection timed out",
-        ));
-        assert!(is_timeout_error(&io_error));
-    }
-
-    #[test]
-    fn test_is_timeout_error_io_non_timeout() {
-        let io_error = SqlxError::Io(std::io::Error::new(
-            std::io::ErrorKind::ConnectionRefused,
-            "connection refused",
-        ));
-        assert!(!is_timeout_error(&io_error));
-    }
-
-    #[test]
-    fn test_is_timeout_error_protocol_timeout() {
-        let protocol_error = SqlxError::Protocol("operation timeout".to_string());
-        assert!(is_timeout_error(&protocol_error));
-
-        let protocol_non_timeout = SqlxError::Protocol("invalid protocol".to_string());
-        assert!(!is_timeout_error(&protocol_non_timeout));
-    }
-
-    #[test]
-    fn test_is_timeout_error_database_with_timeout_codes() {
-        // Test various timeout-related SQLSTATE codes
-        assert!(is_timeout_error(&db_err(
-            "canceling statement due to statement timeout",
-            Some("57014"),
-            ErrorKind::Other
-        )));
-        assert!(is_timeout_error(&db_err(
-            "lock not available",
-            Some("55P03"),
-            ErrorKind::Other
-        )));
-        assert!(is_timeout_error(&db_err(
-            "terminating connection due to idle-in-transaction timeout",
-            Some("25P03"),
-            ErrorKind::Other
-        )));
-    }
-
-    #[test]
-    fn test_is_timeout_error_database_non_timeout_codes() {
-        // Test non-timeout SQLSTATE codes
-        assert!(!is_timeout_error(&db_err(
-            "duplicate key value violates unique constraint",
-            Some("23505"),
-            ErrorKind::UniqueViolation
-        )));
-        assert!(!is_timeout_error(&db_err(
-            "syntax error at or near",
-            Some("42601"),
-            ErrorKind::Other
-        )));
-    }
-
-    #[test]
-    fn test_is_timeout_error_database_message_fallback() {
-        // Test message heuristics when no SQLSTATE code is available
-        assert!(is_timeout_error(&db_err(
-            "operation timeout",
-            None,
-            ErrorKind::Other
-        )));
-        assert!(is_timeout_error(&db_err(
-            "canceling statement due to timeout",
-            None,
-            ErrorKind::Other
-        )));
-        assert!(is_timeout_error(&db_err(
-            "cancelling statement due to timeout",
-            None,
-            ErrorKind::Other
-        )));
-
-        // Non-timeout messages
-        assert!(!is_timeout_error(&db_err(
-            "column does not exist",
-            None,
-            ErrorKind::Other
-        )));
-        assert!(!is_timeout_error(&db_err(
-            "relation does not exist",
-            None,
-            ErrorKind::Other
-        )));
-    }
-
-    #[test]
-    fn test_custom_database_error_conversion_timeout() {
-        // Test that CustomDatabaseError::Timeout converts to the timeout error type
-        use tokio::time::{timeout, Duration};
-
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let elapsed_error = rt.block_on(async {
-            timeout(
-                Duration::from_nanos(1),
-                tokio::time::sleep(Duration::from_secs(1)),
-            )
-            .await
-            .unwrap_err()
-        });
-
-        let timeout_error = CustomDatabaseError::Timeout(elapsed_error);
-        // This test just ensures conversion compiles - actual usage depends on consuming crate
-        assert!(matches!(timeout_error, CustomDatabaseError::Timeout(_)));
-    }
-
-    #[test]
-    fn test_custom_database_error_conversion_sqlx_timeout() {
-        // Test that sqlx timeout errors are detected by is_timeout_error
-        let sqlx_timeout = SqlxError::PoolTimedOut;
-        assert!(is_timeout_error(&sqlx_timeout));
-
-        let timeout_error = CustomDatabaseError::Other(sqlx_timeout);
-        assert!(matches!(timeout_error, CustomDatabaseError::Other(_)));
-    }
-
-    #[test]
-    fn test_custom_database_error_conversion_sqlx_non_timeout() {
-        // Test that non-timeout sqlx errors are not detected as timeouts
-        let sqlx_error = SqlxError::RowNotFound;
-        assert!(!is_timeout_error(&sqlx_error));
-
-        let other_error = CustomDatabaseError::Other(sqlx_error);
-        assert!(matches!(other_error, CustomDatabaseError::Other(_)));
-    }
-
-    #[test]
-    fn test_extract_timeout_type_pool_timeout() {
-        assert_eq!(
-            extract_timeout_type(&SqlxError::PoolTimedOut),
-            Some("pool_timeout")
-        );
-    }
-
-    #[test]
-    fn test_extract_timeout_type_io_timeout() {
-        let io_error = SqlxError::Io(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            "connection timed out",
-        ));
-        assert_eq!(extract_timeout_type(&io_error), Some("io_timeout"));
-    }
-
-    #[test]
-    fn test_extract_timeout_type_io_non_timeout() {
-        let io_error = SqlxError::Io(std::io::Error::new(
-            std::io::ErrorKind::ConnectionRefused,
-            "connection refused",
-        ));
-        assert_eq!(extract_timeout_type(&io_error), None);
-    }
-
-    #[test]
-    fn test_extract_timeout_type_protocol_timeout() {
-        let protocol_error = SqlxError::Protocol("operation timeout".to_string());
-        assert_eq!(
-            extract_timeout_type(&protocol_error),
-            Some("protocol_timeout")
-        );
-
-        let protocol_non_timeout = SqlxError::Protocol("invalid protocol".to_string());
-        assert_eq!(extract_timeout_type(&protocol_non_timeout), None);
-    }
-
-    #[test]
-    fn test_extract_timeout_type_database_with_timeout_codes() {
-        // Test various timeout-related SQLSTATE codes
-        assert_eq!(
-            extract_timeout_type(&db_err(
-                "canceling statement due to statement timeout",
-                Some("57014"),
-                ErrorKind::Other
-            )),
-            Some("query_canceled")
-        );
-
-        assert_eq!(
-            extract_timeout_type(&db_err(
-                "lock not available",
-                Some("55P03"),
-                ErrorKind::Other
-            )),
-            Some("lock_not_available")
-        );
-
-        assert_eq!(
-            extract_timeout_type(&db_err(
-                "terminating connection due to idle-in-transaction timeout",
-                Some("25P03"),
-                ErrorKind::Other
-            )),
-            Some("idle_in_transaction_timeout")
-        );
-    }
-
-    #[test]
-    fn test_extract_timeout_type_database_non_timeout_codes() {
-        // Test non-timeout SQLSTATE codes
-        assert_eq!(
-            extract_timeout_type(&db_err(
-                "duplicate key value violates unique constraint",
-                Some("23505"),
-                ErrorKind::UniqueViolation
-            )),
-            None
-        );
-
-        assert_eq!(
-            extract_timeout_type(&db_err(
-                "syntax error at or near",
-                Some("42601"),
-                ErrorKind::Other
-            )),
-            None
-        );
-    }
-
-    #[test]
-    fn test_extract_timeout_type_database_message_fallback() {
-        // Test message heuristics when no SQLSTATE code is available
-        assert_eq!(
-            extract_timeout_type(&db_err("operation timeout", None, ErrorKind::Other)),
-            Some("database_timeout")
-        );
-
-        assert_eq!(
-            extract_timeout_type(&db_err(
-                "canceling statement due to timeout",
-                None,
-                ErrorKind::Other
-            )),
-            Some("query_canceled")
-        );
-
-        assert_eq!(
-            extract_timeout_type(&db_err(
-                "cancelling statement due to timeout",
-                None,
-                ErrorKind::Other
-            )),
-            Some("query_canceled")
-        );
-
-        // Non-timeout messages
-        assert_eq!(
-            extract_timeout_type(&db_err("column does not exist", None, ErrorKind::Other)),
-            None
-        );
-
-        assert_eq!(
-            extract_timeout_type(&db_err("relation does not exist", None, ErrorKind::Other)),
-            None
-        );
-    }
-
-    #[test]
-    fn test_extract_timeout_type_non_timeout_error() {
-        assert_eq!(extract_timeout_type(&SqlxError::RowNotFound), None);
-        assert_eq!(
-            extract_timeout_type(&SqlxError::ColumnNotFound("test".to_string())),
-            None
-        );
     }
 }

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -327,7 +327,7 @@ impl MockRedisClient {
     }
 
     // Helper method to safely lock the calls mutex
-    fn lock_calls(&self) -> std::sync::MutexGuard<'_, Vec<MockRedisCall>> {
+    fn lock_calls(&self) -> std::sync::MutexGuard<Vec<MockRedisCall>> {
         match self.calls.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -1,7 +1,7 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use common_cookieless::CookielessManagerError;
-use common_database::{extract_timeout_type, is_timeout_error, CustomDatabaseError};
+use common_database::CustomDatabaseError;
 use common_redis::CustomRedisError;
 use thiserror::Error;
 
@@ -52,7 +52,7 @@ pub enum FlagError {
     #[error("Database error: {0}")]
     DatabaseError(sqlx::Error, Option<String>),
     #[error("Timed out while fetching data")]
-    TimeoutError(Option<String>),
+    TimeoutError,
     #[error("No group type mappings")]
     NoGroupTypeMappings,
     #[error("Dependency of type {0} with id {1} not found")]
@@ -91,7 +91,7 @@ impl FlagError {
             FlagError::RedisDataParsingError
             | FlagError::RedisUnavailable
             | FlagError::DatabaseUnavailable
-            | FlagError::TimeoutError(_) => StatusCode::SERVICE_UNAVAILABLE,
+            | FlagError::TimeoutError => StatusCode::SERVICE_UNAVAILABLE,
 
             FlagError::CookielessError(
                 CookielessManagerError::HashError(_)
@@ -185,9 +185,8 @@ impl IntoResponse for FlagError {
                     "A database error occurred. Please try again later or contact support if the problem persists.".to_string(),
                 )
             }
-            FlagError::TimeoutError(ref timeout_type) => {
-                let timeout_desc = timeout_type.as_deref().unwrap_or("unknown type");
-                tracing::error!("Timeout error ({}): {:?}", timeout_desc, self);
+            FlagError::TimeoutError => {
+                tracing::error!("Timeout error: {:?}", self);
                 (
                     StatusCode::SERVICE_UNAVAILABLE,
                     "The request timed out. This could be due to high load or network issues. Please try again later.".to_string(),
@@ -265,7 +264,7 @@ impl From<CustomRedisError> for FlagError {
         match e {
             CustomRedisError::NotFound => FlagError::TokenValidationError,
             CustomRedisError::ParseError(_) => FlagError::RedisDataParsingError,
-            CustomRedisError::Timeout => FlagError::TimeoutError(Some("redis_timeout".to_string())),
+            CustomRedisError::Timeout => FlagError::TimeoutError,
             CustomRedisError::Other(_) => FlagError::RedisUnavailable,
         }
     }
@@ -274,19 +273,8 @@ impl From<CustomRedisError> for FlagError {
 impl From<CustomDatabaseError> for FlagError {
     fn from(e: CustomDatabaseError) -> Self {
         match e {
-            CustomDatabaseError::Timeout(_) => {
-                FlagError::TimeoutError(Some("client_timeout".to_string()))
-            }
-            CustomDatabaseError::Other(sqlx_error) => {
-                // Check if it's a timeout-related SQL error
-                if is_timeout_error(&sqlx_error) {
-                    FlagError::TimeoutError(
-                        extract_timeout_type(&sqlx_error).map(|s| s.to_string()),
-                    )
-                } else {
-                    FlagError::DatabaseUnavailable
-                }
-            }
+            CustomDatabaseError::Other(_) => FlagError::DatabaseUnavailable,
+            CustomDatabaseError::Timeout(_) => FlagError::TimeoutError,
         }
     }
 }
@@ -295,14 +283,7 @@ impl From<sqlx::Error> for FlagError {
     fn from(e: sqlx::Error) -> Self {
         match e {
             sqlx::Error::RowNotFound => FlagError::RowNotFound,
-            _ => {
-                // Check if it's a timeout-related SQL error
-                if is_timeout_error(&e) {
-                    FlagError::TimeoutError(extract_timeout_type(&e).map(|s| s.to_string()))
-                } else {
-                    FlagError::DatabaseError(e, None)
-                }
-            }
+            _ => FlagError::DatabaseError(e, None),
         }
     }
 }
@@ -310,7 +291,6 @@ impl From<sqlx::Error> for FlagError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::time::{timeout, Duration};
 
     #[test]
     fn test_is_5xx() {
@@ -319,7 +299,7 @@ mod tests {
         assert!(FlagError::CacheUpdateError.is_5xx());
         assert!(FlagError::DatabaseUnavailable.is_5xx());
         assert!(FlagError::RedisUnavailable.is_5xx());
-        assert!(FlagError::TimeoutError(None).is_5xx());
+        assert!(FlagError::TimeoutError.is_5xx());
         assert!(FlagError::ClientFacing(ClientFacingError::ServiceUnavailable).is_5xx());
 
         // Test 4XX errors
@@ -335,59 +315,5 @@ mod tests {
         assert!(!FlagError::NoTokenError.is_5xx());
         assert!(!FlagError::TokenValidationError.is_5xx());
         assert!(!FlagError::PersonNotFound.is_5xx());
-    }
-
-    #[test]
-    fn test_custom_database_error_conversion_timeout() {
-        // Test that CustomDatabaseError::Timeout converts to FlagError::TimeoutError with client_timeout
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let elapsed_error = rt.block_on(async {
-            timeout(
-                Duration::from_nanos(1),
-                tokio::time::sleep(Duration::from_secs(1)),
-            )
-            .await
-            .unwrap_err()
-        });
-
-        let timeout_error = CustomDatabaseError::Timeout(elapsed_error);
-        let flag_error: FlagError = timeout_error.into();
-        assert!(
-            matches!(flag_error, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "client_timeout")
-        );
-    }
-
-    #[test]
-    fn test_custom_database_error_conversion_sqlx_timeout() {
-        // Test that sqlx timeout errors convert to FlagError::TimeoutError with pool_timeout
-        let sqlx_timeout = CustomDatabaseError::Other(sqlx::Error::PoolTimedOut);
-        let flag_error: FlagError = sqlx_timeout.into();
-        assert!(
-            matches!(flag_error, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "pool_timeout")
-        );
-    }
-
-    #[test]
-    fn test_custom_database_error_conversion_sqlx_non_timeout() {
-        // Test that non-timeout sqlx errors convert to FlagError::DatabaseUnavailable
-        let sqlx_error = CustomDatabaseError::Other(sqlx::Error::RowNotFound);
-        let flag_error: FlagError = sqlx_error.into();
-        assert!(matches!(flag_error, FlagError::DatabaseUnavailable));
-    }
-
-    #[test]
-    fn test_direct_sqlx_timeout_conversion() {
-        // Test that direct sqlx timeout errors convert to FlagError::TimeoutError with type
-        let sqlx_timeout: FlagError = sqlx::Error::PoolTimedOut.into();
-        assert!(
-            matches!(sqlx_timeout, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "pool_timeout")
-        );
-    }
-
-    #[test]
-    fn test_direct_sqlx_non_timeout_conversion() {
-        // Test that direct non-timeout sqlx errors are handled correctly
-        let sqlx_error: FlagError = sqlx::Error::RowNotFound.into();
-        assert!(matches!(sqlx_error, FlagError::RowNotFound));
     }
 }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -13,6 +13,7 @@ use common_types::{PersonId, ProjectId, TeamId};
 use serde_json::Value;
 use sha1::{Digest, Sha1};
 use sqlx::{Acquire, Row};
+use tokio::time::timeout;
 use tracing::{info, instrument, warn};
 
 // Add thread-local imports for test-specific counter
@@ -35,11 +36,6 @@ use crate::{
 };
 
 use super::{flag_group_type_mapping::GroupTypeIndex, flag_matching::FlagEvaluationState};
-
-// Write timeout constants - for writing hash overrides to the database
-// This is the only place where the /flags service writes to the database
-const WRITE_STATEMENT_TIMEOUT: Duration = Duration::from_millis(1000);
-const WRITE_LOCK_TIMEOUT: Duration = Duration::from_millis(500);
 
 const LONG_SCALE: u64 = 0xfffffffffffffff;
 
@@ -687,20 +683,6 @@ async fn try_set_feature_flag_hash_key_overrides(
     persons_conn_timer.fin();
     let mut transaction = persons_conn.begin().await?;
 
-    // Set longer timeouts for this write operation
-    sqlx::query(&format!(
-        "SET LOCAL statement_timeout = '{}ms'",
-        WRITE_STATEMENT_TIMEOUT.as_millis()
-    ))
-    .execute(&mut *transaction)
-    .await?;
-    sqlx::query(&format!(
-        "SET LOCAL lock_timeout = '{}ms'",
-        WRITE_LOCK_TIMEOUT.as_millis()
-    ))
-    .execute(&mut *transaction)
-    .await?;
-
     // Query 1: Get all person data - person_ids + existing overrides + validation (person pool)
     let person_data_query = r#"
             SELECT DISTINCT 
@@ -953,6 +935,8 @@ async fn try_should_write_hash_key_override(
     distinct_ids: &[String],
     project_id: ProjectId,
 ) -> Result<bool, FlagError> {
+    const QUERY_TIMEOUT: Duration = Duration::from_millis(1000);
+
     // Query 1: Get person_ids and existing overrides from person pool in one shot
     let person_data_query = r#"
         SELECT DISTINCT
@@ -973,94 +957,109 @@ async fn try_should_write_hash_key_override(
             AND flag.active = TRUE
             AND flag.deleted = FALSE
     "#;
-    // Get connection from persons pool for person data
-    let persons_labels = [
-        ("pool".to_string(), "persons_reader".to_string()),
-        (
-            "operation".to_string(),
-            "should_write_hash_key_override".to_string(),
-        ),
-    ];
-    let persons_conn_timer = common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &persons_labels);
-    let mut persons_conn = router
-        .get_persons_reader()
-        .get_connection()
-        .await
-        .map_err(FlagError::from)?;
-    persons_conn_timer.fin();
 
-    // Step 1: Get person data and existing overrides
-    let person_query_labels = [
-        (
-            "query".to_string(),
-            "person_data_with_overrides".to_string(),
-        ),
-        ("operation".to_string(), "should_write_check".to_string()),
-    ];
-    let person_query_timer =
-        common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &person_query_labels);
-    let person_data_rows = sqlx::query(person_data_query)
-        .bind(team_id)
-        .bind(distinct_ids)
-        .fetch_all(&mut *persons_conn)
-        .await
-        .map_err(|e| {
-            FlagError::DatabaseError(e, Some("Failed to fetch person data".to_string()))
-        })?;
-    person_query_timer.fin();
+    let result = timeout(QUERY_TIMEOUT, async {
+        // Get connection from persons pool for person data
+        let persons_labels = [
+            ("pool".to_string(), "persons_reader".to_string()),
+            (
+                "operation".to_string(),
+                "should_write_hash_key_override".to_string(),
+            ),
+        ];
+        let persons_conn_timer =
+            common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &persons_labels);
+        let mut persons_conn = router
+            .get_persons_reader()
+            .get_connection()
+            .await
+            .map_err(FlagError::from)?;
+        persons_conn_timer.fin();
 
-    // If no person_ids found, there's nothing to check
-    if person_data_rows.is_empty() {
-        return Ok(false);
-    }
+        // Step 1: Get person data and existing overrides
+        let person_query_labels = [
+            (
+                "query".to_string(),
+                "person_data_with_overrides".to_string(),
+            ),
+            ("operation".to_string(), "should_write_check".to_string()),
+        ];
+        let person_query_timer =
+            common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &person_query_labels);
+        let person_data_rows = sqlx::query(person_data_query)
+            .bind(team_id)
+            .bind(distinct_ids)
+            .fetch_all(&mut *persons_conn)
+            .await
+            .map_err(|e| {
+                FlagError::DatabaseError(e, Some("Failed to fetch person data".to_string()))
+            })?;
+        person_query_timer.fin();
 
-    // Extract existing flag keys from overrides
-    let existing_flag_keys: HashSet<String> = person_data_rows
-        .iter()
-        .filter_map(|row| row.try_get::<String, _>("feature_flag_key").ok())
-        .collect();
+        // If no person_ids found, there's nothing to check
+        if person_data_rows.is_empty() {
+            return Ok(false);
+        }
 
-    // Step 2: Get active feature flags with experience continuity from non-persons pool
-    // Get connection from non-persons pool for flag data
-    let non_persons_labels = [
-        ("pool".to_string(), "non_persons_reader".to_string()),
-        (
-            "operation".to_string(),
-            "should_write_hash_key_override".to_string(),
-        ),
-    ];
-    let non_persons_conn_timer =
-        common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &non_persons_labels);
-    let mut non_persons_conn = router
-        .get_non_persons_reader()
-        .get_connection()
-        .await
-        .map_err(FlagError::from)?;
-    non_persons_conn_timer.fin();
-    let flags_labels = [
-        (
-            "query".to_string(),
-            "active_flags_with_continuity".to_string(),
-        ),
-        ("operation".to_string(), "should_write_check".to_string()),
-    ];
-    let flags_query_timer = common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
-    let flag_rows = sqlx::query(flags_query)
-        .bind(project_id)
-        .fetch_all(&mut *non_persons_conn)
-        .await
-        .map_err(|e| FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string())))?;
-    flags_query_timer.fin();
+        // Extract existing flag keys from overrides
+        let existing_flag_keys: HashSet<String> = person_data_rows
+            .iter()
+            .filter_map(|row| row.try_get::<String, _>("feature_flag_key").ok())
+            .collect();
 
-    // Check if there are any flags that don't have overrides
-    for row in flag_rows {
-        let flag_key: String = row.get("key");
-        if !existing_flag_keys.contains(&flag_key) {
-            return Ok(true); // Found a flag without override
+        // Step 2: Get active feature flags with experience continuity from non-persons pool
+        // Get connection from non-persons pool for flag data
+        let non_persons_labels = [
+            ("pool".to_string(), "non_persons_reader".to_string()),
+            (
+                "operation".to_string(),
+                "should_write_hash_key_override".to_string(),
+            ),
+        ];
+        let non_persons_conn_timer =
+            common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &non_persons_labels);
+        let mut non_persons_conn = router
+            .get_non_persons_reader()
+            .get_connection()
+            .await
+            .map_err(FlagError::from)?;
+        non_persons_conn_timer.fin();
+        let flags_labels = [
+            (
+                "query".to_string(),
+                "active_flags_with_continuity".to_string(),
+            ),
+            ("operation".to_string(), "should_write_check".to_string()),
+        ];
+        let flags_query_timer =
+            common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
+        let flag_rows = sqlx::query(flags_query)
+            .bind(project_id)
+            .fetch_all(&mut *non_persons_conn)
+            .await
+            .map_err(|e| FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string())))?;
+        flags_query_timer.fin();
+
+        // Check if there are any flags that don't have overrides
+        for row in flag_rows {
+            let flag_key: String = row.get("key");
+            if !existing_flag_keys.contains(&flag_key) {
+                return Ok(true); // Found a flag without override
+            }
+        }
+
+        Ok::<bool, FlagError>(false) // All flags have overrides
+    })
+    .await;
+
+    match result {
+        Ok(Ok(flags_present)) => Ok(flags_present),
+        Ok(Err(e)) => Err(e),
+        Err(_) => {
+            // Handle timeout
+            Err(FlagError::TimeoutError)
         }
     }
-
-    Ok(false) // All flags have overrides
 }
 
 #[cfg(test)]
@@ -1959,7 +1958,7 @@ mod tests {
 
         // Test that configuration errors don't trigger retries
         let config_error = FlagError::DatabaseError(
-            SqlxError::Configuration(Box::new(std::io::Error::other("invalid connection string"))),
+            SqlxError::Configuration("invalid connection string".into()),
             None,
         );
         assert!(!should_retry_on_error(&config_error));
@@ -1971,7 +1970,7 @@ mod tests {
         assert!(!should_retry_on_error(&column_error));
 
         // Test that other error types don't trigger retries
-        let timeout_error_variant = FlagError::TimeoutError(None);
+        let timeout_error_variant = FlagError::TimeoutError;
         assert!(!should_retry_on_error(&timeout_error_variant));
 
         let missing_id_error = FlagError::MissingDistinctId;

--- a/rust/feature-flags/src/metrics/utils.rs
+++ b/rust/feature-flags/src/metrics/utils.rs
@@ -57,15 +57,7 @@ pub fn parse_exception_for_prometheus_label(err: &FlagError) -> &'static str {
         }
         FlagError::DatabaseUnavailable => "database_unavailable",
         FlagError::RedisUnavailable => "redis_unavailable",
-        FlagError::TimeoutError(ref timeout_type) => {
-            match timeout_type {
-                Some(ref timeout_type) => {
-                    // Return timeout type with "timeout:" prefix for granular metrics
-                    Box::leak(format!("timeout:{timeout_type}").into_boxed_str())
-                }
-                None => "timeout_error",
-            }
-        }
+        FlagError::TimeoutError => "timeout_error",
         FlagError::NoGroupTypeMappings => "no_group_type_mappings",
         FlagError::DependencyNotFound(dependency_type, _) => match dependency_type {
             DependencyType::Cohort => "dependency_not_found_cohort",
@@ -179,46 +171,4 @@ fn test_multiple_team_ids() {
     let filtered_labels = filter(&labels);
 
     assert_eq!(filtered_labels, labels);
-}
-
-#[test]
-fn test_timeout_error_prometheus_labels() {
-    // Test generic timeout error
-    let timeout_error = FlagError::TimeoutError(None);
-    assert_eq!(
-        parse_exception_for_prometheus_label(&timeout_error),
-        "timeout_error"
-    );
-
-    // Test specific timeout types
-    let query_canceled_error = FlagError::TimeoutError(Some("query_canceled".to_string()));
-    assert_eq!(
-        parse_exception_for_prometheus_label(&query_canceled_error),
-        "timeout:query_canceled"
-    );
-
-    let lock_timeout_error = FlagError::TimeoutError(Some("lock_not_available".to_string()));
-    assert_eq!(
-        parse_exception_for_prometheus_label(&lock_timeout_error),
-        "timeout:lock_not_available"
-    );
-
-    let pool_timeout_error = FlagError::TimeoutError(Some("pool_timeout".to_string()));
-    assert_eq!(
-        parse_exception_for_prometheus_label(&pool_timeout_error),
-        "timeout:pool_timeout"
-    );
-
-    let client_timeout_error = FlagError::TimeoutError(Some("client_timeout".to_string()));
-    assert_eq!(
-        parse_exception_for_prometheus_label(&client_timeout_error),
-        "timeout:client_timeout"
-    );
-
-    // Test unknown timeout type
-    let unknown_timeout_error = FlagError::TimeoutError(Some("unknown_type".to_string()));
-    assert_eq!(
-        parse_exception_for_prometheus_label(&unknown_timeout_error),
-        "timeout:unknown_type"
-    );
 }

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -10,24 +10,14 @@ use crate::{
 };
 use anyhow::Error;
 use axum::async_trait;
-use common_database::{get_pool_with_timeouts, Client, CustomDatabaseError, DatabaseTimeouts};
+use common_database::{get_pool, Client, CustomDatabaseError};
 use common_redis::{Client as RedisClientTrait, RedisClient};
 use common_types::{PersonId, TeamId};
 use rand::{distributions::Alphanumeric, Rng};
 use serde_json::{json, Value};
-use sqlx::{pool::PoolConnection, Error as SqlxError, Postgres, Row};
-use std::{sync::Arc, time::Duration};
+use sqlx::{pool::PoolConnection, postgres::PgRow, Error as SqlxError, Postgres, Row};
+use std::sync::Arc;
 use uuid::Uuid;
-
-// Test database timeouts - generous timeouts for test environment
-pub const TEST_TIMEOUTS: DatabaseTimeouts = DatabaseTimeouts {
-    statement_timeout: Duration::from_secs(5),
-    lock_timeout: Duration::from_secs(2),
-    acquire_timeout: Duration::from_secs(10),
-    idle_timeout: Duration::from_secs(300),  // 5 minutes
-    max_lifetime: Duration::from_secs(1800), // 30 minutes
-    idle_in_transaction_session_timeout: Duration::from_secs(30), // More generous for tests
-};
 
 pub fn random_string(prefix: &str, length: usize) -> String {
     let suffix: String = rand::thread_rng()
@@ -149,29 +139,19 @@ pub fn create_flag_from_json(json_value: Option<String>) -> Vec<FeatureFlag> {
 
 pub async fn setup_pg_reader_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
-    let test_timeouts = TEST_TIMEOUTS;
     Arc::new(
-        get_pool_with_timeouts(
-            &config.read_database_url,
-            config.max_pg_connections,
-            test_timeouts,
-        )
-        .await
-        .expect("Failed to create Postgres client"),
+        get_pool(&config.read_database_url, config.max_pg_connections)
+            .await
+            .expect("Failed to create Postgres client"),
     )
 }
 
 pub async fn setup_pg_writer_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
-    let test_timeouts = TEST_TIMEOUTS;
     Arc::new(
-        get_pool_with_timeouts(
-            &config.write_database_url,
-            config.max_pg_connections,
-            test_timeouts,
-        )
-        .await
-        .expect("Failed to create Postgres client"),
+        get_pool(&config.write_database_url, config.max_pg_connections)
+            .await
+            .expect("Failed to create Postgres client"),
     )
 }
 
@@ -181,39 +161,29 @@ pub async fn setup_dual_pg_readers(
     config: Option<&Config>,
 ) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
-    let test_timeouts = TEST_TIMEOUTS;
 
     if config.is_persons_db_routing_enabled() {
         // Separate persons and non-persons databases
         let persons_reader = Arc::new(
-            get_pool_with_timeouts(
+            get_pool(
                 &config.get_persons_read_database_url(),
                 config.max_pg_connections,
-                test_timeouts.clone(),
             )
             .await
             .expect("Failed to create Postgres persons reader client"),
         );
         let non_persons_reader = Arc::new(
-            get_pool_with_timeouts(
-                &config.read_database_url,
-                config.max_pg_connections,
-                test_timeouts,
-            )
-            .await
-            .expect("Failed to create Postgres client"),
+            get_pool(&config.read_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
         );
         (persons_reader, non_persons_reader)
     } else {
         // Same database for both
         let client = Arc::new(
-            get_pool_with_timeouts(
-                &config.read_database_url,
-                config.max_pg_connections,
-                test_timeouts,
-            )
-            .await
-            .expect("Failed to create Postgres client"),
+            get_pool(&config.read_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
         );
         (client.clone(), client)
     }
@@ -225,39 +195,29 @@ pub async fn setup_dual_pg_writers(
     config: Option<&Config>,
 ) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
-    let test_timeouts = TEST_TIMEOUTS;
 
     if config.is_persons_db_routing_enabled() {
         // Separate persons and non-persons databases
         let persons_writer = Arc::new(
-            get_pool_with_timeouts(
+            get_pool(
                 &config.get_persons_write_database_url(),
                 config.max_pg_connections,
-                test_timeouts.clone(),
             )
             .await
             .expect("Failed to create Postgres persons writer client"),
         );
         let non_persons_writer = Arc::new(
-            get_pool_with_timeouts(
-                &config.write_database_url,
-                config.max_pg_connections,
-                test_timeouts,
-            )
-            .await
-            .expect("Failed to create Postgres client"),
+            get_pool(&config.write_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
         );
         (persons_writer, non_persons_writer)
     } else {
         // Same database for both
         let client = Arc::new(
-            get_pool_with_timeouts(
-                &config.write_database_url,
-                config.max_pg_connections,
-                test_timeouts,
-            )
-            .await
-            .expect("Failed to create Postgres client"),
+            get_pool(&config.write_database_url, config.max_pg_connections)
+                .await
+                .expect("Failed to create Postgres client"),
         );
         (client.clone(), client)
     }
@@ -267,6 +227,16 @@ pub struct MockPgClient;
 
 #[async_trait]
 impl Client for MockPgClient {
+    async fn run_query(
+        &self,
+        _query: String,
+        _parameters: Vec<String>,
+        _timeout_ms: Option<u64>,
+    ) -> Result<Vec<PgRow>, CustomDatabaseError> {
+        // Simulate a database connection failure
+        Err(CustomDatabaseError::Other(SqlxError::PoolTimedOut))
+    }
+
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
         // Simulate a database connection failure
         Err(CustomDatabaseError::Other(SqlxError::PoolTimedOut))
@@ -290,15 +260,15 @@ pub async fn insert_new_team_in_pg(
     const ORG_ID: &str = "019026a4be8000005bf3171d00629163";
 
     // Create new organization from scratch (in non-persons database)
-    let mut conn = non_persons_client.get_connection().await?;
-    sqlx::query(r#"INSERT INTO posthog_organization
+    non_persons_client.run_query(
+        r#"INSERT INTO posthog_organization
         (id, name, slug, created_at, updated_at, plugins_access_level, for_internal_metrics, is_member_join_email_enabled, enforce_2fa, is_hipaa, customer_id, available_product_features, personalization, setup_section_2_completed, domain_whitelist, members_can_use_personal_api_keys, allow_publicly_shared_resources)
         VALUES
         ($1::uuid, 'Test Organization', 'test-organization', '2024-06-17 14:40:49.298579+00:00', '2024-06-17 14:40:49.298593+00:00', 9, false, true, NULL, false, NULL, '{}', '{}', true, '{}', true, true)
-        ON CONFLICT DO NOTHING"#)
-        .bind(ORG_ID)
-        .execute(&mut *conn)
-        .await?;
+        ON CONFLICT DO NOTHING"#.to_string(),
+        vec![ORG_ID.to_string()],
+        Some(2000),
+    ).await?;
 
     // Create team model
     let id = match team_id {


### PR DESCRIPTION
… (#38686)"

This reverts commit 1f82fe5e658814673106fe6001f5eacfd5f2a7f8.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
