### PR TITLE
chore(kafka-dedup): refactor deduplication logic

### DIFF
--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -7,6 +7,13 @@ use serde_json::Value;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use uuid::Uuid;
 
+/// Information about the library/SDK that sent an event
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LibraryInfo {
+    pub name: String,
+    pub version: Option<String>,
+}
+
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct RawEvent {
     #[serde(
@@ -237,6 +244,24 @@ impl RawEvent {
         if let Some(value) = self.properties.get_mut(key) {
             *value = f(value.take());
         }
+    }
+
+    /// Extract library information from the event properties
+    /// Returns None if $lib property is not present
+    pub fn extract_library_info(&self) -> Option<LibraryInfo> {
+        let name = self
+            .properties
+            .get("$lib")
+            .and_then(|v| v.as_str())
+            .map(String::from)?;
+
+        let version = self
+            .properties
+            .get("$lib_version")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        Some(LibraryInfo { name, version })
     }
 }
 

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -335,7 +335,9 @@ mod tests {
 
     use super::*;
     use crate::checkpoint::CheckpointConfig;
-    use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
+    use crate::store::{
+        DeduplicationStore, DeduplicationStoreConfig, TimestampKey, TimestampMetadata,
+    };
 
     use common_types::RawEvent;
     use tempfile::TempDir;
@@ -394,7 +396,9 @@ mod tests {
 
         // Add an event to the store
         let event = create_test_event();
-        store.handle_event_with_raw(&event).unwrap();
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
 
         let tmp_checkpoint_dir = TempDir::new().unwrap();
         let config = CheckpointConfig {
@@ -452,7 +456,9 @@ mod tests {
 
         // Add an event to the store
         let event = create_test_event();
-        store.handle_event_with_raw(&event).unwrap();
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
 
         let partition = Partition::new("some_test_topic".to_string(), 0);
 

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -643,7 +643,9 @@ impl Drop for CheckpointManager {
 mod tests {
     use super::*;
     use crate::checkpoint::worker::CheckpointTarget;
-    use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
+    use crate::store::{
+        DeduplicationStore, DeduplicationStoreConfig, TimestampKey, TimestampMetadata,
+    };
     use common_types::RawEvent;
     use std::{collections::HashMap, path::PathBuf, time::Duration};
     use tempfile::TempDir;
@@ -775,8 +777,11 @@ mod tests {
 
         // Add events to the stores
         let event = create_test_event();
-        store1.handle_event_with_raw(&event).unwrap();
-        store2.handle_event_with_raw(&event).unwrap();
+        // Add test data directly to stores
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store1.put_timestamp_record(&key, &metadata).unwrap();
+        store2.put_timestamp_record(&key, &metadata).unwrap();
 
         // add dedup stores to manager
         let stores = store_manager.stores();
@@ -840,9 +845,13 @@ mod tests {
 
         // Add an event
         let event1 = create_test_event();
-        store.handle_event_with_raw(&event1).unwrap();
+        let key1 = TimestampKey::from(&event1);
+        let metadata1 = TimestampMetadata::new(&event1);
+        store.put_timestamp_record(&key1, &metadata1).unwrap();
         let event2 = create_test_event();
-        store.handle_event_with_raw(&event2).unwrap();
+        let key2 = TimestampKey::from(&event2);
+        let metadata2 = TimestampMetadata::new(&event2);
+        store.put_timestamp_record(&key2, &metadata2).unwrap();
 
         // Create manager with short interval for testing
         let tmp_checkpoint_dir = TempDir::new().unwrap();
@@ -971,8 +980,11 @@ mod tests {
 
         // Add events to the stores
         let event = create_test_event();
-        store1.handle_event_with_raw(&event).unwrap();
-        store2.handle_event_with_raw(&event).unwrap();
+        // Add test data directly to stores
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store1.put_timestamp_record(&key, &metadata).unwrap();
+        store2.put_timestamp_record(&key, &metadata).unwrap();
 
         // add dedup stores to manager
         let stores = store_manager.stores();
@@ -1036,8 +1048,11 @@ mod tests {
 
         // Add events to the stores
         let event = create_test_event();
-        store1.handle_event_with_raw(&event).unwrap();
-        store2.handle_event_with_raw(&event).unwrap();
+        // Add test data directly to stores
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store1.put_timestamp_record(&key, &metadata).unwrap();
+        store2.put_timestamp_record(&key, &metadata).unwrap();
 
         // add dedup stores to manager
         let stores = store_manager.stores();
@@ -1102,7 +1117,9 @@ mod tests {
             let event = create_test_event();
             let part = Partition::new("max_inflight_checkpoints".to_string(), i);
             let store = create_test_store(part.topic(), part.partition_number());
-            store.handle_event_with_raw(&event).unwrap();
+            let key = TimestampKey::from(&event);
+            let metadata = TimestampMetadata::new(&event);
+            store.put_timestamp_record(&key, &metadata).unwrap();
             stores.insert(part, store);
         }
 
@@ -1172,9 +1189,11 @@ mod tests {
 
         // Add events to the stores
         let event = create_test_event();
-        store1.handle_event_with_raw(&event).unwrap();
-        store2.handle_event_with_raw(&event).unwrap();
-        store3.handle_event_with_raw(&event).unwrap();
+        let key = crate::store::keys::TimestampKey::from(&event);
+        let metadata = crate::store::metadata::TimestampMetadata::new(&event);
+        store1.put_timestamp_record(&key, &metadata).unwrap();
+        store2.put_timestamp_record(&key, &metadata).unwrap();
+        store3.put_timestamp_record(&key, &metadata).unwrap();
 
         // add dedup stores to manager
         let stores = store_manager.stores();

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -8,12 +8,26 @@ use rdkafka::{ClientConfig, Message};
 use serde_json;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::kafka::message::{AckableMessage, MessageProcessor};
 use crate::metrics::MetricsHelper;
-use crate::metrics_const::DEDUPLICATION_RESULT_COUNTER;
-use crate::store::deduplication_store::DeduplicationResult;
+use crate::metrics_const::{
+    DEDUPLICATION_RESULT_COUNTER, DUPLICATE_EVENTS_TOTAL_COUNTER,
+    TIMESTAMP_DEDUP_DIFFERENT_FIELDS_HISTOGRAM, TIMESTAMP_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM,
+    TIMESTAMP_DEDUP_FIELD_DIFFERENCES_COUNTER, TIMESTAMP_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM,
+    TIMESTAMP_DEDUP_SIMILARITY_SCORE_HISTOGRAM, TIMESTAMP_DEDUP_UNIQUE_UUIDS_HISTOGRAM,
+    UNIQUE_EVENTS_TOTAL_COUNTER, UUID_DEDUP_DIFFERENT_FIELDS_HISTOGRAM,
+    UUID_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM, UUID_DEDUP_FIELD_DIFFERENCES_COUNTER,
+    UUID_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM, UUID_DEDUP_SIMILARITY_SCORE_HISTOGRAM,
+    UUID_DEDUP_TIMESTAMP_VARIANCE_HISTOGRAM, UUID_DEDUP_UNIQUE_TIMESTAMPS_HISTOGRAM,
+};
+use crate::rocksdb::dedup_metadata::DedupFieldName;
+use crate::store::deduplication_store::{
+    DeduplicationResult, DeduplicationResultReason, DeduplicationType,
+};
+use crate::store::keys::{TimestampKey, UuidKey};
+use crate::store::metadata::{TimestampMetadata, UuidMetadata};
 use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
 use crate::store_manager::StoreManager;
 use crate::utils::timestamp;
@@ -71,6 +85,264 @@ impl DeduplicationProcessor {
         self.store_manager.get_or_create(topic, partition).await
     }
 
+    /// Main deduplication logic - checks both timestamp and UUID patterns
+    async fn deduplicate_event(
+        &self,
+        raw_event: &RawEvent,
+        store: &DeduplicationStore,
+        metrics: &MetricsHelper,
+    ) -> Result<DeduplicationResult> {
+        // Track timestamp-based deduplication
+        let deduplication_result = self.check_timestamp_duplicate(raw_event, store, metrics)?;
+
+        if !matches!(deduplication_result, DeduplicationResult::New) {
+            return Ok(deduplication_result);
+        }
+
+        // Track UUID-based deduplication (only if UUID exists)
+        if raw_event.uuid.is_some() {
+            let deduplication_result = self.check_uuid_duplicate(raw_event, store, metrics)?;
+            return Ok(deduplication_result);
+        }
+
+        Ok(deduplication_result)
+    }
+
+    /// Check for timestamp-based duplicates
+    fn check_timestamp_duplicate(
+        &self,
+        raw_event: &RawEvent,
+        store: &DeduplicationStore,
+        metrics: &MetricsHelper,
+    ) -> Result<DeduplicationResult> {
+        let key = TimestampKey::from(raw_event);
+
+        // Check if this is a duplicate
+        let existing_metadata = store.get_timestamp_record(&key)?;
+
+        if let Some(mut metadata) = existing_metadata {
+            // Key exists - it's a duplicate
+
+            // Calculate similarity
+            let similarity = metadata.calculate_similarity(raw_event)?;
+
+            // Always update metadata to track all seen events
+            metadata.update_duplicate(raw_event);
+
+            // Determine the deduplication result based on similarity
+            let dedup_result = if similarity.overall_score == 1.0 {
+                DeduplicationResult::ConfirmedDuplicate(
+                    DeduplicationType::Timestamp,
+                    DeduplicationResultReason::SameEvent,
+                )
+            } else if similarity.different_fields.len() == 1
+                && similarity.different_fields[0].0 == DedupFieldName::Uuid
+            {
+                DeduplicationResult::ConfirmedDuplicate(
+                    DeduplicationType::Timestamp,
+                    DeduplicationResultReason::OnlyUuidDifferent,
+                )
+            } else {
+                DeduplicationResult::PotentialDuplicate(DeduplicationType::Timestamp)
+            };
+
+            // Log the duplicate
+            info!(
+                "Timestamp duplicate: {} for key {:?}, Similarity: {:.2}",
+                metadata.get_metrics_summary(),
+                key,
+                similarity.overall_score
+            );
+
+            // Emit metrics
+            if let Some(lib_info) = raw_event.extract_library_info() {
+                metrics
+                    .counter(DUPLICATE_EVENTS_TOTAL_COUNTER)
+                    .with_label("lib", &lib_info.name)
+                    .with_label("dedup_type", "timestamp")
+                    .increment(1);
+
+                metrics
+                    .histogram(TIMESTAMP_DEDUP_UNIQUE_UUIDS_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(metadata.seen_uuids.len() as f64);
+
+                metrics
+                    .histogram(TIMESTAMP_DEDUP_SIMILARITY_SCORE_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.overall_score);
+
+                metrics
+                    .histogram(TIMESTAMP_DEDUP_DIFFERENT_FIELDS_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.different_field_count as f64);
+
+                metrics
+                    .histogram(TIMESTAMP_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.different_property_count as f64);
+
+                metrics
+                    .histogram(TIMESTAMP_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.properties_similarity);
+
+                // Emit counters for specific fields that differ
+                for (field_name, _, _) in &similarity.different_fields {
+                    metrics
+                        .counter(TIMESTAMP_DEDUP_FIELD_DIFFERENCES_COUNTER)
+                        .with_label("lib", &lib_info.name)
+                        .with_label("field", &field_name.to_string())
+                        .increment(1);
+                }
+            }
+
+            // Store updated metadata
+            store.put_timestamp_record(&key, &metadata)?;
+
+            return Ok(dedup_result);
+        }
+
+        // Key doesn't exist - store it with initial metadata
+        let metadata = TimestampMetadata::new(raw_event);
+        store.put_timestamp_record(&key, &metadata)?;
+
+        // Track unique event
+        if let Some(lib_info) = raw_event.extract_library_info() {
+            metrics
+                .counter(UNIQUE_EVENTS_TOTAL_COUNTER)
+                .with_label("lib", &lib_info.name)
+                .with_label("dedup_type", "timestamp")
+                .increment(1);
+        }
+
+        Ok(DeduplicationResult::New)
+    }
+
+    /// Check for UUID-based duplicates
+    fn check_uuid_duplicate(
+        &self,
+        raw_event: &RawEvent,
+        store: &DeduplicationStore,
+        metrics: &MetricsHelper,
+    ) -> Result<DeduplicationResult> {
+        let key = UuidKey::from(raw_event);
+
+        // Extract timestamp for indexing
+        let timestamp = raw_event
+            .timestamp
+            .as_ref()
+            .and_then(|t| crate::utils::timestamp::parse_timestamp(t))
+            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis() as u64);
+
+        // Check if this UUID combination exists
+        let existing_metadata = store.get_uuid_record(&key)?;
+
+        if let Some(mut metadata) = existing_metadata {
+            // UUID combination exists - it's a duplicate
+
+            // Calculate similarity
+            let similarity = metadata.calculate_similarity(raw_event)?;
+
+            // Always update metadata to track all seen events
+            metadata.update_duplicate(raw_event);
+
+            // Determine the deduplication result based on similarity
+            let dedup_result = if similarity.overall_score == 1.0 {
+                DeduplicationResult::ConfirmedDuplicate(
+                    DeduplicationType::UUID,
+                    DeduplicationResultReason::SameEvent,
+                )
+            } else if similarity.different_fields.len() == 1
+                && similarity.different_fields[0].0 == DedupFieldName::Timestamp
+            {
+                DeduplicationResult::ConfirmedDuplicate(
+                    DeduplicationType::UUID,
+                    DeduplicationResultReason::OnlyTimestampDifferent,
+                )
+            } else {
+                DeduplicationResult::PotentialDuplicate(DeduplicationType::UUID)
+            };
+
+            // Log the duplicate
+            info!(
+                "UUID duplicate: {} for key {:?}",
+                metadata.get_metrics_summary(),
+                key
+            );
+
+            // Emit metrics
+            if let Some(lib_info) = raw_event.extract_library_info() {
+                metrics
+                    .counter(DUPLICATE_EVENTS_TOTAL_COUNTER)
+                    .with_label("lib", &lib_info.name)
+                    .with_label("dedup_type", "uuid")
+                    .increment(1);
+
+                metrics
+                    .histogram(UUID_DEDUP_TIMESTAMP_VARIANCE_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(metadata.get_timestamp_variance() as f64);
+
+                metrics
+                    .histogram(UUID_DEDUP_UNIQUE_TIMESTAMPS_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(metadata.seen_timestamps.len() as f64);
+
+                metrics
+                    .histogram(UUID_DEDUP_SIMILARITY_SCORE_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.overall_score);
+
+                metrics
+                    .histogram(UUID_DEDUP_DIFFERENT_FIELDS_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.different_field_count as f64);
+
+                metrics
+                    .histogram(UUID_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.different_property_count as f64);
+
+                metrics
+                    .histogram(UUID_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM)
+                    .with_label("lib", &lib_info.name)
+                    .record(similarity.properties_similarity);
+
+                // Emit counters for specific fields that differ
+                for (field_name, _, _) in &similarity.different_fields {
+                    metrics
+                        .counter(UUID_DEDUP_FIELD_DIFFERENCES_COUNTER)
+                        .with_label("lib", &lib_info.name)
+                        .with_label("field", &field_name.to_string())
+                        .increment(1);
+                }
+            }
+
+            // Store updated metadata
+            store.put_uuid_record(&key, &metadata, timestamp)?;
+
+            return Ok(dedup_result);
+        }
+
+        // New UUID combination - store it
+        let metadata = UuidMetadata::new(raw_event);
+
+        // Store in UUID CF (with timestamp index handled automatically)
+        store.put_uuid_record(&key, &metadata, timestamp)?;
+
+        // Track new UUID combination
+        if let Some(lib_info) = raw_event.extract_library_info() {
+            metrics
+                .counter(UNIQUE_EVENTS_TOTAL_COUNTER)
+                .with_label("lib", &lib_info.name)
+                .with_label("dedup_type", "uuid")
+                .increment(1);
+        }
+
+        Ok(DeduplicationResult::New)
+    }
+
     /// Process a raw event through deduplication and publish if not duplicate
     async fn process_raw_event(
         &self,
@@ -81,6 +353,10 @@ impl DeduplicationProcessor {
     ) -> Result<bool> {
         // Get the store for this partition
         let store = self.get_or_create_store(ctx.topic, ctx.partition).await?;
+
+        // Create metrics helper for this partition
+        let metrics = MetricsHelper::with_partition(ctx.topic, ctx.partition)
+            .with_label("service", "kafka-deduplicator");
 
         // Extract key for deduplication - always use composite key (timestamp:distinct_id:token:event_name)
         // UUID is only used for Kafka partitioning, NOT for deduplication
@@ -97,8 +373,8 @@ impl DeduplicationProcessor {
             dedup_key, ctx.topic, ctx.partition, ctx.offset
         );
 
-        // Use the store's handle_event_with_raw method which checks for duplicates, stores if new, and tracks metrics
-        let deduplication_result = store.handle_event_with_raw(&raw_event)?;
+        // Use the processor's deduplication logic to check for duplicates
+        let deduplication_result = self.deduplicate_event(&raw_event, &store, &metrics).await?;
 
         // Emit metrics for the deduplication result
         self.emit_deduplication_result_metrics(ctx.topic, ctx.partition, &deduplication_result);
@@ -504,5 +780,425 @@ mod tests {
         assert_eq!(event.event, deserialized.event);
         assert_eq!(event.uuid, deserialized.uuid);
         assert_eq!(event.distinct_id, deserialized.distinct_id);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_deduplication_new_event() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let event = RawEvent {
+            uuid: Some(Uuid::new_v4()),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        let result = processor
+            .check_timestamp_duplicate(&event, &store, &metrics)
+            .unwrap();
+        assert_eq!(result, DeduplicationResult::New);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_deduplication_exact_duplicate() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let event = RawEvent {
+            uuid: Some(Uuid::new_v4()),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        // First event should be new
+        let result1 = processor
+            .check_timestamp_duplicate(&event, &store, &metrics)
+            .unwrap();
+        assert_eq!(result1, DeduplicationResult::New);
+
+        // Exact duplicate should be confirmed duplicate
+        let result2 = processor
+            .check_timestamp_duplicate(&event, &store, &metrics)
+            .unwrap();
+        assert_eq!(
+            result2,
+            DeduplicationResult::ConfirmedDuplicate(
+                DeduplicationType::Timestamp,
+                DeduplicationResultReason::SameEvent
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_deduplication_only_uuid_different() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let event1 = RawEvent {
+            uuid: Some(Uuid::new_v4()),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        // First event should be new
+        let result1 = processor
+            .check_timestamp_duplicate(&event1, &store, &metrics)
+            .unwrap();
+        assert_eq!(result1, DeduplicationResult::New);
+
+        // Same event with different UUID
+        let event2 = RawEvent {
+            uuid: Some(Uuid::new_v4()),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        let result2 = processor
+            .check_timestamp_duplicate(&event2, &store, &metrics)
+            .unwrap();
+        assert_eq!(
+            result2,
+            DeduplicationResult::ConfirmedDuplicate(
+                DeduplicationType::Timestamp,
+                DeduplicationResultReason::OnlyUuidDifferent
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_deduplication_potential_duplicate() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let uuid = Uuid::new_v4(); // Use the same UUID for both events
+        let mut properties1 = HashMap::new();
+        properties1.insert("prop1".to_string(), json!("value1"));
+
+        let event1 = RawEvent {
+            uuid: Some(uuid),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: properties1,
+            ..Default::default()
+        };
+
+        // First event should be new
+        let result1 = processor
+            .check_timestamp_duplicate(&event1, &store, &metrics)
+            .unwrap();
+        assert_eq!(result1, DeduplicationResult::New);
+
+        // Similar event with different properties but same UUID
+        let mut properties2 = HashMap::new();
+        properties2.insert("prop1".to_string(), json!("value2"));
+        properties2.insert("prop2".to_string(), json!("extra"));
+
+        let event2 = RawEvent {
+            uuid: Some(uuid), // Same UUID as event1
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: properties2,
+            ..Default::default()
+        };
+
+        let result2 = processor
+            .check_timestamp_duplicate(&event2, &store, &metrics)
+            .unwrap();
+        assert_eq!(
+            result2,
+            DeduplicationResult::PotentialDuplicate(DeduplicationType::Timestamp)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_uuid_deduplication_new_event() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let event = RawEvent {
+            uuid: Some(Uuid::new_v4()),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        let result = processor
+            .check_uuid_duplicate(&event, &store, &metrics)
+            .unwrap();
+        assert_eq!(result, DeduplicationResult::New);
+    }
+
+    #[tokio::test]
+    async fn test_uuid_deduplication_only_timestamp_different() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let uuid = Uuid::new_v4();
+        let event1 = RawEvent {
+            uuid: Some(uuid),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        // First event should be new
+        let result1 = processor
+            .check_uuid_duplicate(&event1, &store, &metrics)
+            .unwrap();
+        assert_eq!(result1, DeduplicationResult::New);
+
+        // Same event with different timestamp
+        let event2 = RawEvent {
+            uuid: Some(uuid),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:01Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        let result2 = processor
+            .check_uuid_duplicate(&event2, &store, &metrics)
+            .unwrap();
+        assert_eq!(
+            result2,
+            DeduplicationResult::ConfirmedDuplicate(
+                DeduplicationType::UUID,
+                DeduplicationResultReason::OnlyTimestampDifferent
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_combined_deduplication_flow() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let uuid = Uuid::new_v4();
+        let event = RawEvent {
+            uuid: Some(uuid),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        // First check should return new
+        let result1 = processor
+            .deduplicate_event(&event, &store, &metrics)
+            .await
+            .unwrap();
+        assert_eq!(result1, DeduplicationResult::New);
+
+        // Second check with same event should detect timestamp duplicate
+        let result2 = processor
+            .deduplicate_event(&event, &store, &metrics)
+            .await
+            .unwrap();
+        assert_eq!(
+            result2,
+            DeduplicationResult::ConfirmedDuplicate(
+                DeduplicationType::Timestamp,
+                DeduplicationResultReason::SameEvent
+            )
+        );
+
+        // Event with different timestamp but same UUID should detect timestamp first
+        let event3 = RawEvent {
+            uuid: Some(uuid),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:01Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        // Since timestamp is different, it passes timestamp check and goes to UUID check
+        let result3 = processor
+            .deduplicate_event(&event3, &store, &metrics)
+            .await
+            .unwrap();
+        assert_eq!(
+            result3,
+            DeduplicationResult::ConfirmedDuplicate(
+                DeduplicationType::UUID,
+                DeduplicationResultReason::OnlyTimestampDifferent
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deduplication_without_uuid() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let event = RawEvent {
+            uuid: None,
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties: HashMap::new(),
+            ..Default::default()
+        };
+
+        // First event without UUID should be new
+        let result1 = processor
+            .deduplicate_event(&event, &store, &metrics)
+            .await
+            .unwrap();
+        assert_eq!(result1, DeduplicationResult::New);
+
+        // Duplicate event without UUID should be detected by timestamp
+        let result2 = processor
+            .deduplicate_event(&event, &store, &metrics)
+            .await
+            .unwrap();
+        assert_eq!(
+            result2,
+            DeduplicationResult::ConfirmedDuplicate(
+                DeduplicationType::Timestamp,
+                DeduplicationResultReason::SameEvent
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deduplication_with_library_metrics() {
+        let (config, _temp_dir) = create_test_config();
+        let store_manager = Arc::new(StoreManager::new(config.store_config.clone()));
+        let processor = DeduplicationProcessor::new(config, store_manager).unwrap();
+
+        let store = processor
+            .get_or_create_store("test-topic", 0)
+            .await
+            .unwrap();
+        let metrics = MetricsHelper::with_partition("test-topic", 0)
+            .with_label("service", "kafka-deduplicator");
+
+        let mut properties = HashMap::new();
+        properties.insert("$lib".to_string(), json!("posthog-js"));
+        properties.insert("$lib_version".to_string(), json!("1.0.0"));
+
+        let event = RawEvent {
+            uuid: Some(Uuid::new_v4()),
+            event: "test_event".to_string(),
+            distinct_id: Some(json!("user1")),
+            token: Some("token1".to_string()),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            properties,
+            ..Default::default()
+        };
+
+        // Process event twice to test metrics emission with library info
+        let result1 = processor
+            .check_timestamp_duplicate(&event, &store, &metrics)
+            .unwrap();
+        assert_eq!(result1, DeduplicationResult::New);
+
+        let result2 = processor
+            .check_timestamp_duplicate(&event, &store, &metrics)
+            .unwrap();
+        assert_eq!(
+            result2,
+            DeduplicationResult::ConfirmedDuplicate(
+                DeduplicationType::Timestamp,
+                DeduplicationResultReason::SameEvent
+            )
+        );
     }
 }

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -3,38 +3,13 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
-use common_types::RawEvent;
 use rocksdb::{ColumnFamilyDescriptor, Options};
 use tracing::info;
 
-use crate::metrics::MetricsHelper;
-use crate::metrics_const::*;
-use crate::rocksdb::dedup_metadata::DedupFieldName;
 use crate::rocksdb::store::RocksDbStore;
 
 use super::keys::{TimestampKey, UuidIndexKey, UuidKey};
 use super::metadata::{TimestampMetadata, UuidMetadata};
-
-const UNKNOWN_STR: &str = "unknown";
-
-/// Extract library name and version from RawEvent properties
-fn extract_library_info(event: &RawEvent) -> (String, String) {
-    let lib_name = event
-        .properties
-        .get("$lib")
-        .and_then(|v| v.as_str())
-        .unwrap_or(UNKNOWN_STR)
-        .to_string();
-
-    let lib_version = event
-        .properties
-        .get("$lib_version")
-        .and_then(|v| v.as_str())
-        .unwrap_or(UNKNOWN_STR)
-        .to_string();
-
-    (lib_name, lib_version)
-}
 
 #[derive(Debug, Clone)]
 pub struct DeduplicationStoreConfig {
@@ -49,7 +24,6 @@ pub struct DeduplicationStore {
     store: Arc<RocksDbStore>,
     topic: String,
     partition: i32,
-    metrics: MetricsHelper,
 }
 
 #[derive(strum_macros::Display, Debug, Copy, Clone, PartialEq)]
@@ -86,7 +60,8 @@ impl DeduplicationStore {
     const UUID_TIMESTAMP_INDEX_CF: &'static str = "uuid_timestamp_index"; // For cleanup
 
     pub fn new(config: DeduplicationStoreConfig, topic: String, partition: i32) -> Result<Self> {
-        let metrics = MetricsHelper::with_partition(&topic, partition)
+        // Create metrics helper for the RocksDB store
+        let metrics = crate::metrics::MetricsHelper::with_partition(&topic, partition)
             .with_label("service", "kafka-deduplicator");
 
         // Create all three column families
@@ -97,15 +72,81 @@ impl DeduplicationStore {
                 ColumnFamilyDescriptor::new(Self::UUID_CF, Options::default()),
                 ColumnFamilyDescriptor::new(Self::UUID_TIMESTAMP_INDEX_CF, Options::default()),
             ],
-            metrics.clone(),
+            metrics,
         )?;
 
         Ok(Self {
             store: Arc::new(store),
             topic,
             partition,
-            metrics,
         })
+    }
+
+    // Storage operations for each column family
+
+    /// Get a timestamp record from the store
+    pub fn get_timestamp_record(&self, key: &TimestampKey) -> Result<Option<TimestampMetadata>> {
+        let key_bytes: Vec<u8> = key.into();
+        match self.store.get(Self::TIMESTAMP_CF, &key_bytes)? {
+            Some(bytes) => {
+                let metadata =
+                    bincode::serde::decode_from_slice(&bytes, bincode::config::standard())
+                        .map(|(m, _)| m)
+                        .context("Failed to deserialize timestamp metadata")?;
+                Ok(Some(metadata))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Put a timestamp record in the store
+    pub fn put_timestamp_record(
+        &self,
+        key: &TimestampKey,
+        metadata: &TimestampMetadata,
+    ) -> Result<()> {
+        let key_bytes: Vec<u8> = key.into();
+        let value = bincode::serde::encode_to_vec(metadata, bincode::config::standard())
+            .context("Failed to serialize timestamp metadata")?;
+        self.store.put(Self::TIMESTAMP_CF, &key_bytes, &value)
+    }
+
+    /// Get a UUID record from the store
+    pub fn get_uuid_record(&self, key: &UuidKey) -> Result<Option<UuidMetadata>> {
+        let key_bytes: Vec<u8> = key.into();
+        match self.store.get(Self::UUID_CF, &key_bytes)? {
+            Some(bytes) => {
+                let metadata =
+                    bincode::serde::decode_from_slice(&bytes, bincode::config::standard())
+                        .map(|(m, _)| m)
+                        .context("Failed to deserialize UUID metadata")?;
+                Ok(Some(metadata))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Put a UUID record in the store and automatically create the timestamp index
+    pub fn put_uuid_record(
+        &self,
+        key: &UuidKey,
+        metadata: &UuidMetadata,
+        timestamp: u64,
+    ) -> Result<()> {
+        let key_bytes: Vec<u8> = key.into();
+        let value = bincode::serde::encode_to_vec(metadata, bincode::config::standard())
+            .context("Failed to serialize UUID metadata")?;
+
+        // Store the UUID record
+        self.store.put(Self::UUID_CF, &key_bytes, &value)?;
+
+        // Automatically create the timestamp index for cleanup
+        let index_key = UuidIndexKey::new(timestamp, key_bytes.clone());
+        let index_key_bytes: Vec<u8> = index_key.into();
+        self.store
+            .put(Self::UUID_TIMESTAMP_INDEX_CF, &index_key_bytes, &key_bytes)?;
+
+        Ok(())
     }
 
     /// Get non-duplicated keys based on timestamp pattern (for batch processing)
@@ -131,359 +172,6 @@ impl DeduplicationStore {
             .collect();
 
         Ok(non_duplicated)
-    }
-
-    /// Check if an event should be excluded from deduplication
-    fn is_excluded_event(event: &RawEvent) -> bool {
-        matches!(
-            event.event.as_str(),
-            "$feature_flag_called" | "$autocapture"
-        )
-    }
-
-    /// Handle an event, tracking both timestamp and UUID patterns
-    pub fn handle_event_with_raw(&self, raw_event: &RawEvent) -> Result<DeduplicationResult> {
-        let _start_time = Instant::now();
-
-        // Check if this event type should be excluded from deduplication
-        if Self::is_excluded_event(raw_event) {
-            return Ok(DeduplicationResult::Skipped);
-        }
-
-        // Track timestamp-based deduplication
-        let deduplication_result = self.handle_timestamp_dedup(raw_event)?;
-
-        if !matches!(deduplication_result, DeduplicationResult::New) {
-            return Ok(deduplication_result);
-        }
-
-        // Track UUID-based deduplication (only if UUID exists)
-        if raw_event.uuid.is_some() {
-            let deduplication_result = self.handle_uuid_dedup(raw_event)?;
-            return Ok(deduplication_result);
-        }
-
-        Ok(deduplication_result)
-    }
-
-    /// Handle timestamp-based deduplication
-    fn handle_timestamp_dedup(&self, raw_event: &RawEvent) -> Result<DeduplicationResult> {
-        let key = TimestampKey::from(raw_event);
-        let key_bytes: Vec<u8> = (&key).into();
-
-        // Check if this is a duplicate
-        let existing_metadata = self.store.get(Self::TIMESTAMP_CF, &key_bytes)?;
-
-        if let Some(existing_bytes) = existing_metadata {
-            // Key exists - it's a duplicate
-            let mut metadata: TimestampMetadata =
-                bincode::serde::decode_from_slice(&existing_bytes, bincode::config::standard())
-                    .map(|(m, _)| m)
-                    .context("Failed to deserialize timestamp metadata")?;
-
-            // Calculate similarity
-            let similarity = metadata.calculate_similarity(raw_event)?;
-
-            // Always update metadata to track all seen events
-            metadata.update_duplicate(raw_event);
-
-            // Determine the deduplication result based on similarity
-            let dedup_result = if similarity.overall_score == 1.0 {
-                DeduplicationResult::ConfirmedDuplicate(
-                    DeduplicationType::Timestamp,
-                    DeduplicationResultReason::SameEvent,
-                )
-            } else if similarity.different_fields.len() == 1
-                && similarity.different_fields[0].0 == DedupFieldName::Uuid
-            {
-                DeduplicationResult::ConfirmedDuplicate(
-                    DeduplicationType::Timestamp,
-                    DeduplicationResultReason::OnlyUuidDifferent,
-                )
-            } else {
-                DeduplicationResult::PotentialDuplicate(DeduplicationType::Timestamp)
-            };
-
-            // Format different fields for logging
-            let different_fields_str = if similarity.different_fields.is_empty() {
-                "none".to_string()
-            } else {
-                similarity
-                    .different_fields
-                    .iter()
-                    .map(|(field, orig, new)| format!("{field}({orig}->{new})"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-
-            // Format different properties for logging
-            let different_properties_str = if similarity.different_properties.is_empty() {
-                "none".to_string()
-            } else {
-                similarity
-                    .different_properties
-                    .iter()
-                    .map(|(prop, values)| {
-                        if let Some((orig, new)) = values {
-                            format!("{prop}({orig}->{new})")
-                        } else {
-                            prop.clone()
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-
-            // Log the duplicate
-            info!(
-                "Timestamp {}: {} for key {:?}, Similarity: {:.2}, Different fields: [{}], Different properties: [{}]",
-                dedup_result,
-                metadata.get_metrics_summary(),
-                key,
-                similarity.overall_score,
-                different_fields_str,
-                different_properties_str
-            );
-
-            // Emit metrics
-            let (lib_name, _lib_version) = extract_library_info(raw_event);
-            self.metrics
-                .counter(DUPLICATE_EVENTS_TOTAL_COUNTER)
-                .with_label("lib", &lib_name)
-                .with_label("dedup_type", "timestamp")
-                .increment(1);
-
-            self.metrics
-                .histogram(TIMESTAMP_DEDUP_UNIQUE_UUIDS_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(metadata.seen_uuids.len() as f64);
-
-            self.metrics
-                .histogram(TIMESTAMP_DEDUP_SIMILARITY_SCORE_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.overall_score);
-
-            self.metrics
-                .histogram(TIMESTAMP_DEDUP_DIFFERENT_FIELDS_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.different_field_count as f64);
-
-            self.metrics
-                .histogram(TIMESTAMP_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.different_property_count as f64);
-
-            self.metrics
-                .histogram(TIMESTAMP_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.properties_similarity);
-
-            // Emit counters for specific fields that differ
-            for (field_name, _, _) in &similarity.different_fields {
-                self.metrics
-                    .counter(TIMESTAMP_DEDUP_FIELD_DIFFERENCES_COUNTER)
-                    .with_label("lib", &lib_name)
-                    .with_label("field", &field_name.to_string())
-                    .increment(1);
-            }
-
-            // Store updated metadata
-            let serialized = bincode::serde::encode_to_vec(&metadata, bincode::config::standard())
-                .context("Failed to serialize timestamp metadata")?;
-            self.store
-                .put(Self::TIMESTAMP_CF, &key_bytes, &serialized)?;
-
-            return Ok(dedup_result);
-        }
-
-        // Key doesn't exist - store it with initial metadata
-        let metadata = TimestampMetadata::new(raw_event);
-        let serialized = bincode::serde::encode_to_vec(&metadata, bincode::config::standard())
-            .context("Failed to serialize timestamp metadata")?;
-
-        self.store
-            .put_batch(Self::TIMESTAMP_CF, vec![(&key_bytes, &serialized)])?;
-
-        // Track unique event
-        let (lib_name, _lib_version) = extract_library_info(raw_event);
-        self.metrics
-            .counter(UNIQUE_EVENTS_TOTAL_COUNTER)
-            .with_label("lib", &lib_name)
-            .with_label("dedup_type", "timestamp")
-            .increment(1);
-
-        Ok(DeduplicationResult::New) // New event
-    }
-
-    /// Handle UUID-based deduplication
-    fn handle_uuid_dedup(&self, raw_event: &RawEvent) -> Result<DeduplicationResult> {
-        let key = UuidKey::from(raw_event);
-        let key_bytes: Vec<u8> = (&key).into();
-
-        // Extract timestamp for indexing
-        let timestamp = raw_event
-            .timestamp
-            .as_ref()
-            .and_then(|t| crate::utils::timestamp::parse_timestamp(t))
-            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis() as u64);
-
-        // Check if this UUID combination exists
-        let existing_metadata = self.store.get(Self::UUID_CF, &key_bytes)?;
-
-        if let Some(existing_bytes) = existing_metadata {
-            // UUID combination exists - it's a duplicate
-            let mut metadata: UuidMetadata =
-                bincode::serde::decode_from_slice(&existing_bytes, bincode::config::standard())
-                    .map(|(m, _)| m)
-                    .context("Failed to deserialize UUID metadata")?;
-
-            // Calculate similarity
-            let similarity = metadata.calculate_similarity(raw_event)?;
-
-            // Always update metadata to track all seen events
-            metadata.update_duplicate(raw_event);
-
-            // Determine the deduplication result based on similarity
-            let dedup_result = if similarity.overall_score == 1.0 {
-                DeduplicationResult::ConfirmedDuplicate(
-                    DeduplicationType::UUID,
-                    DeduplicationResultReason::SameEvent,
-                )
-            } else if similarity.different_fields.len() == 1
-                && similarity.different_fields[0].0 == DedupFieldName::Timestamp
-            {
-                DeduplicationResult::ConfirmedDuplicate(
-                    DeduplicationType::UUID,
-                    DeduplicationResultReason::OnlyTimestampDifferent,
-                )
-            } else {
-                DeduplicationResult::PotentialDuplicate(DeduplicationType::UUID)
-            };
-
-            // Format different fields for logging
-            let different_fields_str = if similarity.different_fields.is_empty() {
-                "none".to_string()
-            } else {
-                similarity
-                    .different_fields
-                    .iter()
-                    .map(|(field, orig, new)| format!("{field}({orig}->{new})"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-
-            // Format different properties for logging
-            let different_properties_str = if similarity.different_properties.is_empty() {
-                "none".to_string()
-            } else {
-                similarity
-                    .different_properties
-                    .iter()
-                    .map(|(prop, values)| {
-                        if let Some((orig, new)) = values {
-                            format!("{prop}({orig}->{new})")
-                        } else {
-                            prop.clone()
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-
-            // Log the duplicate
-            info!(
-                "UUID {}: {} for key {:?}, Similarity: {:.2}, Different fields: [{}], Different properties: [{}]",
-                dedup_result,
-                metadata.get_metrics_summary(),
-                key,
-                similarity.overall_score,
-                different_fields_str,
-                different_properties_str
-            );
-
-            // Emit metrics
-            let (lib_name, _) = extract_library_info(raw_event);
-
-            self.metrics
-                .counter(DUPLICATE_EVENTS_TOTAL_COUNTER)
-                .with_label("lib", &lib_name)
-                .with_label("dedup_type", "uuid")
-                .increment(1);
-
-            self.metrics
-                .histogram(UUID_DEDUP_TIMESTAMP_VARIANCE_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(metadata.get_timestamp_variance() as f64);
-
-            self.metrics
-                .histogram(UUID_DEDUP_UNIQUE_TIMESTAMPS_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(metadata.seen_timestamps.len() as f64);
-
-            self.metrics
-                .histogram(UUID_DEDUP_SIMILARITY_SCORE_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.overall_score);
-
-            self.metrics
-                .histogram(UUID_DEDUP_DIFFERENT_FIELDS_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.different_field_count as f64);
-
-            self.metrics
-                .histogram(UUID_DEDUP_DIFFERENT_PROPERTIES_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.different_property_count as f64);
-
-            self.metrics
-                .histogram(UUID_DEDUP_PROPERTIES_SIMILARITY_HISTOGRAM)
-                .with_label("lib", &lib_name)
-                .record(similarity.properties_similarity);
-
-            // Emit counters for specific fields that differ
-            for (field_name, _, _) in &similarity.different_fields {
-                self.metrics
-                    .counter(UUID_DEDUP_FIELD_DIFFERENCES_COUNTER)
-                    .with_label("lib", &lib_name)
-                    .with_label("field", &field_name.to_string())
-                    .increment(1);
-            }
-
-            // Store updated metadata
-            let serialized = bincode::serde::encode_to_vec(&metadata, bincode::config::standard())
-                .context("Failed to serialize UUID metadata")?;
-            self.store.put(Self::UUID_CF, &key_bytes, &serialized)?;
-
-            return Ok(dedup_result);
-        }
-
-        // New UUID combination - store it
-        let metadata = UuidMetadata::new(raw_event);
-        let serialized = bincode::serde::encode_to_vec(&metadata, bincode::config::standard())
-            .context("Failed to serialize UUID metadata")?;
-
-        // Store in UUID CF
-        self.store
-            .put_batch(Self::UUID_CF, vec![(&key_bytes, &serialized)])?;
-
-        // Also store in timestamp index for cleanup
-        let index_key = UuidIndexKey::new(timestamp, key_bytes.clone());
-        let index_key_bytes: Vec<u8> = index_key.into();
-        // Value is just the UUID key bytes for reference
-        self.store.put_batch(
-            Self::UUID_TIMESTAMP_INDEX_CF,
-            vec![(&index_key_bytes, &key_bytes)],
-        )?;
-
-        // Track new UUID combination
-        let (lib_name, _lib_version) = extract_library_info(raw_event);
-        self.metrics
-            .counter(UNIQUE_EVENTS_TOTAL_COUNTER)
-            .with_label("lib", &lib_name)
-            .with_label("dedup_type", "uuid")
-            .increment(1);
-
-        Ok(DeduplicationResult::New) // New UUID combination
     }
 
     pub fn cleanup_old_entries(&self) -> Result<u64> {
@@ -725,504 +413,132 @@ impl DeduplicationStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::keys::{UuidIndexKey, UuidKey};
+    use common_types::RawEvent;
     use tempfile::TempDir;
 
-    fn create_test_store(max_capacity: Option<u64>) -> (DeduplicationStore, TempDir) {
+    fn create_test_store() -> (DeduplicationStore, TempDir) {
         let temp_dir = TempDir::new().unwrap();
-        let max_capacity = max_capacity.unwrap_or(1_000_000);
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
-            max_capacity,
+            max_capacity: 1_000_000,
         };
         let store = DeduplicationStore::new(config, "test_topic".to_string(), 0).unwrap();
         (store, temp_dir)
     }
 
-    fn create_test_raw_event_with_timestamp(
-        distinct_id: &str,
-        token: &str,
-        event_name: &str,
-        timestamp: Option<String>,
-    ) -> RawEvent {
+    fn create_test_raw_event() -> RawEvent {
         RawEvent {
             uuid: Some(uuid::Uuid::new_v4()),
-            event: event_name.to_string(),
-            distinct_id: Some(serde_json::Value::String(distinct_id.to_string())),
-            token: Some(token.to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: timestamp.or_else(|| Some(chrono::Utc::now().to_rfc3339())),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_handle_event_new() {
-        let (store, _temp_dir) = create_test_store(None);
-        let event = create_test_raw_event_with_timestamp(
-            "user1",
-            "token1",
-            "event1",
-            Some("2021-01-01T00:00:00Z".to_string()),
-        );
-
-        let result = store.handle_event_with_raw(&event).unwrap();
-        assert_eq!(result, DeduplicationResult::New); // Should be new
-    }
-
-    #[test]
-    fn test_handle_event_duplicate() {
-        let (store, _temp_dir) = create_test_store(None);
-        let timestamp = Some("2021-01-01T00:00:00Z".to_string());
-        let event1 =
-            create_test_raw_event_with_timestamp("user1", "token1", "event1", timestamp.clone());
-        let event2 =
-            create_test_raw_event_with_timestamp("user1", "token1", "event1", timestamp.clone());
-
-        assert_eq!(
-            store.handle_event_with_raw(&event1).unwrap(),
-            DeduplicationResult::New
-        ); // First is new
-        assert_eq!(
-            store.handle_event_with_raw(&event2).unwrap(),
-            DeduplicationResult::ConfirmedDuplicate(
-                DeduplicationType::Timestamp,
-                DeduplicationResultReason::OnlyUuidDifferent
-            )
-        ); // Second is duplicate (only UUID differs)
-    }
-
-    #[test]
-    fn test_dual_tracking() {
-        let (store, _temp_dir) = create_test_store(None);
-        let uuid1 = uuid::Uuid::new_v4();
-        let uuid2 = uuid::Uuid::new_v4();
-
-        // Create events with same timestamp but different UUIDs
-        let event1 = RawEvent {
-            uuid: Some(uuid1),
-            event: "page_view".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("token1".to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: Some("2021-01-01T00:00:00Z".to_string()),
-            ..Default::default()
-        };
-
-        let event2 = RawEvent {
-            uuid: Some(uuid2),
-            event: "page_view".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("token1".to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: Some("2021-01-01T00:00:00Z".to_string()),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            store.handle_event_with_raw(&event1).unwrap(),
-            DeduplicationResult::New
-        ); // First is new
-        assert_eq!(
-            store.handle_event_with_raw(&event2).unwrap(),
-            DeduplicationResult::ConfirmedDuplicate(
-                DeduplicationType::Timestamp,
-                DeduplicationResultReason::OnlyUuidDifferent
-            )
-        ); // Second is duplicate by timestamp (only UUID differs)
-
-        // Now test with same UUID but different timestamp
-        let event3 = RawEvent {
-            uuid: Some(uuid1),
-            event: "page_view".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("token1".to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: Some("2021-01-01T00:00:10Z".to_string()), // Different timestamp
-            ..Default::default()
-        };
-
-        assert_eq!(
-            store.handle_event_with_raw(&event3).unwrap(),
-            DeduplicationResult::ConfirmedDuplicate(
-                DeduplicationType::UUID,
-                DeduplicationResultReason::OnlyTimestampDifferent
-            )
-        ); // New by timestamp, but duplicate by UUID
-    }
-
-    #[test]
-    fn test_uuid_timestamp_index_creation() {
-        let (store, _temp_dir) = create_test_store(None);
-        let uuid = uuid::Uuid::new_v4();
-        let timestamp = "2021-01-01T00:00:00Z";
-
-        let event = RawEvent {
-            uuid: Some(uuid),
-            event: "test_event".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("token1".to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: Some(timestamp.to_string()),
-            ..Default::default()
-        };
-
-        // Process the event
-        assert_eq!(
-            store.handle_event_with_raw(&event).unwrap(),
-            DeduplicationResult::New
-        );
-
-        // Verify that the timestamp index was created
-        let timestamp_ms = crate::utils::timestamp::parse_timestamp(timestamp).unwrap();
-
-        // Create the UuidKey to match the format used in the code
-        let uuid_key = UuidKey::from(&event);
-        let uuid_key_bytes: Vec<u8> = (&uuid_key).into();
-
-        // Create the index key using the UuidIndexKey struct
-        let index_key_struct = UuidIndexKey::new(timestamp_ms, uuid_key_bytes.clone());
-        let index_key: Vec<u8> = index_key_struct.into();
-
-        // Check that the index entry exists
-        let index_value = store
-            .store
-            .get(DeduplicationStore::UUID_TIMESTAMP_INDEX_CF, &index_key)
-            .unwrap();
-        assert!(index_value.is_some());
-
-        // Verify the index value points to the UUID key bytes
-        let stored_uuid_key = index_value.unwrap();
-        assert_eq!(stored_uuid_key, uuid_key_bytes);
-    }
-
-    #[test]
-    fn test_uuid_tracking_with_multiple_timestamps() {
-        let (store, _temp_dir) = create_test_store(None);
-        let uuid = uuid::Uuid::new_v4();
-
-        // Same UUID, different timestamps
-        let event1 = RawEvent {
-            uuid: Some(uuid),
             event: "test_event".to_string(),
             distinct_id: Some(serde_json::Value::String("user1".to_string())),
             token: Some("token1".to_string()),
             properties: std::collections::HashMap::new(),
             timestamp: Some("2021-01-01T00:00:00Z".to_string()),
             ..Default::default()
-        };
-
-        let event2 = RawEvent {
-            uuid: Some(uuid),
-            event: "test_event".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("token1".to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: Some("2021-01-01T00:00:10Z".to_string()),
-            ..Default::default()
-        };
-
-        let event3 = RawEvent {
-            uuid: Some(uuid),
-            event: "test_event".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("token1".to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: Some("2021-01-01T00:00:05Z".to_string()),
-            ..Default::default()
-        };
-
-        // First event is new
-        assert_eq!(
-            store.handle_event_with_raw(&event1).unwrap(),
-            DeduplicationResult::New
-        );
-
-        // Second and third are duplicates by UUID (but different timestamps)
-        assert_eq!(
-            store.handle_event_with_raw(&event2).unwrap(),
-            DeduplicationResult::ConfirmedDuplicate(
-                DeduplicationType::UUID,
-                DeduplicationResultReason::OnlyTimestampDifferent
-            )
-        ); // New timestamp
-        assert_eq!(
-            store.handle_event_with_raw(&event3).unwrap(),
-            DeduplicationResult::ConfirmedDuplicate(
-                DeduplicationType::UUID,
-                DeduplicationResultReason::OnlyTimestampDifferent
-            )
-        ); // New timestamp
-
-        // Verify UUID metadata tracks all timestamps
-        let uuid_key = UuidKey::from(&event1);
-        let uuid_key_bytes: Vec<u8> = (&uuid_key).into();
-        let metadata_bytes = store
-            .store
-            .get(DeduplicationStore::UUID_CF, &uuid_key_bytes)
-            .unwrap()
-            .unwrap();
-        let metadata: UuidMetadata =
-            bincode::serde::decode_from_slice(&metadata_bytes, bincode::config::standard())
-                .map(|(m, _)| m)
-                .unwrap();
-
-        // Should have 3 unique timestamps
-        assert_eq!(metadata.seen_timestamps.len(), 3);
-        assert_eq!(metadata.duplicate_count, 2); // Two duplicates after the first
-        assert_eq!(metadata.get_timestamp_variance(), 10000); // 10 seconds in ms
+        }
     }
 
     #[test]
-    fn test_cleanup_with_uuid_records() {
-        let (store, _temp_dir) = create_test_store(Some(1000)); // Small capacity to force cleanup
+    fn test_timestamp_record_storage() {
+        let (store, _temp_dir) = create_test_store();
 
-        // Use timestamps relative to now for predictable cleanup behavior
-        let now = chrono::Utc::now();
-        let old_timestamp = (now - chrono::Duration::days(10)).to_rfc3339();
-        let new_timestamp = (now - chrono::Duration::days(5)).to_rfc3339();
+        // Create a test key and metadata
+        let event = create_test_raw_event();
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
 
-        // Add many old events to ensure database has measurable size
-        let old_uuids: Vec<uuid::Uuid> = (0..1000).map(|_| uuid::Uuid::new_v4()).collect();
-        for (i, uuid) in old_uuids.iter().enumerate() {
-            let event = RawEvent {
-                uuid: Some(*uuid),
-                event: format!("old_event_{i}"),
-                distinct_id: Some(serde_json::Value::String(format!("old_user_{i}"))),
-                token: Some("token1".to_string()),
-                properties: std::collections::HashMap::from([
-                    ("key1".to_string(), serde_json::json!("value1")),
-                    ("key2".to_string(), serde_json::json!("value2")),
-                ]),
-                timestamp: Some(old_timestamp.clone()),
-                ..Default::default()
-            };
-            store.handle_event_with_raw(&event).unwrap();
+        // Should not exist initially
+        assert!(store.get_timestamp_record(&key).unwrap().is_none());
+
+        // Store the metadata
+        store.put_timestamp_record(&key, &metadata).unwrap();
+
+        // Should exist now
+        let retrieved = store.get_timestamp_record(&key).unwrap();
+        assert!(retrieved.is_some());
+
+        // Verify the metadata was stored correctly
+        let retrieved_metadata = retrieved.unwrap();
+        assert_eq!(retrieved_metadata.duplicate_count, 0);
+        // Verify the original event was stored correctly by converting back
+        let stored_event = retrieved_metadata.get_original_event().unwrap();
+        assert_eq!(stored_event.event, event.event);
+        assert_eq!(stored_event.uuid, event.uuid);
+        assert_eq!(stored_event.distinct_id, event.distinct_id);
+        assert_eq!(stored_event.token, event.token);
+        assert_eq!(retrieved_metadata.seen_uuids.len(), 1);
+        if let Some(uuid) = event.uuid {
+            assert!(retrieved_metadata.seen_uuids.contains(&uuid.to_string()));
         }
+    }
 
-        // Add new events (should be kept)
-        let new_uuids: Vec<uuid::Uuid> = (0..100).map(|_| uuid::Uuid::new_v4()).collect();
-        for (i, uuid) in new_uuids.iter().enumerate() {
-            let event = RawEvent {
-                uuid: Some(*uuid),
-                event: format!("new_event_{i}"),
-                distinct_id: Some(serde_json::Value::String(format!("new_user_{i}"))),
-                token: Some("token1".to_string()),
-                properties: std::collections::HashMap::from([
-                    ("key1".to_string(), serde_json::json!("value1")),
-                    ("key2".to_string(), serde_json::json!("value2")),
-                ]),
-                timestamp: Some(new_timestamp.clone()),
-                ..Default::default()
-            };
-            store.handle_event_with_raw(&event).unwrap();
-        }
+    #[test]
+    fn test_uuid_record_storage() {
+        let (store, _temp_dir) = create_test_store();
 
-        // Compact and flush to ensure data is written to SST files
+        // Create a test key and metadata
+        let event = create_test_raw_event();
+        let key = UuidKey::from(&event);
+        let metadata = UuidMetadata::new(&event);
+        let timestamp = 1234567890;
+
+        // Should not exist initially
+        assert!(store.get_uuid_record(&key).unwrap().is_none());
+
+        // Store the metadata
+        store.put_uuid_record(&key, &metadata, timestamp).unwrap();
+
+        // Should exist now
+        let retrieved = store.get_uuid_record(&key).unwrap();
+        assert!(retrieved.is_some());
+
+        // Verify the metadata was stored correctly
+        let retrieved_metadata = retrieved.unwrap();
+        assert_eq!(retrieved_metadata.duplicate_count, 0);
+        // Verify the original event was stored correctly by converting back
+        let stored_event = retrieved_metadata.get_original_event().unwrap();
+        assert_eq!(stored_event.event, event.event);
+        assert_eq!(stored_event.uuid, event.uuid);
+        assert_eq!(stored_event.distinct_id, event.distinct_id);
+        assert_eq!(stored_event.token, event.token);
+        assert_eq!(retrieved_metadata.seen_timestamps.len(), 1);
+    }
+
+    #[test]
+    fn test_batch_deduplication() {
+        let (store, _temp_dir) = create_test_store();
+
+        // Create test keys as raw bytes (since get_non_duplicated_keys still uses raw bytes)
+        let keys: Vec<&[u8]> = vec![b"key1", b"key2", b"key3"];
+
+        // All should be non-duplicated initially
+        let non_dup = store.get_non_duplicated_keys(keys.clone()).unwrap();
+        assert_eq!(non_dup.len(), 3);
+
+        // Add one key to timestamp CF directly (using raw store access for this test)
         store
             .store
-            .compact_cf(DeduplicationStore::TIMESTAMP_CF)
+            .put(DeduplicationStore::TIMESTAMP_CF, b"key2", b"value2")
             .unwrap();
-        store.store.compact_cf(DeduplicationStore::UUID_CF).unwrap();
-        store
-            .store
-            .compact_cf(DeduplicationStore::UUID_TIMESTAMP_INDEX_CF)
-            .unwrap();
+
+        // Now only 2 should be non-duplicated
+        let non_dup = store.get_non_duplicated_keys(keys).unwrap();
+        assert_eq!(non_dup.len(), 2);
+        assert!(!non_dup.contains(&b"key2".as_ref()));
+    }
+
+    #[test]
+    fn test_store_creation_and_basic_operations() {
+        let (store, _temp_dir) = create_test_store();
+
+        // Test that store was created successfully
+        assert_eq!(store.get_topic(), "test_topic");
+        assert_eq!(store.get_partition(), 0);
+
+        // Test flush doesn't error
         store.flush().unwrap();
 
-        // Force cleanup with 40% to clean up events older than 6 days
-        // With 10 days of data, 40% means we clean up to 6 days ago
-        // Since new events are 5 days old, they should be kept
-        store.cleanup_old_entries_with_percentage(0.40).unwrap();
-
-        // Verify some old UUID records can be added again (were cleaned)
-        for i in 0..5 {
-            let test_uuid = uuid::Uuid::new_v4();
-            let old_event = RawEvent {
-                uuid: Some(test_uuid),
-                event: format!("old_event_{i}"),
-                distinct_id: Some(serde_json::Value::String(format!("old_user_{i}"))),
-                token: Some("token1".to_string()),
-                properties: std::collections::HashMap::new(),
-                timestamp: Some(old_timestamp.clone()),
-                ..Default::default()
-            };
-
-            // These should be new again after cleanup (timestamp records were deleted)
-            assert_eq!(
-                store.handle_event_with_raw(&old_event).unwrap(),
-                DeduplicationResult::New
-            );
-        }
-
-        // Verify new records are still detected as duplicates
-        for (i, &uuid) in new_uuids.iter().take(5).enumerate() {
-            let test_event = RawEvent {
-                uuid: Some(uuid),
-                event: format!("new_event_{i}"),
-                distinct_id: Some(serde_json::Value::String(format!("new_user_{i}"))),
-                token: Some("token1".to_string()),
-                properties: std::collections::HashMap::new(),
-                timestamp: Some(new_timestamp.clone()),
-                ..Default::default()
-            };
-
-            // These should still be duplicates (not cleaned up)
-            assert_eq!(
-                store.handle_event_with_raw(&test_event).unwrap(),
-                DeduplicationResult::PotentialDuplicate(DeduplicationType::Timestamp)
-            );
-        }
-    }
-
-    #[test]
-    fn test_batch_deletion_boundaries() {
-        let (store, _temp_dir) = create_test_store(Some(1000)); // Small capacity to force cleanup
-
-        // Use timestamps relative to now for predictable cleanup behavior
-        let now = chrono::Utc::now();
-        let base_timestamp = now - chrono::Duration::days(10);
-        let base_ms = base_timestamp.timestamp_millis() as u64;
-
-        // Create 2500 events (more than BATCH_SIZE of 1000) with sequential timestamps
-        for i in 0..2500 {
-            let timestamp_ms = base_ms + i;
-            let timestamp = chrono::DateTime::from_timestamp_millis(timestamp_ms as i64)
-                .unwrap()
-                .to_rfc3339();
-
-            let event = RawEvent {
-                uuid: Some(uuid::Uuid::new_v4()),
-                event: "batch_test".to_string(),
-                distinct_id: Some(serde_json::Value::String(format!("user{i}"))),
-                token: Some("token1".to_string()),
-                properties: std::collections::HashMap::from([(
-                    "data".to_string(),
-                    serde_json::json!(format!("value_{}", i)),
-                )]),
-                timestamp: Some(timestamp),
-                ..Default::default()
-            };
-            store.handle_event_with_raw(&event).unwrap();
-        }
-
-        // Add some newer events that shouldn't be cleaned
-        let new_base_timestamp = now - chrono::Duration::days(5); // 5 days ago
-        let new_base_ms = new_base_timestamp.timestamp_millis() as u64;
-        for i in 0..100 {
-            let timestamp_ms = new_base_ms + i;
-            let timestamp = chrono::DateTime::from_timestamp_millis(timestamp_ms as i64)
-                .unwrap()
-                .to_rfc3339();
-
-            let event = RawEvent {
-                uuid: Some(uuid::Uuid::new_v4()),
-                event: "new_batch_test".to_string(),
-                distinct_id: Some(serde_json::Value::String(format!("new_user{i}"))),
-                token: Some("token1".to_string()),
-                properties: std::collections::HashMap::new(),
-                timestamp: Some(timestamp),
-                ..Default::default()
-            };
-            store.handle_event_with_raw(&event).unwrap();
-        }
-
-        // Compact and flush to ensure proper size reporting
-        store
-            .store
-            .compact_cf(DeduplicationStore::TIMESTAMP_CF)
-            .unwrap();
-        store.store.compact_cf(DeduplicationStore::UUID_CF).unwrap();
-        store
-            .store
-            .compact_cf(DeduplicationStore::UUID_TIMESTAMP_INDEX_CF)
-            .unwrap();
-        store.flush().unwrap();
-
-        // Count initial UUID records
-        let uuid_cf = store
-            .store
-            .get_cf_handle(DeduplicationStore::UUID_CF)
-            .unwrap();
-        let mut count_before = 0;
-        let mut iter = store
-            .store
-            .db
-            .iterator_cf(&uuid_cf, rocksdb::IteratorMode::Start);
-        while iter.next().is_some() {
-            count_before += 1;
-        }
-        assert_eq!(count_before, 2600); // 2500 old + 100 new
-
-        // Trigger cleanup with 40% to clean up events older than 6 days
-        // With 10 days of data, 40% means we clean up to 6 days ago
-        // This should remove the 10-day-old events but keep the 5-day-old events
-        store.cleanup_old_entries_with_percentage(0.40).unwrap();
-
-        // Count remaining UUID records
-        let mut count_after = 0;
-        let mut iter_after = store
-            .store
-            .db
-            .iterator_cf(&uuid_cf, rocksdb::IteratorMode::Start);
-        while iter_after.next().is_some() {
-            count_after += 1;
-        }
-
-        // Should have cleaned up old records
-        // With percentage-based cleanup, we expect approximately the new 100 to remain
-        assert!(count_after < count_before);
-        assert!(count_after <= 200); // Should have at most the new 100 + some boundary cases
-    }
-
-    #[test]
-    fn test_no_uuid_event_handling() {
-        let (store, _temp_dir) = create_test_store(None);
-
-        // Event without UUID
-        let event = RawEvent {
-            uuid: None, // No UUID
-            event: "no_uuid_event".to_string(),
-            distinct_id: Some(serde_json::Value::String("user1".to_string())),
-            token: Some("token1".to_string()),
-            properties: std::collections::HashMap::new(),
-            timestamp: Some("2021-01-01T00:00:00Z".to_string()),
-            ..Default::default()
-        };
-
-        // Should be tracked only in timestamp CF, not UUID CF
-        assert_eq!(
-            store.handle_event_with_raw(&event).unwrap(),
-            DeduplicationResult::New
-        );
-
-        // Duplicate by timestamp
-        assert_eq!(
-            store.handle_event_with_raw(&event).unwrap(),
-            DeduplicationResult::ConfirmedDuplicate(
-                DeduplicationType::Timestamp,
-                DeduplicationResultReason::SameEvent
-            )
-        );
-
-        // Verify no UUID tracking occurred
-        let uuid_cf = store
-            .store
-            .get_cf_handle(DeduplicationStore::UUID_CF)
-            .unwrap();
-        let mut iter = store
-            .store
-            .db
-            .iterator_cf(&uuid_cf, rocksdb::IteratorMode::Start);
-        assert!(iter.next().is_none()); // UUID CF should be empty
-
-        // Verify timestamp tracking worked
-        let timestamp_key = TimestampKey::from(&event);
-        let timestamp_key_bytes: Vec<u8> = (&timestamp_key).into();
-        let timestamp_metadata = store
-            .store
-            .get(DeduplicationStore::TIMESTAMP_CF, &timestamp_key_bytes)
-            .unwrap();
-        assert!(timestamp_metadata.is_some());
+        // Test getting total size (should not error)
+        let _size = store.get_total_size().unwrap();
     }
 }

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use kafka_deduplicator::store::deduplication_store::DeduplicationResult;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -12,7 +11,7 @@ use kafka_deduplicator::checkpoint::{
 };
 use kafka_deduplicator::checkpoint_manager::CheckpointManager;
 use kafka_deduplicator::kafka::types::Partition;
-use kafka_deduplicator::store::{DeduplicationStore, DeduplicationStoreConfig};
+use kafka_deduplicator::store::{DeduplicationStore, DeduplicationStoreConfig, TimestampMetadata};
 use kafka_deduplicator::store_manager::StoreManager;
 
 use common_types::RawEvent;
@@ -277,9 +276,9 @@ async fn test_manual_checkpoint_export_incremental() {
         create_test_raw_event("user2", "token1", "event2"),
     ];
     for event in &events {
-        let result = store.handle_event_with_raw(event);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), DeduplicationResult::New); // All events should be new
+        let key = event.into();
+        let metadata = TimestampMetadata::new(event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
     }
 
     let tmp_checkpoint_dir = TempDir::new().unwrap();
@@ -366,9 +365,9 @@ async fn test_checkpoint_manual_export_full() {
         create_test_raw_event("user2", "token1", "event2"),
     ];
     for event in &events {
-        let result = store.handle_event_with_raw(event);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), DeduplicationResult::New); // All events should be new
+        let key = event.into();
+        let metadata = TimestampMetadata::new(event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
     }
 
     let tmp_checkpoint_dir = TempDir::new().unwrap();
@@ -448,9 +447,9 @@ async fn test_incremental_vs_full_upload_serial() {
         create_test_raw_event("user2", "token1", "event2"),
     ];
     for event in &events {
-        let result = store.handle_event_with_raw(event);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), DeduplicationResult::New); // All events should be new
+        let key = event.into();
+        let metadata = TimestampMetadata::new(event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
     }
 
     let tmp_checkpoint_dir = TempDir::new().unwrap();
@@ -524,9 +523,9 @@ async fn test_unavailable_uploader() {
         create_test_raw_event("user2", "token1", "event2"),
     ];
     for event in &events {
-        let result = store.handle_event_with_raw(event);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), DeduplicationResult::New); // All events should be new
+        let key = event.into();
+        let metadata = TimestampMetadata::new(event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
     }
 
     let tmp_checkpoint_dir = TempDir::new().unwrap();
@@ -580,9 +579,9 @@ async fn test_unpopulated_exporter() {
         create_test_raw_event("user2", "token1", "event2"),
     ];
     for event in &events {
-        let result = store.handle_event_with_raw(event);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), DeduplicationResult::New); // All events should be new
+        let key = event.into();
+        let metadata = TimestampMetadata::new(event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
     }
 
     let tmp_checkpoint_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Problem

The DeduplicationStore held most of the deduplication logic, we wanted to add a producer to the pipeline and it makes more sense that the deduplication logic resides in the DeduplicationProcessor as well as the management of the outputs and the DeduplicationStore should mainly handle the serialization and deserialization of events and stored metadata.

## Changes

- Moved all deduplication logic from the store to the processor
