### PR TITLE
feat(max): frontend support for deep research templates

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -16868,6 +16868,10 @@
                     },
                     "type": "array"
                 },
+                "event": {
+                    "enum": ["loaded", "updated"],
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -145,6 +145,7 @@ export interface NotebookUpdateMessage extends BaseAssistantMessage {
     notebook_id: string
     content: ProsemirrorJSONContent
     notebook_type?: Category
+    event?: 'loaded' | 'updated'
     conversation_notebooks?: NotebookInfo[]
     current_run_notebooks?: NotebookInfo[]
     tool_calls?: AssistantToolCall[]

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -512,7 +512,11 @@ function NotebookUpdateAnswer({ message }: NotebookUpdateAnswerProps): JSX.Eleme
             <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2">
                     <IconCheck className="text-success size-4" />
-                    <span>A notebook has been updated</span>
+                    <span>
+                        {message.event === 'loaded'
+                            ? 'A deep research template notebook has been loaded'
+                            : 'A notebook has been updated'}
+                    </span>
                 </div>
                 <LemonButton onClick={() => handleOpenNotebook()} size="xsmall" type="primary" icon={<IconOpenInNew />}>
                     Open notebook

--- a/frontend/src/scenes/max/components/DeepResearchTemplatePicker.tsx
+++ b/frontend/src/scenes/max/components/DeepResearchTemplatePicker.tsx
@@ -1,0 +1,132 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { LemonButton, LemonDropdown } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { NotebookTarget } from 'scenes/notebooks/types'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { notebooksModel } from '~/models/notebooksModel'
+import { AssistantMessageType } from '~/queries/schema/schema-assistant-messages'
+
+import { maxLogic } from '../maxLogic'
+import { maxThreadLogic } from '../maxThreadLogic'
+
+export function DeepResearchTemplatePicker(): JSX.Element | null {
+    const { deepResearchMode, threadRaw, deepResearchTemplate } = useValues(maxThreadLogic)
+    const { setDeepResearchTemplate } = useActions(maxThreadLogic)
+    const { setQuestion } = useActions(maxLogic)
+    const { currentProjectId } = useValues(projectLogic)
+    const { createNotebook } = useActions(notebooksModel)
+
+    // Don't show the template picker if conversation has already started (has human messages)
+    const hasHumanMessages = threadRaw?.some((msg) => msg.type === AssistantMessageType.Human) || false
+    if (!deepResearchMode || hasHumanMessages) {
+        return null
+    }
+
+    const handleCreateCustomTemplate = (): void => {
+        // Backend will automatically populate with DEFAULT_CUSTOM_DEEP_RESEARCH_NOTEBOOK when tags include template_deep_research
+        createNotebook(NotebookTarget.Scene, undefined, undefined, undefined, ['template_deep_research'])
+    }
+
+    return (
+        <LemonDropdown
+            overlay={
+                <div className="flex flex-col p-1 min-w-60">
+                    <div className="px-1 pb-1 text-muted text-xs">Curated templates</div>
+                    <RemoteNotebookTemplates
+                        currentProjectId={currentProjectId}
+                        setDeepResearchTemplate={setDeepResearchTemplate}
+                    />
+                    <div className="border-t border-border mt-1 pt-1">
+                        <LemonButton onClick={handleCreateCustomTemplate} fullWidth size="small" type="secondary">
+                            Create custom template
+                        </LemonButton>
+                    </div>
+                    {deepResearchTemplate && (
+                        <LemonButton
+                            className="mt-1"
+                            onClick={() => {
+                                setDeepResearchTemplate(null)
+                                setQuestion('')
+                            }}
+                            fullWidth
+                            size="small"
+                            type="secondary"
+                        >
+                            Clear template
+                        </LemonButton>
+                    )}
+                </div>
+            }
+        >
+            <LemonButton size="small" type={deepResearchTemplate ? 'primary' : 'secondary'}>
+                {deepResearchTemplate ? 'Template selected' : 'Select template'}
+            </LemonButton>
+        </LemonDropdown>
+    )
+}
+
+function RemoteNotebookTemplates({
+    currentProjectId,
+    setDeepResearchTemplate,
+}: {
+    currentProjectId: number | null
+    setDeepResearchTemplate: (ref: any) => void
+}): JSX.Element {
+    const [items, setItems] = useState<Array<{ short_id: string; title: string }>>([])
+    const [loading, setLoading] = useState(false)
+
+    useEffect(() => {
+        let mounted = true
+        if (!currentProjectId) {
+            setItems([])
+            return
+        }
+        setLoading(true)
+        const url = `api/projects/${currentProjectId}/notebooks?tags=template_deep_research`
+        api.get(url)
+            .then((res) => {
+                const results = (res?.results || res || []) as Array<{ short_id: string; title: string }>
+                if (mounted) {
+                    setItems(results)
+                }
+            })
+            .finally(() => {
+                if (mounted) {
+                    setLoading(false)
+                }
+            })
+        return () => {
+            mounted = false
+        }
+    }, [currentProjectId])
+
+    if (loading) {
+        return <div className="px-1 py-0.5 text-xs text-muted">Loading…</div>
+    }
+
+    if (!items.length) {
+        return <div className="px-1 py-0.5 text-xs text-muted">No curated templates found</div>
+    }
+
+    return (
+        <>
+            {items.map((n) => (
+                <LemonButton
+                    key={n.short_id}
+                    onClick={() => {
+                        setDeepResearchTemplate({ notebook_short_id: n.short_id, notebook_title: n.title })
+                    }}
+                    fullWidth
+                    size="small"
+                    type="tertiary"
+                >
+                    {n.title}
+                </LemonButton>
+            ))}
+        </>
+    )
+}

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -19,6 +19,7 @@ import { maxGlobalLogic } from '../maxGlobalLogic'
 import { maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
 import { MAX_SLASH_COMMANDS } from '../slash-commands'
+import { DeepResearchTemplatePicker } from './DeepResearchTemplatePicker'
 import { SlashCommandAutocomplete } from './SlashCommandAutocomplete'
 import { ToolsDisplay } from './ToolsDisplay'
 
@@ -56,6 +57,8 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
     const { question } = useValues(maxLogic)
     const { setQuestion } = useActions(maxLogic)
     const { threadLoading, inputDisabled, submissionDisabledReason, deepResearchMode } = useValues(maxThreadLogic)
+    const threadValues: any = useValues(maxThreadLogic as any)
+    const deepResearchTemplate = threadValues.deepResearchTemplate as any
     const { askMax, stopGeneration, completeThreadGeneration, setDeepResearchMode } = useActions(maxThreadLogic)
 
     const [showAutocomplete, setShowAutocomplete] = useState(false)
@@ -124,12 +127,14 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                         ? 'Thinking…'
                                         : isThreadVisible
                                           ? placeholder || 'Ask follow-up (/ for commands)'
-                                          : 'Ask away (/ for commands)'
+                                          : deepResearchTemplate
+                                            ? 'Template loaded, ask away (/ for commands)'
+                                            : 'Ask away (/ for commands)'
                                 }
                                 onPressEnter={() => {
-                                    if (question && !submissionDisabledReason && !threadLoading) {
+                                    if (!submissionDisabledReason && !threadLoading) {
                                         onSubmit?.()
-                                        askMax(question)
+                                        askMax(question || null)
                                     }
                                 }}
                                 disabled={inputDisabled}
@@ -163,7 +168,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                     if (threadLoading) {
                                         stopGeneration()
                                     } else {
-                                        askMax(question)
+                                        askMax(question || null)
                                     }
                                 }}
                                 tooltip={
@@ -200,6 +205,11 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                     bottomActions={bottomActions}
                     deepResearchMode={deepResearchMode}
                 />
+                {deepResearchMode && (
+                    <div className="flex justify-end gap-1 w-full p-1">
+                        <DeepResearchTemplatePicker />
+                    </div>
+                )}
                 {showDeepResearchModeToggle && (
                     <div className="flex justify-end gap-1 w-full p-1">
                         <LemonSwitch


### PR DESCRIPTION
## Problem

For Max Deep Research, one possible pain point during the onboarding phase is for the user to go through receiving a long list of questions from Max that needs to be answered. This can feel tiresome and make the experience not particularly great.

**Idea**: Have a list of curated + custom templates (notebooks) that the user can compile in their own time and then load as onboarding step when starting Deep Research.

This PR builds on top of the backend support in Max and Notebooks API (https://github.com/PostHog/posthog/pull/39104) and adds UI support.

## How did you test this code?

- [x] manual tests

https://github.com/user-attachments/assets/1ede596e-54d4-4db6-b8b8-84e80ec757b8

