### PR TITLE
chore(flags): Add metric for send_cohorts parameter to local_evaluation

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -16,6 +16,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework import exceptions, request, serializers, status, viewsets
 from rest_framework.response import Response
+from statshog.defaults.django import statsd
 
 from posthog.schema import PropertyOperator
 
@@ -1366,6 +1367,9 @@ class FeatureFlagViewSet(
         logger = logging.getLogger(__name__)
 
         include_cohorts = "send_cohorts" in request.GET
+
+        # Track send_cohorts parameter usage
+        statsd.incr("posthog_local_evaluation_request", tags={"send_cohorts": str(include_cohorts).lower()})
 
         try:
             # Check if team is quota limited for feature flags


### PR DESCRIPTION
## Problem

We recently updated all the supported clients to ensure they include "send_cohorts" when calling this endpoint.

Now we want to get an idea of how often is this called without that parameter?

## Changes

Add a metric for `local_evaluation` 

## How did you test this code?

Manually

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
