### PR TITLE
feat(err): add "open all" button

### DIFF
--- a/products/error_tracking/frontend/components/IssueActions/IssueActions.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/IssueActions.tsx
@@ -2,6 +2,9 @@ import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonDialog, LemonSelect } from '@posthog/lemon-ui'
 
+import { sceneLogic } from 'scenes/sceneLogic'
+import { urls } from 'scenes/urls'
+
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
 import { FilterLogicalOperator, HogQLPropertyFilter, PropertyFilterType, UniversalFiltersGroup } from '~/types'
 
@@ -22,8 +25,18 @@ export function IssueActions({ issues, selectedIds }: IssueActionsProps): JSX.El
     const { filterGroup } = useValues(issueFiltersLogic)
     const { setFilterGroup } = useActions(issueFiltersLogic)
     const { setSelectedIssueIds } = useActions(bulkSelectLogic)
+    const { newTab } = useActions(sceneLogic)
 
     const hasAtLeastTwoIssues = selectedIds.length >= 2
+
+    const openInNewTabs = (): void => {
+        selectedIds.forEach((id) => {
+            const issue = issues.find((issue) => issue.id === id)
+            if (issue) {
+                newTab(urls.errorTrackingIssue(id, { timestamp: issue.last_seen }))
+            }
+        })
+    }
 
     const excludeSelectedIssues = (): void => {
         const quotedIds = selectedIds.map((id) => `'${id}'`).join(', ')
@@ -63,6 +76,9 @@ export function IssueActions({ issues, selectedIds }: IssueActionsProps): JSX.El
     return (
         <div className="flex gap-x-2 justify-between">
             <div className="flex gap-x-2">
+                <LemonButton type="secondary" size="small" onClick={openInNewTabs}>
+                    Open all
+                </LemonButton>
                 <LemonButton
                     disabledReason={!hasAtLeastTwoIssues ? 'Select at least two issues to merge' : null}
                     type="secondary"

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -15,7 +15,7 @@ use cymbal::{
 use metrics::histogram;
 use rdkafka::types::RDKafkaErrorCode;
 use tokio::task::JoinHandle;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 common_alloc::used!();
@@ -144,6 +144,7 @@ async fn main() {
         metrics::counter!(EVENTS_WRITTEN).increment(to_emit.len() as u64);
 
         let emit_time = common_metrics::timing_guard(EMIT_EVENTS_TIME, &[]);
+        debug!("Emitting {} events", to_emit.len());
         let results = txn
             .send_keyed_iter_to_kafka(
                 &context.config.events_topic,


### PR DESCRIPTION
Random airport thought - we've got tabs, use 'em

Idea is to enable using tabs as a work queue (open them all, then go one by one doing whats needed). I do this all the time with browser tabs, zendesk etc.

There's an argument that the better version of this is a little box-arrow icon beside each issues title, or even that clicking an issue title itself should open a new tab rather than navigating this one. I'll defer to the UI gods on what the ideal approach here is.

<img width="469" height="301" alt="image" src="https://github.com/user-attachments/assets/96cb9ead-8d73-4071-9558-ec42c60a2d82" />
