### PR TITLE
feat(propdefs): test batch write query variants

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/propdefs-skip-locked'
 jobs:
     build:
         name: build ${{ matrix.image }}

--- a/rust/property-defs-rs/src/batch_ingestion.rs
+++ b/rust/property-defs-rs/src/batch_ingestion.rs
@@ -368,7 +368,6 @@ async fn write_event_properties_batch(
 
         match result {
             Err(e) => {
-                println!("<DEBUG ({})> Batch write to posthog_eventproperty error: {:?}", tries, &e);
                 if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
                     metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "failed")])
                         .increment(1);
@@ -491,7 +490,6 @@ async fn write_property_definitions_batch(
 
         match result {
             Err(e) => {
-                println!("<DEBUG ({})> Batch write to posthog_propertydefinition error: {:?}", tries, &e);
                 if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
                     metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "failed")])
                         .increment(1);
@@ -611,7 +609,6 @@ async fn write_event_definitions_batch(
 
         match result {
             Err(e) => {
-                println!("<DEBUG ({})> Batch write to posthog_eventdefinition error: {:?}", tries, &e);
                 if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
                     metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "failed")])
                         .increment(1);


### PR DESCRIPTION
## Problem
We would like to experiment with reduced lock contention across pods and PG connections. If successful, this would unlock a less well-grouped source topic partitioning strategy that will help avoid lag due to hot partitions.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Rework the batch write SQL to apply `FOR UPDATE SKIP LOCKED` on existing rows in the batch
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, in CI (batch write test suites) and in test deploy when PR is approved, prior to merge.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog updates required
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
