### PR TITLE
fix(ux): cmd+b in notebooks

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1066,6 +1066,11 @@ export const sceneLogic = kea<sceneLogicType>([
     afterMount(({ actions, cache, values }) => {
         cache.onKeyDown = (event: KeyboardEvent) => {
             if ((event.ctrlKey || event.metaKey) && event.key === 'b') {
+                const element = event.target as HTMLElement
+                if (element?.closest('.NotebookEditor')) {
+                    return
+                }
+
                 event.preventDefault()
                 event.stopPropagation()
                 if (event.shiftKey) {


### PR DESCRIPTION
## Problem

Pressing CMD+B in a notebook opens a new tab, instead of making the text bold.

## Changes

Ignore the hotkey when in a notebook.

## How did you test this code?

Was in a notebook, pressed CMD+B, text went bold without a new tab opening.