### PR TITLE
feat(customers): Summarize person sessions

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -146,6 +146,7 @@ import {
     SessionRecordingSnapshotResponse,
     SessionRecordingType,
     SessionRecordingUpdateType,
+    SessionSummaryResponse,
     SharingConfigurationType,
     SlackChannelType,
     SubscriptionType,
@@ -1510,6 +1511,11 @@ export class ApiRequest {
 
     public datasetItem(id: string, teamId?: TeamType['id']): ApiRequest {
         return this.environmentsDetail(teamId).addPathComponent('dataset_items').addPathComponent(id)
+    }
+
+    // Session summary
+    public sessionSummary(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('session_summaries')
     }
 }
 
@@ -4339,6 +4345,12 @@ const api = {
             url = next
         }
         return results
+    },
+
+    sessionSummaries: {
+        async create(data: { session_ids: string[]; focus_area?: string }): Promise<SessionSummaryResponse> {
+            return await new ApiRequest().sessionSummary().withAction('create_session_summaries').create({ data })
+        },
     },
 }
 

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/AISessionSummary.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/AISessionSummary.tsx
@@ -1,0 +1,168 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconChevronRight, IconSparkles } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { pluralize } from 'lib/utils'
+
+import { TimelineEntry } from '~/queries/schema/schema-general'
+import { EnrichedSessionGroupSummaryPattern } from '~/types'
+
+import { notebookNodePersonFeedLogic } from './notebookNodePersonFeedLogic'
+
+export function AISessionSummary({ personId }: { personId: string }): JSX.Element | null {
+    const logic = notebookNodePersonFeedLogic({ personId })
+    const { canSummarize, sessions, sessionSummary, sessionSummaryLoading, summarizingState } = useValues(logic)
+    const { summarizeSessions } = useActions(logic)
+
+    if (!canSummarize) {
+        return null
+    }
+
+    const pluralizedSessions = pluralize((sessions as TimelineEntry[]).length, 'session')
+
+    return (
+        <>
+            <div className="mb-4 p-4 bg-surface-secondary rounded border">
+                {!sessionSummary && summarizingState === 'idle' && (
+                    <div className="flex items-center justify-between">
+                        <AISummaryMessage
+                            heading="AI Session Summary"
+                            subheading={`Analyze ${pluralizedSessions} and identify patterns`}
+                        />
+                        <LemonButton
+                            type="primary"
+                            icon={<IconSparkles />}
+                            onClick={summarizeSessions}
+                            loading={sessionSummaryLoading}
+                            data-attr="person-feed-summarize-sessions"
+                        >
+                            Summarize Sessions
+                        </LemonButton>
+                    </div>
+                )}
+
+                {summarizingState === 'loading' && (
+                    <AISummaryMessage
+                        heading="Generating AI Summary"
+                        subheading={`This may take 1-5 minutes. Analyzing ${pluralizedSessions} for patterns and insights.`}
+                    />
+                )}
+
+                {sessionSummary && summarizingState === 'success' && (
+                    <div className="space-y-2">
+                        <AISummaryMessage
+                            heading="Summary Results"
+                            subheading="Summary generated successfully! Patterns are displayed below."
+                        />
+                        <p className="text-sm text-muted">
+                            {pluralize(sessionSummary.summary?.patterns?.length || 0, 'pattern')} found
+                        </p>
+                        {sessionSummary.patterns.map((pattern: EnrichedSessionGroupSummaryPattern) => (
+                            <PatternCard key={pattern.pattern_id} pattern={pattern} />
+                        ))}
+                    </div>
+                )}
+
+                {summarizingState === 'error' && (
+                    <AISummaryMessage
+                        heading="Error Generating Summary"
+                        subheading="An error occurred while generating the summary. Please try again."
+                    />
+                )}
+            </div>
+        </>
+    )
+}
+
+function AISummaryMessage({ heading, subheading }: { heading: string; subheading: string }): JSX.Element {
+    return (
+        <div className="mb-2">
+            <div>
+                <h3 className="font-semibold mb-1">{heading}</h3>
+                <div className="text-sm text-muted">{subheading}</div>
+            </div>
+        </div>
+    )
+}
+
+const severityColors: Record<string, string> = {
+    critical: 'text-danger',
+    high: 'text-warning',
+    medium: 'text-muted',
+    low: 'text-success',
+}
+
+const severityIcons: Record<string, string> = {
+    critical: '🔴',
+    high: '🟠',
+    medium: '🟡',
+    low: '🟢',
+}
+
+const PatternCard = ({ pattern }: { pattern: EnrichedSessionGroupSummaryPattern }): JSX.Element => {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const severityIcon = severityIcons[pattern.severity] || '⚪'
+    const severityColor = severityColors[pattern.severity] || 'text-muted'
+
+    const sessionsAffectedPercent = (pattern.stats.sessions_affected_ratio * 100).toFixed(0)
+    const successRate = (pattern.stats.segments_success_ratio * 100).toFixed(0)
+
+    return (
+        <div className="border rounded bg-bg-light mb-2">
+            <LemonButton
+                onClick={() => setIsExpanded(!isExpanded)}
+                icon={
+                    <IconChevronRight
+                        className={`w-3 h-3 opacity-80 transition-transform ${!isExpanded ? '' : 'rotate-90'}`}
+                    />
+                }
+                className="w-full py-3 flex gap-2 hover:bg-surface-secondary transition-colors text-left"
+            >
+                <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-1">
+                        <span className="text-base">{severityIcon}</span>
+                        <span className="font-semibold">{pattern.pattern_name}</span>
+                        <span className={`text-xs ${severityColor} uppercase`}>{pattern.severity}</span>
+                    </div>
+                    <p className="text-sm text-muted">{pattern.pattern_description}</p>
+                    <div className="flex gap-4 mt-2 text-xs text-muted">
+                        <span>
+                            <strong>{sessionsAffectedPercent}%</strong> sessions affected
+                        </span>
+                        <span>
+                            <strong>{successRate}%</strong> success rate
+                        </span>
+                        <span>
+                            <strong>{pattern.stats.occurences}</strong> occurrences
+                        </span>
+                    </div>
+                </div>
+            </LemonButton>
+
+            {isExpanded && (
+                <div className="p-3 border-t">
+                    <div className="ml-6">
+                        <div className="mb-2">
+                            <h4 className="font-semibold text-sm mb-1">Detection Indicators</h4>
+                            <ul className="list-disc list-inside text-sm space-y-1">
+                                {pattern.indicators.map((indicator, idx) => (
+                                    <li key={idx} className="text-muted">
+                                        {indicator}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+
+                        {pattern.events.length > 0 && (
+                            <div className="text-xs text-muted">
+                                {pluralize(pattern.events.length, 'example')} available
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
@@ -10,6 +10,7 @@ import { PersonType } from '~/types'
 
 import { createPostHogWidgetNode } from '../NodeWrapper'
 import { notebookNodeLogic } from '../notebookNodeLogic'
+import { AISessionSummary } from './AISessionSummary'
 import { Session } from './Session'
 import { notebookNodePersonFeedLogic } from './notebookNodePersonFeedLogic'
 
@@ -35,6 +36,8 @@ const Feed = ({ person }: FeedProps): JSX.Element => {
 
     return (
         <div className="p-2">
+            <AISessionSummary personId={id} />
+            <h3 className="font-semibold mb-2">Session Timeline</h3>
             {sessions.map((session: any) => (
                 <Session key={session.sessionId} session={session} />
             ))}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.test.ts
@@ -1,0 +1,358 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { SessionSummaryResponse } from '~/types'
+
+import { notebookNodePersonFeedLogic } from './notebookNodePersonFeedLogic'
+
+const mockSessionSummaryResponse: SessionSummaryResponse = {
+    patterns: [
+        {
+            pattern_id: 1,
+            pattern_name: 'High Error Rate',
+            pattern_description: 'Users encountering multiple errors during checkout process',
+            severity: 'high' as const,
+            indicators: ['Multiple 4xx errors', 'Long response times', 'Failed transactions'],
+            events: [],
+            stats: {
+                occurences: 15,
+                sessions_affected: 8,
+                sessions_affected_ratio: 0.4,
+                segments_success_ratio: 0.2,
+            },
+        },
+        {
+            pattern_id: 2,
+            pattern_name: 'Successful Navigation',
+            pattern_description: 'Users successfully completing their intended workflow',
+            severity: 'low' as const,
+            indicators: ['Smooth page transitions', 'Quick load times', 'Successful form submissions'],
+            events: [],
+            stats: {
+                occurences: 25,
+                sessions_affected: 12,
+                sessions_affected_ratio: 0.6,
+                segments_success_ratio: 0.9,
+            },
+        },
+    ],
+}
+
+const mockSessionsWithRecording = [
+    { sessionId: 'session-1', recording_duration_s: 120 },
+    { sessionId: 'session-2', recording_duration_s: 300 },
+    { sessionId: 'session-3', recording_duration_s: 180 },
+]
+
+const mockSessionsWithoutRecording = [
+    { sessionId: 'session-4', recording_duration_s: 0 },
+    { sessionId: 'session-5', recording_duration_s: null },
+]
+
+const mockMixedSessions = [
+    { sessionId: 'session-1', recording_duration_s: 120 },
+    { sessionId: 'session-2', recording_duration_s: 0 },
+    { sessionId: 'session-3', recording_duration_s: 180 },
+    { sessionId: 'session-4', recording_duration_s: null },
+]
+
+describe('notebookNodePersonFeedLogic', () => {
+    let logic: ReturnType<typeof notebookNodePersonFeedLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    describe('sessions loading', () => {
+        it('loads sessions timeline on mount', async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadSessionsTimeline', 'loadSessionsTimelineSuccess'])
+                .toMatchValues({
+                    sessions: mockSessionsWithRecording,
+                    sessionsLoading: false,
+                })
+        })
+
+        it('handles sessions loading failure', async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: () => [500, { detail: 'Internal badaras error' }],
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadSessionsTimeline', 'loadSessionsTimelineFailure'])
+                .toMatchValues({
+                    sessions: null,
+                    sessionsLoading: false,
+                })
+        })
+    })
+
+    describe('sessionIdsWithRecording selector', () => {
+        it('filters sessions with recordings and returns session IDs', async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadSessionsTimelineSuccess'])
+                .toMatchValues({
+                    sessionIdsWithRecording: ['session-1', 'session-2', 'session-3'],
+                })
+        })
+
+        it('returns empty array when no sessions have recordings', async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithoutRecording,
+                    },
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['loadSessionsTimelineSuccess']).toMatchValues({
+                sessionIdsWithRecording: [],
+            })
+        })
+
+        it('filters mixed sessions correctly', async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockMixedSessions,
+                    },
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadSessionsTimelineSuccess'])
+                .toMatchValues({
+                    sessionIdsWithRecording: ['session-1', 'session-3'],
+                })
+        })
+    })
+
+    describe('canSummarize selector', () => {
+        it('returns true when AI_SESSION_SUMMARY feature flag is enabled', async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                },
+            })
+            featureFlagLogic.actions.setFeatureFlags([], {
+                [FEATURE_FLAGS.AI_SESSION_SUMMARY]: true,
+            })
+
+            // Set feature flag to true
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            expect(logic.values.canSummarize).toBe(true)
+        })
+
+        it('returns false when AI_SESSION_SUMMARY feature flag is disabled', async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                },
+            })
+            featureFlagLogic.actions.setFeatureFlags([], {
+                [FEATURE_FLAGS.AI_SESSION_SUMMARY]: false,
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            expect(logic.values.canSummarize).toBe(false)
+        })
+    })
+
+    describe('session summarization', () => {
+        beforeEach(async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                    [`/api/environments/${MOCK_TEAM_ID}/session_summaries/create_session_summaries`]: jest
+                        .fn()
+                        .mockResolvedValue([200, mockSessionSummaryResponse]),
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            // Wait for sessions to load
+            await expectLogic(logic).toDispatchActions(['loadSessionsTimelineSuccess'])
+        })
+
+        it('successfully summarizes sessions', async () => {
+            logic.actions.summarizeSessions()
+
+            await expectLogic(logic)
+                .toDispatchActions(['summarizeSessions', 'summarizeSessionsSuccess'])
+                .toMatchValues({
+                    sessionSummary: mockSessionSummaryResponse,
+                    summarizingState: 'success',
+                    sessionSummaryLoading: false,
+                })
+        })
+
+        it('handles summarization failure', async () => {
+            // Override the mock to return an error
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                    [`/api/environments/${MOCK_TEAM_ID}/session_summaries/create_session_summaries`]: jest
+                        .fn()
+                        .mockResolvedValue([500, { detail: 'Internal server error' }]),
+                },
+            })
+
+            logic.actions.summarizeSessions()
+
+            await expectLogic(logic)
+                .toDispatchActions(['summarizeSessions', 'summarizeSessionsFailure'])
+                .toMatchValues({
+                    sessionSummary: null,
+                    summarizingState: 'error',
+                    sessionSummaryLoading: false,
+                })
+        })
+
+        it('sets loading state during summarization', async () => {
+            // Mock a delayed response
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                    [`/api/projects/${MOCK_TEAM_ID}/session_summaries/create_session_summaries`]: () =>
+                        new Promise((resolve) => {
+                            setTimeout(() => resolve([200, mockSessionSummaryResponse]), 100)
+                        }),
+                },
+            })
+
+            logic.actions.summarizeSessions()
+
+            // Should immediately set loading state
+            expect(logic.values.summarizingState).toBe('loading')
+            expect(logic.values.sessionSummaryLoading).toBe(true)
+
+            await expectLogic(logic).toDispatchActions(['summarizeSessionsSuccess']).toMatchValues({
+                sessionSummary: mockSessionSummaryResponse,
+                summarizingState: 'success',
+                sessionSummaryLoading: false,
+            })
+        })
+
+        it('does not summarize when no sessions with recordings exist', async () => {
+            // Setup logic with no recording sessions
+            logic.unmount()
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithoutRecording,
+                    },
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['loadSessionsTimelineSuccess'])
+
+            logic.actions.summarizeSessions()
+
+            await expectLogic(logic)
+                .toDispatchActions(['summarizeSessions', 'summarizeSessionsSuccess'])
+                .toFinishAllListeners()
+                .toMatchValues({
+                    sessionSummary: null,
+                    summarizingState: 'success',
+                    sessionSummaryLoading: false,
+                })
+        })
+    })
+
+    describe('summarizing state management', () => {
+        beforeEach(async () => {
+            useMocks({
+                post: {
+                    [`/api/environments/${MOCK_TEAM_ID}/query/`]: {
+                        results: mockSessionsWithRecording,
+                    },
+                },
+            })
+
+            logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['loadSessionsTimelineSuccess'])
+        })
+
+        it('starts with idle state', () => {
+            expect(logic.values.summarizingState).toBe('idle')
+        })
+
+        it('can set summarizing state manually', () => {
+            logic.actions.setSummarizingState('loading')
+            expect(logic.values.summarizingState).toBe('loading')
+
+            logic.actions.setSummarizingState('success')
+            expect(logic.values.summarizingState).toBe('success')
+
+            logic.actions.setSummarizingState('error')
+            expect(logic.values.summarizingState).toBe('error')
+
+            logic.actions.setSummarizingState('idle')
+            expect(logic.values.summarizingState).toBe('idle')
+        })
+    })
+})

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.ts
@@ -1,9 +1,15 @@
-import { afterMount, kea, key, path, props } from 'kea'
-import { loaders } from 'kea-loaders'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { lazyLoaders, loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { performQuery } from '~/queries/query'
 import { NodeKind, SessionsTimelineQuery, SessionsTimelineQueryResponse } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
+import { SessionSummaryResponse } from '~/types'
 
 import type { notebookNodePersonFeedLogicType } from './notebookNodePersonFeedLogicType'
 
@@ -15,8 +21,16 @@ export const notebookNodePersonFeedLogic = kea<notebookNodePersonFeedLogicType>(
     props({} as NotebookNodePersonFeedLogicProps),
     path((key) => ['scenes', 'notebooks', 'Notebook', 'Nodes', 'notebookNodePersonFeedLogic', key]),
     key(({ personId }) => personId),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags']],
+    })),
 
