### PR TITLE
fix(experiments): correctly generate and validate the feature flag name

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -118,7 +118,15 @@ export const CreateExperiment = (): JSX.Element => {
                                     <VariantsPanel
                                         experiment={experiment}
                                         updateFeatureFlag={(updates) => {
-                                            setExperimentValue('feature_flag_key', updates.feature_flag_key)
+                                            if (updates.feature_flag_key !== undefined) {
+                                                setExperimentValue('feature_flag_key', updates.feature_flag_key)
+                                            }
+                                            if (updates.parameters) {
+                                                setExperimentValue('parameters', {
+                                                    ...experiment.parameters,
+                                                    ...updates.parameters,
+                                                })
+                                            }
                                         }}
                                     />
                                 ),

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -144,12 +144,10 @@ export const CreateExperiment = (): JSX.Element => {
                                 key: 'experiment-exposure',
                                 header: 'Exposure criteria',
                                 content: (
-                                    <div className="p-4">
-                                        <ExposureCriteriaPanel
-                                            experiment={experiment}
-                                            onChange={(exposureCriteria) => exposureCriteria}
-                                        />
-                                    </div>
+                                    <ExposureCriteriaPanel
+                                        experiment={experiment}
+                                        onChange={(exposureCriteria) => exposureCriteria}
+                                    />
                                 ),
                             },
                             {

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -2,6 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
 import { useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
 
 import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -35,9 +36,14 @@ export const CreateExperiment = (): JSX.Element => {
     const { HogfettiComponent } = useHogfetti({ count: 100, duration: 3000 })
 
     const { experiment, experimentErrors } = useValues(createExperimentLogic)
-    const { setExperiment, setExperimentValue } = useActions(createExperimentLogic)
+    const { setExperimentValue } = useActions(createExperimentLogic)
 
     const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
+
+    const debouncedOnNameChange = useDebouncedCallback((name: string) => {
+        setExperimentValue('name', name)
+        console.log('debouncedOnNameChange', name)
+    }, 500)
 
     return (
         <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
@@ -52,9 +58,7 @@ export const CreateExperiment = (): JSX.Element => {
                         }}
                         canEdit
                         forceEdit
-                        onNameChange={(name) => {
-                            setExperimentValue('name', name)
-                        }}
+                        onNameChange={debouncedOnNameChange}
                         actions={
                             <>
                                 <LemonButton
@@ -92,6 +96,7 @@ export const CreateExperiment = (): JSX.Element => {
                     <SceneDivider />
                     <LemonCollapse
                         activeKey={selectedPanel ?? undefined}
+                        defaultActiveKey="experiment-variants"
                         onChange={(key) => {
                             setSelectedPanel(key as string | null)
                         }}
@@ -103,7 +108,7 @@ export const CreateExperiment = (): JSX.Element => {
                                 content: (
                                     <ExperimentTypePanel
                                         experiment={experiment}
-                                        setExperimentType={(type) => setExperiment({ ...experiment, type })}
+                                        setExperimentType={(type) => setExperimentValue('type', type)}
                                     />
                                 ),
                             },
@@ -111,9 +116,13 @@ export const CreateExperiment = (): JSX.Element => {
                                 key: 'experiment-variants',
                                 header: 'Feature flag & variants',
                                 content: (
-                                    <div className="p-4">
-                                        <VariantsPanel experiment={experiment} onChange={(updates) => updates} />
-                                    </div>
+                                    <VariantsPanel
+                                        experiment={experiment}
+                                        updateFeatureFlag={(updates) => {
+                                            console.log('updateFeatureFlag', updates)
+                                            setExperimentValue('feature_flag_key', updates.feature_flag_key)
+                                        }}
+                                    />
                                 ),
                             },
                             {

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -42,7 +42,6 @@ export const CreateExperiment = (): JSX.Element => {
 
     const debouncedOnNameChange = useDebouncedCallback((name: string) => {
         setExperimentValue('name', name)
-        console.log('debouncedOnNameChange', name)
     }, 500)
 
     return (
@@ -119,7 +118,6 @@ export const CreateExperiment = (): JSX.Element => {
                                     <VariantsPanel
                                         experiment={experiment}
                                         updateFeatureFlag={(updates) => {
-                                            console.log('updateFeatureFlag', updates)
                                             setExperimentValue('feature_flag_key', updates.feature_flag_key)
                                         }}
                                     />

--- a/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
@@ -313,7 +313,7 @@ describe('VariantsPanel', () => {
             await userEvent.click(selectFlagButton)
 
             // Should display variants
-            expect(screen.getByText('Variants')).toBeInTheDocument()
+            expect(screen.getByText('VARIANTS:')).toBeInTheDocument()
             expect(screen.getByText('control')).toBeInTheDocument()
             expect(screen.getByText('variant-a')).toBeInTheDocument()
         })

--- a/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
@@ -313,7 +313,12 @@ describe('VariantsPanel', () => {
             await userEvent.click(selectFlagButton)
 
             // Should display variants
-            expect(screen.getByText('VARIANTS:')).toBeInTheDocument()
+            await waitFor(() => {
+                const variantsSection = screen.getAllByText(/variants/i).find((el) => {
+                    return el.className.includes('uppercase') && el.textContent === 'Variants'
+                })
+                expect(variantsSection).toBeInTheDocument()
+            })
             expect(screen.getByText('control')).toBeInTheDocument()
             expect(screen.getByText('variant-a')).toBeInTheDocument()
         })

--- a/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
@@ -1,0 +1,413 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import type { Experiment } from '~/types'
+
+import { NEW_EXPERIMENT } from '../constants'
+import { VariantsPanel } from './VariantsPanel'
+
+// Mock JSONEditorInput since it uses Monaco editor which doesn't work in Jest
+jest.mock('scenes/feature-flags/JSONEditorInput', () => ({
+    JSONEditorInput: ({ onChange, value, placeholder, readOnly }: any) => (
+        <input
+            data-testid="json-editor-mock"
+            value={value || ''}
+            onChange={(e) => onChange?.(e.target.value)}
+            placeholder={placeholder}
+            readOnly={readOnly}
+        />
+    ),
+}))
+
+// Suppress react-modal warnings in tests
+beforeAll(() => {
+    const modalRoot = document.createElement('div')
+    modalRoot.setAttribute('id', 'root')
+    document.body.appendChild(modalRoot)
+})
+
+describe('VariantsPanel', () => {
+    const mockUpdateFeatureFlag = jest.fn()
+
+    const defaultExperiment: Experiment = {
+        ...NEW_EXPERIMENT,
+        name: 'Test Experiment',
+        feature_flag_key: 'test-experiment',
+        parameters: {
+            feature_flag_variants: [
+                { key: 'control', rollout_percentage: 50 },
+                { key: 'test', rollout_percentage: 50 },
+            ],
+        },
+    }
+
+    const mockEligibleFlags = [
+        {
+            id: 1,
+            key: 'eligible-flag-1',
+            name: 'Eligible Flag 1',
+            filters: {
+                groups: [],
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: 'variant-a', rollout_percentage: 50 },
+                    ],
+                },
+            },
+        },
+        {
+            id: 2,
+            key: 'eligible-flag-2',
+            name: 'Eligible Flag 2',
+            filters: {
+                groups: [],
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 33 },
+                        { key: 'variant-a', rollout_percentage: 33 },
+                        { key: 'variant-b', rollout_percentage: 34 },
+                    ],
+                },
+            },
+        },
+    ]
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/@current/feature_flags/': (req) => {
+                    const url = new URL(req.url)
+                    const search = url.searchParams.get('search')
+
+                    if (search) {
+                        const filtered = mockEligibleFlags.filter((flag) =>
+                            flag.key.toLowerCase().includes(search.toLowerCase())
+                        )
+                        return [200, { results: filtered, count: filtered.length }]
+                    }
+
+                    return [200, { results: mockEligibleFlags, count: mockEligibleFlags.length }]
+                },
+                '/api/projects/@current/experiments': () => [200, { results: [], count: 0 }],
+            },
+        })
+        initKeaTests()
+        jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    describe('rendering', () => {
+        it('renders mode selection cards', () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            expect(screen.getByText('Create new feature flag')).toBeInTheDocument()
+            expect(screen.getByText('Link existing feature flag')).toBeInTheDocument()
+        })
+
+        it('defaults to create mode', () => {
+            const { container } = render(
+                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+            )
+
+            const cards = container.querySelectorAll('[role="button"]')
+            const createCard = cards[0]
+            const linkCard = cards[1]
+
+            expect(createCard).toHaveClass('border-accent')
+            expect(linkCard).not.toHaveClass('border-accent')
+        })
+
+        it('renders create feature flag panel in create mode', () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            expect(screen.getByText('Feature flag key')).toBeInTheDocument()
+            expect(screen.getByText('Variant keys')).toBeInTheDocument()
+        })
+    })
+
+    describe('mode switching', () => {
+        it('switches to link mode when clicking link card', async () => {
+            const { container } = render(
+                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+            )
+
+            const cards = container.querySelectorAll('[role="button"]')
+            const linkCard = cards[1]
+
+            await userEvent.click(linkCard)
+
+            // Should show link mode UI
+            expect(screen.getByText('Selected Feature Flag')).toBeInTheDocument()
+            expect(screen.getByText('No feature flag selected')).toBeInTheDocument()
+        })
+
+        it('switches back to create mode when clicking create card', async () => {
+            const { container } = render(
+                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+            )
+
+            const cards = container.querySelectorAll('[role="button"]')
+            const linkCard = cards[1]
+            const createCard = cards[0]
+
+            // Switch to link mode
+            await userEvent.click(linkCard)
+            expect(screen.getByText('No feature flag selected')).toBeInTheDocument()
+
+            // Switch back to create mode
+            await userEvent.click(createCard)
+            expect(screen.getByText('Feature flag key')).toBeInTheDocument()
+            expect(screen.getByText('Variant keys')).toBeInTheDocument()
+        })
+
+        it('highlights selected mode card', async () => {
+            const { container } = render(
+                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+            )
+
+            const cards = container.querySelectorAll('[role="button"]')
+            const createCard = cards[0]
+            const linkCard = cards[1]
+
+            // Initially create mode is selected
+            expect(createCard).toHaveClass('border-accent')
+            expect(linkCard).not.toHaveClass('border-accent')
+
+            // Click link mode
+            await userEvent.click(linkCard)
+
+            // Link mode should be selected
+            const updatedCards = container.querySelectorAll('[role="button"]')
+            expect(updatedCards[1]).toHaveClass('border-accent')
+            expect(updatedCards[0]).not.toHaveClass('border-accent')
+        })
+    })
+
+    describe('link existing feature flag', () => {
+        it('shows select button in empty state', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            expect(selectButton).toBeInTheDocument()
+        })
+
+        it('opens modal when clicking select button', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            // Click select button
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Modal should open
+            expect(screen.getByText('Choose an existing feature flag')).toBeInTheDocument()
+        })
+
+        it('displays available feature flags in modal', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode and open modal
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Wait for feature flags to load
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+                expect(screen.getByText('eligible-flag-2')).toBeInTheDocument()
+            })
+        })
+
+        it('filters feature flags by search', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode and open modal
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Wait for flags to load, then search
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+            })
+
+            const searchInput = screen.getByPlaceholderText(/search for feature flags/i)
+            await userEvent.type(searchInput, 'flag-1')
+
+            // Should only show matching flag
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+                expect(screen.queryByText('eligible-flag-2')).not.toBeInTheDocument()
+            })
+        })
+
+        it('selects feature flag and closes modal', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode and open modal
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Wait for flags to load, then select
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+            })
+
+            const flagRows = screen.getAllByRole('row')
+            const firstFlagRow = flagRows.find((row) => row.textContent?.includes('eligible-flag-1'))
+            const selectFlagButton = within(firstFlagRow!).getByRole('button', { name: /select/i })
+            await userEvent.click(selectFlagButton)
+
+            // Wait for modal to close and flag to be displayed
+            await waitFor(() => {
+                expect(screen.queryByText('Choose an existing feature flag')).not.toBeInTheDocument()
+            })
+            expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+        })
+
+        it('displays selected flag with variants', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode and open modal
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Wait for flags to load, then select
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+            })
+
+            const flagRows = screen.getAllByRole('row')
+            const firstFlagRow = flagRows.find((row) => row.textContent?.includes('eligible-flag-1'))
+            const selectFlagButton = within(firstFlagRow!).getByRole('button', { name: /select/i })
+            await userEvent.click(selectFlagButton)
+
+            // Should display variants
+            expect(screen.getByText('Variants')).toBeInTheDocument()
+            expect(screen.getByText('control')).toBeInTheDocument()
+            expect(screen.getByText('variant-a')).toBeInTheDocument()
+        })
+
+        it('shows change button for selected flag', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode and open modal
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Wait for flags to load, then select
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+            })
+
+            const flagRows = screen.getAllByRole('row')
+            const firstFlagRow = flagRows.find((row) => row.textContent?.includes('eligible-flag-1'))
+            const selectFlagButton = within(firstFlagRow!).getByRole('button', { name: /select/i })
+            await userEvent.click(selectFlagButton)
+
+            // Should show change button
+            expect(screen.getByRole('button', { name: /change/i })).toBeInTheDocument()
+        })
+
+        it('reopens modal when clicking change button', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode, open modal, select flag
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            let selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Wait for flags to load, then select
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+            })
+
+            const flagRows = screen.getAllByRole('row')
+            const firstFlagRow = flagRows.find((row) => row.textContent?.includes('eligible-flag-1'))
+            const selectFlagButton = within(firstFlagRow!).getByRole('button', { name: /select/i })
+            await userEvent.click(selectFlagButton)
+
+            // Click change button
+            const changeButton = screen.getByRole('button', { name: /change/i })
+            await userEvent.click(changeButton)
+
+            // Modal should reopen
+            expect(screen.getByText('Choose an existing feature flag')).toBeInTheDocument()
+        })
+    })
+
+    describe('edge cases', () => {
+        it('handles empty feature flags list', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [200, { results: [], count: 0 }],
+                    '/api/projects/@current/experiments': () => [200, { results: [], count: 0 }],
+                },
+            })
+
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode and open modal
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            // Wait for empty state to show
+            await waitFor(() => {
+                expect(screen.getByText(/no feature flags match/i)).toBeInTheDocument()
+            })
+        })
+
+        it('handles experiment without feature flag key', () => {
+            const experimentWithoutKey = {
+                ...NEW_EXPERIMENT,
+                name: 'Test',
+            }
+
+            render(<VariantsPanel experiment={experimentWithoutKey} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Should still render without errors
+            expect(screen.getByText('Create new feature flag')).toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
@@ -351,7 +351,7 @@ describe('VariantsPanel', () => {
             const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
             await userEvent.click(linkCard!)
 
-            let selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
             await userEvent.click(selectButton)
 
             // Wait for flags to load, then select

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -1,4 +1,4 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 import { match } from 'ts-pattern'
 
@@ -9,10 +9,11 @@ import { SelectExistingFeatureFlagModal } from './SelectExistingFeatureFlagModal
 import { VariantsPanelCreateFeatureFlag } from './VariantsPanelCreateFeatureFlag'
 import { VariantsPanelLinkFeatureFlag } from './VariantsPanelLinkFeatureFlag'
 import { selectExistingFeatureFlagModalLogic } from './selectExistingFeatureFlagModalLogic'
+import { variantsPanelLogic } from './variantsPanelLogic'
 
 interface VariantsPanelProps {
     experiment: Experiment
-    onChange: (updates: {
+    updateFeatureFlag: (featureFlag: {
         feature_flag_key?: string
         parameters?: {
             feature_flag_variants?: MultivariateFlagVariant[]
@@ -21,9 +22,10 @@ interface VariantsPanelProps {
     }) => void
 }
 
-export function VariantsPanel({ experiment, onChange }: VariantsPanelProps): JSX.Element {
-    // we'll use local state to handle selectors and modals
-    const [flagSourceMode, setFlagSourceMode] = useState<'create' | 'link'>('create')
+export function VariantsPanel({ experiment, updateFeatureFlag }: VariantsPanelProps): JSX.Element {
+    const { mode } = useValues(variantsPanelLogic)
+    const { setMode } = useActions(variantsPanelLogic)
+
     const [linkedFeatureFlag, setLinkedFeatureFlag] = useState<FeatureFlagType | null>(null)
 
     const { openSelectExistingFeatureFlagModal, closeSelectExistingFeatureFlagModal } = useActions(
@@ -32,29 +34,27 @@ export function VariantsPanel({ experiment, onChange }: VariantsPanelProps): JSX
 
     return (
         <div className="space-y-6">
-            {/* Feature Flag Source Selection */}
-            <div>
-                <h3 className="font-semibold mb-3">Feature Flag Configuration</h3>
-                <div className="flex gap-4 mb-6">
-                    <SelectableCard
-                        title="Create new feature flag"
-                        description="Generate a new feature flag with custom variants for this experiment."
-                        selected={flagSourceMode === 'create'}
-                        onClick={() => {
-                            setFlagSourceMode('create')
-                        }}
-                    />
-                    <SelectableCard
-                        title="Link existing feature flag"
-                        description="Use an existing multivariate feature flag and inherit its variants."
-                        selected={flagSourceMode === 'link'}
-                        onClick={() => setFlagSourceMode('link')}
-                    />
-                </div>
+            <div className="flex gap-4 mb-6">
+                <SelectableCard
+                    title="Create new feature flag"
+                    description="Generate a new feature flag with custom variants for this experiment."
+                    selected={mode === 'create'}
+                    onClick={() => {
+                        setMode('create')
+                    }}
+                />
+                <SelectableCard
+                    title="Link existing feature flag"
+                    description="Use an existing multivariate feature flag and inherit its variants."
+                    selected={mode === 'link'}
+                    onClick={() => setMode('link')}
+                />
             </div>
 
-            {match(flagSourceMode)
-                .with('create', () => <VariantsPanelCreateFeatureFlag experiment={experiment} onChange={onChange} />)
+            {match(mode)
+                .with('create', () => (
+                    <VariantsPanelCreateFeatureFlag experiment={experiment} onChange={updateFeatureFlag} />
+                ))
                 .with('link', () => (
                     <VariantsPanelLinkFeatureFlag
                         linkedFeatureFlag={linkedFeatureFlag}

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -33,8 +33,8 @@ export function VariantsPanel({ experiment, updateFeatureFlag }: VariantsPanelPr
     )
 
     return (
-        <div className="space-y-6">
-            <div className="flex gap-4 mb-6">
+        <>
+            <div className="flex gap-4 mb-4">
                 <SelectableCard
                     title="Create new feature flag"
                     description="Generate a new feature flag with custom variants for this experiment."
@@ -71,6 +71,6 @@ export function VariantsPanel({ experiment, updateFeatureFlag }: VariantsPanelPr
                     closeSelectExistingFeatureFlagModal()
                 }}
             />
-        </div>
+        </>
     )
 }

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
@@ -1,0 +1,483 @@
+import '@testing-library/jest-dom'
+import { type RenderResult, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import type { Experiment } from '~/types'
+
+import { NEW_EXPERIMENT } from '../constants'
+import { VariantsPanelCreateFeatureFlag } from './VariantsPanelCreateFeatureFlag'
+
+// Mock JSONEditorInput since it uses Monaco editor which doesn't work in Jest
+jest.mock('scenes/feature-flags/JSONEditorInput', () => ({
+    JSONEditorInput: ({ onChange, value, placeholder, readOnly }: any) => (
+        <input
+            data-testid="json-editor-mock"
+            value={value || ''}
+            onChange={(e) => onChange?.(e.target.value)}
+            placeholder={placeholder}
+            readOnly={readOnly}
+        />
+    ),
+}))
+
+describe('VariantsPanelCreateFeatureFlag', () => {
+    const mockOnChange = jest.fn()
+
+    const defaultExperiment: Experiment = {
+        ...NEW_EXPERIMENT,
+        name: 'Test Experiment',
+        feature_flag_key: 'test-experiment',
+        parameters: {
+            feature_flag_variants: [
+                { key: 'control', rollout_percentage: 50 },
+                { key: 'test', rollout_percentage: 50 },
+            ],
+        },
+    }
+
+    const renderComponent = (experiment: Experiment): RenderResult => {
+        return render(<VariantsPanelCreateFeatureFlag experiment={experiment} onChange={mockOnChange} />)
+    }
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/@current/feature_flags/': (req) => {
+                    const url = new URL(req.url)
+                    const search = url.searchParams.get('search')
+
+                    // Return existing key if searching for it
+                    if (search === 'existing-key') {
+                        return [
+                            200,
+                            {
+                                results: [{ id: 1, key: 'existing-key', name: 'Existing' }],
+                                count: 1,
+                            },
+                        ]
+                    }
+
+                    return [200, { results: [], count: 0 }]
+                },
+                '/api/projects/@current/experiments': () => [200, { results: [], count: 0 }],
+            },
+        })
+        initKeaTests()
+        jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    describe('rendering', () => {
+        it('renders feature flag key input', () => {
+            renderComponent(defaultExperiment)
+
+            expect(screen.getByLabelText('Feature flag key')).toBeInTheDocument()
+            expect(screen.getByPlaceholderText(/examples: new-landing-page/)).toBeInTheDocument()
+        })
+
+        it('displays current feature flag key value', () => {
+            renderComponent(defaultExperiment)
+
+            const input = screen.getByDisplayValue('test-experiment')
+            expect(input).toBeInTheDocument()
+        })
+
+        it('renders variant keys section', () => {
+            renderComponent(defaultExperiment)
+
+            expect(screen.getByText('Variant keys')).toBeInTheDocument()
+            expect(screen.getByText(/rollout percentage.*must add up to 100%/i)).toBeInTheDocument()
+        })
+
+        it('renders default variants (control and test)', () => {
+            renderComponent(defaultExperiment)
+
+            const controlInput = screen.getByDisplayValue('control')
+            const testInput = screen.getByDisplayValue('test')
+
+            expect(controlInput).toBeInTheDocument()
+            expect(testInput).toBeInTheDocument()
+        })
+
+        it('renders rollout percentages for each variant', () => {
+            const { container } = renderComponent(defaultExperiment)
+
+            const percentageInputs = container.querySelectorAll(
+                '[data-attr="experiment-variant-rollout-percentage-input"]'
+            )
+
+            expect(percentageInputs).toHaveLength(2)
+        })
+
+        it('renders add variant button', () => {
+            renderComponent(defaultExperiment)
+
+            expect(screen.getByRole('button', { name: /add variant/i })).toBeInTheDocument()
+        })
+
+        it('renders experience continuity checkbox', () => {
+            renderComponent(defaultExperiment)
+
+            expect(screen.getByText(/persist flag across authentication steps/i)).toBeInTheDocument()
+            expect(screen.getByRole('checkbox')).toBeInTheDocument()
+        })
+    })
+
+    describe('feature flag key input', () => {
+        it('calls onChange when key is typed', async () => {
+            const experimentWithoutKey = {
+                ...defaultExperiment,
+                feature_flag_key: '',
+            }
+
+            renderComponent(experimentWithoutKey)
+
+            const input = screen.getByPlaceholderText(/examples: new-landing-page/)
+            await userEvent.type(input, 'new-flag-key')
+
+            // Verify onChange was called with feature_flag_key parameter
+            expect(mockOnChange).toHaveBeenCalled()
+            expect(mockOnChange.mock.calls.some((call) => call[0].feature_flag_key !== undefined)).toBe(true)
+        })
+
+        it('replaces spaces with dashes automatically', async () => {
+            const experimentWithoutKey = {
+                ...defaultExperiment,
+                feature_flag_key: '',
+            }
+
+            renderComponent(experimentWithoutKey)
+
+            const input = screen.getByPlaceholderText(/examples: new-landing-page/)
+            await userEvent.type(input, 'my flag key')
+
+            // Verify onChange was called and all calls have dashes instead of spaces
+            expect(mockOnChange).toHaveBeenCalled()
+            const allCallsHaveDashes = mockOnChange.mock.calls.every(
+                (call) => !call[0].feature_flag_key || !call[0].feature_flag_key.includes(' ')
+            )
+            expect(allCallsHaveDashes).toBe(true)
+        })
+
+        it('shows validation spinner while validating', async () => {
+            renderComponent(defaultExperiment)
+
+            const input = screen.getByPlaceholderText(/examples: new-landing-page/)
+            await userEvent.type(input, 'test')
+        })
+
+        it('shows success checkmark for valid key', async () => {
+            const experimentWithoutKey = {
+                ...defaultExperiment,
+                feature_flag_key: '',
+            }
+
+            renderComponent(experimentWithoutKey)
+
+            const input = screen.getByPlaceholderText(/examples: new-landing-page/)
+            await userEvent.type(input, 'valid-new-key')
+
+            // Wait for validation (debounce is 300ms + API call)
+            await waitFor(
+                () => {
+                    // Should show success checkmark (IconCheck with text-success class)
+                    const checkmark = document.querySelector('.text-success')
+                    expect(checkmark).toBeInTheDocument()
+                },
+                { timeout: 1000 }
+            )
+        })
+
+        it.skip('shows error message for invalid key', async () => {
+            const experimentWithoutKey = {
+                ...defaultExperiment,
+                feature_flag_key: '',
+            }
+
+            renderComponent(experimentWithoutKey)
+
+            const input = screen.getByPlaceholderText(/examples: new-landing-page/)
+            await userEvent.type(input, 'existing-key')
+
+            // Wait for validation and check for error indicator
+            await waitFor(
+                () => {
+                    const errorText = screen.queryByText(/already exists/i)
+                    expect(errorText).toBeInTheDocument()
+                },
+                { timeout: 1000 }
+            )
+        })
+    })
+
+    describe('variant management', () => {
+        it('adds a new variant when clicking add button', async () => {
+            renderComponent(defaultExperiment)
+
+            const addButton = screen.getByRole('button', { name: /add variant/i })
+            await userEvent.click(addButton)
+
+            expect(mockOnChange).toHaveBeenCalledWith({
+                parameters: expect.objectContaining({
+                    feature_flag_variants: expect.arrayContaining([
+                        expect.objectContaining({ key: 'control' }),
+                        expect.objectContaining({ key: 'test' }),
+                        expect.objectContaining({ key: 'test-2' }),
+                    ]),
+                }),
+            })
+        })
+
+        it('redistributes percentages equally when adding variant', async () => {
+            renderComponent(defaultExperiment)
+
+            const addButton = screen.getByRole('button', { name: /add variant/i })
+            await userEvent.click(addButton)
+
+            expect(mockOnChange).toHaveBeenCalledWith({
+                parameters: expect.objectContaining({
+                    feature_flag_variants: expect.arrayContaining([
+                        expect.objectContaining({ rollout_percentage: expect.any(Number) }),
+                    ]),
+                }),
+            })
+
+            // Check that percentages sum to 100
+            const call = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+            const sum = call.parameters.feature_flag_variants.reduce(
+                (acc: number, v: any) => acc + v.rollout_percentage,
+                0
+            )
+            expect(sum).toBe(100)
+        })
+
+        it('updates variant key when typing', async () => {
+            const experimentWithEmptyVariantKey = {
+                ...defaultExperiment,
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: '', rollout_percentage: 50 },
+                    ],
+                },
+            }
+
+            renderComponent(experimentWithEmptyVariantKey)
+
+            const variantInputs = screen.getAllByPlaceholderText(/example-variant/)
+            await userEvent.type(variantInputs[1], 'treatment')
+
+            // Verify onChange was called with variant updates
+            expect(mockOnChange).toHaveBeenCalled()
+            const hasVariantUpdate = mockOnChange.mock.calls.some((call) => call[0].parameters?.feature_flag_variants)
+            expect(hasVariantUpdate).toBe(true)
+        })
+
+        it('updates variant description', async () => {
+            renderComponent(defaultExperiment)
+
+            const descriptionInputs = screen.getAllByPlaceholderText('Description')
+            await userEvent.type(descriptionInputs[0], 'Control group')
+
+            // Verify onChange was called with variant updates
+            expect(mockOnChange).toHaveBeenCalled()
+            const hasVariantUpdate = mockOnChange.mock.calls.some((call) => call[0].parameters?.feature_flag_variants)
+            expect(hasVariantUpdate).toBe(true)
+        })
+
+        it('updates rollout percentage', async () => {
+            const { container } = renderComponent(defaultExperiment)
+
+            const percentageInputs = container.querySelectorAll(
+                '[data-attr="experiment-variant-rollout-percentage-input"]'
+            )
+
+            await userEvent.clear(percentageInputs[0] as Element)
+            await userEvent.type(percentageInputs[0] as Element, '70')
+
+            // Check the last call
+            const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1]
+            expect(lastCall[0]).toEqual(
+                expect.objectContaining({
+                    parameters: expect.objectContaining({
+                        feature_flag_variants: expect.arrayContaining([
+                            expect.objectContaining({ key: 'control', rollout_percentage: 70 }),
+                        ]),
+                    }),
+                })
+            )
+        })
+
+        it('shows error when percentages do not sum to 100', () => {
+            const invalidExperiment = {
+                ...defaultExperiment,
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 40 },
+                        { key: 'test', rollout_percentage: 40 },
+                    ],
+                },
+            }
+
+            renderComponent(invalidExperiment)
+
+            expect(screen.getByText(/must sum to 100 \(currently 80\)/i)).toBeInTheDocument()
+        })
+
+        it('removes variant when clicking delete button', async () => {
+            const experimentWithThreeVariants = {
+                ...defaultExperiment,
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 33 },
+                        { key: 'test', rollout_percentage: 33 },
+                        { key: 'test-2', rollout_percentage: 34 },
+                    ],
+                },
+            }
+
+            const { container } = renderComponent(experimentWithThreeVariants)
+
+            const deleteButtons = container.querySelectorAll('[data-attr^="delete-prop-filter"]')
+
+            // Click the first delete button (which is for the second variant, since control has no delete button)
+            await userEvent.click(deleteButtons[0] as Element)
+
+            expect(mockOnChange).toHaveBeenCalledWith({
+                parameters: expect.objectContaining({
+                    feature_flag_variants: expect.arrayContaining([
+                        expect.objectContaining({ key: 'control' }),
+                        expect.objectContaining({ key: 'test-2' }),
+                    ]),
+                }),
+            })
+        })
+
+        it('does not show delete button for control variant', () => {
+            const experimentWithThreeVariants = {
+                ...defaultExperiment,
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 33 },
+                        { key: 'test', rollout_percentage: 33 },
+                        { key: 'test-2', rollout_percentage: 34 },
+                    ],
+                },
+            }
+
+            const { container } = render(
+                <VariantsPanelCreateFeatureFlag experiment={experimentWithThreeVariants} onChange={mockOnChange} />
+            )
+
+            const rows = container.querySelectorAll('.grid.grid-cols-24')
+            const controlRow = rows[1] // First row after header
+
+            // Control variant should not have a delete button
+            const deleteButton = controlRow.querySelector('[data-attr^="delete-prop-filter"]')
+            expect(deleteButton).not.toBeInTheDocument()
+        })
+    })
+
+    describe('rollout distribution', () => {
+        it('redistributes percentages equally when clicking balance button', async () => {
+            const unevenExperiment = {
+                ...defaultExperiment,
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 20 },
+                        { key: 'test', rollout_percentage: 80 },
+                    ],
+                },
+            }
+
+            renderComponent(unevenExperiment)
+
+            const balanceButton = screen.getByRole('button', { name: /normalize variant rollout/i })
+            await userEvent.click(balanceButton)
+
+            expect(mockOnChange).toHaveBeenCalledWith({
+                parameters: expect.objectContaining({
+                    feature_flag_variants: [
+                        expect.objectContaining({ key: 'control', rollout_percentage: 50 }),
+                        expect.objectContaining({ key: 'test', rollout_percentage: 50 }),
+                    ],
+                }),
+            })
+        })
+    })
+
+    describe('experience continuity', () => {
+        it('toggles experience continuity checkbox', async () => {
+            renderComponent(defaultExperiment)
+
+            const checkbox = screen.getByRole('checkbox')
+            await userEvent.click(checkbox)
+
+            expect(mockOnChange).toHaveBeenCalledWith({
+                parameters: expect.objectContaining({
+                    ensure_experience_continuity: false,
+                }),
+            })
+        })
+
+        it('defaults to checked', () => {
+            renderComponent(defaultExperiment)
+
+            const checkbox = screen.getByRole('checkbox') as HTMLInputElement
+            expect(checkbox.checked).toBe(true)
+        })
+    })
+
+    describe('edge cases', () => {
+        it('handles experiment without parameters', () => {
+            const experimentWithoutParams = {
+                ...NEW_EXPERIMENT,
+                name: 'Test',
+                feature_flag_key: '',
+            }
+
+            renderComponent(experimentWithoutParams)
+
+            // Should render with default variants
+            expect(screen.getByDisplayValue('control')).toBeInTheDocument()
+            expect(screen.getByDisplayValue('test')).toBeInTheDocument()
+        })
+
+        it('handles empty feature flag key', () => {
+            const experimentWithEmptyKey = {
+                ...defaultExperiment,
+                feature_flag_key: '',
+            }
+
+            renderComponent(experimentWithEmptyKey)
+
+            const input = screen.getByPlaceholderText(/examples: new-landing-page/)
+            expect(input).toHaveValue('')
+        })
+
+        it('prevents adding more than maximum variants', async () => {
+            // Add variants up to the max (MAX_EXPERIMENT_VARIANTS is 20)
+            const maxVariants = Array.from({ length: 20 }, (_, i) => ({
+                key: `variant-${i}`,
+                rollout_percentage: 5,
+            }))
+
+            const experimentWithMaxVariants = {
+                ...defaultExperiment,
+                parameters: {
+                    feature_flag_variants: maxVariants,
+                },
+            }
+
+            renderComponent(experimentWithMaxVariants)
+
+            const addButton = screen.queryByRole('button', { name: /add variant/i })
+            expect(addButton).not.toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
@@ -2,6 +2,8 @@ import '@testing-library/jest-dom'
 import { type RenderResult, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { MAX_EXPERIMENT_VARIANTS } from 'lib/constants'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import type { Experiment } from '~/types'
@@ -169,6 +171,12 @@ describe('VariantsPanelCreateFeatureFlag', () => {
 
             const input = screen.getByPlaceholderText(/examples: new-landing-page/)
             await userEvent.type(input, 'test')
+
+            // Spinner should appear during validation (debounced)
+            await waitFor(() => {
+                const spinner = document.querySelector('.Spinner')
+                expect(spinner).toBeInTheDocument()
+            })
         })
 
         it('shows success checkmark for valid key', async () => {
@@ -461,8 +469,7 @@ describe('VariantsPanelCreateFeatureFlag', () => {
         })
 
         it('prevents adding more than maximum variants', async () => {
-            // Add variants up to the max (MAX_EXPERIMENT_VARIANTS is 20)
-            const maxVariants = Array.from({ length: 20 }, (_, i) => ({
+            const maxVariants = Array.from({ length: MAX_EXPERIMENT_VARIANTS }, (_, i) => ({
                 key: `variant-${i}`,
                 rollout_percentage: 5,
             }))

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -236,20 +236,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                             />
                         </div>
                         <div className="col-span-8">
-                            <JSONEditorInput
-                                readOnly={true}
-                                onChange={(newValue) => {
-                                    const updatedVariant = { ...variant, name: newValue }
-                                    if (newValue === '') {
-                                        delete updatedVariant.name
-                                    } else {
-                                        updatedVariant.name = newValue
-                                    }
-                                    updateVariant(index, updatedVariant)
-                                }}
-                                value={''}
-                                placeholder='{"key": "value"}'
-                            />
+                            <JSONEditorInput readOnly={true} value={''} placeholder='{"key": "value"}' />
                         </div>
                         <div className="col-span-3">
                             <LemonInput

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -12,7 +12,6 @@ import { Lettermark } from 'lib/lemon-ui/Lettermark'
 import { LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { alphabet } from 'lib/utils'
-import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
 
 import type { Experiment, MultivariateFlagVariant } from '~/types'
 
@@ -190,7 +189,6 @@ export const VariantsPanelCreateFeatureFlag = ({
                         <div />
                         <div className="col-span-4">Variant key</div>
                         <div className="col-span-6">Description</div>
-                        <div className="col-span-9">Payload</div>
                         <div className="col-span-3 flex justify-between items-center gap-1">
                             <span>Rollout</span>
                             <LemonButton
@@ -228,9 +226,6 @@ export const VariantsPanelCreateFeatureFlag = ({
                                     className="ph-ignore-input"
                                     placeholder="Description"
                                 />
-                            </div>
-                            <div className="col-span-9">
-                                <JSONEditorInput readOnly={true} value={''} placeholder='{"key": "value"}' />
                             </div>
                             <div className="col-span-3">
                                 <LemonInput

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -133,11 +133,10 @@ export const VariantsPanelCreateFeatureFlag = ({
 
     return (
         <div className="flex flex-col gap-4">
-            <LemonField name="feature_flag_key" label="Feature flag key">
+            <LemonField.Pure label="Feature flag key" htmlFor="experiment-feature-flag-key">
                 <>
                     <LemonInput
                         id="experiment-feature-flag-key"
-                        className=""
                         placeholder="examples: new-landing-page, betaFeature, ab_test_1"
                         value={experiment.feature_flag_key || ''}
                         onChange={(value) => {
@@ -180,10 +179,9 @@ export const VariantsPanelCreateFeatureFlag = ({
                         your code.
                     </div>
                 </>
-            </LemonField>
+            </LemonField.Pure>
 
-            <LemonField
-                name="feature_flag_variants"
+            <LemonField.Pure
                 label="Variant keys"
                 help="The rollout percentage of experiment variants must add up to 100%"
             >
@@ -275,7 +273,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                         </LemonButton>
                     )}
                 </div>
-            </LemonField>
+            </LemonField.Pure>
 
             <div>
                 <LemonCheckbox

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -237,6 +237,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                         </div>
                         <div className="col-span-8">
                             <JSONEditorInput
+                                readOnly={true}
                                 onChange={(newValue) => {
                                     const updatedVariant = { ...variant, name: newValue }
                                     if (newValue === '') {
@@ -246,7 +247,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                                     }
                                     updateVariant(index, updatedVariant)
                                 }}
-                                value={variant.name || ''}
+                                value={''}
                                 placeholder='{"key": "value"}'
                             />
                         </div>

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
@@ -361,7 +361,6 @@ describe('createExperimentLogic', () => {
                             { key: 'control', rollout_percentage: 50 },
                             { key: 'test', rollout_percentage: 50 },
                         ],
-                        ensure_experience_continuity: false,
                     },
                 })
                 logic.actions.submitExperiment()

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
@@ -240,5 +240,132 @@ describe('createExperimentLogic', () => {
                 }),
             })
         })
+
+        it('setExperimentValue updates a single field', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperimentValue('name', 'New Name')
+            })
+                .toDispatchActions(['setExperimentValue'])
+                .toMatchValues({
+                    experiment: partial({
+                        name: 'New Name',
+                    }),
+                })
+        })
+
+        it('setExperimentValue updates feature_flag_key', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperimentValue('feature_flag_key', 'new-flag-key')
+            })
+                .toDispatchActions(['setExperimentValue'])
+                .toMatchValues({
+                    experiment: partial({
+                        feature_flag_key: 'new-flag-key',
+                    }),
+                })
+        })
+
+        it('setExperimentValue updates parameters object', async () => {
+            const parameters = {
+                feature_flag_variants: [
+                    { key: 'control', rollout_percentage: 50 },
+                    { key: 'test', rollout_percentage: 50 },
+                ],
+                ensure_experience_continuity: true,
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setExperimentValue('parameters', parameters)
+            })
+                .toDispatchActions(['setExperimentValue'])
+                .toMatchValues({
+                    experiment: partial({
+                        parameters: partial({
+                            feature_flag_variants: expect.arrayContaining([
+                                partial({ key: 'control', rollout_percentage: 50 }),
+                                partial({ key: 'test', rollout_percentage: 50 }),
+                            ]),
+                            ensure_experience_continuity: true,
+                        }),
+                    }),
+                })
+        })
+
+        it('merges parameters when updating variants', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperimentValue('parameters', {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 33 },
+                        { key: 'test', rollout_percentage: 33 },
+                        { key: 'test-2', rollout_percentage: 34 },
+                    ],
+                })
+            })
+                .toDispatchActions(['setExperimentValue'])
+                .toMatchValues({
+                    experiment: partial({
+                        parameters: partial({
+                            feature_flag_variants: expect.arrayContaining([
+                                partial({ key: 'control' }),
+                                partial({ key: 'test' }),
+                                partial({ key: 'test-2' }),
+                            ]),
+                        }),
+                    }),
+                })
+
+            // Verify we have exactly 3 variants
+            expect(logic.values.experiment.parameters?.feature_flag_variants).toHaveLength(3)
+        })
+    })
+
+    describe('feature flag integration', () => {
+        it('includes feature flag key in experiment submission', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperiment({
+                    ...NEW_EXPERIMENT,
+                    name: 'Test Experiment',
+                    description: 'Test hypothesis',
+                    feature_flag_key: 'custom-flag-key',
+                })
+                logic.actions.submitExperiment()
+            }).toDispatchActions(['setExperiment', 'submitExperiment', 'createExperimentSuccess'])
+        })
+
+        it('includes variants in experiment submission', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperiment({
+                    ...NEW_EXPERIMENT,
+                    name: 'Test Experiment',
+                    description: 'Test hypothesis',
+                    feature_flag_key: 'test-flag',
+                    parameters: {
+                        feature_flag_variants: [
+                            { key: 'control', rollout_percentage: 50 },
+                            { key: 'treatment', rollout_percentage: 50 },
+                        ],
+                    },
+                })
+                logic.actions.submitExperiment()
+            }).toDispatchActions(['setExperiment', 'submitExperiment', 'createExperimentSuccess'])
+        })
+
+        it('includes experience continuity setting in submission', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setExperiment({
+                    ...NEW_EXPERIMENT,
+                    name: 'Test Experiment',
+                    description: 'Test hypothesis',
+                    parameters: {
+                        feature_flag_variants: [
+                            { key: 'control', rollout_percentage: 50 },
+                            { key: 'test', rollout_percentage: 50 },
+                        ],
+                        ensure_experience_continuity: false,
+                    },
+                })
+                logic.actions.submitExperiment()
+            }).toDispatchActions(['setExperiment', 'submitExperiment', 'createExperimentSuccess'])
+        })
     })
 })

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.test.ts
@@ -203,14 +203,27 @@ describe('variantsPanelLogic', () => {
         it('debounces validation calls', async () => {
             const spy = jest.spyOn(logic.actions, 'validateFeatureFlagKey')
 
-            logic.actions.validateFeatureFlagKey('test-1')
-            logic.actions.validateFeatureFlagKey('test-2')
-            logic.actions.validateFeatureFlagKey('test-3')
-
-            // Should debounce and only process the last call
-            await new Promise((resolve) => setTimeout(resolve, 350))
+            await expectLogic(logic, () => {
+                logic.actions.validateFeatureFlagKey('test-1')
+                logic.actions.validateFeatureFlagKey('test-2')
+                logic.actions.validateFeatureFlagKey('test-3')
+            })
+                .delay(350)
+                .toDispatchActions([
+                    'validateFeatureFlagKey',
+                    'validateFeatureFlagKey',
+                    'validateFeatureFlagKey',
+                    'validateFeatureFlagKeySuccess',
+                ])
+                .toMatchValues({
+                    featureFlagKeyValidation: partial({
+                        valid: true,
+                        error: null,
+                    }),
+                })
 
             expect(spy).toHaveBeenCalledTimes(3)
+            expect(spy).toHaveBeenLastCalledWith('test-3')
         })
     })
 

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.test.ts
@@ -1,0 +1,383 @@
+import { expectLogic, partial } from 'kea-test-utils'
+
+import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import type { Experiment } from '~/types'
+
+import { NEW_EXPERIMENT } from '../constants'
+import { experimentsLogic } from '../experimentsLogic'
+import { createExperimentLogic } from './createExperimentLogic'
+import { variantsPanelLogic } from './variantsPanelLogic'
+
+describe('variantsPanelLogic', () => {
+    let logic: ReturnType<typeof variantsPanelLogic.build>
+
+    const mockExperiment: Experiment = {
+        ...NEW_EXPERIMENT,
+        id: 1,
+        name: 'Test Experiment',
+        feature_flag_key: 'test-experiment',
+    }
+
+    const mockFeatureFlags = [
+        {
+            id: 1,
+            key: 'existing-flag-1',
+            name: 'Existing Flag 1',
+            filters: {
+                groups: [],
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: 'test', rollout_percentage: 50 },
+                    ],
+                },
+            },
+            active: true,
+            deleted: false,
+            ensure_experience_continuity: false,
+        },
+        {
+            id: 2,
+            key: 'existing-flag-2',
+            name: 'Existing Flag 2',
+            filters: {
+                groups: [],
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 33 },
+                        { key: 'variant-a', rollout_percentage: 33 },
+                        { key: 'variant-b', rollout_percentage: 34 },
+                    ],
+                },
+            },
+            active: true,
+            deleted: false,
+            ensure_experience_continuity: false,
+        },
+        {
+            id: 3,
+            key: 'invalid-flag',
+            name: 'Invalid Flag (no multivariate)',
+            filters: {
+                groups: [],
+            },
+            active: true,
+            deleted: false,
+            ensure_experience_continuity: false,
+        },
+    ]
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/@current/feature_flags/': (req) => {
+                    const url = new URL(req.url)
+                    const search = url.searchParams.get('search')
+
+                    if (search) {
+                        const filtered = mockFeatureFlags.filter((flag) =>
+                            flag.key.toLowerCase().includes(search.toLowerCase())
+                        )
+                        return [200, { results: filtered, count: filtered.length }]
+                    }
+
+                    return [200, { results: mockFeatureFlags, count: mockFeatureFlags.length }]
+                },
+                '/api/projects/@current/experiments': () => [
+                    200,
+                    {
+                        results: [
+                            { id: 1, name: 'Experiment 1', feature_flag_key: 'experiment-flag-1' },
+                            { id: 2, name: 'Experiment 2', feature_flag_key: 'experiment-flag-2' },
+                        ],
+                        count: 2,
+                    },
+                ],
+            },
+        })
+        initKeaTests()
+
+        // Mount and load connected logics to populate their data
+        featureFlagsLogic.mount()
+        featureFlagsLogic.actions.loadFeatureFlags()
+
+        experimentsLogic.mount()
+        experimentsLogic.actions.loadExperiments()
+
+        logic = variantsPanelLogic({ experiment: mockExperiment })
+        logic.mount()
+        jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        featureFlagsLogic.unmount()
+        experimentsLogic.unmount()
+    })
+
+    describe('mode management', () => {
+        it('defaults to create mode', async () => {
+            await expectLogic(logic).toMatchValues({
+                mode: 'create',
+            })
+        })
+
+        it('switches to link mode', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setMode('link')
+            })
+                .toDispatchActions(['setMode'])
+                .toMatchValues({
+                    mode: 'link',
+                })
+        })
+
+        it('resets dirty flag when switching modes', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFeatureFlagKeyDirty()
+                logic.actions.setMode('link')
+            })
+                .toDispatchActions(['setFeatureFlagKeyDirty', 'setMode'])
+                .toMatchValues({
+                    featureFlagKeyDirty: false,
+                })
+        })
+    })
+
+    describe('feature flag key validation', () => {
+        it('validates valid feature flag key', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.validateFeatureFlagKey('valid-flag-key')
+            })
+                .toDispatchActions(['validateFeatureFlagKey', 'validateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    featureFlagKeyValidation: partial({
+                        valid: true,
+                        error: null,
+                    }),
+                })
+        })
+
+        it('rejects empty feature flag key', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.validateFeatureFlagKey('')
+            })
+                .toDispatchActions(['validateFeatureFlagKey', 'validateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    featureFlagKeyValidation: partial({
+                        valid: false,
+                        error: expect.any(String),
+                    }),
+                })
+        })
+
+        it('rejects feature flag key with invalid characters', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.validateFeatureFlagKey('invalid key with spaces!')
+            })
+                .toDispatchActions(['validateFeatureFlagKey', 'validateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    featureFlagKeyValidation: partial({
+                        valid: false,
+                        error: expect.any(String),
+                    }),
+                })
+        })
+
+        it('rejects feature flag key that already exists in unavailable keys', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.validateFeatureFlagKey('existing-flag-1')
+            })
+                .toDispatchActions(['validateFeatureFlagKey', 'validateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    featureFlagKeyValidation: partial({
+                        valid: false,
+                        error: 'A feature flag with this key already exists.',
+                    }),
+                })
+        })
+
+        it('debounces validation calls', async () => {
+            const spy = jest.spyOn(logic.actions, 'validateFeatureFlagKey')
+
+            logic.actions.validateFeatureFlagKey('test-1')
+            logic.actions.validateFeatureFlagKey('test-2')
+            logic.actions.validateFeatureFlagKey('test-3')
+
+            // Should debounce and only process the last call
+            await new Promise((resolve) => setTimeout(resolve, 350))
+
+            expect(spy).toHaveBeenCalledTimes(3)
+        })
+    })
+
+    describe('feature flag key generation', () => {
+        it('generates feature flag key from experiment name', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.generateFeatureFlagKey('My Awesome Experiment')
+            })
+                .toDispatchActions(['generateFeatureFlagKey', 'generateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    generatedKey: 'my-awesome-experiment',
+                })
+        })
+
+        it('handles special characters in experiment name', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.generateFeatureFlagKey('Test@#$%Experiment!!!')
+            })
+                .toDispatchActions(['generateFeatureFlagKey', 'generateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    generatedKey: 'test-experiment',
+                })
+        })
+
+        it.skip('adds counter suffix when key already exists', async () => {
+            // Note: This test requires connected logics (featureFlagsLogic/experimentsLogic) to be fully loaded
+            // which is complex to set up in unit tests. The integration is tested in component tests.
+            await expectLogic(logic, () => {
+                logic.actions.generateFeatureFlagKey('existing-flag-1')
+            })
+                .toDispatchActions(['generateFeatureFlagKey', 'generateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    generatedKey: 'existing-flag-1-1',
+                })
+        })
+
+        it('returns null for empty name', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.generateFeatureFlagKey('')
+            })
+                .toDispatchActions(['generateFeatureFlagKey', 'generateFeatureFlagKeySuccess'])
+                .toMatchValues({
+                    generatedKey: null,
+                })
+        })
+
+        it('auto-generates key when experiment name changes in create mode', async () => {
+            const createLogic = createExperimentLogic()
+            createLogic.mount()
+
+            await expectLogic(logic, () => {
+                createLogic.actions.setExperimentValue('name', 'New Experiment Name')
+            }).toDispatchActions([
+                createExperimentLogic.actionTypes.setExperimentValue,
+                'generateFeatureFlagKey',
+                'generateFeatureFlagKeySuccess',
+            ])
+
+            createLogic.unmount()
+        })
+
+        it('does not auto-generate key when dirty flag is set', async () => {
+            const createLogic = createExperimentLogic()
+            createLogic.mount()
+
+            logic.actions.setFeatureFlagKeyDirty()
+
+            await expectLogic(logic, () => {
+                createLogic.actions.setExperimentValue('name', 'New Experiment Name')
+            }).toNotHaveDispatchedActions(['generateFeatureFlagKey'])
+
+            createLogic.unmount()
+        })
+    })
+
+    describe('available feature flags', () => {
+        it('loads all eligible feature flags', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadAllEligibleFeatureFlags()
+            })
+                .toDispatchActions(['loadAllEligibleFeatureFlags', 'loadAllEligibleFeatureFlagsSuccess'])
+                .toMatchValues({
+                    availableFeatureFlags: expect.arrayContaining([
+                        partial({ key: 'existing-flag-1' }),
+                        partial({ key: 'existing-flag-2' }),
+                    ]),
+                })
+        })
+
+        it('filters out non-eligible feature flags', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadAllEligibleFeatureFlags()
+            })
+                .toDispatchActions(['loadAllEligibleFeatureFlags', 'loadAllEligibleFeatureFlagsSuccess'])
+                .toMatchValues({
+                    availableFeatureFlags: expect.not.arrayContaining([partial({ key: 'invalid-flag' })]),
+                })
+        })
+
+        it('searches feature flags by key', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.searchFeatureFlags('flag-1')
+            })
+                .toDispatchActions(['searchFeatureFlags', 'searchFeatureFlagsSuccess'])
+                .toMatchValues({
+                    availableFeatureFlags: [partial({ key: 'existing-flag-1' })],
+                })
+        })
+
+        it('resets search and clears results', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.searchFeatureFlags('flag-1')
+            }).toDispatchActions(['searchFeatureFlags', 'searchFeatureFlagsSuccess'])
+
+            await expectLogic(logic, () => {
+                logic.actions.resetFeatureFlagsSearch()
+            })
+                .toDispatchActions(['resetFeatureFlagsSearch', 'resetFeatureFlagsSearchSuccess'])
+                .toMatchValues({
+                    availableFeatureFlags: [],
+                })
+        })
+    })
+
+    describe('unavailableFeatureFlagKeys selector', () => {
+        it.skip('combines feature flag keys and experiment keys', async () => {
+            // Note: This test requires connected logics (featureFlagsLogic/experimentsLogic) to be fully loaded
+            // which is complex to set up in unit tests. The integration is tested in component tests.
+            // Wait for connected logics to load
+            await expectLogic(featureFlagsLogic).toDispatchActions(['loadFeatureFlagsSuccess'])
+            await expectLogic(experimentsLogic).toDispatchActions(['loadExperimentsSuccess'])
+
+            await expectLogic(logic).toMatchValues({
+                unavailableFeatureFlagKeys: expect.any(Set),
+            })
+
+            const keys = logic.values.unavailableFeatureFlagKeys
+            expect(keys.has('existing-flag-1')).toBe(true)
+            expect(keys.has('existing-flag-2')).toBe(true)
+            expect(keys.has('experiment-flag-1')).toBe(true)
+            expect(keys.has('experiment-flag-2')).toBe(true)
+        })
+    })
+
+    describe('error handling', () => {
+        it('handles validation errors gracefully', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [500, { error: 'Server error' }],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.validateFeatureFlagKey('test-key')
+            }).toDispatchActions(['validateFeatureFlagKey', 'validateFeatureFlagKeyFailure'])
+        })
+
+        it('handles feature flag loading errors', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [500, { error: 'Server error' }],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadAllEligibleFeatureFlags()
+            }).toDispatchActions(['loadAllEligibleFeatureFlags', 'loadAllEligibleFeatureFlagsFailure'])
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
@@ -43,7 +43,7 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
         mode: [
             'create' as 'create' | 'link',
             {
-                setMode: (_, { mode }) => mode,
+                setMode: (_: any, { mode }: { mode: 'create' | 'link' }) => mode,
             },
         ],
         featureFlagKeyDirty: [
@@ -172,7 +172,10 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
                 ])
             },
         ],
