### PR TITLE
chore(flags): Provide more granular metrics around timeouts

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -4,20 +4,17 @@ use anyhow::Result;
 use async_trait::async_trait;
 use sqlx::{
     pool::PoolConnection,
-    postgres::{PgPool, PgPoolOptions, PgRow},
+    postgres::{PgPool, PgPoolOptions},
     Error as SqlxError, Postgres,
 };
 use thiserror::Error;
-use tokio::time::timeout;
-
-const DATABASE_TIMEOUT_MILLISECS: u64 = 1000;
 
 #[derive(Error, Debug)]
 pub enum CustomDatabaseError {
     #[error("Pg error: {0}")]
     Other(#[from] sqlx::Error),
 
-    #[error("Timeout error")]
+    #[error("Client timeout error")]
     Timeout(#[from] tokio::time::error::Elapsed),
 }
 
@@ -25,17 +22,11 @@ pub type PostgresReader = Arc<dyn Client + Send + Sync>;
 pub type PostgresWriter = Arc<dyn Client + Send + Sync>;
 
 /// A simple db wrapper
-/// Supports running any arbitrary query with a timeout.
+/// Supports getting connections from the pool.
 /// TODO: Make sqlx prepared statements work with pgbouncer, potentially by setting pooling mode to session.
 #[async_trait]
 pub trait Client {
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError>;
-    async fn run_query(
-        &self,
-        query: String,
-        parameters: Vec<String>,
-        timeout_ms: Option<u64>,
-    ) -> Result<Vec<PgRow>, CustomDatabaseError>;
 
     fn get_pool_stats(&self) -> Option<PoolStats>;
 }
@@ -124,30 +115,9 @@ impl Client for PgPool {
         })
     }
 
-    async fn run_query(
-        &self,
-        query: String,
-        parameters: Vec<String>,
-        timeout_ms: Option<u64>,
-    ) -> Result<Vec<PgRow>, CustomDatabaseError> {
-        let built_query = sqlx::query(&query);
-        let built_query = parameters
-            .iter()
-            .fold(built_query, |acc, param| acc.bind(param));
-        let query_results = built_query.fetch_all(self);
-
-        let timeout_ms = match timeout_ms {
-            Some(ms) => ms,
-            None => DATABASE_TIMEOUT_MILLISECS,
-        };
-
-        let fut = timeout(Duration::from_millis(timeout_ms), query_results).await?;
-
-        Ok(fut?)
-    }
-
     async fn get_connection(&self) -> Result<PoolConnection<Postgres>, CustomDatabaseError> {
-        Ok(self.acquire().await?)
+        let conn = self.acquire().await?;
+        Ok(conn)
     }
 }
 
@@ -166,6 +136,84 @@ pub fn is_foreign_key_constraint_error(error: &SqlxError) -> bool {
             }
         }
         _ => false,
