### PR TITLE
chore(myke): add pod termination timer for cdp

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -327,6 +327,9 @@ export function getDefaultConfig(): PluginsServerConfig {
         SES_ACCESS_KEY_ID: isTestEnv() || isDevEnv() ? 'test' : '',
         SES_SECRET_ACCESS_KEY: isTestEnv() || isDevEnv() ? 'test' : '',
         SES_REGION: 'us-east-1',
+
+        // Pod termination
+        POD_TERMINATION_ENABLED: false,
     }
 }
 

--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -60,6 +60,7 @@ export class PluginServer {
     hub?: Hub
     expressApp: express.Application
     nodeInstrumentation: NodeInstrumentation
+    private podTerminationTimer?: NodeJS.Timeout
 
     constructor(
         config: Partial<PluginsServerConfig> = {},
@@ -74,6 +75,23 @@ export class PluginServer {
 
         this.expressApp = setupExpressApp()
         this.nodeInstrumentation = new NodeInstrumentation(this.config)
+    }
+
+    private setupPodTermination(): void {
+        // Base timeout: 1 hour (3600000 ms)
+        const baseTimeoutMs = 60 * 60 * 1000
+
+        // Add jitter: random value between 0-15 minutes (0-900000 ms)
+        const jitterMs = Math.random() * 15 * 60 * 1000
+
+        const totalTimeoutMs = baseTimeoutMs + jitterMs
+
+        logger.info('⏰', `Pod termination scheduled in ${Math.round(totalTimeoutMs / 1000 / 60)} minutes`)
+
+        this.podTerminationTimer = setTimeout(() => {
+            logger.info('⏰', 'Pod termination timeout reached, shutting down gracefully...')
+            void this.stop()
+        }, totalTimeoutMs)
     }
 
     async start(): Promise<void> {
@@ -269,6 +287,11 @@ export class PluginServer {
 
             pluginServerStartupTimeMs.inc(Date.now() - startupTimer.valueOf())
             logger.info('🚀', `All systems go in ${Date.now() - startupTimer.valueOf()}ms`)
+
+            // Setup pod termination if enabled
+            if (this.config.POD_TERMINATION_ENABLED) {
+                this.setupPodTermination()
+            }
         } catch (error) {
             captureException(error)
             logger.error('💥', 'Launchpad failure!', { error: error.stack ?? error })
@@ -311,6 +334,12 @@ export class PluginServer {
         }
 
         this.stopping = true
+
+        // Clear pod termination timer if it exists
+        if (this.podTerminationTimer) {
+            clearTimeout(this.podTerminationTimer)
+            this.podTerminationTimer = undefined
+        }
 
         this.nodeInstrumentation.cleanup()
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -474,6 +474,9 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     HEAP_DUMP_S3_PREFIX: string
     HEAP_DUMP_S3_ENDPOINT: string
     HEAP_DUMP_S3_REGION: string
+
+    // Pod termination
+    POD_TERMINATION_ENABLED: boolean
 }
 
 export interface Hub extends PluginsServerConfig {


### PR DESCRIPTION
## Problem

due to a mem leak and a some pods getting stuck on consumption we for now want to kill our pods controlled periodically. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- added termination of pods 
- added jitter to not terminate them all at once 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- rolling out on dev to see if it works
- proceed with rollout on prod after dev is confirmed

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
