### PR TITLE
feat: hide hidden properties when listing them 

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 import urllib
-import builtins
+import dataclasses
 from datetime import datetime
 from typing import Any, Iterator, List, Optional, Union  # noqa: UP035
 
@@ -41,6 +41,16 @@ from posthog.utils import convert_property_value, flatten, relative_date_parse
 tracer = trace.get_tracer(__name__)
 
 QUERY_DEFAULT_EXPORT_LIMIT = 3_500
+
+
+@dataclasses.dataclass(frozen=True)
+class EventValueQueryParams:
+    event_names: list[str]
+    is_column: bool
+    key: str
+    team: Team
+    items: Iterator[tuple[str, str | list[object]]]
+    value: str | None
 
 
 class ElementSerializer(serializers.ModelSerializer):
@@ -274,35 +284,33 @@ class EventViewSet(
         if not key:
             raise serializers.ValidationError("You must provide a key")
 
-        event_names = request.GET.getlist("event_name", None)
-        is_column = request.GET.get("is_column", "false").lower() == "true"
+        query_params = EventValueQueryParams(
+            event_names=request.GET.getlist("event_name", None),
+            is_column=request.GET.get("is_column", "false").lower() == "true",
+            key=key,
+            team=team,
+            items=request.GET.items(),
+            value=request.GET.get("value"),
+        )
 
         if key == "custom_event":
-            return self._custom_event_values(team)
+            return self._custom_event_values(query_params)
         else:
             # Check if this property is hidden (enterprise feature)
             if self._is_property_hidden(key, team):
                 return response.Response([])
 
-            return self._event_property_values(
-                event_names, is_column, key, team, request.GET.items(), request.GET.get("value")
-            )
+            return self._event_property_values(query_params)
 
     @tracer.start_as_current_span("events_api_event_property_values")
     def _event_property_values(
         self,
-        # list is defined locally so messy to use as a type :/
-        event_names: builtins.list[str],
-        is_column: bool,
-        key: str,
-        team: Team,
-        items: Iterator[tuple[str, str]],
-        value: str | None,
+        query_params: EventValueQueryParams,
     ) -> response.Response:
-        date_from = relative_date_parse("-7d", team.timezone_info).strftime("%Y-%m-%d 00:00:00")
+        date_from = relative_date_parse("-7d", query_params.team.timezone_info).strftime("%Y-%m-%d 00:00:00")
         date_to = timezone.now().strftime("%Y-%m-%d 23:59:59")
 
-        chain: list[str | int] = [key] if is_column else ["properties", key]
+        chain: list[str | int] = [query_params.key] if query_params.is_column else ["properties", query_params.key]
         conditions: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.GtEq,
@@ -321,7 +329,7 @@ class EventViewSet(
             ),
         ]
         # Handle property filters from query parameters
-        for param_key, param_value in items:
+        for param_key, param_value in query_params.items:
             if param_key.startswith("properties_"):
                 property_key = param_key.replace("properties_", "", 1)
                 try:
@@ -333,29 +341,29 @@ class EventViewSet(
                 except json.JSONDecodeError:
                     # If not JSON, treat as single value
                     conditions.append(create_property_conditions(property_key, param_value))
-        if event_names and len(event_names) > 0:
+        if query_params.event_names and len(query_params.event_names) > 0:
             event_conditions: list[ast.Expr] = [
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
                     left=ast.Field(chain=["event"]),
                     right=ast.Constant(value=event_name),
                 )
-                for event_name in event_names
+                for event_name in query_params.event_names
             ]
             if len(event_conditions) > 1:
                 conditions.append(ast.Or(exprs=event_conditions))
             else:
                 conditions.append(event_conditions[0])
-        if value:
+        if query_params.value:
             conditions.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.ILike,
                     left=ast.Call(name="toString", args=[ast.Field(chain=chain)]),
-                    right=ast.Constant(value=f"%{value}%"),
+                    right=ast.Constant(value=f"%{query_params.value}%"),
                 )
             )
         order_by = []
