### PR TITLE
feat(llma): optimize traces query

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -299,6 +299,7 @@ export const FEATURE_FLAGS = {
     REPLAY_EXPORT_FULL_VIDEO: 'replay-export-full-video', // owner: @veryayskiy #team-replay
     PLATFORM_PAYGATE_CTA: 'platform-paygate-cta', // owner: @a-lider #team-platform-features
     LLM_ANALYTICS_DATASETS: 'llm-analytics-datasets', // owner: #team-llm-analytics #team-max-ai
+    LLM_ANALYTICS_TRACES_QUERY_V2: 'llma-traces-query-v2', // owner: #team-llm-analytics
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-max-ai
     NOTEBOOKS_COLLAPSIBLE_SECTIONS: 'notebooks-collapsible-sections', // owner: @daibhin @benjackwhite

--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -8,6 +8,7 @@ import structlog
 
 from posthog.schema import (
     CachedTracesQueryResponse,
+    DateRange,
     IntervalType,
     LLMTrace,
     LLMTraceEvent,
@@ -21,6 +22,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
+from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
@@ -63,19 +65,82 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             offset=self.query.offset,
         )
 
-    def _calculate(self):
-        with self.timings.measure("traces_query_hogql_execute"):
+    def _get_trace_ids(self) -> tuple[list[str], datetime | None, datetime | None]:
+        """Execute a separate query to get relevant trace IDs and their time range."""
+        with self.timings.measure("traces_query_trace_ids_execute"):
             # Calculate max number of events needed with current offset and limit
             limit_value = self.query.limit if self.query.limit else 100
             offset_value = self.query.offset if self.query.offset else 0
             pagination_limit = limit_value + offset_value + 1
 
-            query_result = self.paginator.execute_hogql_query(
-                query=self.to_query(),
+            trace_ids_query = parse_select(
+                """
+                SELECT
+                    groupArray(trace_id) as trace_ids,
+                    min(first_ts) as min_timestamp,
+                    max(last_ts) as max_timestamp
+                FROM (
+                    SELECT
+                        properties.$ai_trace_id as trace_id,
+                        min(timestamp) as first_ts,
+                        max(timestamp) as last_ts
+                    FROM events
+                    WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
+                      AND {conditions}
+                    GROUP BY trace_id
+                    ORDER BY max(timestamp) DESC
+                    LIMIT {limit}
+                )
+                """,
+            )
+
+            trace_ids_result = execute_hogql_query(
+                query_type="TracesQuery_TraceIds",
+                query=trace_ids_query,
                 placeholders={
-                    "subquery_conditions": self._get_subquery_filter(),
-                    "filter_conditions": self._get_where_clause(),
-                    "pagination_limit": ast.Constant(value=pagination_limit),
+                    "conditions": self._get_subquery_filter(),
+                    "limit": ast.Constant(value=pagination_limit),
+                },
+                team=self.team,
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
+
+            # Extract trace IDs and time range from results
+            if not trace_ids_result.results or not trace_ids_result.results[0]:
+                return [], None, None
+
+            trace_ids_array, min_timestamp, max_timestamp = trace_ids_result.results[0]
+
+            # Filter out any null/empty trace IDs and convert to strings
+            trace_ids = [str(tid) for tid in (trace_ids_array or []) if tid]
+
+            return trace_ids, min_timestamp, max_timestamp
+
+    def _calculate(self):
+        # First, get the trace IDs and time range
+        trace_ids, min_timestamp, max_timestamp = self._get_trace_ids()
+
+        # If no trace IDs found, return empty results
+        if not trace_ids:
+            return TracesQueryResponse(
+                columns=[],
+                results=[],
+                timings=self.timings.to_list(),
+                hogql="",
+                modifiers=self.modifiers,
+                **self.paginator.response_params(),
+            )
+
+        # Create a narrowed date range if we have timestamps
+        narrowed_date_range = self._create_narrowed_date_range(min_timestamp, max_timestamp)
+
+        with self.timings.measure("traces_query_hogql_execute"):
+            query_result = self.paginator.execute_hogql_query(
+                query=self.to_query(trace_ids),
+                placeholders={
+                    "filter_conditions": self._get_where_clause(date_range=narrowed_date_range),
                 },
                 team=self.team,
                 query_type=NodeKind.TRACES_QUERY,
@@ -96,18 +161,13 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             **self.paginator.response_params(),
         )
 
-    def to_query(self):
+    def to_query(self, trace_ids: list[str]):
+        # Separate query to build the trace IDs tuple for the IN clause
+        # Without using a tuple, the data skipping index is not used
+        trace_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids])
+
         query = parse_select(
             """
-            WITH relevant_trace_ids AS (
-                SELECT properties.$ai_trace_id as trace_id
-                FROM events
-                WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
-                  AND {subquery_conditions}
-                ORDER BY timestamp DESC
-                LIMIT 1 BY properties.$ai_trace_id
-                LIMIT {pagination_limit}
-            )
             SELECT
                 properties.$ai_trace_id AS id,
                 min(timestamp) AS first_timestamp,
@@ -182,13 +242,27 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             WHERE event IN (
                 '$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace'
             )
-              AND properties.$ai_trace_id IN (SELECT trace_id FROM relevant_trace_ids)
               AND {filter_conditions}
             GROUP BY properties.$ai_trace_id
             ORDER BY first_timestamp DESC
             """,
         )
-        return cast(ast.SelectQuery, query)
+
+        # Add the trace IDs filter to the WHERE clause
+        query = cast(ast.SelectQuery, query)
+
+        trace_id_filter = ast.CompareOperation(
+            op=ast.CompareOperationOp.In,
+            left=ast.Field(chain=["properties", "$ai_trace_id"]),
+            right=trace_ids_tuple,
+        )
+
+        if query.where:
+            query.where = ast.And(exprs=[query.where, trace_id_filter])
+        else:
+            query.where = trace_id_filter
+
+        return query
 
     def get_cache_payload(self):
         return {
@@ -201,6 +275,25 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
     def _date_range(self):
         # Minute-level precision for 10m capture range
         return TracesQueryDateRange(self.query.dateRange, self.team, IntervalType.MINUTE, datetime.now())
+
+    def _create_narrowed_date_range(
+        self, min_timestamp: datetime | None, max_timestamp: datetime | None
+    ) -> TracesQueryDateRange | None:
+        """Create a narrowed date range based on the actual data timestamps."""
+        if min_timestamp is None or max_timestamp is None:
+            return None
+
+        # Create a custom date range with the min/max timestamps
+        # The TracesQueryDateRange class will automatically add the 10-minute capture range buffer
+        # through its overridden date_from() and date_to() methods
+        narrowed_range = TracesQueryDateRange(
+            DateRange(date_from=min_timestamp.isoformat(), date_to=max_timestamp.isoformat(), explicitDate=True),
+            self.team,
+            IntervalType.MINUTE,
+            datetime.now(),
+        )
+
+        return narrowed_range
 
     def _map_results(self, columns: list[str], query_results: list):
         mapped_results = [dict(zip(columns, value)) for value in query_results]
@@ -283,6 +376,11 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
     def _get_subquery_filter(self) -> ast.Expr:
         exprs: list[ast.Expr] = [
             ast.Call(name="isNotNull", args=[ast.Field(chain=["properties", "$ai_trace_id"])]),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.NotEq,
+                left=ast.Field(chain=["properties", "$ai_trace_id"]),
+                right=ast.Constant(value=""),
+            ),
             self._get_where_clause(),
         ]
 
@@ -304,17 +402,20 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
 
         return ast.And(exprs=property_filters)
 
-    def _get_where_clause(self) -> ast.Expr:
+    def _get_where_clause(self, date_range: TracesQueryDateRange | None = None) -> ast.Expr:
+        # Use the provided date range or fall back to the default
+        effective_date_range = date_range if date_range is not None else self._date_range
+
         where_exprs: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.GtEq,
                 left=ast.Field(chain=["events", "timestamp"]),
-                right=self._date_range.date_from_as_hogql(),
+                right=effective_date_range.date_from_as_hogql(),
             ),
             ast.CompareOperation(
                 op=ast.CompareOperationOp.LtEq,
                 left=ast.Field(chain=["events", "timestamp"]),
-                right=self._date_range.date_to_as_hogql(),
+                right=effective_date_range.date_to_as_hogql(),
             ),
         ]
 

