### PR TITLE
feat(max): Summarize sessions of users who dropped off

### DIFF
--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -677,6 +677,7 @@ class RootNodeTools(AssistantNode):
                 session_summarization_query=tool_call.args["session_summarization_query"],
                 # Safety net in case the argument is missing to avoid raising exceptions internally
                 should_use_current_filters=tool_call.args.get("should_use_current_filters", False),
+                session_ids=tool_call.args.get("session_ids"),
                 root_tool_calls_count=tool_call_count + 1,
             )
         elif ToolClass := get_contextual_tool_class(tool_call.name):
@@ -754,7 +755,7 @@ class RootNodeTools(AssistantNode):
                 return "insights"
             elif state.search_insights_query:
                 return "insights_search"
-            elif state.session_summarization_query:
+            elif state.session_summarization_query or state.session_ids:
                 return "session_summarization"
             else:
                 return "search_documentation"

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -145,8 +145,9 @@ Follow these guidelines when summarizing session recordings:
 """
 
 SESSION_SUMMARIZATION_PROMPT_NO_REPLAY_CONTEXT = """
-There are no current filters in the user's UI context. It means that you need to:
-- Convert the user query into a `session_summarization_query`
+There are no current filters in the user's UI context. It means that:
+- If specific session IDs are provided by the user, use them directly in the `session_ids` parameter
+- Otherwise, convert the user query into a `session_summarization_query`
 - The query should be used to search for relevant sessions and then summarize them
 - Assume the `should_use_current_filters` should be always `false`
 """

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -60,6 +60,9 @@ class session_summarization(BaseModel):
       * When users asks to update, change, or adjust session recordings filters
     """
 
+    session_ids: list[str] | None = Field(
+        description="Optional list of specific, already-provided session IDs to summarize. If provided, these sessions will be summarized directly without generating recording filters from the query. In that case, should_use_current_filters should be false, and session_summarization_query empty.",
+    )
     session_summarization_query: str = Field(
         description="""
         - The user's complete query for session recordings summarization.

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -202,6 +202,10 @@ class _SharedAssistantState(BaseState):
     """
     Whether to use current filters from user's UI to find relevant sessions.
     """
+    session_ids: Optional[list[str]] = Field(default=None)
+    """
+    Optional list of specific session IDs to summarize directly.
+    """
     notebook_id: Optional[str] = Field(default=None)
     """
     The ID of the notebook being used.

--- a/frontend/src/scenes/funnels/FunnelStepMore.tsx
+++ b/frontend/src/scenes/funnels/FunnelStepMore.tsx
@@ -1,13 +1,19 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 import { useCallback } from 'react'
+
+import { lemonToast } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { urls } from 'scenes/urls'
 
-import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
-import { FunnelPathType, PathType } from '~/types'
+import { sidePanelLogic } from '~/layout/navigation-3000/sidepanel/sidePanelLogic'
+import { performQuery } from '~/queries/query'
+import { ActorsQuery, FunnelsActorsQuery, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
+import { FunnelPathType, PathType, SidePanelTab } from '~/types'
 
 import { funnelDataLogic } from './funnelDataLogic'
 
@@ -18,6 +24,9 @@ type FunnelStepMoreProps = {
 export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { querySource } = useValues(funnelDataLogic(insightProps))
+    const { openSidePanel } = useActions(sidePanelLogic)
+
+    const summarizeInsight = useSummarizeInsight()
 
     const stepNumber = stepIndex + 1
     const getPathUrl = useCallback(
@@ -44,6 +53,61 @@ export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element 
         },
         [querySource, stepNumber]
     )
+
+    const summarizeDropoffSessions = useCallback(async (): Promise<void> => {
+        if (!querySource) {
+            return
+        }
+
+        try {
+            // Create a query to get users who dropped off at this step
+            const funnelsActorsQuery: FunnelsActorsQuery = {
+                kind: NodeKind.FunnelsActorsQuery,
+                source: querySource,
+                funnelStep: -stepNumber, // Negative step number for drop-offs
+                includeRecordings: true,
+            }
+
+            const actorsQuery: ActorsQuery = {
+                kind: NodeKind.ActorsQuery,
+                source: funnelsActorsQuery,
+                select: ['person', 'matched_recordings'],
+            }
+
+            // Execute the query to get dropped-off users and their session recordings
+            const result = await performQuery(actorsQuery)
+
+            // Extract session IDs from the matched recordings
+            const sessionIds: string[] = []
+            if (result?.results) {
+                for (const row of result.results) {
+                    const matchedRecordings = row[1] // matched_recordings is the second column
+                    if (Array.isArray(matchedRecordings)) {
+                        for (const recording of matchedRecordings) {
+                            if (recording?.session_id) {
+                                sessionIds.push(recording.session_id)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (sessionIds.length === 0) {
+                lemonToast.info('No session recordings found for dropped-off users at this step')
+                return
+            }
+
+            // Call Max with session summarization using the extracted session IDs
+            const query =
+                `Summarize sessions of users who dropped off at step ${stepNumber} of this funnel:\n${summarizeInsight(querySource)}\n` +
+                `The specific session IDs to use are: ${sessionIds.join(', ')}`
+            // Call Max with the session summarization request
+            openSidePanel(SidePanelTab.Max, '!' + query)
+        } catch (error) {
+            posthog.captureException(error)
+            lemonToast.error(`Failed to get session IDs for dropped-off users: ${error}`)
+        }
+    }, [querySource, stepNumber, openSidePanel, summarizeInsight])
 
     // Don't show paths modal if aggregating by groups - paths is user-based!
     if (querySource?.aggregation_group_type_index != undefined) {
@@ -77,6 +141,11 @@ export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element 
                     {stepNumber > 1 && (
                         <LemonButton fullWidth to={getPathUrl(FunnelPathType.before, true)}>
                             Show user paths before dropoff
+                        </LemonButton>
+                    )}
+                    {stepNumber > 1 && (
+                        <LemonButton fullWidth onClick={summarizeDropoffSessions}>
+                            Summarize sessions of users who dropped off
                         </LemonButton>
                     )}
                 </>

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -29,6 +29,7 @@ import {
     isEventsQuery,
     isFunnelsQuery,
     isHogQLQuery,
+    isInsightQueryNode,
     isInsightVizNode,
     isLifecycleQuery,
     isPathsQuery,
@@ -262,9 +263,11 @@ export interface SummaryContext {
 export function summarizeInsight(query: Node | undefined | null, context: SummaryContext): string {
     return isInsightVizNode(query)
         ? summarizeInsightQuery(query.source, context)
-        : !!query && !isInsightVizNode(query)
-          ? summarizeQuery(query)
-          : ''
+        : isInsightQueryNode(query)
+          ? summarizeInsightQuery(query, context)
+          : !!query && !isInsightVizNode(query)
+            ? summarizeQuery(query)
+            : ''
 }
 
 export function useSummarizeInsight(): (query: Node | undefined | null) => string {


### PR DESCRIPTION
## Problem

Session summaries are powerful, but our hypothesis is that they're most useful when you have a specific area you want to focus on. A natural one is churn: why did people in this funnel not convert at step X? Currently there's no affordance for this.

## Changes

Introducing the "Summarize sessions of users who dropped off" button.

## How did you test this code?

TODO
