### PR TITLE
fix: only delete blocks if recording consists of 1 more blocks

### DIFF
--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -66,11 +66,11 @@ async def load_recording_blocks(input: RecordingInput) -> list[RecordingBlock]:
             "ttl_days": 365,
         }
 
+        ch_query_id = str(uuid4())
+        logger.info(f"Querying ClickHouse with query_id: {ch_query_id}")
         raw_response: bytes = b""
         async with get_client() as client:
-            async with client.aget_query(
-                query=query, query_parameters=parameters, query_id=str(uuid4())
-            ) as ch_response:
+            async with client.aget_query(query=query, query_parameters=parameters, query_id=ch_query_id) as ch_response:
                 raw_response = await ch_response.content.read()
 
         block_listing: RecordingBlockListing | None = SessionReplayEvents.build_recording_block_listing(

--- a/posthog/temporal/delete_recordings/workflows.py
+++ b/posthog/temporal/delete_recordings/workflows.py
@@ -41,16 +41,17 @@ class DeleteRecordingWorkflow(PostHogWorkflow):
             heartbeat_timeout=timedelta(seconds=10),
         )
 
-        await workflow.execute_activity(
-            delete_recording_blocks,
-            DeleteRecordingBlocksInput(recording=recording_input, blocks=recording_blocks),
-            start_to_close_timeout=timedelta(minutes=10),
-            retry_policy=common.RetryPolicy(
-                maximum_attempts=2,
-                initial_interval=timedelta(minutes=1),
-            ),
-            heartbeat_timeout=timedelta(seconds=10),
-        )
+        if len(recording_blocks) > 0:
+            await workflow.execute_activity(
+                delete_recording_blocks,
+                DeleteRecordingBlocksInput(recording=recording_input, blocks=recording_blocks),
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=common.RetryPolicy(
+                    maximum_attempts=2,
+                    initial_interval=timedelta(minutes=1),
+                ),
+                heartbeat_timeout=timedelta(seconds=10),
+            )
 
 
 @workflow.defn(name="delete-recordings-with-person")


### PR DESCRIPTION
Only delete data if there is any data to delete, duh.