### PR TITLE
fix(data-warehouse): Use the correct sort for vitally

### DIFF
--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -77,7 +77,7 @@ class VitallySource(BaseSource[VitallySourceConfig]):
             partition_mode="datetime",
             partition_format="month",
             partition_keys=["created_at"],
-            sort_mode="desc",
+            sort_mode="desc" if inputs.schema_name == "Messages" else "asc",
         )
 
     @property


### PR DESCRIPTION
## Changes
- I made a mistake and changed this in a previous PR
- Changing it back for all tables that arent `messages`
