### PR TITLE
fix: Do not create file system entries for internal notebooks

### DIFF
--- a/posthog/models/file_system/test/test_file_system_mixin.py
+++ b/posthog/models/file_system/test/test_file_system_mixin.py
@@ -157,3 +157,36 @@ class TestFileSystemSyncMixin(TestCase):
         note.delete()
         fs_entry2 = FileSystem.objects.filter(team=self.team, type="notebook", ref=str(note_id)).first()
         assert fs_entry2 is None
+
+    def test_notebook_internal_visibility(self):
+        note = Notebook.objects.create(
+            team=self.team, title="My Notebook", created_by=self.user, visibility=Notebook.Visibility.INTERNAL
+        )
+        fs_entry = FileSystem.objects.filter(team=self.team, type="notebook", ref=str(note.id)).first()
+
+        assert fs_entry is None, "Should not create file system entry for internal notebook"
+        assert note.get_file_system_representation().should_delete, "Internal notebook should be set for deletion"
+
+    def test_notebook_internal_visibility_delete_existing_entry(self):
+        note = Notebook.objects.create(
+            team=self.team, title="My Notebook", created_by=self.user, visibility=Notebook.Visibility.INTERNAL
+        )
+        fs_entry = FileSystem.objects.create(
+            team=self.team,
+            path=f"{note._get_assigned_folder('Unfiled/Notebooks')}/My Notebook",
+            depth=2,
+            type="notebook",
+            ref=str(note.short_id),
+            href=f"/notebooks/{note.short_id}",
+            meta={"created_at": str(note.created_at)},
+            shortcut=False,
+            created_by_id=self.user.id,
+            created_at=note.created_at,
+        )
+        fs_entry_id = fs_entry.id
+
+        note.save()
+
+        assert (
+            FileSystem.objects.filter(id=fs_entry_id).exists() is False
+        ), "Existing entries for internal notebooks should be deleted"

--- a/posthog/models/notebook/notebook.py
+++ b/posthog/models/notebook/notebook.py
@@ -53,5 +53,5 @@ class Notebook(FileSystemSyncMixin, RootTeamMixin, UUIDTModel):
             name=self.title or "Untitled",
             href=f"/notebooks/{self.short_id}",
             meta={"created_at": str(self.created_at), "created_by": self.created_by_id},
-            should_delete=self.deleted,
+            should_delete=self.deleted or self.visibility == self.Visibility.INTERNAL,
         )


### PR DESCRIPTION
## Problem
We are creating file system entries for internal notebooks. This should not happen, as these notebooks are embedded in group details page and we don't want to show them anywhere else in the app.

<img width="642" height="798" alt="image" src="https://github.com/user-attachments/assets/7645443e-19ab-4904-ae17-851825e58eea" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Add a check for visibility when setting `should_delete` flag in Notebook's `get_file_system_representation` method

The nice thing about this approach is that it deletes current rogue entries. The bad, is that it performs an [unnecessary query to delete existing entries](https://github.com/PostHog/posthog/blob/2eed04af1fc5d052d4767cf89ce81fedad9b7971/posthog/models/file_system/file_system.py#L104). Not sure if a concern.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests + locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