-    loaders(({ props }) => ({
+    actions({
+        summarizeSessions: true,
+        setSummarizingState: (state: 'idle' | 'loading' | 'success' | 'error') => ({ state }),
+    }),
+
+    lazyLoaders(({ props }) => ({
         sessions: [
             null as SessionsTimelineQueryResponse['results'] | null,
             {
@@ -32,7 +46,54 @@ export const notebookNodePersonFeedLogic = kea<notebookNodePersonFeedLogicType>(
             },
         ],
     })),
-    afterMount(({ actions }) => {
-        actions.loadSessionsTimeline()
+
+    loaders(({ actions, values }) => ({
+        sessionSummary: [
+            null as SessionSummaryResponse | null,
+            {
+                summarizeSessions: async () => {
+                    try {
+                        actions.setSummarizingState('loading')
+                        const sessionsWithRecordings = values?.sessions
+                            ?.filter((session) => !!session.recording_duration_s)
+                            .map((session) => session.sessionId)
+                            .filter((id) => id !== undefined)
+                        if (sessionsWithRecordings) {
+                            return await api.sessionSummaries.create({
+                                session_ids: sessionsWithRecordings,
+                            })
+                        }
+                    } catch (error) {
+                        posthog.captureException(error)
+                        throw error
+                    }
+                },
+            },
+        ],
+    })),
+
+    reducers({
+        summarizingState: [
+            'idle' as 'idle' | 'loading' | 'success' | 'error',
+            {
+                setSummarizingState: (_, { state }) => state,
+            },
+        ],
     }),
+
+    selectors({
+        canSummarize: [
+            (s) => [s.featureFlags, s.sessions],
+            (featureFlags, sessions) => featureFlags[FEATURE_FLAGS.AI_SESSION_SUMMARY] && sessions?.length > 0,
+        ],
+    }),
+
+    listeners(({ actions }) => ({
+        summarizeSessionsSuccess: () => {
+            actions.setSummarizingState('success')
+        },
+        summarizeSessionsFailure: () => {
+            actions.setSummarizingState('error')
+        },
+    })),
 ])

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5813,3 +5813,52 @@ export interface DatasetItem {
     created_at: string
     deleted: boolean
 }
+
+// Session Summaries
+export interface SessionSummaryResponse {
+    patterns: EnrichedSessionGroupSummaryPattern[]
+}
+
+export interface EnrichedSessionGroupSummaryPattern {
+    pattern_id: number
+    pattern_name: string
+    pattern_description: string
+    severity: 'low' | 'medium' | 'high' | 'critical'
+    indicators: string[]
+    events: PatternAssignedEventSegmentContext[]
+    stats: EnrichedSessionGroupSummaryPatternStats
+}
+
+export interface EnrichedSessionGroupSummaryPatternStats {
+    occurences: number
+    sessions_affected: number
+    sessions_affected_ratio: number
+    segments_success_ratio: number
+}
+
+export interface PatternAssignedEventSegmentContext {
+    segment_name: string
+    segment_outcome: string
+    segment_success: boolean
+    segment_index: number
+    previous_events_in_segment: EnrichedPatternAssignedEvent[]
+    target_event: EnrichedPatternAssignedEvent
+    next_events_in_segment: EnrichedPatternAssignedEvent[]
+}
+
+export interface EnrichedPatternAssignedEvent {
+    event_id: string
+    event_uuid: string
+    session_id: string
+    description: string
+    abandonment: boolean
+    confusion: boolean
+    exception: string | null
+    timestamp: string
+    milliseconds_since_start: number
+    window_id: string | null
+    current_url: string | null
+    event: string
+    event_type: string | null
+    event_index: number
+}


### PR DESCRIPTION
## Problem
We're displaying the event feed, but it's hard to read. Let's add AI summary to that
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/38941
## Changes
- Add `AISessionSummary` on top of the event feed in person feed, when feature flag is enabled

This is an experiment, not sure if going to work well. Some problems I expect:
- Small number of sessions with recordings, leading to the analysis not to find patterns and error out.
	- Follow up would be to fetch sessions to summarize independently from the feed, using a time window (last 7d, 30d, etc)
- Results are not persisted anywhere. If user switches tab within the tab (wut) it will reset the logic and lose the ongoing request.
	- Follow up would be to persist data in person feed canvas (create an actual notebook and persist data in it)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Initial state
<img width="3248" height="1942" alt="image" src="https://github.com/user-attachments/assets/d30d880f-3a1d-49f3-8154-384df55146f8" />

### Results
<img width="3248" height="1942" alt="image" src="https://github.com/user-attachments/assets/1d8e7559-4006-48f4-ab40-95a2667f3eb1" />

### Results expanded
<img width="3248" height="1942" alt="image" src="https://github.com/user-attachments/assets/2257774c-4bcc-440f-935a-809065e4dc4f" />

### No sessions to summarize
<img width="1624" height="971" alt="image" src="https://github.com/user-attachments/assets/aa214be8-0f13-4f97-ac0b-9960d1b8bff8" />

### Loading state
<img width="1624" height="971" alt="image" src="https://github.com/user-attachments/assets/9666961e-33cc-47f3-b75b-9d16018beb89" />

### Error state
<img width="1580" height="927" alt="image" src="https://github.com/user-attachments/assets/e061e744-329c-4f5a-9879-440c875a527f" />

## How did you test this code?
- Unit tests for logic file
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
