### PR TITLE
fix: close old connections in billing consumer and quota limiting

### DIFF
--- a/ee/billing/queue/BillingConsumer.py
+++ b/ee/billing/queue/BillingConsumer.py
@@ -3,6 +3,8 @@ import json
 import logging
 from typing import Any, Optional
 
+from django.db import close_old_connections
+
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.exceptions_capture import capture_exception
 from posthog.models.organization import Organization
@@ -25,6 +27,8 @@ class BillingConsumer(SQSConsumer):
         Args:
             message: The SQS message to process
         """
+        close_old_connections()
+
         try:
             raw_body = message.get("Body", "{}")
             message_attributes = message.get("MessageAttributes", {})

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Optional, TypedDict, cast
 
+from django.conf import settings
 from django.db import close_old_connections
 from django.db.models import Q
 from django.utils import timezone
@@ -695,7 +696,10 @@ def update_all_orgs_billing_quotas(
         # Check and refresh DB connections if needed on every iteration.
         # The database_sync_to_async wrapper only closes connections at start/end,
         # but this loop can run for up to 30min.
-        close_old_connections()
+        # Skip in tests to avoid breaking test transactions.
+
+        if not settings.TEST:
+            close_old_connections()
 
         try:
             org = orgs_by_id[org_id]

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Optional, TypedDict, cast
 
+from django.db import close_old_connections
 from django.db.models import Q
 from django.utils import timezone
 
@@ -691,6 +692,11 @@ def update_all_orgs_billing_quotas(
     # Find all orgs that should be rate limited
     report_index = 1
     for org_id, todays_report in todays_usage_report.items():
+        # Check and refresh DB connections if needed on every iteration.
+        # The database_sync_to_async wrapper only closes connections at start/end,
+        # but this loop can run for up to 30min.
+        close_old_connections()
+
         try:
             org = orgs_by_id[org_id]
 


### PR DESCRIPTION
## Problem
- We've been getting `OperationalError: the connection is closed` in a couple of places for a while
  - Billing SQS consumer when processing messages
  - Quota limiting runs (5-30min) across tens of thousands of orgs 

## Changes
- Added `close_old_connections()` to refresh stale connections if needed
  - Billing SQS consumer - at the start of each message processing
  - Quota limiting - every iteration in the org loop
    - Ideally, we should refactor quota limiting so that e.g. each org update is a separate activity with retries and wrapped in `database_sync_to_async` (which refreshes connections), but we're planning on moving quota limiting to `billing` soon anyway

## How did you test this code?

n/a (I'll monitor first runs and errors after deploying)