### PR TITLE
fix: be persistent in backup status checking for CH

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -398,7 +398,7 @@ def wait_for_backup(
     done = False
     tries = 0
     if backup:
-        while not done and tries < 5:
+        while not done:
             tries += 1
             map_hosts(backup.wait).result().values()
             most_recent_status = get_most_recent_status(map_hosts(backup.status).result().values())
@@ -406,7 +406,7 @@ def wait_for_backup(
                 continue
             if most_recent_status and most_recent_status.status == "BACKUP_CREATED":
                 done = True
-            if most_recent_status and most_recent_status.status != "BACKUP_CREATED":
+            if (most_recent_status and most_recent_status.status != "BACKUP_CREATED") or tries >= 5:
                 raise ValueError(
                     f"Backup {backup.path} finished with an unexpected status: {most_recent_status.status} on the host {most_recent_status.hostname}."
                 )

--- a/dags/backups.py
+++ b/dags/backups.py
@@ -395,13 +395,19 @@ def wait_for_backup(
             )
         return cluster.map_hosts_by_role(fn=func, node_role=NodeRole.DATA, workload=config.workload)
 
+    done = False
     if backup:
-        map_hosts(backup.wait).result().values()
-        most_recent_status = get_most_recent_status(map_hosts(backup.status).result().values())
-        if most_recent_status and most_recent_status.status != "BACKUP_CREATED":
-            raise ValueError(
-                f"Backup {backup.path} finished with an unexpected status: {most_recent_status.status} on the host {most_recent_status.hostname}."
-            )
+        while not done:
+            map_hosts(backup.wait).result().values()
+            most_recent_status = get_most_recent_status(map_hosts(backup.status).result().values())
+            if most_recent_status and most_recent_status.status == "CREATING_BACKUP":
+                continue
+            if most_recent_status and most_recent_status.status == "BACKUP_CREATED":
+                done = True
+            if most_recent_status and most_recent_status.status != "BACKUP_CREATED":
+                raise ValueError(
+                    f"Backup {backup.path} finished with an unexpected status: {most_recent_status.status} on the host {most_recent_status.hostname}."
+                )
     else:
         context.log.info("No backup to wait for")
 

--- a/dags/backups.py
+++ b/dags/backups.py
@@ -396,8 +396,10 @@ def wait_for_backup(
         return cluster.map_hosts_by_role(fn=func, node_role=NodeRole.DATA, workload=config.workload)
 
     done = False
+    tries = 0
     if backup:
-        while not done:
+        while not done and tries < 5:
+            tries += 1
             map_hosts(backup.wait).result().values()
             most_recent_status = get_most_recent_status(map_hosts(backup.status).result().values())
             if most_recent_status and most_recent_status.status == "CREATING_BACKUP":

--- a/dags/backups.py
+++ b/dags/backups.py
@@ -406,7 +406,9 @@ def wait_for_backup(
                 continue
             if most_recent_status and most_recent_status.status == "BACKUP_CREATED":
                 done = True
-            if (most_recent_status and most_recent_status.status != "BACKUP_CREATED") or tries >= 5:
+            if (most_recent_status and most_recent_status.status != "BACKUP_CREATED") or (
+                most_recent_status and tries >= 5
+            ):
                 raise ValueError(
                     f"Backup {backup.path} finished with an unexpected status: {most_recent_status.status} on the host {most_recent_status.hostname}."
                 )


### PR DESCRIPTION
## Problem

Be a bit more persistent during backup completion checking since we are saying some backups failed when they are actually still in process.
```
The above exception was caused by the following exception:
ValueError: Backup posthog/... finished with an unexpected status: CREATING_BACKUP on the host prod-1
```
## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
