### PR TITLE
feat(kafka-deduplicator): enable cooperative sticky partition assignment

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -13,6 +13,11 @@ pub struct Config {
     #[envconfig(default = "kafka-deduplicator")]
     pub kafka_consumer_group: String,
 
+    // supplied by k8s deploy env, used as part of kafka
+    // consumer client ID for sticky partition mappings
+    #[envconfig(from = "HOSTNAME")]
+    pub pod_hostname: Option<String>,
+
     #[envconfig(default = "events")]
     pub kafka_consumer_topic: String,
 

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -51,6 +51,18 @@ impl ConsumerConfigBuilder {
         self
     }
 
+    /// Enable sticky partition assignments based on the kafka client ID supplied
+    pub fn with_sticky_partition_assignment(mut self, client_id: Option<&str>) -> Self {
+        match client_id {
+            Some(found_client_id) => {
+                self.config.set("client.id", found_client_id.to_string());
+                self.config.set("partition.assignment.strategy", "cooperative-sticky");
+            }
+            None => {},
+        }
+        self
+    }
+
     /// Build the final configuration
     pub fn build(self) -> ClientConfig {
         self.config

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -54,7 +54,7 @@ impl ConsumerConfigBuilder {
     /// Enable sticky partition assignments based on the kafka client ID supplied
     pub fn with_sticky_partition_assignment(mut self, client_id: Option<&str>) -> Self {
         if let Some(found_client_id) = client_id {
-            self.config.set("client.id", found_client_id.to_string());
+            self.config.set("client.id", found_client_id);
             self.config
                 .set("partition.assignment.strategy", "cooperative-sticky");
         }

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -53,12 +53,10 @@ impl ConsumerConfigBuilder {
 
     /// Enable sticky partition assignments based on the kafka client ID supplied
     pub fn with_sticky_partition_assignment(mut self, client_id: Option<&str>) -> Self {
-        match client_id {
-            Some(found_client_id) => {
-                self.config.set("client.id", found_client_id.to_string());
-                self.config.set("partition.assignment.strategy", "cooperative-sticky");
-            }
-            None => {},
+        if let Some(found_client_id) = client_id {
+            self.config.set("client.id", found_client_id.to_string());
+            self.config
+                .set("partition.assignment.strategy", "cooperative-sticky");
         }
         self
     }

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -152,6 +152,7 @@ impl KafkaDeduplicatorService {
         let consumer_config =
             ConsumerConfigBuilder::new(&self.config.kafka_hosts, &self.config.kafka_consumer_group)
                 .with_tls(self.config.kafka_tls)
+                .with_sticky_partition_assignment(self.config.pod_hostname.as_deref())
                 .offset_reset(&self.config.kafka_consumer_offset_reset)
                 .build();
 


### PR DESCRIPTION
## Problem
We would like to take advantage of the stable k8s pod name (injected as env var `HOSTNAME`) of each `StatefulSet` member in the consumer group to enable [cooperative sticky partition assignment](https://www.confluent.io/blog/cooperative-rebalancing-in-kafka-streams-consumer-ksqldb/#incremental-cooperative-rebalancing-protocol) in our `librdkafka` client.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add new config field to extract `HOSTNAME` from the pod'd deploy env
* Add consumer config builder logic to:
    * Apply the `HOSTNAME` as consumer group `client.id`
    * Enable cooperative sticky assignment policy in the client

☝️ this is conditional on `HOSTNAME` being set as expected in the pod env, which it will be due to our use of `StatefulSet` in the `kafka-deduplicator` deploys

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog update required
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
