### PR TITLE
fix: freeze time in story file

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
@@ -22,6 +22,9 @@ const meta: Meta<typeof ItemEvent> = {
             get: {},
         }),
     ],
+    parameters: {
+        mockDate: '2025-09-23',
+    },
 }
 export default meta
 


### PR DESCRIPTION
noticed this story flaps once a month when the date changes 🫠 