### PR TITLE
fix: allow non captured events again

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
+++ b/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
@@ -250,6 +250,7 @@ export function SurveyEventTrigger(): JSX.Element {
                                     setAddEventPopoverOpen(false)
                                 }
                             }}
+                            allowNonCapturedEvents
                             taxonomicGroupTypes={[
                                 TaxonomicFilterGroupType.CustomEvents,
                                 TaxonomicFilterGroupType.Events,


### PR DESCRIPTION
allow non captured events again on surveys