### PR TITLE
fix: memoise player inspector list item

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -2,7 +2,7 @@ import './PlayerInspectorList.scss'
 
 import { range } from 'd3'
 import { useActions, useValues } from 'kea'
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import AutoSizer from 'react-virtualized/dist/es/AutoSizer'
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized/dist/es/CellMeasurer'
 import { List, ListRowRenderer } from 'react-virtualized/dist/es/List'
@@ -78,12 +78,15 @@ export function PlayerInspectorList(): JSX.Element {
                             key={index}
                             item={items[index]}
                             index={index}
-                            onLayout={({ height }) => {
-                                // Optimization to ensure that we only call measure if the dimensions have actually changed
-                                if (height !== cellMeasurerCache.getHeight(index, 0)) {
-                                    measure()
-                                }
-                            }}
+                            onLayout={useCallback(
+                                ({ height }) => {
+                                    // Optimization to ensure that we only call measure if the dimensions have actually changed
+                                    if (height !== cellMeasurerCache.getHeight(index, 0)) {
+                                        measure()
+                                    }
+                                },
+                                [measure]
+                            )}
                         />
                     </div>
                 )}

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -68,6 +68,17 @@ export function PlayerInspectorList(): JSX.Element {
         }
     }, [playbackIndicatorIndex]) // oxlint-disable-line react-hooks/exhaustive-deps
 
+    const createLayoutHandler = useCallback(
+        (measure: () => void, index: number) => {
+            return ({ height }: { height: number }) => {
+                if (height !== cellMeasurerCache.getHeight(index, 0)) {
+                    measure()
+                }
+            }
+        },
+        [cellMeasurerCache]
+    )
+
     const renderRow: ListRowRenderer = ({ index, key, parent, style }) => {
         return (
             <CellMeasurer cache={cellMeasurerCache} columnIndex={0} key={key} rowIndex={index} parent={parent}>
@@ -78,15 +89,7 @@ export function PlayerInspectorList(): JSX.Element {
                             key={index}
                             item={items[index]}
                             index={index}
-                            onLayout={useCallback(
-                                ({ height }) => {
-                                    // Optimization to ensure that we only call measure if the dimensions have actually changed
-                                    if (height !== cellMeasurerCache.getHeight(index, 0)) {
-                                        measure()
-                                    }
-                                },
-                                [measure]
-                            )}
+                            onLayout={createLayoutHandler(measure, index)}
                         />
                     </div>
                 )}

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { FunctionComponent, isValidElement, useEffect, useRef } from 'react'
+import { FunctionComponent, isValidElement, memo, useEffect, useRef } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import useResizeObserver from 'use-resize-observer'
 
@@ -24,7 +24,7 @@ import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import { Dayjs } from 'lib/dayjs'
 import useIsHovering from 'lib/hooks/useIsHovering'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { ceilMsToClosestSecond } from 'lib/utils'
+import { ceilMsToClosestSecond, objectsEqual } from 'lib/utils'
 import { ItemTimeDisplay } from 'scenes/session-recordings/components/ItemTimeDisplay'
 import {
     ItemAnyComment,
@@ -222,7 +222,7 @@ function RowItemDetail({
     )
 }
 
-export function PlayerInspectorListItem({
+export const PlayerInspectorListItem = memo(function PlayerInspectorListItem({
     item,
     index,
     onLayout,
@@ -389,4 +389,4 @@ export function PlayerInspectorListItem({
             ) : null}
         </div>
     )
-}
+}, objectsEqual)


### PR DESCRIPTION
lifted out of #39067 which has a snapshot change i don't understand

memoise the player inspector list item since we abolutely spam rendering this component and there are always at least 30 in the page