### PR TITLE
docs(flags): Add Java snippets for feature flags, experiments

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -238,3 +238,21 @@ else:
         </>
     )
 }
+
+export function JavaSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
+    return (
+        <>
+            <CodeSnippet language={Language.Java} wrap>
+                {`Object flagValue = postHog.getFeatureFlag("user distinct id", "${flagKey}");
+if ("${variant}".equals(flagValue)) {
+    // Do something differently for this user
+} else {
+    // It's a good idea to let control variant always be the default behaviour,
+    // so if something goes wrong with flag evaluation, you don't break your app.
+}
+`}
+            </CodeSnippet>
+            <ServerSideWarning />
+        </>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentImplementationDetails.tsx
+++ b/frontend/src/scenes/experiments/ExperimentImplementationDetails.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 
+import { IconServer } from '@posthog/icons'
 import { LemonSelect, Link } from '@posthog/lemon-ui'
 
 import {
@@ -22,6 +23,7 @@ import {
     GolangSnippet,
     IOSSnippet,
     JSSnippet,
+    JavaSnippet,
     NodeJSSnippet,
     PHPSnippet,
     PythonSnippet,
@@ -130,6 +132,14 @@ export const OPTIONS = [
         documentationLink: `${DOC_BASE_URL}libraries/ruby${UTM_TAGS}${FF_ANCHOR}`,
         Icon: IconRuby,
         Snippet: RubySnippet,
+        type: LibraryType.Server,
+    },
+    {
+        value: 'Java',
+        key: SDKKey.JAVA,
+        documentationLink: `${DOC_BASE_URL}libraries/java${UTM_TAGS}${FF_ANCHOR}`,
+        Icon: IconServer,
+        Snippet: JavaSnippet,
         type: LibraryType.Server,
     },
 ]

--- a/frontend/src/scenes/feature-flags/FeatureFlagCodeOptions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagCodeOptions.tsx
@@ -25,6 +25,7 @@ import {
     GolangSnippet,
     JSBootstrappingSnippet,
     JSSnippet,
+    JavaSnippet,
     NodeJSSnippet,
     PHPSnippet,
     PythonSnippet,
@@ -160,6 +161,14 @@ export const OPTIONS: InstructionOption[] = [
         key: SDKKey.DOTNET,
         Icon: IconCSharp,
     },
+    {
+        value: 'Java',
+        documentationLink: `${DOC_BASE_URL}libraries/java${UTM_TAGS}`,
+        Snippet: JavaSnippet,
+        type: LibraryType.Server,
+        key: SDKKey.JAVA,
+        Icon: IconServer,
+    },
 ]
 
 export const LOCAL_EVALUATION_LIBRARIES: string[] = [
@@ -184,6 +193,7 @@ export const PAYLOAD_LIBRARIES: string[] = [
     SDKKey.FLUTTER,
     SDKKey.DOTNET,
     SDKKey.GO,
+    SDKKey.JAVA,
 ]
 
 export const REMOTE_CONFIGURATION_LIBRARIES: string[] = [

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -484,6 +484,31 @@ if (${conditional}) {
     )
 }
 
+export function JavaSnippet({ flagKey, multivariant, payload }: FeatureFlagSnippet): JSX.Element {
+    const distinctId = 'user distinct id'
+    let snippet = ''
+    if (payload) {
+        snippet = `postHog.getFeatureFlagPayload("${distinctId}", "${flagKey}")`
+    } else if (multivariant) {
+        snippet = `Object flagValue = postHog.getFeatureFlag("${distinctId}", "${flagKey}");
+if ("example-variant".equals(flagValue)) {
+    // Do something differently for this user
+}`
+    } else {
+        snippet = `if (postHog.isFeatureEnabled("${distinctId}", "${flagKey}")) {
+    // Do something differently for this user
+}`
+    }
+
+    return (
+        <>
+            <CodeSnippet language={Language.Java} wrap>
+                {snippet}
+            </CodeSnippet>
+        </>
+    )
+}
+
 export function AndroidSnippet({ flagKey, multivariant, payload }: FeatureFlagSnippet): JSX.Element {
     const clientSuffix = 'PostHog.'
 


### PR DESCRIPTION
## Problem

We're adding support for a server-side Java SDK, and this change adds code snippets to feature flags and experiments for Java.

## Changes

<img width="802" height="380" alt="image" src="https://github.com/user-attachments/assets/2896f617-a7ee-4bc6-b528-a12308c64f50" />

<img width="802" height="400" alt="image" src="https://github.com/user-attachments/assets/a61de7ad-edf9-44f1-be0a-eb0c97514172" />

<img width="1189" height="337" alt="image" src="https://github.com/user-attachments/assets/6ef80ef1-5019-4c16-bc5a-80c7e0fc6d10" />