### PR TITLE
fix: survey and cdp quota resources

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -333,7 +333,7 @@ class BillingManager:
                 recordings=usage_summary["recordings"],
                 surveys=usage_summary.get("surveys", {}),
                 rows_synced=usage_summary.get("rows_synced", {}),
-                cdp_invocations=usage_summary.get("cdp_invocations", {}),
+                cdp_trigger_events=usage_summary.get("cdp_trigger_events", {}),
                 rows_exported=usage_summary.get("rows_exported", {}),
                 feature_flag_requests=usage_summary.get("feature_flag_requests", {}),
                 api_queries_read_bytes=usage_summary.get("api_queries_read_bytes", {}),

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -331,7 +331,7 @@ class BillingManager:
                 events=usage_summary["events"],
                 exceptions=usage_summary.get("exceptions", {}),
                 recordings=usage_summary["recordings"],
-                surveys=usage_summary.get("surveys", {}),
+                survey_responses=usage_summary.get("survey_responses", {}),
                 rows_synced=usage_summary.get("rows_synced", {}),
                 cdp_trigger_events=usage_summary.get("cdp_trigger_events", {}),
                 rows_exported=usage_summary.get("rows_exported", {}),

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -62,7 +62,7 @@ class QuotaResource(Enum):
     ROWS_SYNCED = "rows_synced"
     FEATURE_FLAG_REQUESTS = "feature_flag_requests"
     API_QUERIES = "api_queries_read_bytes"
-    SURVEYS = "surveys"
+    SURVEY_RESPONSES = "survey_responses"
     LLM_EVENTS = "llm_events"
     CDP_TRIGGER_EVENTS = "cdp_trigger_events"
     ROWS_EXPORTED = "rows_exported"
