### PR TITLE
fix(plugin-server): handle correctly empty attributes during chainToElements

### DIFF
--- a/frontend/src/lib/utils/elements-chain.ts
+++ b/frontend/src/lib/utils/elements-chain.ts
@@ -10,7 +10,7 @@ export function chainToElements(chain: string, options: { throwOnError?: boolean
     // Below splits the tag/classes from attributes
     // Needs a regex because classes can have : too
     const splitClassAttributes = /(.*?)($|:([a-zA-Z\-_0-9]*=.*))/g
-    const parseAttributesRegex = /((.*?)="(.*?[^\\])")/gm
+    const parseAttributesRegex = /((.*?)="((?:\\"|[^"])*)")/gm
 
     chain = chain.replace(/\n/g, '')
 

--- a/plugin-server/src/utils/db/elements-chain.ts
+++ b/plugin-server/src/utils/db/elements-chain.ts
@@ -8,7 +8,11 @@ const splitChainRegex = createTrackedRE2(/(?:[^\s;"]|"(?:[^"\\]|\\.)*")+/g, unde
 // Below splits the tag/classes from attributes
 // Needs a regex because classes can have : too
 const splitClassAttributes = createTrackedRE2(/(.*?)($|:([a-zA-Z\-_0-9]*=.*))/g, undefined, 'elements-chain:splitClass')
-const parseAttributesRegex = createTrackedRE2(/((.*?)="(.*?[^\\])")/gm, undefined, 'elements-chain:parseAttributes')
+const parseAttributesRegex = createTrackedRE2(
+    /((.*?)="((?:\\"|[^"])*)")/gm,
+    undefined,
+    'elements-chain:parseAttributes'
+)
 const newLine = createTrackedRE2(/\\n/g, undefined, 'elements-chain:newLine')
 
 export function elementsToString(elements: Element[]): string {

--- a/plugin-server/tests/utils/db/elements-chain.test.ts
+++ b/plugin-server/tests/utils/db/elements-chain.test.ts
@@ -109,6 +109,19 @@ describe('elementsToString and chainToElements', () => {
         expect(elementsString).toEqual('.another.something:attr__class="something another"nth-child="0"nth-of-type="0"')
         expect(chainToElements(elementsString, 0)).toEqual([expect.objectContaining(element)])
     })
+
+    it('handles empty attributes', () => {
+        const element = {
+            tag_name: 'div',
+            attributes: {
+                empty: '',
+            },
+        }
+        const elementsString = elementsToString([element])
+
+        expect(elementsString).toEqual('div:empty=""nth-child="0"nth-of-type="0"')
+        expect(chainToElements(elementsString, 0)).toEqual([expect.objectContaining(element)])
+    })
 })
 
 describe('extractElements()', () => {


### PR DESCRIPTION
## Problem

The `parseAttributesRegex` regex does not handle empty attributes correctly.

**Input**
```
div:empty=""nth-child="0"nth-of-type="0"
```
**Observed**
```javascript
[{
  attributes: {
    empty: '"nth-child=',
    '0"nth-of-type': '0'
  },
  order: 0,
  tag_name: 'div'
}]
```

**Expected**
```javascript      
[{
  attributes: {
    empty: ''
  },
  order: 0,
  tag_name: 'div',
  nth_child: 0,
  nth_of_type: 0
}]
```

## Consequences

I do not know how the `nth_child` and `nth_of_type` are used internally, so I cannot help here.

The thing I noticed is that when you inspect an event (i.e. Activity > Explore > Expand an autocapture event > Select tab "Elements") the reconstitued DOM is not correct.

<img width="794" height="161" alt="image" src="https://github.com/user-attachments/assets/721f4d6c-a7c2-4354-b5a7-e7746a6fe7a8" />

## How to reproduce

You can either use the test I added to reproduce the bug in a controlled environment.

Otherwise, you can run PostHog on an simple application and add a button that has empty attributes.
For instance:

```html
<div data-attr="attr" data-attr2="attr2" data-empty="" data-attr3="attr3">
  <button>Click me</button>
</div>
```

## Additional context

I discovered the bug, because I need to mask the values of all attributes excepted some.
So I hooked on the `before_send` function to modify the attributes, and instead of using some custom made function/regex to unparse the `$chain_elements`, I decided to reuse your logic.

## Changes

With the help of @joc-mer, we adapted the regex to support empty attributes.

## How did you test this code?

The code was tested by adding a new unit test and checking current tests do not break.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

