### PR TITLE
feat(max): deep research template system

### DIFF
--- a/ee/hogai/assistant/assistant.py
+++ b/ee/hogai/assistant/assistant.py
@@ -9,6 +9,8 @@ from ee.hogai.assistant.base import BaseAssistant
 from ee.hogai.assistant.deep_research_assistant import DeepResearchAssistant
 from ee.hogai.assistant.insights_assistant import InsightsAssistant
 from ee.hogai.assistant.main_assistant import MainAssistant
+from ee.hogai.graph.deep_research.types import DeepResearchState, PartialDeepResearchState
+from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from ee.hogai.utils.types.base import AssistantMode
 from ee.hogai.utils.types.composed import AssistantMaxGraphState, AssistantMaxPartialGraphState
 from ee.models import Conversation
@@ -30,23 +32,59 @@ class Assistant:
         trace_id: Optional[str | UUID] = None,
         initial_state: Optional[AssistantMaxGraphState | AssistantMaxPartialGraphState] = None,
         billing_context: Optional[MaxBillingContext] = None,
+        deep_research_template: Optional[dict[str, Any]] = None,
     ) -> BaseAssistant:
-        assistant_class: type[BaseAssistant]
         if mode == AssistantMode.ASSISTANT:
-            assistant_class = MainAssistant
+            assistant_initial_state: Optional[AssistantState | PartialAssistantState] = None
+            if initial_state is not None:
+                if isinstance(initial_state, (AssistantState | PartialAssistantState)):
+                    assistant_initial_state = initial_state
+            return MainAssistant(
+                team,
+                conversation,
+                new_message=new_message,
+                user=user,
+                session_id=session_id,
+                contextual_tools=contextual_tools,
+                is_new_conversation=is_new_conversation,
+                trace_id=trace_id,
+                billing_context=billing_context,
+                initial_state=assistant_initial_state,
+            )
         elif mode == AssistantMode.INSIGHTS_TOOL:
-            assistant_class = InsightsAssistant
+            assistant_initial_state = None
+            if initial_state is not None:
+                if isinstance(initial_state, (AssistantState | PartialAssistantState)):
+                    assistant_initial_state = initial_state
+            return InsightsAssistant(
+                team,
+                conversation,
+                new_message=new_message,
+                user=user,
+                session_id=session_id,
+                contextual_tools=contextual_tools,
+                is_new_conversation=is_new_conversation,
+                trace_id=trace_id,
+                billing_context=billing_context,
+                initial_state=assistant_initial_state,
+            )
         elif mode == AssistantMode.DEEP_RESEARCH:
-            assistant_class = DeepResearchAssistant
-        return assistant_class(
-            team,
-            conversation,
-            new_message=new_message,
-            user=user,
-            session_id=session_id,
-            contextual_tools=contextual_tools,
-            is_new_conversation=is_new_conversation,
-            trace_id=trace_id,
-            billing_context=billing_context,
-            initial_state=initial_state,  # type: ignore
-        )
+            deep_research_initial_state: Optional[DeepResearchState | PartialDeepResearchState] = None
+            if initial_state is not None:
+                if isinstance(initial_state, (DeepResearchState | PartialDeepResearchState)):
+                    deep_research_initial_state = initial_state
+            return DeepResearchAssistant(
+                team,
+                conversation,
+                new_message=new_message,
+                user=user,
+                session_id=session_id,
+                contextual_tools=contextual_tools,
+                is_new_conversation=is_new_conversation,
+                trace_id=trace_id,
+                billing_context=billing_context,
+                initial_state=deep_research_initial_state,
+                deep_research_template=deep_research_template,
+            )
+        else:
+            raise ValueError(f"Unknown assistant mode: {mode}")

--- a/ee/hogai/assistant/base.py
+++ b/ee/hogai/assistant/base.py
@@ -101,6 +101,7 @@ class BaseAssistant(ABC):
         billing_context: Optional[MaxBillingContext] = None,
         initial_state: Optional[AssistantMaxGraphState | AssistantMaxPartialGraphState] = None,
         callback_handler: Optional[BaseCallbackHandler] = None,
