### PR TITLE
fix: no need to check resource when filtering network requests

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
@@ -109,32 +109,25 @@ function networkMatch(
 ): SharedListMiniFilter | null {
     if (isNavigationEvent(item)) {
         return miniFiltersByKey['performance-document']
-    } else if (
-        item.data.entry_type === 'resource' &&
-        ['fetch', 'xmlhttprequest'].includes(item.data.initiator_type || '')
-    ) {
+    } else if (['fetch', 'xmlhttprequest'].includes(item.data.initiator_type || '')) {
         return miniFiltersByKey['performance-fetch']
     } else if (
-        item.data.entry_type === 'resource' &&
-        (item.data.initiator_type === 'script' ||
-            (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.js')))
+        item.data.initiator_type === 'script' ||
+        (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.js'))
     ) {
         return miniFiltersByKey['performance-assets-js']
     } else if (
-        item.data.entry_type === 'resource' &&
-        (item.data.initiator_type === 'css' ||
-            (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.css')))
+        item.data.initiator_type === 'css' ||
+        (['link', 'other'].includes(item.data.initiator_type || '') && item.data.name?.includes('.css'))
     ) {
         return miniFiltersByKey['performance-assets-css']
     } else if (
-        item.data.entry_type === 'resource' &&
-        (item.data.initiator_type === 'img' ||
-            (['link', 'other'].includes(item.data.initiator_type || '') &&
-                !!IMAGE_WEB_EXTENSIONS.some((ext) => item.data.name?.includes(`.${ext}`))))
+        item.data.initiator_type === 'img' ||
+        (['link', 'other'].includes(item.data.initiator_type || '') &&
+            !!IMAGE_WEB_EXTENSIONS.some((ext) => item.data.name?.includes(`.${ext}`)))
     ) {
         return miniFiltersByKey['performance-assets-img']
     } else if (
-        item.data.entry_type === 'resource' &&
         ['other'].includes(item.data.initiator_type || '') &&
         ![...IMAGE_WEB_EXTENSIONS, 'css', 'js'].some((ext) => item.data.name?.includes(`.${ext}`))
     ) {


### PR DESCRIPTION
see: https://posthog.slack.com/archives/C074A08LP1B/p1759329248011989

a customer's site is not providing performance data to us for all of their network calls

we check for a value only provided by the performance observer when filtering for "displayable" requests

so we hide the request
but it's not necessary

we can't draw a detailed timeline for the request, but we can show it