### PR TITLE
fix: Cast created_at to datetime for persons batch exports

### DIFF
--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -94,7 +94,7 @@ FROM (
         p.properties AS properties,
         pd.version AS person_distinct_id_version,
         p.version AS person_version,
-        toDateTime(p.created_at) AS created_at,
+        toDateTime64(p.created_at, 3) AS created_at,
         toBool(p.is_deleted) AS is_deleted,
         multiIf(
             (
@@ -159,7 +159,7 @@ SELECT
     p.properties AS properties,
     pd.version AS person_distinct_id_version,
     p.version AS person_version,
-    toDateTime(p.created_at) AS created_at,
+    toDateTime64(p.created_at, 3) AS created_at,
     toBool(p.is_deleted) AS is_deleted,
     multiIf(
         pd._timestamp < {interval_end}::DateTime64
@@ -731,7 +731,7 @@ SELECT
     p.properties AS properties,
     pd.version AS person_distinct_id_version,
     p.version AS person_version,
-    toDateTime(p.created_at) AS created_at,
+    toDateTime64(p.created_at, 3) AS created_at,
     toBool(p.is_deleted) AS is_deleted,
     multiIf(
         pd._timestamp < {interval_end}::DateTime64
@@ -886,7 +886,7 @@ FROM (
         p.properties AS properties,
         pd.version AS person_distinct_id_version,
         p.version AS person_version,
-        toDateTime(p.created_at) AS created_at,
+        toDateTime64(p.created_at, 3) AS created_at,
         toBool(p.is_deleted) AS is_deleted,
         multiIf(
             (

--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -94,7 +94,7 @@ FROM (
         p.properties AS properties,
         pd.version AS person_distinct_id_version,
         p.version AS person_version,
-        p.created_at AS created_at,
+        toDateTime64(p.created_at) AS created_at,
         toBool(p.is_deleted) AS is_deleted,
         multiIf(
             (
@@ -159,7 +159,7 @@ SELECT
     p.properties AS properties,
     pd.version AS person_distinct_id_version,
     p.version AS person_version,
-    p.created_at AS created_at,
+    toDateTime64(p.created_at) AS created_at,
     toBool(p.is_deleted) AS is_deleted,
     multiIf(
         pd._timestamp < {interval_end}::DateTime64
@@ -731,7 +731,7 @@ SELECT
     p.properties AS properties,
     pd.version AS person_distinct_id_version,
     p.version AS person_version,
-    p.created_at AS created_at,
+    toDateTime64(p.created_at) AS created_at,
     toBool(p.is_deleted) AS is_deleted,
     multiIf(
         pd._timestamp < {interval_end}::DateTime64
@@ -886,7 +886,7 @@ FROM (
         p.properties AS properties,
         pd.version AS person_distinct_id_version,
         p.version AS person_version,
-        p.created_at AS created_at,
+        toDateTime64(p.created_at) AS created_at,
         toBool(p.is_deleted) AS is_deleted,
         multiIf(
             (

--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -94,7 +94,7 @@ FROM (
         p.properties AS properties,
         pd.version AS person_distinct_id_version,
         p.version AS person_version,
-        toDateTime64(p.created_at) AS created_at,
+        toDateTime(p.created_at) AS created_at,
         toBool(p.is_deleted) AS is_deleted,
         multiIf(
             (
@@ -159,7 +159,7 @@ SELECT
     p.properties AS properties,
     pd.version AS person_distinct_id_version,
     p.version AS person_version,
-    toDateTime64(p.created_at) AS created_at,
+    toDateTime(p.created_at) AS created_at,
     toBool(p.is_deleted) AS is_deleted,
     multiIf(
         pd._timestamp < {interval_end}::DateTime64
@@ -731,7 +731,7 @@ SELECT
     p.properties AS properties,
     pd.version AS person_distinct_id_version,
     p.version AS person_version,
-    toDateTime64(p.created_at) AS created_at,
+    toDateTime(p.created_at) AS created_at,
     toBool(p.is_deleted) AS is_deleted,
     multiIf(
         pd._timestamp < {interval_end}::DateTime64
@@ -886,7 +886,7 @@ FROM (
         p.properties AS properties,
         pd.version AS person_distinct_id_version,
         p.version AS person_version,
-        toDateTime64(p.created_at) AS created_at,
+        toDateTime(p.created_at) AS created_at,
         toBool(p.is_deleted) AS is_deleted,
         multiIf(
             (


### PR DESCRIPTION
## Problem

We need to ensure `created_at` is of type `DateTime64`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Force cast `created_at` to `DateTime64` when batch exporting.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