+        deep_research_template: Optional[dict[str, Any]] = None,
     ):
         self._team = team
         self._contextual_tools = contextual_tools or {}
@@ -138,6 +139,7 @@ class BaseAssistant(ABC):
         self._mode = mode
         self._initial_state = initial_state
         self._commentary_chunk = None
+        self._deep_research_template = deep_research_template
 
     @property
     @abstractmethod

--- a/ee/hogai/graph/deep_research/notebook/nodes.py
+++ b/ee/hogai/graph/deep_research/notebook/nodes.py
@@ -1,7 +1,19 @@
+from uuid import uuid4
+
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
+from posthoganalytics import capture_exception
 
-from posthog.schema import DeepResearchNotebook, DeepResearchType, HumanMessage
+from posthog.schema import (
+    DeepResearchNotebook,
+    DeepResearchType,
+    HumanMessage,
+    NotebookUpdateMessage,
+    ProsemirrorJSONContent,
+)
+
+from posthog.models.notebook.notebook import Notebook
+from posthog.sync import database_sync_to_async
 
 from ee.hogai.graph.deep_research.base.nodes import DeepResearchNode
 from ee.hogai.graph.deep_research.notebook.prompts import DEEP_RESEARCH_NOTEBOOK_PLANNING_PROMPT
@@ -15,18 +27,47 @@ class DeepResearchNotebookPlanningNode(DeepResearchNode):
         return DeepResearchNodeName.NOTEBOOK_PLANNING
 
     async def arun(self, state: DeepResearchState, config: RunnableConfig) -> PartialDeepResearchState:
+        # Load template
+        template_markdown = await self._retrieve_template_markdown(state)
         # We use instructions with the OpenAI Responses API
         instructions = DEEP_RESEARCH_NOTEBOOK_PLANNING_PROMPT.format(
             core_memory=await self._aget_core_memory(),
         )
 
+        # Get last message if available, otherwise use empty string for template-only mode
+        if not state.messages:
+            raise IndexError("No messages in state")
+
         last_message = state.messages[-1]
         if not isinstance(last_message, HumanMessage):
             raise ValueError("Last message is not a human message.")
 
+        human_content = last_message.content if last_message else ""
+        # If a template was provided, emit a synthetic "loaded notebook" message once
+        pre_messages: list = []
+        if template_markdown and not state.has_emitted_template_loaded:
+            serializer = self._get_notebook_serializer()
+            json_content = serializer.from_markdown_to_json(template_markdown)
+            loaded_message = NotebookUpdateMessage(
+                id=str(uuid4()),
+                notebook_id=str(state.template_notebook_short_id or ""),
+                content=ProsemirrorJSONContent.model_validate(json_content.model_dump(exclude_none=True)),
+                notebook_type="deep_research",
+                event="loaded",
+            )
+            await self._write_message(loaded_message)
+            pre_messages.append(loaded_message)
+
+        # If template exists, use it (with or without additional human content)
+        # If no template, use human content (which should exist in this case)
+        if template_markdown:
+            human_message = f"{template_markdown}\n\n{human_content}" if human_content else template_markdown
+        else:
+            human_message = human_content
+
         prompt = ChatPromptTemplate.from_messages(
             [
-                ("human", last_message.content),
+                ("human", human_message),
             ]
         )
 
@@ -49,8 +90,46 @@ class DeepResearchNotebookPlanningNode(DeepResearchNode):
         notebook_update_message.current_run_notebooks = current_run_notebooks
 
         return PartialDeepResearchState(
-            messages=[notebook_update_message],
+            messages=[*pre_messages, notebook_update_message],
             previous_response_id=None,  # we reset the previous response id because we're starting a new conversation after the onboarding
             conversation_notebooks=[notebook_info],
             current_run_notebooks=current_run_notebooks,
+            has_emitted_template_loaded=True if pre_messages else state.has_emitted_template_loaded,
         )