@@ -80,7 +80,7 @@ OVERAGE_BUFFER = {
     QuotaResource.ROWS_SYNCED: 0,
     QuotaResource.FEATURE_FLAG_REQUESTS: 0,
     QuotaResource.API_QUERIES: 0,
-    QuotaResource.SURVEYS: 0,
+    QuotaResource.SURVEY_RESPONSES: 0,
     QuotaResource.LLM_EVENTS: 0,
     QuotaResource.CDP_TRIGGER_EVENTS: 0,
     QuotaResource.ROWS_EXPORTED: 0,
@@ -93,7 +93,7 @@ TRUST_SCORE_KEYS = {
     QuotaResource.ROWS_SYNCED: "rows_synced",
     QuotaResource.FEATURE_FLAG_REQUESTS: "feature_flags",
     QuotaResource.API_QUERIES: "api_queries",
-    QuotaResource.SURVEYS: "surveys",
+    QuotaResource.SURVEY_RESPONSES: "surveys",
     QuotaResource.LLM_EVENTS: "llm_events",
     QuotaResource.CDP_TRIGGER_EVENTS: "realtime_destinations",
     QuotaResource.ROWS_EXPORTED: "rows_exported",
@@ -107,7 +107,7 @@ class UsageCounters(TypedDict):
     rows_synced: int
     feature_flags: int
     api_queries_read_bytes: int
-    surveys: int
+    survey_responses: int
     llm_events: int
     cdp_trigger_events: int
     rows_exported: int
@@ -652,7 +652,7 @@ def update_all_orgs_billing_quotas(
             rows_synced=all_data["teams_with_rows_synced_in_period"].get(team.id, 0),
             feature_flags=decide_requests + (local_evaluation_requests * 10),  # Same weighting as in _get_team_report
             api_queries_read_bytes=all_data["teams_with_api_queries_read_bytes"].get(team.id, 0),
-            surveys=all_data["teams_with_survey_responses_count_in_period"].get(team.id, 0),
+            survey_responses=all_data["teams_with_survey_responses_count_in_period"].get(team.id, 0),
             llm_events=all_data["teams_with_ai_event_count_in_period"].get(team.id, 0),
             cdp_trigger_events=all_data["teams_with_cdp_trigger_events_metrics"].get(team.id, 0),
             rows_exported=all_data["teams_with_rows_exported_in_period"].get(team.id, 0),
@@ -670,7 +670,7 @@ def update_all_orgs_billing_quotas(
 
     # Now we have the usage for all orgs for the current day
     # orgs_by_id is a dict of orgs by id (e.g. {"018e9acf-b488-0000-259c-534bcef40359": <Organization: 018e9acf-b488-0000-259c-534bcef40359>})
-    # todays_usage_report is a dict of orgs by id with their usage for the current day (e.g. {"018e9acf-b488-0000-259c-534bcef40359": {"events": 100, "exceptions": 100, "recordings": 100, "rows_synced": 100, "feature_flag_requests": 100, "api_queries_read_bytes": 100, "surveys": 100}})
+    # todays_usage_report is a dict of orgs by id with their usage for the current day (e.g. {"018e9acf-b488-0000-259c-534bcef40359": {"events": 100, "exceptions": 100, "recordings": 100, "rows_synced": 100, "feature_flag_requests": 100, "api_queries_read_bytes": 100, "survey_responses": 100}})
     quota_limited_orgs: dict[str, dict[str, int]] = {x.value: {} for x in QuotaResource}
     quota_limiting_suspended_orgs: dict[str, dict[str, int]] = {x.value: {} for x in QuotaResource}
 
@@ -684,7 +684,7 @@ def update_all_orgs_billing_quotas(
             resource, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
     # We have the teams that are currently under quota limits
-    # previously_quota_limited_team_tokens is a dict of resources to team tokens from redis (e.g. {"events": ["phc_123", "phc_456"], "exceptions": ["phc_123", "phc_456"], "recordings": ["phc_123", "phc_456"], "rows_synced": ["phc_123", "phc_456"], "feature_flag_requests": ["phc_123", "phc_456"], "api_queries_read_bytes": ["phc_123", "phc_456"], "surveys": ["phc_123", "phc_456"]})
+    # previously_quota_limited_team_tokens is a dict of resources to team tokens from redis (e.g. {"events": ["phc_123", "phc_456"], "exceptions": ["phc_123", "phc_456"], "recordings": ["phc_123", "phc_456"], "rows_synced": ["phc_123", "phc_456"], "feature_flag_requests": ["phc_123", "phc_456"], "api_queries_read_bytes": ["phc_123", "phc_456"], "survey_responses": ["phc_123", "phc_456"]})
 
     # Find all orgs that should be rate limited
     report_index = 1
@@ -713,8 +713,8 @@ def update_all_orgs_billing_quotas(
             capture_exception(e, {"organization_id": org_id})
 
     # Now we have the teams that are currently under quota limits
-    # quota_limited_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "exceptions": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "api_queries_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "surveys": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
-    # quota_limiting_suspended_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "exceptions": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "api_queries_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "surveys": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
+    # quota_limited_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "exceptions": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "api_queries_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "survey_responses": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
+    # quota_limiting_suspended_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "exceptions": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "api_queries_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "survey_responses": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
 
     quota_limited_teams: dict[str, dict[str, int]] = {x.value: {} for x in QuotaResource}
     quota_limiting_suspended_teams: dict[str, dict[str, int]] = {x.value: {} for x in QuotaResource}
@@ -737,8 +737,8 @@ def update_all_orgs_billing_quotas(
                     orgs_with_changes.add(org_id)
 
     # Now we have the teams that are currently under quota limits
-    # quota_limited_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "exceptions": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "api_queries_read_bytes": {"phc_123": 1737867600}, "surveys": {"phc_123": 1737867600}})
-    # quota_limiting_suspended_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "exceptions": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "api_queries_read_bytes": {"phc_123": 1737867600}, "surveys": {"phc_123": 1737867600}})
+    # quota_limited_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "exceptions": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "api_queries_read_bytes": {"phc_123": 1737867600}, "survey_responses": {"phc_123": 1737867600}})
+    # quota_limiting_suspended_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "exceptions": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "api_queries_read_bytes": {"phc_123": 1737867600}, "survey_responses": {"phc_123": 1737867600}})
 
     for org_id in orgs_with_changes:
         properties = {
@@ -748,7 +748,7 @@ def update_all_orgs_billing_quotas(
             "quota_limited_rows_synced": quota_limited_orgs["rows_synced"].get(org_id, None),
             "quota_limited_feature_flags": quota_limited_orgs["feature_flag_requests"].get(org_id, None),
             "quota_limited_api_queries": quota_limited_orgs["api_queries_read_bytes"].get(org_id, None),
-            "quota_limited_surveys": quota_limited_orgs["surveys"].get(org_id, None),
+            "quota_limited_survey_responses": quota_limited_orgs["survey_responses"].get(org_id, None),
             "quota_limited_llm_events": quota_limited_orgs["llm_events"].get(org_id, None),
             "quota_limited_cdp_trigger_events": quota_limited_orgs["cdp_trigger_events"].get(org_id, None),
             "quota_limited_rows_exported": quota_limited_orgs["rows_exported"].get(org_id, None),

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -55,6 +55,7 @@ class OrgQuotaLimitingInformation(TypedDict):
     quota_limiting_suspended_until: Optional[int]
 
 
+# These quota resource identifiers match billing default_plans_config.yml usage_key
 class QuotaResource(Enum):
     EVENTS = "events"
     EXCEPTIONS = "exceptions"
@@ -86,6 +87,7 @@ OVERAGE_BUFFER = {
     QuotaResource.ROWS_EXPORTED: 0,
 }
 
+# These trust score keys match billing default_plans_config.yml product keys (top level key)
 TRUST_SCORE_KEYS = {
     QuotaResource.EVENTS: "events",
     QuotaResource.EXCEPTIONS: "exceptions",

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -64,7 +64,7 @@ class QuotaResource(Enum):
     API_QUERIES = "api_queries_read_bytes"
     SURVEYS = "surveys"
     LLM_EVENTS = "llm_events"
-    CDP_INVOCATIONS = "cdp_invocations"
+    CDP_TRIGGER_EVENTS = "cdp_trigger_events"
     ROWS_EXPORTED = "rows_exported"
 
 
@@ -82,7 +82,7 @@ OVERAGE_BUFFER = {
     QuotaResource.API_QUERIES: 0,
     QuotaResource.SURVEYS: 0,
     QuotaResource.LLM_EVENTS: 0,
-    QuotaResource.CDP_INVOCATIONS: 0,
+    QuotaResource.CDP_TRIGGER_EVENTS: 0,
     QuotaResource.ROWS_EXPORTED: 0,
 }
 
@@ -95,7 +95,7 @@ TRUST_SCORE_KEYS = {
     QuotaResource.API_QUERIES: "api_queries",
     QuotaResource.SURVEYS: "surveys",
     QuotaResource.LLM_EVENTS: "llm_events",
-    QuotaResource.CDP_INVOCATIONS: "cdp_invocations",
+    QuotaResource.CDP_TRIGGER_EVENTS: "realtime_destinations",
     QuotaResource.ROWS_EXPORTED: "rows_exported",
 }
 
@@ -109,7 +109,7 @@ class UsageCounters(TypedDict):
     api_queries_read_bytes: int
     surveys: int
     llm_events: int
-    cdp_invocations: int
+    cdp_trigger_events: int
     rows_exported: int
 
 
@@ -610,7 +610,7 @@ def update_all_orgs_billing_quotas(
             )
         ),
         "teams_with_api_queries_read_bytes": convert_team_usage_rows_to_dict(api_queries_usage["read_bytes"]),
-        "teams_with_cdp_invocations_metrics": convert_team_usage_rows_to_dict(
+        "teams_with_cdp_trigger_events_metrics": convert_team_usage_rows_to_dict(
             get_teams_with_cdp_billable_invocations_in_period(period_start, period_end)
         ),
         "teams_with_rows_exported_in_period": convert_team_usage_rows_to_dict(
@@ -654,7 +654,7 @@ def update_all_orgs_billing_quotas(
             api_queries_read_bytes=all_data["teams_with_api_queries_read_bytes"].get(team.id, 0),
             surveys=all_data["teams_with_survey_responses_count_in_period"].get(team.id, 0),
             llm_events=all_data["teams_with_ai_event_count_in_period"].get(team.id, 0),
-            cdp_invocations=all_data["teams_with_cdp_invocations_metrics"].get(team.id, 0),
+            cdp_trigger_events=all_data["teams_with_cdp_trigger_events_metrics"].get(team.id, 0),
             rows_exported=all_data["teams_with_rows_exported_in_period"].get(team.id, 0),
         )
 
@@ -750,7 +750,7 @@ def update_all_orgs_billing_quotas(
             "quota_limited_api_queries": quota_limited_orgs["api_queries_read_bytes"].get(org_id, None),
             "quota_limited_surveys": quota_limited_orgs["surveys"].get(org_id, None),
             "quota_limited_llm_events": quota_limited_orgs["llm_events"].get(org_id, None),
-            "quota_limited_cdp_invocations": quota_limited_orgs["cdp_invocations"].get(org_id, None),
+            "quota_limited_cdp_trigger_events": quota_limited_orgs["cdp_trigger_events"].get(org_id, None),
             "quota_limited_rows_exported": quota_limited_orgs["rows_exported"].get(org_id, None),
         }
 

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -157,7 +157,7 @@ class TestBillingManager(BaseTest):
             "llm_events": {"usage": 50, "limit": 1000, "todays_usage": 2},
             "cdp_trigger_events": {"usage": 10, "limit": 100, "todays_usage": 5},
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
-            "surveys": {
+            "survey_responses": {
                 "usage": 10,
                 "limit": 100,
                 "todays_usage": 5,
@@ -183,7 +183,7 @@ class TestBillingManager(BaseTest):
                     "feature_flag_requests": {"usage": 25, "limit": 300},
                     "api_queries_read_bytes": {"usage": 1000, "limit": 1000000},
                     "llm_events": {"usage": 50, "limit": 1000},
-                    "surveys": {"usage": 10, "limit": 100},
+                    "survey_responses": {"usage": 10, "limit": 100},
                     "cdp_trigger_events": {"usage": 10, "limit": 100},
                 },
                 "billing_period": {
@@ -222,7 +222,7 @@ class TestBillingManager(BaseTest):
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
             "api_queries_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
             "cdp_trigger_events": {"usage": 10, "limit": 100, "todays_usage": 5},
-            "surveys": {
+            "survey_responses": {
                 "usage": 10,
                 "limit": 100,
                 "todays_usage": 5,

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -155,7 +155,7 @@ class TestBillingManager(BaseTest):
             "feature_flag_requests": {"usage": 25, "limit": 300, "todays_usage": 5},
             "api_queries_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
             "llm_events": {"usage": 50, "limit": 1000, "todays_usage": 2},
-            "cdp_invocations": {"usage": 10, "limit": 100, "todays_usage": 5},
+            "cdp_trigger_events": {"usage": 10, "limit": 100, "todays_usage": 5},
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
             "surveys": {
                 "usage": 10,
@@ -184,7 +184,7 @@ class TestBillingManager(BaseTest):
                     "api_queries_read_bytes": {"usage": 1000, "limit": 1000000},
                     "llm_events": {"usage": 50, "limit": 1000},
                     "surveys": {"usage": 10, "limit": 100},
-                    "cdp_invocations": {"usage": 10, "limit": 100},
+                    "cdp_trigger_events": {"usage": 10, "limit": 100},
                 },
                 "billing_period": {
                     "current_period_start": "2024-01-01T00:00:00Z",
@@ -221,7 +221,7 @@ class TestBillingManager(BaseTest):
             "llm_events": {"usage": 50, "limit": 1000, "todays_usage": 2},
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
             "api_queries_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
-            "cdp_invocations": {"usage": 10, "limit": 100, "todays_usage": 5},
+            "cdp_trigger_events": {"usage": 10, "limit": 100, "todays_usage": 5},
             "surveys": {
                 "usage": 10,
                 "limit": 100,

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -46,7 +46,7 @@ class TestQuotaLimiting(BaseTest):
         self.redis_client.delete(f"@posthog/quota-limits/recordings")
         self.redis_client.delete(f"@posthog/quota-limits/rows_synced")
         self.redis_client.delete(f"@posthog/quota-limits/api_queries_read_bytes")
-        self.redis_client.delete(f"@posthog/quota-limits/surveys")
+        self.redis_client.delete(f"@posthog/quota-limits/survey_responses")
         self.redis_client.delete(f"@posthog/quota-limits/rows_exported")
         self.redis_client.delete(f"@posthog/quota-limits/llm_events")
         self.redis_client.delete(f"@posthog/quota-limits/cdp_trigger_events")
@@ -55,7 +55,7 @@ class TestQuotaLimiting(BaseTest):
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/recordings")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/rows_synced")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/api_queries_read_bytes")
-        self.redis_client.delete(f"@posthog/quota-limiting-suspended/surveys")
+        self.redis_client.delete(f"@posthog/quota-limiting-suspended/survey_responses")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/rows_exported")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/llm_events")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/cdp_trigger_events")
@@ -73,7 +73,7 @@ class TestQuotaLimiting(BaseTest):
                 "feature_flag_requests": {"usage": 5, "limit": 100},
                 "api_queries_read_bytes": {"usage": 10, "limit": 100},
                 "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-                "surveys": {"usage": 10, "limit": 100},
+                "survey_responses": {"usage": 10, "limit": 100},
             }
             self.organization.save()
 
@@ -122,7 +122,7 @@ class TestQuotaLimiting(BaseTest):
         assert quota_limited_orgs["rows_synced"] == {}
         assert quota_limited_orgs["feature_flag_requests"] == {}
         assert quota_limited_orgs["api_queries_read_bytes"] == {}
-        assert quota_limited_orgs["surveys"] == {}
+        assert quota_limited_orgs["survey_responses"] == {}
         assert quota_limited_orgs["rows_exported"] == {}
         assert quota_limiting_suspended_orgs["events"] == {}
         assert quota_limiting_suspended_orgs["exceptions"] == {}
@@ -130,7 +130,7 @@ class TestQuotaLimiting(BaseTest):
         assert quota_limiting_suspended_orgs["rows_synced"] == {}
         assert quota_limiting_suspended_orgs["feature_flag_requests"] == {}
         assert quota_limiting_suspended_orgs["api_queries_read_bytes"] == {}
-        assert quota_limiting_suspended_orgs["surveys"] == {}
+        assert quota_limiting_suspended_orgs["survey_responses"] == {}
         assert quota_limiting_suspended_orgs["rows_exported"] == {}
         assert self.redis_client.zrange(f"@posthog/quota-limits/events", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/exceptions", 0, -1) == []
@@ -138,7 +138,7 @@ class TestQuotaLimiting(BaseTest):
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_synced", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/feature_flag_requests", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/api_queries_read_bytes", 0, -1) == []
-        assert self.redis_client.zrange(f"@posthog/quota-limits/surveys", 0, -1) == []
+        assert self.redis_client.zrange(f"@posthog/quota-limits/survey_responses", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_exported", 0, -1) == []
 
         patch_capture.reset_mock()
@@ -183,7 +183,7 @@ class TestQuotaLimiting(BaseTest):
         assert quota_limited_orgs["rows_synced"] == {}
         assert quota_limited_orgs["feature_flag_requests"] == {}
         assert quota_limited_orgs["api_queries_read_bytes"] == {}
-        assert quota_limited_orgs["surveys"] == {}
+        assert quota_limited_orgs["survey_responses"] == {}
         assert quota_limited_orgs["rows_exported"] == {}
         assert quota_limiting_suspended_orgs["events"] == {}
         assert quota_limiting_suspended_orgs["exceptions"] == {}
@@ -191,7 +191,7 @@ class TestQuotaLimiting(BaseTest):
         assert quota_limiting_suspended_orgs["rows_synced"] == {}
         assert quota_limiting_suspended_orgs["feature_flag_requests"] == {}
         assert quota_limiting_suspended_orgs["api_queries_read_bytes"] == {}
-        assert quota_limiting_suspended_orgs["surveys"] == {}
+        assert quota_limiting_suspended_orgs["survey_responses"] == {}
         assert quota_limiting_suspended_orgs["rows_exported"] == {}
         assert self.redis_client.zrange(f"@posthog/quota-limits/events", 0, -1) == [self.team.api_token.encode("UTF-8")]
         assert self.redis_client.zrange(f"@posthog/quota-limits/exceptions", 0, -1) == []
@@ -199,7 +199,7 @@ class TestQuotaLimiting(BaseTest):
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_synced", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/feature_flag_requests", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/api_queries_read_bytes", 0, -1) == []
-        assert self.redis_client.zrange(f"@posthog/quota-limits/surveys", 0, -1) == []
+        assert self.redis_client.zrange(f"@posthog/quota-limits/survey_responses", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_exported", 0, -1) == []
 
     @patch("posthoganalytics.capture")
@@ -214,7 +214,7 @@ class TestQuotaLimiting(BaseTest):
             "feature_flag_requests": {"usage": 5, "limit": 100, "todays_usage": 0},
             "api_queries_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 0},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100, "todays_usage": 0},
+            "survey_responses": {"usage": 10, "limit": 100, "todays_usage": 0},
         }
         self.organization.customer_trust_scores = zero_trust_scores()
         self.organization.save()
@@ -231,7 +231,7 @@ class TestQuotaLimiting(BaseTest):
         assert quota_limited_orgs["rows_synced"] == {}
         assert quota_limited_orgs["feature_flag_requests"] == {}
         assert quota_limited_orgs["api_queries_read_bytes"] == {}
-        assert quota_limited_orgs["surveys"] == {}
+        assert quota_limited_orgs["survey_responses"] == {}
         assert quota_limited_orgs["rows_exported"] == {}
         assert quota_limiting_suspended_orgs["events"] == {}
         assert quota_limiting_suspended_orgs["exceptions"] == {}
@@ -239,7 +239,7 @@ class TestQuotaLimiting(BaseTest):
         assert quota_limiting_suspended_orgs["rows_synced"] == {}
         assert quota_limiting_suspended_orgs["feature_flag_requests"] == {}
         assert quota_limiting_suspended_orgs["api_queries_read_bytes"] == {}
-        assert quota_limiting_suspended_orgs["surveys"] == {}
+        assert quota_limiting_suspended_orgs["survey_responses"] == {}
         assert quota_limiting_suspended_orgs["rows_exported"] == {}
 
         assert self.redis_client.zrange(f"@posthog/quota-limits/events", 0, -1) == []
@@ -248,7 +248,7 @@ class TestQuotaLimiting(BaseTest):
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_synced", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/feature_flag_requests", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/api_queries_read_bytes", 0, -1) == []
-        assert self.redis_client.zrange(f"@posthog/quota-limits/surveys", 0, -1) == []
+        assert self.redis_client.zrange(f"@posthog/quota-limits/survey_responses", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_exported", 0, -1) == []
 
     def test_billing_rate_limit_not_set_if_missing_org_usage(self) -> None:
@@ -275,13 +275,13 @@ class TestQuotaLimiting(BaseTest):
         assert quota_limited_orgs["recordings"] == {}
         assert quota_limited_orgs["rows_synced"] == {}
         assert quota_limited_orgs["feature_flag_requests"] == {}
-        assert quota_limited_orgs["surveys"] == {}
+        assert quota_limited_orgs["survey_responses"] == {}
         assert quota_limiting_suspended_orgs["events"] == {}
         assert quota_limiting_suspended_orgs["exceptions"] == {}
         assert quota_limiting_suspended_orgs["recordings"] == {}
         assert quota_limiting_suspended_orgs["rows_synced"] == {}
         assert quota_limiting_suspended_orgs["feature_flag_requests"] == {}
-        assert quota_limiting_suspended_orgs["surveys"] == {}
+        assert quota_limiting_suspended_orgs["survey_responses"] == {}
 
         assert self.redis_client.zrange(f"@posthog/quota-limits/events", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/exceptions", 0, -1) == []
@@ -289,7 +289,7 @@ class TestQuotaLimiting(BaseTest):
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_synced", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/feature_flag_requests", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/api_queries_read_bytes", 0, -1) == []
-        assert self.redis_client.zrange(f"@posthog/quota-limits/surveys", 0, -1) == []
+        assert self.redis_client.zrange(f"@posthog/quota-limits/survey_responses", 0, -1) == []
         assert self.redis_client.zrange(f"@posthog/quota-limits/rows_exported", 0, -1) == []
 
     @patch("posthoganalytics.capture")
@@ -354,7 +354,7 @@ class TestQuotaLimiting(BaseTest):
                 "quota_limited_api_queries": None,
                 "quota_limited_rows_synced": None,
                 "quota_limited_feature_flags": None,
-                "quota_limited_surveys": None,
+                "quota_limited_survey_responses": None,
                 "quota_limited_llm_events": None,
                 "quota_limited_cdp_trigger_events": None,
                 "quota_limited_rows_exported": None,
@@ -385,7 +385,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 0,
                 "feature_flags": 0,
                 TRUST_SCORE_KEYS[QuotaResource.API_QUERIES]: 0,
-                "surveys": 0,
+                "survey_responses": 0,
                 "rows_exported": 0,
             }
             self.organization.save()
@@ -463,7 +463,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 0,
                 "feature_flags": 0,
                 TRUST_SCORE_KEYS[QuotaResource.API_QUERIES]: 0,
-                "surveys": 0,
+                "survey_responses": 0,
             }
             self.organization.usage = create_usage_summary(
                 events={"usage": 109, "limit": 100, "quota_limiting_suspended_until": 1611705600},
@@ -486,7 +486,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 0,
                 "feature_flags": 0,
                 TRUST_SCORE_KEYS[QuotaResource.API_QUERIES]: 0,
-                "surveys": 0,
+                "survey_responses": 0,
             }
             self.organization.usage = create_usage_summary(
                 events={"usage": 109, "limit": 100},
@@ -527,7 +527,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 0,
                 "feature_flags": 0,
                 TRUST_SCORE_KEYS[QuotaResource.API_QUERIES]: 0,
-                "surveys": 0,
+                "survey_responses": 0,
             }
             self.organization.usage = create_usage_summary(
                 events={"usage": 109, "limit": 100, "quota_limiting_suspended_until": 1611705600},
@@ -552,7 +552,7 @@ class TestQuotaLimiting(BaseTest):
             "rows_synced": {"usage": 5, "limit": 100},
             "feature_flag_requests": {"usage": 5, "limit": 100},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100},
+            "survey_responses": {"usage": 10, "limit": 100},
         }
         self.organization.save()
 
@@ -566,7 +566,7 @@ class TestQuotaLimiting(BaseTest):
                 "2021-01-01T00:00:00Z",
                 "2021-01-31T23:59:59Z",
             ],
-            "surveys": {"usage": 20, "limit": 100},
+            "survey_responses": {"usage": 20, "limit": 100},
         }
 
         assert set_org_usage_summary(self.organization, new_usage=new_usage)
@@ -578,7 +578,7 @@ class TestQuotaLimiting(BaseTest):
             "rows_synced": {"usage": 6, "limit": 100, "todays_usage": 0},
             "feature_flag_requests": {"usage": 6, "limit": 100, "todays_usage": 0},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 20, "limit": 100, "todays_usage": 0},
+            "survey_responses": {"usage": 20, "limit": 100, "todays_usage": 0},
         }
 
     def test_set_org_usage_summary_does_nothing_if_the_same(self):
@@ -589,7 +589,7 @@ class TestQuotaLimiting(BaseTest):
             "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 11},
             "feature_flag_requests": {"usage": 5, "limit": 100, "todays_usage": 11},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100, "todays_usage": 50},
+            "survey_responses": {"usage": 10, "limit": 100, "todays_usage": 50},
         }
         self.organization.save()
 
@@ -603,7 +603,7 @@ class TestQuotaLimiting(BaseTest):
                 "2021-01-01T00:00:00Z",
                 "2021-01-31T23:59:59Z",
             ],
-            "surveys": {"usage": 10, "limit": 100},
+            "survey_responses": {"usage": 10, "limit": 100},
         }
 
         assert not set_org_usage_summary(self.organization, new_usage=new_usage)
@@ -615,7 +615,7 @@ class TestQuotaLimiting(BaseTest):
             "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 11},
             "feature_flag_requests": {"usage": 5, "limit": 100, "todays_usage": 11},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100, "todays_usage": 50},
+            "survey_responses": {"usage": 10, "limit": 100, "todays_usage": 50},
         }
 
     def test_set_org_usage_summary_updates_todays_usage(self):
@@ -626,7 +626,7 @@ class TestQuotaLimiting(BaseTest):
             "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 11},
             "feature_flag_requests": {"usage": 5, "limit": 100, "todays_usage": 11},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100, "todays_usage": 50},
+            "survey_responses": {"usage": 10, "limit": 100, "todays_usage": 50},
         }
         self.organization.save()
 
@@ -638,7 +638,7 @@ class TestQuotaLimiting(BaseTest):
                 "recordings": 21,
                 "rows_synced": 21,
                 "feature_flag_requests": 21,
-                "surveys": 21,
+                "survey_responses": 21,
             },
         )
 
@@ -649,7 +649,7 @@ class TestQuotaLimiting(BaseTest):
             "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 21},
             "feature_flag_requests": {"usage": 5, "limit": 100, "todays_usage": 21},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100, "todays_usage": 21},
