### PR TITLE
fix(kafka-deduplicator): handle clippy warning observed in dev

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -416,7 +416,8 @@ impl CheckpointManager {
             counter_for_partition = *counter_guard.get(partition).unwrap_or(&0_u32);
         }
 
-        if counter_for_partition % full_checkpoint_interval == 0 {
+        // when full_checkpoint_interval is 0, we default to always performing Full checkpoints
+        if counter_for_partition.is_multiple_of(full_checkpoint_interval) {
             CheckpointMode::Full
         } else {
             CheckpointMode::Incremental


### PR DESCRIPTION
## Problem
Seeing a warning in local dev sometimes when I am not running linter in `flox` and therefore using a slightly newer version of clippy and friends
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Use `is_mulitple_of()` in place of explicit mod check in `CheckpointMode` selection logic. This is a no-op change

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog updates needed
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
