### PR TITLE
fix: Change icon of aalog page

### DIFF
--- a/frontend/src/scenes/audit-logs/AdvancedActivityLogsScene.tsx
+++ b/frontend/src/scenes/audit-logs/AdvancedActivityLogsScene.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconActivity } from '@posthog/icons'
+import { IconNotification } from '@posthog/icons'
 import { LemonTabs } from '@posthog/lemon-ui'
 
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
@@ -50,7 +50,7 @@ export function AdvancedActivityLogsScene(): JSX.Element | null {
                 description="Track all changes and activities in your organization with detailed filtering and export capabilities."
                 resourceType={{
                     type: 'team_activity',
-                    forceIcon: <IconActivity />,
+                    forceIcon: <IconNotification />,
                 }}
             />
             <SceneDivider />

--- a/frontend/src/scenes/audit-logs/AuditLogTable.tsx
+++ b/frontend/src/scenes/audit-logs/AuditLogTable.tsx
@@ -99,7 +99,12 @@ export function AuditLogTable({ logItems, pagination }: AuditLogTableProps): JSX
                 onRowCollapse: (logItem, index) => toggleRowExpansion(logItem, index),
             }}
             onRow={(logItem, index) => ({
-                onClick: () => toggleRowExpansion(logItem, index),
+                onClick: (e) => {
+                    if ((e.target as HTMLElement).closest('.LemonTable__toggle')) {
+                        return
+                    }
+                    toggleRowExpansion(logItem, index)
+                },
                 style: { cursor: 'pointer' },
             })}
             pagination={pagination}


### PR DESCRIPTION
## Changes

- Fix the expand/contract button on the activity logs table actually work.
- Change the page icon to be consistent with the sidebar Team Activity.
