### PR TITLE
feat(experiments): Remove step_sessions from timeseries results

### DIFF
--- a/dags/experiments.py
+++ b/dags/experiments.py
@@ -90,13 +90,13 @@ def _get_experiment_metrics(context: dagster.SensorEvaluationContext) -> list[tu
 
 def _remove_step_sessions_from_experiment_result(result: ExperimentQueryResponse) -> ExperimentQueryResponse:
     """
-    Remove step_sessions fields from experiment results to reduce API response size.
+    Remove step_sessions values from experiment results to reduce API response size.
     """
-    if hasattr(result.baseline, "step_sessions") and result.baseline.step_sessions is not None:
+    if result.baseline is not None:
         result.baseline.step_sessions = None
 
-    for variant in result.variant_results:
-        if hasattr(variant, "step_sessions") and variant.step_sessions is not None:
+    if result.variant_results is not None:
+        for variant in result.variant_results:
             variant.step_sessions = None
 
     return result

--- a/dags/experiments.py
+++ b/dags/experiments.py
@@ -16,7 +16,13 @@ from django.db.models import Q
 
 import dagster
 
-from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
+from posthog.schema import (
+    ExperimentFunnelMetric,
+    ExperimentMeanMetric,
+    ExperimentQuery,
+    ExperimentQueryResponse,
+    ExperimentRatioMetric,
+)
 
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.models.experiment import Experiment, ExperimentMetricResult
@@ -80,6 +86,20 @@ def _get_experiment_metrics(context: dagster.SensorEvaluationContext) -> list[tu
             experiment_metrics.append((experiment.id, metric_uuid, fingerprint, metric))
 
     return experiment_metrics
+
+
+def _remove_step_sessions_from_experiment_result(result: ExperimentQueryResponse) -> ExperimentQueryResponse:
+    """
+    Remove step_sessions fields from experiment results to reduce API response size.
+    """
+    if hasattr(result.baseline, "step_sessions") and result.baseline.step_sessions is not None:
+        result.baseline.step_sessions = None
+
+    for variant in result.variant_results:
+        if hasattr(variant, "step_sessions") and variant.step_sessions is not None:
+            variant.step_sessions = None
+
+    return result
 
 
 def _parse_partition_key(partition_key: str) -> tuple[int, str, str]:
@@ -162,6 +182,8 @@ def experiment_timeseries(context: dagster.AssetExecutionContext) -> dict[str, A
 
         query_runner = ExperimentQueryRunner(query=experiment_query, team=experiment.team)
         result = query_runner._calculate()
+
+        result = _remove_step_sessions_from_experiment_result(result)
 
         completed_at = datetime.now(ZoneInfo("UTC"))
 


### PR DESCRIPTION
## Problem
The `step_sessions` field in experiment results contains a lot of data that's not needed for the timeseries. When querying for the entire timeseries, the response size explodes because of this.

## Changes
Added a cleaning method that removes `step_sessions` fields from baseline and variant results before persisting timeseries data.

## How did you test this code?
Manually tested that the field is no longer included.