### PR TITLE
feat(experiments): adding exposure criteria panel.

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -19,6 +19,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { MetricsReorderModal } from '../MetricsView/MetricsReorderModal'
 import { ExperimentTypePanel } from './ExperimentTypePanel'
+import { ExposureCriteriaPanel } from './ExposureCriteriaPanel'
 import { VariantsPanel } from './VariantsPanel'
 import { createExperimentLogic } from './createExperimentLogic'
 
@@ -129,7 +130,10 @@ export const CreateExperiment = (): JSX.Element => {
                                 header: 'Exposure criteria',
                                 content: (
                                     <div className="p-4">
-                                        <span>Exposure Criteria Panel Goes Here</span>
+                                        <ExposureCriteriaPanel
+                                            experiment={experiment}
+                                            onChange={(exposureCriteria) => exposureCriteria}
+                                        />
                                     </div>
                                 ),
                             },

--- a/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
+++ b/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
@@ -1,0 +1,161 @@
+import { useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonSelect, LemonTag } from '@posthog/lemon-ui'
+
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
+import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
+import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ExperimentEventExposureConfig, NodeKind } from '~/queries/schema/schema-general'
+import { Experiment, FilterType } from '~/types'
+
+import { commonActionFilterProps } from '../Metrics/Selectors'
+import { SelectableCard } from '../components/SelectableCard'
+import { exposureConfigToFilter, filterToExposureConfig } from '../utils'
+
+type ExposureCriteriaPanelProps = {
+    experiment: Experiment
+    onChange: (exposureCriteria: Experiment['exposure_criteria']) => void
+}
+
+export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteriaPanelProps): JSX.Element {
+    const [selectedExposureType, setSelectedExposureType] = useState<'default' | 'custom'>('default')
+
+    const { currentTeam } = useValues(teamLogic)
+    const hasFilters = (currentTeam?.test_account_filters || []).length > 0
+
+    return (
+        <div className="space-y-4">
+            <div className="text-sm text-muted">
+                Configure when users are considered exposed to the experiment and included in the analysis.
+            </div>
+
+            {/* Exposure Type Selection */}
+            <div className="flex gap-4 mb-4">
+                <SelectableCard
+                    title="Default"
+                    description={
+                        <>
+                            When a <LemonTag>$feature_flag_called</LemonTag> event is recorded, a user is considered{' '}
+                            <strong>exposed</strong> to the experiment.
+                        </>
+                    }
+                    selected={selectedExposureType === 'default'}
+                    onClick={() => {
+                        setSelectedExposureType('default')
+                        onChange({
+                            exposure_config: undefined,
+                        })
+                    }}
+                />
+                <SelectableCard
+                    title="Custom"
+                    description={
+                        <>
+                            Select a custom event to signal that users reached the part of your app where the experiment
+                            runs. You can also filter out users you would like to exclude.
+                        </>
+                    }
+                    selected={selectedExposureType === 'custom'}
+                    onClick={() => {
+                        setSelectedExposureType('custom')
+                        onChange({
+                            exposure_config: {
+                                kind: NodeKind.ExperimentEventExposureConfig,
+                                event: '$feature_flag_called',
+                                properties: [],
+                            },
+                        })
+                    }}
+                />
+            </div>
+
+            {/* Custom Event Configuration */}
+            {selectedExposureType === 'custom' && (
+                <div className="mb-4">
+                    <ActionFilter
+                        bordered
+                        filters={exposureConfigToFilter(
+                            experiment.exposure_criteria?.exposure_config ||
+                                ({
+                                    kind: NodeKind.ExperimentEventExposureConfig,
+                                    event: '$feature_flag_called',
+                                    properties: [],
+                                } as ExperimentEventExposureConfig)
+                        )}
+                        setFilters={({ events }: Partial<FilterType>): void => {
+                            const entity = events?.[0]
+                            if (entity) {
+                                onChange({
+                                    exposure_config: filterToExposureConfig(entity),
+                                })
+                            }
+                        }}
+                        typeKey="experiment-exposure-config"
+                        buttonCopy="Add exposure event"
+                        showSeriesIndicator={false}
+                        hideRename={true}
+                        entitiesLimit={1}
+                        mathAvailability={MathAvailability.None}
+                        showNumericalPropsOnly={false}
+                        actionsTaxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+                        propertiesTaxonomicGroupTypes={commonActionFilterProps.propertiesTaxonomicGroupTypes}
+                    />
+                </div>
+            )}
+
+            {/* Multiple Variant Handling */}
+            <div className="max-w-120">
+                <label className="block text-sm font-medium text-default mb-2">Multiple variant handling</label>
+                <LemonSelect
+                    value={experiment.exposure_criteria?.multiple_variant_handling || 'exclude'}
+                    onChange={(value) => {
+                        onChange({
+                            multiple_variant_handling: value as 'exclude' | 'first_seen',
+                        })
+                    }}
+                    options={[
+                        {
+                            value: 'exclude',
+                            label: 'Exclude from analysis',
+                            'data-attr': 'multiple-handling-exclude',
+                        },
+                        {
+                            value: 'first_seen',
+                            label: 'Use first seen variant',
+                            'data-attr': 'multiple-handling-first-seen',
+                        },
+                    ]}
+                    placeholder="Select handling method"
+                    fullWidth
+                />
+                <div className="text-xs text-muted mt-1">
+                    {experiment.exposure_criteria?.multiple_variant_handling === 'first_seen' &&
+                        'Users exposed to multiple variants will be analyzed using their first seen variant.'}
+                    {(!experiment.exposure_criteria?.multiple_variant_handling ||
+                        experiment.exposure_criteria?.multiple_variant_handling === 'exclude') &&
+                        'Users exposed to multiple variants will be excluded from the analysis (recommended).'}
+                </div>
+            </div>
+
+            {/* Test Account Filtering */}
+            <div className="max-w-120">
+                <TestAccountFilterSwitch
+                    checked={(() => {
+                        const val = experiment.exposure_criteria?.filterTestAccounts
+                        return hasFilters ? !!val : false
+                    })()}
+                    onChange={(checked: boolean) => {
+                        onChange({
+                            filterTestAccounts: checked,
+                        })
+                    }}
+                    fullWidth
+                />
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Problem

Exposure criteria is missing as a step when creating an experiment.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adds a duplication of the exposure criteria panel from the ExperimentView into a collapsible section of the new create experiment page.

| Default exposure criteria | Custom exposure criteria |
| - | - |
| <img width="963" height="851" alt="image" src="https://github.com/user-attachments/assets/e4084d84-5a58-402f-b0da-87aeb2ad4ec5" /> | <img width="964" height="851" alt="image" src="https://github.com/user-attachments/assets/e709ef36-0d0e-40fd-80d5-d870236843b6" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/61fd3e83-0042-4b63-bf6b-7ff81303884d)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
