### PR TITLE
fix(ci): correct reviewers syntax in update-bot-ips workflow

### DIFF
--- a/.github/workflows/update-bot-ips.yml
+++ b/.github/workflows/update-bot-ips.yml
@@ -59,5 +59,5 @@ jobs:
                       automated
                       bot-ips
                       dependencies
-                  reviewers:
-                      - PostHog/team-messaging
+                  reviewers: |
+                      PostHog/team-messaging


### PR DESCRIPTION
## Problem

I am seeing failures here after merging into master. e.g: https://github.com/PostHog/posthog/actions/runs/18164327882/workflow
It seems it is failing because it expects a comma-separated list or the pipe syntax.

## Changes

Change the syntax.

## How did you test this code?

I did not 😓 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
