### PR TITLE
fix: load metric container via activity instead of via workflow

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import asyncio
 import builtins
 from collections.abc import Callable
@@ -870,7 +871,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             distinct_ids=person.distinct_ids,
             team_id=person.team.id,
         )
-        workflow_id = f"delete-recordings-with-person-{person.uuid}"
+        workflow_id = f"delete-recordings-with-person-{person.uuid}-{uuid.uuid4()}"
 
         asyncio.run(
             temporal.start_workflow(

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -394,20 +394,22 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         )
 
         with patch("posthog.api.person.sync_connect") as mock_connect:
-            mock_client = mock.AsyncMock()
-            mock_connect.return_value = mock_client
-            response = self.client.delete(f"/api/person/{person.uuid}/?delete_recordings=true")
-            mock_connect.assert_called_once()
-            mock_client.start_workflow.assert_called_once()
-            mock_client.start_workflow.assert_called_with(
-                "delete-recordings-with-person",
-                RecordingsWithPersonInput(
-                    distinct_ids=["person_1", "anonymous_id"],
-                    team_id=self.team.id,
-                ),
-                id=f"delete-recordings-with-person-{person.uuid}",
-                task_queue=GENERAL_PURPOSE_TASK_QUEUE,
-            )
+            with patch("posthog.api.person.uuid") as mock_uuid:
+                mock_uuid.uuid4.return_value = "1234"
+                mock_client = mock.AsyncMock()
+                mock_connect.return_value = mock_client
+                response = self.client.delete(f"/api/person/{person.uuid}/?delete_recordings=true&delete_events=true")
+                mock_connect.assert_called_once()
+                mock_client.start_workflow.assert_called_once()
+                mock_client.start_workflow.assert_called_with(
+                    "delete-recordings-with-person",
+                    RecordingsWithPersonInput(
+                        distinct_ids=["person_1", "anonymous_id"],
+                        team_id=self.team.id,
+                    ),
+                    id=f"delete-recordings-with-person-{person.uuid}-1234",
+                    task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+                )
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(response.content, b"")  # Empty response
@@ -426,20 +428,22 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         _create_event(event="test", team=self.team, distinct_id="someone_else")
 
         with patch("posthog.api.person.sync_connect") as mock_connect:
-            mock_client = mock.AsyncMock()
-            mock_connect.return_value = mock_client
-            response = self.client.delete(f"/api/person/{person.uuid}/?delete_recordings=true&delete_events=true")
-            mock_connect.assert_called_once()
-            mock_client.start_workflow.assert_called_once()
-            mock_client.start_workflow.assert_called_with(
-                "delete-recordings-with-person",
-                RecordingsWithPersonInput(
-                    distinct_ids=["person_1", "anonymous_id"],
-                    team_id=self.team.id,
-                ),
-                id=f"delete-recordings-with-person-{person.uuid}",
-                task_queue=GENERAL_PURPOSE_TASK_QUEUE,
-            )
+            with patch("posthog.api.person.uuid") as mock_uuid:
+                mock_uuid.uuid4.return_value = "1234"
+                mock_client = mock.AsyncMock()
+                mock_connect.return_value = mock_client
+                response = self.client.delete(f"/api/person/{person.uuid}/?delete_recordings=true&delete_events=true")
+                mock_connect.assert_called_once()
+                mock_client.start_workflow.assert_called_once()
+                mock_client.start_workflow.assert_called_with(
+                    "delete-recordings-with-person",
+                    RecordingsWithPersonInput(
+                        distinct_ids=["person_1", "anonymous_id"],
+                        team_id=self.team.id,
+                    ),
+                    id=f"delete-recordings-with-person-{person.uuid}-1234",
+                    task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+                )
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(response.content, b"")  # Empty response

--- a/posthog/temporal/delete_recordings/metrics.py
+++ b/posthog/temporal/delete_recordings/metrics.py
@@ -1,10 +1,10 @@
-from temporalio import workflow
+from temporalio import activity
 from temporalio.common import MetricCounter
 
 
 def get_block_loaded_counter() -> MetricCounter:
-    return workflow.metric_meter().create_counter("recording_block_loaded", "Number of recording blocks loaded.")
+    return activity.metric_meter().create_counter("recording_block_loaded", "Number of recording blocks loaded.")
 
 
 def get_block_deleted_counter() -> MetricCounter:
-    return workflow.metric_meter().create_counter("recording_block_deleted", "Number of recording blocks deleted.")
+    return activity.metric_meter().create_counter("recording_block_deleted", "Number of recording blocks deleted.")


### PR DESCRIPTION
Fix for delete-recordings workflow failing due to activities trying to fetch metrics object via the workflow when not inside a valid workflow context.