### PR TITLE
feat(ux): tab groups

### DIFF
--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -1,5 +1,6 @@
 import './Link.scss'
 
+import { useValues } from 'kea'
 import { router } from 'kea-router'
 import React, { useContext } from 'react'
 
@@ -12,6 +13,7 @@ import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { addProjectIdIfMissing } from 'lib/utils/router-utils'
 import { useNotebookDrag } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 import { WithinSidePanelContext, sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SidePanelTab } from '~/types'
@@ -129,6 +131,7 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
     ) => {
         const externalLink = isExternalLink(to)
         const withinSidePanel = useContext(WithinSidePanelContext)
+        const { activeTab } = useValues(sceneLogic)
         const { elementProps: draggableProps } = useNotebookDrag({
             href: typeof to === 'string' ? to : undefined,
         })
@@ -186,10 +189,10 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
                     }
                 }
             } else if (target === '_blank' && !externalLink && to && typeof to === 'string') {
-                // For internal links, open in new PostHog tab
+                // For internal links, open in new PostHog tab with parent tab tracking
                 event.preventDefault()
                 event.stopPropagation()
-                newInternalTab(to)
+                newInternalTab(to, activeTab?.id)
             }
         }
 

--- a/frontend/src/lib/utils/newInternalTab.tsx
+++ b/frontend/src/lib/utils/newInternalTab.tsx
@@ -2,9 +2,9 @@ import { getContext } from 'kea'
 
 export const NEW_INTERNAL_TAB = 'NEW_INTERNAL_TAB'
 
-export function newInternalTab(path?: string): void {
+export function newInternalTab(path?: string, parentTabId?: string): void {
     getContext().store.dispatch({
         type: NEW_INTERNAL_TAB,
-        payload: { path },
+        payload: { path, parentTabId },
     })
 }

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -160,6 +160,9 @@ export interface SceneTab {
     sceneId?: string
     sceneKey?: string
     sceneParams?: SceneParams
+
+    // Tab grouping - tracks which tab opened this tab
+    parentTabId?: string
 }
 
 export interface SceneParams {


### PR DESCRIPTION
## Problem
We have tabs, we have internal (target="_blank") links opening new tabs, but when get put onto your new tab you lose context...  This solves this with features like:
* Open new tab index +1 (next to parent)
* Visual queue (less important, but nice to have)
* Close child tab and return to parent

![2025-09-27 10 08 33](https://github.com/user-attachments/assets/aec39668-4420-48c6-80eb-c1f42dc016ce)

This will open the way for UI elements in the scene like "Close tab and return" in cases like when you're editing an insight from a dashboard perhaps.
