### PR TITLE
fix(notebook): Pasting various URLs doesn't create the correct node as `pasteOptions.find` don't match

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeCohort.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeCohort.tsx
@@ -17,7 +17,7 @@ import { PropertyFilterType } from '~/types'
 
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
-import { INTEGER_REGEX_MATCH_GROUPS } from './utils'
+import { INTEGER_REGEX_MATCH_GROUPS, OPTIONAL_PROJECT_NON_CAPTURE_GROUP } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeCohortAttributes>): JSX.Element => {
     const { id } = attributes
@@ -169,7 +169,7 @@ export const NotebookNodeCohort = createPostHogWidgetNode<NotebookNodeCohortAttr
         id: {},
     },
     pasteOptions: {
-        find: urls.cohort(INTEGER_REGEX_MATCH_GROUPS),
+        find: OPTIONAL_PROJECT_NON_CAPTURE_GROUP + urls.cohort(INTEGER_REGEX_MATCH_GROUPS),
         getAttributes: async (match) => {
             return { id: parseInt(match[1]) }
         },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeEarlyAccessFeature.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeEarlyAccessFeature.tsx
@@ -21,7 +21,7 @@ import {
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { buildFlagContent } from './NotebookNodeFlag'
 import { notebookNodeLogic } from './notebookNodeLogic'
-import { UUID_REGEX_MATCH_GROUPS } from './utils'
+import { OPTIONAL_PROJECT_NON_CAPTURE_GROUP, UUID_REGEX_MATCH_GROUPS } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeEarlyAccessAttributes>): JSX.Element => {
     const { id } = attributes
@@ -138,7 +138,7 @@ export const NotebookNodeEarlyAccessFeature = createPostHogWidgetNode<NotebookNo
         id: {},
     },
     pasteOptions: {
-        find: urls.earlyAccessFeature(UUID_REGEX_MATCH_GROUPS),
+        find: OPTIONAL_PROJECT_NON_CAPTURE_GROUP + urls.earlyAccessFeature(UUID_REGEX_MATCH_GROUPS),
         getAttributes: async (match) => {
             return { id: match[1] }
         },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
@@ -17,7 +17,7 @@ import { urls } from 'scenes/urls'
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { buildFlagContent } from './NotebookNodeFlag'
 import { notebookNodeLogic } from './notebookNodeLogic'
-import { INTEGER_REGEX_MATCH_GROUPS } from './utils'
+import { INTEGER_REGEX_MATCH_GROUPS, OPTIONAL_PROJECT_NON_CAPTURE_GROUP } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttributes>): JSX.Element => {
     const { id } = attributes
@@ -120,7 +120,7 @@ export const NotebookNodeExperiment = createPostHogWidgetNode<NotebookNodeExperi
         id: {},
     },
     pasteOptions: {
-        find: urls.experiment(INTEGER_REGEX_MATCH_GROUPS),
+        find: OPTIONAL_PROJECT_NON_CAPTURE_GROUP + urls.experiment(INTEGER_REGEX_MATCH_GROUPS),
         getAttributes: async (match) => {
             return { id: parseInt(match[1]) }
         },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeFlag.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeFlag.tsx
@@ -21,7 +21,7 @@ import { notebookNodeFlagLogic } from './NotebookNodeFlagLogic'
 import { buildPlaylistContent } from './NotebookNodePlaylist'
 import { buildSurveyContent } from './NotebookNodeSurvey'
 import { notebookNodeLogic } from './notebookNodeLogic'
-import { INTEGER_REGEX_MATCH_GROUPS } from './utils'
+import { INTEGER_REGEX_MATCH_GROUPS, OPTIONAL_PROJECT_NON_CAPTURE_GROUP } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeFlagAttributes>): JSX.Element => {
     const { id } = attributes
@@ -155,7 +155,7 @@ export const NotebookNodeFlag = createPostHogWidgetNode<NotebookNodeFlagAttribut
         id: {},
     },
     pasteOptions: {
-        find: urls.featureFlag(INTEGER_REGEX_MATCH_GROUPS),
+        find: OPTIONAL_PROJECT_NON_CAPTURE_GROUP + urls.featureFlag(INTEGER_REGEX_MATCH_GROUPS),
         getAttributes: async (match) => {
             return { id: match[1] as FeatureFlagLogicProps['id'] }
         },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -19,6 +19,7 @@ import { NodeKind } from '~/queries/schema/schema-general'
 
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
+import { OPTIONAL_PROJECT_NON_CAPTURE_GROUP } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttributes>): JSX.Element => {
     const { id, distinctId } = attributes
@@ -183,7 +184,7 @@ export const NotebookNodePerson = createPostHogWidgetNode<NotebookNodePersonAttr
     },
     // FIXME: pasteOptions is not really working. Maybe change to personByUUID
     pasteOptions: {
-        find: urls.personByDistinctId('(.+)', false),
+        find: OPTIONAL_PROJECT_NON_CAPTURE_GROUP + urls.personByDistinctId('(.+)', false),
         getAttributes: async (match) => {
             return { distinctId: match[1], id: undefined }
         },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSurvey.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSurvey.tsx
@@ -20,7 +20,7 @@ import { FeatureFlagBasicType, Survey } from '~/types'
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { buildFlagContent } from './NotebookNodeFlag'
 import { notebookNodeLogic } from './notebookNodeLogic'
-import { UUID_REGEX_MATCH_GROUPS } from './utils'
+import { OPTIONAL_PROJECT_NON_CAPTURE_GROUP, UUID_REGEX_MATCH_GROUPS } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeSurveyAttributes>): JSX.Element => {
     const { id } = attributes
@@ -123,7 +123,7 @@ export const NotebookNodeSurvey = createPostHogWidgetNode<NotebookNodeSurveyAttr
         id: {},
     },
     pasteOptions: {
-        find: urls.survey(UUID_REGEX_MATCH_GROUPS),
+        find: OPTIONAL_PROJECT_NON_CAPTURE_GROUP + urls.survey(UUID_REGEX_MATCH_GROUPS),
         getAttributes: async (match) => {
             return { id: match[1] }
         },

--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -11,6 +11,7 @@ import { CustomNotebookNodeAttributes, NotebookNodeAttributes } from '../types'
 export const INTEGER_REGEX_MATCH_GROUPS = '([0-9]*)(.*)'
 export const SHORT_CODE_REGEX_MATCH_GROUPS = '([0-9a-zA-Z]*)(.*)'
 export const UUID_REGEX_MATCH_GROUPS = '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(.*)'
+export const OPTIONAL_PROJECT_NON_CAPTURE_GROUP = '(?:/project/[0-9]*)?'
 
 export function createUrlRegex(path: string | RegExp, origin?: string): RegExp {
     origin = (origin || window.location.origin).replace('.', '\\.')


### PR DESCRIPTION
## Problem

One example is the cohort URL, when its pasted into the notebook, I believe the correct behavior should be that it creates a cohort node, similar to if you were to drag it in:


https://github.com/user-attachments/assets/2dfe995b-219f-4f1c-bbf3-6515daf42152

Drag and drop is working as expected:


https://github.com/user-attachments/assets/e6c45127-9f2a-4384-bdec-8164d7c478c2

I believe the issue is that at some point `/project/${projectId}` was added to the url that are shown in the browser, but the notebook paste regex is not updated to handle it. 

## Changes


https://github.com/user-attachments/assets/1c5f7d8a-d739-4fb5-b72c-7a3a50ed8240

### Alternative
Initially I thought of adding this check here:

https://github.com/PostHog/posthog/blob/44b1f40c1ac624ab9c77787414e28668cc953a6e/frontend/src/scenes/notebooks/Nodes/utils.tsx#L15-L18

But I realised that its too implicit and maybe its better to handle the case one by one. 


## How did you test this code?

Locally:
1) Open a notebook on the side panel
2) Go to a cohort
3) Copy the cohort url: something like https://us.posthog.com/project/156702/cohorts?page=1
4) Paste it into the notebook, you should see the cohort node being created.
