### PR TITLE
fix: Replace `team:read` scopes with `project:read`

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -654,7 +654,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
     @action(
         methods=["PATCH"],
         detail=True,
-        required_scopes=["team:read"],
+        required_scopes=["project:read"],
     )
     def add_product_intent(self, request: request.Request, *args, **kwargs):
         project = self.get_object()
@@ -679,7 +679,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
     @action(
         methods=["PATCH"],
         detail=True,
-        required_scopes=["team:read"],
+        required_scopes=["project:read"],
     )
     def complete_product_onboarding(self, request: request.Request, *args, **kwargs):
         project = self.get_object()

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -773,7 +773,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
             request_fields = set(request.data.keys())
             non_team_config_fields = request_fields - TEAM_CONFIG_FIELDS_SET
             if not non_team_config_fields:
-                return ["team:read"]
+                return ["project:read"]
 
         # Fall back to the default behavior
         return None
@@ -933,7 +933,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
     @action(
         methods=["PATCH"],
         detail=True,
-        required_scopes=["team:read"],
+        required_scopes=["project:read"],
     )
     def add_product_intent(self, request: request.Request, *args, **kwargs):
         team = self.get_object()
@@ -957,7 +957,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
     @action(
         methods=["PATCH"],
         detail=True,
-        required_scopes=["team:read"],
+        required_scopes=["project:read"],
     )
     def complete_product_onboarding(self, request: request.Request, *args, **kwargs):
         team = self.get_object()
@@ -999,7 +999,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
 
         return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data)
 
-    @action(methods=["GET"], detail=True, required_scopes=["team:read"], url_path="event_ingestion_restrictions")
+    @action(methods=["GET"], detail=True, required_scopes=["project:read"], url_path="event_ingestion_restrictions")
     def event_ingestion_restrictions(self, request, **kwargs):
         team = self.get_object()
         restrictions = EventIngestionRestrictionConfig.objects.filter(token=team.api_token)

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -96,7 +96,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
 
     def dangerously_get_required_scopes(self):
         if self.action == "authenticate":
-            return ["team:read"]
+            return ["project:read"]
 
         return []
 


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C02E3BKC78F/p1759311678846809

I've not updated the `team:read` scopes that still live in the [`TeamViewSet` class](https://github.com/PostHog/posthog/blob/abfe27fa06340f5262cf0c18815369f99fe7df28/posthog/api/team.py#L736) - my understanding is that's related to environments and probably where these scopes were aimed for.
