### PR TITLE
fix: rely on bool not object to render less

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -19,7 +19,7 @@ export function PlayerInspectorList(): JSX.Element {
     const { logicProps, snapshotsLoaded } = useValues(sessionRecordingPlayerLogic)
     const inspectorLogic = playerInspectorLogic(logicProps)
 
-    const { items, inspectorDataState, playbackIndicatorIndex, playbackIndicatorIndexStop, syncScrollPaused } =
+    const { items, isLoading, isReady, playbackIndicatorIndex, playbackIndicatorIndexStop, syncScrollPaused } =
         useValues(inspectorLogic)
     const { setSyncScrollPaused } = useActions(inspectorLogic)
 
@@ -126,15 +126,11 @@ export function PlayerInspectorList(): JSX.Element {
                         )}
                     </AutoSizer>
                 </div>
-            ) : inspectorDataState['events'] === 'loading' ||
-              inspectorDataState['console'] === 'loading' ||
-              inspectorDataState['network'] === 'loading' ? (
+            ) : isLoading ? (
                 <div className="p-2">
                     <LemonSkeleton className="my-1 h-8" repeat={20} fade />
                 </div>
-            ) : inspectorDataState['events'] === 'ready' ||
-              inspectorDataState['console'] === 'ready' ||
-              inspectorDataState['network'] === 'ready' ? (
+            ) : isReady ? (
                 // If we are "ready" but with no results this must mean some results are filtered out
                 <div className="p-16 text-center text-secondary">No results matching your filters.</div>
             ) : null}

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemAppState.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemAppState.stories.tsx
@@ -53,5 +53,6 @@ AppStateItem.args = {
             payload: { user: { id: 1, name: 'John Doe' } },
             nextState: { user: { id: 1, name: 'John Doe' } },
         },
+        key: 'id',
     },
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemComment.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemComment.stories.tsx
@@ -48,6 +48,7 @@ function makeNotebookItem(
         type: 'comment',
         source: 'notebook',
         search: '',
+        key: 'id',
         ...itemOverrides,
     }
 }
@@ -84,6 +85,7 @@ function makeCommentItem(
         type: 'comment',
         source: 'comment',
         search: '',
+        key: 'id',
         ...itemOverrides,
     }
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.stories.tsx
@@ -56,5 +56,6 @@ ConsoleLogItem.args = {
         timeInRecording: 123,
         search: 'some text',
         type: 'console',
+        key: 'some-key',
     },
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryFn, StoryObj } from '@storybook/react'
 
 import { now } from 'lib/dayjs'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { uuid } from 'lib/utils'
 import {
     ItemEvent,
     ItemEventDetail,
@@ -49,6 +50,7 @@ function makeItem(
         timeInRecording: 0,
         timestamp: now(),
         type: 'events',
+        key: `some-key-${uuid()}`,
         ...itemOverrides,
     }
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -98,6 +98,7 @@ export type InspectorListItemBase = {
     windowId?: string
     windowNumber?: number | '?' | undefined
     type: InspectorListItemType
+    key: string
 }
 
 export type InspectorListItemEvent = InspectorListItemBase & {
@@ -456,6 +457,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                     windowId: windowId,
                                     windowNumber: windowNumberForID(windowId),
                                     highlightColor: 'warning',
+                                    key: `${timestamp.valueOf()}-offline-status-${tag}`,
                                 } satisfies InspectorListOfflineStatusChange)
                             }
 
@@ -470,6 +472,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                     windowId: windowId,
                                     windowNumber: windowNumberForID(windowId),
                                     highlightColor: 'warning',
+                                    key: `${timestamp.valueOf()}-browser-visibility-${tag}`,
                                 } satisfies InspectorListBrowserVisibility)
                             }
 
@@ -492,6 +495,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                         windowId: windowId,
                                         windowNumber: windowNumberForID(windowId),
                                         stateEvent,
+                                        key: `${timestamp.valueOf()}-app-state-${actionTitle}`,
                                     })
                                 }
                             }
