### PR TITLE
chore: Add `gemini-flash-latest` provider costs

### DIFF
--- a/plugin-server/src/ingestion/ai-costs/providers/llm-provider-costs.json
+++ b/plugin-server/src/ingestion/ai-costs/providers/llm-provider-costs.json
@@ -1777,6 +1777,14 @@
         }
     },
     {
+        "model": "gemini-flash-latest",
+        "provider": "gemini",
+        "cost": {
+            "prompt_token": 3e-7,
+            "completion_token": 0.0000025
+        }
+    },
+    {
         "model": "gemini-2.5-flash-lite",
         "provider": "gemini",
         "cost": {


### PR DESCRIPTION
## Problem

Add `gemini-flash-latest` to the LLM provider costs file.

<img width="574" height="195" alt="image" src="https://github.com/user-attachments/assets/f0288cc1-26eb-4520-aa84-6f5d7d8cb91d" />

https://posthoghelp.zendesk.com/agent/tickets/39129 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41498)