### PR TITLE
fix(shortcuts): Add success toast message when adding shortcut item (#38974)

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -37,6 +37,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { FileSystemEntry, FileSystemIconType, FileSystemImport } from '~/queries/schema/schema-general'
 import { UserBasicType } from '~/types'
 
+import { panelLayoutLogic } from '../panelLayoutLogic'
 import type { projectTreeDataLogicType } from './projectTreeDataLogicType'
 import { getExperimentalProductsTree } from './projectTreeWebAnalyticsExperiment'
 
@@ -55,6 +56,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
         ],
+        actions: [panelLayoutLogic, ['setActivePanelIdentifier']],
     })),
     actions({
         loadUnfiledItems: true,
@@ -271,6 +273,15 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                                   href: item.href,
                               }
                     const response = await api.fileSystemShortcuts.create(shortcutItem)
+                    lemonToast.success('Shortcut created successfully', {
+                        button: {
+                            label: 'View',
+                            dataAttr: 'project-tree-view-shortcuts',
+                            action: () => {
+                                actions.setActivePanelIdentifier('Shortcuts')
+                            },
+                        },
+                    })
                     return [...values.shortcutData, response]
                 },
                 deleteShortcut: async ({ id }) => {


### PR DESCRIPTION
## Problem

Closes #38974

## Changes


https://github.com/user-attachments/assets/75124a3c-0c29-4b1e-8176-74d497a645a2



## How did you test this code?

Locally:
1) Click on `People` on the left side bar
2) Look for `Persons` and click on the triple dot beside it
3) Click `Add to shortcuts panel`

You should see the toast message, and clicking `View` will open the side panel 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._