### PR TITLE
fix: use simpler query to look up session IDs for set of distinct IDs

### DIFF
--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -443,7 +443,7 @@ class SessionReplayEvents:
         format: Optional[str] = None,
     ):
         """
-        Helper function to build a query for listing all session IDs for a given distinct ID
+        Helper function to build a query for listing all session IDs for a given set of distinct IDs
         """
         query = """
                 SELECT

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -438,6 +438,33 @@ class SessionReplayEvents:
         ).calculate()
         return result.columns, result.results
 
+    @staticmethod
+    def get_sessions_from_distinct_id_query(
+        format: Optional[str] = None,
+    ):
+        """
+        Helper function to build a query for listing all session IDs for a given distinct ID
+        """
+        query = """
+                SELECT
+                    session_id
+                FROM
+                    session_replay_events
+                PREWHERE
+                    team_id = %(team_id)s
+                    AND distinct_id IN (%(distinct_ids)s)
+                    AND min_first_timestamp <= %(python_now)s
+                    AND min_first_timestamp >= %(python_now)s - interval %(ttl_days)s days
+                    AND addDays(dateTrunc('DAY', min_first_timestamp), 1) >= %(python_now)s - interval coalesce(retention_period_days, 365) days
+                GROUP BY
+                    session_id
+                {optional_format_clause}
+                """
+        query = query.format(
+            optional_format_clause=(f"FORMAT {format}" if format else ""),
+        )
+        return query
+
 
 def ttl_days(team: Team) -> int:
     if is_cloud():

--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -6,13 +6,6 @@ import pytz
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
-from posthog.schema import RecordingsQuery
-
-from posthog.hogql.context import HogQLContext
-from posthog.hogql.printer import print_ast
-
-from posthog.models import Team
-from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.session_recordings.session_recording_v2_service import (
     RecordingBlock,
@@ -20,7 +13,6 @@ from posthog.session_recordings.session_recording_v2_service import (
     build_block_list,
 )
 from posthog.storage import session_recording_v2_object_storage
-from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -132,32 +124,18 @@ async def load_recordings_with_person(input: RecordingsWithPersonInput) -> list[
         logger = LOGGER.bind()
         logger.info(f"Loading all sessions for {len(input.distinct_ids)} distinct IDs")
 
-        team = await Team.objects.aget(id=input.team_id)
+        query: str = SessionReplayEvents.get_sessions_from_distinct_id_query(format="JSON")
+        parameters = {
+            "team_id": input.team_id,
+            "distinct_ids": input.distinct_ids,
+            "python_now": datetime.now(pytz.timezone("UTC")),
+            "ttl_days": 365,
+        }
 
-        logger.info("Building ClickHouse query")
-        query = SessionRecordingListFromQuery(
-            team,
-            RecordingsQuery(distinct_ids=input.distinct_ids, date_from=f"-{team.session_recording_retention_period}"),
-        )
-
-        hogql_query = await database_sync_to_async(query.get_query)()
-
-        hogql_context = HogQLContext(
-            team=team,
-            output_format="JSON",
-            enable_select_queries=True,
-        )
-
-        raw_query = await database_sync_to_async(print_ast)(
-            hogql_query,
-            hogql_context,
-            "clickhouse",
-        )
-
-        logger.info("Querying ClickHouse")
+        raw_response: bytes = b""
         async with get_client() as client:
             async with client.aget_query(
-                query=raw_query, query_parameters=hogql_context.values, query_id=str(uuid4())
+                query=query, query_parameters=parameters, query_id=str(uuid4())
             ) as ch_response:
                 raw_response = await ch_response.content.read()
 

--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -132,6 +132,7 @@ async def load_recordings_with_person(input: RecordingsWithPersonInput) -> list[
             "ttl_days": 365,
         }
 
+        logger.info("Querying ClickHouse")
         raw_response: bytes = b""
         async with get_client() as client:
             async with client.aget_query(


### PR DESCRIPTION
Current implementation hits the 1-minute timeout when querying ClickHouse for session IDs. This PR swaps out the query for a much simpler one to get the query-time down.