### PR TITLE
fix(shortcuts): Hide 'Delete folder' and 'Rename' in shortcuts for folder items

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
@@ -281,7 +281,9 @@ export function MenuItems({
                 </MenuItem>
             ) : null}
 
-            {item.record?.path && item.record?.type === 'folder' ? (
+            {item.record?.path &&
+            item.record?.type === 'folder' &&
+            !(item.id.startsWith('shortcuts://') || item.id.startsWith('shortcuts/')) ? (
                 <MenuItem
                     asChild
                     onClick={(e) => {
@@ -318,7 +320,9 @@ export function MenuItems({
                 >
                     <ButtonPrimitive menuItem>Delete shortcut</ButtonPrimitive>
                 </MenuItem>
-            ) : item.record?.path && item.record?.type === 'folder' ? (
+            ) : item.record?.path &&
+              item.record?.type === 'folder' &&
+              !(item.id.startsWith('shortcuts://') || item.id.startsWith('shortcuts/')) ? (
                 <MenuItem
                     asChild
                     onClick={(e) => {


### PR DESCRIPTION
## Problem

`Rename` and `Delete Folder` does not work for folder shortcut options:


https://github.com/user-attachments/assets/3e8cc537-9617-41a8-a047-77b6defd17da



## Changes


https://github.com/user-attachments/assets/4ccbdc15-7f91-464c-bcfa-f2eb19d74698



## How did you test this code?

Locally:
1) Add a folder to `shortcuts`
2) Go to the left side bar and click on `Shortcuts`
3) Go to the folder that you added and click on the triple dots options icon, you should not see `Rename` and `Delete folder` in the menu

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._


