### PR TITLE
fix: fallback to `$group_type` and `$group_key` when adding group props

### DIFF
--- a/plugin-server/src/worker/ingestion/groups.test.ts
+++ b/plugin-server/src/worker/ingestion/groups.test.ts
@@ -49,4 +49,21 @@ describe('addGroupProperties()', () => {
         expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'project')
         expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'foobar')
     })
+
+    it('falls back on $group_type and $group_key', async () => {
+        const properties = {
+            foo: 'bar',
+            $group_type: 'project',
+            $group_key: 'web',
+        }
+
+        expect(await addGroupProperties(2, 2 as ProjectId, properties, mockGroupTypeManager)).toEqual({
+            foo: 'bar',
+            $group_type: 'project',
+            $group_key: 'web',
+            $group_0: 'web',
+        })
+
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 2, 'project')
+    })
 })

--- a/plugin-server/src/worker/ingestion/groups.ts
+++ b/plugin-server/src/worker/ingestion/groups.ts
@@ -9,11 +9,20 @@ export async function addGroupProperties(
     properties: Properties,
     groupTypeManager: GroupTypeManager
 ): Promise<Properties> {
-    for (const [groupType, groupIdentifier] of Object.entries(properties.$groups || {})) {
-        const columnIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, groupType)
+    if (properties.$groups) {
+        for (const [groupType, groupIdentifier] of Object.entries(properties.$groups)) {
+            const columnIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, groupType)
+            if (columnIndex !== null) {
+                // :TODO: Update event column instead
+                properties[`$group_${columnIndex}`] = groupIdentifier
+            }
+        }
+        // for $groupidentify events, the $groups property is not always set
+    } else if (properties.$group_type && properties.$group_key) {
+        const columnIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, properties.$group_type)
         if (columnIndex !== null) {
             // :TODO: Update event column instead
-            properties[`$group_${columnIndex}`] = groupIdentifier
+            properties[`$group_${columnIndex}`] = properties.$group_key
         }
     }
     return properties


### PR DESCRIPTION
## Problem

`$groupidentify` events can't be related to users if the `$groups` property isn't sent with the event - which not all PostHog SDKs do.

## Changes

If `properties.$groups` is missing, add group properties from the `$group_key` and `$group_type` properties instead.

