### PR TITLE
chore(capture): Declutter capture logs

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -308,7 +308,7 @@ pub async fn event(
                     "processing",
                     state.capture_mode.as_tag(),
                 );
-                error!("event: rejected payload: {}", err);
+                warn!("event: rejected payload: {}", err);
                 return Err(err);
             }
 
@@ -373,7 +373,7 @@ pub async fn recording(
                     "processing",
                     state.capture_mode.as_tag(),
                 );
-                error!("recordings:rejected payload: {:?}", err);
+                warn!("recordings:rejected payload: {:?}", err);
                 return Err(err);
             }
             Ok(CaptureResponse {


### PR DESCRIPTION
## Problem

Currently we have error logs for an expected behavior, which is rejecting messages due to them being invalid. 

## Changes

- Changed `rejected payload` logs from `error` to `warn`

