### PR TITLE
fix(dw): placeholder value in stripe secret form field

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -63,7 +63,7 @@ You can also simplify the setup by selecting **read** for the **entire resource*
                         label="API key",
                         type=SourceFieldInputConfigType.PASSWORD,
                         required=True,
-                        placeholder="rk_live_...",
+                        placeholder="sk_live_...",
                     ),
                 ],
             ),


### PR DESCRIPTION
## Problem

stripe secret starts with sk but the placeholder has "rk" simple typo probably

## Changes

fix typo.

## How did you test this code?

ran locally