### PR TITLE
fix: increase timeout for child workflow

### DIFF
--- a/posthog/temporal/delete_recordings/workflows.py
+++ b/posthog/temporal/delete_recordings/workflows.py
@@ -44,7 +44,7 @@ class DeleteRecordingWorkflow(PostHogWorkflow):
         await workflow.execute_activity(
             delete_recording_blocks,
             DeleteRecordingBlocksInput(recording=recording_input, blocks=recording_blocks),
-            start_to_close_timeout=timedelta(minutes=1),
+            start_to_close_timeout=timedelta(minutes=10),
             retry_policy=common.RetryPolicy(
                 maximum_attempts=2,
                 initial_interval=timedelta(minutes=1),
@@ -77,10 +77,10 @@ class DeleteRecordingsWithPersonWorkflow(PostHogWorkflow):
         async with asyncio.TaskGroup() as delete_recordings:
             for session_id in session_ids:
                 delete_recordings.create_task(
-                    workflow.execute_child_workflow(
+                    workflow.start_child_workflow(
                         DeleteRecordingWorkflow.run,
                         RecordingInput(session_id=session_id, team_id=input.team_id),
                         parent_close_policy=ParentClosePolicy.ABANDON,
-                        execution_timeout=timedelta(minutes=1),
+                        execution_timeout=timedelta(minutes=10),
                     )
                 )

--- a/posthog/temporal/tests/delete_recordings/test_workflows.py
+++ b/posthog/temporal/tests/delete_recordings/test_workflows.py
@@ -1,4 +1,5 @@
 import uuid
+import asyncio
 from datetime import datetime, timedelta
 
 import pytest
@@ -144,12 +145,17 @@ async def test_delete_recording_with_person_workflow():
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
+            parent_id = str(uuid.uuid4())
+
             await env.client.execute_workflow(
                 DeleteRecordingsWithPersonWorkflow.run,
                 RecordingsWithPersonInput(distinct_ids=TEST_DISTINCT_IDS, team_id=TEST_TEAM_ID),
-                id=str(uuid.uuid4()),
+                id=parent_id,
                 task_queue=task_queue_name,
             )
+
+            # Wait a short while to let child workflows complete
+            await asyncio.sleep(3)
 
     # Check that all recording blocks were deleted
     assert TEST_SESSIONS == {


### PR DESCRIPTION
The delete-recordings workflow will time out when deleting very large recordings - let's increase the timeout value to avoid that.