+            "survey_responses": {"usage": 10, "limit": 100, "todays_usage": 21},
         }
 
     def test_org_quota_limited_until(self):
@@ -668,7 +668,7 @@ class TestQuotaLimiting(BaseTest):
             QuotaResource.ROWS_SYNCED, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
         previously_quota_limited_team_tokens_surveys = list_limited_team_attributes(
-            QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+            QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
         assert (
             org_quota_limited_until(
@@ -685,7 +685,7 @@ class TestQuotaLimiting(BaseTest):
             "feature_flag_requests": {"usage": 99, "limit": 100},
             "api_queries_read_bytes": {"usage": 99, "limit": 100},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100},
+            "survey_responses": {"usage": 10, "limit": 100},
         }
 
         # Not over quota
@@ -778,18 +778,18 @@ class TestQuotaLimiting(BaseTest):
         }
 
         # Not over quota
-        self.organization.usage["surveys"]["usage"] = 99
+        self.organization.usage["survey_responses"]["usage"] = 99
         assert (
             org_quota_limited_until(
-                self.organization, QuotaResource.SURVEYS, previously_quota_limited_team_tokens_surveys
+                self.organization, QuotaResource.SURVEY_RESPONSES, previously_quota_limited_team_tokens_surveys
             )
             is None
         )
 
         # Over quota
