### PR TITLE
fix(batch-exports): Set higher keepalive_timeout for S3 connection

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from django.conf import settings
 
 import aioboto3
+from aiobotocore.config import AioConfig
 from temporalio import activity
 
 from posthog.clickhouse import query_tagging
@@ -69,6 +70,9 @@ async def get_s3_client():
         aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
         endpoint_url=_get_s3_endpoint_url(),
         region_name=settings.BATCH_EXPORT_OBJECT_STORAGE_REGION,
+        # aiobotocore defaults keepalive_timeout to 12 seconds, which can be low for
+        # slower batch exports.
+        config=AioConfig(connector_args={"keepalive_timeout": 60}),
     ) as s3_client:
         yield s3_client
 


### PR DESCRIPTION
## Problem

By default, aiobotocore sets a 12 second keepalive_timeout for S3 connections. However, some slower, less performant batch exports can hit this timeout.

We are working on performance improvements, but in the meantime let's allow a larger timeout here.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Set `keepalive_timeout` to 60 seconds. Will likely need to adjust more after testing, but this seemed like a good starting point.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I didn't. Looks harmless.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
