### PR TITLE
fix: browser suggests a mem leak in the context menu

### DIFF
--- a/frontend/src/lib/hooks/useScrollable.ts
+++ b/frontend/src/lib/hooks/useScrollable.ts
@@ -56,10 +56,11 @@ export function useScrollable(): { ref: React.MutableRefObject<HTMLDivElement | 
             const timeout = setTimeout(() => updateIsScrollable(element), 200)
             return () => {
                 element.removeEventListener('scroll', handler)
-                clearInterval(timeout)
+                clearTimeout(timeout)
             }
         }
-    }, [scrollRef.current])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     useLayoutEffect(() => {
         const element = scrollRef.current

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -485,11 +485,11 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                 </Link>
                             </ContextMenuTrigger>
 
-                            {isContextMenuOpenForItem === item.id && itemContextMenu?.(item) ? (
+                            {itemContextMenu?.(item) && (
                                 <ContextMenuContent loop className="max-w-[250px]">
                                     {itemContextMenu(item)}
                                 </ContextMenuContent>
-                            ) : null}
+                            )}
                         </ContextMenu>
                     )
 


### PR DESCRIPTION
still following my nose



## Claude says

The effect can run multiple times when:
  - Component re-renders (from width/height changes in
   useResizeObserver)
  - scrollRef.current value is different on that
  re-render

  Each re-run:
  1. Creates a new handler function
  2. Adds a new scroll listener
  3. Cleanup tries to remove a listener, but only
  removes ONE

  This means event listeners accumulate on the
  element. Every time ContextMenu mounts/unmounts,
  more listeners pile up, causing the memory leak.

  Why [] Fixes It

  With [], the effect runs exactly once per component
  lifecycle:
  - Setup once on mount → one listener
  - Cleanup once on unmount → removes that listener
  - No accumulation

Related to #32479
