### PR TITLE
feat(kafka-deduplicator): implement flamegraph SVG endpoint for pprof profiler

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -78,6 +78,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2502,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,12 +2529,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3771,6 +3806,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash 0.8.11",
+ "indexmap 2.7.1",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,6 +3888,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4196,6 +4260,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -4671,6 +4741,16 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-integer"
@@ -5343,24 +5423,26 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
+ "aligned-vec",
  "backtrace",
  "cfg-if",
  "findshlibs",
+ "inferno",
  "libc",
  "log",
  "nix",
  "once_cell",
- "parking_lot",
  "protobuf",
- "protobuf-codegen-pure",
+ "protobuf-codegen",
  "smallvec",
+ "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -5507,27 +5589,53 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "protobuf-codegen"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
- "protobuf",
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "protobuf-codegen-pure"
-version = "2.28.0"
+name = "protobuf-codegen"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
+ "anyhow",
+ "once_cell",
  "protobuf",
- "protobuf-codegen",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.1",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5594,6 +5702,15 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5981,6 +6098,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6176,6 +6302,19 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6798,6 +6937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7040,6 +7188,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "string_cache"
@@ -7459,14 +7613,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand 2.3.0",
+ "getrandom 0.3.1",
  "once_cell",
- "rustix 0.38.41",
+ "rustix 1.1.2",
  "windows-sys 0.59.0",
 ]
 

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.21"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
-pprof = { version = "0.13", features = ["protobuf-codec"] }
+pprof = { version = "0.15", features = ["protobuf-codec", "flamegraph"] }
 rdkafka = { workspace = true }
 rocksdb = "0.24.0"
 serde = { workspace = true }

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -21,7 +21,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
 use kafka_deduplicator::{
-    config::Config, service::KafkaDeduplicatorService, utils::pprof::handle_profile,
+    config::Config,
+    service::KafkaDeduplicatorService,
+    utils::pprof::{handle_flamegraph, handle_profile},
 };
 
 common_alloc::used!();
@@ -128,7 +130,9 @@ fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
         );
 
     let router = if config.enable_pprof {
-        router.route("/pprof/profile", get(handle_profile))
+        router
+            .route("/pprof/profile", get(handle_profile))
+            .route("/pprof/flamegraph", get(handle_flamegraph))
     } else {
         router
     };

--- a/rust/kafka-deduplicator/src/utils/pprof.rs
+++ b/rust/kafka-deduplicator/src/utils/pprof.rs
@@ -1,3 +1,6 @@
+use std::io::Write;
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use axum::{
     extract::Query,
@@ -6,9 +9,8 @@ use axum::{
 };
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use pprof::{protos::Message, ProfilerGuardBuilder};
+use pprof::{flamegraph::Options, protos::Message, ProfilerGuardBuilder};
 use serde::Deserialize;
-use std::time::Duration;
 use tokio::time::sleep;
 
 #[derive(Deserialize)]
@@ -17,7 +19,24 @@ pub struct ProfileQueryParams {
     pub seconds: Option<u64>,
     // profiler samplefrequency in Hz
     pub frequency: Option<i32>,
+
+    // flamegraph SVG generator options
+    pub image_width: Option<usize>,
 }
+
+//
+// Generate a flamegraph SVG image of the profiler data
+//
+// Example:
+// curl -vsSL -X GET "http://<POD_URL>:<POD_PORT>/pprof/profile?seconds=10&frequency=200" > profile.pb.gz
+//
+// Example:
+// curl -vsSL -X GET "http://<POD_URL>:<POD_PORT>/pprof/flamegraph?seconds=10&frequency=200&image_width=2500" > flamegraph.svg.gz
+//
+// NOTE: if deployed to k8s, use "kubectl port-forward" to forward the port
+//       to your local machine, then replace <POD_URL> with "localhost"
+
+const DEFAULT_IMAGE_WIDTH: usize = 2500;
 
 pub async fn handle_profile(
     Query(params): Query<ProfileQueryParams>,
@@ -29,10 +48,29 @@ pub async fn handle_profile(
         Ok(body) => Ok((
             StatusCode::OK,
             [("Content-Type", "application/octet-stream")],
-            [(
-                "Content-Disposition",
-                "attachment; filename=\"profile.pb.gz\"",
-            )],
+            body,
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [("Content-Type", "text/plain")],
+            e.to_string(),
+        )
+            .into_response()),
+    }
+}
+
+pub async fn handle_flamegraph(
+    Query(params): Query<ProfileQueryParams>,
+) -> Result<Response, Response> {
+    let seconds = params.seconds.unwrap_or(10);
+    let frequency = params.frequency.unwrap_or(200);
+    let image_width = params.image_width.unwrap_or(DEFAULT_IMAGE_WIDTH);
+
+    match generate_flamegraph(frequency, seconds, image_width).await {
+        Ok(body) => Ok((
+            StatusCode::OK,
+            [("Content-Type", "application/octet-stream")],
             body,
         )
             .into_response()),
@@ -69,6 +107,40 @@ async fn generate_report(frequency: i32, seconds: u64) -> Result<Vec<u8>> {
     encoder
         .finish()
         .context("Failed to finish encoding profile")?;
+
+    Ok(body)
+}
+
+async fn generate_flamegraph(frequency: i32, seconds: u64, image_width: usize) -> Result<Vec<u8>> {
+    let guard = ProfilerGuardBuilder::default()
+        .frequency(frequency)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()
+        .context("Failed to build profiler guard")?;
+
+    sleep(Duration::from_secs(seconds)).await;
+
+    let mut options = Options::default();
+    options.image_width = Some(image_width);
+    let mut buf = Vec::new(); // buffer to store the flamegraph image
+
+    // generate the flamegraph report with given options
+    guard
+        .report()
+        .build()
+        .context("Failed to build flamegraph report")?
+        .flamegraph_with_options(&mut buf, &mut options)
+        .context("Failed to populate flamgegraph image buffer")?;
+
+    // GZIP the flamegraph image buffer before returning it
+    let mut body = Vec::new();
+    let mut encoder = GzEncoder::new(&mut body, Compression::default());
+    encoder
+        .write_all(&buf)
+        .context("Failed to write flamegraph image to buffer")?;
+    encoder
+        .finish()
+        .context("Failed to finish encoding flamegraph image to buffer")?;
 
     Ok(body)
 }

--- a/rust/kafka-deduplicator/src/utils/pprof.rs
+++ b/rust/kafka-deduplicator/src/utils/pprof.rs
@@ -130,7 +130,7 @@ async fn generate_flamegraph(frequency: i32, seconds: u64, image_width: usize) -
         .build()
         .context("Failed to build flamegraph report")?
         .flamegraph_with_options(&mut buf, &mut options)
-        .context("Failed to populate flamgegraph image buffer")?;
+        .context("Failed to populate flamegraph image buffer")?;
 
     // GZIP the flamegraph image buffer before returning it
     let mut body = Vec::new();


### PR DESCRIPTION
## Problem
It would be nice to also generate profile traces in `kafka-deduplicator` as flamegraph SVG images.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement flamegraph `pprof` generation
* Implement endpoint handler and routing for the same

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI - deploy test forthcoming! 🚀 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog update needed.
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