@@ -518,6 +522,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                     windowId: windowId,
                                     windowNumber: windowNumberForID(windowId),
                                     data: getPayloadFor(customEvent, tag),
+                                    key: `${timestamp.valueOf()}-doctor-${tag}`,
                                 })
                             }
                         }
@@ -535,6 +540,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                 windowId: windowId,
                                 windowNumber: windowNumberForID(windowId),
                                 data: { snapshotSize: humanizeBytes(estimateSize(snapshot)) },
+                                key: `${timestamp.valueOf()}-doctor-full-snapshot`,
                             })
                         }
 
@@ -584,6 +590,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                             level === 'error' ? 'danger' : level === 'warn' ? 'warning' : undefined,
                                         windowId: windowId,
                                         windowNumber: windowNumberForID(windowId),
+                                        key: `${itemTimestamp.valueOf()}-console-${level}-${consoleLogs.length - 1}`,
                                     })
                                 }
                             }
@@ -600,6 +607,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                         tag: 'count of snapshot types by window',
                         search: 'count of snapshot types by window',
                         data: snapshotCounts,
+                        key: `${start.valueOf()}-doctor-snapshot-counts`,
                     })
                 }
 
@@ -644,6 +652,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             data: comment,
                             windowId: windowIdForTimestamp(timestamp.valueOf()),
                             windowNumber: windowNumberForID(windowIdForTimestamp(timestamp.valueOf())),
+                            key: `notebook-comment-${comment.id}`,
                         })
                     }
                 }
@@ -676,6 +685,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             windowNumber: windowNumberForID(windowIdForTimestamp(timestamp.valueOf())),
                             data: comment,
                             search: getText(comment),
+                            key: `comment-${comment.id}`,
                         }
                         items.push(item)
                     }
@@ -706,6 +716,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             timestamp,
                             timeInRecording,
                             search: 'inactiv',
+                            key: `inactivity-${segment.startTimestamp}`,
                         })
                     })
 
@@ -724,6 +735,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                         clickCount: sessionPlayerMetaData?.click_count || null,
                         keypressCount: sessionPlayerMetaData?.keypress_count || null,
                         errorCount: 0,
+                        key: `inspector-summary-${start.valueOf()}`,
                     })
                 }
 
@@ -836,6 +848,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                         highlightColor: (responseStatus || 0) >= 400 ? 'danger' : undefined,
                         windowId: event.window_id,
                         windowNumber: windowNumberForID(event.window_id),
+                        key: `performance-${event.uuid}`,
                     })
                 }
 
@@ -883,6 +896,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                               : undefined,
                         windowId: event.properties?.$window_id,
                         windowNumber: windowNumberForID(event.properties?.$window_id),
+                        key: `event-${event.id}`,
                     })
                 }
 
@@ -1055,6 +1069,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                 return eventAndCommentItems
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         inspectorDataState: [
@@ -1121,6 +1136,16 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             },
         ],
 
+        isLoading: [
+            (s) => [s.inspectorDataState],
+            (inspectorDataState): boolean => Object.values(inspectorDataState).some((state) => state === 'loading'),
+        ],
+
+        isReady: [
+            (s) => [s.inspectorDataState],
+            (inspectorDataState): boolean => Object.values(inspectorDataState).every((state) => state === 'ready'),
+        ],
+
         playbackIndicatorIndex: [
             (s) => [s.currentPlayerTime, s.items],
             (playerTime, items): number => {
@@ -1160,6 +1185,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 }
                 return fuse.search(searchQuery).map((x) => x.item)
             },
+            { resultEqualityCheck: objectsEqual },
         ],
 
         allItemsList: [(s) => [s.allItems], (allItemsData): InspectorListItem[] => allItemsData.items],


### PR DESCRIPTION
lifted out of #39067 which has a snapshot change i don't understandlifted out of #39067 which has a snapshot change i don't understand

we were missing an item in the inspectorDataState so weren't waiting correctly

but also since inspectorDataState is recreated frequently we would render every time it changed

by giving the logic a bool selector we render only when the thing we care about changes