--- a/posthog/hogql_queries/ai/traces_query_runner_v2.py
+++ b/posthog/hogql_queries/ai/traces_query_runner_v2.py
@@ -8,6 +8,7 @@ import structlog
 
 from posthog.schema import (
     CachedTracesQueryResponse,
+    DateRange,
     IntervalType,
     LLMTrace,
     LLMTraceEvent,
@@ -21,6 +22,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
+from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
@@ -29,7 +31,7 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 logger = structlog.get_logger(__name__)
 
 
-class TracesQueryDateRange(QueryDateRange):
+class TracesQueryDateRangeV2(QueryDateRange):
     """
     Extends the QueryDateRange to include a capture range of 10 minutes before and after the date range.
     It's a naive assumption that a trace finishes generating within 10 minutes of the first event so we can apply the date filters.
@@ -50,7 +52,7 @@ class TracesQueryDateRange(QueryDateRange):
         return super().date_to() + timedelta(minutes=self.CAPTURE_RANGE_MINUTES)
 
 
-class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
+class TracesQueryRunnerV2(AnalyticsQueryRunner[TracesQueryResponse]):
     query: TracesQuery
     cached_response: CachedTracesQueryResponse
     paginator: HogQLHasMorePaginator
@@ -63,19 +65,82 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             offset=self.query.offset,
         )
 
-    def _calculate(self):
-        with self.timings.measure("traces_query_hogql_execute"):
+    def _get_trace_ids(self) -> tuple[list[str], datetime | None, datetime | None]:
+        """Execute a separate query to get relevant trace IDs and their time range."""
+        with self.timings.measure("traces_query_trace_ids_execute"):
             # Calculate max number of events needed with current offset and limit
             limit_value = self.query.limit if self.query.limit else 100
             offset_value = self.query.offset if self.query.offset else 0
             pagination_limit = limit_value + offset_value + 1
 
-            query_result = self.paginator.execute_hogql_query(
-                query=self.to_query(),
+            trace_ids_query = parse_select(
+                """
+                SELECT
+                    groupArray(trace_id) as trace_ids,
+                    min(first_ts) as min_timestamp,
+                    max(last_ts) as max_timestamp
+                FROM (
+                    SELECT
+                        properties.$ai_trace_id as trace_id,
+                        min(timestamp) as first_ts,
+                        max(timestamp) as last_ts
+                    FROM events
+                    WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
+                      AND {conditions}
+                    GROUP BY trace_id
+                    ORDER BY max(timestamp) DESC
+                    LIMIT {limit}
+                )
+                """,
+            )
+
+            trace_ids_result = execute_hogql_query(
+                query_type="TracesQuery_TraceIds",
+                query=trace_ids_query,
                 placeholders={
-                    "subquery_conditions": self._get_subquery_filter(),
-                    "filter_conditions": self._get_where_clause(),
-                    "pagination_limit": ast.Constant(value=pagination_limit),
+                    "conditions": self._get_subquery_filter(),
+                    "limit": ast.Constant(value=pagination_limit),
+                },
+                team=self.team,
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
+
+            # Extract trace IDs and time range from results
+            if not trace_ids_result.results or not trace_ids_result.results[0]:
+                return [], None, None
+
+            trace_ids_array, min_timestamp, max_timestamp = trace_ids_result.results[0]
+
+            # Filter out any null/empty trace IDs and convert to strings
+            trace_ids = [str(tid) for tid in (trace_ids_array or []) if tid]
+
+            return trace_ids, min_timestamp, max_timestamp
+
+    def _calculate(self):
+        # First, get the trace IDs and time range
+        trace_ids, min_timestamp, max_timestamp = self._get_trace_ids()
+
+        # If no trace IDs found, return empty results
+        if not trace_ids:
+            return TracesQueryResponse(
+                columns=[],
+                results=[],
+                timings=self.timings.to_list(),
+                hogql="",
+                modifiers=self.modifiers,
+                **self.paginator.response_params(),
+            )
+
+        # Create a narrowed date range if we have timestamps
+        narrowed_date_range = self._create_narrowed_date_range(min_timestamp, max_timestamp)
+
+        with self.timings.measure("traces_query_hogql_execute"):
+            query_result = self.paginator.execute_hogql_query(
+                query=self.to_query(trace_ids),
+                placeholders={
+                    "filter_conditions": self._get_where_clause(date_range=narrowed_date_range),
                 },
                 team=self.team,
                 query_type=NodeKind.TRACES_QUERY,
@@ -96,18 +161,13 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             **self.paginator.response_params(),
         )
 
-    def to_query(self):
+    def to_query(self, trace_ids: list[str]):
+        # Separate query to build the trace IDs tuple for the IN clause
+        # Without using a tuple, the data skipping index is not used
+        trace_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids])
+
         query = parse_select(
             """
-            WITH relevant_trace_ids AS (
-                SELECT properties.$ai_trace_id as trace_id
-                FROM events
-                WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
-                  AND {subquery_conditions}
-                ORDER BY timestamp DESC
-                LIMIT 1 BY properties.$ai_trace_id
-                LIMIT {pagination_limit}
-            )
             SELECT
                 properties.$ai_trace_id AS id,
                 min(timestamp) AS first_timestamp,
@@ -182,13 +242,27 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             WHERE event IN (
                 '$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace'
             )
-              AND properties.$ai_trace_id IN (SELECT trace_id FROM relevant_trace_ids)
               AND {filter_conditions}
             GROUP BY properties.$ai_trace_id
             ORDER BY first_timestamp DESC
             """,
         )
-        return cast(ast.SelectQuery, query)
+
+        # Add the trace IDs filter to the WHERE clause
+        query = cast(ast.SelectQuery, query)
+
+        trace_id_filter = ast.CompareOperation(
+            op=ast.CompareOperationOp.In,
+            left=ast.Field(chain=["properties", "$ai_trace_id"]),
+            right=trace_ids_tuple,
+        )
+
+        if query.where:
+            query.where = ast.And(exprs=[query.where, trace_id_filter])
+        else:
+            query.where = trace_id_filter
+
+        return query
 
     def get_cache_payload(self):
         return {
@@ -200,7 +274,26 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
     @cached_property
     def _date_range(self):
         # Minute-level precision for 10m capture range
-        return TracesQueryDateRange(self.query.dateRange, self.team, IntervalType.MINUTE, datetime.now())
+        return TracesQueryDateRangeV2(self.query.dateRange, self.team, IntervalType.MINUTE, datetime.now())
+
+    def _create_narrowed_date_range(
+        self, min_timestamp: datetime | None, max_timestamp: datetime | None
+    ) -> TracesQueryDateRangeV2 | None:
+        """Create a narrowed date range based on the actual data timestamps."""
+        if min_timestamp is None or max_timestamp is None:
+            return None
+
+        # Create a custom date range with the min/max timestamps
+        # The TracesQueryDateRangeV2 class will automatically add the 10-minute capture range buffer
+        # through its overridden date_from() and date_to() methods
+        narrowed_range = TracesQueryDateRangeV2(
+            DateRange(date_from=min_timestamp.isoformat(), date_to=max_timestamp.isoformat(), explicitDate=True),
+            self.team,
+            IntervalType.MINUTE,
+            datetime.now(),
+        )
+
+        return narrowed_range
 
     def _map_results(self, columns: list[str], query_results: list):
         mapped_results = [dict(zip(columns, value)) for value in query_results]
@@ -283,6 +376,11 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
     def _get_subquery_filter(self) -> ast.Expr:
         exprs: list[ast.Expr] = [
             ast.Call(name="isNotNull", args=[ast.Field(chain=["properties", "$ai_trace_id"])]),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.NotEq,
+                left=ast.Field(chain=["properties", "$ai_trace_id"]),
+                right=ast.Constant(value=""),
+            ),
             self._get_where_clause(),
         ]
 
@@ -304,17 +402,20 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
 
         return ast.And(exprs=property_filters)
 
-    def _get_where_clause(self) -> ast.Expr:
+    def _get_where_clause(self, date_range: TracesQueryDateRangeV2 | None = None) -> ast.Expr:
+        # Use the provided date range or fall back to the default
+        effective_date_range = date_range if date_range is not None else self._date_range
+
         where_exprs: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.GtEq,
                 left=ast.Field(chain=["events", "timestamp"]),
-                right=self._date_range.date_from_as_hogql(),
+                right=effective_date_range.date_from_as_hogql(),
             ),
             ast.CompareOperation(
                 op=ast.CompareOperationOp.LtEq,
                 left=ast.Field(chain=["events", "timestamp"]),
-                right=self._date_range.date_to_as_hogql(),
+                right=effective_date_range.date_to_as_hogql(),
             ),
         ]
 

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -90,6 +90,30 @@ def insight_funnels_use_udf_trends(team: Team) -> bool:
     )
 
 
+def llm_analytics_traces_query_v2(team: Team) -> bool:
+    """
+    Use the v2 implementation of the traces query runner for LLM Analytics.
+    """
+    return posthoganalytics.feature_enabled(
+        "llma-traces-query-v2",
+        str(team.uuid),
+        groups={
+            "organization": str(team.organization_id),
+            "project": str(team.id),
+        },
+        group_properties={
+            "organization": {
+                "id": str(team.organization_id),
+            },
+            "project": {
+                "id": str(team.id),
+            },
+        },
+        only_evaluate_locally=True,
+        send_feature_flag_events=False,
+    )
+
+
 def insight_api_use_legacy_queries(team: Team) -> bool:
     """
     Use the legacy implementation of insight api calculation endpoints.

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -109,7 +109,7 @@ def llm_analytics_traces_query_v2(team: Team) -> bool:
                 "id": str(team.id),
             },
         },
