### PR TITLE
fix(messaging): have SES webhook endpoint accept text/plain content

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -126,7 +126,7 @@ export class CdpApi {
         router.get('/public/webhooks/:webhook_id', asyncHandler(this.handleWebhook()))
         router.get('/public/m/pixel', asyncHandler(this.getEmailTrackingPixel()))
         router.post('/public/m/mailjet_webhook', asyncHandler(this.postMailjetWebhook()))
-        router.post('/public/m/ses_webhook', asyncHandler(this.postSesWebhook()))
+        router.post('/public/m/ses_webhook', express.text(), asyncHandler(this.postSesWebhook()))
         router.get('/public/m/redirect', asyncHandler(this.getEmailTrackingRedirect()))
 
         return router

--- a/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email-tracking.service.ts
@@ -4,6 +4,7 @@ import express from 'ultimate-express'
 import { ModifiedRequest } from '~/api/router'
 import { CyclotronJobInvocationHogFunction, MinimalAppMetric } from '~/cdp/types'
 import { defaultConfig } from '~/config/config'
+import { parseJSON } from '~/utils/json-parse'
 import { captureException } from '~/utils/posthog'
 
 import { Hub } from '../../../types'
@@ -177,13 +178,13 @@ export class EmailTrackingService {
     }
 
     public async handleSesWebhook(req: ModifiedRequest): Promise<{ status: number; message?: string }> {
-        if (!req.rawBody) {
+        if (!req.body) {
             return { status: 403, message: 'Missing request body' }
         }
 
         try {
             const { status, body, metrics } = await this.sesWebhookHandler.handleWebhook({
-                body: req.rawBody,
+                body: parseJSON(req.body),
                 headers: req.headers,
                 verifySignature: true,
             })


### PR DESCRIPTION
## Problem

We don't seem to be receiving SNS subscription requests to https://app.dev.posthog.dev/public/m/ses_webhook 
After hitting it with some example SNS requests, it seems that this is because the router is rejecting `Content-Type: text/plain;` requests, which is what all inbound requests from SNS are going to be: https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.prepare.html

<img width="689" height="339" alt="image" src="https://github.com/user-attachments/assets/c4947eca-377c-426b-8e65-a3b87afafcce" />


## Changes

Makes just this one endpoint accept text content. Parses the json from req.body accordingly.

## How did you test this code?

After the change, a sample SNS request is being parsed correctly now locally:
<img width="690" height="735" alt="Screenshot 2025-10-02 at 3 58 15 PM" src="https://github.com/user-attachments/assets/7b66271b-50c8-40aa-8797-cb1b1b4a0204" />

