### PR TITLE
fix: tooltip heading styling

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.scss
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.scss
@@ -43,6 +43,7 @@
         margin-bottom: 0.375em;
         font-weight: 600;
         line-height: 1.2;
+        color: inherit;
     }
 
     h1,

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarTicks.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarTicks.tsx
@@ -75,8 +75,9 @@ function PlayerSeekbarTick({
             onClick={onClick}
         >
             <Tooltip
+                visible={true}
                 placement="top-start"
-                delayMs={50}
+                delayMs={10}
                 onOpen={() => {
                     posthog.capture('player seekbar tick tooltip shown', {
                         item_type: item.type,

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarTicks.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarTicks.tsx
@@ -75,7 +75,6 @@ function PlayerSeekbarTick({
             onClick={onClick}
         >
             <Tooltip
-                visible={true}
                 placement="top-start"
                 delayMs={10}
                 onOpen={() => {


### PR DESCRIPTION
headings in lemon markdown in tooltips only ever head black for text
so they didn't work well in light or dark mode

well, not any more

(flyby, less delay before showing tooltips in replayer)