### PR TITLE
fix(flags): Added if check and return error for filters with empty groups fix#38896 

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -394,6 +394,12 @@ class FeatureFlagSerializer(
             # mypy cannot tell that self.instance is a FeatureFlag
             return self.instance.filters
 
+        groups = filters.get("groups", [])
+        if isinstance(groups, list) and len(groups) == 0:
+            raise serializers.ValidationError(
+            "Feature flag filters must contain at least one condition set. Empty 'groups' array is not allowed."
+            )
+
         aggregation_group_type_index = filters.get("aggregation_group_type_index", None)
 
         def properties_all_match(predicate):

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -397,7 +397,7 @@ class FeatureFlagSerializer(
         groups = filters.get("groups", [])
         if isinstance(groups, list) and len(groups) == 0:
             raise serializers.ValidationError(
-            "Feature flag filters must contain at least one condition set. Empty 'groups' array is not allowed."
+                "Feature flag filters must contain at least one condition set. Empty 'groups' array is not allowed."
             )
 
         aggregation_group_type_index = filters.get("aggregation_group_type_index", None)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #38896 

## Changes
Added if check for empty groups and gave an proper error for for creating a feature flag with empty groups
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

* **Bug Fixes**
  * Prevents saving feature flag filters with an empty "groups" list; attempts now return a clear validation error.