### PR TITLE
fix(messaging): incorrect SNS notification parsing

### DIFF
--- a/plugin-server/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/ses.test.ts
@@ -1,0 +1,154 @@
+import { SesWebhookHandler } from './ses'
+
+describe('SesWebhookHandler', () => {
+    let handler: SesWebhookHandler
+    beforeEach(() => {
+        handler = new SesWebhookHandler()
+    })
+
+    const baseMail = {
+        timestamp: '2025-10-03T12:00:00Z',
+        source: 'sender@example.com',
+        messageId: 'msg-123',
+        destination: ['to@example.com'],
+        tags: { ph_id: ['ph_fn_id=abc123&ph_inv_id=inv456'] },
+    }
+
+    it('parses a raw Open event', async () => {
+        const body = [
+            {
+                eventType: 'Open',
+                mail: baseMail,
+                open: {
+                    ipAddress: '1.2.3.4',
+                    userAgent: 'UA',
+                    timestamp: '2025-10-03T12:01:00Z',
+                },
+            },
+        ]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.body).toEqual({ ok: true })
+        expect(result.metrics).toEqual([
+            {
+                functionId: 'abc123',
+                invocationId: 'inv456',
+                metricName: 'email_opened',
+            },
+        ])
+    })
+
+    it('parses a raw Click event', async () => {
+        const body = [
+            {
+                eventType: 'Click',
+                mail: baseMail,
+                click: {
+                    ipAddress: '1.2.3.4',
+                    link: 'https://example.com',
+                    userAgent: 'UA',
+                    timestamp: '2025-10-03T12:02:00Z',
+                },
+            },
+        ]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.metrics?.[0].metricName).toBe('email_link_clicked')
+    })
+
+    it('parses a raw Delivery event', async () => {
+        const body = [
+            {
+                eventType: 'Delivery',
+                mail: baseMail,
+                delivery: {
+                    processingTimeMillis: 1000,
+                    smtpResponse: '250 OK',
+                    reportingMTA: 'mta',
+                    timestamp: '2025-10-03T12:03:00Z',
+                    recipients: ['to@example.com'],
+                },
+            },
+        ]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.metrics?.[0].metricName).toBe('email_sent')
+    })
+
+    it('parses a raw Bounce event', async () => {
+        const body = [
+            {
+                eventType: 'Bounce',
+                mail: baseMail,
+                bounce: {
+                    bounceType: 'Permanent',
+                    bouncedRecipients: [
+                        { emailAddress: 'to@example.com', action: 'failed', status: '5.1.1', diagnosticCode: 'bad' },
+                    ],
+                    timestamp: '2025-10-03T12:04:00Z',
+                    reportingMTA: 'mta',
+                },
+            },
+        ]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.metrics?.[0].metricName).toBe('email_bounced')
+    })
+
+    it('parses a raw Complaint event', async () => {
+        const body = [
+            {
+                eventType: 'Complaint',
+                mail: baseMail,
+                complaint: {
+                    complainedRecipients: [{ emailAddress: 'to@example.com' }],
+                    timestamp: '2025-10-03T12:05:00Z',
+                },
+            },
+        ]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.metrics?.[0].metricName).toBe('email_blocked')
+    })
+
+    it('returns 200 and no metrics if tracking code is missing', async () => {
+        const body = [
+            {
+                eventType: 'Open',
+                mail: { ...baseMail, tags: {} },
+                open: {
+                    ipAddress: '1.2.3.4',
+                    userAgent: 'UA',
+                    timestamp: '2025-10-03T12:01:00Z',
+                },
+            },
+        ]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.metrics).toEqual([])
+    })
+
+    it('parses an SNS envelope Notification event', async () => {
+        const snsEnvelope = {
+            Type: 'Notification',
+            MessageId: 'sns-msg-1',
+            TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-topic',
+            Message: JSON.stringify({
+                eventType: 'Open',
+                mail: baseMail,
+                open: {
+                    ipAddress: '1.2.3.4',
+                    userAgent: 'UA',
+                    timestamp: '2025-10-03T12:01:00Z',
+                },
+            }),
+            Timestamp: '2025-10-03T12:10:00Z',
+            SignatureVersion: '1',
+            Signature: 'fake',
+            SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+        }
+        const result = await handler.handleWebhook({ body: snsEnvelope, headers: {}, verifySignature: false })
+        expect(result.status).toBe(200)
+        expect(result.metrics?.[0].metricName).toBe('email_opened')
+    })
+})

--- a/plugin-server/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/ses.test.ts
@@ -1,4 +1,5 @@
 import { SesWebhookHandler } from './ses'
+import { generateEmailTrackingCode } from './tracking-code'
 
 describe('SesWebhookHandler', () => {
     let handler: SesWebhookHandler
@@ -11,7 +12,7 @@ describe('SesWebhookHandler', () => {
         source: 'sender@example.com',
         messageId: 'msg-123',
         destination: ['to@example.com'],
-        tags: { ph_id: ['ph_fn_id=abc123&ph_inv_id=inv456'] },
+        tags: { ph_id: [generateEmailTrackingCode({ functionId: 'abc123', id: 'inv456' })] },
     }
 
     it('parses a raw Open event', async () => {

--- a/plugin-server/src/cdp/services/messaging/helpers/ses.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/ses.ts
@@ -218,8 +218,8 @@ export class SesWebhookHandler {
             const env = SnsEnvelopeSchema.parse(body)
             if (env.Type === 'Notification') {
                 const inner = parseJSON(env.Message)
-                const records = SesEventBatchSchema.parse(inner)
-                return { mode: 'sns', envelope: env, records }
+                const record = SesEventRecordSchema.parse(inner)
+                return { mode: 'sns', envelope: env, records: [record] }
             }
             // For non-Notification, return envelope; caller decides how to handle
             return { mode: 'sns', envelope: env }


### PR DESCRIPTION
## Problem

We don't seem to be parsing single-SNS event callbacks properly. Here's a [real example from Loki](https://grafana.dev.posthog.dev/a/grafana-lokiexplore-app/explore/service/cdp-api-webhooks/logs?patterns=%5B%5D&from=2025-10-03T18:11:45.952Z&to=2025-10-03T18:23:13.485Z&var-lineFormat=&var-ds=P44D702D3E93867EC&var-filters=service_name%7C%3D%7Ccdp-api-webhooks&var-fields=msg%7C%21%3D%7C%7B%22value%22:%22%5BCDP-API%5D%20%F0%9F%92%9A%20Server%20liveness%20check%20succeeded%22__gfc__%22parser%22:%22structuredMetadata%22%7D,%5BCDP-API%5D%20%F0%9F%92%9A%20Server%20liveness%20check%20succeeded&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&sortOrder=%22Descending%22&wrapLogMessage=false&prettifyLogMessage=false&timezone=browser&var-all-fields=msg%7C%21%3D%7C%7B%22value%22:%22%5BCDP-API%5D%20%F0%9F%92%9A%20Server%20liveness%20check%20succeeded%22__gfc__%22parser%22:%22structuredMetadata%22%7D,%5BCDP-API%5D%20%F0%9F%92%9A%20Server%20liveness%20check%20succeeded):

<img width="909" height="501" alt="image" src="https://github.com/user-attachments/assets/1e0cf31a-3c31-47bf-be95-0993a1256776" />


## Changes

Fix parsing

## How did you test this code?

Added unit tests for parsing behavior so we have can start to form a baseline understanding of SNS webhook body shape

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