+
+    @database_sync_to_async
+    def get_notebook(self, state: DeepResearchState) -> Notebook:
+        return Notebook.objects.filter(
+            team=self._team, short_id=str(state.template_notebook_short_id), deleted=False
+        ).first()
+
+    async def _retrieve_template_markdown(self, state: DeepResearchState) -> str | None:
+        if not (
+            state.template_notebook_short_id and not state.template_markdown and not state.has_emitted_template_loaded
+        ):
+            return state.template_markdown
+
+        try:
+            notebook = await self.get_notebook(state)
+
+            if not notebook:
+                return state.template_markdown
+
+            text_content = getattr(notebook, "text_content", None)
+            if text_content:
+                return text_content
+
+            content = getattr(notebook, "content", None)
+            if content:
+                try:
+                    nb_json = ProsemirrorJSONContent.model_validate(notebook.content)
+                    from ee.hogai.notebook.notebook_serializer import NotebookSerializer
+
+                    return NotebookSerializer().from_json_to_markdown(nb_json)
+                except Exception:
+                    return state.template_markdown
+
+            return state.template_markdown
+        except Exception as e:
+            capture_exception(e)
+            return state.template_markdown

--- a/ee/hogai/graph/deep_research/onboarding/nodes.py
+++ b/ee/hogai/graph/deep_research/onboarding/nodes.py
@@ -20,6 +20,12 @@ class DeepResearchOnboardingNode(DeepResearchNode):
         return DeepResearchNodeName.NOTEBOOK_PLANNING
 
     def should_run_onboarding_at_start(self, state: DeepResearchState) -> Literal["onboarding", "planning", "continue"]:
+        # Skipping onboarding when provided a template
+        if state.skip_onboarding:
+            if state.current_run_notebooks:
+                return "continue"
+            return "planning"
+
         if not state.messages:
             return "onboarding"
 

--- a/ee/hogai/graph/deep_research/types.py
+++ b/ee/hogai/graph/deep_research/types.py
@@ -63,6 +63,22 @@ class _SharedDeepResearchState(BaseStateWithMessages, BaseStateWithTasks):
     """
     Notebooks created in the current deep research run (reset on new run).
     """
+    skip_onboarding: Annotated[Optional[bool], replace] = Field(default=None)
+    """
+    If true, skip the onboarding node routing and go straight to planning.
+    """
+    template_markdown: Annotated[Optional[str], replace] = Field(default=None)
+    """
+    Template markdown content when deep research starts from a template.
+    """
+    template_notebook_short_id: Annotated[Optional[str], replace] = Field(default=None)
+    """
+    Template notebook ID when deep research starts from a template.
+    """
+    has_emitted_template_loaded: Annotated[bool, replace] = Field(default=False)
+    """
+    Whether the template loaded message has been emitted.
+    """
 
 
 class DeepResearchState(_SharedDeepResearchState):

