### PR TITLE
chore: exclude exceptions caused by posthog sdk

### DIFF
--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -220,7 +220,7 @@ class TestQuotaLimiting(BaseTest):
         self.organization.save()
 
         time.sleep(1)
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             quota_limited_orgs, quota_limiting_suspended_orgs = update_all_orgs_billing_quotas()
         # Shouldn't be called due to lazy evaluation of the conditional
         patch_feature_enabled.assert_not_called()

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -29,6 +29,7 @@ from ee.billing.quota_limiting import (
     update_all_orgs_billing_quotas,
     update_org_billing_quotas,
 )
+from ee.clickhouse.materialized_columns.columns import materialize
 
 
 def zero_trust_scores():
@@ -59,6 +60,7 @@ class TestQuotaLimiting(BaseTest):
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/rows_exported")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/llm_events")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/cdp_trigger_events")
+        materialize("events", "$exception_values")
 
     @patch("posthoganalytics.capture")
     @patch("posthoganalytics.feature_enabled", return_value=True)
@@ -220,7 +222,7 @@ class TestQuotaLimiting(BaseTest):
         self.organization.save()
 
         time.sleep(1)
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             quota_limited_orgs, quota_limiting_suspended_orgs = update_all_orgs_billing_quotas()
         # Shouldn't be called due to lazy evaluation of the conditional
         patch_feature_enabled.assert_not_called()

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -480,6 +480,8 @@
          COUNT() as count
   FROM events
   WHERE event = '$exception'
+    AND not arrayExists(x -> x != ''
+                        AND position(x, 'persistence.isDisabled is not a function') > 0, JSONExtract(coalesce('replaceRegexpAll(JSONExtractRaw(properties, \'$exception_values\'), \'^"|"$\', \'\')', '[]'), 'Array(String)'))
     AND timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -481,7 +481,7 @@
   FROM events
   WHERE event = '$exception'
     AND not arrayExists(x -> x != ''
-                        AND position(x, 'persistence.isDisabled is not a function') > 0, JSONExtract(coalesce('replaceRegexpAll(JSONExtractRaw(properties, \'$exception_values\'), \'^"|"$\', \'\')', '[]'), 'Array(String)'))
+                        AND position(x, 'persistence.isDisabled is not a function') > 0, JSONExtract(coalesce(mat_$exception_values, '[]'), 'Array(String)'))
     AND timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -960,7 +960,7 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesM
 
 @freeze_time("2022-01-09T00:01:00Z")
 class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin):
-    @also_test_with_materialized_columns(event_properties=["$lib"], verify_no_jsonextract=False)
+    @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     def test_usage_report_replay(self) -> None:
         _setup_replay_data(self.team.pk, include_mobile_replay=False)
 
@@ -981,7 +981,7 @@ class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyT
         assert org_reports[str(self.organization.id)].mobile_recording_count_in_period == 0
         assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 0
 
-    @also_test_with_materialized_columns(event_properties=["$lib"], verify_no_jsonextract=False)
+    @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     def test_usage_report_replay_with_zero_duration(self) -> None:
         _setup_replay_data(self.team.pk, include_mobile_replay=False, include_zero_duration=True)
 
@@ -1003,7 +1003,7 @@ class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyT
         assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 0
         assert org_reports[str(self.organization.id)].zero_duration_recording_count_in_period == 1
 
-    @also_test_with_materialized_columns(event_properties=["$lib"], verify_no_jsonextract=False)
+    @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     def test_usage_report_replay_with_mobile(self) -> None:
         _setup_replay_data(self.team.pk, include_mobile_replay=True)
 
@@ -1024,7 +1024,7 @@ class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyT
         assert org_reports[str(self.organization.id)].mobile_recording_count_in_period == 1
         assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 0
 
-    @also_test_with_materialized_columns(event_properties=["$lib"], verify_no_jsonextract=False)
+    @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     def test_usage_report_replay_with_billable_mobile(self) -> None:
         _setup_replay_data(self.team.pk, include_mobile_replay=True)
 
@@ -1079,7 +1079,7 @@ class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyT
 
 
 class TestHogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin):
-    # @also_test_with_materialized_columns(event_properties=["$lib"], verify_no_jsonextract=False)
+    # @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     @pytest.mark.skip(reason="Skipping due to flakiness")
     def test_usage_report_hogql_queries(self) -> None:
         for _ in range(0, 100):
