### PR TITLE
chore(err): make sure we can talk to s3 on startup

### DIFF
--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -88,6 +88,8 @@ impl AppContext {
         let s3_client = S3Client::new(s3_client);
         let s3_client = Arc::new(s3_client);
 
+        s3_client.ping_bucket(&config.object_storage_bucket).await?;
+
         let ss_cache = Arc::new(Mutex::new(SymbolSetCache::new(
             config.symbol_store_cache_max_bytes,
         )));

--- a/rust/cymbal/src/symbol_store/s3.rs
+++ b/rust/cymbal/src/symbol_store/s3.rs
@@ -62,4 +62,23 @@ impl S3Impl {
             .fin();
         res
     }
+
+    // Simply assert we can do a ListBucket operation, returning an error if not. This is
+    // useful during app startup to ensure the bucket is accessible.
+    #[allow(dead_code)]
+    pub async fn ping_bucket(&self, bucket: &str) -> Result<(), UnhandledError> {
+        let res = self
+            .inner
+            .list_objects_v2()
+            .bucket(bucket)
+            .prefix("")
+            .send()
+            .await;
+
+        if let Err(e) = res {
+            Err(S3Error::from(e).into())
+        } else {
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
About to rollout the adoption of IAM based auth for s3 operations, want to make sure we fail fast on startup if s3 isn't reachable, rather than failing somewhere deep in the symbol store or, worse, deleting symbol records we shouldn't