### PR TITLE
feat(sessions): Add sessions table version to query debugger

### DIFF
--- a/frontend/src/scenes/debug/Modifiers.tsx
+++ b/frontend/src/scenes/debug/Modifiers.tsx
@@ -175,7 +175,7 @@ export function Modifiers<Q extends { response?: Record<string, any>; modifiers?
             </LemonLabel>
 
             <LemonLabel className={labelClassName}>
-                <div>Session table version</div>
+                <div>Session table version:</div>
                 <LemonSelect<Exclude<HogQLQueryModifiers['sessionTableVersion'], undefined>>
                     options={[
                         { value: 'auto', label: 'auto' },

--- a/frontend/src/scenes/debug/Modifiers.tsx
+++ b/frontend/src/scenes/debug/Modifiers.tsx
@@ -173,6 +173,25 @@ export function Modifiers<Q extends { response?: Record<string, any>; modifiers?
                     }
                 />
             </LemonLabel>
+
+            <LemonLabel className={labelClassName}>
+                <div>Session table version</div>
+                <LemonSelect<Exclude<HogQLQueryModifiers['sessionTableVersion'], undefined>>
+                    options={[
+                        { value: 'auto', label: 'auto' },
+                        { value: 'v1', label: 'v1' },
+                        { value: 'v2', label: 'v2' },
+                        { value: 'v3', label: 'v3' },
+                    ]}
+                    onChange={(value) =>
+                        setQuery({
+                            ...query,
+                            modifiers: { ...query.modifiers, sessionTableVersion: value },
+                        })
+                    }
+                    value={query.modifiers?.sessionTableVersion ?? response?.modifiers?.sessionTableVersion ?? 'auto'}
+                />
+            </LemonLabel>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

In the debugger, I want to compare results of the same query with different table versions

## Changes

Add a dropdown to the query debugger

## How did you test this code?

n/a

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
