### PR TITLE
chore: add tsconfig to error tracking

### DIFF
--- a/products/error_tracking/tsconfig.json
+++ b/products/error_tracking/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true
+    },
+    "include": ["src", "**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
## Problem

Importing dependencies in the error tracking product often resolves to `node_modules` which breaks my frontend server. This is exclusively a VSCode (/ Cursor) problem because it ignores package.json files and relies on a tsconfig for resolution suggestions

## Changes

Implemented the fix discussed in https://posthog.slack.com/archives/C08499A7REU/p1755005946088249?thread_ts=1755004927.176519&cid=C08499A7REU