### PR TITLE
fix: Freeze time to expect partition 202408 to be cleaned.

### DIFF
--- a/dags/tests/test_deletes.py
+++ b/dags/tests/test_deletes.py
@@ -3,6 +3,7 @@ from functools import partial
 from uuid import UUID
 
 import pytest
+from freezegun import freeze_time
 
 from clickhouse_driver import Client
 
@@ -518,6 +519,7 @@ def test_cleanup_old_events_by_partition(cluster: ClickhouseCluster):
 
 
 @pytest.mark.django_db
+@freeze_time("2025-09-15")
 def test_cleanup_old_events_delete_query_format(cluster: ClickhouseCluster, snapshot):
     from unittest.mock import patch
 


### PR DESCRIPTION
## Problem

- The test depends on dynamic time calc, i.e. `now() - 400 days` to determine partition to clean. So as time passes it starts to fail compared to the snap which was done in sept 2025.

## Changes

- Freeze time on the test.
