### PR TITLE
chore(flags): Replace statsd with prometheus counter

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -14,9 +14,9 @@ from django.dispatch import receiver
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
+from prometheus_client import Counter
 from rest_framework import exceptions, request, serializers, status, viewsets
 from rest_framework.response import Response
-from statshog.defaults.django import statsd
 
 from posthog.schema import PropertyOperator
 
@@ -76,6 +76,12 @@ from posthog.settings.feature_flags import LOCAL_EVAL_RATE_LIMITS, REMOTE_CONFIG
 BEHAVIOURAL_COHORT_FOUND_ERROR_CODE = "behavioral_cohort_found"
 
 MAX_PROPERTY_VALUES = 1000
+
+LOCAL_EVALUATION_REQUEST_COUNTER = Counter(
+    "posthog_local_evaluation_request_total",
+    "Local evaluation API requests",
+    labelnames=["send_cohorts"],
+)
 
 
 class LocalEvaluationThrottle(BurstRateThrottle):
@@ -1369,7 +1375,7 @@ class FeatureFlagViewSet(
         include_cohorts = "send_cohorts" in request.GET
 
         # Track send_cohorts parameter usage
-        statsd.incr("posthog_local_evaluation_request", tags={"send_cohorts": str(include_cohorts).lower()})
+        LOCAL_EVALUATION_REQUEST_COUNTER.labels(send_cohorts=str(include_cohorts).lower()).inc()
 
         try:
             # Check if team is quota limited for feature flags


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/38894 I added a counter for local evaluation requests. But I used the outdated statsd lib instead of prometheus counters.

## Changes

Use prometheus counter.

## How did you test this code?

Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
