### PR TITLE
fix: catch BlockDeletedError and track them appropriately

### DIFF
--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -16,7 +16,11 @@ from posthog.storage import session_recording_v2_object_storage
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
-from posthog.temporal.delete_recordings.metrics import get_block_deleted_counter, get_block_loaded_counter
+from posthog.temporal.delete_recordings.metrics import (
+    get_block_deleted_counter,
+    get_block_deleted_error_counter,
+    get_block_loaded_counter,
+)
 from posthog.temporal.delete_recordings.types import (
     DeleteRecordingBlocksInput,
     DeleteRecordingError,
@@ -95,10 +99,15 @@ async def delete_recording_blocks(input: DeleteRecordingBlocksInput) -> None:
         logger.info("Deleting recording blocks")
         async with session_recording_v2_object_storage.async_client() as storage:
             block_deleted_counter = get_block_deleted_counter()
+            block_deleted_error_counter = get_block_deleted_error_counter()
 
             for block in input.blocks:
-                await storage.delete_block(block.url)
-                block_deleted_counter.add(1)
+                try:
+                    await storage.delete_block(block.url)
+                    block_deleted_counter.add(1)
+                except session_recording_v2_object_storage.BlockDeleteError:
+                    logger.warning(f"Failed to delete block at {block.url}, skipping...")
+                    block_deleted_error_counter.add(1)
 
         logger.info(f"Successfully deleted {len(input.blocks)} blocks")
 

--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -98,18 +98,21 @@ async def delete_recording_blocks(input: DeleteRecordingBlocksInput) -> None:
         logger = LOGGER.bind()
         logger.info("Deleting recording blocks")
         async with session_recording_v2_object_storage.async_client() as storage:
-            block_deleted_counter = get_block_deleted_counter()
-            block_deleted_error_counter = get_block_deleted_error_counter()
+            block_deleted_counter = 0
+            block_deleted_error_counter = 0
 
             for block in input.blocks:
                 try:
                     await storage.delete_block(block.url)
-                    block_deleted_counter.add(1)
+                    block_deleted_counter += 1
                 except session_recording_v2_object_storage.BlockDeleteError:
                     logger.warning(f"Failed to delete block at {block.url}, skipping...")
-                    block_deleted_error_counter.add(1)
+                    block_deleted_error_counter += 1
 
-        logger.info(f"Successfully deleted {len(input.blocks)} blocks")
+        get_block_deleted_counter().add(block_deleted_counter)
+        get_block_deleted_error_counter().add(block_deleted_error_counter)
+        logger.info(f"Successfully deleted {block_deleted_counter} blocks")
+        logger.info(f"Skipped {block_deleted_error_counter} blocks")
 
 
 def _parse_session_recording_list_response(raw_response: bytes) -> list[str]:

--- a/posthog/temporal/delete_recordings/metrics.py
+++ b/posthog/temporal/delete_recordings/metrics.py
@@ -8,3 +8,9 @@ def get_block_loaded_counter() -> MetricCounter:
 
 def get_block_deleted_counter() -> MetricCounter:
     return activity.metric_meter().create_counter("recording_block_deleted", "Number of recording blocks deleted.")
+
+
+def get_block_deleted_error_counter() -> MetricCounter:
+    return activity.metric_meter().create_counter(
+        "recording_block_deleted_error", "Number of recording block errors encountered."
+    )


### PR DESCRIPTION
Let's make sure the delete activity runs to completion even if one or more of the blocks fail to delete for whatever reason