### PR TITLE
feat(experiments): Add saved metric uuids to mapping records

### DIFF
--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -148,7 +148,9 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
                     ],
                     "properties": [],
                 },
-                "saved_metrics_ids": [{"id": saved_metric_id, "metadata": {"type": "secondary"}}],
+                "saved_metrics_ids": [
+                    {"id": saved_metric_id, "metadata": {"type": "secondary", "uuid": "test-uuid-1"}}
+                ],
             },
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -160,7 +162,7 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
 
         self.assertEqual(Experiment.objects.get(pk=exp_id).saved_metrics.count(), 1)
         experiment_to_saved_metric = Experiment.objects.get(pk=exp_id).experimenttosavedmetric_set.first()
-        self.assertEqual(experiment_to_saved_metric.metadata, {"type": "secondary"})
+        self.assertEqual(experiment_to_saved_metric.metadata, {"type": "secondary", "uuid": "test-uuid-1"})
         saved_metric = Experiment.objects.get(pk=exp_id).saved_metrics.first()
         self.assertEqual(saved_metric.id, saved_metric_id)
         self.assertEqual(

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -139,9 +139,7 @@ export function SharedMetricModal({
                                             : 'primary_metrics_ordered_uuids']: newOrderingArray,
                                     })
 
-                                    addSharedMetricsToExperiment(selectedMetricIds, {
-                                        type: isSecondary ? 'secondary' : 'primary',
-                                    })
+                                    addSharedMetricsToExperiment(selectedMetricIds, !!isSecondary)
                                     isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
                                 }}
                                 type="primary"


### PR DESCRIPTION
## Problem
I'm implementing timeseries calculation for saved metrics. The link between experiments and saved metrics lives in the `ExperimentToSavedMetric` model (a many-to-many relationship), not on the experiment itself. To figure out which experiment–saved_metric combinations to calculate, we need to check those records. We also need the saved metric uuid there so we can build the Dagster partition key, which requires it.

## Changes
Add saved metric uuid to `ExperimentToSavedMetric.metadata`.

## How did you test this code?
- Manually tested that newly added `ExperimentToSavedMetric` contains metadata.uuid
- Updated tests