### PR TITLE
feat(experiments): adding targeting panel to create experiment.

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -18,6 +18,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { MetricsReorderModal } from '../MetricsView/MetricsReorderModal'
+import { TargetingPanel } from './TargetingPanel'
 import { VariantsPanel } from './VariantsPanel'
 import { createExperimentLogic } from './createExperimentLogic'
 import { ExperimentTypePanel } from './panels/ExperimentTypePanel'
@@ -120,7 +121,24 @@ export const CreateExperiment = (): JSX.Element => {
                                 header: 'Targeting',
                                 content: (
                                     <div className="p-4">
-                                        <span>Targeting Panel Goes Here</span>
+                                        <TargetingPanel
+                                            id={experiment.id?.toString() || 'new'}
+                                            filters={
+                                                experiment.feature_flag_filters || {
+                                                    groups: [
+                                                        {
+                                                            properties: [],
+                                                            rollout_percentage: 100,
+                                                            variant: null,
+                                                        },
+                                                    ],
+                                                    aggregation_group_type_index: null,
+                                                }
+                                            }
+                                            onChange={(filters: any) => {
+                                                setExperimentValue('feature_flag_filters', filters)
+                                            }}
+                                        />
                                     </div>
                                 ),
                             },

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -15,6 +15,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { FeatureFlagFilters } from '~/types'
 
 import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { MetricsReorderModal } from '../MetricsView/MetricsReorderModal'
@@ -135,7 +136,7 @@ export const CreateExperiment = (): JSX.Element => {
                                                     aggregation_group_type_index: null,
                                                 }
                                             }
