### PR TITLE
fix: use correct queue for delete-recording workflows

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -30,7 +30,7 @@ from posthog.api.documentation import PersonPropertiesSerializer, extend_schema
 from posthog.api.insight import capture_legacy_api_call
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action, format_paginated_url, get_pk_or_uuid, get_target_entity
-from posthog.constants import GENERAL_PURPOSE_TASK_QUEUE, INSIGHT_FUNNELS, LIMIT, OFFSET, FunnelVizType
+from posthog.constants import INSIGHT_FUNNELS, LIMIT, OFFSET, SESSION_REPLAY_TASK_QUEUE, FunnelVizType
 from posthog.decorators import cached_by_filters
 from posthog.logging.timing import timed
 from posthog.metrics import LABEL_TEAM_ID
@@ -878,7 +878,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 "delete-recordings-with-person",
                 input,
                 id=workflow_id,
-                task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+                task_queue=SESSION_REPLAY_TASK_QUEUE,
             )
         )
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -23,7 +23,7 @@ from rest_framework import status
 
 import posthog.models.person.deletion
 from posthog.clickhouse.client import sync_execute
-from posthog.constants import GENERAL_PURPOSE_TASK_QUEUE
+from posthog.constants import SESSION_REPLAY_TASK_QUEUE
 from posthog.models import Cohort, Organization, Person, PropertyDefinition, Team
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.person import PersonDistinctId
@@ -408,7 +408,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                         team_id=self.team.id,
                     ),
                     id=f"delete-recordings-with-person-{person.uuid}-1234",
-                    task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+                    task_queue=SESSION_REPLAY_TASK_QUEUE,
                 )
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
@@ -442,7 +442,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                         team_id=self.team.id,
                     ),
                     id=f"delete-recordings-with-person-{person.uuid}-1234",
-                    task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+                    task_queue=SESSION_REPLAY_TASK_QUEUE,
                 )
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
Use correct queue for delete-recording workflows