-        self.organization.usage["surveys"]["usage"] = 101
+        self.organization.usage["survey_responses"]["usage"] = 101
         assert org_quota_limited_until(
-            self.organization, QuotaResource.SURVEYS, previously_quota_limited_team_tokens_surveys
+            self.organization, QuotaResource.SURVEY_RESPONSES, previously_quota_limited_team_tokens_surveys
         ) == {
             "quota_limited_until": 1612137599,
             "quota_limiting_suspended_until": None,
@@ -803,7 +803,7 @@ class TestQuotaLimiting(BaseTest):
                 TRUST_SCORE_KEYS[QuotaResource.ROWS_SYNCED]: 10,
                 TRUST_SCORE_KEYS[QuotaResource.FEATURE_FLAG_REQUESTS]: 10,
                 TRUST_SCORE_KEYS[QuotaResource.API_QUERIES]: 10,
-                TRUST_SCORE_KEYS[QuotaResource.SURVEYS]: 7,
+                TRUST_SCORE_KEYS[QuotaResource.SURVEY_RESPONSES]: 7,
             }
 
             # Update to be over quota on all resources
@@ -815,7 +815,7 @@ class TestQuotaLimiting(BaseTest):
                 "feature_flag_requests": {"usage": 101, "limit": 100},
                 "api_queries_read_bytes": {"usage": 101, "limit": 100},
                 "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-                "surveys": {"usage": 101, "limit": 100},
