### PR TITLE
chore(err): use role and token file, if available

### DIFF
--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -84,7 +84,7 @@ impl AppContext {
         let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
         let pool = options.connect(&config.database_url).await?;
 
-        let s3_client = aws_sdk_s3::Client::from_conf(get_aws_config(&config).await);
+        let s3_client = aws_sdk_s3::Client::from_conf(get_aws_config(config).await);
         let s3_client = S3Client::new(s3_client);
         let s3_client = Arc::new(s3_client);
 

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -184,7 +184,6 @@ fn default_maxmind_db_path() -> PathBuf {
         .join("GeoLite2-City.mmdb")
 }
 
-// Resolves the s3 client configuration, handling
 pub async fn get_aws_config(config: &Config) -> aws_sdk_s3::Config {
     // If we have a role ARN and token file, which are added to the container due to the SA annotation we use in prod
     if std::env::var("AWS_ROLE_ARN").is_ok() && std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE").is_ok()


### PR DESCRIPTION
This is the most backwards (and sideways to self-hosted) compatible way I could figure to do this - detect the creds, use em if they're set, fallback to the existing method otherwise