### PR TITLE
feat(customers): Create NotebookNodeLLMTrace component

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -25272,6 +25272,10 @@
                 "offset": {
                     "$ref": "#/definitions/integer"
                 },
+                "personId": {
+                    "description": "Person who performed the event",
+                    "type": "string"
+                },
                 "properties": {
                     "description": "Properties configurable in the interface",
                     "items": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3379,6 +3379,8 @@ export interface TracesQuery extends DataNode<TracesQueryResponse> {
     showColumnConfigurator?: boolean
     /** Properties configurable in the interface */
     properties?: AnyPropertyFilter[]
+    /** Person who performed the event */
+    personId?: string
 }
 
 export interface TraceQueryResponse extends AnalyticsQueryResponseBase {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 
-import { LLMAnalyticsTraces } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
+import { BaseLLMAnalyticsTraces } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
+import { llmAnalyticsLogic } from 'products/llm_analytics/frontend/llmAnalyticsLogic'
 
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { createPostHogWidgetNode } from './NodeWrapper'
@@ -14,7 +15,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
         return null
     }
 
-    return <LLMAnalyticsTraces personId={personId} />
+    return <BaseLLMAnalyticsTraces logic={llmAnalyticsLogic({ personId })} />
 }
 
 type NotebookNodeLLMTraceAttributes = {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -1,0 +1,29 @@
+import { useValues } from 'kea'
+
+import { LLMAnalyticsTraces } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
+
+import { NotebookNodeType } from '../types'
+import { createPostHogWidgetNode } from './NodeWrapper'
+import { notebookNodeLogic } from './notebookNodeLogic'
+
+const Component = (): JSX.Element | null => {
+    const { expanded } = useValues(notebookNodeLogic)
+
+    if (!expanded) {
+        return null
+    }
+
+    return <LLMAnalyticsTraces />
+}
+
+type NotebookNodeLLMTraceAttributes = {}
+
+export const NotebookNodeLLMTrace = createPostHogWidgetNode<NotebookNodeLLMTraceAttributes>({
+    nodeType: NotebookNodeType.LLMTrace,
+    titlePlaceholder: 'Traces',
+    Component,
+    resizeable: false,
+    expandable: true,
+    startExpanded: true,
+    attributes: {},
+})

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -2,21 +2,24 @@ import { useValues } from 'kea'
 
 import { LLMAnalyticsTraces } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
 
-import { NotebookNodeType } from '../types'
+import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { createPostHogWidgetNode } from './NodeWrapper'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
-const Component = (): JSX.Element | null => {
+const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttributes>): JSX.Element | null => {
     const { expanded } = useValues(notebookNodeLogic)
+    const { personId } = attributes
 
     if (!expanded) {
         return null
     }
 
-    return <LLMAnalyticsTraces />
+    return <LLMAnalyticsTraces personId={personId} />
 }
 
-type NotebookNodeLLMTraceAttributes = {}
+type NotebookNodeLLMTraceAttributes = {
+    personId?: string
+}
 
 export const NotebookNodeLLMTrace = createPostHogWidgetNode<NotebookNodeLLMTraceAttributes>({
     nodeType: NotebookNodeType.LLMTrace,
@@ -25,5 +28,7 @@ export const NotebookNodeLLMTrace = createPostHogWidgetNode<NotebookNodeLLMTrace
     resizeable: false,
     expandable: true,
     startExpanded: true,
-    attributes: {},
+    attributes: {
+        personId: {},
+    },
 })

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -29,6 +29,7 @@ import { NotebookNodeFlag } from '../Nodes/NotebookNodeFlag'
 import { NotebookNodeFlagCodeExample } from '../Nodes/NotebookNodeFlagCodeExample'
 import { NotebookNodeGroup } from '../Nodes/NotebookNodeGroup'
 import { NotebookNodeImage } from '../Nodes/NotebookNodeImage'
+import { NotebookNodeLLMTrace } from '../Nodes/NotebookNodeLLMTrace'
 import { NotebookNodeLatex } from '../Nodes/NotebookNodeLatex'
 import { NotebookNodeMap } from '../Nodes/NotebookNodeMap'
 import { NotebookNodePerson } from '../Nodes/NotebookNodePerson'
@@ -133,6 +134,7 @@ export function Editor(): JSX.Element {
         NotebookNodePersonFeed,
         NotebookNodeMap,
         NotebookNodeTaskCreate,
+        NotebookNodeLLMTrace,
     ]
 
     if (hasCollapsibleSections) {

--- a/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
@@ -29,6 +29,7 @@ export const fromNodeTypeToLabel: Omit<
     [NotebookNodeType.Cohort]: 'Cohorts',
     [NotebookNodeType.Group]: 'Groups',
     [NotebookNodeType.TaskCreate]: 'Task suggestions',
+    [NotebookNodeType.LLMTrace]: 'LLM traces',
 }
 
 export function ContainsTypeFilters({

--- a/frontend/src/scenes/notebooks/types.ts
+++ b/frontend/src/scenes/notebooks/types.ts
@@ -57,6 +57,7 @@ export enum NotebookNodeType {
     Embed = 'ph-embed',
     Latex = 'ph-latex',
     TaskCreate = 'ph-task-create',
+    LLMTrace = 'ph-llm-trace',
 }
 
 export type NotebookNodeResource = {

--- a/frontend/src/scenes/notebooks/utils.ts
+++ b/frontend/src/scenes/notebooks/utils.ts
@@ -48,6 +48,7 @@ export const textContent = (node: RichContentNode): string => {
         [NotebookNodeType.Person]: customOrTitleSerializer,
         [NotebookNodeType.Query]: customOrTitleSerializer,
         [NotebookNodeType.Recording]: customOrTitleSerializer,
+        [NotebookNodeType.LLMTrace]: customOrTitleSerializer,
         [NotebookNodeType.RecordingPlaylist]: customOrTitleSerializer,
         [NotebookNodeType.ReplayTimestamp]: customOrTitleSerializer,
         [NotebookNodeType.Survey]: customOrTitleSerializer,

--- a/frontend/src/scenes/persons/PersonFeedCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonFeedCanvas.tsx
@@ -53,6 +53,10 @@ const PersonFeedCanvas = ({ person }: PersonFeedCanvasProps): JSX.Element => {
                             ],
                         },
                     },
+                    {
+                        type: 'ph-llm-trace',
+                        attrs: { personId: id, nodeId: uuid() },
+                    },
                 ],
             }}
         />

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -75,11 +75,19 @@ function createInitialExceptionsPayload(personId: string): DataTableNode {
 export const personsLogic = kea<personsLogicType>([
     props({} as PersonsLogicProps),
     key((props) => {
+        if (props.urlId) {
+            return `url_${props.urlId}`
+        }
+
         if (props.fixedProperties) {
             return JSON.stringify(props.fixedProperties)
         }
 
-        return props.cohort ? `cohort_${props.cohort}` : 'scene'
+        if (props.cohort) {
+            return `cohort_${props.cohort}`
+        }
+
+        return 'scene'
     }),
     path((key) => ['scenes', 'persons', 'personsLogic', key]),
     connect(() => ({

--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -290,6 +290,15 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
         if properties_filter is not None:
             exprs.append(properties_filter)
 
+        if self.query.personId:
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["person_id"]),
+                    right=ast.Constant(value=self.query.personId),
+                )
+            )
+
         return ast.And(exprs=exprs)
 
     def _get_properties_filter(self) -> ast.Expr | None:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -11044,6 +11044,7 @@ class TracesQuery(BaseModel):
         default=None, description="Modifiers used when performing the query"
     )
     offset: Optional[int] = None
+    personId: Optional[str] = Field(default=None, description="Person who performed the event")
     properties: Optional[
         list[
             Union[

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -16,12 +16,7 @@ import { LLMMessageDisplay } from './ConversationDisplay/ConversationMessagesDis
 import { llmAnalyticsLogic } from './llmAnalyticsLogic'
 import { formatLLMCost, formatLLMLatency, formatLLMUsage, normalizeMessages, removeMilliseconds } from './utils'
 
-interface LLMAnalyticsTracesProps {
-    personId?: string
-}
-
-export function LLMAnalyticsTraces({ personId = undefined }: LLMAnalyticsTracesProps): JSX.Element {
-    const logic = llmAnalyticsLogic({ personId })
+export function BaseLLMAnalyticsTraces({ logic }: { logic: ReturnType<typeof llmAnalyticsLogic> }): JSX.Element {
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(logic)
     const { tracesQuery } = useValues(logic)
 
@@ -84,6 +79,10 @@ export function LLMAnalyticsTraces({ personId = undefined }: LLMAnalyticsTracesP
             uniqueKey="llm-analytics-traces"
         />
     )
+}
+
+export function LLMAnalyticsTraces(): JSX.Element {
+    return <BaseLLMAnalyticsTraces logic={llmAnalyticsLogic()} />
 }
 
 const IDColumn: QueryContextColumnComponent = ({ record }) => {

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -16,10 +16,14 @@ import { LLMMessageDisplay } from './ConversationDisplay/ConversationMessagesDis
 import { llmAnalyticsLogic } from './llmAnalyticsLogic'
 import { formatLLMCost, formatLLMLatency, formatLLMUsage, normalizeMessages, removeMilliseconds } from './utils'
 
-export function LLMAnalyticsTraces(): JSX.Element {
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(llmAnalyticsLogic)
+interface LLMAnalyticsTracesProps {
+    personId?: string
+}
 
-    const { tracesQuery } = useValues(llmAnalyticsLogic)
+export function LLMAnalyticsTraces({ personId = undefined }: LLMAnalyticsTracesProps): JSX.Element {
+    const logic = llmAnalyticsLogic({ personId })
+    const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(logic)
+    const { tracesQuery } = useValues(logic)
 
     return (
         <DataTable

--- a/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
@@ -50,6 +50,10 @@ export interface QueryTile {
     }
 }
 
+export interface LLMAnalyticsLogicProps {
+    personId?: string
+}
+
 /**
  * Helper function to get date range for a specific day.
  * @param day - The day string from the chart (e.g., "2024-01-15")
@@ -65,7 +69,8 @@ function getDayDateRange(day: string): { date_from: string; date_to: string } {
 
 export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
     path(['products', 'llm_analytics', 'frontend', 'llmAnalyticsLogic']),
-
+    props({} as LLMAnalyticsLogicProps),
+    key((props: LLMAnalyticsLogicProps) => props?.personId || 'llmAnalyticsScene'),
     connect(() => ({ values: [sceneLogic, ['sceneKey'], groupsModel, ['groupsEnabled']] })),
 
     actions({
@@ -596,6 +601,7 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
                 s.dateFilter,
                 s.shouldFilterTestAccounts,
                 s.propertyFilters,
+                (_, props) => props.personId,
                 groupsModel.selectors.groupsTaxonomicTypes,
                 featureFlagLogic.selectors.featureFlags,
             ],
@@ -603,6 +609,7 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
                 dateFilter,
                 shouldFilterTestAccounts,
                 propertyFilters,
+                personId,
                 groupsTaxonomicTypes,
                 featureFlags
             ): DataTableNode => ({
@@ -615,6 +622,7 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
                     },
                     filterTestAccounts: shouldFilterTestAccounts ?? false,
                     properties: propertyFilters,
+                    ...(personId ? { personId } : {}),
                 },
                 columns: [
                     'id',

--- a/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
@@ -52,6 +52,7 @@ export interface QueryTile {
 
 export interface LLMAnalyticsLogicProps {
     personId?: string
+    tabId?: string
 }
 
 /**


### PR DESCRIPTION
## Problem
~We're not displaying the llm traces of a person anywhere in the app. The only way to see the traces of an individual is to filter traces table by sql, then get the person id and use it there.~ I was wrong, `users` tab let's you see individuals with llm traces and clicking a person gets you to their traces.

Still, it is useful to have this information on the user profile, so we don't need to navigate to llmAnalytics when viewing a person record.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/38967
## Changes
- Support filtering by person id in `TracesQueryRunner`
- Create `NotebookNodeLLMTrace`
- Add new node to `PersonFeedCanvas`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/83d3e140-eaad-488d-b353-797f4a179dac" />

## How did you test this code?
- Unit tests for query runner changes
- Manual tests for the UI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
