### PR TITLE
fix: reduce job frequency to once daily but increase expiry

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -107,10 +107,10 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     sender.add_periodic_task(
-        crontab(hour="*", minute="0"),  # hourly
+        crontab(hour="1", minute="0"),  # daily
         enforce_max_replay_retention_period.s(),
-        name="hourly enforce max replay retention period",
-        expires=30 * 60,  # half hour
+        name="daily enforce max replay retention period",
+        expires=12 * 60 * 60,  # 12 hours
     )
 
     # Update events table partitions twice a week


### PR DESCRIPTION
On the current schedule this Celery job does not get picked up before it expires. We don't need it to run hourly or even close to hourly so this PR reduces the frequency to once-daily and then increases the expiry to 12 hours (from 30 mins).
