### PR TITLE
fix(max): remove double icon

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -799,7 +799,6 @@ const VisualizationAnswer = React.memo(function VisualizationAnswer({
                                               ? urls.insightView(message.short_id as InsightShortId)
                                               : urls.insightNew({ query })
                                       }
-                                      icon={<IconOpenInNew />}
                                       size="xsmall"
                                       targetBlank
                                       tooltip={message.short_id ? 'Open insight' : 'Open as new insight'}

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -799,8 +799,8 @@ const VisualizationAnswer = React.memo(function VisualizationAnswer({
                                               ? urls.insightView(message.short_id as InsightShortId)
                                               : urls.insightNew({ query })
                                       }
+                                      icon={<IconOpenInNew />}
                                       size="xsmall"
-                                      targetBlank
                                       tooltip={message.short_id ? 'Open insight' : 'Open as new insight'}
                                   />
                               )}


### PR DESCRIPTION
## Problem
LemonButton now includes by default an icon when the button has a `targetBlank` parameter. That breaks Max's insight visualizations as they now show two icons.

## Changes
Remove the `targetBlank` parameter.

## How did you test this code?
Locally