### PR TITLE
fix(billing): Increase the number of elements that `scrollToProduct` can move to

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -919,7 +919,10 @@ export const billingLogic = kea<billingLogicType>([
             }
         },
         scrollToProduct: ({ productType }) => {
-            const element = document.querySelector(`[data-attr="billing-product-addon-${productType}"]`)
+            let element = document.querySelector(`[data-attr="billing-product-addon-${productType}"]`)
+            if (element == null) {
+                element = document.querySelector(`[data-attr="billing-product-${productType}"]`)
+            }
             element?.scrollIntoView({
                 behavior: 'smooth',
                 block: 'center',


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/39140

## Changes


https://github.com/user-attachments/assets/b2d208fb-f076-45c3-b44b-9d9883f685fa

### Alternatives
So far there are two `data-attr` that `scrollToProduct` is used for:

https://github.com/PostHog/posthog/blob/6f0d4b0f9f0fc52c6303c681f0615fb107192914/frontend/src/scenes/billing/BillingProduct.tsx#L112

https://github.com/PostHog/posthog/blob/6f0d4b0f9f0fc52c6303c681f0615fb107192914/frontend/src/scenes/billing/BillingProductAddon.tsx#L68

We can also choose to update the `data-attr` such that it has a more common key.

## How did you test this code?

Locally:

1) Go to http://localhost:8010/organization/billing/overview
2) If you can't see the `You're on the Pay-as-you-go plan.` banner, you have to update your `billingLogic.tsx` to have the `showBillingHero` as true and `billingPlan` to be `BillingPlan.Paid`.
3) Click on `Platforms add-ons`
4) It should scroll down to the addons section of `Platform and support`
