### PR TITLE
feat(ci): Push tag@digest references to CI

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -109,7 +109,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "posthog",
@@ -135,7 +135,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "ingestion",
@@ -161,7 +161,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker",
@@ -182,7 +182,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-batch-exports",
@@ -208,7 +208,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-max-ai",
@@ -234,7 +234,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-tasks-agent",
@@ -275,7 +275,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-billing",
@@ -296,7 +296,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-video-export",
@@ -317,7 +317,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-general-purpose",
@@ -338,7 +338,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-messaging",
@@ -364,7 +364,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-data-warehouse",
@@ -385,7 +385,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-data-warehouse-compaction",
@@ -406,7 +406,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-data-modeling",


### PR DESCRIPTION
## Problem

Images are deployed with just their Docker SHA256 digest which is not very human-friendly to determine which commit hash has been deployed with that image.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