+                "survey_responses": {"usage": 101, "limit": 100},
             }
 
             # All resources over quota
@@ -850,7 +850,7 @@ class TestQuotaLimiting(BaseTest):
                 "quota_limiting_suspended_until": 1611878400,  # grace period 3 days
             }
             assert org_quota_limited_until(
-                self.organization, QuotaResource.SURVEYS, previously_quota_limited_team_tokens_surveys
+                self.organization, QuotaResource.SURVEY_RESPONSES, previously_quota_limited_team_tokens_surveys
             ) == {
                 "quota_limited_until": None,
                 "quota_limiting_suspended_until": 1611705600,  # grace period 1 day
@@ -871,7 +871,7 @@ class TestQuotaLimiting(BaseTest):
             QuotaResource.ROWS_SYNCED, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
         previously_quota_limited_team_tokens_surveys = list_limited_team_attributes(
-            QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+            QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
         assert (
             org_quota_limited_until(
@@ -887,7 +887,7 @@ class TestQuotaLimiting(BaseTest):
             "rows_synced": {"usage": 100, "limit": 90},
             "feature_flag_requests": {"usage": 100, "limit": 90},
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-            "surveys": {"usage": 10, "limit": 100},
+            "survey_responses": {"usage": 10, "limit": 100},
         }
         self.organization.never_drop_data = True
 
@@ -917,7 +917,7 @@ class TestQuotaLimiting(BaseTest):
         )
         assert (
             org_quota_limited_until(
-                self.organization, QuotaResource.SURVEYS, previously_quota_limited_team_tokens_surveys
+                self.organization, QuotaResource.SURVEY_RESPONSES, previously_quota_limited_team_tokens_surveys
             )
             is None
         )
@@ -941,7 +941,7 @@ class TestQuotaLimiting(BaseTest):
                 QuotaResource.ROWS_SYNCED, {"1337": now + 10000}, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
             )
             replace_limited_team_tokens(
-                QuotaResource.SURVEYS, {"5678": now + 10000}, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                QuotaResource.SURVEY_RESPONSES, {"5678": now + 10000}, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
             )
             self.organization.usage = {
                 "events": {"usage": 99, "limit": 100},
@@ -950,7 +950,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": {"usage": 35, "limit": 100},
                 "feature_flag_requests": {"usage": 5, "limit": 100},
                 "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-                "surveys": {"usage": 10, "limit": 100},
+                "survey_responses": {"usage": 10, "limit": 100},
             }
 
             update_org_billing_quotas(self.organization)
@@ -963,14 +963,14 @@ class TestQuotaLimiting(BaseTest):
             assert list_limited_team_attributes(
                 QuotaResource.ROWS_SYNCED, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
             ) == ["1337"]
-            assert list_limited_team_attributes(QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY) == [
-                "5678"
-            ]
+            assert list_limited_team_attributes(
+                QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+            ) == ["5678"]
 
             self.organization.usage["events"]["usage"] = 120
             self.organization.usage["exceptions"]["usage"] = 120
             self.organization.usage["rows_synced"]["usage"] = 120
-            self.organization.usage["surveys"]["usage"] = 120
+            self.organization.usage["survey_responses"]["usage"] = 120
             update_org_billing_quotas(self.organization)
             assert sorted(
                 list_limited_team_attributes(QuotaResource.EVENTS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
@@ -984,13 +984,15 @@ class TestQuotaLimiting(BaseTest):
                 list_limited_team_attributes(QuotaResource.ROWS_SYNCED, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
             ) == sorted(["1337", str(self.team.api_token), str(other_team.api_token)])
             assert sorted(
-                list_limited_team_attributes(QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
+                list_limited_team_attributes(
+                    QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                )
             ) == sorted(["5678", self.team.api_token, other_team.api_token])
 
             self.organization.usage["events"]["usage"] = 80
             self.organization.usage["exceptions"]["usage"] = 80
             self.organization.usage["rows_synced"]["usage"] = 36
-            self.organization.usage["surveys"]["usage"] = 80
+            self.organization.usage["survey_responses"]["usage"] = 80
             update_org_billing_quotas(self.organization)
             assert sorted(
                 list_limited_team_attributes(QuotaResource.EVENTS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
@@ -1002,7 +1004,9 @@ class TestQuotaLimiting(BaseTest):
                 list_limited_team_attributes(QuotaResource.ROWS_SYNCED, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
             ) == sorted(["1337"])
             assert sorted(
-                list_limited_team_attributes(QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
+                list_limited_team_attributes(
+                    QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                )
             ) == sorted(["5678"])
 
             self.organization.customer_trust_scores = {
@@ -1012,14 +1016,14 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 7,
                 "feature_flags": 10,
                 TRUST_SCORE_KEYS[QuotaResource.API_QUERIES]: 10,
-                "surveys": 10,
+                "survey_responses": 10,
             }
             self.organization.save()
 
             self.organization.usage["events"]["usage"] = 120
             self.organization.usage["exceptions"]["usage"] = 120
             self.organization.usage["rows_synced"]["usage"] = 120
-            self.organization.usage["surveys"]["usage"] = 120
+            self.organization.usage["survey_responses"]["usage"] = 120
             update_org_billing_quotas(self.organization)
             assert sorted(
                 list_limited_team_attributes(QuotaResource.EVENTS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
@@ -1045,16 +1049,20 @@ class TestQuotaLimiting(BaseTest):
                 )
             ) == sorted([str(self.team.api_token), str(other_team.api_token)])
             assert sorted(
-                list_limited_team_attributes(QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
+                list_limited_team_attributes(
+                    QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                )
             ) == sorted(["5678"])
             assert sorted(
-                list_limited_team_attributes(QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITING_SUSPENDED_KEY)
+                list_limited_team_attributes(
+                    QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITING_SUSPENDED_KEY
+                )
             ) == sorted([str(self.team.api_token), str(other_team.api_token)])
 
             self.organization.usage["events"]["usage"] = 80
             self.organization.usage["exceptions"]["usage"] = 80
             self.organization.usage["rows_synced"]["usage"] = 36
-            self.organization.usage["surveys"]["usage"] = 80
+            self.organization.usage["survey_responses"]["usage"] = 80
             update_org_billing_quotas(self.organization)
             assert sorted(
                 list_limited_team_attributes(QuotaResource.EVENTS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
@@ -1066,7 +1074,9 @@ class TestQuotaLimiting(BaseTest):
                 list_limited_team_attributes(QuotaResource.ROWS_SYNCED, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
             ) == sorted(["1337"])
             assert sorted(
-                list_limited_team_attributes(QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
+                list_limited_team_attributes(
+                    QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                )
             ) == sorted(["5678"])
 
     @patch("ee.billing.quota_limiting.capture_exception")
@@ -1104,7 +1114,7 @@ class TestQuotaLimiting(BaseTest):
                 "feature_flag_requests": {"usage": 110, "limit": 100},
                 "api_queries_read_bytes": {"usage": 10, "limit": 100},
                 "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-                "surveys": {"usage": 10, "limit": 100},
+                "survey_responses": {"usage": 10, "limit": 100},
             }
             self.organization.customer_trust_scores = zero_trust_scores()
             self.organization.save()
@@ -1177,7 +1187,7 @@ class TestQuotaLimiting(BaseTest):
                 "feature_flag_requests": {"usage": 110, "limit": 100},
                 "api_queries_read_bytes": {"usage": 10, "limit": 100},
                 "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-                "surveys": {"usage": 10, "limit": 100},
+                "survey_responses": {"usage": 10, "limit": 100},
             }
             org_id = str(self.organization.id)
 
@@ -1361,7 +1371,7 @@ class TestQuotaLimiting(BaseTest):
         with self.settings(USE_TZ=False):
             # Set up usage data with surveys over the limit
             self.organization.usage = {
-                "surveys": {"usage": 95, "limit": 100, "todays_usage": 10},  # 105 total, over limit of 100
+                "survey_responses": {"usage": 95, "limit": 100, "todays_usage": 10},  # 105 total, over limit of 100
                 "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
             }
             self.organization.customer_trust_scores = {"surveys": 0}  # Low trust score
@@ -1372,13 +1382,13 @@ class TestQuotaLimiting(BaseTest):
 
             # Verify team token was added to quota limited list
             limited_tokens = list_limited_team_attributes(
-                QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
             )
             assert self.team.api_token in limited_tokens
 
             # Verify org usage was updated with quota_limited_until
             self.organization.refresh_from_db()
-            assert self.organization.usage["surveys"].get("quota_limited_until") is not None
+            assert self.organization.usage["survey_responses"].get("quota_limited_until") is not None
 
             # Verify analytics event was captured
             mock_capture.assert_called()
@@ -1391,7 +1401,7 @@ class TestQuotaLimiting(BaseTest):
                     break
 
             assert org_action_call is not None
-            assert org_action_call[1]["properties"]["resource"] == "surveys"
+            assert org_action_call[1]["properties"]["resource"] == "survey_responses"
             assert org_action_call[1]["properties"]["current_usage"] == 105
             assert org_action_call[1]["properties"]["event"] == "suspended"
 
@@ -1401,7 +1411,7 @@ class TestQuotaLimiting(BaseTest):
         with self.settings(USE_TZ=False):
             # Set up usage data with surveys under the limit
             self.organization.usage = {
-                "surveys": {"usage": 80, "limit": 100, "todays_usage": 5},  # 85 total, under limit
+                "survey_responses": {"usage": 80, "limit": 100, "todays_usage": 5},  # 85 total, under limit
                 "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
             }
             self.organization.save()
@@ -1411,13 +1421,13 @@ class TestQuotaLimiting(BaseTest):
 
             # Verify team token was NOT added to quota limited list
             limited_tokens = list_limited_team_attributes(
-                QuotaResource.SURVEYS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                QuotaResource.SURVEY_RESPONSES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
             )
             assert self.team.api_token not in limited_tokens
 
             # Verify org usage does not have quota_limited_until
             self.organization.refresh_from_db()
-            assert self.organization.usage["surveys"].get("quota_limited_until") is None
+            assert self.organization.usage["survey_responses"].get("quota_limited_until") is None
 
     @freeze_time("2021-01-25T23:59:59Z")
     @patch("posthoganalytics.capture")
@@ -1495,7 +1505,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 0,
                 "feature_flags": 0,
                 "api_queries": 0,
-                "surveys": 0,
+                "survey_responses": 0,
                 "llm_events": 0,
             }
             self.organization.usage = {
@@ -1582,7 +1592,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 0,
                 "feature_flags": 0,
                 "api_queries": 0,
-                "surveys": 0,
+                "survey_responses": 0,
                 "llm_events": 7,  # High trust score
             }
             self.organization.usage = {

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -49,7 +49,7 @@ class TestQuotaLimiting(BaseTest):
         self.redis_client.delete(f"@posthog/quota-limits/surveys")
         self.redis_client.delete(f"@posthog/quota-limits/rows_exported")
         self.redis_client.delete(f"@posthog/quota-limits/llm_events")
-        self.redis_client.delete(f"@posthog/quota-limits/cdp_invocations")
+        self.redis_client.delete(f"@posthog/quota-limits/cdp_trigger_events")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/events")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/exceptions")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/recordings")
@@ -58,7 +58,7 @@ class TestQuotaLimiting(BaseTest):
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/surveys")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/rows_exported")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/llm_events")
-        self.redis_client.delete(f"@posthog/quota-limiting-suspended/cdp_invocations")
+        self.redis_client.delete(f"@posthog/quota-limiting-suspended/cdp_trigger_events")
 
     @patch("posthoganalytics.capture")
     @patch("posthoganalytics.feature_enabled", return_value=True)
@@ -356,7 +356,7 @@ class TestQuotaLimiting(BaseTest):
                 "quota_limited_feature_flags": None,
                 "quota_limited_surveys": None,
                 "quota_limited_llm_events": None,
-                "quota_limited_cdp_invocations": None,
+                "quota_limited_cdp_trigger_events": None,
                 "quota_limited_rows_exported": None,
             }
             assert org_action_call.kwargs.get("groups") == {

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -1016,7 +1016,7 @@ class TestQuotaLimiting(BaseTest):
                 "rows_synced": 7,
                 "feature_flags": 10,
                 TRUST_SCORE_KEYS[QuotaResource.API_QUERIES]: 10,
-                "survey_responses": 10,
+                "surveys": 10,
             }
             self.organization.save()
 

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -170,7 +170,10 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                     logger.error('🔴', 'Error checking rate limit for hog function', { err: e })
                 }
 
-                const isQuotaLimited = await this.hub.quotaLimiting.isTeamQuotaLimited(item.teamId, 'cdp_invocations')
+                const isQuotaLimited = await this.hub.quotaLimiting.isTeamQuotaLimited(
+                    item.teamId,
+                    'cdp_trigger_events'
+                )
 
                 // The legacy addon was not usage based so we skip dropping if they are on it
                 const isTeamOnLegacyAddon = !!teamsById[`${item.teamId}`]?.available_features.includes('data_pipelines')

--- a/plugin-server/src/common/services/quota-limiting.service.ts
+++ b/plugin-server/src/common/services/quota-limiting.service.ts
@@ -6,7 +6,7 @@ import { LazyLoader } from '../../utils/lazy-loader'
 import { logger } from '../../utils/logger'
 
 // subset of resources that we care about in this service
-export type QuotaResource = 'events' | 'cdp_invocations'
+export type QuotaResource = 'events' | 'cdp_trigger_events'
 
 export const QUOTA_LIMITER_CACHE_KEY = '@posthog/quota-limits/'
 

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -42,7 +42,7 @@ class OrganizationUsageInfo(TypedDict):
     recordings: Optional[OrganizationUsageResource]
     surveys: Optional[OrganizationUsageResource]
     rows_synced: Optional[OrganizationUsageResource]
-    cdp_invocations: Optional[OrganizationUsageResource]
+    cdp_trigger_events: Optional[OrganizationUsageResource]
     rows_exported: Optional[OrganizationUsageResource]
     feature_flag_requests: Optional[OrganizationUsageResource]
     api_queries_read_bytes: Optional[OrganizationUsageResource]

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -40,7 +40,7 @@ class OrganizationUsageInfo(TypedDict):
     events: Optional[OrganizationUsageResource]
     exceptions: Optional[OrganizationUsageResource]
     recordings: Optional[OrganizationUsageResource]
-    surveys: Optional[OrganizationUsageResource]
+    survey_responses: Optional[OrganizationUsageResource]
     rows_synced: Optional[OrganizationUsageResource]
     cdp_trigger_events: Optional[OrganizationUsageResource]
     rows_exported: Optional[OrganizationUsageResource]

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -1154,7 +1154,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
 
     // Configure set_nx_ex to return true (key was set successfully, first time seeing this submission)
     let mut redis_client = MockRedisClient::new();
-    let survey_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "surveys");
+    let survey_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "survey_responses");
     redis_client = redis_client.zrangebyscore_ret(&survey_key, vec![token.to_string()]);
     let submission_key = format!("survey-submission:{token}:submission_first");
     redis_client = redis_client.set_nx_ex_ret(&submission_key, Ok(true));
@@ -1226,7 +1226,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
     };
 
     // Configure MockRedisClient for survey quota limited scenario
-    let survey_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "surveys");
+    let survey_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "survey_responses");
     let mut redis_client =
         MockRedisClient::new().zrangebyscore_ret(&survey_key, vec![token.to_string()]);
 
