### PR TITLE
feat(experiments): unified create experiment base structure

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -315,6 +315,7 @@ export const FEATURE_FLAGS = {
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     SEEKBAR_PREVIEW_SCRUBBING: 'seekbar-preview-scrubbing', // owner: @pauldambra #team-replay
     EXPERIMENTS_BREAKDOWN_FILTER: 'experiments-breakdown-filter', // owner: @rodrigoi #team-experiments
+    EXPERIMENTS_UNIFIED_CREATE_FORM: 'experiments-unified-create-form', // owner: @rodrigoi #team-experiments
     TARGETED_PRODUCT_UPSELL: 'targeted-product-upsell', // owner: @raquelmsmith
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1,11 +1,13 @@
 import { useValues } from 'kea'
 
 import { NotFound } from 'lib/components/NotFound'
-import { SceneExport } from 'scenes/sceneTypes'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import type { SceneExport } from 'scenes/sceneTypes'
 
 import { ExperimentForm } from './ExperimentForm'
 import { ExperimentView } from './ExperimentView/ExperimentView'
-import { ExperimentLogicProps, FORM_MODES, experimentLogic } from './experimentLogic'
+import { CreateExperiment } from './create/CreateExperiment'
+import { type ExperimentLogicProps, FORM_MODES, experimentLogic } from './experimentLogic'
 
 export const scene: SceneExport<ExperimentLogicProps> = {
     component: Experiment,
@@ -18,9 +20,14 @@ export const scene: SceneExport<ExperimentLogicProps> = {
 
 export function Experiment(): JSX.Element {
     const { formMode, experimentMissing } = useValues(experimentLogic)
+    const isUnifiedCreateFormEnabled = useFeatureFlag('EXPERIMENTS_UNIFIED_CREATE_FORM', 'test')
 
     if (experimentMissing) {
         return <NotFound object="experiment" />
+    }
+
+    if (isUnifiedCreateFormEnabled && formMode === FORM_MODES.create) {
+        return <CreateExperiment />
     }
 
     return ([FORM_MODES.create, FORM_MODES.duplicate] as string[]).includes(formMode) ? (

--- a/frontend/src/scenes/experiments/components/SelectableCard.tsx
+++ b/frontend/src/scenes/experiments/components/SelectableCard.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { cn } from 'lib/utils/css-classes'
 
 type SelectableCardProps = {
-    title: string
+    title: ReactNode
     description: ReactNode
     selected: boolean
     onClick: () => void

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -1,4 +1,5 @@
 import { BaseMathType, ExperimentConclusion, GroupMathType, HogQLMathType, PropertyMathType } from '~/types'
+import type { Experiment } from '~/types'
 
 export enum MetricInsightId {
     Trends = 'new-experiment-trends-metric',
@@ -53,5 +54,34 @@ export const CONCLUSION_DISPLAY_CONFIG: Record<
         description:
             'The experiment data is unreliable due to issues like tracking errors, incorrect setup, or external disruptions.',
         color: 'bg-muted-alt',
+    },
+}
+
+export const NEW_EXPERIMENT: Experiment = {
+    id: 'new',
+    name: '',
+    description: '',
+    type: 'product',
+    feature_flag_key: '',
+    filters: {},
+    metrics: [] as any[],
+    metrics_secondary: [] as any[],
+    secondary_metrics: [] as any[],
+    primary_metrics_ordered_uuids: null,
+    secondary_metrics_ordered_uuids: null,
+    saved_metrics_ids: [] as any[],
+    saved_metrics: [] as any[],
+    parameters: {
+        feature_flag_variants: [
+            { key: 'control', rollout_percentage: 50 },
+            { key: 'test', rollout_percentage: 50 },
+        ] as any[],
+    },
+    created_at: null,
+    created_by: null,
+    updated_at: null,
+    holdout_id: null,
+    exposure_criteria: {
+        filterTestAccounts: true,
     },
 }

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -1,0 +1,162 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+import { router } from 'kea-router'
+import { useState } from 'react'
+
+import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
+import { IconErrorOutline } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { MetricSourceModal } from '../Metrics/MetricSourceModal'
+import { MetricsReorderModal } from '../MetricsView/MetricsReorderModal'
+import { createExperimentLogic } from './createExperimentLogic'
+import { ExperimentTypePanel } from './panels/ExperimentTypePanel'
+
+const LemonFieldError = ({ error }: { error: string }): JSX.Element => {
+    return (
+        <div className="text-danger flex items-center gap-1 text-sm">
+            <IconErrorOutline className="text-xl shrink-0" /> {error}
+        </div>
+    )
+}
+
+export const CreateExperiment = (): JSX.Element => {
+    const { HogfettiComponent } = useHogfetti({ count: 100, duration: 3000 })
+
+    const { experiment, experimentErrors } = useValues(createExperimentLogic)
+    const { setExperiment, setExperimentValue } = useActions(createExperimentLogic)
+
+    const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
+
+    return (
+        <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
+            <Form logic={createExperimentLogic} formKey="experiment" enableFormOnSubmit>
+                <HogfettiComponent />
+                <SceneContent className="max-w-none flex-1">
+                    <SceneTitleSection
+                        name={experiment.name}
+                        description={null}
+                        resourceType={{
+                            type: 'experiment',
+                        }}
+                        canEdit
+                        forceEdit
+                        onNameChange={(name) => {
+                            setExperimentValue('name', name)
+                        }}
+                        actions={
+                            <>
+                                <LemonButton
+                                    data-attr="cancel-experiment"
+                                    type="secondary"
+                                    size="small"
+                                    onClick={() => {
+                                        router.actions.push(urls.experiments())
+                                    }}
+                                >
+                                    Cancel
+                                </LemonButton>
+                                <LemonButton data-attr="save-experiment" type="primary" size="small" htmlType="submit">
+                                    Save as draft
+                                </LemonButton>
+                            </>
+                        }
+                    />
+                    {experimentErrors.name && typeof experimentErrors.name === 'string' && (
+                        <LemonFieldError error={experimentErrors.name} />
+                    )}
+                    <SceneDivider />
+                    <SceneSection title="Hypothesis" description="Describe your experiment in a few sentences.">
+                        <LemonField name="description">
+                            <LemonTextArea
+                                placeholder="The goal of this experiment is ..."
+                                data-attr="experiment-hypothesis"
+                                value={experiment.description}
+                                onChange={(value) => {
+                                    setExperimentValue('description', value)
+                                }}
+                            />
+                        </LemonField>
+                    </SceneSection>
+                    <SceneDivider />
+                    <LemonCollapse
+                        activeKey={selectedPanel ?? undefined}
+                        onChange={(key) => {
+                            setSelectedPanel(key as string | null)
+                        }}
+                        className="bg-surface-primary"
+                        panels={[
+                            {
+                                key: 'experiment-type',
+                                header: 'Experiment type',
+                                content: (
+                                    <ExperimentTypePanel
+                                        experiment={experiment}
+                                        setExperimentType={(type) => setExperiment({ ...experiment, type })}
+                                    />
+                                ),
+                            },
+                            {
+                                key: 'experiment-variants',
+                                header: 'Feature flag & variants',
+                                content: (
+                                    <div className="p-4">
+                                        <span>Variants Panel Goes Here</span>
+                                    </div>
+                                ),
+                            },
+                            {
+                                key: 'experiment-targeting',
+                                header: 'Targeting',
+                                content: (
+                                    <div className="p-4">
+                                        <span>Targeting Panel Goes Here</span>
+                                    </div>
+                                ),
+                            },
+                            {
+                                key: 'experiment-exposure',
+                                header: 'Exposure criteria',
+                                content: (
+                                    <div className="p-4">
+                                        <span>Exposure Criteria Panel Goes Here</span>
+                                    </div>
+                                ),
+                            },
+                            {
+                                key: 'experiment-metrics',
+                                header: 'Metrics',
+                                content: (
+                                    <div className="p-4">
+                                        <span>Metrics Panel Goes Here</span>
+                                    </div>
+                                ),
+                            },
+                        ]}
+                    />
+                </SceneContent>
+            </Form>
+            {/* Sidebar Checklist */}
+            <div className="h-full">
+                <div className="sticky top-16">
+                    <span>Sidebar Checklist Goes Here</span>
+                </div>
+            </div>
+
+            {/* Metric Modals */}
+            <MetricSourceModal isSecondary={false} />
+            <MetricSourceModal isSecondary={true} />
+            <MetricsReorderModal isSecondary={false} />
+            <MetricsReorderModal isSecondary={true} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -1,0 +1,97 @@
+import { actions, connect, kea, listeners, path, props, reducers } from 'kea'
+import { forms } from 'kea-forms'
+import { router } from 'kea-router'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { ProductIntentContext } from 'lib/utils/product-intents'
+import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
+import type { Experiment, FeatureFlagFilters } from '~/types'
+import { ProductKey } from '~/types'
+
+import { NEW_EXPERIMENT } from '../constants'
+import type { createExperimentLogicType } from './createExperimentLogicType'
+
+export const createExperimentLogic = kea<createExperimentLogicType>([
+    props(() => ({})),
+    path(['scenes', 'experiments', 'create', 'createExperimentLogic']),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags']],
+        actions: [
+            eventUsageLogic,
+            ['reportExperimentCreated'],
+            featureFlagsLogic,
+            ['updateFlag'],
+            teamLogic,
+            ['addProductIntent'],
+        ],
+    })),
+    forms(() => ({
+        experiment: {
+            options: { showErrorsOnTouch: true },
+            defaults: { ...NEW_EXPERIMENT } as Experiment,
+            errors: ({ name, description }: Experiment) => ({
+                name: !name ? 'Name is required' : undefined,
+                description: !description ? 'Hypothesis is required' : undefined,
+            }),
+        },
+    })),
+    actions(() => ({
+        setExperiment: (experiment: Experiment) => ({ experiment }),
+        createExperiment: () => ({}),
+        createExperimentSuccess: true,
+    })),
+    reducers(() => ({
+        experiment: [
+            { ...NEW_EXPERIMENT } as Experiment & { feature_flag_filters?: FeatureFlagFilters },
+            {
+                setExperiment: (_, { experiment }) => experiment,
+                updateFeatureFlagKey: (state, { key }) => ({ ...state, feature_flag_key: key }),
+            },
+        ],
+    })),
+    listeners(({ values, actions }) => ({
+        setExperiment: () => {},
+        setExperimentValue: () => {},
+        createExperiment: async () => {
+            const response = (await api.create(`api/projects/@current/experiments`, values.experiment)) as Experiment
+
+            if (response.id) {
+                // Report analytics
+                actions.reportExperimentCreated(response)
+                actions.addProductIntent({
+                    product_type: ProductKey.EXPERIMENTS,
+                    intent_context: ProductIntentContext.EXPERIMENT_CREATED,
+                })
+
+                // Signal successful creation (triggers Hogfetti in component)
+                actions.createExperimentSuccess()
+
+                // Refresh tree navigation
+                refreshTreeItem('experiment', String(response.id))
+                if (response.feature_flag?.id) {
+                    refreshTreeItem('feature_flag', String(response.feature_flag.id))
+                }
+
+                // Show success toast
+                lemonToast.success('Experiment created successfully!', {
+                    button: {
+                        label: 'View it',
+                        action: () => {
+                            router.actions.push(urls.experiment(response.id))
+                        },
+                    },
+                })
+
+                // Navigate to experiment page
+                router.actions.push(urls.experiment(response.id))
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/experiments/create/panels/ExperimentTypePanel.tsx
+++ b/frontend/src/scenes/experiments/create/panels/ExperimentTypePanel.tsx
@@ -1,0 +1,33 @@
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { SelectableCard } from 'scenes/experiments/components/SelectableCard'
+
+import type { Experiment } from '~/types'
+
+type ExperimentTypePanelProps = {
+    experiment: Experiment
+    setExperimentType: (type: 'product' | 'web') => void
+}
+
+export const ExperimentTypePanel = ({ experiment, setExperimentType }: ExperimentTypePanelProps): JSX.Element => (
+    <div className="flex gap-4">
+        <SelectableCard
+            title="Product experiment"
+            description="Use custom code to manage how variants modify your product."
+            selected={experiment.type === 'product'}
+            onClick={() => setExperimentType('product')}
+        />
+        <SelectableCard
+            title={
+                <span>
+                    No-Code experiment&nbsp;
+                    <LemonTag type="option" size="small">
+                        Beta
+                    </LemonTag>
+                </span>
+            }
+            description="Define variants on your website using the PostHog toolbar, no coding required."
+            selected={experiment.type === 'web'}
+            onClick={() => setExperimentType('web')}
+        />
+    </div>
+)


### PR DESCRIPTION
> [!IMPORTANT]
> This feature is set up behind the `experiments-unified-create-form` feature flag for users on the `test` variant. Verify that this protection is in place in production.

## Problem

The current create form for creating experiments does not cover all the necessary options to effectively create a launchable experiment, resulting in a split experience between this form and the experiment view.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are redesigning the create experiment experience from the ground up to provide users with a straightforward UI that helps them understand the context of a new experiment and offers sensible defaults.

This PR adds the base structure and the first panel for this unified experience. This includes form defaults and the Kea logic for managing state and form validation.

This first panel is the simplest of all, but it illustrates the design principles: React components as independent as possible from the experiment logic, which use callbacks so that state is modified in a parent component.

| Experiment Type |
| - |
| <img width="3514" height="1660" alt="localhost_8010_project_1_experiments_new (2)" src="https://github.com/user-attachments/assets/60756995-0809-4ad7-8413-c0138ea07923" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/2226a636-975b-4d9b-94df-be73df97ed8c)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