-        only_evaluate_locally=True,
+        only_evaluate_locally=False,
         send_feature_flag_events=False,
     )
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -651,15 +651,28 @@ def get_query_runner(
             modifiers=modifiers,
         )
     if kind == "TracesQuery":
-        from .ai.traces_query_runner import TracesQueryRunner
+        from .legacy_compatibility.feature_flag import llm_analytics_traces_query_v2
 
-        return TracesQueryRunner(
-            query=cast(TracesQuery | dict[str, Any], query),
-            team=team,
-            timings=timings,
-            limit_context=limit_context,
-            modifiers=modifiers,
-        )
+        if llm_analytics_traces_query_v2(team):
+            from .ai.traces_query_runner_v2 import TracesQueryRunnerV2
+
+            return TracesQueryRunnerV2(
+                query=cast(TracesQuery | dict[str, Any], query),
+                team=team,
+                timings=timings,
+                limit_context=limit_context,
+                modifiers=modifiers,
+            )
+        else:
+            from .ai.traces_query_runner import TracesQueryRunner
+
+            return TracesQueryRunner(
+                query=cast(TracesQuery | dict[str, Any], query),
+                team=team,
+                timings=timings,
+                limit_context=limit_context,
+                modifiers=modifiers,
+            )
     if kind == "TraceQuery":
         from .ai.trace_query_runner import TraceQueryRunner
 


### PR DESCRIPTION
## Problem

The TracesQuery returning the data to show in the traces list is very slow, especially for high volume users.

## Changes

This creates a TracesQueryV2, behind a feature flag, and does the following:
- runs a separate query to fetch the trace IDs that are relevant for the results, since the data skipping index could not be used with the previous CTE
- using the previously mentioned query, the min and max timestamps for those traces' events are used to reduce the time range of the second query
- `LIMIT 1 BY properties.$ai_trace_id` is removed, since it was one of the big culprits that made it slow

If we wouldn't join with the persons table, this would be blazing fast (even for the high volume users). This might still be somewhat fast in its current state, but it's getting hard to test it properly with the split queries. This is why I'm shipping this behind a feature flag, to check its performance in prod.

Since I'm creating a new file for this V2 query, it's hard to review. However, you can look at the [first commit](https://github.com/PostHog/posthog/commit/e6bc3966919d3f2e807853bb3c31928c04ae0830) to see the actual query changes in a diff.

## How did you test this code?

Manually.