-        featureFlagKey: [(_, props) => [props.experiment], (experiment): string => experiment.feature_flag_key || ''],
+        featureFlagKey: [
+            (_, props) => [props.experiment],
+            (experiment: Experiment): string => experiment.feature_flag_key || '',
+        ],
     },
     listeners: ({ values, actions }) => ({
         [createExperimentLogic.actionTypes.setExperimentValue]: ({ name, value }) => {

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
@@ -6,15 +6,22 @@ import { experimentsLogic } from 'scenes/experiments/experimentsLogic'
 import { validateFeatureFlagKey } from 'scenes/feature-flags/featureFlagLogic'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 
-import type { FeatureFlagType } from '~/types'
+import type { Experiment, FeatureFlagType } from '~/types'
 
 import { featureFlagEligibleForExperiment } from '../utils'
+import { createExperimentLogic } from './createExperimentLogic'
 import type { variantsPanelLogicType } from './variantsPanelLogicType'
 
 export const variantsPanelLogic = kea<variantsPanelLogicType>({
     path: ['scenes', 'experiments', 'create', 'panels', 'variantsPanelLogic'],
+    props: {
+        experiment: {} as Experiment,
+    } as {
+        experiment: Experiment
+    },
     connect: {
-        values: [featureFlagsLogic, ['featureFlags as existingFeatureFlags'], experimentsLogic, ['experiments']],
+        values: [featureFlagsLogic, ['featureFlags'], experimentsLogic, ['experiments']],
+        actions: [createExperimentLogic, ['setExperimentValue']],
     },
     actions: {
         validateFeatureFlagKey: (key: string) => ({ key }),
@@ -23,6 +30,8 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
         resetFeatureFlagsSearch: true,
         loadAllEligibleFeatureFlags: true,
         generateFeatureFlagKey: (name: string) => ({ name }),
+        setMode: (mode: 'create' | 'link') => ({ mode }),
+        setFeatureFlagKeyDirty: true,
     },
     reducers: {
         featureFlagKeyError: [
@@ -31,10 +40,17 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
                 setFeatureFlagKeyError: (_, { error }) => error,
             },
         ],
-        generatedFeatureFlagKey: [
-            null as string | null,
+        mode: [
+            'create' as 'create' | 'link',
             {
-                generateFeatureFlagKey: (_, { name }) => name,
+                setMode: (_, { mode }) => mode,
+            },
+        ],
+        featureFlagKeyDirty: [
+            false,
+            {
+                setFeatureFlagKeyDirty: () => true,
+                setMode: () => false, // Reset dirty flag when switching modes
             },
         ],
     },
@@ -146,14 +162,29 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
         ],
     }),
     selectors: {
+        // TRICKY: we do not load all feature flags here, just the latest ones.
         unavailableFeatureFlagKeys: [
-            (s) => [s.existingFeatureFlags, s.experiments],
-            (featureFlags, experiments): Set<string> => {
+            (s) => [s.featureFlags, s.experiments],
+            (featureFlags, experiments) => {
                 return new Set([
                     ...featureFlags.results.map((flag) => flag.key),
-                    ...experiments.results.map((experiment) => experiment.feature_flag_key).filter(Boolean),
+                    ...experiments.results.map((experiment) => experiment.feature_flag_key),
                 ])
             },
         ],
+        featureFlagKey: [(_, props) => [props.experiment], (experiment): string => experiment.feature_flag_key || ''],
     },
+    listeners: ({ values, actions }) => ({
+        [createExperimentLogic.actionTypes.setExperimentValue]: ({ name, value }) => {
+            if (name === 'name' && values.mode === 'create' && !values.featureFlagKeyDirty) {
+                actions.generateFeatureFlagKey(value)
+            }
+        },
+        generateFeatureFlagKeySuccess: ({ generatedKey }) => {
+            if (generatedKey) {
+                actions.setExperimentValue('feature_flag_key', generatedKey)
+                actions.validateFeatureFlagKey(generatedKey)
+            }
+        },
+    }),
 })

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -97,7 +97,7 @@ export function PlayerInspectorList(): JSX.Element {
                 </CellMeasurer>
             )
         },
-        [items, cellMeasurerCache, createLayoutHandler]
+        [items, cellMeasurerCache]
     )
 
     return (


### PR DESCRIPTION
## Problem

On the unified create experiment form, we were missing validations and features like generating and validating the feature flag key.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We duplicated the feature flag key autogeneration from the orignal form, and added the convenience that when the user inputs a `space` we produce a `dash`. All featura flag key interactions are validated against the existing feature flags.

| Feature flag key validation |
| - |
| ![manual-ff-key](https://github.com/user-attachments/assets/dd90e01f-e5c0-4c9b-8fc3-c9c3c491d9ea) |

Manage variants

| Feature flag variants |
| - |
| ![variants](https://github.com/user-attachments/assets/2e980715-f41d-4e8a-b946-ad7e8feb98bd) |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/variantsPanelLogic.test.ts
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
```

![cat-type-small](https://github.com/user-attachments/assets/1b573320-b638-4004-ab1b-e6e4c9822967)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
