### PR TITLE
fix(ingestion): retry on distinct id fk constraint failure

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-merge-types.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-types.ts
@@ -67,6 +67,18 @@ export class TargetPersonNotFoundError extends PersonMergePersonNotFoundError {
 }
 
 /**
+ * Error when source person cannot be deleted due to concurrent distinct ID additions.
+ * This occurs when a concurrent merge operation adds a distinct ID to the person being
+ * deleted, causing a foreign key constraint violation. The retry will refresh the person
+ * data and move all distinct IDs (including the newly added ones) before attempting deletion.
+ */
+export class SourcePersonHasDistinctIdsError extends PersonMergePersonNotFoundError {
+    constructor(message: string) {
+        super(message, 'source')
+    }
+}
+
+/**
  * Result of a person merge operation
  */
 export type PersonMergeResult =


### PR DESCRIPTION
## Problem

There is a race condition around person merges that looks like this:
1. TX A: an event in a batch gets a $create_alias event for person A (target) and person B (source)
2. TX A: it moves the distinct ids belonging to person B to person A (hasn't yet deleted person B)
3. TX B: a second $create_alias event in the batch (concurrently processed)  merges Person C (source) into Person B (target)
4. TX B: person C distinct ids get moved to person B
5. TX A: the merge transaction is still opened and is looking to delete person B after the merge. person B has a distinct id associated with it, so the distinct id foreign key constraint is triggered and we get an error.

## Changes

Force a retry on fk constraint errors from the DB when we fail during the delete action of a person merge.

## How did you test this code?

This code has some e2e tests that cover the scenario I laid out above. It currently isn't being caught by that branch because our current test database does not have any constraints set up on it, just plain tables.

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
