### PR TITLE
fix(messaging): Allow SES to use global creds

### DIFF
--- a/products/messaging/backend/providers/ses.py
+++ b/products/messaging/backend/providers/ses.py
@@ -12,11 +12,6 @@ logger = logging.getLogger(__name__)
 
 class SESProvider:
     def __init__(self):
-        self.access_key_id = self.get_access_key_id()
-        self.secret_access_key = self.get_secret_access_key()
-        self.region = self.get_region()
-        self.endpoint_url = self.get_endpoint_url()
-
         # Initialize SES client
         self.client = boto3.client(
             "ses",

--- a/products/messaging/backend/providers/ses.py
+++ b/products/messaging/backend/providers/ses.py
@@ -20,33 +20,11 @@ class SESProvider:
         # Initialize SES client
         self.client = boto3.client(
             "ses",
-            aws_access_key_id=self.access_key_id,
-            aws_secret_access_key=self.secret_access_key,
-            region_name=self.region,
-            endpoint_url=self.endpoint_url if self.endpoint_url else None,
+            aws_access_key_id=settings.SES_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.SES_SECRET_ACCESS_KEY,
+            region_name=settings.SES_REGION,
+            endpoint_url=settings.SES_ENDPOINT if settings.SES_ENDPOINT else None,
         )
-
-    @classmethod
-    def get_access_key_id(cls) -> str:
-        access_key_id = settings.SES_ACCESS_KEY_ID
-        if not access_key_id:
-            raise ValueError("SES_ACCESS_KEY_ID is not set in environment or settings")
-        return access_key_id
-
-    @classmethod
-    def get_secret_access_key(cls) -> str:
-        secret_access_key = settings.SES_SECRET_ACCESS_KEY
-        if not secret_access_key:
-            raise ValueError("SES_SECRET_ACCESS_KEY is not set in environment or settings")
-        return secret_access_key
-
-    @classmethod
-    def get_region(cls) -> str:
-        return settings.SES_REGION
-
-    @classmethod
-    def get_endpoint_url(cls) -> str | None:
-        return settings.SES_ENDPOINT
 
     def create_email_domain(self, domain: str, team_id: int):
         # NOTE: For sesv1 creation is done through verification

--- a/products/messaging/backend/test/test_ses_provider.py
+++ b/products/messaging/backend/test/test_ses_provider.py
@@ -24,19 +24,7 @@ class TestSESProvider(TestCase):
             SES_ENDPOINT="",
         ):
             provider = SESProvider()
-            assert provider.access_key_id == "test_access_key"
-            assert provider.secret_access_key == "test_secret_key"
-            assert provider.region == "us-east-1"
-
-    def test_init_missing_access_key(self):
-        with override_settings(SES_ACCESS_KEY_ID="", SES_SECRET_ACCESS_KEY="test_secret_key"):
-            with pytest.raises(ValueError, match="SES_ACCESS_KEY_ID is not set"):
-                SESProvider()
-
-    def test_init_missing_secret_key(self):
-        with override_settings(SES_ACCESS_KEY_ID="test_access_key", SES_SECRET_ACCESS_KEY=""):
-            with pytest.raises(ValueError, match="SES_SECRET_ACCESS_KEY is not set"):
-                SESProvider()
+            assert provider.client
 
     def test_create_email_domain_success(self):
         provider = SESProvider()


### PR DESCRIPTION
## Problem

On cloud we are using roles, not credentials so we dont want to raise if they aren't set

## Changes

* Simplifies it

