### PR TITLE
fix: Fix revenue analytics evals

### DIFF
--- a/ee/hogai/eval/ci/max_tools/eval_revenue_analytics_filter_generation.py
+++ b/ee/hogai/eval/ci/max_tools/eval_revenue_analytics_filter_generation.py
@@ -235,10 +235,10 @@ async def eval_tool_filter_revenue_analytics(call_filter_revenue_analytics, pyte
             ),
             # Comprehensive filter combination
             EvalCase(
-                input="Show me my revenue in 2024 split by product for those in Austria",
+                input="Show me my revenue in 2023 split by product for those in Austria",
                 expected=RevenueAnalyticsAssistantFilters(
-                    date_from="2024-01-01T00:00:00:000",
-                    date_to=None,
+                    date_from="2023-01-01T00:00:00:000",
+                    date_to="2023-12-31T23:59:59:999",
                     properties=[
                         RevenueAnalyticsPropertyFilter(
                             key="revenue_analytics_customer.country",
@@ -254,13 +254,13 @@ async def eval_tool_filter_revenue_analytics(call_filter_revenue_analytics, pyte
             ),
             # Test time-based filtering
             EvalCase(
-                input="Assuming we're in 2024, show me my MRR data since the 1st of August",
-                expected=DUMMY_CURRENT_FILTERS.model_copy(update={"date_from": "2024-08-01T00:00:00:000"}),
+                input="Assuming we're in 2023, show me my MRR data since the 1st of August",
+                expected=DUMMY_CURRENT_FILTERS.model_copy(update={"date_from": "2023-08-01T00:00:00:000"}),
             ),
             EvalCase(
-                input="Assuming we're in 2024, show me my revenue in September",
+                input="Assuming we're in 2023, show me my revenue in September",
                 expected=DUMMY_CURRENT_FILTERS.model_copy(
-                    update={"date_from": "2024-09-01T00:00:00:000", "date_to": "2024-09-30T23:59:59:999"}
+                    update={"date_from": "2023-09-01T00:00:00:000", "date_to": "2023-09-30T23:59:59:999"}
                 ),
             ),
         ],

--- a/ee/hogai/eval/ci/max_tools/eval_revenue_analytics_filter_generation.py
+++ b/ee/hogai/eval/ci/max_tools/eval_revenue_analytics_filter_generation.py
@@ -238,7 +238,7 @@ async def eval_tool_filter_revenue_analytics(call_filter_revenue_analytics, pyte
                 input="Show me my revenue in 2024 split by product for those in Austria",
                 expected=RevenueAnalyticsAssistantFilters(
                     date_from="2024-01-01T00:00:00:000",
-                    date_to="2024-12-31T23:59:59:999",
+                    date_to=None,
                     properties=[
                         RevenueAnalyticsPropertyFilter(
                             key="revenue_analytics_customer.country",
@@ -254,11 +254,11 @@ async def eval_tool_filter_revenue_analytics(call_filter_revenue_analytics, pyte
             ),
             # Test time-based filtering
             EvalCase(
-                input="Assuming we're in 2024, show me recordings since the 1st of August",
+                input="Assuming we're in 2024, show me my MRR data since the 1st of August",
                 expected=DUMMY_CURRENT_FILTERS.model_copy(update={"date_from": "2024-08-01T00:00:00:000"}),
             ),
             EvalCase(
-                input="Assuming we're in 2024, show me recordings from the 1st of September through the 31st of September",
+                input="Assuming we're in 2024, show me my revenue in September",
                 expected=DUMMY_CURRENT_FILTERS.model_copy(
                     update={"date_from": "2024-09-01T00:00:00:000", "date_to": "2024-09-30T23:59:59:999"}
                 ),

--- a/products/revenue_analytics/backend/prompts.py
+++ b/products/revenue_analytics/backend/prompts.py
@@ -152,7 +152,7 @@ Below is a refined description for the `date_from` and `date_to` fields and thei
 
 <date_to>
 - Default Value: Set as null when the date range extends to today. Set as null when the user does not specify an end date.
-- Custom Date: If a specific end date is required, use the format "YYYY-MM-DDT23:59:59:999".
+- Custom Date: If the user mentions a specific end date (either by saying it or mentioning it only wants data for a specific month/year), use the format "YYYY-MM-DDT23:59:59:999".
 </date_to>
 </date_fields>
 """.strip()


### PR DESCRIPTION
Referenced some stuff from session replay, and also improve prompt to solve date inconsistencies

<img width="416" height="390" alt="image" src="https://github.com/user-attachments/assets/9711b347-e76f-4b8e-86dc-c6ba6a1315a9" />