### PR TITLE
fix(messaging): propagate caputure events in hogflows

### DIFF
--- a/plugin-server/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/hog_function.ts
@@ -40,6 +40,9 @@ export class HogFunctionHandler implements ActionHandler {
             })
         })
 
+        // Collect captured PostHog events
+        result.capturedPostHogEvents = [...result.capturedPostHogEvents, ...functionResult.capturedPostHogEvents]
+
         if (!functionResult.finished) {
             // Set the state of the function result on the substate of the flow for the next execution
             result.invocation.state.currentAction!.hogFunctionState = functionResult.invocation.state

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -94,6 +94,35 @@ describe('Hogflow Executor', () => {
             ],
         })
 
+        await insertHogFunctionTemplate(hub.postgres, {
+            id: 'template-posthog-capture',
+            name: 'Capture a PostHog event',
+            code: `
+postHogCapture({
+  'event': inputs.event,
+  'distinct_id': inputs.distinct_id,
+  'properties': inputs.properties
+})
+`,
+            inputs_schema: [
+                {
+                    key: 'event',
+                    type: 'string',
+                    required: true,
+                },
+                {
+                    key: 'distinct_id',
+                    type: 'string',
+                    required: true,
+                },
+                {
+                    key: 'properties',
+                    type: 'dictionary',
+                    required: false,
+                },
+            ],
+        })
+
         executor = new HogFlowExecutorService(hogFlowFunctionsService, recipientPreferencesService)
     })
 
@@ -936,6 +965,143 @@ describe('Hogflow Executor', () => {
                     expect(result.invocation.state.currentAction!.id).toEqual(nextActionId)
                 }
             )
+        })
+
+        describe('capturedPostHogEvents', () => {
+            it('should collect capturedPostHogEvents from hog function actions', async () => {
+                const hogFlow = createHogFlow({
+                    actions: {
+                        capture_function: {
+                            type: 'function',
+                            config: {
+                                template_id: 'template-posthog-capture',
+                                inputs: {
+                                    event: { value: 'custom_event' },
+                                    distinct_id: { value: '{event.distinct_id}' },
+                                    properties: {
+                                        value: {
+                                            user: '{event.properties.user_name}',
+                                            value: '{event.properties.value}',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        exit: {
+                            type: 'exit',
+                            config: {},
+                        },
+                    },
+                    edges: [
+                        {
+                            from: 'trigger',
+                            to: 'capture_function',
+                            type: 'continue',
+                        },
+                        {
+                            from: 'capture_function',
+                            to: 'exit',
+                            type: 'continue',
+                        },
+                    ],
+                })
+
+                const invocation = createExampleHogFlowInvocation(hogFlow, {
+                    event: {
+                        ...createHogExecutionGlobals().event,
+                        properties: { user_name: 'Test User', value: 'test-value-123' },
+                    },
+                })
+
+                const result = await executor.execute(invocation)
+
+                expect(result.finished).toBe(true)
+                expect(result.error).toBeUndefined()
+
+                // Verify that capturedPostHogEvents are collected (the fix)
+                expect(result.capturedPostHogEvents).toBeDefined()
+                expect(result.capturedPostHogEvents).toHaveLength(1)
+                expect(result.capturedPostHogEvents[0]).toMatchObject({
+                    team_id: 1,
+                    event: 'custom_event',
+                    distinct_id: '{event.distinct_id}',
+                    properties: {
+                        user: '{event.properties.user_name}',
+                        value: '{event.properties.value}',
+                    },
+                })
+            })
+
+            it('should collect capturedPostHogEvents from multiple hog function actions', async () => {
+                const hogFlow = createHogFlow({
+                    actions: {
+                        capture_function_1: {
+                            type: 'function',
+                            config: {
+                                template_id: 'template-posthog-capture',
+                                inputs: {
+                                    event: { value: 'custom_event' },
+                                    distinct_id: { value: 'user1' },
+                                    properties: { value: { user: 'User1', value: 'value1' } },
+                                },
+                            },
+                        },
+                        capture_function_2: {
+                            type: 'function',
+                            config: {
+                                template_id: 'template-posthog-capture',
+                                inputs: {
+                                    event: { value: 'custom_event' },
+                                    distinct_id: { value: 'user2' },
+                                    properties: { value: { user: 'User2', value: 'value2' } },
+                                },
+                            },
+                        },
+                        exit: {
+                            type: 'exit',
+                            config: {},
+                        },
+                    },
+                    edges: [
+                        {
+                            from: 'trigger',
+                            to: 'capture_function_1',
+                            type: 'continue',
+                        },
+                        {
+                            from: 'capture_function_1',
+                            to: 'capture_function_2',
+                            type: 'continue',
+                        },
+                        {
+                            from: 'capture_function_2',
+                            to: 'exit',
+                            type: 'continue',
+                        },
+                    ],
+                })
+
+                const invocation = createExampleHogFlowInvocation(hogFlow)
+
+                const result = await executor.execute(invocation)
+
+                expect(result.finished).toBe(true)
+                expect(result.error).toBeUndefined()
+
+                // Should collect events from both functions
+                expect(result.capturedPostHogEvents).toBeDefined()
+                expect(result.capturedPostHogEvents).toHaveLength(2)
+                expect(result.capturedPostHogEvents[0]).toMatchObject({
+                    event: 'custom_event',
+                    distinct_id: 'user1',
+                    properties: { user: 'User1', value: 'value1' },
+                })
+                expect(result.capturedPostHogEvents[1]).toMatchObject({
+                    event: 'custom_event',
+                    distinct_id: 'user2',
+                    properties: { user: 'User2', value: 'value2' },
+                })
+            })
         })
     })
 })

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon'
 import { FixtureHogFlowBuilder, SimpleHogFlowRepresentation } from '~/cdp/_tests/builders/hogflow.builder'
 import { createHogExecutionGlobals, insertHogFunctionTemplate } from '~/cdp/_tests/fixtures'
 import { compileHog } from '~/cdp/templates/compiler'
+import { template as posthogCaptureTemplate } from '~/cdp/templates/_destinations/posthog_capture/posthog-capture.template'
 import { HogFlow } from '~/schema/hogflow'
 import { resetTestDatabase } from '~/tests/helpers/sql'
 
@@ -94,34 +95,7 @@ describe('Hogflow Executor', () => {
             ],
         })
 
