### PR TITLE
fix(dashboards): fix flaky test with non-deterministic text tile ordering

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard_text_tiles.py
+++ b/posthog/api/test/dashboards/test_dashboard_text_tiles.py
@@ -221,10 +221,12 @@ class TestDashboardTiles(APIBaseTest, QueryMatchingTest):
             dashboard_id, text="i am a third text"
         )
         assert len(with_another_tile_dashboard_json["tiles"]) == 2
-        assert [t["text"]["body"] for t in with_another_tile_dashboard_json["tiles"]] == [
-            "soy texto",
-            "i am a third text",
-        ]
+        assert sorted([t["text"]["body"] for t in with_another_tile_dashboard_json["tiles"]]) == sorted(
+            [
+                "soy texto",
+                "i am a third text",
+            ]
+        )
 
     def test_cannot_create_text_tile_with_body_over_4000_characters(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})


### PR DESCRIPTION
## Summary
Fixed flaky `test_do_not_see_deleted_text_tiles_when_adding_new_ones` test that was failing intermittently due to non-deterministic ordering of text tiles in the API response.

## Root Cause
Text tiles are ordered by `insight__order` in the `dashboard_queryset` method, which is NULL for text tiles (since they don't have associated insights). This results in database-dependent ordering that can vary between test runs, making any assertion that depends on a specific order flaky.

## Changes
- Modified the test assertion to sort both the actual and expected lists before comparison
- This makes the test order-independent while still validating that the correct tiles are returned

## Test Plan
Ran the test multiple times to confirm it passes consistently.