### PR TITLE
fix: run child workflows in smaller batches to avoid exhausting quota

### DIFF
--- a/posthog/temporal/delete_recordings/types.py
+++ b/posthog/temporal/delete_recordings/types.py
@@ -19,6 +19,7 @@ class DeleteRecordingBlocksInput:
 class RecordingsWithPersonInput:
     distinct_ids: list[str]
     team_id: int
+    batch_size: int = 100
 
 
 class DeleteRecordingError(Exception):

--- a/posthog/temporal/delete_recordings/utils.py
+++ b/posthog/temporal/delete_recordings/utils.py
@@ -1,0 +1,15 @@
+from itertools import islice
+
+
+def batched(iterable, batch_size: int):
+    # batched('ABCDEFG', 2) → AB CD EF G
+
+    # https://docs.python.org/3/library/itertools.html#itertools.batched
+
+    if batch_size < 1:
+        raise ValueError("batch_size must be at least one")
+
+    iterator = iter(iterable)
+
+    while batch := tuple(islice(iterator, batch_size)):
+        yield batch

--- a/posthog/temporal/delete_recordings/workflows.py
+++ b/posthog/temporal/delete_recordings/workflows.py
@@ -85,5 +85,9 @@ class DeleteRecordingsWithPersonWorkflow(PostHogWorkflow):
                             RecordingInput(session_id=session_id, team_id=input.team_id),
                             parent_close_policy=ParentClosePolicy.ABANDON,
                             execution_timeout=timedelta(minutes=10),
+                            retry_policy=common.RetryPolicy(
+                                maximum_attempts=2,
+                                initial_interval=timedelta(minutes=1),
+                            ),
                         )
                     )


### PR DESCRIPTION
Maximum number of pending child workflows is 2000. With this PR we now run these in batches of 100 to avoid exhausting the quota.