### PR TITLE
chore: Move up button to customize group dashboard

### DIFF
--- a/frontend/src/scenes/groups/GroupOverview.tsx
+++ b/frontend/src/scenes/groups/GroupOverview.tsx
@@ -24,10 +24,7 @@ export function GroupOverview({ groupData }: { groupData: Group }): JSX.Element 
                     <GroupPeopleCard groupData={groupData} />
                 </div>
             </div>
-            <div>
-                <h2>Insights</h2>
-                <GroupDashboardCard />
-            </div>
+            <GroupDashboardCard />
         </div>
     )
 }

--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -38,7 +38,12 @@ function GroupDetailDashboard({
         }
     }, [groupTypeDetailDashboard, groupData, groupTypeName, setProperties, setLoadLayoutFromServerOnPreview])
 
-    return <Dashboard id={groupTypeDetailDashboard.toString()} placement={DashboardPlacement.Group} />
+    return (
+        <div className="flex flex-col gap-0">
+            <h2>Insights</h2>
+            <Dashboard id={groupTypeDetailDashboard.toString()} placement={DashboardPlacement.Group} />
+        </div>
+    )
 }
 
 export function GroupDashboardCard(): JSX.Element {
@@ -58,6 +63,20 @@ export function GroupDashboardCard(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-4">
+            <div className="flex flex-row justify-between items-center">
+                <h2>Insights</h2>
+                <LemonButton
+                    type="secondary"
+                    disabled={creatingDetailDashboard}
+                    onClick={() => {
+                        setCreatingDetailDashboard(true)
+                        reportGroupTypeDetailDashboardCreated()
+                        createDetailDashboard(groupData.group_type_index)
+                    }}
+                >
+                    Customize
+                </LemonButton>
+            </div>
             <div className="grid grid-cols-2 gap-2">
                 <QueryCard
                     title="Top paths"
@@ -267,19 +286,6 @@ export function GroupDashboardCard(): JSX.Element {
                     }
                     context={{ refresh: 'force_blocking' }}
                 />
-            </div>
-            <div className="flex justify-end">
-                <LemonButton
-                    type="secondary"
-                    disabled={creatingDetailDashboard}
-                    onClick={() => {
-                        setCreatingDetailDashboard(true)
-                        reportGroupTypeDetailDashboardCreated()
-                        createDetailDashboard(groupData.group_type_index)
-                    }}
-                >
-                    Customize
-                </LemonButton>
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem
Button was at the bottom and hard to find. Even had customers asking for the ability to customize the dashboard (it is available for everyone).
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Move the button up, to make it easier to find.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
