### PR TITLE
fix: error tracking related issues use get_feature_flag_payload for remote config flag

### DIFF
--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -330,14 +330,15 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
         return similar_embeddings
 
     def _get_embedding_configuration(self) -> tuple[float, str, int]:
-        """Get embedding configuration from remote config or return defaults."""
+        """Get embedding configuration from feature flag or return defaults."""
         min_distance_threshold = DEFAULT_MIN_DISTANCE_THRESHOLD
         model_name = DEFAULT_EMBEDDING_MODEL_NAME
         embedding_version = DEFAULT_EMBEDDING_VERSION
 
-        # Try to get configuration from remote config, fall back to defaults if not available
+        # Try to get configuration from feature flag, fall back to defaults if not available
         try:
-            config_json = posthoganalytics.get_remote_config_payload("error-tracking-embedding-configuration")
+            team_id = str(self.team.id)
+            config_json = posthoganalytics.get_feature_flag_payload("error-tracking-embedding-configuration", team_id)
             if config_json:
                 config_payload = json.loads(config_json)
 


### PR DESCRIPTION
## Problem

follow up https://github.com/PostHog/posthog/pull/39008

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
