### PR TITLE
fix(cohorts): Skip caching dependencies for cohorts with invalid filters

### DIFF
--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -41,7 +41,7 @@ def extract_cohort_dependencies(cohort: Cohort) -> set[int]:
                     dependencies.add(prop.value)
         except ValidationError as e:
             COHORT_DEPENDENCY_CACHE_COUNTER.labels(cache_type="dependencies", result="invalid").inc()
-            logger.exception("Skipping cohort with invalid filters", cohort_id=cohort.id, error=str(e))
+            logger.warning("Skipping cohort with invalid filters", cohort_id=cohort.id, error=str(e))
     return dependencies
 
 


### PR DESCRIPTION
## Problem

In some cases `cohort.properties` raises a ValidationError. If this occurs, we'll skip the cohort.

```
  File \"/code/posthog/models/cohort/dependencies.py\", line 37, in extract_cohort_dependencies
    for prop in cohort.properties.flat:
                ^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/cohort/cohort.py\", line 215, in properties
    return Filter(data={**self.filters, \"is_simplified\": True}).property_groups
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/filters/mixins/property.py\", line 15, in property_groups
    return self._parse_data(key=PROPERTIES)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/filters/mixins/property.py\", line 31, in _parse_data
    return self._parse_property_group(loaded_props)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/filters/mixins/property.py\", line 99, in _parse_property_group
    self._parse_property_group_list(group[\"values\"]),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/filters/mixins/property.py\", line 123, in _parse_property_group_list
    return [self._parse_property_group(group) for group in prop_list]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/filters/mixins/property.py\", line 123, in <listcomp>
    return [self._parse_property_group(group) for group in prop_list]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/filters/mixins/property.py\", line 99, in _parse_property_group
    self._parse_property_group_list(group[\"values\"]),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/code/posthog/models/filters/mixins/property.py\", line 120, in _parse_property_group_list
    raise ValidationError(\"Property list cannot contain both PropertyGroup and Property objects\")
```

## Changes

The exception is now handled gracefully. Any cohort with properties that cannot be enumerated will be skipped.

## How did you test this code?

I've added a unit test.