@@ -1301,7 +1301,7 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
     };
 
     // Configure MockRedisClient for survey quota limited scenario
-    let survey_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "surveys");
+    let survey_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, "survey_responses");
     let mut redis_client =
         MockRedisClient::new().zrangebyscore_ret(&survey_key, vec![token.to_string()]);
 

--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -56,7 +56,7 @@ impl QuotaResource {
             Self::Recordings => "recordings",
             Self::Replay => "replay",
             Self::FeatureFlags => "feature_flag_requests",
-            Self::Surveys => "surveys",
+            Self::Surveys => "survey_responses",
             Self::LLMEvents => "llm_events",
         }
     }


### PR DESCRIPTION
## Problem

- `posthog_organization.usage` had blanks (`{}`) for `surveys` and `cdp_invocations` due to wrong mappings to `billing_usagereport.org_usage_summary` keys (because of this nobody ever got quota limited for these) which we didn't catch during the initial quota limiting PRs for these products

## Changes

- Renamed `cdp_invocations` to `cdp_trigger_events` and `surveys` to `survey_responses` (incl. plugin survey and rust capture)
- Fixed mappings to `customer_trust_scores` (which are based on product keys)

Since these never worked, there are no redis keys to migrate (but I've confirmed it on US and EU just in case to make sure).

For more context see [Slack thread](https://posthog.slack.com/archives/C08ERRQT41E/p1758882444206819).

## How did you test this code?

Updated existing tests