### PR TITLE
fix(batch-exports): Various fixes for Databricks backend

### DIFF
--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -636,7 +636,7 @@ def databricks_integration(team, user):
     return Integration.objects.create(
         team=team,
         kind=Integration.IntegrationKind.DATABRICKS,
-        integration_id=str(team.pk),
+        integration_id="my-server-hostname",
         config={"server_hostname": "my-server-hostname"},
         sensitive_config={"client_id": "my-client-id", "client_secret": "my-client-secret"},
         created_by=user,
@@ -798,7 +798,7 @@ def test_creating_databricks_batch_export_fails_if_integration_is_invalid(
     integration = Integration.objects.create(
         team=team,
         kind=Integration.IntegrationKind.DATABRICKS,
-        integration_id=str(team.pk),
+        integration_id="my-server-hostname",
         config={"server_hostname": "my-server-hostname"},
         sensitive_config={"client_id": "my-client-id"},
         created_by=user,
@@ -889,7 +889,7 @@ def test_creating_databricks_batch_export_fails_if_integration_is_not_the_correc
     integration = Integration.objects.create(
         team=team,
         kind=Integration.IntegrationKind.SLACK,
-        integration_id=str(team.pk),
+        integration_id="my-server-hostname",
         config={"server_hostname": "my-server-hostname"},
         sensitive_config={"client_id": "my-client-id"},
         created_by=user,

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -3,6 +3,7 @@ import typing as t
 import datetime as dt
 
 import pytest
+from unittest import mock
 
 from django.conf import settings
 from django.test.client import Client as HttpClient
@@ -19,6 +20,7 @@ from posthog.api.test.batch_exports.operations import (
 )
 from posthog.batch_exports.service import sync_batch_export
 from posthog.models import BatchExport, BatchExportDestination
+from posthog.models.integration import Integration
 from posthog.temporal.common.codec import EncryptionCodec
 
 pytestmark = [
@@ -488,3 +490,166 @@ def test_switching_snowflake_auth_type_to_keypair_requires_private_key(
     batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
     assert batch_export["destination"]["type"] == "Snowflake"
     assert batch_export["destination"]["config"]["authentication_type"] == "password"
+
+
+@pytest.fixture
+def databricks_integration(team, user):
+    """Create a Databricks integration."""
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.DATABRICKS,
+        integration_id="my-server-hostname",
+        config={"server_hostname": "my-server-hostname"},
+        sensitive_config={"client_id": "my-client-id", "client_secret": "my-client-secret"},
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def databricks_integration_2(team, user):
+    """Create a second Databricks integration."""
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.DATABRICKS,
+        integration_id="my-server-hostname-2",
+        config={"server_hostname": "my-server-hostname-2"},
+        sensitive_config={"client_id": "my-client-id", "client_secret": "my-client-secret"},
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def enable_databricks(team):
+    """Enable the Databricks batch exports feature flag to be able to run the test."""
+    with mock.patch(
+        "posthog.batch_exports.http.posthoganalytics.feature_enabled",
+        return_value=True,
+    ):
+        yield
+
+
+def test_can_update_batch_export_with_integration(
+    client: HttpClient,
+    temporal,
+    organization,
+    team,
+    user,
+    databricks_integration,
+    databricks_integration_2,
+    enable_databricks,
+):
+    """Test we can update a batch export with an integration (for example Databricks)."""
+
+    destination_data = {
+        "type": "Databricks",
+        "integration": databricks_integration.id,
+        "config": {
+            "http_path": "my-http-path",
+            "catalog": "my-catalog",
+            "schema": "my-schema",
+            "table_name": "my-table-name",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-databricks-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    client.force_login(user)
+
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
+    old_schedule = describe_schedule(temporal, batch_export["id"])
+
+    new_batch_export_data = {
+        "destination": {
+            "type": "Databricks",
+            "integration": databricks_integration_2.id,
+            "config": {
+                "http_path": "my-http-path",
+                "catalog": "my-catalog",
+                "schema": "my-schema",
+                "table_name": "my-table-name",
+            },
+        },
+    }
+
+    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    response_data: dict[str, t.Any] = get_batch_export_ok(client, team.pk, batch_export["id"])
+    assert response_data["interval"] == "hour"
+    assert response_data["destination"]["integration"] == databricks_integration_2.id
+    assert response_data["destination"]["config"] == {
+        "http_path": "my-http-path",
+        "catalog": "my-catalog",
+        "schema": "my-schema",
+        "table_name": "my-table-name",
+    }
+
+    # validate the underlying temporal schedule has been updated
+    codec = EncryptionCodec(settings=settings)
+    new_schedule = describe_schedule(temporal, batch_export["id"])
+    assert old_schedule.schedule.spec.intervals[0].every == new_schedule.schedule.spec.intervals[0].every
+    decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
+    assert args["integration_id"] == databricks_integration_2.id
+
+
+def test_can_update_batch_export_with_integration_to_none(
+    client: HttpClient,
+    temporal,
+    organization,
+    team,
+    user,
+    databricks_integration,
+    enable_databricks,
+):
+    """Test we cannot update a batch export that requires an integration to None."""
+
+    destination_data = {
+        "type": "Databricks",
+        "integration": databricks_integration.id,
+        "config": {
+            "http_path": "my-http-path",
+            "catalog": "my-catalog",
+            "schema": "my-schema",
+            "table_name": "my-table-name",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-databricks-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    client.force_login(user)
+
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
+
+    new_batch_export_data = {
+        "destination": {
+            "type": "Databricks",
+            "integration": None,
+            "config": {
+                "http_path": "my-http-path",
+                "catalog": "my-catalog",
+                "schema": "my-schema",
+                "table_name": "my-table-name",
+            },
+        },
+    }
+
+    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "integration is required for Databricks batch exports" in response.json()["detail"]

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -417,7 +417,7 @@ class TestDatabricksIntegration:
             {
                 "kind": "databricks",
                 "config": {
-                    "server_hostname": "my-account.cloud.databricks.com",
+                    "server_hostname": "databricks.com",
                     "client_id": "client_id",
                     "client_secret": "client_secret",
                 },
@@ -433,10 +433,10 @@ class TestDatabricksIntegration:
         integration = Integration.objects.get(id=id)
         assert integration.kind == "databricks"
         assert integration.team == self.team
-        assert integration.config == {"server_hostname": "my-account.cloud.databricks.com"}
+        assert integration.config == {"server_hostname": "databricks.com"}
         assert integration.sensitive_config == {"client_id": "client_id", "client_secret": "client_secret"}
         assert integration.created_by == self.user
-        assert integration.integration_id == "my-account.cloud.databricks.com"
+        assert integration.integration_id == "databricks.com"
 
     @pytest.mark.parametrize(
         "invalid_config,expected_error_message",

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -417,7 +417,7 @@ class TestDatabricksIntegration:
             {
                 "kind": "databricks",
                 "config": {
-                    "server_hostname": "databricks.com",
+                    "server_hostname": "my-account.cloud.databricks.com",
                     "client_id": "client_id",
                     "client_secret": "client_secret",
                 },
@@ -433,10 +433,10 @@ class TestDatabricksIntegration:
         integration = Integration.objects.get(id=id)
         assert integration.kind == "databricks"
         assert integration.team == self.team
-        assert integration.config == {"server_hostname": "databricks.com"}
+        assert integration.config == {"server_hostname": "my-account.cloud.databricks.com"}
         assert integration.sensitive_config == {"client_id": "client_id", "client_secret": "client_secret"}
         assert integration.created_by == self.user
-        assert integration.integration_id == "databricks.com"
+        assert integration.integration_id == "my-account.cloud.databricks.com"
 
     @pytest.mark.parametrize(
         "invalid_config,expected_error_message",

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -574,6 +574,8 @@ class BatchExportSerializer(serializers.ModelSerializer):
                     **batch_export.destination.config,
                     **destination_data.get("config", {}),
                 }
+                integration = destination_data.get("integration", batch_export.destination.integration)
+                batch_export.destination.integration = integration
 
             if hogql_query := validated_data.pop("hogql_query", None):
                 batch_export_schema = self.serialize_hogql_query_to_batch_export_schema(hogql_query)

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -115,6 +115,8 @@ class Integration(models.Model):
             return self.integration_id or "unknown ID"
         if self.kind == "github":
             return dot_get(self.config, "account.name", self.integration_id)
+        if self.kind == "databricks":
+            return self.integration_id or "unknown ID"
         if self.kind == "email":
             return self.config.get("email", self.integration_id)
 
@@ -1861,9 +1863,9 @@ class DatabricksIntegration:
             sock.close()
         except OSError:
             raise DatabricksIntegrationError(
-                f"Databricks integration is not valid: could not connect to '{server_hostname}'"
+                f"Databricks integration error: could not connect to hostname '{server_hostname}'"
             )
         except Exception:
             raise DatabricksIntegrationError(
-                f"Databricks integration is not valid: could not connect to '{server_hostname}'"
+                f"Databricks integration error: could not connect to hostname '{server_hostname}'"
             )

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -15,7 +15,6 @@ from django.db import models
 import jwt
 import requests
 import structlog
-import databricks.sdk.environments
 from google.auth.transport.requests import Request as GoogleRequest
 from google.oauth2 import service_account
 from prometheus_client import Counter
@@ -1847,25 +1846,13 @@ class DatabricksIntegration:
 
         This is a quick check to ensure the host is valid and that we can connect to it (testing connectivity to a SQL
         warehouse requires a warehouse http_path in addition to these parameters so it not possible to perform a full
-        test here).
+        test here)
         """
         # we expect a hostname, not a full URL
         if server_hostname.startswith("http"):
             raise DatabricksIntegrationError(
                 f"Databricks integration is not valid: 'server_hostname' should not be a full URL"
             )
-
-        # check if the hostname is a valid Databricks hostname
-        environment = None
-        for env in databricks.sdk.environments.ALL_ENVS:
-            if server_hostname.endswith(env.dns_zone):
-                environment = env
-                break
-        if environment is None:
-            raise DatabricksIntegrationError(
-                f"Databricks integration is not valid: '{server_hostname}' is not a valid Databricks hostname"
-            )
-
         # TCP connectivity check
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -15,6 +15,7 @@ from django.db import models
 import jwt
 import requests
 import structlog
+import databricks.sdk.environments
 from google.auth.transport.requests import Request as GoogleRequest
 from google.oauth2 import service_account
 from prometheus_client import Counter
@@ -1846,13 +1847,25 @@ class DatabricksIntegration:
 
         This is a quick check to ensure the host is valid and that we can connect to it (testing connectivity to a SQL
         warehouse requires a warehouse http_path in addition to these parameters so it not possible to perform a full
-        test here)
+        test here).
         """
         # we expect a hostname, not a full URL
         if server_hostname.startswith("http"):
             raise DatabricksIntegrationError(
                 f"Databricks integration is not valid: 'server_hostname' should not be a full URL"
             )
+
+        # check if the hostname is a valid Databricks hostname
+        environment = None
+        for env in databricks.sdk.environments.ALL_ENVS:
+            if server_hostname.endswith(env.dns_zone):
+                environment = env
+                break
+        if environment is None:
+            raise DatabricksIntegrationError(
+                f"Databricks integration is not valid: '{server_hostname}' is not a valid Databricks hostname"
+            )
+
         # TCP connectivity check
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -592,7 +592,7 @@ class TestDatabricksIntegrationModel(BaseTest):
             8, "nodename nor servname provided, or not known"
         )
         with pytest.raises(
-            DatabricksIntegrationError, match="Databricks integration is not valid: could not connect to 'invalid'"
+            DatabricksIntegrationError, match="Databricks integration error: could not connect to hostname 'invalid'"
         ):
             DatabricksIntegration.integration_from_config(
                 team_id=self.team.pk,

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -575,38 +575,24 @@ class TestDatabricksIntegrationModel(BaseTest):
         mock_socket.return_value.connect.return_value = None
         integration = DatabricksIntegration.integration_from_config(
             team_id=self.team.pk,
-            server_hostname="my-account.cloud.databricks.com",
+            server_hostname="databricks.com",
             client_id="client_id",
             client_secret="client_secret",
             created_by=self.user,
         )
         assert integration.team == self.team
         assert integration.created_by == self.user
-        assert integration.config == {"server_hostname": "my-account.cloud.databricks.com"}
+        assert integration.config == {"server_hostname": "databricks.com"}
         assert integration.sensitive_config == {"client_id": "client_id", "client_secret": "client_secret"}
 
     @patch("posthog.models.integration.socket.socket")
     def test_integration_from_config_with_invalid_server_hostname(self, mock_socket):
-        # this is the error raised when our basic connection test fails
+        # this is the error raised when the server hostname is invalid
         mock_socket.return_value.connect.side_effect = socket.gaierror(
             8, "nodename nor servname provided, or not known"
         )
         with pytest.raises(
-            DatabricksIntegrationError,
-            match="Databricks integration error: could not connect to hostname 'invalid.cloud.databricks.com'",
-        ):
-            DatabricksIntegration.integration_from_config(
-                team_id=self.team.pk,
-                server_hostname="invalid.cloud.databricks.com",
-                client_id="client_id",
-                client_secret="client_secret",
-                created_by=self.user,
-            )
-
-    def test_integration_from_config_with_non_databricks_server_hostname(self):
-        with pytest.raises(
-            DatabricksIntegrationError,
-            match="Databricks integration is not valid: 'invalid' is not a valid Databricks hostname",
+            DatabricksIntegrationError, match="Databricks integration error: could not connect to hostname 'invalid'"
         ):
             DatabricksIntegration.integration_from_config(
                 team_id=self.team.pk,

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -575,24 +575,38 @@ class TestDatabricksIntegrationModel(BaseTest):
         mock_socket.return_value.connect.return_value = None
         integration = DatabricksIntegration.integration_from_config(
             team_id=self.team.pk,
-            server_hostname="databricks.com",
+            server_hostname="my-account.cloud.databricks.com",
             client_id="client_id",
             client_secret="client_secret",
             created_by=self.user,
         )
         assert integration.team == self.team
         assert integration.created_by == self.user
-        assert integration.config == {"server_hostname": "databricks.com"}
+        assert integration.config == {"server_hostname": "my-account.cloud.databricks.com"}
         assert integration.sensitive_config == {"client_id": "client_id", "client_secret": "client_secret"}
 
     @patch("posthog.models.integration.socket.socket")
     def test_integration_from_config_with_invalid_server_hostname(self, mock_socket):
-        # this is the error raised when the server hostname is invalid
+        # this is the error raised when our basic connection test fails
         mock_socket.return_value.connect.side_effect = socket.gaierror(
             8, "nodename nor servname provided, or not known"
         )
         with pytest.raises(
-            DatabricksIntegrationError, match="Databricks integration error: could not connect to hostname 'invalid'"
+            DatabricksIntegrationError,
+            match="Databricks integration error: could not connect to hostname 'invalid.cloud.databricks.com'",
+        ):
+            DatabricksIntegration.integration_from_config(
+                team_id=self.team.pk,
+                server_hostname="invalid.cloud.databricks.com",
+                client_id="client_id",
+                client_secret="client_secret",
+                created_by=self.user,
+            )
+
+    def test_integration_from_config_with_non_databricks_server_hostname(self):
+        with pytest.raises(
+            DatabricksIntegrationError,
+            match="Databricks integration is not valid: 'invalid' is not a valid Databricks hostname",
         ):
             DatabricksIntegration.integration_from_config(
                 team_id=self.team.pk,

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -14,7 +14,7 @@ from django.conf import settings
 import pyarrow as pa
 from databricks import sql
 from databricks.sdk._base_client import _BaseClient
-from databricks.sdk.core import Config, oauth_service_principal
+from databricks.sdk.core import Config, ConfigAttribute, oauth_service_principal
 from databricks.sdk.oauth import (
     OidcEndpoints,
     get_account_endpoints,
@@ -146,6 +146,14 @@ class DatabricksConfig(Config):
     I have opened an issue with Databricks to make this timeout configurable:
     https://github.com/databricks/databricks-sdk-py/issues/1046
     """
+
+    # These are required since the Databricks SDK tries to fetch annotations from the Config class, and annotations are
+    # not inherited by base classes
+    host: str = ConfigAttribute(env="DATABRICKS_HOST")  # type: ignore
+    client_id: str = ConfigAttribute(env="DATABRICKS_CLIENT_ID")  # type: ignore
+    client_secret: str = ConfigAttribute(env="DATABRICKS_CLIENT_SECRET")  # type: ignore
+    disable_async_token_refresh: bool = ConfigAttribute(env="DATABRICKS_DISABLE_ASYNC_TOKEN_REFRESH")  # type: ignore
+    auth_type: str = ConfigAttribute(env="DATABRICKS_AUTH_TYPE")  # type: ignore
 
     @property
     def oidc_endpoints(self) -> OidcEndpoints | None:

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -274,7 +274,7 @@ class DatabricksClient:
                 self.http_path,
             )
             raise DatabricksConnectionError(
-                f"Failed to connect to Databricks. Please check that the server_hostname and http_path are valid."
+                "Failed to connect to Databricks. Please check that your connection details are valid."
             )
         except OperationalError as err:
             self.logger.info(

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -944,8 +944,11 @@ async def insert_into_databricks_activity_from_stage(inputs: DatabricksInsertInp
         requires_merge, merge_key, update_key = _get_databricks_merge_config(model=model)
 
         data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
+        # include attempt in the stage table name to avoid collisions if multiple attempts are running at the same time
+        # (ideally this should never happen but it has in the past)
+        attempt = activity.info().attempt
         stage_table_name: str | None = (
-            f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}" if requires_merge else None
+            f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}_{attempt}" if requires_merge else None
         )
         volume_name = f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}"
         volume_path = f"/Volumes/{inputs.catalog}/{inputs.schema}/{volume_name}"

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -114,6 +114,7 @@ class DatabricksInsertInputs(BatchExportInsertInputs):
         evolution](https://docs.databricks.com/aws/en/delta/update-schema#automatic-schema-evolution-for-delta-lake-merge).
         This means the target table will automatically be updated with the schema of the source table (however, no
         columns will be dropped from the target table).
+        NOTE: currently we don't expose this in the frontend as we're assuming all users would want to use this.
     table_partition_field: the field to partition the table by.
         If None, we will use the default partition by field for the model (if exists)
     """

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -13,14 +13,7 @@ from django.conf import settings
 
 import pyarrow as pa
 from databricks import sql
-from databricks.sdk._base_client import _BaseClient
 from databricks.sdk.core import Config, oauth_service_principal
-from databricks.sdk.oauth import (
-    OidcEndpoints,
-    get_account_endpoints,
-    get_azure_entra_id_workspace_endpoints,
-    get_workspace_endpoints,
-)
 from databricks.sql.client import Connection
 from databricks.sql.exc import OperationalError, ServerOperationError
 from databricks.sql.types import Row
@@ -135,29 +128,6 @@ class DatabricksInsertInputs(BatchExportInsertInputs):
     table_partition_field: str | None = None
 
 
-class DatabricksConfig(Config):
-    """Config for Databricks.
-
-    We need to override the oidc_endpoints method to use a custom client with a custom timeout since the default
-    implementation uses an unconfigurable timeout of 5 minutes. This means our code just hangs if the user provides
-    invalid connection parameters.
-
-    I have opened an issue with Databricks to make this timeout configurable:
-    https://github.com/databricks/databricks-sdk-py/issues/1046
-    """
-
-    @property
-    def oidc_endpoints(self) -> OidcEndpoints | None:
-        self._fix_host_if_needed()
-        if not self.host:
-            return None
-        if self.is_azure and self.azure_client_id:
-            return get_azure_entra_id_workspace_endpoints(self.host)
-        if self.is_account_client and self.account_id:
-            return get_account_endpoints(self.host, self.account_id)
-        return get_workspace_endpoints(self.host, client=_BaseClient(retry_timeout_seconds=5))
-
-
 class DatabricksClient:
     # How often to poll for query status. This is a trade-off between responsiveness and number of
     # queries we make to Databricks. 1 second has been chosen rather arbitrarily.
@@ -211,10 +181,21 @@ class DatabricksClient:
         return self._connection
 
     async def _connect(self):
-        """Establish a raw Databricks connection in a separate thread."""
+        """Establish a raw Databricks connection in a separate thread.
+
+        Note: The get_credential_provider can hang for up to 5 mins if an invalid host is provided. This is because the
+        Databricks SDK is using a default timeout of 5 minutes when fetching the oidc endpoints.
+
+        (We did try to override the timeout by subclassing the Config class, but it didn't work for some reason).
+
+        I have opened an issue with Databricks to make this timeout configurable:
+        https://github.com/databricks/databricks-sdk-py/issues/1046
+
+        In the meantime, we try to handle this the best we can by validating the hostname in the integration model.
+        """
 
         def get_credential_provider():
-            config = DatabricksConfig(
+            config = Config(
                 host=f"https://{self.server_hostname}",
                 client_id=self.client_id,
                 client_secret=self.client_secret,
@@ -252,7 +233,7 @@ class DatabricksClient:
                 self.http_path,
             )
             raise DatabricksConnectionError(
-                f"Failed to connect to Databricks. Please check that the server_hostname and http_path are valid."
+                "Failed to connect to Databricks. Please check that your connection details are valid."
             )
         except OperationalError as err:
             self.logger.info(

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/README.md
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/README.md
@@ -15,5 +15,5 @@ To enable testing for Databricks batch exports we require:
 The tests can then be run using a command such as the following:
 
 ```bash
-DEBUG=1 DATABRICKS_SERVER_HOSTNAME=my-host.cloud.databricks.com DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/my-warehouse DATABRICKS_CLIENT_ID=my-client-id DATABRICKS_CLIENT_SECRET=my-client-secret pytest products/batch_exports/backend/tests/temporal/destinations/databricks/test_workflow.py
+DEBUG=1 DATABRICKS_BE_SERVER_HOSTNAME=my-host.cloud.databricks.com DATABRICKS_BE_HTTP_PATH=/sql/1.0/warehouses/my-warehouse DATABRICKS_BE_CLIENT_ID=my-client-id DATABRICKS_BE_CLIENT_SECRET=my-client-secret pytest products/batch_exports/backend/tests/temporal/destinations/databricks/test_workflow.py
 ```

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
@@ -174,10 +174,10 @@ async def test_get_copy_into_table_from_volume_query():
     )
 
 
-async def test_connect_when_invalid_connection_details():
-    """Test that we raise an error when the connection details are invalid."""
+async def test_connect_when_invalid_host():
+    """Test that we raise an error when the host is invalid."""
     client = DatabricksClient(
-        server_hostname="databricks.com",
+        server_hostname="invalid",
         http_path="test",
         client_id="test",
         client_secret="test",
@@ -186,7 +186,7 @@ async def test_connect_when_invalid_connection_details():
     )
     with pytest.raises(
         DatabricksConnectionError,
-        match="Failed to connect to Databricks. Please check that your connection details are valid.",
+        match="Failed to connect to Databricks. Please check that the server_hostname and http_path are valid.",
     ):
         async with client.connect():
             pass

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
@@ -186,7 +186,7 @@ async def test_connect_when_invalid_host():
     )
     with pytest.raises(
         DatabricksConnectionError,
-        match="Failed to connect to Databricks. Please check that the server_hostname and http_path are valid.",
+        match="Failed to connect to Databricks. Please check that your connection details are valid.",
     ):
         async with client.connect():
             pass

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
@@ -174,10 +174,10 @@ async def test_get_copy_into_table_from_volume_query():
     )
 
 
-async def test_connect_when_invalid_host():
-    """Test that we raise an error when the host is invalid."""
+async def test_connect_when_invalid_connection_details():
+    """Test that we raise an error when the connection details are invalid."""
     client = DatabricksClient(
-        server_hostname="invalid",
+        server_hostname="databricks.com",
         http_path="test",
         client_id="test",
         client_secret="test",
@@ -186,7 +186,7 @@ async def test_connect_when_invalid_host():
     )
     with pytest.raises(
         DatabricksConnectionError,
-        match="Failed to connect to Databricks. Please check that the server_hostname and http_path are valid.",
+        match="Failed to connect to Databricks. Please check that your connection details are valid.",
     ):
         async with client.connect():
             pass

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_workflow.py
@@ -42,11 +42,13 @@ from products.batch_exports.backend.tests.temporal.destinations.base_destination
     assert_clickhouse_records_in_destination,
 )
 
+# Note: we add _BE to the env vars to avoid conflicts with env vars the Databricks SDK is automatically looking for,
+# which can cause issues.
 REQUIRED_ENV_VARS = (
-    "DATABRICKS_SERVER_HOSTNAME",
-    "DATABRICKS_HTTP_PATH",
-    "DATABRICKS_CLIENT_ID",
-    "DATABRICKS_CLIENT_SECRET",
+    "DATABRICKS_BE_SERVER_HOSTNAME",
+    "DATABRICKS_BE_HTTP_PATH",
+    "DATABRICKS_BE_CLIENT_ID",
+    "DATABRICKS_BE_CLIENT_SECRET",
 )
 
 
@@ -93,7 +95,7 @@ class DatabricksDestinationTest(BaseDestinationTest):
     def get_destination_config(self, team_id: int) -> dict:
         """Provide test configuration for Databricks destination."""
         return {
-            "http_path": os.getenv("DATABRICKS_HTTP_PATH"),
+            "http_path": os.getenv("DATABRICKS_BE_HTTP_PATH"),
             "catalog": os.getenv("DATABRICKS_CATALOG", f"batch_export_tests"),
             # use a hyphen in the schema name to test we handle it correctly
             "schema": os.getenv("DATABRICKS_SCHEMA", f"test_workflow_schema-{team_id}"),
@@ -107,15 +109,15 @@ class DatabricksDestinationTest(BaseDestinationTest):
         NOTE: we're using machine-to-machine OAuth here:
         https://docs.databricks.com/aws/en/dev-tools/python-sql-connector#oauth-machine-to-machine-m2m-authentication
         """
-        server_hostname = os.getenv("DATABRICKS_SERVER_HOSTNAME")
+        server_hostname = os.getenv("DATABRICKS_BE_SERVER_HOSTNAME")
         integration = await Integration.objects.acreate(
             team_id=team_id,
             kind=Integration.IntegrationKind.DATABRICKS,
             integration_id=server_hostname,
             config={"server_hostname": server_hostname},
             sensitive_config={
-                "client_id": os.getenv("DATABRICKS_CLIENT_ID"),
-                "client_secret": os.getenv("DATABRICKS_CLIENT_SECRET"),
+                "client_id": os.getenv("DATABRICKS_BE_CLIENT_ID"),
+                "client_secret": os.getenv("DATABRICKS_BE_CLIENT_SECRET"),
             },
         )
         return integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,8 +166,8 @@ dependencies = [
     "linkedin-api-client>=0.3.0",
     "aiobotocore>=2.7.0",
     "runloop-api-client>=0.60.0",
-    "databricks-sql-connector~=4.1.2",
-    "databricks-sdk~=0.66.0",
+    "databricks-sql-connector~=4.1.3",
+    "databricks-sdk~=0.67.0",
     "litellm>=1.77.7",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1244,20 +1244,20 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.66.0"
+version = "0.67.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/c0/11a97a60a2e2d8d413845d5b7c146a3a83df5e3e37b614169f7bb5f89ca6/databricks_sdk-0.66.0.tar.gz", hash = "sha256:0168e0ffdee8a11ee527e6de888ce0f6ed587329cf0c84038fb215a8b732600f", size = 759829, upload-time = "2025-09-22T13:07:25.024Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/5b/df3e5424d833e4f3f9b42c409ef8b513e468c9cdf06c2a9935c6cbc4d128/databricks_sdk-0.67.0.tar.gz", hash = "sha256:f923227babcaad428b0c2eede2755ebe9deb996e2c8654f179eb37f486b37a36", size = 761000, upload-time = "2025-09-25T13:32:10.858Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/2b/579c272505a3b98cbabad80b517574607022219b3207c65b09c8222d8ac7/databricks_sdk-0.66.0-py3-none-any.whl", hash = "sha256:be4d7e48a682fc4cb8dc51730e660492054e143c7831c8f5485025cc72b0c765", size = 717483, upload-time = "2025-09-22T13:07:23.008Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ca/2aff3817041483fb8e4f75a74a36ff4ca3a826e276becd1179a591b6348f/databricks_sdk-0.67.0-py3-none-any.whl", hash = "sha256:ef49e49db45ed12c015a32a6f9d4ba395850f25bb3dcffdcaf31a5167fe03ee2", size = 718422, upload-time = "2025-09-25T13:32:09.011Z" },
 ]
 
 [[package]]
 name = "databricks-sql-connector"
-version = "4.1.2"
+version = "4.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lz4" },
@@ -1270,9 +1270,9 @@ dependencies = [
     { name = "thrift" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/75/2587e876e545849cc89e64d1aee2d021126bd92ab46f7eec5194a6f6a395/databricks_sql_connector-4.1.2.tar.gz", hash = "sha256:7a4eee6c773e0415731530dd812cc4bae04067e73521e5f6161c05d25233e5e7", size = 175173, upload-time = "2025-08-22T12:10:45.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/e9/6f538a27ffa79a34ddb7ea61e18fdce8420aca899c7cecdcad61b56d75c7/databricks_sql_connector-4.1.3.tar.gz", hash = "sha256:225cef7c3454e93d7a700dd336c665a44b04ab8f80236bd9be815bc42e7d2468", size = 175553, upload-time = "2025-09-17T17:56:28.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/ea/322be8c8b845f8fb3e7f879164c1c73bb269671460f1f031391ae800cea8/databricks_sql_connector-4.1.2-py3-none-any.whl", hash = "sha256:b2d05bde9eb48226a6ca56b2e862150445a323e93504379605568371c4c0af19", size = 198429, upload-time = "2025-08-22T12:10:43.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6f/56617e6a866d8f0ba54f1df1b7d2feb9fe63e27e06033c81ce20ad894721/databricks_sql_connector-4.1.3-py3-none-any.whl", hash = "sha256:471c5acc2ce4ee4efedf66d33e6f86f5cd349496a85826ee95fc59b485d2daef", size = 198774, upload-time = "2025-09-17T17:56:27.112Z" },
 ]
 
 [[package]]
@@ -4392,8 +4392,8 @@ requires-dist = [
     { name = "dagster-postgres", specifier = "==0.26.18" },
     { name = "dagster-slack", specifier = "==0.26.18" },
     { name = "dagster-webserver", specifier = "==1.10.18" },
-    { name = "databricks-sdk", specifier = "~=0.66.0" },
-    { name = "databricks-sql-connector", specifier = "~=4.1.2" },
+    { name = "databricks-sdk", specifier = "~=0.67.0" },
+    { name = "databricks-sql-connector", specifier = "~=4.1.3" },
     { name = "deltalake", specifier = "==0.25.2" },
     { name = "dj-database-url", specifier = "==0.5.0" },
     { name = "django", specifier = "~=4.2.17" },


### PR DESCRIPTION
## Problem

There were a few issues with the Databricks backend code that came up when integrating with the frontend:
- We weren't raising validation errors correctly when attempting to create a new integration
- In a [previous PR](https://github.com/PostHog/posthog/pull/38730) we tried to subclass the Databricks `Config` class to customise the connection retry timeout. This works perfectly when running the tests via `pytest`, however for some strange reason, this breaks when running the workflow locally in Temporal; the Databricks client raises a connection error immediately. This would happen even if the subclass doesn't override any existing behaviour. I spent quite a bit of time trying to figure out what was going on but couldn't get anywhere. I think the easiest thing to do is to validate the hostname by using a list of valid hostname patterns, which should catch the majority of issues.
- We're not adding the attempt number to the stage table name; we should add this like we've done with other destinations
- Updating the integration id for an existing batch export doesn't work

## Changes

Fix the above issues.

Update tests and make some of them simpler.

Upgrade the Databricks sql-connector and SDK package versions.

## How did you test this code?

Manual and automated tests
