### PR TITLE
fix(data-warehouse): Handle datetimes that come in as strings

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -290,6 +290,19 @@ def test_table_from_py_list_with_ipv6_address():
     )
 
 
+def test_table_from_py_list_with_string_like_dates():
+    table = table_from_py_list([{"column": "2024-01-01T00:00:00"}])
+
+    assert table.equals(pa.table({"column": [parser.parse("2024-01-01T00:00:00")]}))
+    assert table.schema.equals(
+        pa.schema(
+            [
+                ("column", pa.timestamp("us")),
+            ]
+        )
+    )
+
+
 def test_normalize_table_column_names_prevents_collisions():
     # Create a table with columns that would collide when normalized
     table = pa.table({"foo___bar": ["value1"], "foo_bar": ["value2"], "another___field": ["value3"]})

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -653,6 +653,7 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
 
                 adjusted_field = arrow_schema.field(field_index).with_nullable(has_nulls)
                 arrow_schema = arrow_schema.set(field_index, adjusted_field)
+                val = safe_parse_datetime(val)
 
             # Upscale second timestamps to microsecond
             if pa.types.is_timestamp(field.type) and issubclass(py_type, int) and field.type.unit == "s":


### PR DESCRIPTION
## Problem
- Some vitally fields were datetimes being disguised as strings

## Changes
- If a field looks like a datetime in string format, then parse it as a datetime

## How did you test this code?
Unit tests innit 