-        if value:
+        if query_params.value:
             order_by = [
                 ast.OrderExpr(
                     expr=ast.Call(name="length", args=[ast.Call(name="toString", args=[ast.Field(chain=chain)])]),
@@ -370,7 +378,7 @@ class EventViewSet(
             order_by=order_by,
             limit=ast.Constant(value=10),
         )
-        result = execute_hogql_query(query, team=team)
+        result = execute_hogql_query(query, team=query_params.team)
         values = []
         for value in result.results:
             if isinstance(value[0], float | int | bool | uuid.UUID):
@@ -401,7 +409,7 @@ class EventViewSet(
         return property_is_hidden
 
     @tracer.start_as_current_span("events_api_custom_event_values")
-    def _custom_event_values(self, team: Team) -> response.Response:
+    def _custom_event_values(self, query_params: EventValueQueryParams) -> response.Response:
         system_events = [
             event_name
             for event_name in CORE_FILTER_DEFINITIONS_BY_GROUP["events"].keys()
@@ -418,7 +426,7 @@ class EventViewSet(
             ),
             order_by=[ast.OrderExpr(expr=ast.Field(chain=["event"]), order="ASC")],
         )
-        result = execute_hogql_query(query, team=team)
+        result = execute_hogql_query(query, team=query_params.team)
         return response.Response([{"name": event[0]} for event in result.results])
 
 

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 import urllib
+import builtins
 from datetime import datetime
 from typing import Any, Iterator, List, Optional, Union  # noqa: UP035
 
@@ -196,7 +197,7 @@ class EventViewSet(
                 action_id=request.GET.get("action_id"),
             )
 
-            # Retry the query without the 1 day optimization
+            # Retry the query without the 1-day optimization
             if len(query_result) < limit:
                 query_result = query_events_list(
                     unbounded_date_from=True,  # only this changed from the query above
@@ -290,7 +291,8 @@ class EventViewSet(
     @tracer.start_as_current_span("events_api_event_property_values")
     def _event_property_values(
         self,
-        event_names: list[str],
+        # list is defined locally so messy to use as a type :/
+        event_names: builtins.list[str],
         is_column: bool,
         key: str,
         team: Team,
@@ -299,6 +301,7 @@ class EventViewSet(
     ) -> response.Response:
         date_from = relative_date_parse("-7d", team.timezone_info).strftime("%Y-%m-%d 00:00:00")
         date_to = timezone.now().strftime("%Y-%m-%d 23:59:59")
+
         chain: list[str | int] = [key] if is_column else ["properties", key]
         conditions: list[ast.Expr] = [
             ast.CompareOperation(

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -25,7 +25,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.clickhouse.client import query_with_columns
 from posthog.exceptions_capture import capture_exception
-from posthog.models import Element, Filter, Person
+from posthog.models import Element, Filter, Person, PropertyDefinition
 from posthog.models.event.query_event_list import query_events_list
 from posthog.models.event.sql import SELECT_ONE_EVENT_SQL
 from posthog.models.event.util import ClickhouseEventSerializer
@@ -299,7 +299,7 @@ class EventViewSet(
                 hidden_property_exists = EnterprisePropertyDefinition.objects.filter(
                     team=team,
                     name=key,
-                    type=1,  # PropertyDefinition.Type.EVENT
+                    type=PropertyDefinition.Type.EVENT.value,
                     hidden=True,
                 ).exists()
                 if hidden_property_exists:

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -263,6 +263,42 @@
                     allow_experimental_join_condition=1
   '''
 # ---
+# name: TestEvents.test_event_property_values_with_hidden_properties
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'visible_prop'), ''), 'null'), '^"|"$', '') AS visible_prop
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'visible_prop'), ''), 'null'), '^"|"$', '')))
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestEvents.test_event_property_values_with_hidden_properties_materialized
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT nullIf(nullIf(events.mat_visible_prop, ''), 'null') AS visible_prop
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2025-09-24 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2025-10-01 23:59:59'), isNotNull(nullIf(nullIf(events.mat_visible_prop, ''), 'null')))
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestEvents.test_event_property_values_without_hidden_properties
   '''
   /* user_id:0 request:_snapshot_ */

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -131,21 +131,6 @@
                     allow_experimental_join_condition=1
   '''
 # ---
-# name: TestEvents.test_event_property_values.7
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
-  FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = '404_i_dont_exist')
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
-  '''
-# ---
 # name: TestEvents.test_event_property_values_materialized
   '''
   /* user_id:0 request:_snapshot_ */
@@ -278,18 +263,39 @@
                     allow_experimental_join_condition=1
   '''
 # ---
-# name: TestEvents.test_event_property_values_materialized.7
+# name: TestEvents.test_event_property_values_without_hidden_properties
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', '') AS test_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = '404_i_dont_exist')
-    AND "mat_random_prop" ILIKE '%qw%'
-  order by length("mat_random_prop")
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', '')))
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestEvents.test_event_property_values_without_hidden_properties_materialized
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT nullIf(nullIf(events.mat_test_prop, ''), 'null') AS test_prop
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2025-09-24 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2025-10-01 23:59:59'), isNotNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
   '''
 # ---

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -64,17 +64,14 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=2").json()
-        self.assertEqual(
-            response["results"][0]["person"],
-            {
-                "distinct_ids": ["2"],
-                "is_identified": True,
-                "properties": {"email": "tim@posthog.com"},
-            },
-        )
-        self.assertEqual(response["results"][0]["elements"][0]["tag_name"], "button")
-        self.assertEqual(response["results"][0]["elements"][0]["order"], 0)
-        self.assertEqual(response["results"][0]["elements"][1]["order"], 1)
+        assert response["results"][0]["person"] == {
+            "distinct_ids": ["2"],
+            "is_identified": True,
+            "properties": {"email": "tim@posthog.com"},
+        }
+        assert response["results"][0]["elements"][0]["tag_name"] == "button"
+        assert response["results"][0]["elements"][0]["order"] == 0
+        assert response["results"][0]["elements"][1]["order"] == 1
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_filter_events_by_event_name(self):
@@ -101,7 +98,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         # instance setting check, person and distinct id
         with self.assertNumQueries(10):
             response = self.client.get(f"/api/projects/{self.team.id}/events/?event=event_name").json()
-            self.assertEqual(response["results"][0]["event"], "event_name")
+            assert response["results"][0]["event"] == "event_name"
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_filter_events_by_properties(self):
@@ -134,17 +131,14 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                 f"/api/projects/{self.team.id}/events/?properties=%s"
                 % (json.dumps([{"key": "$browser", "value": "Safari"}]))
             ).json()
-        self.assertEqual(response["results"][0]["id"], event2_uuid)
+        assert response["results"][0]["id"] == event2_uuid
 
         properties = "invalid_json"
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?properties={properties}")
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertDictEqual(
-            response.json(),
-            self.validation_error_response("Properties are unparsable!", "invalid_input"),
-        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == self.validation_error_response("Properties are unparsable!", "invalid_input")
 
     def test_filter_events_by_precalculated_cohort(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
@@ -186,7 +180,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                     % (json.dumps([{"key": "id", "value": cohort1.id, "type": "cohort"}]))
                 ).json()
 
-        self.assertEqual(len(response["results"]), 2)
+        assert len(response["results"]) == 2
 
     def test_filter_by_person(self):
         person = _create_person(
@@ -217,16 +211,16 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?person_id={person.pk}").json()
-        self.assertEqual(len(response["results"]), 2)
-        self.assertEqual(response["results"][0]["elements"], [])
+        assert len(response["results"]) == 2
+        assert response["results"][0]["elements"] == []
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?person_id={person.uuid}").json()
-        self.assertEqual(len(response["results"]), 2)
+        assert len(response["results"]) == 2
 
     def test_filter_by_nonexisting_person(self):
         response = self.client.get(f"/api/projects/{self.team.id}/events/?person_id=5555555555")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()["results"]), 0)
+        assert response.status_code == 200
+        assert len(response.json()["results"]) == 0
 
     @freeze_time("2020-01-10")
     def test_event_column_values(self):
@@ -275,25 +269,23 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         # distinct_id
         response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=distinct_id&is_column=true").json()
-        self.assertEqual(sorted(x["name"] for x in response), sorted(["bla", "ble", "blu"]))
+        assert sorted(x["name"] for x in response) == sorted(["bla", "ble", "blu"])
 
         # event
         response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=event&is_column=true").json()
-        self.assertEqual(
-            sorted(x["name"] for x in response), sorted(["another random event", "random event 1", "random event 2"])
+        assert sorted(x["name"] for x in response) == sorted(
+            ["another random event", "random event 1", "random event 2"]
         )
 
         # person_id
         response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=person_id&is_column=true").json()
-        self.assertEqual(
-            sorted(x["name"] for x in response), sorted([str(person3.uuid), str(person2.uuid), str(person1.uuid)])
-        )
+        assert sorted(x["name"] for x in response) == sorted([str(person3.uuid), str(person2.uuid), str(person1.uuid)])
 
         # Search
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/values/?key=event&is_column=true&value=another"
         ).json()
-        self.assertEqual(response, [{"name": "another random event"}])
+        assert response == [{"name": "another random event"}]
 
     def test_custom_event_values(self):
         events = ["test", "new event", "another event"]
@@ -308,7 +300,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                 },
             )
         response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=custom_event").json()
-        self.assertListEqual(sorted(events), sorted(event["name"] for event in response))
+        assert sorted(events) == sorted(event["name"] for event in response)
 
     @also_test_with_materialized_columns(["random_prop"])
     @snapshot_clickhouse_queries
@@ -396,45 +388,42 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=random_prop").json()
 
             keys = [resp["name"].replace(" ", "") for resp in response]
-            self.assertCountEqual(
-                keys,
-                [
-                    "asdf",
-                    "qwerty",
-                    "565",
-                    "false",
-                    "true",
-                    '{"first_name":"Mary","last_name":"Smith"}',
-                    "item1",
-                    "item2",
-                    "item3",
-                ],
-            )
-            self.assertEqual(len(response), 9)
+            assert set(keys) == {
+                "asdf",
+                "qwerty",
+                "565",
+                "false",
+                "true",
+                '{"first_name":"Mary","last_name":"Smith"}',
+                "item1",
+                "item2",
+                "item3",
+            }
+            assert len(response) == 9
 
             response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=random_prop&value=qw").json()
-            self.assertEqual(response[0]["name"], "qwerty")
+            assert response[0]["name"] == "qwerty"
 
             response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=random_prop&value=QW").json()
-            self.assertEqual(response[0]["name"], "qwerty")
+            assert response[0]["name"] == "qwerty"
 
             response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=random_prop&value=6").json()
-            self.assertEqual(response[0]["name"], "565")
+            assert response[0]["name"] == "565"
 
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&value=6&event_name=random event"
             ).json()
-            self.assertEqual(response[0]["name"], "565")
+            assert response[0]["name"] == "565"
 
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&value=6&event_name=foo&event_name=random event"
             ).json()
-            self.assertEqual(response[0]["name"], "565")
+            assert response[0]["name"] == "565"
 
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&value=qw&event_name=404_i_dont_exist"
             ).json()
-            self.assertEqual(response, [])
+            assert response == []
 
     @freeze_time("2020-01-20 20:00:00")
     @also_test_with_materialized_columns(["test_prop"])
@@ -464,10 +453,10 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         # When property is not hidden, all values should be returned
         keys = [resp["name"] for resp in response]
-        self.assertIn("visible_value", keys)
-        self.assertIn("hidden_value", keys)
-        self.assertIn("another_visible", keys)
-        self.assertEqual(len(response), 3)
+        assert "visible_value" in keys
+        assert "hidden_value" in keys
+        assert "another_visible" in keys
+        assert len(response) == 3
 
     @freeze_time("2020-01-20 20:00:00")
     @also_test_with_materialized_columns(["hidden_prop", "visible_prop"])
@@ -500,14 +489,14 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         # Test hidden property returns no values
         hidden_response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=hidden_prop").json()
-        self.assertEqual(len(hidden_response), 0)
+        assert len(hidden_response) == 0
 
         # Test visible property still returns values
         visible_response = self.client.get(f"/api/projects/{self.team.id}/events/values/?key=visible_prop").json()
-        self.assertEqual(len(visible_response), 2)
+        assert len(visible_response) == 2
         visible_keys = [resp["name"] for resp in visible_response]
-        self.assertIn("should_appear", visible_keys)
-        self.assertIn("also_visible", visible_keys)
+        assert "should_appear" in visible_keys
+        assert "also_visible" in visible_keys
 
     def test_property_values_with_property_filters(self):
         with freeze_time("2020-01-20 20:00:00"):
@@ -534,15 +523,15 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop=value1"
             ).json()
-            self.assertEqual(len(response), 2)
-            self.assertCountEqual([r["name"] for r in response], ["asdf", "qwerty"])
+            assert len(response) == 2
+            assert {r["name"] for r in response} == {"asdf", "qwerty"}
 
             # Test array property filter
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop={json.dumps(['value1', 'value2'])}"
             ).json()
-            self.assertEqual(len(response), 3)
-            self.assertCountEqual([r["name"] for r in response], ["asdf", "qwerty", "no match"])
+            assert len(response) == 3
+            assert {r["name"] for r in response} == {"asdf", "qwerty", "no match"}
 
             # Test multiple property filters
             _create_event(
@@ -554,8 +543,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop=value1&properties_another_filter=other1"
             ).json()
-            self.assertEqual(len(response), 1)
-            self.assertEqual(response[0]["name"], "both filters")
+            assert len(response) == 1
+            assert response[0]["name"] == "both filters"
 
     def test_property_values_with_property_filters_error_handling(self):
         with freeze_time("2020-01-20 20:00:00"):
@@ -576,26 +565,26 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop=[value1,value2"
             ).json()
-            self.assertEqual(len(response), 0)  # No matches because "[value1,value2" is treated as a literal string
+            assert len(response) == 0  # No matches because "[value1,value2" is treated as a literal string
 
             # Empty value
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop="
             ).json()
-            self.assertEqual(len(response), 0)
+            assert len(response) == 0
 
             # Invalid JSON object - should be treated as a single value
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop={{invalid:json}}"
             ).json()
-            self.assertEqual(len(response), 0)
+            assert len(response) == 0
 
             # Array with mixed types - should convert all values to strings for comparison
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop={json.dumps(['123', 'true', 'value1'])}"
             ).json()
-            self.assertEqual(len(response), 2)  # Should match both values since filter_prop="value1" exists
-            self.assertCountEqual([r["name"] for r in response], ["asdf", "qwerty"])
+            assert len(response) == 2  # Should match both values since filter_prop="value1" exists
+            assert {r["name"] for r in response} == {"asdf", "qwerty"}
 
             # Test with non-string property values
             _create_event(
@@ -607,8 +596,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop={json.dumps(['TRUE'])}"
             ).json()
-            self.assertEqual(len(response), 1)  # Should match because "TRUE".lower() == "true"
-            self.assertEqual(response[0]["name"], "123")  # The value should be preserved as a string
+            assert len(response) == 1  # Should match because "TRUE".lower() == "true"
+            assert response[0]["name"] == "123"  # The value should be preserved as a string
 
     def test_before_and_after(self):
         user = self._create_user("tim")
@@ -629,37 +618,37 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         # with relative values
         with freeze_time("2020-01-11T12:03:03.829294Z"):
             response = self.client.get(f"/api/projects/{self.team.id}/events/?after=4d&before=1d").json()
-            self.assertEqual(len(response["results"]), 2)
+            assert len(response["results"]) == 2
 
             response = self.client.get(f"/api/projects/{self.team.id}/events/?after=6d&before=2h").json()
-            self.assertEqual(len(response["results"]), 3)
+            assert len(response["results"]) == 3
 
             response = self.client.get(f"/api/projects/{self.team.id}/events/?before=4d").json()
-            self.assertEqual(len(response["results"]), 1)
+            assert len(response["results"]) == 1
 
         action = Action.objects.create(team=self.team, steps_json=[{"event": "sign up"}])
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?after=2020-01-09T00:00:00.000Z&action_id=%s" % action.pk
         ).json()
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual(response["results"][0]["id"], event1_uuid)
+        assert len(response["results"]) == 1
+        assert response["results"][0]["id"] == event1_uuid
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?before=2020-01-09T00:00:00.000Z&action_id=%s" % action.pk
         ).json()
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual(response["results"][0]["id"], event2_uuid)
+        assert len(response["results"]) == 1
+        assert response["results"][0]["id"] == event2_uuid
 
         # without action
         response = self.client.get(f"/api/projects/{self.team.id}/events/?after=2020-01-09T00:00:00.000Z").json()
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual(response["results"][0]["id"], event1_uuid)
+        assert len(response["results"]) == 1
+        assert response["results"][0]["id"] == event1_uuid
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?before=2020-01-09T00:00:00.000Z").json()
-        self.assertEqual(len(response["results"]), 2)
-        self.assertEqual(response["results"][0]["id"], event2_uuid)
-        self.assertEqual(response["results"][1]["id"], event3_uuid)
+        assert len(response["results"]) == 2
+        assert response["results"][0]["id"] == event2_uuid
+        assert response["results"][1]["id"] == event3_uuid
 
     def test_pagination(self):
         with freeze_time("2021-10-10T12:03:03.829294Z"):
@@ -672,39 +661,37 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                     timestamp=timezone.now() - relativedelta(months=11) + relativedelta(days=idx, seconds=idx),
                 )
             response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=1").json()
-            self.assertEqual(len(response["results"]), 100)
-            self.assertIn(
-                f"http://testserver/api/projects/{self.team.id}/events/?distinct_id=1&before=",
-                unquote(response["next"]),
+            assert len(response["results"]) == 100
+            assert f"http://testserver/api/projects/{self.team.id}/events/?distinct_id=1&before=" in unquote(
+                response["next"]
             )
             response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=1").json()
-            self.assertEqual(len(response["results"]), 100)
-            self.assertIn(
-                f"http://testserver/api/projects/{self.team.id}/events/?distinct_id=1&before=",
-                unquote(response["next"]),
+            assert len(response["results"]) == 100
+            assert f"http://testserver/api/projects/{self.team.id}/events/?distinct_id=1&before=" in unquote(
+                response["next"]
             )
 
             page2 = self.client.get(response["next"]).json()
 
             from posthog.clickhouse.client import sync_execute
 
-            self.assertEqual(
+            assert (
                 sync_execute(
                     "select count(*) from events where team_id = %(team_id)s",
                     {"team_id": self.team.pk},
-                )[0][0],
-                250,
+                )[0][0]
+                == 250
             )
 
-            self.assertEqual(len(page2["results"]), 100)
-            self.assertEqual(
-                unquote(page2["next"]),
-                f"http://testserver/api/projects/{self.team.id}/events/?distinct_id=1&before=2020-12-30T12:03:53.829294+00:00",
+            assert len(page2["results"]) == 100
+            assert (
+                unquote(page2["next"])
+                == f"http://testserver/api/projects/{self.team.id}/events/?distinct_id=1&before=2020-12-30T12:03:53.829294+00:00"
             )
 
             page3 = self.client.get(page2["next"]).json()
-            self.assertEqual(len(page3["results"]), 50)
-            self.assertIsNone(page3["next"])
+            assert len(page3["results"]) == 50
+            assert page3["next"] is None
 
     def test_pagination_bounded_date_range(self):
         with freeze_time("2021-10-10T12:03:03.829294Z"):
@@ -722,37 +709,37 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                     timestamp=now + relativedelta(days=idx, seconds=-idx),
                 )
             response = self.client.get(f"/api/projects/{self.team.id}/events/?{params_string}").json()
-            self.assertEqual(len(response["results"]), 10)
-            self.assertIn("before=", unquote(response["next"]))
-            self.assertIn(f"after={after}", unquote(response["next"]))
+            assert len(response["results"]) == 10
+            assert "before=" in unquote(response["next"])
+            assert f"after={after}" in unquote(response["next"])
 
             params = {"distinct_id": "1", "after": after, "before": before, "limit": 10}
             params_string = urlencode(params)
 
             response = self.client.get(f"/api/projects/{self.team.id}/events/?{params_string}").json()
-            self.assertEqual(len(response["results"]), 10)
-            self.assertIn(f"before=", unquote(response["next"]))
-            self.assertIn(f"after={after}", unquote(response["next"]))
+            assert len(response["results"]) == 10
+            assert "before=" in unquote(response["next"])
+            assert f"after={after}" in unquote(response["next"])
 
             page2 = self.client.get(response["next"]).json()
 
             from posthog.clickhouse.client import sync_execute
 
-            self.assertEqual(
+            assert (
                 sync_execute(
                     "select count(*) from events where team_id = %(team_id)s",
                     {"team_id": self.team.pk},
-                )[0][0],
-                25,
+                )[0][0]
+                == 25
             )
 
-            self.assertEqual(len(page2["results"]), 10)
-            self.assertIn(f"before=", unquote(page2["next"]))
-            self.assertIn(f"after={after}", unquote(page2["next"]))
+            assert len(page2["results"]) == 10
+            assert "before=" in unquote(page2["next"])
+            assert f"after={after}" in unquote(page2["next"])
 
             page3 = self.client.get(page2["next"]).json()
-            self.assertEqual(len(page3["results"]), 3)
-            self.assertIsNone(page3["next"])
+            assert len(page3["results"]) == 3
+            assert page3["next"] is None
 
     def test_ascending_order_timestamp(self):
         for idx in range(20):
@@ -766,11 +753,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?distinct_id=1&limit=10&orderBy={json.dumps(['timestamp'])}"
         ).json()
-        self.assertEqual(len(response["results"]), 10)
-        self.assertLess(
-            parser.parse(response["results"][0]["timestamp"]),
-            parser.parse(response["results"][-1]["timestamp"]),
-        )
+        assert len(response["results"]) == 10
+        assert parser.parse(response["results"][0]["timestamp"]) < parser.parse(response["results"][-1]["timestamp"])
         assert "after=" in response["next"]
 
     def test_default_descending_order_timestamp(self):
@@ -783,11 +767,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=1&limit=10").json()
-        self.assertEqual(len(response["results"]), 10)
-        self.assertGreater(
-            parser.parse(response["results"][0]["timestamp"]),
-            parser.parse(response["results"][-1]["timestamp"]),
-        )
+        assert len(response["results"]) == 10
+        assert parser.parse(response["results"][0]["timestamp"]) > parser.parse(response["results"][-1]["timestamp"])
         assert "before=" in response["next"]
 
     def test_specified_descending_order_timestamp(self):
@@ -802,19 +783,16 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?distinct_id=1&limit=10&orderBy={json.dumps(['-timestamp'])}"
         ).json()
-        self.assertEqual(len(response["results"]), 10)
-        self.assertGreater(
-            parser.parse(response["results"][0]["timestamp"]),
-            parser.parse(response["results"][-1]["timestamp"]),
-        )
+        assert len(response["results"]) == 10
+        assert parser.parse(response["results"][0]["timestamp"]) > parser.parse(response["results"][-1]["timestamp"])
         assert "before=" in response["next"]
 
     def test_action_no_steps(self):
         action = Action.objects.create(team=self.team)
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?action_id=%s" % action.pk)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()["results"]), 0)
+        assert response.status_code == 200
+        assert len(response.json()["results"]) == 0
 
     def test_get_single_action(self):
         event1_uuid = _create_event(
@@ -824,9 +802,9 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             properties={"key": "test_val"},
         )
         response = self.client.get(f"/api/projects/{self.team.id}/events/%s/" % event1_uuid)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["event"], "sign up")
-        self.assertEqual(response.json()["properties"], {"key": "test_val"})
+        assert response.status_code == 200
+        assert response.json()["event"] == "sign up"
+        assert response.json()["properties"] == {"key": "test_val"}
 
     def test_events_in_future(self):
         with freeze_time("2012-01-15T04:01:34.000Z"):
@@ -846,7 +824,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
         with freeze_time("2012-01-15T04:01:34.000Z"):
             response = self.client.get(f"/api/projects/{self.team.id}/events/").json()
-        self.assertEqual(len(response["results"]), 1)
+        assert len(response["results"]) == 1
 
     def test_get_event_by_id(self):
         _create_person(
@@ -858,29 +836,23 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         event_id = _create_event(team=self.team, event="event", distinct_id="1", timestamp=timezone.now())
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
-        self.assertEqual(response_json["event"], "event")
-        self.assertIsNone(response_json["person"])
+        assert response_json["event"] == "event"
+        assert response_json["person"] is None
 
         with_person_response = self.client.get(f"/api/projects/{self.team.id}/events/{event_id}?include_person=true")
-        self.assertEqual(with_person_response.status_code, status.HTTP_200_OK)
+        assert with_person_response.status_code == status.HTTP_200_OK
         with_person_response_json = with_person_response.json()
-        self.assertEqual(with_person_response_json["event"], "event")
-        self.assertIsNotNone(with_person_response_json["person"])
+        assert with_person_response_json["event"] == "event"
+        assert with_person_response_json["person"] is not None
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/123456")
         # EE will inform the user the ID passed is not a valid UUID
-        self.assertIn(
-            response.status_code,
-            [status.HTTP_404_NOT_FOUND, status.HTTP_400_BAD_REQUEST],
-        )
+        assert response.status_code in [status.HTTP_404_NOT_FOUND, status.HTTP_400_BAD_REQUEST]
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/im_a_string_not_an_integer")
-        self.assertIn(
-            response.status_code,
-            [status.HTTP_404_NOT_FOUND, status.HTTP_400_BAD_REQUEST],
-        )
+        assert response.status_code in [status.HTTP_404_NOT_FOUND, status.HTTP_400_BAD_REQUEST]
 
     def test_limit(self):
         _create_person(
@@ -914,17 +886,17 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?limit=1").json()
-        self.assertEqual(1, len(response["results"]))
+        assert len(response["results"]) == 1
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?limit=2").json()
-        self.assertEqual(2, len(response["results"]))
+        assert len(response["results"]) == 2
 
     def test_get_events_with_specified_token(self):
         _, _, user2 = User.objects.bootstrap("Test", "team2@posthog.com", None)
         assert user2.team is not None
         assert self.team is not None
 
-        self.assertNotEqual(user2.team.id, self.team.id)
+        assert user2.team.id != self.team.id
 
         event1_uuid = _create_event(
             team=self.team,
@@ -959,15 +931,15 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             data={"token": user2.team.api_token},
         )
 
-        self.assertEqual(response_team1.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_team1_token.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_team1.json(), response_team1_token.json())
-        self.assertNotEqual(response_team1.json(), response_team2_event2.json())
-        self.assertEqual(response_team2_event1.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response_team2_event2.status_code, status.HTTP_200_OK)
+        assert response_team1.status_code == status.HTTP_200_OK
+        assert response_team1_token.status_code == status.HTTP_200_OK
+        assert response_team1.json() == response_team1_token.json()
+        assert response_team1.json() != response_team2_event2.json()
+        assert response_team2_event1.status_code == status.HTTP_403_FORBIDDEN
+        assert response_team2_event2.status_code == status.HTTP_200_OK
 
         response_invalid_token = self.client.get(f"/api/projects/{self.team.id}/events?token=invalid")
-        self.assertEqual(response_invalid_token.status_code, 401)
+        assert response_invalid_token.status_code == 401
 
     @patch("posthog.models.event.query_event_list.insight_query_with_columns")
     def test_optimize_query(self, patch_query_with_columns):
@@ -985,8 +957,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             }
         ]
         response = self.client.get(f"/api/projects/{self.team.id}/events/").json()
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual(patch_query_with_columns.call_count, 2)
+        assert len(response["results"]) == 1
+        assert patch_query_with_columns.call_count == 2
 
         patch_query_with_columns.return_value = [
             {
@@ -1001,7 +973,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             for _ in range(0, 100)
         ]
         response = self.client.get(f"/api/projects/{self.team.id}/events/").json()
-        self.assertEqual(patch_query_with_columns.call_count, 3)
+        assert patch_query_with_columns.call_count == 3
 
     @patch("posthog.models.event.query_event_list.insight_query_with_columns", wraps=insight_query_with_columns)
     def test_optimize_query_with_bounded_dates(self, patch_query_with_columns):
@@ -1019,8 +991,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?after=2021-01-01&before=2024-01-01T02:02:02Z"
         ).json()
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual(patch_query_with_columns.call_count, 2)
+        assert len(response["results"]) == 1
+        assert patch_query_with_columns.call_count == 2
 
         [
             _create_event(
@@ -1035,16 +1007,16 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?after=2023-01-01T01:01:00Z&before=2024-01-01T02:02:01Z"
         ).json()
-        self.assertEqual(patch_query_with_columns.call_count, 3)
-        self.assertEqual(len(response["results"]), 100)
+        assert patch_query_with_columns.call_count == 3
+        assert len(response["results"]) == 100
 
         # Test for the bug where we wouldn't respect ?after if we had more 100 results on the same day
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?after=2024-01-01T01:02:00Z&before=2024-01-01T01:04:01Z"
         ).json()
-        self.assertEqual(len(response["results"]), 99)
-        self.assertEqual(patch_query_with_columns.call_count, 5)
-        self.assertIsNone(response["next"])
+        assert len(response["results"]) == 99
+        assert patch_query_with_columns.call_count == 5
+        assert response["next"] is None
 
     def test_filter_events_by_being_after_properties_with_date_type(self):
         journeys_for(
@@ -1083,11 +1055,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
         ).json()
 
-        self.assertEqual(len(response["results"]), 2)
-        self.assertEqual(
-            [r["event"] for r in response["results"]],
-            ["should_be_included", "should_be_included"],
-        )
+        assert len(response["results"]) == 2
+        assert [r["event"] for r in response["results"]] == ["should_be_included", "should_be_included"]
 
     def test_filter_events_by_being_before_properties_with_date_type(self):
         journeys_for(
@@ -1125,8 +1094,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
         ).json()
 
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual([r["event"] for r in response["results"]], ["should_be_included"])
+        assert len(response["results"]) == 1
+        assert [r["event"] for r in response["results"]] == ["should_be_included"]
 
     def test_filter_events_with_date_format(self):
         journeys_for(
@@ -1171,5 +1140,5 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
         ).json()
 
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual([r["event"] for r in response["results"]], ["should_be_included"])
+        assert len(response["results"]) == 1
+        assert [r["event"] for r in response["results"]] == ["should_be_included"]

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -523,14 +523,12 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop=value1"
             ).json()
-            assert len(response) == 2
             assert {r["name"] for r in response} == {"asdf", "qwerty"}
 
             # Test array property filter
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop={json.dumps(['value1', 'value2'])}"
             ).json()
-            assert len(response) == 3
             assert {r["name"] for r in response} == {"asdf", "qwerty", "no match"}
 
             # Test multiple property filters
@@ -583,7 +581,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/values/?key=random_prop&properties_filter_prop={json.dumps(['123', 'true', 'value1'])}"
             ).json()
-            assert len(response) == 2  # Should match both values since filter_prop="value1" exists
             assert {r["name"] for r in response} == {"asdf", "qwerty"}
 
             # Test with non-string property values
@@ -1055,7 +1052,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
         ).json()
 
-        assert len(response["results"]) == 2
         assert [r["event"] for r in response["results"]] == ["should_be_included", "should_be_included"]
 
     def test_filter_events_by_being_before_properties_with_date_type(self):
@@ -1094,7 +1090,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
         ).json()
 
-        assert len(response["results"]) == 1
         assert [r["event"] for r in response["results"]] == ["should_be_included"]
 
     def test_filter_events_with_date_format(self):
@@ -1140,5 +1135,4 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
         ).json()
 
-        assert len(response["results"]) == 1
         assert [r["event"] for r in response["results"]] == ["should_be_included"]


### PR DESCRIPTION
see: https://posthog.slack.com/archives/C02E3BKC78F/p1759273737971579

when we list the properties for an event we don't take into account if the property has been hidden by users

but, well, we should

i couldn't bare to leave the code i found as it was, so it might be worth reviewing in commit order