### PR TITLE
fix(capture): fix activate connections logic

### DIFF
--- a/rust/capture/src/metrics_middleware.rs
+++ b/rust/capture/src/metrics_middleware.rs
@@ -9,11 +9,22 @@ use axum::{
     middleware::Next,
     response::IntoResponse,
 };
-use metrics::{gauge, histogram};
+use metrics::gauge;
 
 // Global atomic counter for active connections
 static ACTIVE_CONNECTIONS: AtomicUsize = AtomicUsize::new(0);
-pub const METRIC_CAPTURE_REQUEST_SIZE_BYTES: &str = "capture_request_size_bytes";
+
+// Guard to ensure connection count is decremented even on panic
+struct ConnectionGuard;
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        let connections = ACTIVE_CONNECTIONS
+            .fetch_sub(1, Ordering::Relaxed)
+            .saturating_sub(1);
+        gauge!(METRIC_CAPTURE_ACTIVE_CONNECTIONS).set(connections as f64);
+    }
+}
 const METRIC_CAPTURE_ACTIVE_CONNECTIONS: &str = "capture_active_connections";
 const METRIC_HTTP_REQUESTS_TOTAL: &str = "http_requests_total";
 const METRIC_HTTP_REQUESTS_DURATION_SECONDS: &str = "http_requests_duration_seconds";
@@ -35,33 +46,13 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     // Track active connections
     let connections = ACTIVE_CONNECTIONS.fetch_add(1, Ordering::Relaxed) + 1;
     gauge!(METRIC_CAPTURE_ACTIVE_CONNECTIONS).set(connections as f64);
-
-    // Track request content length
-    let content_length = req
-        .headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(0);
-
-    if content_length > 0 {
-        // Record request size with context
-        histogram!(
-            METRIC_CAPTURE_REQUEST_SIZE_BYTES,
-            "endpoint" => path.clone(),
-        )
-        .record(content_length as f64);
-    }
+    let _guard = ConnectionGuard;
 
     // Run the rest of the request handling first, so we can measure it and get response
     // codes.
     let response = next.run(req).await;
 
     let latency = start.elapsed().as_secs_f64();
-    // Clean up connection count
-    let connections = ACTIVE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed) - 1;
-    gauge!(METRIC_CAPTURE_ACTIVE_CONNECTIONS).set(connections as f64);
-
     let status = response.status().as_u16().to_string();
 
     let labels = [

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -4,8 +4,6 @@ use limiters::redis::QuotaResource;
 use metrics::counter;
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
-use crate::metrics_middleware::METRIC_CAPTURE_REQUEST_SIZE_BYTES;
-
 pub const CAPTURE_EVENTS_DROPPED_TOTAL: &str = "capture_events_dropped_total";
 
 pub fn report_dropped_events(cause: &'static str, quantity: u64) {
@@ -41,18 +39,6 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
     const BATCH_SIZES: &[f64] = &[
         1.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0,
     ];
-    // Buckets for request content-length in bytes (1KB to 20MB)
-    const REQUEST_SIZE_BYTES: &[f64] = &[
-        1024.0,       // 1 KB
-        10_240.0,     // 10 KB
-        102_400.0,    // 100 KB
-        512_000.0,    // 500 KB
-        1_048_576.0,  // 1 MB
-        5_242_880.0,  // 5 MB
-        10_485_760.0, // 10 MB
-        20_971_520.0, // 20 MB
-        52_428_800.0, // 50 MB (for edge cases)
-    ];
 
     PrometheusBuilder::new()
         .set_buckets_for_metric(
@@ -61,11 +47,6 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
         )
         .unwrap()
         .set_buckets_for_metric(Matcher::Suffix("_batch_size".to_string()), BATCH_SIZES)
-        .unwrap()
-        .set_buckets_for_metric(
-            Matcher::Full(METRIC_CAPTURE_REQUEST_SIZE_BYTES.to_string()),
-            REQUEST_SIZE_BYTES,
-        )
         .unwrap()
         .install_recorder()
         .unwrap()


### PR DESCRIPTION
## Problem

In production we're seeing the metric not being decreased correctly, this is probably due to how we handle errors. This PR aims to consistently decrease the active connection metric when we finish a connection 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