-        await insertHogFunctionTemplate(hub.postgres, {
-            id: 'template-posthog-capture',
-            name: 'Capture a PostHog event',
-            code: `
-postHogCapture({
-  'event': inputs.event,
-  'distinct_id': inputs.distinct_id,
-  'properties': inputs.properties
-})
-`,
-            inputs_schema: [
-                {
-                    key: 'event',
-                    type: 'string',
-                    required: true,
-                },
-                {
-                    key: 'distinct_id',
-                    type: 'string',
-                    required: true,
-                },
-                {
-                    key: 'properties',
-                    type: 'dictionary',
-                    required: false,
-                },
-            ],
-        })
+        await insertHogFunctionTemplate(hub.postgres, posthogCaptureTemplate)
 
         executor = new HogFlowExecutorService(hogFlowFunctionsService, recipientPreferencesService)
     })

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1018,7 +1018,6 @@ postHogCapture({
                 expect(result.finished).toBe(true)
                 expect(result.error).toBeUndefined()
 
-                // Verify that capturedPostHogEvents are collected (the fix)
                 expect(result.capturedPostHogEvents).toBeDefined()
                 expect(result.capturedPostHogEvents).toHaveLength(1)
                 expect(result.capturedPostHogEvents[0]).toMatchObject({
@@ -1088,8 +1087,6 @@ postHogCapture({
                 expect(result.finished).toBe(true)
                 expect(result.error).toBeUndefined()
 
-                // Should collect events from both functions
-                expect(result.capturedPostHogEvents).toBeDefined()
                 expect(result.capturedPostHogEvents).toHaveLength(2)
                 expect(result.capturedPostHogEvents[0]).toMatchObject({
                     event: 'custom_event',

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -6,6 +6,7 @@ import { UUIDT } from '../../../utils/utils'
 import {
     CyclotronJobInvocationHogFlow,
     CyclotronJobInvocationResult,
+    HogFunctionCapturedEvent,
     HogFunctionFilterGlobals,
     HogFunctionInvocationGlobals,
     LogEntry,
@@ -124,6 +125,7 @@ export class HogFlowExecutorService {
         let result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow> | null = null
         const metrics: MinimalAppMetric[] = []
         const logs: MinimalLogEntry[] = []
+        const capturedPostHogEvents: HogFunctionCapturedEvent[] = []
 
         const earlyExitResult = await this.shouldExitEarly(invocation)
         if (earlyExitResult) {
@@ -154,6 +156,7 @@ export class HogFlowExecutorService {
 
             logs.push(...result.logs)
             metrics.push(...result.metrics)
+            capturedPostHogEvents.push(...result.capturedPostHogEvents)
 
             if (this.shouldEndHogFlowExecution(result, logs)) {
                 break
@@ -162,6 +165,7 @@ export class HogFlowExecutorService {
 
         result.logs = logs
         result.metrics = metrics
+        result.capturedPostHogEvents = capturedPostHogEvents
 
         return result
     }


### PR DESCRIPTION
## Problem

resolves https://github.com/PostHog/posthog/pull/38324, #38325

This fixes an issue where `capturedPostHogEvents` were not being properly collected and propagated in the CDP cyclotron worker hogflow consumer. When hog functions executed within hogflows captured PostHog events, these events were being lost instead of being passed through to the result, preventing them from being processed correctly downstream.

<img width="469" height="437" alt="image" src="https://github.com/user-attachments/assets/4b05c1b0-7e04-42da-9953-8ad64ba2e461" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Added event collection logic in `HogFunctionHandler` to merge `capturedPostHogEvents` from function results into the main result
- Added `capturedPostHogEvents` array initialization and collection in `HogFlowExecutorService` to properly aggregate events from all executed actions
- Added missing `HogFunctionCapturedEvent` import in the executor service

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