--- a/posthog/notebooks/curated_templates.py
+++ b/posthog/notebooks/curated_templates.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+# Curated deep-research notebook templates stored as ProseMirror JSON
+
+CURATED_DEEP_RESEARCH_NOTEBOOKS: list[dict] = [
+    {
+        "id": "dr-conversion-regression-analysis",
+        "title": "Conversion regression analysis",
+        "content": {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "heading",
+                    "attrs": {"level": 1},
+                    "content": [{"type": "text", "text": "Conversion regression analysis"}],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Objective"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Analyze the drop in conversion rate observed since <date-range>. Identify impacted surfaces, segments, and likely causes.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Scope"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Users: <e.g., new users vs returning>, Geography: <e.g., US/EU>, Timeframe: <e.g., last 30/90 days>.",
+                        }
+                    ],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Key flows / features: <e.g., signup → onboarding → first key action>.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Success metrics"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Primary: overall conversion rate (visit → signup, signup → activation). Secondary: step-level conversion in critical funnels.",
+                        }
+                    ],
+                },
+                {
+                    "type": "heading",
+                    "attrs": {"level": 2},
+                    "content": [{"type": "text", "text": "Context & hypotheses"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Recent changes: <release / pricing / UX>. Hypotheses: <traffic shift / bug / performance / experiment impact>.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Questions"}]},
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "- When did the regression start? Is it seasonal?"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "- Which segments (device, geo, source) are most impacted?"}],
+                },
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Which funnel steps are most affected?"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "- Are there concurrent experiment or feature changes correlating with the drop?",
+                        }
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        "id": "dr-funnel-drop-investigation",
+        "title": "Funnel drop investigation",
+        "content": {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "heading",
+                    "attrs": {"level": 1},
+                    "content": [{"type": "text", "text": "Funnel drop investigation"}],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Objective"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Locate and quantify the largest drops in the <target funnel> and prioritize fixes for the highest-impact steps.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Scope"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Timeframe: <e.g., last 14/28 days>. Audience: <e.g., all/new users>. Flow: <define steps>.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Success metrics"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Step-wise conversion rates, absolute and relative drop, impact in users and %.",
+                        }
+                    ],
+                },
+                {
+                    "type": "heading",
+                    "attrs": {"level": 2},
+                    "content": [{"type": "text", "text": "Context & hypotheses"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Known issues or UI friction: <list>. Hypotheses: <validation / latency / mobile UX / pricing friction>.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Questions"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Which step has the largest drop?"}]},
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "- Are certain segments disproportionately affected?"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "- Did the drop coincide with a release/flag rollout?"}],
+                },
+            ],
+        },
+    },
+    {
+        "id": "dr-feature-launch-postmortem",
+        "title": "Feature launch postmortem",
+        "content": {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "heading",
+                    "attrs": {"level": 1},
+                    "content": [{"type": "text", "text": "Feature launch postmortem"}],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Objective"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Assess adoption, engagement, performance, and downstream impact of the <feature> launch.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Scope"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Cohorts: exposed vs control (if available). Timeframe: <pre>/<post>. Platforms: <web/iOS/Android>.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Success metrics"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Adoption (reach, activation), engagement (DAU/WAU, retention on feature), conversion impact.",
+                        }
+                    ],
+                },
+                {
+                    "type": "heading",
+                    "attrs": {"level": 2},
+                    "content": [{"type": "text", "text": "Context & hypotheses"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "Rollout flags, known issues, marketing pushes, seasonality."}
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Questions"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Did the feature move the primary KPI?"}]},
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "- Are there regressions in adjacent flows?"}],
+                },
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Which segments over/under-performed?"}]},
+            ],
+        },
+    },
+    {
+        "id": "dr-retention-cohort-deep-dive",
+        "title": "Retention cohort deep dive",
+        "content": {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "heading",
+                    "attrs": {"level": 1},
+                    "content": [{"type": "text", "text": "Retention cohort deep dive"}],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Objective"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Understand retention by cohort, lifecycle stage, and product usage patterns to identify levers to improve week N retention.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Scope"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Cohorts: signup week cohorts over last <N> weeks. Segments: device, geo, acquisition source.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Success metrics"}]},
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "D1/D7/D28 retention, mean vs median activity, stickiness."}],
+                },
+                {
+                    "type": "heading",
+                    "attrs": {"level": 2},
+                    "content": [{"type": "text", "text": "Context & hypotheses"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "Activation criteria, onboarding changes, pricing/events changes."}
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Questions"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Which cohorts underperform baseline?"}]},
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "- What usage patterns correlate with higher retention?"}],
+                },
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Which segments are most sensitive?"}]},
+            ],
+        },
+    },
+    {
+        "id": "dr-growth-experiment-analysis",
+        "title": "Growth experiment analysis",
+        "content": {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "heading",
+                    "attrs": {"level": 1},
+                    "content": [{"type": "text", "text": "Growth experiment analysis"}],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Objective"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Evaluate results for the <experiment>, quantify lift, heterogeneity of effects, and guardrail impacts.",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Scope"}]},
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Arms: control vs variant(s). Exposure: <flag/rollout>. Timeframe: <start – end>.",
+                        }
+                    ],
+                },
+                {
+                    "type": "heading",
+                    "attrs": {"level": 2},
+                    "content": [{"type": "text", "text": "Primary/secondary metrics"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Primary: <conversion/retention/revenue>. Secondary: guardrails (latency, error rate, churn, units).",
+                        }
+                    ],
+                },
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Questions"}]},
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "- Did we reach power? Is lift statistically significant?"}],
+                },
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Any segment-level interactions?"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "- Any negative guardrail movement?"}]},
+            ],
+        },
+    },
+]
+
+# Default structure for user-created custom deep research notebooks
+# This is NOT seeded into the database, but used when creating custom templates on-demand
+DEFAULT_CUSTOM_DEEP_RESEARCH_NOTEBOOK = {
+    "id": "dr-custom-research",
+    "title": "Custom Deep Research Template",
+    "content": {
+        "type": "doc",
+        "content": [
+            {
+                "type": "heading",
+                "attrs": {"level": 1},
+                "content": [{"type": "text", "text": "Custom research"}],
+            },
+            {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Objective"}]},
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "What specific question are you trying to answer? What business impact does this have?",
+                    }
+                ],
+            },
+            {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Scope"}]},
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Users: <which user segments?>"}],
+            },
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Timeframe: <what time period?>"}],
+            },
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Features/flows: <which parts of the product?>"}],
+            },
+            {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Success metrics"}]},
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "What KPIs define success? Any comparison points or benchmarks?"}],
+            },
+            {
+                "type": "heading",
+                "attrs": {"level": 2},
+                "content": [{"type": "text", "text": "Context & hypotheses"}],
+            },
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "Recent changes, working hypotheses, or constraints to be aware of."}
+                ],
+            },
+            {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Questions"}]},
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "- What specific questions do you need answered?"}],
+            },
+        ],
+    },
+}

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1969,6 +1969,11 @@ class NodeKind(StrEnum):
     VECTOR_SEARCH_QUERY = "VectorSearchQuery"
 
 
