### PR TITLE
chore: opt back out of lazy loaded replay

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -71,7 +71,6 @@ export function loadPostHogJS(): void {
             __preview_remote_config: true,
             __preview_flags_v2: true,
             __add_tracing_headers: ['eu.posthog.com', 'us.posthog.com'],
-            __preview_eager_load_replay: false,
             __preview_disable_xhr_credentials: true,
         })
 


### PR DESCRIPTION
i'm ready to try releasing lazy loaded replay again

i want to rule out our current strange playback meta bug as being related to lazy loaded

so switch posthog back to the current default so I can confirm that before changing the default for everyone