+    }
+}
+
+/// Determines if a sqlx::Error represents a timeout-related failure
+pub fn is_timeout_error(error: &SqlxError) -> bool {
+    match error {
+        // Pool acquisition timed out
+        SqlxError::PoolTimedOut => true,
+
+        // IO-level timeout (network/socket)
+        SqlxError::Io(e) if e.kind() == std::io::ErrorKind::TimedOut => true,
+
+        // Protocol text sometimes includes "timeout"
+        SqlxError::Protocol(msg) => msg.to_lowercase().contains("timeout"),
+
+        // Database-reported timeouts/cancels
+        SqlxError::Database(db_error) => {
+            if let Some(code) = db_error.code() {
+                let code = code.as_ref();
+                // 57014: query_canceled (e.g., statement_timeout)
+                // 55P03: lock_not_available (e.g., lock_timeout)
+                // 25P03: idle_in_transaction_session_timeout
+                code == "57014" || code == "55P03" || code == "25P03"
+            } else {
+                // Fallback heuristic (less reliable than SQLSTATE)
+                let msg = db_error.message().to_lowercase();
+                msg.contains("timeout")
+                    || msg.contains("canceling")   // Postgres US spelling
+                    || msg.contains("cancelling") // just in case
+            }
+        }
+
+        _ => false,
+    }
+}
+
+/// Extract the specific type of timeout from a sqlx::Error
+pub fn extract_timeout_type(error: &SqlxError) -> Option<&'static str> {
+    match error {
+        // Pool acquisition timed out
+        SqlxError::PoolTimedOut => Some("pool_timeout"),
+
+        // IO-level timeout (network/socket)
+        SqlxError::Io(e) if e.kind() == std::io::ErrorKind::TimedOut => Some("io_timeout"),
+
+        // Protocol text sometimes includes "timeout"
+        SqlxError::Protocol(msg) if msg.to_lowercase().contains("timeout") => {
+            Some("protocol_timeout")
+        }
+
+        // Database-reported timeouts/cancels
+        SqlxError::Database(db_error) => {
+            if let Some(code) = db_error.code() {
+                let code = code.as_ref();
+                match code {
+                    // 57014: query_canceled (e.g., statement_timeout)
+                    "57014" => Some("query_canceled"),
+                    // 55P03: lock_not_available (e.g., lock_timeout)
+                    "55P03" => Some("lock_not_available"),
+                    // 25P03: idle_in_transaction_session_timeout
+                    "25P03" => Some("idle_in_transaction_timeout"),
+                    _ => None,
+                }
+            } else {
+                // Fallback heuristic (less reliable than SQLSTATE)
+                // Check more specific patterns first
+                let msg = db_error.message().to_lowercase();
+                if msg.contains("canceling") || msg.contains("cancelling") {
+                    Some("query_canceled")
+                } else if msg.contains("timeout") {
+                    Some("database_timeout")
+                } else {
+                    None
+                }
+            }
+        }
+
+        _ => None,
     }
 }
 
