### PR TITLE
fix(max): max memory fixes

### DIFF
--- a/ee/hogai/eval/ci/eval_memory.py
+++ b/ee/hogai/eval/ci/eval_memory.py
@@ -26,8 +26,9 @@ class MemoryContentRelevance(LLMClassifier):
             prompt_template="""Evaluate if the memory content is relevant and well-formatted.
 
 Context:
-- Memory content should only contain factual information about the product or company
-- Personal information or irrelevant details should be omitted
+- Memory content should contain factual information about the product or company
+- When users explicitly request to save information (e.g., "remember that...", "remember this..."), the information should be saved even if it's not product-related (e.g., personal preferences, user context)
+- Personal information or irrelevant details should be omitted UNLESS explicitly requested
 - Facts should be stated clearly and consistently
 - When replacing facts, the new fact should be logically related to the original
 
@@ -164,6 +165,15 @@ async def eval_memory(call_node, pytestconfig):
                     id="6",
                     name="core_memory_append",
                     args={"memory_content": "Our main KPI is monthly active users (MAU)"},
+                ),
+            ),
+            # Test explicit non-product-related memory request
+            EvalCase(
+                input="Remember my favorite treat is chocolate",
+                expected=AssistantToolCall(
+                    id="7",
+                    name="core_memory_append",
+                    args={"memory_content": "The user's favorite treat is chocolate."},
                 ),
             ),
             # Test /remember slash command with no arg

--- a/ee/hogai/graph/memory/prompts.py
+++ b/ee/hogai/graph/memory/prompts.py
@@ -123,10 +123,14 @@ When new information is provided, follow these steps:
 Ignore phrases that:
 - Are too vague or generic without specific details (e.g., "pageview trend").
 - Do not describe actions, attributes, or implications related to the company or product.
+- EXCEPTION: Always save information when explicitly requested by the user, even if vague or not product-related.
 </instructions>
 
 <examples>
 Here are some few shot examples:
+
+Output: The user's favorite treat is chocolate.
+Reasoning: The user explicitly asked to save it.
 
 Input: Track a churn rate by using `cancel_subscription` divided by `subscription_paid` event.
 Output: To track a churn rate, use the `cancel_subscription` divided by `subscription_paid` events.


### PR DESCRIPTION
## Problem

When users explicitly asked Max to remember something (e.g., "Remember that my favorite treat is chocolate"), the memory collector would evaluate whether the content was product-related *before* checking if the user explicitly requested to save it. This caused Max to reject personal or non-product information even when users clearly wanted it saved.

Additionally, If a user cleared Max's memory via the Settings UI (setting `text` to empty string), subsequent attempts to append new memories would fail because `append_core_memory()` only checked `if self.text == ""` which doesn't properly handle falsy values.

Based on feedback ticket https://posthoghelp.zendesk.com/agent/tickets/39283 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41135) 

## Changes

- Prioritize explicit user requests
- Reordered prompt instructions to check for explicit "remember"/"save"/"note" phrases **first**
- Only evaluate product-relevance if no explicit request was detected
- Added clear example based on user feedback (`chroma`)

## How did you test this code?

- [x] manual tests
- [x] unit tests

**before**:

https://github.com/user-attachments/assets/1145c1be-e14c-450b-b0d8-47b143c57745

**after**:

https://github.com/user-attachments/assets/a35289d8-32cf-491c-9c4a-ddfb69af88a5
