### PR TITLE
chore: label subscription metrics with execution path

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -24,6 +24,7 @@ DEFAULT_MAX_ASSET_COUNT = 6
 SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
     "subscription_asset_generation_duration_seconds",
     "Time spent generating assets for a subscription",
+    labelnames=["execution_path"],
     buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
 )
 
@@ -32,7 +33,7 @@ def generate_assets(
     resource: Union[Subscription, SharingConfiguration],
     max_asset_count: int = DEFAULT_MAX_ASSET_COUNT,
 ) -> tuple[list[Insight], list[ExportedAsset]]:
-    with SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
+    with SUBSCRIPTION_ASSET_GENERATION_TIMER.labels(execution_path="celery").time():
         if resource.dashboard:
             tiles = list(
                 resource.dashboard.tiles.select_related("insight")
@@ -85,7 +86,7 @@ async def generate_assets_async(
     This function requires "created_by", "insight", "dashboard", "team" be prefetched on the resource
     """
     logger.info("generate_assets_async.starting", resource_id=getattr(resource, "id", None))
-    with SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
+    with SUBSCRIPTION_ASSET_GENERATION_TIMER.labels(execution_path="temporal").time():
         if resource.dashboard:
             # Fetch tiles asynchronously
             dashboard = resource.dashboard  # Capture reference for lambda


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We will eventually migrate from celery to temporary for subscriptions, so knowing how each is performing is useful. Right now, only 10% of subscriptions use temporal. 

## Changes
Add a label for each code path. 


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
