### PR TITLE
chore(deps): upgrade django-structlog to 9.1.0

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     "social_django",
     "django_filters",
     "axes",
+    "django_structlog",
     "drf_spectacular",
     *PRODUCTS_APPS,
     "django_otp",
@@ -79,7 +80,6 @@ MIDDLEWARE = [
     "posthog.gzip_middleware.ScopedGZipMiddleware",
     "posthog.middleware.per_request_logging_context_middleware",
     "django_structlog.middlewares.RequestMiddleware",
-    "django_structlog.middlewares.CeleryMiddleware",
     "posthog.middleware.Fix204Middleware",
     "django.middleware.security.SecurityMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
@@ -112,6 +112,8 @@ MIDDLEWARE = [
     "posthog.middleware.CSPMiddleware",
     "posthoganalytics.integrations.django.PosthogContextMiddleware",
 ]
+
+DJANGO_STRUCTLOG_CELERY_ENABLED = True
 
 if DEBUG:
     # rebase_migration command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "django-prometheus==2.2.0",
     "django-redis==5.2.0",
     "django-statsd==2.5.2",
-    "django-structlog==2.1.3",
+    "django-structlog[celery]~=9.1.0",
     "django-two-factor-auth~=1.18.0",
     "djangorestframework~=3.16.1",
     "djangorestframework-csv~=3.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4411,19 +4411,11 @@ requires-dist = [
     { name = "django-prometheus", specifier = "==2.2.0" },
     { name = "django-redis", specifier = "==5.2.0" },
     { name = "django-statsd", specifier = "==2.5.2" },
-<<<<<<< HEAD
-    { name = "django-structlog", specifier = "==2.1.3" },
+    { name = "django-structlog", extras = ["celery"], specifier = "~=9.1.0" },
     { name = "django-two-factor-auth", specifier = "~=1.18.0" },
     { name = "djangorestframework", specifier = "~=3.16.1" },
     { name = "djangorestframework-csv", specifier = "~=3.0.2" },
     { name = "djangorestframework-dataclasses", specifier = "~=1.4.0" },
-=======
-    { name = "django-structlog", extras = ["celery"], specifier = "~=9.1.0" },
-    { name = "django-two-factor-auth", specifier = "==1.14.0" },
-    { name = "djangorestframework", specifier = "==3.15.1" },
-    { name = "djangorestframework-csv", specifier = "==2.1.1" },
-    { name = "djangorestframework-dataclasses", specifier = "==1.2.0" },
->>>>>>> 06cbe2f4d5 (chore(deps): upgrade django-structlog to 9.1.0)
     { name = "dlt", specifier = "==1.3.0" },
     { name = "dnspython", specifier = "==2.2.1" },
     { name = "drf-exceptions-hog", specifier = "==0.4.0" },
@@ -5277,18 +5269,6 @@ wheels = [
 [[package]]
 name = "python-ipware"
 version = "3.0.0"
-<<<<<<< HEAD
-=======
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/60/da4426c3e9aee56f08b24091a9e85a0414260f928f97afd0013dfbd0332f/python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062", size = 16609, upload-time = "2024-04-19T20:00:58.938Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/bd/ccd7416fdb30f104ddf6cfd8ee9f699441c7d9880a26f9b3089438adee05/python_ipware-3.0.0-py3-none-any.whl", hash = "sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60", size = 10761, upload-time = "2024-04-19T20:00:57.171Z" },
-]
-
-[[package]]
-name = "python-multipart"
-version = "0.0.20"
->>>>>>> 06cbe2f4d5 (chore(deps): upgrade django-structlog to 9.1.0)
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/60/da4426c3e9aee56f08b24091a9e85a0414260f928f97afd0013dfbd0332f/python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062", size = 16609, upload-time = "2024-04-19T20:00:58.938Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1606,16 +1606,22 @@ wheels = [
 
 [[package]]
 name = "django-structlog"
-version = "2.1.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "asgiref" },
     { name = "django" },
     { name = "django-ipware" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/a5/81685c81a673811f9a18c61e7d967e5ad4d6f4e12f08e61ca676265bac44/django-structlog-2.1.3.tar.gz", hash = "sha256:eda70d97217a14f610a59f0d638e5206c59861c5031584c67f0017c88bfdf6c0", size = 13673, upload-time = "2021-09-29T01:14:36.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/8c/cc2711def7a365ce5ff4cee73a57f7ca329369a02715adf7090b208f71fe/django_structlog-9.1.1.tar.gz", hash = "sha256:14342c6c824581f1e063c88a8bc52314cd67995a3bd4a4fc8c27ea37ccd78947", size = 22948, upload-time = "2025-04-07T12:56:35.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/15/b4181fb493d870844c7fa09e9677773f6c5b4c449711704db449dfa5da72/django_structlog-2.1.3-py3-none-any.whl", hash = "sha256:4923f944e35b26920efba5e3254672b55dae064ed5b747c194c4eb3400ac0ee1", size = 13017, upload-time = "2021-09-29T01:14:33.859Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c5/c43b4182464e0dada9674c3e9602222023808ad3be39663074b5f9080a8c/django_structlog-9.1.1-py3-none-any.whl", hash = "sha256:5b6ac3abdf6549e94ccb35160b1f10266f1627c3ac77844571235a08a1ddae66", size = 18087, upload-time = "2025-04-07T12:56:33.394Z" },
+]
+
+[package.optional-dependencies]
+celery = [
+    { name = "celery" },
 ]
 
 [[package]]
@@ -4167,7 +4173,7 @@ dependencies = [
     { name = "django-prometheus" },
     { name = "django-redis" },
     { name = "django-statsd" },
-    { name = "django-structlog" },
+    { name = "django-structlog", extra = ["celery"] },
     { name = "django-two-factor-auth" },
     { name = "djangorestframework" },
     { name = "djangorestframework-csv" },
@@ -4405,11 +4411,19 @@ requires-dist = [
     { name = "django-prometheus", specifier = "==2.2.0" },
     { name = "django-redis", specifier = "==5.2.0" },
     { name = "django-statsd", specifier = "==2.5.2" },
+<<<<<<< HEAD
     { name = "django-structlog", specifier = "==2.1.3" },
     { name = "django-two-factor-auth", specifier = "~=1.18.0" },
     { name = "djangorestframework", specifier = "~=3.16.1" },
     { name = "djangorestframework-csv", specifier = "~=3.0.2" },
     { name = "djangorestframework-dataclasses", specifier = "~=1.4.0" },
+=======
+    { name = "django-structlog", extras = ["celery"], specifier = "~=9.1.0" },
+    { name = "django-two-factor-auth", specifier = "==1.14.0" },
+    { name = "djangorestframework", specifier = "==3.15.1" },
+    { name = "djangorestframework-csv", specifier = "==2.1.1" },
+    { name = "djangorestframework-dataclasses", specifier = "==1.2.0" },
+>>>>>>> 06cbe2f4d5 (chore(deps): upgrade django-structlog to 9.1.0)
     { name = "dlt", specifier = "==1.3.0" },
     { name = "dnspython", specifier = "==2.2.1" },
     { name = "drf-exceptions-hog", specifier = "==0.4.0" },
@@ -5263,6 +5277,18 @@ wheels = [
 [[package]]
 name = "python-ipware"
 version = "3.0.0"
+<<<<<<< HEAD
+=======
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/60/da4426c3e9aee56f08b24091a9e85a0414260f928f97afd0013dfbd0332f/python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062", size = 16609, upload-time = "2024-04-19T20:00:58.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/bd/ccd7416fdb30f104ddf6cfd8ee9f699441c7d9880a26f9b3089438adee05/python_ipware-3.0.0-py3-none-any.whl", hash = "sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60", size = 10761, upload-time = "2024-04-19T20:00:57.171Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+>>>>>>> 06cbe2f4d5 (chore(deps): upgrade django-structlog to 9.1.0)
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/60/da4426c3e9aee56f08b24091a9e85a0414260f928f97afd0013dfbd0332f/python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062", size = 16609, upload-time = "2024-04-19T20:00:58.938Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Upgrades django-structlog from 2.1.3 to 9.1.0, building on top of the axes upgrade (which provides django-ipware 6+ compatibility).

## Changes

- Updated django-structlog to ~=9.1.0 with celery extras
- Added django_structlog to INSTALLED_APPS (required in 6.0+)
- Removed CeleryMiddleware from MIDDLEWARE (deprecated approach)
- Added DJANGO_STRUCTLOG_CELERY_ENABLED = True (new configuration)

## Breaking Changes Handled

**Version 6.0+:**
- django_structlog must be added to INSTALLED_APPS ✅
- Celery integration via DJANGO_STRUCTLOG_CELERY_ENABLED setting instead of middleware ✅

**Version 7.0+:**
- Upgraded django-ipware to version 6 (handled by axes upgrade dependency)

**Version 9.0+:**
- Requires Python 3.9+, Django 4.2+ ✅
- Added type hints (no action needed)

## Test Plan

- Django system check passes
- Application starts successfully
- CI will validate full test suite
