### PR TITLE
fix: increase heartbeat timeout to avoid timing out while updating teams

### DIFF
--- a/posthog/temporal/enforce_max_replay_retention/workflows.py
+++ b/posthog/temporal/enforce_max_replay_retention/workflows.py
@@ -26,5 +26,5 @@ class EnforceMaxReplayRetentionWorkflow(PostHogWorkflow):
                 maximum_attempts=2,
                 initial_interval=timedelta(minutes=1),
             ),
-            heartbeat_timeout=timedelta(seconds=10),
+            heartbeat_timeout=timedelta(minutes=5),
         )


### PR DESCRIPTION
Increase heartbeat timeout and reduce log chatter from sync_to_async decorator.