### PR TITLE
chore(deps): REVERT Update posthog-js to 1.270.0

### DIFF
--- a/ee/frontend/package.json
+++ b/ee/frontend/package.json
@@ -6,7 +6,7 @@
         "mobile-replay:schema:build:json": "pnpm mobile-replay:web:schema:build:json && pnpm mobile-replay:mobile:schema:build:json"
     },
     "dependencies": {
-        "posthog-js": "1.270.0"
+        "posthog-js": "1.269.1"
     },
     "devDependencies": {
         "ts-json-schema-generator": "^v2.4.0-next.6"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -191,7 +191,7 @@
         "openai": "^4.81.0",
         "papaparse": "^5.4.1",
         "pmtiles": "^2.11.0",
-        "posthog-js": "1.270.0",
+        "posthog-js": "1.269.1",
         "posthog-js-lite": "4.1.0",
         "prettier": "^3.6.2",
         "prop-types": "^15.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,8 +372,8 @@ importers:
         specifier: '*'
         version: 8.57.0
       posthog-js:
-        specifier: 1.270.0
-        version: 1.270.0(@rrweb/types@2.0.0-alpha.17)
+        specifier: 1.269.1
+        version: 1.269.1(@rrweb/types@2.0.0-alpha.17)
       prettier:
         specifier: '*'
         version: 3.4.2
@@ -826,8 +826,8 @@ importers:
         specifier: ^2.11.0
         version: 2.11.0
       posthog-js:
-        specifier: 1.270.0
-        version: 1.270.0(@rrweb/types@2.0.0-alpha.17)
+        specifier: 1.269.1
+        version: 1.269.1(@rrweb/types@2.0.0-alpha.17)
       posthog-js-lite:
         specifier: 4.1.0
         version: 4.1.0
@@ -1795,8 +1795,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(kea@3.1.7(react@18.2.0))
       posthog-js:
-        specifier: 1.270.0
-        version: 1.270.0(@rrweb/types@2.0.0-alpha.17)
+        specifier: 1.269.1
+        version: 1.269.1(@rrweb/types@2.0.0-alpha.17)
       react:
         specifier: '*'
         version: 18.2.0
@@ -2132,8 +2132,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(kea@3.1.7(react@18.2.0))
       posthog-js:
-        specifier: 1.270.0
-        version: 1.270.0(@rrweb/types@2.0.0-alpha.17)
+        specifier: 1.269.1
+        version: 1.269.1(@rrweb/types@2.0.0-alpha.17)
       react:
         specifier: '*'
         version: 18.2.0
@@ -2379,8 +2379,8 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1(kea@3.1.7(react@18.2.0))
       posthog-js:
-        specifier: 1.270.0
-        version: 1.270.0(@rrweb/types@2.0.0-alpha.17)
+        specifier: 1.269.1
+        version: 1.269.1(@rrweb/types@2.0.0-alpha.17)
       react:
         specifier: '*'
         version: 18.2.0
@@ -15145,8 +15145,8 @@ packages:
   posthog-js-lite@4.1.0:
     resolution: {integrity: sha512-a+MoPmflhYtnKOuDg7tEgeiwT70mWwcZdqeMhduJw/3LPTFMTvnssTJ0jppmnwTkBoPdBgLYTO40l8k64Tl/yQ==}
 
-  posthog-js@1.270.0:
-    resolution: {integrity: sha512-gJZND8X90pPhj6BP+YeRi0cjUp1QGTLfVBSqQDlxGPS1RpZ4fU0KknQGrt2TYZtFNP44Jjb6Un9XzkOnP65+ew==}
+  posthog-js@1.269.1:
+    resolution: {integrity: sha512-4GrcKQ89uLwBGNtHrhq5QRCzHmPPCxE6i0cDsk4mFMls9iZcsdTpITBNepHbP0Bvn62HZUVAiqGeRlOpy8XeCA==}
     peerDependencies:
       '@rrweb/types': 2.0.0-alpha.17
       rrweb-snapshot: 2.0.0-alpha.17
@@ -35506,7 +35506,7 @@ snapshots:
 
   posthog-js-lite@4.1.0: {}
 
-  posthog-js@1.270.0(@rrweb/types@2.0.0-alpha.17):
+  posthog-js@1.269.1(@rrweb/types@2.0.0-alpha.17):
     dependencies:
       '@posthog/core': 1.2.2
       core-js: 3.45.1

--- a/products/error_tracking/package.json
+++ b/products/error_tracking/package.json
@@ -7,7 +7,7 @@
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.1",
         "kea-subscriptions": "^3.0.1",
-        "posthog-js": "1.270.0"
+        "posthog-js": "1.269.1"
     },
     "peerDependencies": {
         "@dnd-kit/core": "*",

--- a/products/messaging/package.json
+++ b/products/messaging/package.json
@@ -6,7 +6,7 @@
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.1",
         "kea-subscriptions": "^3.0.1",
-        "posthog-js": "1.270.0"
+        "posthog-js": "1.269.1"
     },
     "peerDependencies": {
         "@posthog/icons": "*",

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -4,7 +4,7 @@
         "kea": "^3.1.7",
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.1",
-        "posthog-js": "1.270.0"
+        "posthog-js": "1.269.1"
     },
     "peerDependencies": {
         "@posthog/icons": "*",


### PR DESCRIPTION
Reverts PostHog/posthog#39079

[Context](https://posthog.slack.com/archives/C075D3C5HST/p1759503579040139)