### PR TITLE
fix: replay over-calculating player inspector items

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
@@ -109,32 +109,25 @@ function networkMatch(
 ): SharedListMiniFilter | null {
     if (isNavigationEvent(item)) {
         return miniFiltersByKey['performance-document']
-    } else if (
-        item.data.entry_type === 'resource' &&
-        ['fetch', 'xmlhttprequest'].includes(item.data.initiator_type || '')
-    ) {
+    } else if (['fetch', 'xmlhttprequest'].includes(item.data.initiator_type || '')) {
         return miniFiltersByKey['performance-fetch']
     } else if (
-        item.data.entry_type === 'resource' &&
-        (item.data.initiator_type === 'script' ||
-            (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.js')))
+        item.data.initiator_type === 'script' ||
+        (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.js'))
     ) {
         return miniFiltersByKey['performance-assets-js']
     } else if (
-        item.data.entry_type === 'resource' &&
-        (item.data.initiator_type === 'css' ||
-            (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.css')))
+        item.data.initiator_type === 'css' ||
+        (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.css'))
     ) {
         return miniFiltersByKey['performance-assets-css']
     } else if (
-        item.data.entry_type === 'resource' &&
-        (item.data.initiator_type === 'img' ||
-            (['link', 'other'].includes(item.data.initiator_type || '') &&
-                !!IMAGE_WEB_EXTENSIONS.some((ext) => item.data.name?.includes(`.${ext}`))))
+        item.data.initiator_type === 'img' ||
+        (['link', 'other'].includes(item.data.initiator_type || '') &&
+            !!IMAGE_WEB_EXTENSIONS.some((ext) => item.data.name?.includes(`.${ext}`)))
     ) {
         return miniFiltersByKey['performance-assets-img']
     } else if (
-        item.data.entry_type === 'resource' &&
         ['other'].includes(item.data.initiator_type || '') &&
         ![...IMAGE_WEB_EXTENSIONS, 'css', 'js'].some((ext) => item.data.name?.includes(`.${ext}`))
     ) {

--- a/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 
+import { objectsEqual } from 'lib/utils'
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -211,6 +212,7 @@ export const miniFiltersLogic = kea<miniFiltersLogicType>([
                     enabled: selectedMiniFilters.includes(x.key),
                 }))
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         miniFiltersByKey: [
@@ -221,6 +223,7 @@ export const miniFiltersLogic = kea<miniFiltersLogicType>([
                     return acc
                 }, {})
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         miniFiltersForTypeByKey: [

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -619,6 +619,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     rawConsoleLogs: consoleLogs,
                 }
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         notebookCommentItems: [
@@ -648,6 +649,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 }
                 return items
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         commentItems: [
@@ -680,6 +682,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 }
                 return items
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         allContextItems: [
@@ -729,6 +732,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                 return items
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         allItems: [
@@ -921,6 +925,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     itemsByType,
                 }
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         filteredItems: [
@@ -963,6 +968,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     return acc
                 }, [] as InspectorListItem[])
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         seekbarItems: [


### PR DESCRIPTION
while looking at something else I realised that the player inspector logic was constantly recalculating many of its selectors

well, not any more!