### PR TITLE
perf(ci): extend uv cache optimization to all workflows

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -85,12 +85,14 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install uv
+              id: setup-uv
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
                   version: 0.7.8
 
             - name: Install SAML (python3-saml) dependencies
+              if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -324,6 +324,7 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install uv
+              id: setup-uv
               if: needs.changes.outputs.shouldRun == 'true'
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
@@ -340,7 +341,7 @@ jobs:
                   echo "changed=$changed" >> $GITHUB_OUTPUT
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.shouldRun == 'true'
+              if: needs.changes.outputs.shouldRun == 'true' && steps.setup-uv.outputs.cache-hit != 'true'
               shell: bash
               run: |
                   sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -70,12 +70,14 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install uv
+              id: setup-uv
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
                   version: 0.7.8
 
             - name: Install SAML (python3-saml) dependencies
+              if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
@@ -175,11 +177,13 @@ jobs:
                   python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - name: Install uv
+              id: setup-uv-hogql-python
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
                   version: 0.7.8
             - name: Install SAML (python3-saml) dependencies
+              if: steps.setup-uv-hogql-python.outputs.cache-hit != 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -163,6 +163,7 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install uv
+              id: setup-uv
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
@@ -186,7 +187,7 @@ jobs:
               run: cargo install sqlx-cli@0.7.3 --locked --no-default-features --features native-tls,postgres
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.nodejs == 'true'
+              if: needs.changes.outputs.nodejs == 'true' && steps.setup-uv.outputs.cache-hit != 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -69,6 +69,7 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install uv
+              id: setup-uv
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               if: needs.changes.outputs.python == 'true'
               with:
@@ -76,7 +77,7 @@ jobs:
                   version: 0.7.8
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.python == 'true'
+              if: needs.changes.outputs.python == 'true' && steps.setup-uv.outputs.cache-hit != 'true'
               shell: bash
               run: |
                   sudo apt-get update

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -159,6 +159,7 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install uv
+              id: setup-uv
               if: needs.changes.outputs.rust == 'true'
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
@@ -166,7 +167,7 @@ jobs:
                   version: 0.7.8
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.rust == 'true'
+              if: needs.changes.outputs.rust == 'true' && steps.setup-uv.outputs.cache-hit != 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl postgresql-client

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -43,6 +43,7 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install uv
+              id: setup-uv
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
@@ -71,9 +72,11 @@ jobs:
                   set -m
 
                   (
-                    echo ">>> [Python] Installing SAML (python3-saml) dependencies..."
-                    sudo apt-get update
-                    sudo apt-get install -y libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+                    if [ "${{ steps.setup-uv.outputs.cache-hit }}" != "true" ]; then
+                      echo ">>> [Python] Installing SAML (python3-saml) dependencies..."
+                      sudo apt-get update
+                      sudo apt-get install -y libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+                    fi
 
                     echo ">>> [Python] Installing dependencies..."
                     UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev


### PR DESCRIPTION
Extends the SAML dependency caching optimization from #38929 to all remaining CI workflows.

## Summary

PR #38929 added conditional SAML dependency installation to ci-backend.yml but missed 7 other workflows that also run `uv sync` and need the same optimization.

## Changes

Applied the same cache-hit pattern to:
- ci-nodejs.yml
- ci-hog.yml (2 jobs)
- ci-python.yml
- ci-dagster.yml
- ci-turbo.yml
- ci-rust.yml
- ci-e2e-playwright.yml

Each workflow now skips `apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl` when uv cache hits, saving ~1 minute per workflow run.

## Context

All these workflows run `uv sync --frozen --dev` which installs python3-saml. The SAML deps are only needed for compilation when the uv cache misses. Runtime libraries (`libxml2`, `libxmlsec1t64-openssl`) are pre-installed on Depot runners.