### PR TITLE
fix(shortcuts): Check if non folder item is already in shortcut

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -57,7 +57,7 @@ import { BrowserLikeMenuItems } from './menus/BrowserLikeMenuItems'
 import { ProductAnalyticsMenuItems } from './menus/ProductAnalyticsMenuItems'
 import { SessionReplayMenuItems } from './menus/SessionReplayMenuItems'
 import { projectTreeLogic } from './projectTreeLogic'
-import { calculateMovePath } from './utils'
+import { calculateMovePath, joinPath, splitPath } from './utils'
 
 export interface ProjectTreeProps {
     logicKey?: string // key override?
@@ -80,7 +80,7 @@ export function ProjectTree({
     showRecents,
 }: ProjectTreeProps): JSX.Element {
     const [uniqueKey] = useState(() => `project-tree-${counter++}`)
-    const { viableItems } = useValues(projectTreeDataLogic)
+    const { viableItems, shortcutNonFolderPaths } = useValues(projectTreeDataLogic)
     const { deleteShortcut, addShortcutItem } = useActions(projectTreeDataLogic)
     const { groupTypes } = useValues(groupAnalyticsConfigLogic)
     const { deleteGroupType } = useActions(groupAnalyticsConfigLogic)
@@ -261,6 +261,9 @@ export function ProjectTree({
                 </>
             ) : null
 
+        const isItemAFolder = item.record?.type === 'folder'
+        const itemShortcutPath = joinPath([splitPath(item.record?.path).pop() ?? 'Unnamed'])
+        const isItemAlreadyInShortcut = !isItemAFolder && shortcutNonFolderPaths.has(itemShortcutPath)
         return (
             <>
                 {productMenu}
@@ -352,6 +355,12 @@ export function ProjectTree({
                                 <ButtonPrimitive menuItem>Remove from shortcuts</ButtonPrimitive>
                             </MenuItem>
                         ) : null
+                    ) : isItemAlreadyInShortcut ? (
+                        <MenuItem asChild disabled={true} data-attr="tree-item-menu-add-to-shortcuts-disabutton">
+                            <ButtonPrimitive menuItem disabled={true}>
+                                Already in shortcuts panel
+                            </ButtonPrimitive>
+                        </MenuItem>
                     ) : (
                         <MenuItem
                             asChild

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -356,7 +356,7 @@ export function ProjectTree({
                             </MenuItem>
                         ) : null
                     ) : isItemAlreadyInShortcut ? (
-                        <MenuItem asChild disabled={true} data-attr="tree-item-menu-add-to-shortcuts-disabutton">
+                        <MenuItem asChild disabled={true} data-attr="tree-item-menu-add-to-shortcuts-disabled-button">
                             <ButtonPrimitive menuItem disabled={true}>
                                 Already in shortcuts panel
                             </ButtonPrimitive>

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -737,6 +737,11 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
             (s) => [s.getStaticTreeItems],
             (getStaticTreeItems) => getStaticTreeItems('', false).find((item) => item.id === 'new://')?.children ?? [],
         ],
+        shortcutNonFolderPaths: [
+            (s) => [s.shortcutData],
+            (shortcutData) =>
+                new Set(shortcutData.filter((shortcut) => shortcut.type !== 'folder').map((shortcut) => shortcut.path)),
+        ],
     }),
     listeners(({ actions, values }) => ({
         loadFolder: async ({ folder }) => {


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/38973

I'm not really sure about this solution so feel free to close it or hit me with some feedback!

I'm only tackling the non folder items as a POC, i can try to support folder items as well if we think this is a decent approach

## Changes

https://github.com/user-attachments/assets/5ccdb3b0-dad4-44ed-bc9d-b0085af03a30


## How did you test this code?

Locally:
1) Go to an item on the left sidebar like `SQL editor`
2) Click on the triple dot beside it and select `Add to shortcuts panel`

You should see the item you added in the shortcuts panel, and when you open the item's triple dot again you should see `Already added to shortcuts` and you can't click on it.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
