### PR TITLE
chore(kafka-deduplicator): unit test timestamp conversion

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -38,7 +38,6 @@ impl CheckpointMode {
 pub struct CheckpointTarget {
     // source material (topic, partition, attempt timestamp in microseconds)
     pub partition: Partition,
-    pub checkpoint_epoch_micros: u128,
 
     // local checkpoint path and observability tag
     pub local_path: PathBuf,
@@ -68,7 +67,6 @@ impl CheckpointTarget {
 
         Ok(Self {
             partition,
-            checkpoint_epoch_micros,
             local_path,
             local_path_tag,
             remote_path,
@@ -77,10 +75,12 @@ impl CheckpointTarget {
 
     // convert a SystemTime to a microsecond timestamp
     pub fn format_checkpoint_timestamp(st: SystemTime) -> Result<String> {
-        Ok(format!("{:020}", st
-            .duration_since(UNIX_EPOCH)
-            .context("failed to generate checkpoint timestamp")?
-            .as_micros()))
+        Ok(format!(
+            "{:020}",
+            st.duration_since(UNIX_EPOCH)
+                .context("failed to generate checkpoint timestamp")?
+                .as_micros()
+        ))
     }
 }
 

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -50,8 +50,7 @@ pub struct CheckpointTarget {
 
 impl CheckpointTarget {
     pub fn new(partition: Partition, local_checkpoint_base_dir: &Path) -> Result<Self> {
-        let checkpoint_epoch_micros = Self::generate_checkpoint_timestamp()?;
-        let cp_epoch_micros_str = format!("{checkpoint_epoch_micros:020}");
+        let cp_epoch_micros_str = Self::format_checkpoint_timestamp(SystemTime::now())?;
         let cp_topic = format!("{}{}", CHECKPOINT_TOPIC_PREFIX, &partition.topic());
         let cp_partition = format!(
             "{}{}",
@@ -76,11 +75,12 @@ impl CheckpointTarget {
         })
     }
 
-    fn generate_checkpoint_timestamp() -> Result<u128> {
-        Ok(SystemTime::now()
+    // convert a SystemTime to a microsecond timestamp
+    pub fn format_checkpoint_timestamp(st: SystemTime) -> Result<String> {
+        Ok(format!("{:020}", st
             .duration_since(UNIX_EPOCH)
             .context("failed to generate checkpoint timestamp")?
-            .as_micros())
+            .as_micros()))
     }
 }
 

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -1160,4 +1160,83 @@ mod tests {
             find_local_checkpoint_files(Path::new(&config.local_checkpoint_dir)).unwrap();
         assert!(!found_files.is_empty());
     }
+
+    #[tokio::test]
+    async fn test_cleaner_timestamp_dir_handling() {
+        // Add some test stores
+        let store_manager = create_test_store_manager();
+        let store1 = create_test_store("cleaner_timestamp_dir_handling", 0);
+        let store2 = create_test_store("cleaner_timestamp_dir_handling", 1);
+        let store3 = create_test_store("cleaner_timestamp_dir_handling", 2);
+
+        // Add events to the stores
+        let event = create_test_event();
+        store1.handle_event_with_raw(&event).unwrap();
+        store2.handle_event_with_raw(&event).unwrap();
+        store3.handle_event_with_raw(&event).unwrap();
+
+        // add dedup stores to manager
+        let stores = store_manager.stores();
+        stores.insert(
+            Partition::new("cleaner_timestamp_dir_handling".to_string(), 0),
+            store1,
+        );
+        stores.insert(
+            Partition::new("cleaner_timestamp_dir_handling".to_string(), 1),
+            store2,
+        );
+        stores.insert(
+            Partition::new("cleaner_timestamp_dir_handling".to_string(), 2),
+            store3,
+        );
+
+        let tmp_checkpoint_dir = TempDir::new().unwrap();
+
+        // configure frequent checkpoints to create a few quick timestamp dirs per partition
+        let config = CheckpointConfig {
+            checkpoint_interval: Duration::from_millis(100),
+            cleanup_interval: Duration::from_secs(120),
+            max_local_checkpoints: 3,
+
+            local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        // start the manager and produce some local checkpoint files
+        let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
+        manager.start();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        manager.stop().await;
+
+        // now introspect on the checkpoint directory trees created
+        // to verify timestamp conversion process powering retention
+        // based cleanup is accurate
+        let scan_dirs =
+            CheckpointManager::find_checkpoint_dirs(Path::new(&config.local_checkpoint_dir))
+                .await
+                .unwrap();
+        let scan_dirs_set: HashSet<&Path> =
+            HashSet::from_iter(scan_dirs.iter().map(|p| p.as_path()));
+
+        // extract a set of only the timestamp directory names
+        // perform conversion process into SystemTime timestamps
+        let expected_ts_dirs = scan_dirs_set
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<HashSet<_>>();
+        let scan_ts_values = expected_ts_dirs
+            .iter()
+            .map(|p| CheckpointManager::parse_checkpoint_timestamp(p).unwrap())
+            .collect::<Vec<_>>();
+
+        // convert SystemTime timestamps back to directory names as CheckpointTarget does
+        let got_ts_dirs = scan_ts_values
+            .iter()
+            .map(|p| format!("{:020}", p.duration_since(UNIX_EPOCH).unwrap().as_micros()))
+            .collect::<HashSet<_>>();
+
+        // verify the converted and regenerated directory names are
+        // exactly the same as those we started with
+        assert_eq!(expected_ts_dirs, got_ts_dirs);
+    }
 }

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -642,7 +642,7 @@ impl Drop for CheckpointManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::checkpoint::worker::CheckpointWorker;
+    use crate::checkpoint::worker::CheckpointTarget;
     use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
     use common_types::RawEvent;
     use std::{collections::HashMap, path::PathBuf, time::Duration};
@@ -1234,7 +1234,7 @@ mod tests {
         // convert SystemTime timestamps back to directory names as CheckpointTarget does
         let got_ts_dirs = scan_ts_values
             .iter()
-            .map(|p| CheckpointWorker::format_checkpoint_timestamp(p).unwrap())
+            .map(|p| CheckpointTarget::format_checkpoint_timestamp(*p).unwrap())
             .collect::<HashSet<_>>();
 
         // verify the converted and regenerated directory names are

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -642,6 +642,7 @@ impl Drop for CheckpointManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::checkpoint::worker::CheckpointWorker;
     use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
     use common_types::RawEvent;
     use std::{collections::HashMap, path::PathBuf, time::Duration};
@@ -1218,8 +1219,9 @@ mod tests {
         let scan_dirs_set: HashSet<&Path> =
             HashSet::from_iter(scan_dirs.iter().map(|p| p.as_path()));
 
-        // extract a set of only the timestamp directory names
+        // extract a set of only the timestamp directory names and
         // perform conversion process into SystemTime timestamps
+        // as checkpoint manager does in retention scans
         let expected_ts_dirs = scan_dirs_set
             .iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
@@ -1232,7 +1234,7 @@ mod tests {
         // convert SystemTime timestamps back to directory names as CheckpointTarget does
         let got_ts_dirs = scan_ts_values
             .iter()
-            .map(|p| format!("{:020}", p.duration_since(UNIX_EPOCH).unwrap().as_micros()))
+            .map(|p| CheckpointWorker::format_checkpoint_timestamp(p).unwrap())
             .collect::<HashSet<_>>();
 
         // verify the converted and regenerated directory names are


### PR DESCRIPTION
## Problem
We want to build confidence and avoid regressions regarding partition-limit and retention-based checkpoint cleanup processes.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
While investigating an unrelated checkpoint cleanup behavior remediated elsewhere, I added another unit test for one potentially hazardous piece.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