@@ -515,5 +563,242 @@ mod tests {
         // Test that memory pressure errors are NOT retried to avoid amplifying load
         let memory_err = db_err("out of memory", None, ErrorKind::Other);
         assert!(!is_transient_error(&memory_err));
+    }
+
+    #[test]
+    fn test_is_timeout_error_pool_timeout() {
+        assert!(is_timeout_error(&SqlxError::PoolTimedOut));
+    }
+
+    #[test]
+    fn test_is_timeout_error_io_timeout() {
+        let io_error = SqlxError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "connection timed out",
+        ));
+        assert!(is_timeout_error(&io_error));
+    }
+
+    #[test]
+    fn test_is_timeout_error_io_non_timeout() {
+        let io_error = SqlxError::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused",
+        ));
+        assert!(!is_timeout_error(&io_error));
+    }
+
+    #[test]
+    fn test_is_timeout_error_protocol_timeout() {
+        let protocol_error = SqlxError::Protocol("operation timeout".to_string());
+        assert!(is_timeout_error(&protocol_error));
+
+        let protocol_non_timeout = SqlxError::Protocol("invalid protocol".to_string());
+        assert!(!is_timeout_error(&protocol_non_timeout));
+    }
+
+    #[test]
+    fn test_is_timeout_error_database_with_timeout_codes() {
+        // Test various timeout-related SQLSTATE codes
+        assert!(is_timeout_error(&db_err(
+            "canceling statement due to statement timeout",
+            Some("57014"),
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "lock not available",
+            Some("55P03"),
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "terminating connection due to idle-in-transaction timeout",
+            Some("25P03"),
+            ErrorKind::Other
+        )));
+    }
+
+    #[test]
+    fn test_is_timeout_error_database_non_timeout_codes() {
+        // Test non-timeout SQLSTATE codes
+        assert!(!is_timeout_error(&db_err(
+            "duplicate key value violates unique constraint",
+            Some("23505"),
+            ErrorKind::UniqueViolation
+        )));
+        assert!(!is_timeout_error(&db_err(
+            "syntax error at or near",
+            Some("42601"),
+            ErrorKind::Other
+        )));
+    }
+
+    #[test]
+    fn test_is_timeout_error_database_message_fallback() {
+        // Test message heuristics when no SQLSTATE code is available
+        assert!(is_timeout_error(&db_err(
+            "operation timeout",
+            None,
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "canceling statement due to timeout",
+            None,
+            ErrorKind::Other
+        )));
+        assert!(is_timeout_error(&db_err(
+            "cancelling statement due to timeout",
+            None,
+            ErrorKind::Other
+        )));
+
+        // Non-timeout messages
+        assert!(!is_timeout_error(&db_err(
+            "column does not exist",
+            None,
+            ErrorKind::Other
+        )));
+        assert!(!is_timeout_error(&db_err(
+            "relation does not exist",
+            None,
+            ErrorKind::Other
+        )));
+    }
+
+    #[test]
+    fn test_extract_timeout_type_pool_timeout() {
+        assert_eq!(
+            extract_timeout_type(&SqlxError::PoolTimedOut),
+            Some("pool_timeout")
+        );
+    }
+
+    #[test]
+    fn test_extract_timeout_type_io_timeout() {
+        let io_error = SqlxError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "connection timed out",
+        ));
+        assert_eq!(extract_timeout_type(&io_error), Some("io_timeout"));
+    }
+
+    #[test]
+    fn test_extract_timeout_type_io_non_timeout() {
+        let io_error = SqlxError::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused",
+        ));
+        assert_eq!(extract_timeout_type(&io_error), None);
+    }
+
+    #[test]
+    fn test_extract_timeout_type_protocol_timeout() {
+        let protocol_error = SqlxError::Protocol("operation timeout".to_string());
+        assert_eq!(
+            extract_timeout_type(&protocol_error),
+            Some("protocol_timeout")
+        );
+
+        let protocol_non_timeout = SqlxError::Protocol("invalid protocol".to_string());
+        assert_eq!(extract_timeout_type(&protocol_non_timeout), None);
+    }
+
+    #[test]
+    fn test_extract_timeout_type_database_with_timeout_codes() {
+        // Test various timeout-related SQLSTATE codes
+        assert_eq!(
+            extract_timeout_type(&db_err(
+                "canceling statement due to statement timeout",
+                Some("57014"),
+                ErrorKind::Other
+            )),
+            Some("query_canceled")
+        );
+
+        assert_eq!(
+            extract_timeout_type(&db_err(
+                "lock not available",
+                Some("55P03"),
+                ErrorKind::Other
+            )),
+            Some("lock_not_available")
+        );
+
+        assert_eq!(
+            extract_timeout_type(&db_err(
+                "terminating connection due to idle-in-transaction timeout",
+                Some("25P03"),
+                ErrorKind::Other
+            )),
+            Some("idle_in_transaction_timeout")
+        );
+    }
+
+    #[test]
+    fn test_extract_timeout_type_database_non_timeout_codes() {
+        // Test non-timeout SQLSTATE codes
+        assert_eq!(
+            extract_timeout_type(&db_err(
+                "duplicate key value violates unique constraint",
+                Some("23505"),
+                ErrorKind::UniqueViolation
+            )),
+            None
+        );
+
+        assert_eq!(
+            extract_timeout_type(&db_err(
+                "syntax error at or near",
+                Some("42601"),
+                ErrorKind::Other
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_timeout_type_database_message_fallback() {
+        // Test message heuristics when no SQLSTATE code is available
+        assert_eq!(
+            extract_timeout_type(&db_err("operation timeout", None, ErrorKind::Other)),
+            Some("database_timeout")
+        );
+
+        assert_eq!(
+            extract_timeout_type(&db_err(
+                "canceling statement due to timeout",
+                None,
+                ErrorKind::Other
+            )),
+            Some("query_canceled")
+        );
+
+        assert_eq!(
+            extract_timeout_type(&db_err(
+                "cancelling statement due to timeout",
+                None,
+                ErrorKind::Other
+            )),
+            Some("query_canceled")
+        );
+
+        // Non-timeout messages
+        assert_eq!(
+            extract_timeout_type(&db_err("column does not exist", None, ErrorKind::Other)),
+            None
+        );
+
+        assert_eq!(
+            extract_timeout_type(&db_err("relation does not exist", None, ErrorKind::Other)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_timeout_type_non_timeout_error() {
+        assert_eq!(extract_timeout_type(&SqlxError::RowNotFound), None);
+        assert_eq!(
+            extract_timeout_type(&SqlxError::ColumnNotFound("test".to_string())),
+            None
+        );
     }
 }

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -1,7 +1,7 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use common_cookieless::CookielessManagerError;
-use common_database::CustomDatabaseError;
+use common_database::{extract_timeout_type, is_timeout_error, CustomDatabaseError};
 use common_redis::CustomRedisError;
 use thiserror::Error;
 
@@ -52,7 +52,7 @@ pub enum FlagError {
     #[error("Database error: {0}")]
     DatabaseError(sqlx::Error, Option<String>),
     #[error("Timed out while fetching data")]
-    TimeoutError,
+    TimeoutError(Option<String>),
     #[error("No group type mappings")]
     NoGroupTypeMappings,
     #[error("Dependency of type {0} with id {1} not found")]
@@ -91,7 +91,7 @@ impl FlagError {
             FlagError::RedisDataParsingError
             | FlagError::RedisUnavailable
             | FlagError::DatabaseUnavailable
-            | FlagError::TimeoutError => StatusCode::SERVICE_UNAVAILABLE,
+            | FlagError::TimeoutError(_) => StatusCode::SERVICE_UNAVAILABLE,
 
             FlagError::CookielessError(
                 CookielessManagerError::HashError(_)
@@ -185,8 +185,9 @@ impl IntoResponse for FlagError {
                     "A database error occurred. Please try again later or contact support if the problem persists.".to_string(),
                 )
             }
-            FlagError::TimeoutError => {
-                tracing::error!("Timeout error: {:?}", self);
+            FlagError::TimeoutError(ref timeout_type) => {
+                let timeout_desc = timeout_type.as_deref().unwrap_or("unknown type");
+                tracing::error!("Timeout error ({}): {:?}", timeout_desc, self);
                 (
                     StatusCode::SERVICE_UNAVAILABLE,
                     "The request timed out. This could be due to high load or network issues. Please try again later.".to_string(),
@@ -264,7 +265,7 @@ impl From<CustomRedisError> for FlagError {
         match e {
             CustomRedisError::NotFound => FlagError::TokenValidationError,
             CustomRedisError::ParseError(_) => FlagError::RedisDataParsingError,
-            CustomRedisError::Timeout => FlagError::TimeoutError,
+            CustomRedisError::Timeout => FlagError::TimeoutError(Some("redis_timeout".to_string())),
             CustomRedisError::Other(_) => FlagError::RedisUnavailable,
         }
     }
@@ -273,8 +274,19 @@ impl From<CustomRedisError> for FlagError {
 impl From<CustomDatabaseError> for FlagError {
     fn from(e: CustomDatabaseError) -> Self {
         match e {
-            CustomDatabaseError::Other(_) => FlagError::DatabaseUnavailable,
-            CustomDatabaseError::Timeout(_) => FlagError::TimeoutError,
+            CustomDatabaseError::Timeout(_) => {
+                FlagError::TimeoutError(Some("client_timeout".to_string()))
+            }
+            CustomDatabaseError::Other(sqlx_error) => {
+                // Check if it's a timeout-related SQL error
+                if is_timeout_error(&sqlx_error) {
+                    FlagError::TimeoutError(
+                        extract_timeout_type(&sqlx_error).map(|s| s.to_string()),
+                    )
+                } else {
+                    FlagError::DatabaseUnavailable
+                }
+            }
         }
     }
 }
@@ -283,7 +295,14 @@ impl From<sqlx::Error> for FlagError {
     fn from(e: sqlx::Error) -> Self {
         match e {
             sqlx::Error::RowNotFound => FlagError::RowNotFound,
-            _ => FlagError::DatabaseError(e, None),
+            _ => {
+                // Check if it's a timeout-related SQL error
+                if is_timeout_error(&e) {
+                    FlagError::TimeoutError(extract_timeout_type(&e).map(|s| s.to_string()))
+                } else {
+                    FlagError::DatabaseError(e, None)
+                }
+            }
         }
     }
 }
@@ -291,6 +310,7 @@ impl From<sqlx::Error> for FlagError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::time::{timeout, Duration};
 
     #[test]
     fn test_is_5xx() {
@@ -299,7 +319,7 @@ mod tests {
         assert!(FlagError::CacheUpdateError.is_5xx());
         assert!(FlagError::DatabaseUnavailable.is_5xx());
         assert!(FlagError::RedisUnavailable.is_5xx());
-        assert!(FlagError::TimeoutError.is_5xx());
+        assert!(FlagError::TimeoutError(None).is_5xx());
         assert!(FlagError::ClientFacing(ClientFacingError::ServiceUnavailable).is_5xx());
 
         // Test 4XX errors
@@ -315,5 +335,68 @@ mod tests {
         assert!(!FlagError::NoTokenError.is_5xx());
         assert!(!FlagError::TokenValidationError.is_5xx());
         assert!(!FlagError::PersonNotFound.is_5xx());
+    }
+
+    #[test]
+    fn test_custom_database_error_conversion_timeout() {
+        // Test that CustomDatabaseError::Timeout converts to FlagError::TimeoutError with client_timeout
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let elapsed_error = rt.block_on(async {
+            timeout(
+                Duration::from_nanos(1),
+                tokio::time::sleep(Duration::from_secs(1)),
+            )
+            .await
+            .unwrap_err()
+        });
+
+        let timeout_error = CustomDatabaseError::Timeout(elapsed_error);
+        let flag_error: FlagError = timeout_error.into();
+        assert!(
+            matches!(flag_error, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "client_timeout")
+        );
+    }
+
+    #[test]
+    fn test_custom_database_error_conversion_sqlx_timeout() {
+        // Test that sqlx timeout errors convert to FlagError::TimeoutError with pool_timeout
+        let sqlx_timeout = CustomDatabaseError::Other(sqlx::Error::PoolTimedOut);
+        let flag_error: FlagError = sqlx_timeout.into();
+        assert!(
+            matches!(flag_error, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "pool_timeout")
+        );
+    }
+
+    #[test]
+    fn test_custom_database_error_conversion_sqlx_non_timeout() {
+        // Test that non-timeout sqlx errors convert to FlagError::DatabaseUnavailable
+        let sqlx_error = CustomDatabaseError::Other(sqlx::Error::RowNotFound);
+        let flag_error: FlagError = sqlx_error.into();
+        assert!(matches!(flag_error, FlagError::DatabaseUnavailable));
+    }
+
+    #[test]
+    fn test_direct_sqlx_timeout_conversion() {
+        // Test that direct sqlx timeout errors convert to FlagError::TimeoutError with type
+        let sqlx_timeout: FlagError = sqlx::Error::PoolTimedOut.into();
+        assert!(
+            matches!(sqlx_timeout, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "pool_timeout")
+        );
+    }
+
+    #[test]
+    fn test_direct_sqlx_non_timeout_conversion() {
+        // Test that direct non-timeout sqlx errors are handled correctly
+        let sqlx_error: FlagError = sqlx::Error::RowNotFound.into();
+        assert!(matches!(sqlx_error, FlagError::RowNotFound));
+    }
+
+    #[test]
+    fn test_redis_timeout_conversion() {
+        // Test that Redis timeout errors include timeout type
+        let redis_timeout: FlagError = CustomRedisError::Timeout.into();
+        assert!(
+            matches!(redis_timeout, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "redis_timeout")
+        );
     }
 }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -1057,7 +1057,7 @@ async fn try_should_write_hash_key_override(
         Ok(Err(e)) => Err(e),
         Err(_) => {
             // Handle timeout
-            Err(FlagError::TimeoutError)
+            Err(FlagError::TimeoutError(None))
         }
     }
 }
@@ -1970,7 +1970,7 @@ mod tests {
         assert!(!should_retry_on_error(&column_error));
 
         // Test that other error types don't trigger retries
-        let timeout_error_variant = FlagError::TimeoutError;
+        let timeout_error_variant = FlagError::TimeoutError(None);
         assert!(!should_retry_on_error(&timeout_error_variant));
 
         let missing_id_error = FlagError::MissingDistinctId;


### PR DESCRIPTION
This restores the beneficial changes from PR #38686 without the problematic session-level timeout configuration that caused pool creation failures.

Changes include:
- Add timeout error detection functions (`is_timeout_error`, `extract_timeout_type`)
- Enhanced `FlagError::TimeoutError` to include optional timeout type
- Remove problematic `run_query` method from Client trait
- Update error conversion to classify timeout types granularly
- Add comprehensive tests for timeout detection and error conversion
- Update metrics to include timeout type in Prometheus labels

This provides better observability into different timeout scenarios while avoiding the architectural issues with session-level timeouts.