+class Event(StrEnum):
+    LOADED = "loaded"
+    UPDATED = "updated"
+
+
 class PageURL(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4235,6 +4240,7 @@ class NotebookUpdateMessage(BaseModel):
     content: ProsemirrorJSONContent
     conversation_notebooks: Optional[list[DeepResearchNotebook]] = None
     current_run_notebooks: Optional[list[DeepResearchNotebook]] = None
+    event: Optional[Event] = None
     id: Optional[str] = None
     notebook_id: str
     notebook_type: Literal["deep_research"] = "deep_research"

--- a/posthog/temporal/ai/conversation.py
+++ b/posthog/temporal/ai/conversation.py
@@ -46,6 +46,7 @@ class AssistantConversationRunnerWorkflowInputs:
     session_id: Optional[str] = None
     mode: AssistantMode = AssistantMode.ASSISTANT
     billing_context: Optional[MaxBillingContext] = None
+    deep_research_template: Optional[dict[str, Any]] = None
 
 
 @workflow.defn(name="conversation-processing")
@@ -90,6 +91,8 @@ async def process_conversation_activity(inputs: AssistantConversationRunnerWorkf
 
     human_message = HumanMessage.model_validate(inputs.message) if inputs.message else None
 
+    deep_research_template = inputs.deep_research_template if inputs.mode == AssistantMode.DEEP_RESEARCH else None
+
     assistant = Assistant.create(
         team,
         conversation,
@@ -101,6 +104,7 @@ async def process_conversation_activity(inputs: AssistantConversationRunnerWorkf
         session_id=inputs.session_id,
         mode=inputs.mode,
         billing_context=inputs.billing_context,
+        deep_research_template=deep_research_template,
     )
 
     stream_key = get_conversation_stream_key(inputs.conversation_id)


### PR DESCRIPTION
## Problem

For Max Deep Research, one possible pain point during the onboarding phase is for the user to go through receiving a long list of questions from Max that needs to be answered. This can feel tiresome and make the experience not particularly great.

**Idea**: Have a list of curated + custom templates (notebooks) that the user can compile in their own time and then load as onboarding step when starting Deep Research.

This PR builds on top of the foundational piece for notebooks tags (https://github.com/PostHog/posthog/pull/39101) and add backend support for Max and Notebooks API.

## How did you test this code?

- [x] manual tests
- [x] unit tests

https://github.com/user-attachments/assets/1ede596e-54d4-4db6-b8b8-84e80ec757b8

