### PR TITLE
ci: Fix bugs in deploy hobby and CI

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -34,11 +34,11 @@ jobs:
             - name: Get python deps
               run: pip install python-digitalocean==1.17.0 requests==2.28.1
             - name: Setup DO Hobby Instance
-              run: python3 bin/hobby-ci.py create
+              run: python3 bin/hobby-ci.py create $GITHUB_HEAD_REF
               env:
                   DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
             - name: Run smoke tests on DO
-              run: python3 bin/hobby-ci.py test $GITHUB_HEAD_REF
+              run: python3 bin/hobby-ci.py test
               env:
                   DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
             - name: Post-cleanup step

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -34,7 +34,7 @@ jobs:
             - name: Get python deps
               run: pip install python-digitalocean==1.17.0 requests==2.28.1
             - name: Setup DO Hobby Instance
-              run: python3 bin/hobby-ci.py create $GITHUB_HEAD_REF
+              run: python3 bin/hobby-ci.py create "$GITHUB_HEAD_REF"
               env:
                   DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
             - name: Run smoke tests on DO

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -229,8 +229,14 @@ class HobbyTester:
 def main():
     command = sys.argv[1]
     if command == "create":
-        print("Creating droplet on Digitalocean for testing Hobby Deployment")
-        ht = HobbyTester()
+        if len(sys.argv) < 3:
+            print("Please provide the branch name to test")
+            exit(1)
+        branch = sys.argv[2]
+        print(f"Creating droplet on Digitalocean for testing Hobby Deployment, on branch {branch}")
+        ht = HobbyTester(
+            branch=branch,
+        )
         ht.ensure_droplet(ssh_enabled=True)
         print("Instance has started. You will be able to access it here after PostHog boots (~15 minutes):")
         print(f"https://{ht.hostname}")
@@ -244,19 +250,14 @@ def main():
         HobbyTester.destroy_environment(droplet_id=droplet_id, record_id=domain_record_id)
 
     if command == "test":
-        if len(sys.argv) < 3:
-            print("Please provide the branch name to test")
-            exit(1)
-        branch = sys.argv[2]
         name = os.environ.get("HOBBY_NAME")
         record_id = os.environ.get("HOBBY_DNS_RECORD_ID")
         droplet_id = os.environ.get("HOBBY_DROPLET_ID")
-        print(f"Testing the deployment for {name} on branch {branch}")
+        print("Waiting for deployment to become healthy")
         print(f"Record ID: {record_id}")
         print(f"Droplet ID: {droplet_id}")
 
         ht = HobbyTester(
-            branch=branch,
             name=name,
             record_id=record_id,
             droplet_id=droplet_id,

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -72,10 +72,8 @@ class HobbyTester:
             'echo "Current commit: $CURRENT_COMMIT" \n'
             "cd .. \n"
             f"chmod +x posthog/bin/deploy-hobby \n"
-            f'if [ "{self.branch}" != "main" ] && [ "{self.branch}" != "master" ] && [ -n "{self.branch}" ]; then \n'
-            f'    echo "Using commit hash for feature branch deployment" \n'
-            f"    ./posthog/bin/deploy-hobby $CURRENT_COMMIT {self.hostname} 1 \n"
-            f"fi \n"
+            f'echo "Using commit hash for feature branch deployment" \n'
+            f"./posthog/bin/deploy-hobby $CURRENT_COMMIT {self.hostname} 1 \n"
         )
 
     def block_until_droplet_is_started(self):

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -12,7 +12,7 @@ import urllib3
 import requests
 import digitalocean
 
-DOMAIN = "posthog.cc"
+DOMAIN = os.getenv("HOBBY_DOMAIN", "posthog.cc")
 
 
 class HobbyTester:
@@ -23,7 +23,6 @@ class HobbyTester:
         region="sfo3",
         image="ubuntu-22-04-x64",
         size="s-8vcpu-16gb",
-        release_tag="latest-release",
         branch=None,
         hostname=None,
         domain=DOMAIN,
@@ -36,12 +35,11 @@ class HobbyTester:
             token = os.getenv("DIGITALOCEAN_TOKEN")
         self.token = token
         self.branch = branch
-        self.release_tag = release_tag
-
-        random_bit = "".join(random.choice(string.ascii_lowercase) for i in range(4))
 
         if not name:
-            name = f"do-ci-hobby-deploy-{self.release_tag}-{random_bit}"
+            random_bit = "".join(random.choice(string.ascii_lowercase) for i in range(4))
+            branch_part = self.branch[:7] if self.branch is not None else "none"
+            name = f"do-ci-hobby-deploy-{branch_part}-{random_bit}"
         self.name = name
 
         if not hostname:
@@ -77,9 +75,6 @@ class HobbyTester:
             f'if [ "{self.branch}" != "main" ] && [ "{self.branch}" != "master" ] && [ -n "{self.branch}" ]; then \n'
             f'    echo "Using commit hash for feature branch deployment" \n'
             f"    ./posthog/bin/deploy-hobby $CURRENT_COMMIT {self.hostname} 1 \n"
-            f"else \n"
-            f'     echo "Installing PostHog version: {self.release_tag}" \n'
-            f"    ./posthog/bin/deploy-hobby {self.release_tag} {self.hostname} 1 \n"
             f"fi \n"
         )
 


### PR DESCRIPTION
## Problem

Posthog newbie here. I tried to follow the hobby install an ran into some problems, which was somehow expected.
Being not so sure about the status and what commit to use, I started digging and found that you actually run
a smoke test for the hobby deploy with every pull request. Very cool!

However: 
Digging deeper I found a few problems: hobby-ci.py does not test the actual PR but just the most recent commit

Details:
`hobby-ci.py create` is creating the droplet and also deploying PostHog within the cloud init script
`hobby-ci.py test COMMIT-HASH` does just wait until PostHog becomes live on http. The commit hash is ignored.

When inspecting the `cloud-init-output.log` on the DO instance created, you will see:

````
Using branch: None
error: pathspec 'None' did not match any file(s) known to git
Current commit: 0282ff30fa49e1ac1e9c7d9f5a64760b6cef8c31
Using commit hash for feature branch deployment
````

## Changes

- [x] fix droplet name and remove release-tag in hobby-ci.py
- [x] introduce HOBBY_DOMAIN environment variable to configure a domain other than `posthog.cc`, so I can do testing
- [x] use the correct commit hash

## Additional findings

I discovered the following things that make sense as well:

- no git clone in the installation script, actually only the docker compose files are needed from the repo
- housekeepking in deploy-hobby, remove things around release-tag, which is not used any more and confusing
- switch to Ubuntu 24.04, still it uses Ubuntu 22.04 which will be EOL soon

Feedback to this would be appreciated, so I do another PR for this.

## How did you test this code?

I am testing `hobby-ci.py create` with our own Digital Ocean droplet.
