### PR TITLE
fix: memoise session recording preview rows

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -2,6 +2,7 @@ import './SessionRecordingPreview.scss'
 
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { memo } from 'react'
 
 import { IconBug, IconCursorClick, IconKeyboard, IconLive } from '@posthog/icons'
 
@@ -226,109 +227,116 @@ function ItemCheckbox({ recording }: { recording: SessionRecordingType }): JSX.E
     )
 }
 
-export function SessionRecordingPreview({
-    recording,
-    isActive,
-    onClick,
-    selectable = false,
-}: SessionRecordingPreviewProps): JSX.Element {
-    const { playlistTimestampFormat } = useValues(playerSettingsLogic)
+export const SessionRecordingPreview = memo(
+    function SessionRecordingPreview({
+        recording,
+        isActive,
+        selectable = false,
+    }: SessionRecordingPreviewProps): JSX.Element {
+        const { playlistTimestampFormat } = useValues(playerSettingsLogic)
 
-    const { filters } = useValues(sessionRecordingsPlaylistLogic)
-    const { recordingPropertiesById, recordingPropertiesLoading } = useValues(sessionRecordingsListPropertiesLogic)
+        const { filters } = useValues(sessionRecordingsPlaylistLogic)
+        const { recordingPropertiesById, recordingPropertiesLoading } = useValues(sessionRecordingsListPropertiesLogic)
 
-    const recordingProperties = recordingPropertiesById[recording.id]
-    const loading = !recordingProperties && recordingPropertiesLoading
-    const iconProperties = gatherIconProperties(recordingProperties, recording)
+        const recordingProperties = recordingPropertiesById[recording.id]
+        const loading = !recordingProperties && recordingPropertiesLoading
+        const iconProperties = gatherIconProperties(recordingProperties, recording)
 
-    const iconClassNames = 'text-secondary shrink-0'
+        const iconClassNames = 'text-secondary shrink-0'
 
-    return (
-        <DraggableToNotebook href={urls.replaySingle(recording.id)}>
-            <div
-                key={recording.id}
-                className={clsx(
-                    'SessionRecordingPreview flex overflow-hidden cursor-pointer py-0.5 px-1 text-xs',
-                    isActive && 'SessionRecordingPreview--active'
-                )}
-                onClick={() => onClick?.()}
-            >
-                {selectable && <ItemCheckbox recording={recording} />}
-                <div className="grow overflow-hidden deprecated-space-y-1 ml-1">
-                    <div className="flex items-center justify-between gap-x-0.5">
-                        <div className="flex overflow-hidden font-medium ph-no-capture">
-                            <span className="truncate">{asDisplay(recording.person)}</span>
-                        </div>
-
-                        {playlistTimestampFormat === TimestampFormat.Relative ? (
-                            <TZLabel
-                                className="overflow-hidden text-ellipsis text-xs text-secondary shrink-0"
-                                time={recording.start_time}
-                                placement="right"
-                            />
-                        ) : (
-                            <SimpleTimeLabel
-                                startTime={recording.start_time}
-                                timestampFormat={playlistTimestampFormat}
-                            />
-                        )}
-                    </div>
-
-                    <div className="flex justify-between items-center gap-x-0.5">
-                        <div className="flex deprecated-space-x-2 text-secondary text-sm">
-                            <PropertyIcons
-                                recordingProperties={iconProperties}
-                                iconClassNames={iconClassNames}
-                                loading={loading}
-                            />
-
-                            <div className="flex gap-1">
-                                <Tooltip className="flex items-center" title="Clicks">
-                                    <span className="flex gap-x-0.5">
-                                        <IconCursorClick className={iconClassNames} />
-                                        <span>{recording.click_count}</span>
-                                    </span>
-                                </Tooltip>
-                                <Tooltip className="flex items-center" title="Key presses">
-                                    <span className="flex gap-x-0.5">
-                                        <IconKeyboard className={iconClassNames} />
-                                        <span>{recording.keypress_count}</span>
-                                    </span>
-                                </Tooltip>
-                            </div>
-                        </div>
-
-                        {filters.order === 'console_error_count' ? (
-                            <ErrorCount iconClassNames={iconClassNames} errorCount={recording.console_error_count} />
-                        ) : (
-                            <RecordingDuration
-                                recordingDuration={durationToShow(
-                                    recording,
-                                    filters.order || DEFAULT_RECORDING_FILTERS_ORDER_BY
-                                )}
-                            />
-                        )}
-                    </div>
-
-                    <FirstURL startUrl={recording.start_url} />
-                </div>
-
+        return (
+            <DraggableToNotebook href={urls.replaySingle(recording.id)}>
                 <div
+                    key={recording.id}
                     className={clsx(
-                        'min-w-6 flex flex-col gap-x-0.5 items-center',
-                        // need different margin if the first item is an icon
-                        recording.ongoing ? 'mt-1' : 'mt-2'
+                        'SessionRecordingPreview flex overflow-hidden cursor-pointer py-0.5 px-1 text-xs',
+                        isActive && 'SessionRecordingPreview--active'
                     )}
                 >
-                    {recording.ongoing ? <RecordingOngoingIndicator /> : null}
-                    {!recording.viewed ? (
-                        <UnwatchedIndicator otherViewersCount={recording.viewers?.length || 0} />
-                    ) : null}
+                    {selectable && <ItemCheckbox recording={recording} />}
+                    <div className="grow overflow-hidden deprecated-space-y-1 ml-1">
+                        <div className="flex items-center justify-between gap-x-0.5">
+                            <div className="flex overflow-hidden font-medium ph-no-capture">
+                                <span className="truncate">{asDisplay(recording.person)}</span>
+                            </div>
+
+                            {playlistTimestampFormat === TimestampFormat.Relative ? (
+                                <TZLabel
+                                    className="overflow-hidden text-ellipsis text-xs text-secondary shrink-0"
+                                    time={recording.start_time}
+                                    placement="right"
+                                />
+                            ) : (
+                                <SimpleTimeLabel
+                                    startTime={recording.start_time}
+                                    timestampFormat={playlistTimestampFormat}
+                                />
+                            )}
+                        </div>
+
+                        <div className="flex justify-between items-center gap-x-0.5">
+                            <div className="flex deprecated-space-x-2 text-secondary text-sm">
+                                <PropertyIcons
+                                    recordingProperties={iconProperties}
+                                    iconClassNames={iconClassNames}
+                                    loading={loading}
+                                />
+
+                                <div className="flex gap-1">
+                                    <Tooltip className="flex items-center" title="Clicks">
+                                        <span className="flex gap-x-0.5">
+                                            <IconCursorClick className={iconClassNames} />
+                                            <span>{recording.click_count}</span>
+                                        </span>
+                                    </Tooltip>
+                                    <Tooltip className="flex items-center" title="Key presses">
+                                        <span className="flex gap-x-0.5">
+                                            <IconKeyboard className={iconClassNames} />
+                                            <span>{recording.keypress_count}</span>
+                                        </span>
+                                    </Tooltip>
+                                </div>
+                            </div>
+
+                            {filters.order === 'console_error_count' ? (
+                                <ErrorCount
+                                    iconClassNames={iconClassNames}
+                                    errorCount={recording.console_error_count}
+                                />
+                            ) : (
+                                <RecordingDuration
+                                    recordingDuration={durationToShow(
+                                        recording,
+                                        filters.order || DEFAULT_RECORDING_FILTERS_ORDER_BY
+                                    )}
+                                />
+                            )}
+                        </div>
+
+                        <FirstURL startUrl={recording.start_url} />
+                    </div>
+
+                    <div
+                        className={clsx(
+                            'min-w-6 flex flex-col gap-x-0.5 items-center',
+                            // need different margin if the first item is an icon
+                            recording.ongoing ? 'mt-1' : 'mt-2'
+                        )}
+                    >
+                        {recording.ongoing ? <RecordingOngoingIndicator /> : null}
+                        {!recording.viewed ? (
+                            <UnwatchedIndicator otherViewersCount={recording.viewers?.length || 0} />
+                        ) : null}
+                    </div>
                 </div>
-            </div>
-        </DraggableToNotebook>
-    )
-}
+            </DraggableToNotebook>
+        )
+    },
+    (prevProps, nextProps) =>
+        prevProps.recording.id === nextProps.recording.id &&
+        prevProps.isActive === nextProps.isActive &&
+        prevProps.selectable === nextProps.selectable
+)
 
 export function SessionRecordingPreviewSkeleton(): JSX.Element {
     return (

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -34,7 +34,6 @@ import {
 export interface SessionRecordingPreviewProps {
     recording: SessionRecordingType
     isActive?: boolean
-    onClick?: () => void
     /**
      * Whether to show a sessionRecordingPlaylistLogic selection checkbox on this preview.
      * @default false


### PR DESCRIPTION
lifted out of #39067 which has a snapshot change i don't understand

when first loading we spam re-rendering the preview component in the playlist
let's not