-                                            onChange={(filters: any) => {
+                                            onChange={(filters: FeatureFlagFilters) => {
                                                 setExperimentValue('feature_flag_filters', filters)
                                             }}
                                         />

--- a/frontend/src/scenes/experiments/create/TargetingPanel.tsx
+++ b/frontend/src/scenes/experiments/create/TargetingPanel.tsx
@@ -1,0 +1,309 @@
+import { useActions, useValues } from 'kea'
+
+import { IconCopy, IconPlus, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonDivider, LemonInput, LemonSelect, LemonSnack } from '@posthog/lemon-ui'
+
+import { EditableField } from 'lib/components/EditableField/EditableField'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { INSTANTLY_AVAILABLE_PROPERTIES } from 'lib/constants'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { IconArrowDown, IconArrowUp, IconSubArrowRight } from 'lib/lemon-ui/icons'
+import { capitalizeFirstLetter, humanFriendlyNumber } from 'lib/utils'
+
+import { groupsModel } from '~/models/groupsModel'
+import { AnyPropertyFilter, FeatureFlagGroupType, PropertyFilterType } from '~/types'
+
+import { TargetingPanelLogicProps, targetingPanelLogic } from './targetingPanelLogic'
+
+export function TargetingPanel({ id, filters, onChange, readOnly = false }: TargetingPanelLogicProps): JSX.Element {
+    const logic = targetingPanelLogic({ id, filters, onChange, readOnly })
+    const {
+        filters: currentFilters,
+        taxonomicGroupTypes,
+        affectedUsers,
+        totalUsers,
+        aggregationTargetName,
+    } = useValues(logic)
+
+    const {
+        setAggregationGroupTypeIndex,
+        updateConditionSet,
+        duplicateConditionSet,
+        removeConditionSet,
+        addConditionSet,
+        moveConditionSetUp,
+        moveConditionSetDown,
+    } = useActions(logic)
+
+    const { showGroupsOptions, groupTypes, aggregationLabel } = useValues(groupsModel)
+    const { computeBlastRadiusPercentage } = useValues(logic)
+
+    const filterGroups: FeatureFlagGroupType[] = currentFilters?.groups || []
+
+    const hasNonInstantProperty = (properties: AnyPropertyFilter[]): boolean => {
+        return !!properties.find(
+            (property) =>
+                property.type === PropertyFilterType.Cohort ||
+                !INSTANTLY_AVAILABLE_PROPERTIES.includes(property.key || '')
+        )
+    }
+
+    const renderReleaseConditionGroup = (group: FeatureFlagGroupType, index: number): JSX.Element => {
+        return (
+            <div className="w-full" key={group.sort_key}>
+                {index > 0 && <div className="mb-2 ml-2 text-xs font-semibold text-primary-alt my-1 py-0">OR</div>}
+                <div className="border rounded p-4 bg-surface-primary">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center">
+                            <LemonSnack className="mr-2">Set {index + 1}</LemonSnack>
+                            <div>
+                                {group.properties?.length ? (
+                                    <>
+                                        {readOnly ? (
+                                            <>
+                                                Match <b>{aggregationTargetName}</b> against <b>all</b> criteria
+                                            </>
+                                        ) : (
+                                            <>
+                                                Matching <b>{aggregationTargetName}</b> against the criteria
+                                            </>
+                                        )}
+                                    </>
+                                ) : (
+                                    <>
+                                        Condition set will match <b>all {aggregationTargetName}</b>
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                        {!readOnly && (
+                            <div className="flex">
+                                {filterGroups.length > 1 && (
+                                    <div className="flex mr-2">
+                                        <LemonButton
+                                            icon={<IconArrowDown />}
+                                            noPadding
+                                            tooltip="Move condition set down in precedence"
+                                            disabledReason={
+                                                index === filterGroups.length - 1
+                                                    ? 'Cannot move last condition set down'
+                                                    : affectedUsers[index] === undefined ||
+                                                        affectedUsers[index + 1] === undefined
+                                                      ? 'Cannot move condition sets while calculating affected users'
+                                                      : null
+                                            }
+                                            onClick={() => moveConditionSetDown(index)}
+                                        />
+
+                                        <LemonButton
+                                            icon={<IconArrowUp />}
+                                            noPadding
+                                            tooltip="Move condition set up in precedence"
+                                            disabledReason={
+                                                index === 0
+                                                    ? 'Cannot move first condition set up'
+                                                    : affectedUsers[index] === undefined ||
+                                                        affectedUsers[index - 1] === undefined
+                                                      ? 'Cannot move condition sets while calculating affected users'
+                                                      : null
+                                            }
+                                            onClick={() => moveConditionSetUp(index)}
+                                        />
+                                    </div>
+                                )}
+                                <LemonButton
+                                    icon={<IconCopy />}
+                                    noPadding
+                                    tooltip="Duplicate condition set"
+                                    onClick={() => duplicateConditionSet(index)}
+                                />
+                                {filterGroups.length > 1 && (
+                                    <LemonButton
+                                        icon={<IconTrash />}
+                                        noPadding
+                                        tooltip="Remove condition set"
+                                        onClick={() => removeConditionSet(index)}
+                                    />
+                                )}
+                            </div>
+                        )}
+                    </div>
+                    {!readOnly && (
+                        <div className="mt-3 max-w-md">
+                            <EditableField
+                                multiline
+                                name="description"
+                                value={group.description || ''}
+                                placeholder="Description (optional)"
+                                onSave={(value) => updateConditionSet(index, undefined, undefined, value)}
+                                saveOnBlur={true}
+                                maxLength={600}
+                                data-attr={`condition-set-${index}-description`}
+                                compactButtons
+                            />
+                        </div>
+                    )}
+                    {readOnly && group.description && <div className="mt-2 text-muted">{group.description}</div>}
+                    <LemonDivider className="my-3" />
+                    {!readOnly && hasNonInstantProperty(group.properties || []) && (
+                        <LemonBanner type="info" className="mt-3 mb-3">
+                            These properties aren't immediately available on first page load for unidentified persons.
+                            This experiment requires that at least one event is sent prior to becoming available to your
+                            product or website.
+                        </LemonBanner>
+                    )}
+                    {readOnly ? (
+                        <>
+                            {group.properties?.map((property, idx) => (
+                                <div className="flex flex-row flex-wrap gap-2 items-center mt-2" key={idx}>
+                                    {idx === 0 ? (
+                                        <LemonButton icon={<IconSubArrowRight className="mt-1 -mr-2" />} size="small" />
+                                    ) : (
+                                        <LemonButton icon={<span className="text-sm">&</span>} size="small" />
+                                    )}
+                                    <LemonSnack>
+                                        {property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key}
+                                    </LemonSnack>
+                                </div>
+                            ))}
+                        </>
+                    ) : (
+                        <div>
+                            <PropertyFilters
+                                orFiltering={true}
+                                pageKey={`experiment-targeting-${id}-${group.sort_key}-${filterGroups.length}-${
+                                    currentFilters.aggregation_group_type_index ?? ''
+                                }`}
+                                propertyFilters={group?.properties}
+                                logicalRowDivider
+                                addText="Add condition"
+                                onChange={(properties) => updateConditionSet(index, undefined, properties)}
+                                taxonomicGroupTypes={taxonomicGroupTypes}
+                                hasRowOperator={false}
+                                sendAllKeyUpdates
+                                allowRelativeDateOptions
+                                exactMatchFeatureFlagCohortOperators={true}
+                                hideBehavioralCohorts={true}
+                            />
+                        </div>
+                    )}
+                    {(!readOnly || (readOnly && (group.properties?.length || 0) > 0)) && (
+                        <LemonDivider className="my-3" />
+                    )}
+                    {readOnly ? (
+                        <div className="text-sm">
+                            Rolled out to{' '}
+                            {group.rollout_percentage != null ? <b>{group.rollout_percentage}</b> : <b>100</b>}
+                            <b>%</b>
+                            <span> of </span>
+                            <b>{aggregationTargetName}</b> <span>in this set.</span>
+                        </div>
+                    ) : (
+                        <div className="flex flex-wrap items-center w-full gap-2">
+                            <div className="flex flex-wrap items-center gap-1">
+                                Roll out to{' '}
+                                <LemonSlider
+                                    value={group.rollout_percentage !== null ? group.rollout_percentage : 100}
+                                    onChange={(value) => {
+                                        updateConditionSet(index, value)
+                                    }}
+                                    min={0}
+                                    max={100}
+                                    step={1}
+                                    className="ml-1.5 w-20"
+                                />
+                                <LemonInput
+                                    data-attr="rollout-percentage"
+                                    type="number"
+                                    className="ml-2 mr-1.5 max-w-30"
+                                    onChange={(value: number | undefined): void => {
+                                        updateConditionSet(index, value === undefined ? 0 : value)
+                                    }}
+                                    value={group.rollout_percentage !== null ? group.rollout_percentage : 100}
+                                    min={0}
+                                    max={100}
+                                    step="any"
+                                    suffix={<span>%</span>}
+                                />
+                                of <b>{aggregationTargetName}</b> in this set. Will match approximately{' '}
+                                {affectedUsers[index] !== undefined ? (
+                                    <b>
+                                        {`${
+                                            (computeBlastRadiusPercentage(group.rollout_percentage, index).toPrecision(
+                                                2
+                                            ) as any) * 1
+                                        }% `}
+                                    </b>
+                                ) : (
+                                    <Spinner className="mr-1" />
+                                )}{' '}
+                                {(() => {
+                                    const affectedUserCount = affectedUsers[index]
+                                    if (
+                                        affectedUserCount !== undefined &&
+                                        affectedUserCount >= 0 &&
+                                        totalUsers !== null
+                                    ) {
+                                        return `(${humanFriendlyNumber(
+                                            Math.floor((affectedUserCount * (group.rollout_percentage ?? 100)) / 100)
+                                        )} / ${humanFriendlyNumber(totalUsers)})`
+                                    }
+                                    return ''
+                                })()}{' '}
+                                <span>of total {aggregationTargetName}.</span>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="text-secondary mb-2">
+                Specify {aggregationTargetName} for your experiment. Condition sets are evaluated top to bottom - the
+                first matching set is used. A condition matches when all property filters pass AND the target falls
+                within the rollout percentage.
+            </div>
+
+            {!readOnly && showGroupsOptions && (
+                <div className="flex items-center gap-2">
+                    Match by
+                    <LemonSelect
+                        dropdownMatchSelectWidth={false}
+                        data-attr="experiment-aggregation-filter"
+                        onChange={(value) => {
+                            const groupTypeIndex = value !== -1 ? value : null
+                            setAggregationGroupTypeIndex(groupTypeIndex)
+                        }}
+                        value={
+                            currentFilters.aggregation_group_type_index != null
+                                ? currentFilters.aggregation_group_type_index
+                                : -1
+                        }
+                        options={[
+                            { value: -1, label: 'Users' },
+                            ...Array.from(groupTypes.values()).map((groupType) => ({
+                                value: groupType.group_type_index,
+                                label: capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural),
+                            })),
+                        ]}
+                    />
+                </div>
+            )}
+            <div className="space-y-4">
+                {filterGroups.map((group, index) => (
+                    <div key={group.sort_key || index}>{renderReleaseConditionGroup(group, index)}</div>
+                ))}
+            </div>
+            {!readOnly && (
+                <LemonButton type="secondary" className="mt-0 w-max" onClick={addConditionSet} icon={<IconPlus />}>
+                    Add condition set
+                </LemonButton>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/TargetingPanel.tsx
+++ b/frontend/src/scenes/experiments/create/TargetingPanel.tsx
@@ -230,11 +230,9 @@ export function TargetingPanel({ id, filters, onChange, readOnly = false }: Targ
                                 of <b>{aggregationTargetName}</b> in this set. Will match approximately{' '}
                                 {affectedUsers[index] !== undefined ? (
                                     <b>
-                                        {`${
-                                            (computeBlastRadiusPercentage(group.rollout_percentage, index).toPrecision(
-                                                2
-                                            ) as any) * 1
-                                        }% `}
+                                        {`${Number(
+                                            computeBlastRadiusPercentage(group.rollout_percentage, index).toPrecision(2)
+                                        )}% `}
                                     </b>
                                 ) : (
                                     <Spinner className="mr-1" />

--- a/frontend/src/scenes/experiments/create/targetingPanelLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/targetingPanelLogic.test.ts
@@ -1,0 +1,575 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { FeatureFlagFilters, FeatureFlagGroupType, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { targetingPanelLogic } from './targetingPanelLogic'
+
+function generateFilters(groups: FeatureFlagGroupType[]): FeatureFlagFilters {
+    return { groups, aggregation_group_type_index: null }
+}
+
+describe('targetingPanelLogic', () => {
+    let logic: ReturnType<typeof targetingPanelLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = targetingPanelLogic({
+            id: 'test-experiment',
+            filters: generateFilters([
+                {
+                    properties: [],
+                    rollout_percentage: 100,
+                    variant: null,
+                },
+            ]),
+        })
+        logic.mount()
+
+        useMocks({
+            post: {
+                '/api/projects/:team/feature_flags/user_blast_radius': () => [
+                    200,
+                    { users_affected: 150, total_users: 3000 },
+                ],
+            },
+        })
+    })
+
+    describe('blast radius calculation', () => {
+        it('loads blast radius on mount', async () => {
+            logic?.unmount()
+
+            logic = targetingPanelLogic({
+                id: 'test-experiment',
+                filters: generateFilters([
+                    {
+                        properties: [
+                            {
+                                key: 'country',
+                                value: 'US',
+                                type: PropertyFilterType.Person,
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                        rollout_percentage: 100,
+                        variant: null,
+                    },
+                ]),
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            })
+                .toDispatchActions(['calculateBlastRadius', 'setAffectedUsers', 'setTotalUsers'])
+                .toMatchValues({
+                    affectedUsers: { 0: 150 },
+                    totalUsers: 3000,
+                })
+        })
+
+        it('loads blast radius for multiple condition sets', async () => {
+            logic?.unmount()
+
+            logic = targetingPanelLogic({
+                id: 'test-experiment',
+                filters: generateFilters([
+                    { properties: [], rollout_percentage: 100, variant: null },
+                    {
+                        properties: [
+                            {
+                                key: 'country',
+                                value: 'US',
+                                type: PropertyFilterType.Person,
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                        rollout_percentage: 50,
+                        variant: null,
+                    },
+                    {
+                        properties: [
+                            {
+                                key: 'plan',
+                                value: 'premium',
+                                type: PropertyFilterType.Person,
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                        rollout_percentage: 75,
+                        variant: null,
+                    },
+                ]),
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            })
+                .toDispatchActions(['calculateBlastRadius', 'setAffectedUsers', 'setAffectedUsers', 'setTotalUsers'])
+                .toMatchValues({
+                    totalUsers: 3000,
+                })
+
+            // First condition set should have affected users calculated
+            expect(logic.values.affectedUsers[0]).not.toBeUndefined()
+        })
+
+        it('updates blast radius when updating properties', async () => {
+            logic?.unmount()
+            logic = targetingPanelLogic({
+                id: 'test-experiment',
+                filters: generateFilters([
+                    {
+                        properties: [],
+                        rollout_percentage: 100,
+                        variant: null,
+                    },
+                ]),
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.updateConditionSet(0, undefined, [
+                    {
+                        key: 'country',
+                        value: 'US',
+                        type: PropertyFilterType.Person,
+                        operator: PropertyOperator.Exact,
+                    },
+                ])
+            })
+                .delay(1100)
+                .toDispatchActions(['setAffectedUsers', 'setAffectedUsers', 'setTotalUsers'])
+                .toMatchValues({
+                    totalUsers: 3000,
+                })
+
+            expect(logic.values.affectedUsers[0]).not.toBeUndefined()
+        }, 15000)
+
+        it('does not recalculate when only rollout percentage changes', async () => {
+            jest.spyOn(api, 'create')
+
+            logic?.unmount()
+            logic = targetingPanelLogic({
+                id: 'test-experiment',
+                filters: generateFilters([
+                    {
+                        properties: [],
+                        rollout_percentage: 100,
+                        variant: null,
+                    },
+                ]),
+            })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['setAffectedUsers', 'setTotalUsers'])
+
+            const callCountBefore = (api.create as jest.Mock).mock.calls.length
+
+            await expectLogic(logic, () => {
+                logic.actions.updateConditionSet(0, 50)
+            }).toNotHaveDispatchedActions(['setAffectedUsers', 'setTotalUsers'])
+
+            expect(api.create).toHaveBeenCalledTimes(callCountBefore)
+        })
+
+        it('computes blast radius percentage accurately', () => {
+            logic.actions.setAffectedUsers(0, 150)
+            logic.actions.setAffectedUsers(1, 300)
+            logic.actions.setAffectedUsers(2, 450)
+            logic.actions.setTotalUsers(1500)
+
+            expect(logic.values.computeBlastRadiusPercentage(100, 0)).toBeCloseTo(10, 2)
+            expect(logic.values.computeBlastRadiusPercentage(50, 0)).toBeCloseTo(5, 2)
+
+            expect(logic.values.computeBlastRadiusPercentage(100, 1)).toBeCloseTo(20, 2)
+            expect(logic.values.computeBlastRadiusPercentage(75, 1)).toBeCloseTo(15, 2)
+
+            expect(logic.values.computeBlastRadiusPercentage(100, 2)).toBeCloseTo(30, 2)
+            expect(logic.values.computeBlastRadiusPercentage(33, 2)).toBeCloseTo(9.9, 2)
+        })
+
+        it('handles missing blast radius data gracefully', () => {
+            logic.actions.setAffectedUsers(0, -1)
+            logic.actions.setAffectedUsers(1, undefined)
+            logic.actions.setAffectedUsers(2, 50)
+
+            expect(logic.values.computeBlastRadiusPercentage(100, 0)).toBe(100)
+            expect(logic.values.computeBlastRadiusPercentage(50, 0)).toBe(50)
+
+            expect(logic.values.computeBlastRadiusPercentage(100, 1)).toBe(100)
+            expect(logic.values.computeBlastRadiusPercentage(75, 1)).toBe(75)
+
+            expect(logic.values.computeBlastRadiusPercentage(100, 2)).toBe(100)
+
+            logic.actions.setTotalUsers(200)
+            expect(logic.values.computeBlastRadiusPercentage(100, 2)).toBeCloseTo(25, 2)
+        })
+    })
+
+    describe('condition set management', () => {
+        it('adds a new condition set with 100% rollout', () => {
+            expect(logic.values.filters.groups).toHaveLength(1)
+
+            logic.actions.setTotalUsers(3000)
+            logic.actions.addConditionSet()
+
+            expect(logic.values.filters.groups).toHaveLength(2)
+            expect(logic.values.filters.groups[1].rollout_percentage).toBe(100)
+            expect(logic.values.filters.groups[1].properties).toEqual([])
+            expect(logic.values.affectedUsers[1]).toBe(3000)
+        })
+
+        it('removes a condition set and reindexes affected users', () => {
+            const filters = generateFilters([
+                { properties: [], rollout_percentage: 100, variant: null },
+                { properties: [], rollout_percentage: 75, variant: null },
+                { properties: [], rollout_percentage: 50, variant: null },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.setAffectedUsers(0, 100)
+            logic.actions.setAffectedUsers(1, 200)
+            logic.actions.setAffectedUsers(2, 300)
+
+            logic.actions.removeConditionSet(0)
+
+            expect(logic.values.filters.groups).toHaveLength(2)
+            expect(logic.values.affectedUsers).toEqual({ 0: 200, 1: 300, 2: undefined })
+        })
+
+        it('duplicates a condition set', async () => {
+            const filters = generateFilters([
+                {
+                    properties: [
+                        {
+                            key: 'country',
+                            value: 'US',
+                            type: PropertyFilterType.Person,
+                            operator: PropertyOperator.Exact,
+                        },
+                    ],
+                    rollout_percentage: 75,
+                    variant: null,
+                    description: 'US users',
+                },
+            ])
+            logic.actions.setFilters(filters)
+            logic.actions.setAffectedUsers(0, 250)
+
+            await expectLogic(logic, () => {
+                logic.actions.duplicateConditionSet(0)
+            }).delay(1100)
+
+            expect(logic.values.filters.groups).toHaveLength(2)
+            expect(logic.values.filters.groups[1].rollout_percentage).toBe(75)
+            expect(logic.values.filters.groups[1].description).toBe('US users')
+            expect(logic.values.filters.groups[1].properties).toHaveLength(1)
+            expect(logic.values.filters.groups[1].sort_key).not.toBe(logic.values.filters.groups[0].sort_key)
+            // Affected users are copied after a delay
+            expect(logic.values.affectedUsers[1]).not.toBeUndefined()
+        })
+
+        it('updates rollout percentage', () => {
+            logic.actions.updateConditionSet(0, 50)
+
+            expect(logic.values.filters.groups[0].rollout_percentage).toBe(50)
+        })
+
+        it('updates properties', () => {
+            logic.actions.updateConditionSet(0, undefined, [
+                {
+                    key: 'email',
+                    value: 'test@example.com',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Exact,
+                },
+            ])
+
+            expect(logic.values.filters.groups[0].properties).toHaveLength(1)
+            expect(logic.values.filters.groups[0].properties?.[0].key).toBe('email')
+        })
+
+        it('updates description', () => {
+            logic.actions.updateConditionSet(0, undefined, undefined, 'Test description')
+
+            expect(logic.values.filters.groups[0].description).toBe('Test description')
+        })
+
+        it('clears description when set to empty string', () => {
+            const filters = generateFilters([
+                {
+                    properties: [],
+                    rollout_percentage: 100,
+                    variant: null,
+                    description: 'Existing description',
+                },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.updateConditionSet(0, undefined, undefined, '')
+
+            expect(logic.values.filters.groups[0].description).toBe(null)
+        })
+
+        it('preserves whitespace in description', () => {
+            logic.actions.updateConditionSet(0, undefined, undefined, '  Test description  ')
+
+            expect(logic.values.filters.groups[0].description).toBe('  Test description  ')
+        })
+    })
+
+    describe('moving condition sets', () => {
+        it('moves a condition set up', () => {
+            const filters = generateFilters([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'C' },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetUp(1)
+
+            expect(logic.values.filters.groups).toEqual([
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'C' },
+            ])
+        })
+
+        it('moves a condition set down', () => {
+            const filters = generateFilters([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'C' },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetDown(0)
+
+            expect(logic.values.filters.groups).toEqual([
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'C' },
+            ])
+        })
+
+        it('does not move first condition set up', () => {
+            const filters = generateFilters([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetUp(0)
+
+            expect(logic.values.filters.groups).toEqual([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+            ])
+        })
+
+        it('does not move last condition set down', () => {
+            const filters = generateFilters([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetDown(1)
+
+            expect(logic.values.filters.groups).toEqual([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+            ])
+        })
+
+        it('swaps affected users when moving up', () => {
+            const filters = generateFilters([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'C' },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.setAffectedUsers(0, 100)
+            logic.actions.setAffectedUsers(1, 200)
+            logic.actions.setAffectedUsers(2, 300)
+
+            logic.actions.moveConditionSetUp(1)
+
+            expect(logic.values.affectedUsers).toEqual({ 0: 200, 1: 100, 2: 300 })
+        })
+
+        it('swaps affected users when moving down', () => {
+            const filters = generateFilters([
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'C' },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.setAffectedUsers(0, 100)
+            logic.actions.setAffectedUsers(1, 200)
+            logic.actions.setAffectedUsers(2, 300)
+
+            logic.actions.moveConditionSetDown(0)
+
+            expect(logic.values.affectedUsers).toEqual({ 0: 200, 1: 100, 2: 300 })
+        })
+
+        it('preserves properties when moving', () => {
+            const filters = generateFilters([
+                {
+                    properties: [
+                        {
+                            key: 'country',
+                            value: 'US',
+                            type: PropertyFilterType.Person,
+                            operator: PropertyOperator.Exact,
+                        },
+                    ],
+                    rollout_percentage: 100,
+                    variant: null,
+                    sort_key: 'A',
+                    description: 'US users',
+                },
+                {
+                    properties: [
+                        {
+                            key: 'plan',
+                            value: 'premium',
+                            type: PropertyFilterType.Person,
+                            operator: PropertyOperator.Exact,
+                        },
+                    ],
+                    rollout_percentage: 50,
+                    variant: null,
+                    sort_key: 'B',
+                    description: 'Premium users',
+                },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.moveConditionSetUp(1)
+
+            expect(logic.values.filters.groups[0].description).toBe('Premium users')
+            expect(logic.values.filters.groups[0].properties?.[0].key).toBe('plan')
+            expect(logic.values.filters.groups[1].description).toBe('US users')
+            expect(logic.values.filters.groups[1].properties?.[0].key).toBe('country')
+        })
+    })
+
+    describe('aggregation group type', () => {
+        it('changes aggregation group type and resets filters', () => {
+            const filters = generateFilters([
+                {
+                    properties: [
+                        {
+                            key: 'country',
+                            value: 'US',
+                            type: PropertyFilterType.Person,
+                            operator: PropertyOperator.Exact,
+                        },
+                    ],
+                    rollout_percentage: 75,
+                    variant: null,
+                },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.setAggregationGroupTypeIndex(0)
+
+            expect(logic.values.filters.aggregation_group_type_index).toBe(0)
+            expect(logic.values.filters.groups).toHaveLength(1)
+            expect(logic.values.filters.groups[0].properties).toEqual([])
+            expect(logic.values.filters.groups[0].rollout_percentage).toBe(75)
+        })
+
+        it('preserves rollout percentage when changing aggregation type', () => {
+            const filters = generateFilters([
+                {
+                    properties: [],
+                    rollout_percentage: 50,
+                    variant: null,
+                },
+            ])
+            logic.actions.setFilters(filters)
+
+            logic.actions.setAggregationGroupTypeIndex(1)
+
+            expect(logic.values.filters.groups[0].rollout_percentage).toBe(50)
+        })
+    })
+
+    describe('selectors', () => {
+        it('returns correct aggregation target name for users', () => {
+            expect(logic.values.aggregationTargetName).toBe('users')
+        })
+
+        it('returns correct taxonomic group types for users', () => {
+            expect(logic.values.taxonomicGroupTypes).toContain('cohorts_with_all')
+            expect(logic.values.taxonomicGroupTypes).toContain('person_properties')
+            expect(logic.values.taxonomicGroupTypes).toContain('feature_flags')
+        })
+
+        it('returns correct taxonomic group types for groups', () => {
+            logic.actions.setAggregationGroupTypeIndex(0)
+
+            expect(logic.values.taxonomicGroupTypes).toContain('cohorts_with_all')
+            expect(logic.values.taxonomicGroupTypes).toContain('feature_flags')
+            expect(logic.values.taxonomicGroupTypes).toContain('groups_0')
+        })
+    })
+
+    describe('onChange callback', () => {
+        it('calls onChange when filters change', () => {
+            const onChange = jest.fn()
+            logic?.unmount()
+
+            logic = targetingPanelLogic({
+                id: 'test-experiment',
+                filters: generateFilters([
+                    {
+                        properties: [],
+                        rollout_percentage: 100,
+                        variant: null,
+                    },
+                ]),
+                onChange,
+            })
+            logic.mount()
+
+            logic.actions.updateConditionSet(0, 50)
+
+            expect(onChange).toHaveBeenCalled()
+        })
+
+        it('calls onChange when adding a condition set', () => {
+            const onChange = jest.fn()
+            logic?.unmount()
+
+            logic = targetingPanelLogic({
+                id: 'test-experiment',
+                filters: generateFilters([
+                    {
+                        properties: [],
+                        rollout_percentage: 100,
+                        variant: null,
+                    },
+                ]),
+                onChange,
+            })
+            logic.mount()
+
+            onChange.mockClear()
+            logic.actions.addConditionSet()
+
+            expect(onChange).toHaveBeenCalled()
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/create/targetingPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/targetingPanelLogic.ts
@@ -215,7 +215,7 @@ export const targetingPanelLogic = kea<targetingPanelLogicType>([
         },
         removeConditionSet: ({ index }) => {
             const previousLength = Object.keys(values.affectedUsers).length
-            range(index, previousLength).map((idx) => {
+            range(index, previousLength).forEach((idx) => {
                 const count = previousLength - 1 === idx ? undefined : values.affectedUsers[idx + 1]
                 actions.setAffectedUsers(idx, count)
             })

--- a/frontend/src/scenes/experiments/create/targetingPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/targetingPanelLogic.ts
@@ -1,0 +1,379 @@
+import { actions, afterMount, connect, defaults, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { subscriptions } from 'kea-subscriptions'
+import { v4 as uuidv4 } from 'uuid'
+
+import api from 'lib/api'
+import { isEmptyProperty } from 'lib/components/PropertyFilters/utils'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { objectsEqual, range } from 'lib/utils'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { groupsModel } from '~/models/groupsModel'
+import { AnyPropertyFilter, FeatureFlagFilters, FeatureFlagGroupType, UserBlastRadiusType } from '~/types'
+
+import type { targetingPanelLogicType } from './targetingPanelLogicType'
+
+export interface TargetingPanelLogicProps {
+    filters: FeatureFlagFilters
+    id?: string
+    readOnly?: boolean
+    onChange?: (filters: FeatureFlagFilters) => void
+}
+
+function ensureSortKeys(filters: FeatureFlagFilters): FeatureFlagFilters {
+    return {
+        ...filters,
+        groups: (filters.groups || []).map((group: FeatureFlagGroupType) => ({
+            ...group,
+            sort_key: group.sort_key ?? uuidv4(),
+        })),
+    }
+}
+
+// Helper function to move a condition set to a new index
+function moveConditionSet<T>(groups: T[], index: number, newIndex: number): T[] {
+    const updatedGroups = [...groups]
+    const item = updatedGroups[index]
+    updatedGroups.splice(index, 1)
+    updatedGroups.splice(newIndex, 0, item)
+    return updatedGroups
+}
+
+// Helper function to swap affected users between two indices
+function swapAffectedUsers(
+    affectedUsers: Record<number, number | undefined>,
+    actions: { setAffectedUsers: (index: number, count?: number) => void },
+    fromIndex: number,
+    toIndex: number
+): void {
+    if (!(fromIndex in affectedUsers) || !(toIndex in affectedUsers)) {
+        return
+    }
+
+    const fromCount = affectedUsers[fromIndex]
+    const toCount = affectedUsers[toIndex]
+    actions.setAffectedUsers(toIndex, fromCount)
+    actions.setAffectedUsers(fromIndex, toCount)
+}
+
+export const targetingPanelLogic = kea<targetingPanelLogicType>([
+    path(['scenes', 'experiments', 'create', 'panels', 'targetingPanelLogic']),
+    props({} as TargetingPanelLogicProps),
+    key(({ id }) => id ?? 'new'),
+    connect(() => ({
+        values: [projectLogic, ['currentProjectId'], groupsModel, ['groupTypes', 'aggregationLabel']],
+    })),
+    actions({
+        setFilters: (filters: FeatureFlagFilters) => ({ filters }),
+        setAggregationGroupTypeIndex: (value: number | null) => ({ value }),
+        addConditionSet: true,
+        removeConditionSet: (index: number) => ({ index }),
+        duplicateConditionSet: (index: number) => ({ index }),
+        moveConditionSetUp: (index: number) => ({ index }),
+        moveConditionSetDown: (index: number) => ({ index }),
+        updateConditionSet: (
+            index: number,
+            newRolloutPercentage?: number,
+            newProperties?: AnyPropertyFilter[],
+            newDescription?: string | null
+        ) => ({
+            index,
+            newRolloutPercentage,
+            newProperties,
+            newDescription,
+        }),
+        setAffectedUsers: (index: number, count?: number) => ({ index, count }),
+        setTotalUsers: (count: number) => ({ count }),
+        calculateBlastRadius: true,
+    }),
+    defaults(({ props }) => ({
+        filters: ensureSortKeys(props.filters || { groups: [], aggregation_group_type_index: null }),
+    })),
+    reducers(() => ({
+        filters: {
+            setFilters: (_, { filters }) => {
+                const groupsWithKeys = (filters.groups || []).map((group: FeatureFlagGroupType) => {
+                    if (group.sort_key) {
+                        return group
+                    }
+                    return {
+                        ...group,
+                        sort_key: uuidv4(),
+                    }
+                })
+
+                return { ...filters, groups: groupsWithKeys }
+            },
+            setAggregationGroupTypeIndex: (state, { value }) => {
+                if (!state || state.aggregation_group_type_index === value) {
+                    return state
+                }
+
+                const originalRolloutPercentage = state.groups?.[0]?.rollout_percentage
+
+                return {
+                    ...state,
+                    aggregation_group_type_index: value,
+                    groups: [
+                        {
+                            variant: null,
+                            properties: [],
+                            rollout_percentage: originalRolloutPercentage,
+                            sort_key: uuidv4(),
+                        },
+                    ],
+                }
+            },
+            addConditionSet: (state) => {
+                if (!state) {
+                    return state
+                }
+                const groups = [
+                    ...(state.groups || []),
+                    { properties: [], rollout_percentage: 100, variant: null, sort_key: uuidv4() },
+                ]
+                return { ...state, groups }
+            },
+            removeConditionSet: (state, { index }) => {
+                if (!state) {
+                    return state
+                }
+                const groups = [...state.groups]
+                groups.splice(index, 1)
+                return { ...state, groups }
+            },
+            duplicateConditionSet: (state, { index }) => {
+                if (!state) {
+                    return state
+                }
+                const groups = state.groups.concat([
+                    {
+                        ...state.groups[index],
+                        sort_key: uuidv4(),
+                    },
+                ])
+                return { ...state, groups }
+            },
+            moveConditionSetUp: (state, { index }) => {
+                if (!state || index <= 0) {
+                    return state
+                }
+                return { ...state, groups: moveConditionSet(state.groups, index, index - 1) }
+            },
+            moveConditionSetDown: (state, { index }) => {
+                if (!state || index >= state.groups.length - 1) {
+                    return state
+                }
+                return { ...state, groups: moveConditionSet(state.groups, index, index + 1) }
+            },
+            updateConditionSet: (state, { index, newRolloutPercentage, newProperties, newDescription }) => {
+                if (!state) {
+                    return state
+                }
+                const groups = [...(state.groups || [])]
+                if (newRolloutPercentage !== undefined) {
+                    groups[index] = { ...groups[index], rollout_percentage: newRolloutPercentage }
+                }
+                if (newProperties !== undefined) {
+                    groups[index] = { ...groups[index], properties: newProperties }
+                }
+                if (newDescription !== undefined) {
+                    const description = newDescription && newDescription.trim() ? newDescription : null
+                    groups[index] = { ...groups[index], description }
+                }
+
+                return { ...state, groups }
+            },
+        },
+        affectedUsers: [
+            { 0: undefined } as Record<number, number | undefined>,
+            {
+                setAffectedUsers: (state, { index, count }) => ({
+                    ...state,
+                    [index]: count,
+                }),
+            },
+        ],
+        totalUsers: [
+            null as number | null,
+            {
+                setTotalUsers: (_, { count }) => count,
+            },
+        ],
+    })),
+    listeners(({ actions, values, props }) => ({
+        setFilters: () => {
+            props.onChange?.(values.filters)
+        },
+        setAggregationGroupTypeIndex: () => {
+            props.onChange?.(values.filters)
+            actions.calculateBlastRadius()
+        },
+        addConditionSet: () => {
+            actions.setAffectedUsers(values.filters.groups.length - 1, values.totalUsers || -1)
+            props.onChange?.(values.filters)
+        },
+        removeConditionSet: ({ index }) => {
+            const previousLength = Object.keys(values.affectedUsers).length
+            range(index, previousLength).map((idx) => {
+                const count = previousLength - 1 === idx ? undefined : values.affectedUsers[idx + 1]
+                actions.setAffectedUsers(idx, count)
+            })
+            props.onChange?.(values.filters)
+        },
+        duplicateConditionSet: async ({ index }, breakpoint) => {
+            await breakpoint(1000)
+            const valueForSourceCondition = values.affectedUsers[index]
+            const newIndex = values.filters.groups.length - 1
+            actions.setAffectedUsers(newIndex, valueForSourceCondition)
+            props.onChange?.(values.filters)
+        },
+        updateConditionSet: async ({ index, newProperties }, breakpoint) => {
+            if (newProperties) {
+                actions.setAffectedUsers(index, undefined)
+            }
+
+            if (!newProperties || newProperties.some(isEmptyProperty)) {
+                props.onChange?.(values.filters)
+                return
+            }
+
+            await breakpoint(1000)
+            const response = await api.create(
+                `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
+                {
+                    condition: { properties: newProperties },
+                    group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                }
+            )
+            actions.setAffectedUsers(index, response.users_affected)
+            actions.setTotalUsers(response.total_users)
+            props.onChange?.(values.filters)
+        },
+        moveConditionSetUp: ({ index }) => {
+            swapAffectedUsers(values.affectedUsers, actions, index, index - 1)
+            props.onChange?.(values.filters)
+        },
+        moveConditionSetDown: ({ index }) => {
+            swapAffectedUsers(values.affectedUsers, actions, index, index + 1)
+            props.onChange?.(values.filters)
+        },
+        calculateBlastRadius: async () => {
+            const usersAffected: Promise<UserBlastRadiusType>[] = []
+
+            values.filters?.groups?.forEach((condition, index) => {
+                actions.setAffectedUsers(index, undefined)
+
+                const properties = condition.properties
+                if (!properties || properties.some(isEmptyProperty)) {
+                    usersAffected.push(Promise.resolve({ users_affected: -1, total_users: -1 }))
+                } else if (properties.length === 0) {
+                    const responsePromise = api.create(
+                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
+                        {
+                            condition: { properties: [] },
+                            group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                        }
+                    )
+                    usersAffected.push(responsePromise)
+                } else {
+                    const responsePromise = api.create(
+                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
+                        {
+                            condition,
+                            group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                        }
+                    )
+                    usersAffected.push(responsePromise)
+                }
+            })
+
+            const results = await Promise.all(usersAffected)
+            results.forEach((result, index) => {
+                actions.setAffectedUsers(index, result.users_affected)
+                if (result.total_users !== -1) {
+                    actions.setTotalUsers(result.total_users)
+                }
+            })
+        },
+    })),
+    selectors({
+        aggregationTargetName: [
+            (s) => [s.filters, s.aggregationLabel],
+            (
+                filters: FeatureFlagFilters,
+                aggregationLabel: (index: number) => { singular: string; plural: string }
+            ): string => {
+                if (filters.aggregation_group_type_index != null) {
+                    return aggregationLabel(filters.aggregation_group_type_index).plural
+                }
+                return 'users'
+            },
+        ],
+        taxonomicGroupTypes: [
+            (s) => [s.filters],
+            (filters): TaxonomicFilterGroupType[] => {
+                if (filters.aggregation_group_type_index != null) {
+                    return [
+                        TaxonomicFilterGroupType.CohortsWithAllUsers,
+                        TaxonomicFilterGroupType.FeatureFlags,
+                        `${TaxonomicFilterGroupType.GroupsPrefix}_${filters.aggregation_group_type_index}` as TaxonomicFilterGroupType,
+                        TaxonomicFilterGroupType.Actions,
+                        TaxonomicFilterGroupType.Events,
+                    ]
+                }
+
+                return [
+                    TaxonomicFilterGroupType.CohortsWithAllUsers,
+                    TaxonomicFilterGroupType.FeatureFlags,
+                    TaxonomicFilterGroupType.PersonProperties,
+                    TaxonomicFilterGroupType.Actions,
+                    TaxonomicFilterGroupType.Events,
+                ]
+            },
+        ],
+        computeBlastRadiusPercentage: [
+            (s) => [s.affectedUsers, s.totalUsers],
+            (affectedUsers, totalUsers) => {
+                return (rolloutPercentage: number | null | undefined, index: number): number => {
+                    let effectiveRolloutPercentage: number = rolloutPercentage ?? 100
+                    if (
+                        rolloutPercentage === undefined ||
+                        rolloutPercentage === null ||
+                        (rolloutPercentage && rolloutPercentage > 100)
+                    ) {
+                        effectiveRolloutPercentage = 100
+                    }
+
+                    if (
+                        affectedUsers[index] === -1 ||
+                        totalUsers === -1 ||
+                        !totalUsers ||
+                        affectedUsers[index] === undefined
+                    ) {
+                        return effectiveRolloutPercentage
+                    }
+
+                    let effectiveTotalUsers = totalUsers
+                    if (effectiveTotalUsers === 0) {
+                        effectiveTotalUsers = 1
+                    }
+
+                    return effectiveRolloutPercentage * ((affectedUsers[index] ?? 0) / effectiveTotalUsers)
+                }
+            },
+        ],
+    }),
+    subscriptions(({ props }) => ({
+        filters: (value, oldValue) => {
+            if (!objectsEqual(value, oldValue)) {
+                props.onChange?.(value)
+            }
+        },
+    })),
+    afterMount(({ props, actions }) => {
+        if (!props.readOnly) {
+            actions.calculateBlastRadius()
+        }
+    }),
+])


### PR DESCRIPTION
## Problem

The create experiment form has no support for setting experiment targeting with sensible defaults.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are duplicating code from the Feature Flags creation form into a new component and a kea logic to handle filters and user volume search.

| Targeting Panel |
| - |
| <img width="3286" height="2486" alt="localhost_8010_project_1_experiments_new_status=all page=1 ff_page=2" src="https://github.com/user-attachments/assets/b68bd7d7-3c44-4ad9-9830-f31e50c30e49" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/targetingPanelLogic.test.ts
```

![cat-type-small](https://github.com/user-attachments/assets/8fc1fb2f-7db4-43f1-a792-aa4675aff402)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
