### PR TITLE
fix(batch-exports): Add missing activity

### DIFF
--- a/products/batch_exports/backend/temporal/__init__.py
+++ b/products/batch_exports/backend/temporal/__init__.py
@@ -29,6 +29,7 @@ from products.batch_exports.backend.temporal.destinations.postgres_batch_export 
 from products.batch_exports.backend.temporal.destinations.redshift_batch_export import (
     RedshiftBatchExportWorkflow,
     insert_into_redshift_activity,
+    insert_into_redshift_activity_from_stage,
 )
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
     S3BatchExportWorkflow,
@@ -74,6 +75,7 @@ ACTIVITIES = [
     insert_into_http_activity,
     insert_into_postgres_activity,
     insert_into_redshift_activity,
+    insert_into_redshift_activity_from_stage,
     insert_into_snowflake_activity,
     insert_into_snowflake_activity_from_stage,
     noop_activity,


### PR DESCRIPTION
## Problem

Forgot to add new activity to workers. Unit tests add everything manually so this wasn't caught.

TODO: Have unit tests import the list of activities so that they will fail in case something is missed.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add new activity `insert_into_redshift_activity_from_stage` to list of batch export activities.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
