### PR TITLE
chore: Add git-secrets setup script

### DIFF
--- a/bin/setup-git-secrets
+++ b/bin/setup-git-secrets
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Setting up git-secrets..."
+
+if ! command -v git-secrets &> /dev/null; then
+    echo "git-secrets is not installed."
+    echo ""
+    echo "Please install it first:"
+    echo "  macOS:   brew install git-secrets"
+    echo "  Linux:   Follow instructions at https://github.com/awslabs/git-secrets#installing-git-secrets"
+    echo ""
+    exit 1
+fi
+
+git secrets --install --force
+git secrets --register-aws
+
+echo "✅ git-secrets hooks installed successfully!"
+echo ""
+echo "The following hooks have been configured:"
+echo "  - pre-commit: Scans staged files for secrets"
+echo "  - commit-msg: Scans commit messages for secrets"
+echo "  - prepare-commit-msg: Prepares commit message scanning"
+echo ""
+echo "AWS secret patterns have been registered."


### PR DESCRIPTION
## Summary
- Adds a `./bin/setup-git-secrets` script to enable git-secrets hooks for preventing secrets from being committed

## Details
This PR introduces a setup script that installs [git-secrets](https://github.com/awslabs/git-secrets) hooks locally. The tool helps prevent developers from accidentally committing AWS credentials and other secrets to the repository.

The script installs three git hooks:
- **pre-commit**: Scans staged files for secrets before commit
- **commit-msg**: Scans commit messages for secrets
- **prepare-commit-msg**: Prepares commit message scanning

AWS secret patterns are registered by default.

## Usage
Developers can run:
```bash
./bin/setup-git-secrets
```

## Test plan
- [x] Script checks if git-secrets is installed
- [x] Script provides installation instructions if not found
- [x] Hooks are installed successfully when git-secrets is available
- [x] AWS patterns are registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)