### PR TITLE
fix(customers): Add personId filter in TracesQueryRunnerV2

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -1,6 +1,6 @@
-import { useValues } from 'kea'
+import { BindLogic, useValues } from 'kea'
 
-import { BaseLLMAnalyticsTraces } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
+import { LLMAnalyticsTraces } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
 import { llmAnalyticsLogic } from 'products/llm_analytics/frontend/llmAnalyticsLogic'
 
 import { NotebookNodeProps, NotebookNodeType } from '../types'
@@ -15,7 +15,11 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
         return null
     }
 
-    return <BaseLLMAnalyticsTraces logic={llmAnalyticsLogic({ personId })} />
+    return (
+        <BindLogic logic={llmAnalyticsLogic} props={{ personId }}>
+            <LLMAnalyticsTraces />
+        </BindLogic>
+    )
 }
 
 type NotebookNodeLLMTraceAttributes = {

--- a/posthog/hogql_queries/ai/traces_query_runner_v2.py
+++ b/posthog/hogql_queries/ai/traces_query_runner_v2.py
@@ -402,6 +402,15 @@ class TracesQueryRunnerV2(AnalyticsQueryRunner[TracesQueryResponse]):
         if properties_filter is not None:
             exprs.append(properties_filter)
 
+        if self.query.personId:
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["person_id"]),
+                    right=ast.Constant(value=self.query.personId),
+                )
+            )
+
         return ast.And(exprs=exprs)
 
     def _get_properties_filter(self) -> ast.Expr | None:

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -16,9 +16,9 @@ import { LLMMessageDisplay } from './ConversationDisplay/ConversationMessagesDis
 import { llmAnalyticsLogic } from './llmAnalyticsLogic'
 import { formatLLMCost, formatLLMLatency, formatLLMUsage, normalizeMessages, removeMilliseconds } from './utils'
 
-export function BaseLLMAnalyticsTraces({ logic }: { logic: ReturnType<typeof llmAnalyticsLogic> }): JSX.Element {
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(logic)
-    const { tracesQuery } = useValues(logic)
+export function LLMAnalyticsTraces(): JSX.Element {
+    const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(llmAnalyticsLogic)
+    const { tracesQuery } = useValues(llmAnalyticsLogic)
 
     return (
         <DataTable
@@ -79,10 +79,6 @@ export function BaseLLMAnalyticsTraces({ logic }: { logic: ReturnType<typeof llm
             uniqueKey="llm-analytics-traces"
         />
     )
-}
-
-export function LLMAnalyticsTraces(): JSX.Element {
-    return <BaseLLMAnalyticsTraces logic={llmAnalyticsLogic()} />
 }
 
 const IDColumn: QueryContextColumnComponent = ({ record }) => {


### PR DESCRIPTION
## Problem
In prod, traces in person canvas weren't filtering appropriately. It was showing traces from multiple people into a person view.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/38967
## Changes
- ~Change filter to use distinct id~ The fix was to add the filter by `personId` to `TracesQueryRunnerV2`, as this was the one we were using in prod (hence why the filter in `TracesQueryRunner` didn't work). Testing out in prod with `TracesQueryRunner` returned the expected results, so added the same logic to V2.
- Refactor component to use `BindLogic` to pass in props to logic
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
