### PR TITLE
feat(flags): support anon_distinct_id in person_properties

### DIFF
--- a/rust/feature-flags/src/handler/properties.rs
+++ b/rust/feature-flags/src/handler/properties.rs
@@ -21,7 +21,14 @@ pub fn prepare_overrides(
     let group_property_overrides =
         get_group_property_overrides(groups.clone(), request.group_properties.clone());
 
-    let hash_key_override = request.anon_distinct_id.clone();
+    let hash_key_override = request.anon_distinct_id.clone().or_else(|| {
+        request
+            .person_properties
+            .as_ref()
+            .and_then(|props| props.get("$anon_distinct_id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    });
 
     Ok(RequestPropertyOverrides {
         person_properties: person_property_overrides,
@@ -89,5 +96,121 @@ pub fn get_group_property_overrides(
             Some(result)
         }
         None => existing_overrides,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::flags::flag_request::FlagRequest;
+    use serde_json::json;
+
+    #[test]
+    fn test_anon_distinct_id_from_top_level() {
+        let request = FlagRequest {
+            anon_distinct_id: Some("anon123".to_string()),
+            person_properties: Some(
+                vec![("$anon_distinct_id".to_string(), json!("anon456"))]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let hash_key = request.anon_distinct_id.clone().or_else(|| {
+            request
+                .person_properties
+                .as_ref()
+                .and_then(|props| props.get("$anon_distinct_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+
+        assert_eq!(
+            hash_key,
+            Some("anon123".to_string()),
+            "Top-level anon_distinct_id should take precedence"
+        );
+    }
+
+    #[test]
+    fn test_anon_distinct_id_from_person_properties() {
+        let request = FlagRequest {
+            anon_distinct_id: None,
+            person_properties: Some(
+                vec![("$anon_distinct_id".to_string(), json!("anon456"))]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let hash_key = request.anon_distinct_id.clone().or_else(|| {
+            request
+                .person_properties
+                .as_ref()
+                .and_then(|props| props.get("$anon_distinct_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+
+        assert_eq!(
+            hash_key,
+            Some("anon456".to_string()),
+            "Should fallback to person_properties.$anon_distinct_id"
+        );
+    }
+
+    #[test]
+    fn test_anon_distinct_id_not_present() {
+        let request = FlagRequest {
+            anon_distinct_id: None,
+            person_properties: Some(
+                vec![("other_property".to_string(), json!("value"))]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let hash_key = request.anon_distinct_id.clone().or_else(|| {
+            request
+                .person_properties
+                .as_ref()
+                .and_then(|props| props.get("$anon_distinct_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+
+        assert_eq!(
+            hash_key, None,
+            "Should be None when anon_distinct_id not present anywhere"
+        );
+    }
+
+    #[test]
+    fn test_anon_distinct_id_with_non_string_value() {
+        let request = FlagRequest {
+            anon_distinct_id: None,
+            person_properties: Some(
+                vec![("$anon_distinct_id".to_string(), json!(123))]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let hash_key = request.anon_distinct_id.clone().or_else(|| {
+            request
+                .person_properties
+                .as_ref()
+                .and_then(|props| props.get("$anon_distinct_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+
+        assert_eq!(
+            hash_key, None,
+            "Should be None when anon_distinct_id in person_properties is not a string"
+        );
     }
 }

--- a/rust/feature-flags/src/handler/properties.rs
+++ b/rust/feature-flags/src/handler/properties.rs
@@ -21,6 +21,9 @@ pub fn prepare_overrides(
     let group_property_overrides =
         get_group_property_overrides(groups.clone(), request.group_properties.clone());
 
+    // Determine hash key with precedence: top-level anon_distinct_id > person_properties.$anon_distinct_id
+    // Frontend SDKs automatically include anon_distinct_id at the top level.
+    // Backend SDKs manually override the anon_distinct_id in person_properties if needed.
     let hash_key_override = request.anon_distinct_id.clone().or_else(|| {
         request
             .person_properties

--- a/rust/feature-flags/tests/test_experience_continuity.rs
+++ b/rust/feature-flags/tests/test_experience_continuity.rs
@@ -297,3 +297,219 @@ async fn test_experience_continuity_with_merge() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_anon_distinct_id_from_person_properties() -> Result<()> {
+    let context = TestContext::new(None).await;
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team");
+
+    // Create flag with experience continuity
+    let flag_row = FeatureFlagRow {
+        id: 102,
+        team_id: team.id,
+        name: Some("Person Properties Test Flag".to_string()),
+        key: "person-props-test-flag".to_string(),
+        filters: json!({
+            "groups": [{"rollout_percentage": 50}]
+        }),
+        deleted: false,
+        active: true,
+        ensure_experience_continuity: Some(true),
+        version: Some(1),
+        evaluation_runtime: None,
+        evaluation_tags: None,
+    };
+    context.insert_flag(team.id, Some(flag_row)).await?;
+
+    // Create person with an ID that evaluates to false
+    let user_id = "false_eval_user";
+    context
+        .insert_person(
+            team.id,
+            user_id.to_string(),
+            Some(json!({"email": "false_eval_user@example.com"})),
+        )
+        .await?;
+
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let server = ServerHandle::for_config_with_mock_redis(
+        config,
+        vec![],
+        vec![(team.api_token.clone(), team.id)],
+    )
+    .await;
+
+    // Step 1: Verify user evaluates to false
+    let initial_payload = json!({
+        "token": team.api_token,
+        "distinct_id": user_id,
+    });
+
+    let res = server
+        .send_flags_request(initial_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let json_response = res.json::<Value>().await?;
+
+    assert_eq!(
+        json_response["flags"]["person-props-test-flag"]["enabled"],
+        json!(false),
+        "User should initially evaluate to false"
+    );
+
+    // Step 2: Use an ID that evaluates to true
+    let anon_id = "true_eval_user";
+    let anon_payload = json!({
+        "token": team.api_token,
+        "distinct_id": anon_id,
+    });
+
+    let anon_res = server
+        .send_flags_request(anon_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(anon_res.status(), StatusCode::OK);
+    let anon_json = anon_res.json::<Value>().await?;
+
+    assert_eq!(
+        anon_json["flags"]["person-props-test-flag"]["enabled"],
+        json!(true),
+        "Anon ID should evaluate to true"
+    );
+
+    // Step 3: Set override using $anon_distinct_id in person_properties
+    let override_payload = json!({
+        "token": team.api_token,
+        "distinct_id": user_id,
+        "person_properties": {
+            "$anon_distinct_id": anon_id,
+            "other_prop": "some_value"
+        }
+    });
+
+    let override_res = server
+        .send_flags_request(override_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(override_res.status(), StatusCode::OK);
+    let override_json = override_res.json::<Value>().await?;
+
+    assert_eq!(
+        override_json["flags"]["person-props-test-flag"]["enabled"],
+        json!(true),
+        "With $anon_distinct_id in person_properties, should evaluate to true"
+    );
+
+    // Step 4: Verify override persists without $anon_distinct_id
+    let final_payload = json!({
+        "token": team.api_token,
+        "distinct_id": user_id,
+    });
+
+    let final_res = server
+        .send_flags_request(final_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(final_res.status(), StatusCode::OK);
+    let final_json = final_res.json::<Value>().await?;
+
+    assert_eq!(
+        final_json["flags"]["person-props-test-flag"]["enabled"],
+        json!(true),
+        "Override should persist even without $anon_distinct_id"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_top_level_anon_distinct_id_takes_precedence() -> Result<()> {
+    let context = TestContext::new(None).await;
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team");
+
+    // Create flag
+    let flag_row = FeatureFlagRow {
+        id: 103,
+        team_id: team.id,
+        name: Some("Precedence Test Flag".to_string()),
+        key: "precedence-test-flag".to_string(),
+        filters: json!({
+            "groups": [{"rollout_percentage": 50}]
+        }),
+        deleted: false,
+        active: true,
+        ensure_experience_continuity: Some(true),
+        version: Some(1),
+        evaluation_runtime: None,
+        evaluation_tags: None,
+    };
+    context.insert_flag(team.id, Some(flag_row)).await?;
+
+    // Create person
+    let user_id = "precedence_test_user";
+    context
+        .insert_person(
+            team.id,
+            user_id.to_string(),
+            Some(json!({"email": "precedence@example.com"})),
+        )
+        .await?;
+
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let server = ServerHandle::for_config_with_mock_redis(
+        config,
+        vec![],
+        vec![(team.api_token.clone(), team.id)],
+    )
+    .await;
+
+    // Use two different IDs that evaluate differently
+    let true_eval_id = "true_eval_user";
+    let false_eval_id = "false_eval_user";
+
+    // Verify the true_eval_id evaluates to true
+    let true_check = json!({
+        "token": team.api_token,
+        "distinct_id": true_eval_id,
+    });
+
+    let true_res = server
+        .send_flags_request(true_check.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(true_res.status(), StatusCode::OK);
+    let true_json = true_res.json::<Value>().await?;
+
+    assert_eq!(
+        true_json["flags"]["precedence-test-flag"]["enabled"],
+        json!(true),
+        "true_eval_id should evaluate to true"
+    );
+
+    // Test with BOTH top-level and person_properties $anon_distinct_id
+    // Top-level should win
+    let payload_with_both = json!({
+        "token": team.api_token,
+        "distinct_id": user_id,
+        "$anon_distinct_id": true_eval_id,  // Top level - evaluates to TRUE
+        "person_properties": {
+            "$anon_distinct_id": false_eval_id,  // In person_properties - evaluates to FALSE
+        }
+    });
+
+    let res = server
+        .send_flags_request(payload_with_both.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let json_response = res.json::<Value>().await?;
+
+    assert_eq!(
+        json_response["flags"]["precedence-test-flag"]["enabled"],
+        json!(true),
+        "Top-level $anon_distinct_id should take precedence (evaluates to true)"
+    );
+
+    Ok(())
+}

--- a/rust/feature-flags/tests/test_experience_continuity.rs
+++ b/rust/feature-flags/tests/test_experience_continuity.rs
@@ -310,8 +310,8 @@ async fn test_anon_distinct_id_from_person_properties() -> Result<()> {
     let flag_row = FeatureFlagRow {
         id: 102,
         team_id: team.id,
-        name: Some("Person Properties Test Flag".to_string()),
-        key: "person-props-test-flag".to_string(),
+        name: Some("Experience Flag".to_string()),
+        key: "experience-flag-test".to_string(),
         filters: json!({
             "groups": [{"rollout_percentage": 50}]
         }),
@@ -355,7 +355,7 @@ async fn test_anon_distinct_id_from_person_properties() -> Result<()> {
     let json_response = res.json::<Value>().await?;
 
     assert_eq!(
-        json_response["flags"]["person-props-test-flag"]["enabled"],
+        json_response["flags"]["experience-flag-test"]["enabled"],
         json!(false),
         "User should initially evaluate to false"
     );
@@ -374,7 +374,7 @@ async fn test_anon_distinct_id_from_person_properties() -> Result<()> {
     let anon_json = anon_res.json::<Value>().await?;
 
     assert_eq!(
-        anon_json["flags"]["person-props-test-flag"]["enabled"],
+        anon_json["flags"]["experience-flag-test"]["enabled"],
         json!(true),
         "Anon ID should evaluate to true"
     );
@@ -396,7 +396,7 @@ async fn test_anon_distinct_id_from_person_properties() -> Result<()> {
     let override_json = override_res.json::<Value>().await?;
 
     assert_eq!(
-        override_json["flags"]["person-props-test-flag"]["enabled"],
+        override_json["flags"]["experience-flag-test"]["enabled"],
         json!(true),
         "With $anon_distinct_id in person_properties, should evaluate to true"
     );
@@ -414,7 +414,7 @@ async fn test_anon_distinct_id_from_person_properties() -> Result<()> {
     let final_json = final_res.json::<Value>().await?;
 
     assert_eq!(
-        final_json["flags"]["person-props-test-flag"]["enabled"],
+        final_json["flags"]["experience-flag-test"]["enabled"],
         json!(true),
         "Override should persist even without $anon_distinct_id"
     );
@@ -430,12 +430,12 @@ async fn test_top_level_anon_distinct_id_takes_precedence() -> Result<()> {
         .await
         .expect("Failed to insert team");
 
-    // Create flag
+    // Create flag (use same key as other tests for consistent hashing)
     let flag_row = FeatureFlagRow {
         id: 103,
         team_id: team.id,
-        name: Some("Precedence Test Flag".to_string()),
-        key: "precedence-test-flag".to_string(),
+        name: Some("Experience Flag".to_string()),
+        key: "experience-flag-test".to_string(),
         filters: json!({
             "groups": [{"rollout_percentage": 50}]
         }),
@@ -483,7 +483,7 @@ async fn test_top_level_anon_distinct_id_takes_precedence() -> Result<()> {
     let true_json = true_res.json::<Value>().await?;
 
     assert_eq!(
-        true_json["flags"]["precedence-test-flag"]["enabled"],
+        true_json["flags"]["experience-flag-test"]["enabled"],
         json!(true),
         "true_eval_id should evaluate to true"
     );
@@ -506,7 +506,7 @@ async fn test_top_level_anon_distinct_id_takes_precedence() -> Result<()> {
     let json_response = res.json::<Value>().await?;
 
     assert_eq!(
-        json_response["flags"]["precedence-test-flag"]["enabled"],
+        json_response["flags"]["experience-flag-test"]["enabled"],
         json!(true),
         "Top-level $anon_distinct_id should take precedence (evaluates to true)"
     );


### PR DESCRIPTION
## Problem

Today, flag persistence across authentication only works if the flag is called with a frontend SDK because those are the only SDKs that include the `$anon_distinct_id` which allows the flag service to create and read a hash key override. Backend SDKs don't have the option to include `$anon_distinct_id` so that means the identified distinct_id must be present on the frontend and a feature flag request must be made with both ids from the frontend before the request from the backend can return a consistent evaluation.

However, not all customers identify their user on the frontend. Some customers may want to call the flag with an anon distinct id on the frontend, then identify the user on the backend, and call the flag from the backend. Since the backend request doesn't include `$anon_distinct_id`, the flag evaluation will not be consistent. 

The way around this today is to call Identify on the frontend, which does the following: 
- store the previous distinct_id as the anon_distinct_id 
- call reloadFeatureFlags with both the new distinct_id and anon_distinct_id

https://github.com/PostHog/posthog/issues/38320

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Allow `$anon_distinct_id` in person_properties so that backend SDKs can also create a hash key override. 

Alternatively, we can modify all backend SDKs to allow users to pass in `$anon_distinct_id` at the root level of the request. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Doc change: https://github.com/PostHog/posthog.com/pull/12966

## How did you test this code?

Unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
