### PR TITLE
fix(replay): disable playlist actions if no recordings in the list

### DIFF
--- a/frontend/src/scenes/session-recordings/components/PanelSettings.tsx
+++ b/frontend/src/scenes/session-recordings/components/PanelSettings.tsx
@@ -30,6 +30,7 @@ interface SettingsMenuProps extends Omit<LemonMenuProps, 'items' | 'children'> {
      * Whether the button should be rounded or not
      */
     rounded?: boolean
+    disabledReason?: string
 }
 
 export function SettingsBar({
@@ -65,6 +66,7 @@ export function SettingsMenu({
     highlightWhenActive = true,
     whenUnavailable,
     rounded = false,
+    disabledReason,
     ...props
 }: SettingsMenuProps): JSX.Element {
     const active = items.some((cf) => !!cf.active)
@@ -80,6 +82,7 @@ export function SettingsMenu({
                 status={highlightWhenActive && active ? 'danger' : 'default'}
                 size="xsmall"
                 icon={icon}
+                disabledReason={disabledReason}
             >
                 {label}
             </LemonButton>

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -41,13 +41,16 @@ function getLabel(filters: RecordingUniversalFilters): string {
 function SortedBy({
     filters,
     setFilters,
+    disabledReason,
 }: {
     filters: RecordingUniversalFilters
     setFilters: (filters: Partial<RecordingUniversalFilters>) => void
+    disabledReason?: string
 }): JSX.Element {
     return (
         <SettingsMenu
             highlightWhenActive={false}
+            disabledReason={disabledReason}
             items={[
                 {
                     label: 'Start time',
@@ -332,9 +335,11 @@ export function SessionRecordingsPlaylistTopSettings({
             <div className="flex items-center">
                 <LemonCheckbox
                     disabledReason={
-                        recordings.length > MAX_SELECTED_RECORDINGS
-                            ? `Cannot select more than ${MAX_SELECTED_RECORDINGS} recordings at once`
-                            : undefined
+                        recordings.length === 0
+                            ? 'No recordings'
+                            : recordings.length > MAX_SELECTED_RECORDINGS
+                              ? `Cannot select more than ${MAX_SELECTED_RECORDINGS} recordings at once`
+                              : undefined
                     }
                     checked={checked}
                     onChange={(checked) => handleSelectUnselectAll(checked, type)}
@@ -345,7 +350,12 @@ export function SessionRecordingsPlaylistTopSettings({
                 />
                 {filters && setFilters ? (
                     <span className="text-xs font-normal inline-flex items-center ml-2">
-                        Sort by: <SortedBy filters={filters} setFilters={setFilters} />
+                        Sort by:{' '}
+                        <SortedBy
+                            filters={filters}
+                            setFilters={setFilters}
+                            disabledReason={recordings.length === 0 ? 'No recordings' : undefined}
+                        />
                     </span>
                 ) : null}
             </div>
@@ -381,6 +391,7 @@ export function SessionRecordingsPlaylistTopSettings({
                         },
                     ]}
                     icon={<IconEllipsis className="rotate-90" />}
+                    disabledReason={recordings.length === 0 ? 'No recordings' : undefined}
                 />
             </div>
             <ConfirmDeleteRecordings shortId={shortId} />


### PR DESCRIPTION
We should disable playlist actions if there are no recordings in the list

That includes:

- multi select
- sorting
- other

<img width="389" height="272" alt="Screenshot 2025-10-01 at 14 21 08" src="https://github.com/user-attachments/assets/45047c0c-e2be-4f03-afa9-f32f4c589e23" />
