### PR TITLE
feat: try lazy init clickhouse client

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -199,7 +199,6 @@ def get_client_from_pool(
     readonly=False,
     ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
 ):
-    return None
     """
     Returns the client for a given workload.
 

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -199,6 +199,7 @@ def get_client_from_pool(
     readonly=False,
     ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
 ):
+    return None
     """
     Returns the client for a given workload.
 
@@ -287,4 +288,14 @@ def set_default_clickhouse_workload_type(workload: Workload):
     _default_workload = workload
 
 
-ch_pool = get_pool(workload=Workload.ONLINE)
+class LazyPool:
+    def __init__(self):
+        self._pool = None
+
+    def get_client(self):
+        if self._pool is None:
+            self._pool = get_pool(workload=Workload.ONLINE)
+        return self._pool.get_client()
+
+
+ch_pool = LazyPool()


### PR DESCRIPTION
## Problem

we are initialising clickhouse every time on module load, making very slow django startups time - try lazy loading clickhouse client to push the startup time to when we need it (most django apps don't use clickhouse)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
