### PR TITLE
feat(experiments): link existing feature flag

### DIFF
--- a/frontend/src/scenes/experiments/create/SelectExistingFeatureFlagModal.test.tsx
+++ b/frontend/src/scenes/experiments/create/SelectExistingFeatureFlagModal.test.tsx
@@ -1,0 +1,168 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, FeatureFlagEvaluationRuntime, FeatureFlagType } from '~/types'
+
+import { SelectExistingFeatureFlagModal } from './SelectExistingFeatureFlagModal'
+import { selectExistingFeatureFlagModalLogic } from './selectExistingFeatureFlagModalLogic'
+
+describe('SelectExistingFeatureFlagModal', () => {
+    const mockOnClose = jest.fn()
+    const mockOnSelect = jest.fn()
+    let logic: ReturnType<typeof selectExistingFeatureFlagModalLogic.build>
+
+    const baseFeatureFlag: FeatureFlagType = {
+        id: 1,
+        key: 'test-flag',
+        name: 'Test Flag',
+        filters: {
+            groups: [],
+            payloads: {},
+            multivariate: {
+                variants: [
+                    { key: 'control', rollout_percentage: 50 },
+                    { key: 'test', rollout_percentage: 50 },
+                ],
+            },
+        },
+        created_at: '2021-01-01',
+        updated_at: '2021-01-01',
+        created_by: null,
+        is_simple_flag: false,
+        is_remote_configuration: false,
+        deleted: false,
+        active: true,
+        rollout_percentage: null,
+        experiment_set: null,
+        features: null,
+        surveys: null,
+        rollback_conditions: [],
+        performed_rollback: false,
+        can_edit: true,
+        tags: [],
+        ensure_experience_continuity: null,
+        user_access_level: AccessControlLevel.Admin,
+        status: 'ACTIVE',
+        has_encrypted_payloads: false,
+        version: 0,
+        last_modified_by: null,
+        evaluation_runtime: FeatureFlagEvaluationRuntime.ALL,
+        evaluation_tags: [],
+    }
+
+    const mockFeatureFlags: FeatureFlagType[] = [
+        baseFeatureFlag,
+        {
+            ...baseFeatureFlag,
+            id: 2,
+            key: 'another-flag',
+            name: 'Another Flag',
+            filters: {
+                ...baseFeatureFlag.filters,
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 33 },
+                        { key: 'variant-1', rollout_percentage: 33 },
+                        { key: 'variant-2', rollout_percentage: 34 },
+                    ],
+                },
+            },
+        },
+    ]
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/@current/feature_flags/': () => [
+                    200,
+                    {
+                        results: mockFeatureFlags,
+                        count: mockFeatureFlags.length,
+                    },
+                ],
+            },
+        })
+        initKeaTests()
+        logic = selectExistingFeatureFlagModalLogic()
+        logic.mount()
+        logic.actions.openSelectExistingFeatureFlagModal()
+        jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        cleanup()
+    })
+
+    describe('basic rendering', () => {
+        it('renders modal with title and description', () => {
+            render(<SelectExistingFeatureFlagModal onClose={mockOnClose} onSelect={mockOnSelect} />)
+
+            expect(screen.getByText('Choose an existing feature flag')).toBeInTheDocument()
+            expect(screen.getByText(/Select an existing multivariate feature flag/)).toBeInTheDocument()
+        })
+
+        it('renders search filter', () => {
+            render(<SelectExistingFeatureFlagModal onClose={mockOnClose} onSelect={mockOnSelect} />)
+
+            expect(screen.getByPlaceholderText('Search for feature flags')).toBeInTheDocument()
+        })
+
+        it('renders table columns', () => {
+            render(<SelectExistingFeatureFlagModal onClose={mockOnClose} onSelect={mockOnSelect} />)
+
+            expect(screen.getByText('Key')).toBeInTheDocument()
+            expect(screen.getByText('Name')).toBeInTheDocument()
+        })
+    })
+
+    describe('interactions', () => {
+        it('calls onSelect and onClose when Select button is clicked', async () => {
+            const resetFiltersSpy = jest.spyOn(logic.actions, 'resetFilters')
+
+            render(<SelectExistingFeatureFlagModal onClose={mockOnClose} onSelect={mockOnSelect} />)
+
+            const selectButtons = await screen.findAllByRole('button', { name: 'Select' })
+            await userEvent.click(selectButtons[0])
+
+            expect(mockOnSelect).toHaveBeenCalledWith(mockFeatureFlags[0])
+            expect(resetFiltersSpy).toHaveBeenCalled()
+            expect(mockOnClose).toHaveBeenCalled()
+
+            resetFiltersSpy.mockRestore()
+        })
+
+        it('calls resetFilters and onClose when modal is closed', async () => {
+            const resetFiltersSpy = jest.spyOn(logic.actions, 'resetFilters')
+
+            render(<SelectExistingFeatureFlagModal onClose={mockOnClose} onSelect={mockOnSelect} />)
+
+            const closeButton = screen.getByRole('button', { name: /close/i })
+            await userEvent.click(closeButton)
+
+            expect(resetFiltersSpy).toHaveBeenCalled()
+            expect(mockOnClose).toHaveBeenCalled()
+
+            resetFiltersSpy.mockRestore()
+        })
+
+        it('calls setFilters when sorting is changed', async () => {
+            const setFiltersSpy = jest.spyOn(logic.actions, 'setFilters')
+
+            render(<SelectExistingFeatureFlagModal onClose={mockOnClose} onSelect={mockOnSelect} />)
+
+            const keyHeader = await screen.findByText('Key')
+            await userEvent.click(keyHeader)
+
+            expect(setFiltersSpy).toHaveBeenCalledWith({
+                order: 'key',
+                page: 1,
+            })
+
+            setFiltersSpy.mockRestore()
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/create/SelectExistingFeatureFlagModal.tsx
+++ b/frontend/src/scenes/experiments/create/SelectExistingFeatureFlagModal.tsx
@@ -1,0 +1,120 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonModal, LemonTable, Link } from '@posthog/lemon-ui'
+
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { FeatureFlagFiltersSection } from 'scenes/feature-flags/FeatureFlagFilters'
+import { urls } from 'scenes/urls'
+
+import { FeatureFlagType } from '~/types'
+
+import { featureFlagEligibleForExperiment } from '../utils'
+import { selectExistingFeatureFlagModalLogic } from './selectExistingFeatureFlagModalLogic'
+
+export const SelectExistingFeatureFlagModal = ({
+    onClose,
+    onSelect,
+}: {
+    onClose: () => void
+    onSelect: (flag: FeatureFlagType) => void
+}): JSX.Element => {
+    const { featureFlags, featureFlagsLoading, filters, pagination, isModalOpen } = useValues(
+        selectExistingFeatureFlagModalLogic
+    )
+    const { setFilters, resetFilters } = useActions(selectExistingFeatureFlagModalLogic)
+
+    const handleClose = (): void => {
+        resetFilters()
+        onClose()
+    }
+
+    const filtersSection = (
+        <div className="mb-4">
+            <FeatureFlagFiltersSection
+                filters={filters}
+                setFeatureFlagsFilters={setFilters}
+                searchPlaceholder="Search for feature flags"
+                filtersConfig={{ search: true }}
+            />
+        </div>
+    )
+
+    return (
+        <LemonModal isOpen={isModalOpen} onClose={handleClose} title="Choose an existing feature flag" width="50%">
+            <div className="deprecated-space-y-2">
+                <div className="text-muted mb-2 max-w-xl">
+                    Select an existing multivariate feature flag to use with this experiment. The feature flag must use
+                    multiple variants with <code>'control'</code> as the first, and not be associated with an existing
+                    experiment.
+                </div>
+                {filtersSection}
+                <LemonTable
+                    id="ff"
+                    dataSource={featureFlags.results.filter((featureFlag) => {
+                        try {
+                            return featureFlagEligibleForExperiment(featureFlag)
+                        } catch {
+                            return false
+                        }
+                    })}
+                    loading={featureFlagsLoading}
+                    useURLForSorting={false}
+                    columns={[
+                        {
+                            title: 'Key',
+                            dataIndex: 'key',
+                            sorter: (a, b) => (a.key || '').localeCompare(b.key || ''),
+                            render: (key, flag) => (
+                                <div className="flex items-center">
+                                    <div className="font-semibold">{key}</div>
+                                    <Link
+                                        to={urls.featureFlag(flag.id as number)}
+                                        target="_blank"
+                                        className="flex items-center"
+                                    >
+                                        <IconOpenInNew className="ml-1" />
+                                    </Link>
+                                </div>
+                            ),
+                        },
+                        {
+                            title: 'Name',
+                            dataIndex: 'name',
+                            sorter: (a, b) => (a.name || '').localeCompare(b.name || ''),
+                        },
+                        {
+                            title: null,
+                            render: function RenderActions(_, flag) {
+                                return (
+                                    <div className="flex items-center justify-end">
+                                        <LemonButton
+                                            size="xsmall"
+                                            type="primary"
+                                            disabledReason={undefined}
+                                            onClick={() => {
+                                                onSelect(flag)
+                                                handleClose()
+                                            }}
+                                        >
+                                            Select
+                                        </LemonButton>
+                                    </div>
+                                )
+                            },
+                        },
+                    ]}
+                    emptyState="No feature flags match these filters."
+                    pagination={pagination}
+                    onSort={(newSorting) =>
+                        setFilters({
+                            order: newSorting
+                                ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
+                                : undefined,
+                            page: 1,
+                        })
+                    }
+                />
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -1,18 +1,14 @@
-import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useActions } from 'kea'
+import { useState } from 'react'
 import { match } from 'ts-pattern'
-
-import { LemonButton, LemonInput, LemonModal, LemonTable, Link } from '@posthog/lemon-ui'
-
-import { IconOpenInNew } from 'lib/lemon-ui/icons'
-import { urls } from 'scenes/urls'
 
 import { SelectableCard } from '~/scenes/experiments/components/SelectableCard'
 import type { Experiment, FeatureFlagType, MultivariateFlagVariant } from '~/types'
 
+import { SelectExistingFeatureFlagModal } from './SelectExistingFeatureFlagModal'
 import { VariantsPanelCreateFeatureFlag } from './VariantsPanelCreateFeatureFlag'
 import { VariantsPanelLinkFeatureFlag } from './VariantsPanelLinkFeatureFlag'
-import { variantsPanelLogic } from './variantsPanelLogic'
+import { selectExistingFeatureFlagModalLogic } from './selectExistingFeatureFlagModalLogic'
 
 interface VariantsPanelProps {
     experiment: Experiment
@@ -25,113 +21,14 @@ interface VariantsPanelProps {
     }) => void
 }
 
-const SelectExistingFeatureFlagModal = ({
-    isOpen,
-    onClose,
-    onSelect,
-}: {
-    isOpen: boolean
-    onClose: () => void
-    onSelect: (flag: FeatureFlagType) => void
-}): JSX.Element => {
-    const [search, setSearch] = useState('')
-    const { availableFeatureFlags, availableFeatureFlagsLoading } = useValues(variantsPanelLogic)
-    const { searchFeatureFlags, resetFeatureFlagsSearch, loadAllEligibleFeatureFlags } = useActions(variantsPanelLogic)
-
-    useEffect(() => {
-        // Load all eligible feature flags when modal opens
-        loadAllEligibleFeatureFlags()
-    }, [loadAllEligibleFeatureFlags])
-
-    useEffect(() => {
-        if (search) {
-            searchFeatureFlags(search)
-        } else {
-            // If search is cleared, reload all flags
-            loadAllEligibleFeatureFlags()
-        }
-    }, [search, loadAllEligibleFeatureFlags, searchFeatureFlags])
-
-    const handleClose = (): void => {
-        resetFeatureFlagsSearch()
-        setSearch('')
-        onClose()
-    }
-
-    return (
-        <LemonModal isOpen={isOpen} onClose={handleClose} title="Choose an existing feature flag" width="50%">
-            <div className="space-y-2">
-                <div className="text-muted mb-2 max-w-xl">
-                    Select an existing multivariate feature flag to use with this experiment. The feature flag must use
-                    multiple variants with <code>'control'</code> as the first, and not be associated with an existing
-                    experiment.
-                </div>
-                <div className="mb-4">
-                    <LemonInput
-                        type="search"
-                        placeholder="Search for feature flags"
-                        value={search}
-                        onChange={setSearch}
-                        fullWidth
-                    />
-                </div>
-                <LemonTable
-                    dataSource={availableFeatureFlags}
-                    loading={availableFeatureFlagsLoading}
-                    columns={[
-                        {
-                            title: 'Key',
-                            dataIndex: 'key',
-                            render: (key, flag) => (
-                                <div className="flex items-center">
-                                    <div className="font-semibold">{key}</div>
-                                    <Link
-                                        to={urls.featureFlag(flag.id as number)}
-                                        target="_blank"
-                                        className="flex items-center"
-                                    >
-                                        <IconOpenInNew className="ml-1" />
-                                    </Link>
-                                </div>
-                            ),
-                        },
-                        {
-                            title: 'Name',
-                            dataIndex: 'name',
-                        },
-                        {
-                            title: null,
-                            render: function RenderActions(_, flag) {
-                                return (
-                                    <div className="flex items-center justify-end">
-                                        <LemonButton
-                                            size="xsmall"
-                                            type="primary"
-                                            onClick={() => {
-                                                onSelect(flag)
-                                                handleClose()
-                                            }}
-                                        >
-                                            Select
-                                        </LemonButton>
-                                    </div>
-                                )
-                            },
-                        },
-                    ]}
-                    emptyState="No feature flags match your search. Try different keywords."
-                />
-            </div>
-        </LemonModal>
-    )
-}
-
 export function VariantsPanel({ experiment, onChange }: VariantsPanelProps): JSX.Element {
     // we'll use local state to handle selectors and modals
     const [flagSourceMode, setFlagSourceMode] = useState<'create' | 'link'>('create')
     const [linkedFeatureFlag, setLinkedFeatureFlag] = useState<FeatureFlagType | null>(null)
-    const [showFeatureFlagSelector, setShowFeatureFlagSelector] = useState(false)
-    // Store the created key separately to preserve it when switching modes
+
+    const { openSelectExistingFeatureFlagModal, closeSelectExistingFeatureFlagModal } = useActions(
+        selectExistingFeatureFlagModalLogic
+    )
 
     return (
         <div className="space-y-6">
@@ -161,18 +58,17 @@ export function VariantsPanel({ experiment, onChange }: VariantsPanelProps): JSX
                 .with('link', () => (
                     <VariantsPanelLinkFeatureFlag
                         linkedFeatureFlag={linkedFeatureFlag}
-                        setShowFeatureFlagSelector={setShowFeatureFlagSelector}
+                        setShowFeatureFlagSelector={openSelectExistingFeatureFlagModal}
                     />
                 ))
                 .exhaustive()}
 
             {/* Feature Flag Selection Modal */}
             <SelectExistingFeatureFlagModal
-                isOpen={showFeatureFlagSelector}
-                onClose={() => setShowFeatureFlagSelector(false)}
-                onSelect={(flag) => {
+                onClose={() => closeSelectExistingFeatureFlagModal()}
+                onSelect={(flag: FeatureFlagType) => {
                     setLinkedFeatureFlag(flag)
-                    setShowFeatureFlagSelector(false)
+                    closeSelectExistingFeatureFlagModal()
                 }}
             />
         </div>

--- a/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.test.tsx
@@ -1,0 +1,633 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { AccessControlLevel, FeatureFlagEvaluationRuntime, FeatureFlagType } from '~/types'
+
+import { VariantsPanelLinkFeatureFlag } from './VariantsPanelLinkFeatureFlag'
+
+describe('VariantsPanelLinkFeatureFlag', () => {
+    const mockSetShowFeatureFlagSelector = jest.fn()
+
+    const baseFeatureFlag: FeatureFlagType = {
+        id: 1,
+        key: 'test-experiment-flag',
+        name: 'Test Experiment Feature Flag',
+        filters: {
+            groups: [
+                {
+                    properties: [],
+                    rollout_percentage: 100,
+                },
+            ],
+            payloads: {},
+            multivariate: {
+                variants: [
+                    { key: 'control', rollout_percentage: 50 },
+                    { key: 'test', rollout_percentage: 50 },
+                ],
+            },
+        },
+        created_at: '2021-01-01',
+        updated_at: '2021-01-01',
+        created_by: null,
+        is_simple_flag: false,
+        is_remote_configuration: false,
+        deleted: false,
+        active: true,
+        rollout_percentage: null,
+        experiment_set: null,
+        features: null,
+        surveys: null,
+        rollback_conditions: [],
+        performed_rollback: false,
+        can_edit: true,
+        tags: [],
+        ensure_experience_continuity: null,
+        user_access_level: AccessControlLevel.Admin,
+        status: 'ACTIVE',
+        has_encrypted_payloads: false,
+        version: 0,
+        last_modified_by: null,
+        evaluation_runtime: FeatureFlagEvaluationRuntime.ALL,
+        evaluation_tags: [],
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    describe('empty state', () => {
+        it('renders empty state when no feature flag is selected', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={null}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('No feature flag selected')).toBeInTheDocument()
+            expect(
+                screen.getByText('Select an existing multivariate feature flag to use with this experiment')
+            ).toBeInTheDocument()
+        })
+
+        it('renders Select Feature Flag button in empty state', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={null}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const selectButton = screen.getByRole('button', { name: 'Select Feature Flag' })
+            expect(selectButton).toBeInTheDocument()
+        })
+
+        it('calls setShowFeatureFlagSelector when Select button is clicked', async () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={null}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const selectButton = screen.getByRole('button', { name: 'Select Feature Flag' })
+            await userEvent.click(selectButton)
+
+            expect(mockSetShowFeatureFlagSelector).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('with linked feature flag', () => {
+        it('renders feature flag key and name', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('test-experiment-flag')).toBeInTheDocument()
+            expect(screen.getByText('Test Experiment Feature Flag')).toBeInTheDocument()
+        })
+
+        it('renders external link to feature flag', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const link = screen.getByRole('link', { name: /view feature flag/i })
+            expect(link).toHaveAttribute('href', '/feature_flags/1')
+            expect(link).toHaveAttribute('target', '_blank')
+        })
+
+        it('renders Change button', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const changeButton = screen.getByRole('button', { name: 'Change' })
+            expect(changeButton).toBeInTheDocument()
+        })
+
+        it('calls setShowFeatureFlagSelector when Change button is clicked', async () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const changeButton = screen.getByRole('button', { name: 'Change' })
+            await userEvent.click(changeButton)
+
+            expect(mockSetShowFeatureFlagSelector).toHaveBeenCalledTimes(1)
+        })
+
+        it('renders active status for active flag', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={{ ...baseFeatureFlag, active: true }}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('Active')).toBeInTheDocument()
+            const statusDot = screen.getByTitle('Active')
+            expect(statusDot).toHaveClass('bg-success')
+        })
+
+        it('renders inactive status for inactive flag', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={{ ...baseFeatureFlag, active: false }}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('Inactive')).toBeInTheDocument()
+            const statusDot = screen.getByTitle('Inactive')
+            expect(statusDot).toHaveClass('bg-muted')
+        })
+
+        it('does not render description when name is not set', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={{ ...baseFeatureFlag, name: '' }}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.queryByText('Test Experiment Feature Flag')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('variants display', () => {
+        it('renders all variants', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('control')).toBeInTheDocument()
+            expect(screen.getByText('test')).toBeInTheDocument()
+        })
+
+        it('highlights control variant with primary tag', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const controlTag = screen.getByText('control').closest('.LemonTag')
+            expect(controlTag).toHaveClass('LemonTag--primary')
+        })
+
+        it('renders multiple variants', () => {
+            const flagWithMultipleVariants: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    multivariate: {
+                        variants: [
+                            { key: 'control', rollout_percentage: 25 },
+                            { key: 'variant-1', rollout_percentage: 25 },
+                            { key: 'variant-2', rollout_percentage: 25 },
+                            { key: 'variant-3', rollout_percentage: 25 },
+                        ],
+                    },
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithMultipleVariants}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('control')).toBeInTheDocument()
+            expect(screen.getByText('variant-1')).toBeInTheDocument()
+            expect(screen.getByText('variant-2')).toBeInTheDocument()
+            expect(screen.getByText('variant-3')).toBeInTheDocument()
+        })
+
+        it('handles empty variants array gracefully', () => {
+            const flagWithoutVariants: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    multivariate: undefined,
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithoutVariants}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.queryByText('control')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('targeting summary', () => {
+        it('renders targeting section', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('Targeting')).toBeInTheDocument()
+        })
+
+        it('shows "All users" for groups with no properties', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('100% of all users')).toBeInTheDocument()
+        })
+
+        it('shows rollout percentage for groups', () => {
+            const flagWithRollout: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        {
+                            properties: [],
+                            rollout_percentage: 50,
+                        },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithRollout}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('50% of all users')).toBeInTheDocument()
+        })
+
+        it('shows property conditions count', () => {
+            const flagWithProperties: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        {
+                            properties: [
+                                { key: 'email', value: 'test@example.com', type: 'person', operator: 'exact' },
+                                { key: 'country', value: 'US', type: 'person', operator: 'exact' },
+                            ] as any,
+                            rollout_percentage: 100,
+                        },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithProperties}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('100% of users matching 2 conditions')).toBeInTheDocument()
+        })
+
+        it('shows singular "condition" for one property', () => {
+            const flagWithOneProperty: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        {
+                            properties: [
+                                { key: 'email', value: 'test@example.com', type: 'person', operator: 'exact' },
+                            ] as any,
+                            rollout_percentage: 100,
+                        },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithOneProperty}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('100% of users matching 1 condition')).toBeInTheDocument()
+        })
+
+        it('shows variant targeting when specified', () => {
+            const flagWithVariantTargeting: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        {
+                            properties: [],
+                            rollout_percentage: 100,
+                            variant: 'test',
+                        },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithVariantTargeting}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText(/all users → variant "test"/)).toBeInTheDocument()
+        })
+
+        it('shows "All users" when groups is empty', () => {
+            const flagWithEmptyGroups: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithEmptyGroups}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('All users')).toBeInTheDocument()
+        })
+
+        it('handles simple flag with rollout percentage', () => {
+            const simpleFlag: FeatureFlagType = {
+                ...baseFeatureFlag,
+                is_simple_flag: true,
+                rollout_percentage: 75,
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={simpleFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('75% of all users')).toBeInTheDocument()
+        })
+    })
+
+    describe('targeting summary expansion', () => {
+        it('shows first 2 conditions when there are more than 2', () => {
+            const flagWithManyGroups: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        { properties: [], rollout_percentage: 25 },
+                        { properties: [], rollout_percentage: 50 },
+                        { properties: [], rollout_percentage: 75 },
+                        { properties: [], rollout_percentage: 100 },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithManyGroups}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('25% of all users')).toBeInTheDocument()
+            expect(screen.getByText('50% of all users')).toBeInTheDocument()
+            expect(screen.getByText('+2 more conditions')).toBeInTheDocument()
+        })
+
+        it('shows "+1 more condition" when there are exactly 3 conditions', () => {
+            const flagWithThreeGroups: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        { properties: [], rollout_percentage: 33 },
+                        { properties: [], rollout_percentage: 33 },
+                        { properties: [], rollout_percentage: 34 },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithThreeGroups}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('+1 more condition')).toBeInTheDocument()
+        })
+
+        it('expands to show all conditions when expand button is clicked', async () => {
+            const flagWithManyGroups: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        { properties: [], rollout_percentage: 25 },
+                        { properties: [], rollout_percentage: 50 },
+                        { properties: [], rollout_percentage: 75 },
+                        { properties: [], rollout_percentage: 100 },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithManyGroups}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const expandButton = screen.getByText('+2 more conditions')
+            await userEvent.click(expandButton)
+
+            expect(screen.getByText('25% of all users')).toBeInTheDocument()
+            expect(screen.getByText('50% of all users')).toBeInTheDocument()
+            expect(screen.getByText('75% of all users')).toBeInTheDocument()
+            expect(screen.getByText('100% of all users')).toBeInTheDocument()
+            expect(screen.getByText('Show less')).toBeInTheDocument()
+        })
+
+        it('collapses back when "Show less" is clicked', async () => {
+            const flagWithManyGroups: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        { properties: [], rollout_percentage: 25 },
+                        { properties: [], rollout_percentage: 50 },
+                        { properties: [], rollout_percentage: 75 },
+                        { properties: [], rollout_percentage: 100 },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithManyGroups}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            const expandButton = screen.getByText('+2 more conditions')
+            await userEvent.click(expandButton)
+
+            const collapseButton = screen.getByText('Show less')
+            await userEvent.click(collapseButton)
+
+            expect(screen.queryByText('75% of all users')).not.toBeInTheDocument()
+            expect(screen.queryByText('100% of all users')).not.toBeInTheDocument()
+            expect(screen.getByText('+2 more conditions')).toBeInTheDocument()
+        })
+
+        it('does not show expand/collapse when there are 2 or fewer conditions', () => {
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={baseFeatureFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.queryByText(/more condition/)).not.toBeInTheDocument()
+            expect(screen.queryByText('Show less')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('complex targeting scenarios', () => {
+        it('shows combined rollout and property conditions', () => {
+            const complexFlag: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        {
+                            properties: [
+                                { key: 'email', value: 'test@example.com', type: 'person', operator: 'exact' },
+                            ] as any,
+                            rollout_percentage: 50,
+                        },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={complexFlag}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('50% of users matching 1 condition')).toBeInTheDocument()
+        })
+
+        it('handles null rollout percentage as no rollout', () => {
+            const flagWithNullRollout: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        {
+                            properties: [],
+                            rollout_percentage: null,
+                        },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithNullRollout}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('all users')).toBeInTheDocument()
+        })
+
+        it('handles undefined rollout percentage as no rollout', () => {
+            const flagWithUndefinedRollout: FeatureFlagType = {
+                ...baseFeatureFlag,
+                filters: {
+                    ...baseFeatureFlag.filters,
+                    groups: [
+                        {
+                            properties: [],
+                            rollout_percentage: undefined,
+                        },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanelLinkFeatureFlag
+                    linkedFeatureFlag={flagWithUndefinedRollout}
+                    setShowFeatureFlagSelector={mockSetShowFeatureFlagSelector}
+                />
+            )
+
+            expect(screen.getByText('all users')).toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
@@ -1,6 +1,7 @@
 import { IconToggle } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
@@ -17,48 +18,49 @@ export const VariantsPanelLinkFeatureFlag = ({
     setShowFeatureFlagSelector,
 }: VariantsPanelLinkFeatureFlagProps): JSX.Element => {
     return (
-        <div className="max-w-2xl">
+        <div>
             <label className="text-sm font-semibold">Selected Feature Flag</label>
             {!linkedFeatureFlag ? (
-                <div className="mt-2 p-4 border border-dashed rounded bg-surface-light">
-                    <div className="text-center">
-                        <div className="text-sm text-muted mb-2">No feature flag selected</div>
-                        <LemonButton type="primary" onClick={() => setShowFeatureFlagSelector(true)}>
-                            Select Feature Flag
-                        </LemonButton>
+                <div className="mt-2 p-8 border border-dashed rounded-lg bg-bg-light flex flex-col items-center gap-3">
+                    <div className="flex items-center gap-2">
+                        <IconToggle className="text-muted text-2xl" />
+                        <div className="text-base font-semibold">No feature flag selected</div>
                     </div>
+                    <div className="text-sm text-muted-alt text-center">
+                        Select an existing multivariate feature flag to use with this experiment
+                    </div>
+                    <LemonButton type="primary" size="small" onClick={() => setShowFeatureFlagSelector(true)}>
+                        Select Feature Flag
+                    </LemonButton>
                 </div>
             ) : (
-                <div className="mt-2 border-2 border-primary-light rounded-lg bg-primary-highlight p-4">
-                    <div className="flex justify-between items-start gap-4">
-                        <div className="flex-1">
+                <div className="mt-2 border border-border rounded-lg bg-bg-light shadow-sm p-6">
+                    <div className="flex justify-between items-start gap-6">
+                        <div className="flex-1 space-y-3">
                             <div className="flex items-center gap-2">
-                                <IconToggle className="text-primary" />
-                                <div className="font-semibold text-base">{linkedFeatureFlag.key}</div>
+                                <IconToggle className="text-lg" />
+                                <div className="font-bold text-lg">{linkedFeatureFlag.key}</div>
                                 <Link
                                     to={urls.featureFlag(linkedFeatureFlag.id as number)}
                                     target="_blank"
-                                    className="flex items-center text-primary hover:text-primary-dark"
+                                    className="flex items-center hover:text-link"
                                 >
-                                    <IconOpenInNew className="text-lg" />
+                                    <IconOpenInNew />
                                 </Link>
                             </div>
                             {linkedFeatureFlag.name && (
-                                <div className="text-muted-alt mt-1">{linkedFeatureFlag.name}</div>
+                                <div className="text-sm text-muted-alt">{linkedFeatureFlag.name}</div>
                             )}
-                            <div className="mt-3 flex items-center gap-4">
-                                <div className="flex items-center gap-2">
-                                    <span className="text-xs font-medium text-muted">VARIANTS:</span>
-                                    <div className="flex gap-1">
-                                        {linkedFeatureFlag.filters?.multivariate?.variants?.map(({ key }) => (
-                                            <span
-                                                key={key}
-                                                className="inline-flex items-center px-2 py-0.5 rounded-md bg-bg-light text-xs font-medium"
-                                            >
-                                                {key}
-                                            </span>
-                                        )) || []}
-                                    </div>
+                            <div className="flex items-center gap-3">
+                                <span className="text-2xs uppercase tracking-wide font-semibold text-muted">
+                                    Variants
+                                </span>
+                                <div className="flex flex-wrap gap-1">
+                                    {linkedFeatureFlag.filters?.multivariate?.variants?.map(({ key }) => (
+                                        <LemonTag key={key} type="default">
+                                            {key}
+                                        </LemonTag>
+                                    )) || []}
                                 </div>
                             </div>
                         </div>

--- a/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react'
+import { P, match } from 'ts-pattern'
+
 import { IconToggle } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -10,17 +13,71 @@ import type { FeatureFlagType } from '~/types'
 
 interface VariantsPanelLinkFeatureFlagProps {
     linkedFeatureFlag: FeatureFlagType | null
-    setShowFeatureFlagSelector: (show: boolean) => void
+    setShowFeatureFlagSelector: () => void
+}
+
+function getTargetingSummary(flag: FeatureFlagType): string[] {
+    return match(flag)
+        .with({ is_simple_flag: true, rollout_percentage: P.not(P.nullish) }, (f) => [
+            `${f.rollout_percentage}% of all users`,
+        ])
+        .with({ filters: { groups: P.when((g) => !g || g.length === 0) } }, () => ['All users'])
+        .otherwise((f) =>
+            f.filters.groups.map((group) => {
+                const rollout = group.rollout_percentage != null ? `${group.rollout_percentage}% of ` : ''
+                const users = group.properties?.length
+                    ? `users matching ${group.properties.length} ${group.properties.length === 1 ? 'condition' : 'conditions'}`
+                    : 'all users'
+                const variant = group.variant ? ` → variant "${group.variant}"` : ''
+
+                return `${rollout}${users}${variant}`
+            })
+        )
+}
+
+function TargetingSummary({ flag }: { flag: FeatureFlagType }): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+    const conditions = getTargetingSummary(flag)
+    const hasMultipleConditions = conditions.length > 2
+
+    const displayConditions = expanded ? conditions : conditions.slice(0, 2)
+
+    return (
+        <div className="space-y-2">
+            <div className="text-xs uppercase tracking-wide font-semibold text-muted">Targeting</div>
+            <ul className="list-disc pl-4 text-sm space-y-1">
+                {displayConditions.map((condition, index) => (
+                    <li key={index}>{condition}</li>
+                ))}
+            </ul>
+            {hasMultipleConditions && !expanded && (
+                <button
+                    onClick={() => setExpanded(true)}
+                    className="text-sm text-link hover:underline cursor-pointer pl-4"
+                >
+                    +{conditions.length - 2} more {conditions.length - 2 === 1 ? 'condition' : 'conditions'}
+                </button>
+            )}
+            {expanded && hasMultipleConditions && (
+                <button
+                    onClick={() => setExpanded(false)}
+                    className="text-sm text-link hover:underline cursor-pointer pl-4"
+                >
+                    Show less
+                </button>
+            )}
+        </div>
+    )
 }
 
 export const VariantsPanelLinkFeatureFlag = ({
     linkedFeatureFlag,
     setShowFeatureFlagSelector,
 }: VariantsPanelLinkFeatureFlagProps): JSX.Element => {
-    return (
-        <div>
-            <label className="text-sm font-semibold">Selected Feature Flag</label>
-            {!linkedFeatureFlag ? (
+    if (!linkedFeatureFlag) {
+        return (
+            <div>
+                <label className="text-sm font-semibold">Selected Feature Flag</label>
                 <div className="mt-2 p-8 border border-dashed rounded-lg bg-bg-light flex flex-col items-center gap-3">
                     <div className="flex items-center gap-2">
                         <IconToggle className="text-muted text-2xl" />
@@ -29,47 +86,66 @@ export const VariantsPanelLinkFeatureFlag = ({
                     <div className="text-sm text-muted-alt text-center">
                         Select an existing multivariate feature flag to use with this experiment
                     </div>
-                    <LemonButton type="primary" size="small" onClick={() => setShowFeatureFlagSelector(true)}>
+                    <LemonButton type="primary" size="small" onClick={setShowFeatureFlagSelector}>
                         Select Feature Flag
                     </LemonButton>
                 </div>
-            ) : (
-                <div className="mt-2 border border-border rounded-lg bg-bg-light shadow-sm p-6">
-                    <div className="flex justify-between items-start gap-6">
-                        <div className="flex-1 space-y-3">
-                            <div className="flex items-center gap-2">
-                                <IconToggle className="text-lg" />
-                                <div className="font-bold text-lg">{linkedFeatureFlag.key}</div>
-                                <Link
-                                    to={urls.featureFlag(linkedFeatureFlag.id as number)}
-                                    target="_blank"
-                                    className="flex items-center hover:text-link"
-                                >
-                                    <IconOpenInNew />
-                                </Link>
-                            </div>
-                            {linkedFeatureFlag.name && (
-                                <div className="text-sm text-muted-alt">{linkedFeatureFlag.name}</div>
-                            )}
-                            <div className="flex items-center gap-3">
-                                <span className="text-2xs uppercase tracking-wide font-semibold text-muted">
-                                    Variants
-                                </span>
-                                <div className="flex flex-wrap gap-1">
-                                    {linkedFeatureFlag.filters?.multivariate?.variants?.map(({ key }) => (
-                                        <LemonTag key={key} type="default">
-                                            {key}
-                                        </LemonTag>
-                                    )) || []}
-                                </div>
-                            </div>
-                        </div>
-                        <LemonButton type="secondary" size="small" onClick={() => setShowFeatureFlagSelector(true)}>
-                            Change
-                        </LemonButton>
+            </div>
+        )
+    }
+
+    const variants = linkedFeatureFlag.filters?.multivariate?.variants || []
+
+    return (
+        <div>
+            <label className="text-sm font-semibold">Linked Feature Flag</label>
+            <div className="mt-2 border rounded-lg bg-bg-light p-4 space-y-2">
+                {/* Header: Flag key + link + change button */}
+                <div className="flex flex-row gap-4">
+                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                        <IconToggle className="text-lg flex-shrink-0" />
+                        <div className="font-semibold text-base truncate">{linkedFeatureFlag.key}</div>
+                        <Link
+                            to={urls.featureFlag(linkedFeatureFlag.id as number)}
+                            target="_blank"
+                            className="flex items-center hover:text-link flex-shrink-0"
+                            title="View feature flag"
+                        >
+                            <IconOpenInNew />
+                        </Link>
+                    </div>
+                    <LemonButton type="secondary" size="small" onClick={setShowFeatureFlagSelector}>
+                        Change
+                    </LemonButton>
+                </div>
+
+                {/* Status */}
+                <div className="flex items-center gap-2">
+                    <div
+                        className={`w-2 h-2 rounded-full ${linkedFeatureFlag.active ? 'bg-success' : 'bg-muted'}`}
+                        title={linkedFeatureFlag.active ? 'Active' : 'Inactive'}
+                    />
+                    <span className="text-sm font-medium">{linkedFeatureFlag.active ? 'Active' : 'Inactive'}</span>
+                </div>
+
+                {/* Description */}
+                {linkedFeatureFlag.name && <div className="text-sm text-muted-alt">{linkedFeatureFlag.name}</div>}
+
+                {/* Variants */}
+                <div className="space-y-2">
+                    <div className="text-xs uppercase tracking-wide font-semibold text-muted">Variants</div>
+                    <div className="flex flex-wrap gap-1.5">
+                        {variants.map(({ key }) => (
+                            <LemonTag key={key} type={key === 'control' ? 'primary' : 'default'}>
+                                {key}
+                            </LemonTag>
+                        ))}
                     </div>
                 </div>
-            )}
+
+                {/* Targeting */}
+                <TargetingSummary flag={linkedFeatureFlag} />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
@@ -16,7 +16,7 @@ interface VariantsPanelLinkFeatureFlagProps {
     setShowFeatureFlagSelector: () => void
 }
 
-function getTargetingSummary(flag: FeatureFlagType): string[] {
+const getTargetingSummary = (flag: FeatureFlagType): string[] => {
     return match(flag)
         .with({ is_simple_flag: true, rollout_percentage: P.not(P.nullish) }, (f) => [
             `${f.rollout_percentage}% of all users`,
@@ -35,7 +35,7 @@ function getTargetingSummary(flag: FeatureFlagType): string[] {
         )
 }
 
-function TargetingSummary({ flag }: { flag: FeatureFlagType }): JSX.Element {
+const TargetingSummary = ({ flag }: { flag: FeatureFlagType }): JSX.Element => {
     const [expanded, setExpanded] = useState(false)
     const conditions = getTargetingSummary(flag)
     const hasMultipleConditions = conditions.length > 2

--- a/frontend/src/scenes/experiments/create/selectExistingFeatureFlagModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/selectExistingFeatureFlagModalLogic.test.ts
@@ -1,0 +1,504 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, FeatureFlagEvaluationRuntime, FeatureFlagType } from '~/types'
+
+import { FeatureFlagModalFilters, selectExistingFeatureFlagModalLogic } from './selectExistingFeatureFlagModalLogic'
+
+describe('selectExistingFeatureFlagModalLogic', () => {
+    let logic: ReturnType<typeof selectExistingFeatureFlagModalLogic.build>
+
+    const mockFeatureFlags: FeatureFlagType[] = [
+        {
+            id: 1,
+            key: 'test-flag-1',
+            name: 'Test Flag 1',
+            filters: {
+                groups: [],
+                payloads: {},
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: 'test', rollout_percentage: 50 },
+                    ],
+                },
+            },
+            created_at: '2021-01-01',
+            updated_at: '2021-01-01',
+            created_by: null,
+            is_simple_flag: false,
+            is_remote_configuration: false,
+            deleted: false,
+            active: true,
+            rollout_percentage: null,
+            experiment_set: null,
+            features: null,
+            surveys: null,
+            rollback_conditions: [],
+            performed_rollback: false,
+            can_edit: true,
+            tags: [],
+            ensure_experience_continuity: null,
+            user_access_level: AccessControlLevel.Admin,
+            status: 'ACTIVE',
+            has_encrypted_payloads: false,
+            version: 0,
+            last_modified_by: null,
+            evaluation_runtime: FeatureFlagEvaluationRuntime.ALL,
+            evaluation_tags: [],
+        },
+        {
+            id: 2,
+            key: 'test-flag-2',
+            name: 'Test Flag 2',
+            filters: {
+                groups: [],
+                payloads: {},
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 33 },
+                        { key: 'variant-1', rollout_percentage: 33 },
+                        { key: 'variant-2', rollout_percentage: 34 },
+                    ],
+                },
+            },
+            created_at: '2021-01-02',
+            updated_at: '2021-01-02',
+            created_by: null,
+            is_simple_flag: false,
+            is_remote_configuration: false,
+            deleted: false,
+            active: true,
+            rollout_percentage: null,
+            experiment_set: null,
+            features: null,
+            surveys: null,
+            rollback_conditions: [],
+            performed_rollback: false,
+            can_edit: true,
+            tags: [],
+            ensure_experience_continuity: null,
+            user_access_level: AccessControlLevel.Admin,
+            status: 'ACTIVE',
+            has_encrypted_payloads: false,
+            version: 0,
+            last_modified_by: null,
+            evaluation_runtime: FeatureFlagEvaluationRuntime.ALL,
+            evaluation_tags: [],
+        },
+    ]
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/@current/feature_flags/': (req) => {
+                    const url = new URL(req.url, 'http://localhost')
+                    const search = url.searchParams.get('search')
+
+                    const filteredFlags = search
+                        ? mockFeatureFlags.filter((flag) => flag.key.toLowerCase().includes(search.toLowerCase()))
+                        : mockFeatureFlags
+
+                    return [
+                        200,
+                        {
+                            results: filteredFlags,
+                            count: filteredFlags.length,
+                        },
+                    ]
+                },
+            },
+        })
+        initKeaTests()
+        logic = selectExistingFeatureFlagModalLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('modal state', () => {
+        it('starts with modal closed', async () => {
+            await expectLogic(logic).toMatchValues({
+                isModalOpen: false,
+            })
+        })
+
+        it('opens modal when openSelectExistingFeatureFlagModal is called', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSelectExistingFeatureFlagModal()
+            })
+                .toDispatchActions(['openSelectExistingFeatureFlagModal'])
+                .toMatchValues({
+                    isModalOpen: true,
+                })
+        })
+
+        it('closes modal when closeSelectExistingFeatureFlagModal is called', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSelectExistingFeatureFlagModal()
+                logic.actions.closeSelectExistingFeatureFlagModal()
+            })
+                .toDispatchActions(['openSelectExistingFeatureFlagModal', 'closeSelectExistingFeatureFlagModal'])
+                .toMatchValues({
+                    isModalOpen: false,
+                })
+        })
+
+        it('loads feature flags when modal is opened', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSelectExistingFeatureFlagModal()
+            }).toDispatchActions(['openSelectExistingFeatureFlagModal', 'loadFeatureFlags', 'loadFeatureFlagsSuccess'])
+        })
+    })
+
+    describe('filters management', () => {
+        it('starts with default filters', async () => {
+            await expectLogic(logic).toMatchValues({
+                filters: {
+                    active: undefined,
+                    created_by_id: undefined,
+                    search: undefined,
+                    order: undefined,
+                    page: 1,
+                    evaluation_runtime: undefined,
+                },
+            })
+        })
+
+        it('merges filters when setFilters is called without replace', async () => {
+            const newFilters: Partial<FeatureFlagModalFilters> = {
+                search: 'test',
+                page: 2,
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters(newFilters)
+            })
+                .toDispatchActions(['setFilters'])
+                .toMatchValues({
+                    filters: {
+                        active: undefined,
+                        created_by_id: undefined,
+                        search: 'test',
+                        order: undefined,
+                        page: 2,
+                        evaluation_runtime: undefined,
+                    },
+                })
+        })
+
+        it('replaces filters when setFilters is called with replace=true', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ search: 'first', page: 3 })
+                logic.actions.setFilters({ page: 1 }, true)
+            })
+                .toDispatchActions(['setFilters', 'setFilters'])
+                .toMatchValues({
+                    filters: {
+                        active: undefined,
+                        created_by_id: undefined,
+                        search: undefined,
+                        order: undefined,
+                        page: 1,
+                        evaluation_runtime: undefined,
+                    },
+                })
+        })
+
+        it('resets filters to default when resetFilters is called', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ search: 'test', page: 5, active: 'true' })
+                logic.actions.resetFilters()
+            })
+                .toDispatchActions(['setFilters', 'resetFilters'])
+                .toMatchValues({
+                    filters: {
+                        active: undefined,
+                        created_by_id: undefined,
+                        search: undefined,
+                        order: undefined,
+                        page: 1,
+                        evaluation_runtime: undefined,
+                    },
+                })
+        })
+
+        it('loads feature flags after filter reset', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.resetFilters()
+            }).toDispatchActions(['resetFilters', 'loadFeatureFlags'])
+        })
+
+        it('debounces and loads feature flags after setFilters', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ search: 'test' })
+            })
+                .delay(350)
+                .toDispatchActions(['setFilters', 'loadFeatureFlags'])
+        })
+    })
+
+    describe('feature flags loading', () => {
+        it('loads feature flags successfully', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadFeatureFlags()
+            })
+                .toDispatchActions(['loadFeatureFlags', 'loadFeatureFlagsSuccess'])
+                .toMatchValues({
+                    featureFlags: {
+                        results: mockFeatureFlags,
+                        count: mockFeatureFlags.length,
+                    },
+                })
+        })
+
+        it('filters feature flags by search term', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ search: 'flag-1' })
+            })
+                .delay(350)
+                .toDispatchActions(['setFilters', 'loadFeatureFlags', 'loadFeatureFlagsSuccess'])
+                .toMatchValues({
+                    featureFlags: {
+                        results: [mockFeatureFlags[0]],
+                        count: 1,
+                    },
+                })
+        })
+    })
+
+    describe('pagination', () => {
+        it('calculates pagination correctly when no results', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [
+                        200,
+                        {
+                            results: [],
+                            count: 0,
+                        },
+                    ],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadFeatureFlags()
+            })
+                .toDispatchActions(['loadFeatureFlagsSuccess'])
+                .toMatchValues({
+                    pagination: {
+                        controlled: true,
+                        pageSize: 100,
+                        currentPage: 1,
+                        entryCount: 0,
+                        onForward: undefined,
+                        onBackward: undefined,
+                    },
+                })
+        })
+
+        it('disables forward/backward when only one page', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadFeatureFlags()
+            })
+                .toDispatchActions(['loadFeatureFlagsSuccess'])
+                .toMatchValues({
+                    pagination: {
+                        controlled: true,
+                        pageSize: 100,
+                        currentPage: 1,
+                        entryCount: 2,
+                        onForward: undefined,
+                        onBackward: undefined,
+                    },
+                })
+        })
+
+        it('enables forward button when there are more pages', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [
+                        200,
+                        {
+                            results: mockFeatureFlags,
+                            count: 125,
+                        },
+                    ],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadFeatureFlags()
+            })
+                .toDispatchActions(['loadFeatureFlagsSuccess'])
+                .toMatchValues({
+                    pagination: {
+                        controlled: true,
+                        pageSize: 100,
+                        currentPage: 1,
+                        entryCount: 125,
+                        onForward: expect.any(Function),
+                        onBackward: undefined,
+                    },
+                })
+        })
+
+        it('enables backward button when on page 2+', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [
+                        200,
+                        {
+                            results: mockFeatureFlags,
+                            count: 125,
+                        },
+                    ],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ page: 2 })
+            })
+                .delay(350)
+                .toMatchValues({
+                    pagination: {
+                        controlled: true,
+                        pageSize: 100,
+                        currentPage: 2,
+                        entryCount: 125,
+                        onForward: undefined,
+                        onBackward: expect.any(Function),
+                    },
+                })
+        })
+
+        it('updates page when onForward is called', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [
+                        200,
+                        {
+                            results: mockFeatureFlags,
+                            count: 125,
+                        },
+                    ],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadFeatureFlags()
+            }).toDispatchActions(['loadFeatureFlagsSuccess'])
+
+            const { pagination } = logic.values
+
+            await expectLogic(logic, () => {
+                pagination.onForward?.()
+            })
+                .delay(350)
+                .toMatchValues({
+                    filters: expect.objectContaining({
+                        page: 2,
+                    }),
+                })
+        })
+
+        it('updates page when onBackward is called', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [
+                        200,
+                        {
+                            results: mockFeatureFlags,
+                            count: 125,
+                        },
+                    ],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ page: 3 })
+            })
+                .delay(350)
+                .toDispatchActions(['loadFeatureFlagsSuccess'])
+
+            const { pagination } = logic.values
+
+            await expectLogic(logic, () => {
+                pagination.onBackward?.()
+            })
+                .delay(350)
+                .toMatchValues({
+                    filters: expect.objectContaining({
+                        page: 2,
+                    }),
+                })
+        })
+
+        it('never goes below page 1 when onBackward is called', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [
+                        200,
+                        {
+                            results: mockFeatureFlags,
+                            count: 125,
+                        },
+                    ],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ page: 1 })
+            })
+                .delay(350)
+                .toDispatchActions(['loadFeatureFlagsSuccess'])
+
+            const { pagination } = logic.values
+            expect(pagination.onBackward).toBeUndefined()
+        })
+    })
+
+    describe('paramsFromFilters selector', () => {
+        it('converts filters to API params with limit and offset', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({
+                    search: 'test',
+                    active: 'true',
+                    page: 2,
+                })
+            }).toMatchValues({
+                paramsFromFilters: {
+                    search: 'test',
+                    active: 'true',
+                    page: 2,
+                    limit: 100,
+                    offset: 100,
+                    created_by_id: undefined,
+                    order: undefined,
+                    evaluation_runtime: undefined,
+                },
+            })
+        })
+
+        it('calculates correct offset for different pages', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ page: 1 })
+            }).toMatchValues({
+                paramsFromFilters: expect.objectContaining({
+                    offset: 0,
+                }),
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ page: 3 })
+            }).toMatchValues({
+                paramsFromFilters: expect.objectContaining({
+                    offset: 200,
+                }),
+            })
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/create/selectExistingFeatureFlagModalLogic.ts
+++ b/frontend/src/scenes/experiments/create/selectExistingFeatureFlagModalLogic.ts
@@ -1,0 +1,131 @@
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { PaginationManual } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { toParams } from 'lib/utils'
+import { FLAGS_PER_PAGE } from 'scenes/feature-flags/featureFlagsLogic'
+
+import { FeatureFlagType } from '~/types'
+
+import type { selectExistingFeatureFlagModalLogicType } from './selectExistingFeatureFlagModalLogicType'
+
+export interface FeatureFlagModalFilters {
+    active?: string
+    created_by_id?: number
+    search?: string
+    order?: string
+    page?: number
+    evaluation_runtime?: string
+}
+
+const DEFAULT_FILTERS: FeatureFlagModalFilters = {
+    active: undefined,
+    created_by_id: undefined,
+    search: undefined,
+    order: undefined,
+    page: 1,
+    evaluation_runtime: undefined,
+}
+
+export const selectExistingFeatureFlagModalLogic = kea<selectExistingFeatureFlagModalLogicType>([
+    path(['scenes', 'experiments', 'create', 'selectExistingFeatureFlagModalLogic']),
+
+    actions({
+        openSelectExistingFeatureFlagModal: true,
+        closeSelectExistingFeatureFlagModal: true,
+        setFilters: (filters: Partial<FeatureFlagModalFilters>, replace?: boolean) => ({ filters, replace }),
+        resetFilters: true,
+    }),
+
+    reducers({
+        isModalOpen: [
+            false,
+            {
+                openSelectExistingFeatureFlagModal: () => true,
+                closeSelectExistingFeatureFlagModal: () => false,
+            },
+        ],
+        filters: [
+            DEFAULT_FILTERS,
+            {
+                setFilters: (state, { filters, replace }) => {
+                    if (replace) {
+                        return { ...DEFAULT_FILTERS, ...filters }
+                    }
+                    return { ...state, ...filters }
+                },
+                resetFilters: () => DEFAULT_FILTERS,
+            },
+        ],
+    }),
+
+    listeners(({ actions }) => ({
+        setFilters: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadFeatureFlags()
+        },
+        resetFilters: () => {
+            actions.loadFeatureFlags()
+        },
+        openSelectExistingFeatureFlagModal: () => {
+            actions.loadFeatureFlags()
+        },
+    })),
+
+    loaders(({ values }) => ({
+        featureFlags: [
+            { results: [], count: 0 } as { results: FeatureFlagType[]; count: number },
+            {
+                loadFeatureFlags: async () => {
+                    const response = await api.get(
+                        `api/projects/@current/feature_flags/?${toParams(values.paramsFromFilters)}`
+                    )
+                    return response
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        paramsFromFilters: [
+            (s) => [s.filters],
+            (filters: FeatureFlagModalFilters) => ({
+                ...filters,
+                limit: FLAGS_PER_PAGE,
+                offset: filters.page ? (filters.page - 1) * FLAGS_PER_PAGE : 0,
+            }),
+        ],
+        pagination: [
+            (s) => [s.filters, s.featureFlags],
+            (filters, featureFlags): PaginationManual => {
+                const currentPage = filters.page || 1
+                const hasNextPage = featureFlags.count > currentPage * FLAGS_PER_PAGE
+                const hasPreviousPage = currentPage > 1
+                const needsPagination = featureFlags.count > FLAGS_PER_PAGE
+
+                return {
+                    controlled: true,
+                    pageSize: FLAGS_PER_PAGE,
+                    currentPage,
+                    entryCount: featureFlags.count,
+                    onForward:
+                        needsPagination && hasNextPage
+                            ? () => {
+                                  selectExistingFeatureFlagModalLogic.actions.setFilters({ page: currentPage + 1 })
+                              }
+                            : undefined,
+                    onBackward:
+                        needsPagination && hasPreviousPage
+                            ? () => {
+                                  selectExistingFeatureFlagModalLogic.actions.setFilters({
+                                      page: Math.max(1, currentPage - 1),
+                                  })
+                              }
+                            : undefined,
+                }
+            },
+        ],
+    }),
+])


### PR DESCRIPTION
## Problem

On the new create experiment form, it's not possible to link to an existing feature flag.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've extracted the select feature flag modal into its own component and updated the variants panel to manage state and use the correct modal dialog.

| Select feature Flag | Linked feature flag details |
| - | - |
| <img width="933" height="437" alt="image" src="https://github.com/user-attachments/assets/6d0aa9dd-526b-4724-b69f-311847140df8" /> | <img width="933" height="500" alt="image" src="https://github.com/user-attachments/assets/88a39dd6-0796-47b8-a8b9-67543f3b1649" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/selectExistingFeatureFlagModalLogic.test.ts
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/SelectExistingFeatureFlagModal.test.tsx
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.test.tsx
```

![cat-type-small](https://github.com/user-attachments/assets/c31c6348-18b4-4ee6-ae22-f8a1849b1864)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
