### PR TITLE
feat: adding copy functionality for table results in OutputPane

### DIFF
--- a/frontend/src/lib/utils/dataTableTransformations.ts
+++ b/frontend/src/lib/utils/dataTableTransformations.ts
@@ -1,0 +1,14 @@
+import { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
+
+/**
+ * Transforms DataTable format back to DataTableRow format for clipboard operations
+ */
+export function transformDataTableToDataTableRows(rows: Record<string, any>[], columns: string[]): DataTableRow[] {
+    if (!columns.length || !rows.length) {
+        return []
+    }
+
+    return rows.map((row) => ({
+        result: columns.map((col) => row[col]),
+    }))
+}

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -30,6 +30,7 @@ import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { IconTableChart } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { transformDataTableToDataTableRows } from 'lib/utils/dataTableTransformations'
 import { InsightErrorState, StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { HogQLBoldNumber } from 'scenes/insights/views/BoldNumber/BoldNumber'
 
@@ -595,12 +596,9 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
                                 label,
                                 onClick: () => {
                                     if (response?.columns && rows.length > 0) {
-                                        const columns = response.columns
-                                        const dataTableRows = rows.map((row) => ({
-                                            result: columns.map((col) => row[col]),
-                                        }))
+                                        const dataTableRows = transformDataTableToDataTableRows(rows, response.columns)
                                         const query = createDataTableQuery()
-                                        copyFn(dataTableRows, columns, query)
+                                        copyFn(dataTableRows, response.columns, query)
                                     }
                                 },
                             }))}
@@ -608,7 +606,7 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
                         >
                             <LemonButton
                                 id="sql-editor-copy-dropdown"
-                                disabledReason={!hasColumns ? 'No results to copy' : undefined}
+                                disabledReason={!response?.columns || !rows.length ? 'No results to copy' : undefined}
                                 type="secondary"
                                 icon={<IconCopy />}
                             />


### PR DESCRIPTION
## Problem

Sometimes I would like to easily export result without actually having to export it, I would just want to copy them.

## Changes

- Introduced a dropdown menu for copying table results in CSV, JSON, and Excel formats.
- Added utility functions for clipboard operations and a helper function to create data table queries.
- Enhanced the OutputPane component to support new copy features, improving user experience in data export.

## How did you test this code?
Mannually:

<img width="1286" height="433" alt="image" src="https://github.com/user-attachments/assets/62fde419-15fa-429f-8093-e713bd5ad184" />

CSV:
```
col1,col10,col11,col12,col13,col14,col15,col16,col17,col18,col19,col2,col20,col3,col4,col5,col6,col7,col8,col9
1,10,11,12,13,14,15,16,17,18,19,2,20,3,4,5,6,7,8,9
```
JSON
```
[
    {
        "col1": 1,
        "col2": 2,
        "col3": 3,
        "col4": 4,
        "col5": 5,
        "col6": 6,
        "col7": 7,
        "col8": 8,
        "col9": 9,
        "col10": 10,
        "col11": 11,
        "col12": 12,
        "col13": 13,
        "col14": 14,
        "col15": 15,
        "col16": 16,
        "col17": 17,
        "col18": 18,
        "col19": 19,
        "col20": 20
    }
]
```
EXCEL:
```
col1	col10	col11	col12	col13	col14	col15	col16	col17	col18	col19	col2	col20	col3	col4	col5	col6	col7	col8	col9
1	10	11	12	13	14	15	16	17	18	19	2	20	3	4	5	6	7	8	9
```