### PR TITLE
chore(myke): add more logs to heap dump

### DIFF
--- a/plugin-server/src/utils/heap-dump.test.ts
+++ b/plugin-server/src/utils/heap-dump.test.ts
@@ -47,7 +47,14 @@ describe('heap-dump', () => {
             }
 
             mockUploadDone = jest.fn().mockImplementation(done)
-            return { done: mockUploadDone }
+
+            // Mock the 'on' method for progress tracking
+            const mockOn = jest.fn()
+
+            return {
+                done: mockUploadDone,
+                on: mockOn,
+            }
         })
         jest.mocked(Upload).mockImplementation(mockUpload)
 
@@ -108,6 +115,8 @@ describe('heap-dump', () => {
                             /^heap-dumps\/\d{4}-\d{2}-\d{2}\/heapdump-test-pod-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.heapsnapshot$/
                         ),
                     }),
+                    partSize: 5 * 1024 * 1024, // 5MB
+                    queueSize: 4,
                 })
             )
             expect(mockUploadDone).toHaveBeenCalled()
@@ -138,6 +147,7 @@ describe('heap-dump', () => {
 
             mockUpload.mockImplementationOnce(() => ({
                 done: jest.fn().mockRejectedValue(testError),
+                on: jest.fn(), // Mock the 'on' method for progress tracking
             }))
 
             await expect(createHeapDump(s3Client, 'test-heap-dumps', 'heap-dumps')).rejects.toThrow(testError)

--- a/plugin-server/src/utils/heap-dump.test.ts
+++ b/plugin-server/src/utils/heap-dump.test.ts
@@ -114,9 +114,8 @@ describe('heap-dump', () => {
                         Key: expect.stringMatching(
                             /^heap-dumps\/\d{4}-\d{2}-\d{2}\/heapdump-test-pod-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.heapsnapshot$/
                         ),
+                        Body: expect.any(Object), // PassThrough stream
                     }),
-                    partSize: 5 * 1024 * 1024, // 5MB
-                    queueSize: 4,
                 })
             )
             expect(mockUploadDone).toHaveBeenCalled()


### PR DESCRIPTION
## Problem

upload seems to be started but never finished and the file never appears in s3.
i need more visibility hence more logs

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added timeout protection and added more logging:

 1. 30-minute timeout - Prevents indefinite hangs by racing upload against timeout promise, automatically aborting if exceeded
 2. Progress tracking - Logs upload progress immediately thenevery 5 seconds with percentage, bytes transferred, and duration
 3.  More granular logging - Added specific logs for snapshot creation, S3 initialization, and upload configuration details
 4. Multipart upload config - Explicitly set 5MB chunks and 4 parallel uploads for better large file handling
 5. Abort on timeout - Calls upload.abort() to properly free resources when timing out


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- tests still pass

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
