### PR TITLE
fix(experiments): Use correct order variant order in Exposures

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -40,15 +40,17 @@ export function Exposures(): JSX.Element {
     let totalExposures = 0
     const variants: Array<{ variant: string; count: number; percentage: number }> = []
 
-    if (exposures?.total_exposures) {
-        for (const [, count] of Object.entries(exposures.total_exposures)) {
+    if (exposures?.timeseries) {
+        for (const series of exposures.timeseries) {
+            const count = exposures.total_exposures?.[series.variant] || 0
             totalExposures += Number(count)
         }
 
         // Calculate percentages for each variant
-        for (const [variant, count] of Object.entries(exposures.total_exposures)) {
+        for (const series of exposures.timeseries) {
+            const count = exposures.total_exposures?.[series.variant] || 0
             variants.push({
-                variant,
+                variant: series.variant,
                 count: Number(count),
                 percentage: totalExposures ? (Number(count) / totalExposures) * 100 : 0,
             })


### PR DESCRIPTION
## Problem
The Exposures collapsible header shows variants in wrong order.

## Changes
Change to iterate over `exposures.timeseries` (which the backend always returns correctly ordered) instead of `total_exposures`.

## How did you test this code?
|Before|After|
|----|----|
|<img width="525" height="48" alt="image" src="https://github.com/user-attachments/assets/1809e150-451f-4b79-9d6a-037118683c48" />|<img width="527" height="47" alt="image" src="https://github.com/user-attachments/assets/0c56eeb8-a2e2-4d07-81d0-2174a4d75ffa" />|