### PR TITLE
fix: Don't strip underscores from variables

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/NewVariableModal.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/NewVariableModal.tsx
@@ -22,8 +22,8 @@ const getCodeName = (name: string): string => {
     return (
         name
             .trim()
-            //  Filter out all characters that is not a letter, number or space
-            .replace(/[^a-zA-Z0-9\s]/g, '')
+            //  Filter out all characters that is not a letter, number or space or underscore
+            .replace(/[^a-zA-Z0-9\s_]/g, '')
             .replace(/\s/g, '_')
             .toLowerCase()
     )
@@ -181,7 +181,11 @@ export const NewVariableModal = (): JSX.Element => {
             }
         >
             <div className="gap-4 flex flex-col">
-                <LemonField.Pure label="Name" className="gap-1">
+                <LemonField.Pure
+                    label="Name"
+                    className="gap-1"
+                    info="Variable name must be alphanumeric and can only contain spaces and underscores"
+                >
                     <LemonInput
                         placeholder="Name"
                         value={variable.name}

--- a/posthog/api/insight_variable.py
+++ b/posthog/api/insight_variable.py
@@ -18,9 +18,9 @@ class InsightVariableSerializer(serializers.ModelSerializer):
         validated_data["team_id"] = self.context["team_id"]
         validated_data["created_by"] = self.context["request"].user
 
-        # Strips non alphanumeric values from name (other than spaces)
+        # Strips non alphanumeric values from name (other than spaces and underscores)
         validated_data["code_name"] = (
-            "".join(n for n in validated_data["name"] if n.isalnum() or n == " ").replace(" ", "_").lower()
+            "".join(n for n in validated_data["name"] if n.isalnum() or n == " " or n == "_").replace(" ", "_").lower()
         )
 
         count = InsightVariable.objects.filter(


### PR DESCRIPTION
## Problem

Variable names in sql editor get `_` stripped out, BUT if you input a space, it gets turned into an `_`.

<img width="372" height="193" alt="Screenshot 2025-10-03 at 2 22 28 PM" src="https://github.com/user-attachments/assets/de481d67-0dd4-4a05-b330-06af9379bf40" />

<img width="372" height="193" alt="Screenshot 2025-10-03 at 2 22 41 PM" src="https://github.com/user-attachments/assets/7c909373-c5a3-40cb-b2ab-2c0e681891fb" />

This means `hello_world` turns into `helloworld` but `hello world` saves as `hello_world`.

## Changes

- Tool tip to allow alphanumerics and underscore specifically.
- Frontend regex to allow `_`
- Both `hello world` and `hello_world` gets mapped to `{variable.hello_world}`
- No changes anywhere else

## How did you test this code?

Manual testing

https://github.com/user-attachments/assets/20c47097-1267-4168-ae56-9eb306d2cf3e

Also tested in some queries


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
