### PR TITLE
chore: issue page header

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -1,23 +1,10 @@
 import './ErrorTrackingIssueScene.scss'
 
 import { useActions, useValues } from 'kea'
-import { router } from 'kea-router'
 
-import { IconEllipsis } from '@posthog/icons'
 import { LemonBanner } from '@posthog/lemon-ui'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from 'lib/ui/DropdownMenu/DropdownMenu'
 import { SceneExport } from 'scenes/sceneTypes'
-import { urls } from 'scenes/urls'
-
-import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBreadcrumbs'
 
 import { EventsTable } from '../../components/EventsTable/EventsTable'
 import { ExceptionCard } from '../../components/ExceptionCard'
@@ -25,6 +12,7 @@ import { ErrorFilters } from '../../components/IssueFilters'
 import { Metadata } from '../../components/IssueMetadata'
 import { ErrorTrackingSetupPrompt } from '../../components/SetupPrompt/SetupPrompt'
 import { useErrorTagRenderer } from '../../hooks/use-error-tag-renderer'
+import { Header } from './Header'
 import { ErrorTrackingIssueScenePanel } from './ScenePanel'
 import { ErrorTrackingIssueSceneLogicProps, errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
 
@@ -35,11 +23,10 @@ export const scene: SceneExport<ErrorTrackingIssueSceneLogicProps> = {
 }
 
 export function ErrorTrackingIssueScene(): JSX.Element {
-    const { issue, issueId, issueLoading, selectedEvent, initialEventLoading, eventsQuery, eventsQueryKey } =
+    const { issue, issueLoading, selectedEvent, initialEventLoading, eventsQuery, eventsQueryKey } =
         useValues(errorTrackingIssueSceneLogic)
     const { selectEvent } = useActions(errorTrackingIssueSceneLogic)
     const tagRenderer = useErrorTagRenderer()
-    const hasIssueSplitting = useFeatureFlag('ERROR_TRACKING_ISSUE_SPLITTING')
 
     const isPostHogSDKIssue = selectedEvent?.properties.$exception_values?.some((v: string) =>
         v.includes('persistence.isDisabled is not a function')
@@ -47,30 +34,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
 
     return (
         <ErrorTrackingSetupPrompt>
-            <div className="flex justify-between mb-2 -ml-[var(--button-padding-x-lg)]">
-                <SceneBreadcrumbBackButton />
-                {hasIssueSplitting && (
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <ButtonPrimitive iconOnly>
-                                <IconEllipsis />
-                            </ButtonPrimitive>
-                        </DropdownMenuTrigger>
-
-                        <DropdownMenuContent loop align="end">
-                            <DropdownMenuItem asChild>
-                                <ButtonPrimitive
-                                    size="base"
-                                    menuItem
-                                    onClick={() => router.actions.push(urls.errorTrackingIssueFingerprints(issueId))}
-                                >
-                                    Split issue
-                                </ButtonPrimitive>
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                )}
-            </div>
+            <Header />
 
             {isPostHogSDKIssue && (
                 <LemonBanner

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/Header.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/Header.tsx
@@ -1,0 +1,192 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import posthog from 'posthog-js'
+
+import { IconEllipsis, IconShare } from '@posthog/icons'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { IconComment } from 'lib/lemon-ui/icons'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuOpenIndicator,
+    DropdownMenuTrigger,
+} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { urls } from 'scenes/urls'
+
+import { sidePanelLogic } from '~/layout/navigation-3000/sidepanel/sidePanelLogic'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ErrorTrackingIssue, ErrorTrackingIssueAssignee } from '~/queries/schema/schema-general'
+import { SidePanelTab } from '~/types'
+
+import { AssigneeIconDisplay, AssigneeLabelDisplay } from '../../components/Assignee/AssigneeDisplay'
+import { AssigneeSelect } from '../../components/Assignee/AssigneeSelect'
+import { LabelIndicator, StatusIndicator } from '../../components/Indicators'
+import { errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
+
+const RESOURCE_TYPE = 'issue'
+
+export const Header = (): JSX.Element => {
+    const { issue, issueId, issueLoading } = useValues(errorTrackingIssueSceneLogic)
+    const { updateName, updateDescription, updateAssignee, updateStatus } = useActions(errorTrackingIssueSceneLogic)
+    const hasIssueSplitting = useFeatureFlag('ERROR_TRACKING_ISSUE_SPLITTING')
+    const hasDiscussions = useFeatureFlag('DISCUSSIONS')
+    const { openSidePanel } = useActions(sidePanelLogic)
+
+    return (
+        <div className="flex flex-col gap-1 mb-2">
+            <SceneTitleSection
+                name={issue?.name}
+                description={issue?.description}
+                resourceType={{
+                    type: 'error_tracking',
+                }}
+                isLoading={issueLoading}
+                canEdit
+                onNameChange={updateName}
+                onDescriptionChange={updateDescription}
+                renameDebounceMs={1000}
+                actions={
+                    <>
+                        <ButtonPrimitive
+                            onClick={() => {
+                                if (!hasDiscussions) {
+                                    posthog.updateEarlyAccessFeatureEnrollment('discussions', true)
+                                }
+                                openSidePanel(SidePanelTab.Discussion)
+                            }}
+                            tooltip="Comment"
+                        >
+                            <IconComment />
+                            <span className="hidden @[200px]:block">Comment</span>
+                        </ButtonPrimitive>
+
+                        <ButtonPrimitive
+                            onClick={() => {
+                                if (issue) {
+                                    void copyToClipboard(
+                                        window.location.origin + urls.errorTrackingIssue(issue.id),
+                                        'issue link'
+                                    )
+                                }
+                            }}
+                            tooltip="Share"
+                            data-attr={`${RESOURCE_TYPE}-share`}
+                        >
+                            <IconShare />
+                            <span className="hidden @[200px]:block">Share</span>
+                        </ButtonPrimitive>
+                        {hasIssueSplitting && (
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <ButtonPrimitive iconOnly>
+                                        <IconEllipsis />
+                                    </ButtonPrimitive>
+                                </DropdownMenuTrigger>
+
+                                <DropdownMenuContent loop align="end">
+                                    <DropdownMenuItem asChild>
+                                        <ButtonPrimitive
+                                            size="base"
+                                            menuItem
+                                            onClick={() =>
+                                                router.actions.push(urls.errorTrackingIssueFingerprints(issueId))
+                                            }
+                                        >
+                                            Split issue
+                                        </ButtonPrimitive>
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        )}
+                    </>
+                }
+            />
+            <div className="flex gap-x-2">
+                <IssueStatusSelect status={issue?.status} disabled={issueLoading} onChange={updateStatus} />
+                <IssueAssigneeSelect
+                    assignee={issue?.assignee ?? null}
+                    onChange={updateAssignee}
+                    disabled={issueLoading || issue?.status != 'active'}
+                />
+            </div>
+            <SceneDivider />
+        </div>
+    )
+}
+
+const IssueStatusSelect = ({
+    status,
+    disabled,
+    onChange,
+}: {
+    status?: ErrorTrackingIssue['status']
+    disabled: boolean
+    onChange: (status: ErrorTrackingIssue['status']) => void
+}): JSX.Element => {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <ButtonPrimitive variant="panel" disabled={disabled}>
+                    {status ? (
+                        <StatusIndicator status={status} withTooltip={true} />
+                    ) : (
+                        <LabelIndicator intent="muted" size="small" label="Loading" />
+                    )}
+                    <DropdownMenuOpenIndicator />
+                </ButtonPrimitive>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent loop matchTriggerWidth>
+                {status === 'active' ? (
+                    <>
+                        <DropdownMenuItem asChild>
+                            <ButtonPrimitive menuItem onClick={() => onChange('resolved')}>
+                                <StatusIndicator status="resolved" intent />
+                            </ButtonPrimitive>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem asChild>
+                            <ButtonPrimitive menuItem onClick={() => onChange('suppressed')}>
+                                <StatusIndicator status="suppressed" intent />
+                            </ButtonPrimitive>
+                        </DropdownMenuItem>
+                    </>
+                ) : (
+                    <DropdownMenuItem asChild>
+                        <ButtonPrimitive menuItem onClick={() => onChange('active')}>
+                            <StatusIndicator status="active" intent />
+                        </ButtonPrimitive>
+                    </DropdownMenuItem>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}
+
+const IssueAssigneeSelect = ({
+    assignee,
+    disabled,
+    onChange,
+}: {
+    assignee: ErrorTrackingIssueAssignee | null
+    disabled: boolean
+    onChange: (assignee: ErrorTrackingIssueAssignee | null) => void
+}): JSX.Element => {
+    return (
+        <AssigneeSelect assignee={assignee} onChange={onChange}>
+            {(anyAssignee, isOpen) => (
+                <ButtonPrimitive disabled={disabled} data-state={isOpen ? 'open' : 'closed'} variant="panel">
+                    <div className="flex items-center">
+                        <AssigneeIconDisplay assignee={anyAssignee} size="small" />
+                        <AssigneeLabelDisplay assignee={anyAssignee} className="ml-1" size="small" />
+                    </div>
+                    {!disabled && <DropdownMenuOpenIndicator />}
+                </ButtonPrimitive>
+            )}
+        </AssigneeSelect>
+    )
+}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel.tsx
@@ -1,45 +1,25 @@
 import { useActions, useAsyncActions, useValues } from 'kea'
-import posthog from 'posthog-js'
 import { useEffect, useState } from 'react'
 
-import { IconComment, IconShare } from '@posthog/icons'
 import { LemonModal, Link, Spinner } from '@posthog/lemon-ui'
 
 import { getRuntimeFromLib } from 'lib/components/Errors/utils'
-import { SceneTextInput } from 'lib/components/Scenes/SceneTextInput'
-import { SceneTextarea } from 'lib/components/Scenes/SceneTextarea'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonModalContent, LemonModalHeader } from 'lib/lemon-ui/LemonModal/LemonModal'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuOpenIndicator,
-    DropdownMenuTrigger,
-} from 'lib/ui/DropdownMenu/DropdownMenu'
 import { pluralize } from 'lib/utils'
-import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { urls } from 'scenes/urls'
 
-import { sidePanelLogic } from '~/layout/navigation-3000/sidepanel/sidePanelLogic'
-import { ScenePanelActionsSection, ScenePanelDivider, ScenePanelLabel } from '~/layout/scenes/SceneLayout'
-import { ErrorTrackingIssue, ErrorTrackingIssueAssignee } from '~/queries/schema/schema-general'
-import { SidePanelTab } from '~/types'
+import { ScenePanelLabel } from '~/layout/scenes/SceneLayout'
 
-import { AssigneeIconDisplay, AssigneeLabelDisplay } from '../../components/Assignee/AssigneeDisplay'
-import { AssigneeSelect } from '../../components/Assignee/AssigneeSelect'
 import { ExceptionCard } from '../../components/ExceptionCard'
 import { ExternalReferences } from '../../components/ExternalReferences'
-import { StatusIndicator } from '../../components/Indicators'
 import { issueActionsLogic } from '../../components/IssueActions/issueActionsLogic'
 import { IssueTasks } from '../../components/IssueTasks'
 import { RuntimeIcon } from '../../components/RuntimeIcon'
 import { useErrorTagRenderer } from '../../hooks/use-error-tag-renderer'
 import { ErrorTrackingIssueSceneLogicProps, errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
-
-const RESOURCE_TYPE = 'issue'
 
 interface RelatedIssue {
     id: string
@@ -72,71 +52,12 @@ const IssueModalContent = ({ issueId }: { issueId: string }): JSX.Element => {
 
 export const ErrorTrackingIssueScenePanel = (): JSX.Element | null => {
     const { issue } = useValues(errorTrackingIssueSceneLogic)
-    const { updateName, updateDescription, updateAssignee, updateStatus } = useActions(errorTrackingIssueSceneLogic)
     const hasTasks = useFeatureFlag('TASKS')
     const hasIssueSplitting = useFeatureFlag('ERROR_TRACKING_ISSUE_SPLITTING')
     const hasSimilarIssues = useFeatureFlag('ERROR_TRACKING_RELATED_ISSUES')
-    const hasDiscussions = useFeatureFlag('DISCUSSIONS')
-    const { openSidePanel } = useActions(sidePanelLogic)
 
     return issue ? (
         <div className="flex flex-col gap-2 @container">
-            <ScenePanelActionsSection>
-                <div className="grid grid-cols-2 gap-1">
-                    <ButtonPrimitive
-                        onClick={() => {
-                            if (!hasDiscussions) {
-                                posthog.updateEarlyAccessFeatureEnrollment('discussions', true)
-                            }
-                            openSidePanel(SidePanelTab.Discussion)
-                        }}
-                        tooltip="Comment"
-                        menuItem
-                        className="justify-center"
-                    >
-                        <IconComment />
-                        <span className="hidden @[200px]:block">Comment</span>
-                    </ButtonPrimitive>
-
-                    <ButtonPrimitive
-                        onClick={() => {
-                            void copyToClipboard(
-                                window.location.origin + urls.errorTrackingIssue(issue.id),
-                                'issue link'
-                            )
-                        }}
-                        tooltip="Share"
-                        data-attr={`${RESOURCE_TYPE}-share`}
-                        menuItem
-                        className="justify-center"
-                    >
-                        <IconShare />
-                        <span className="hidden @[200px]:block">Share</span>
-                    </ButtonPrimitive>
-                </div>
-            </ScenePanelActionsSection>
-
-            <ScenePanelDivider />
-
-            <SceneTextInput
-                name="name"
-                defaultValue={issue.name ?? ''}
-                onSave={updateName}
-                dataAttrKey={RESOURCE_TYPE}
-            />
-            <SceneTextarea
-                name="description"
-                defaultValue={issue.description ?? ''}
-                onSave={updateDescription}
-                dataAttrKey={RESOURCE_TYPE}
-            />
-
-            <IssueStatusSelect status={issue.status} onChange={updateStatus} />
-            <IssueAssigneeSelect
-                assignee={issue.assignee}
-                onChange={updateAssignee}
-                disabled={issue.status != 'active'}
-            />
             <IssueExternalReference />
             {hasIssueSplitting && <IssueFingerprints />}
             {hasTasks && <IssueTasks />}
@@ -144,83 +65,6 @@ export const ErrorTrackingIssueScenePanel = (): JSX.Element | null => {
             {hasSimilarIssues && <SimilarIssues />}
         </div>
     ) : null
-}
-
-const IssueStatusSelect = ({
-    status,
-    onChange,
-}: {
-    status: ErrorTrackingIssue['status']
-    onChange: (status: ErrorTrackingIssue['status']) => void
-}): JSX.Element => {
-    return (
-        <ScenePanelLabel title="Status">
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <ButtonPrimitive fullWidth className="flex justify-between" variant="panel" menuItem>
-                        <StatusIndicator status={status} withTooltip={true} />
-                        <DropdownMenuOpenIndicator />
-                    </ButtonPrimitive>
-                </DropdownMenuTrigger>
-
-                <DropdownMenuContent loop matchTriggerWidth>
-                    {status === 'active' ? (
-                        <>
-                            <DropdownMenuItem asChild>
-                                <ButtonPrimitive menuItem onClick={() => onChange('resolved')}>
-                                    <StatusIndicator status="resolved" intent />
-                                </ButtonPrimitive>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem asChild>
-                                <ButtonPrimitive menuItem onClick={() => onChange('suppressed')}>
-                                    <StatusIndicator status="suppressed" intent />
-                                </ButtonPrimitive>
-                            </DropdownMenuItem>
-                        </>
-                    ) : (
-                        <DropdownMenuItem asChild>
-                            <ButtonPrimitive menuItem onClick={() => onChange('active')}>
-                                <StatusIndicator status="active" intent />
-                            </ButtonPrimitive>
-                        </DropdownMenuItem>
-                    )}
-                </DropdownMenuContent>
-            </DropdownMenu>
-        </ScenePanelLabel>
-    )
-}
-
-const IssueAssigneeSelect = ({
-    assignee,
-    disabled,
-    onChange,
-}: {
-    assignee: ErrorTrackingIssueAssignee | null
-    disabled: boolean
-    onChange: (assignee: ErrorTrackingIssueAssignee | null) => void
-}): JSX.Element => {
-    return (
-        <ScenePanelLabel title="Assignee">
-            <AssigneeSelect assignee={assignee} onChange={onChange}>
-                {(anyAssignee, isOpen) => (
-                    <ButtonPrimitive
-                        menuItem
-                        fullWidth
-                        disabled={disabled}
-                        className="flex justify-between"
-                        data-state={isOpen ? 'open' : 'closed'}
-                        variant="panel"
-                    >
-                        <div className="flex items-center">
-                            <AssigneeIconDisplay assignee={anyAssignee} size="small" />
-                            <AssigneeLabelDisplay assignee={anyAssignee} className="ml-1" size="small" />
-                        </div>
-                        {!disabled && <DropdownMenuOpenIndicator />}
-                    </ButtonPrimitive>
-                )}
-            </AssigneeSelect>
-        </ScenePanelLabel>
-    )
 }
 
 const IssueExternalReference = (): JSX.Element => {


### PR DESCRIPTION
## Problem

We're adding a ton of features to the issue page and I don't think our side panel UI is clear, liked or consistent with the rest of the app

## Changes

More to come but this is a first step that moves us to use the same header that we have elsewhere in the app

- Makes primary actions of changing status and assignee clearer
- Cleans up the right hand panel (still considering whether I can remove it entirely)
- Adds a little bit more structure to the page so that we can experiment with multiple tabs (for breakdowns, etc)

|Before|After|
|----|----|
| <img width="1047" height="823" alt="Screenshot 2025-10-07 at 11 06 24" src="https://github.com/user-attachments/assets/8ca99673-3e16-4139-993a-2c0f829e90f2" /> | <img width="1053" height="812" alt="Screenshot 2025-10-07 at 11 01 57" src="https://github.com/user-attachments/assets/04e9e2d1-6505-4f9d-8d73-b7524e2a1cc7" /> |