@@ -1121,7 +1121,7 @@ class TestHogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTa
             assert report.query_api_rows_read == 0
             assert report.event_explorer_api_rows_read == 0
 
-    # @also_test_with_materialized_columns(event_properties=["$lib"], verify_no_jsonextract=False)
+    # @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     @pytest.mark.skip(reason="Skipping due to flakiness")
     def test_usage_report_api_queries(self) -> None:
         for _ in range(0, 100):

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1028,8 +1028,6 @@ def get_teams_with_exceptions_captured_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    values_expression, _ = get_property_string_expr("events", "$exception_values", "'$exception_values'", "properties")
-
     # We are excluding "persistence.isDisabled is not a function" errors because of a bug in our own SDK
     # Can be eventually removed once we're happy that the usage report for 3rd October 2025 does not need to be rerun
     results = sync_execute(
@@ -1038,11 +1036,11 @@ def get_teams_with_exceptions_captured_in_period(
         FROM events
         WHERE
             event = '$exception' AND
-            not arrayExists(x -> x != '' AND position(x, 'persistence.isDisabled is not a function') > 0, JSONExtract(coalesce(%(values_expression)s, '[]'), 'Array(String)')) AND
+            not arrayExists(x -> x != '' AND position(x, 'persistence.isDisabled is not a function') > 0, JSONExtract(coalesce(mat_$exception_values, '[]'), 'Array(String)')) AND
             timestamp >= %(begin)s AND timestamp < %(end)s
         GROUP BY team_id
     """,
-        {"begin": begin, "end": end, "values_expression": values_expression},
+        {"begin": begin, "end": end},
         workload=Workload.OFFLINE,
         settings=CH_BILLING_SETTINGS,
     )

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1032,7 +1032,10 @@ def get_teams_with_exceptions_captured_in_period(
         """
         SELECT team_id, COUNT() as count
         FROM events
-        WHERE event = '$exception' AND timestamp >= %(begin)s AND timestamp < %(end)s
+        WHERE
+            event = '$exception' AND
+            not has(JSONExtract(coalesce(mat_$exception_values, '[]'), 'Array(String)'), 'e.persistence.isDisabled is not a function') AND
+            timestamp >= %(begin)s AND timestamp < %(end)s
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -4,6 +4,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconEllipsis } from '@posthog/icons'
+import { LemonBanner } from '@posthog/lemon-ui'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
@@ -38,6 +39,11 @@ export function ErrorTrackingIssueScene(): JSX.Element {
     const { selectEvent } = useActions(errorTrackingIssueSceneLogic)
     const tagRenderer = useErrorTagRenderer()
     const hasIssueSplitting = useFeatureFlag('ERROR_TRACKING_ISSUE_SPLITTING')
+
+    const isPostHogSDKIssue = selectedEvent?.properties.$exception_values?.some((v: string) =>
+        v.includes('persistence.isDisabled is not a function')
+    )
+
     return (
         <ErrorTrackingSetupPrompt>
             <div className="flex justify-between mb-2 -ml-[var(--button-padding-x-lg)]">
@@ -64,6 +70,17 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                     </DropdownMenu>
                 )}
             </div>
+
+            {isPostHogSDKIssue && (
+                <LemonBanner
+                    type="error"
+                    action={{ to: 'https://status.posthog.com/incidents/l70cgmt7475m', children: 'Read more' }}
+                    className="mb-4"
+                >
+                    This issue was captuered because of a bug in the PostHog SDK. We have fixed the issue and you will
+                    not be charged for any of the associated exception events
+                </LemonBanner>
+            )}
 
             <div className="ErrorTrackingIssue grid grid-cols-4 gap-4">
                 <div className="space-y-2 col-span-3">


### PR DESCRIPTION
## Problem

There was a bug in version 1.270.0 of the JS SDK (https://github.com/PostHog/posthog-js/pull/2355). It was reverted pretty quickly but we should not charge folks for the related exceptions we caught

## Changes

Remove capture of exceptions where `persistence.isDisabled is not a function` was in the message

I also added a banner to the issue page that explains things to the user and links to the incident page
<img width="905" height="489" alt="Screenshot 2025-10-03 at 22 20 51" src="https://github.com/user-attachments/assets/63a80e4e-508a-4e27-8794-40f9a273cacb" />
