### PR TITLE
fix(tabs): double clicking opens rename

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -177,15 +177,11 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
 
     useEffect(() => {
         if (isEditing && inputRef.current) {
-            // bring the tab into focus
-            // oxlint-disable-next-line exhaustive-deps
-            clickOnTab(tab)
-            // focus the input with delay to ensure the tab input is rendered
             setTimeout(() => {
                 inputRef.current?.focus()
             }, 100)
         }
-    }, [isEditing, tab, clickOnTab])
+    }, [isEditing])
 
     return (
         <Link
@@ -250,6 +246,7 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
                             endTabEdit()
                         }
                     }}
+                    autoComplete="off"
                     autoFocus
                     onFocus={(e) => e.target.select()}
                 />


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C08499A7REU/p1759280637136119

## Changes

Fix the loop

## How did you test this code?

![2025-10-01 21 03 58](https://github.com/user-attachments/assets/5659b37e-7c00-4cbf-95bb-bf8819e3130a)
