### PR TITLE
perf(ci): optimize checkout with sparse-checkout for high-frequency workflows

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -506,6 +506,25 @@ jobs:
                   ref: ${{ github.event.pull_request.head.ref }}
                   # Use PostHog Bot token when not on forks to enable proper snapshot updating
                   token: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.POSTHOG_BOT_PAT || github.token }}
+                  sparse-checkout: |
+                      bin/
+                      common/
+                      docker/
+                      ee/
+                      posthog/
+                      products/
+                      frontend/dist/
+                      frontend/public/
+                      frontend/src/queries/schema.json
+                      pyproject.toml
+                      uv.lock
+                      requirements.txt
+                      requirements-dev.txt
+                      mypy.ini
+                      pytest.ini
+                      docker-compose.dev.yml
+                      docker-compose.base.yml
+                  sparse-checkout-cone-mode: false
 
             - name: 'Safeguard: ensure no stray Python modules at product root'
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -112,6 +112,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -151,6 +153,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   ref: master
+                  fetch-depth: 1
 
             - name: Install python dependencies for master
               run: |
@@ -174,6 +177,8 @@ jobs:
             # Now we can consider this PR's migrations
             - name: Checkout this PR
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
 
             - name: Install python dependencies for this PR
               run: |

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -128,9 +128,11 @@ jobs:
             - uses: actions/checkout@v4
               if: needs.changes.outputs.rust == 'true'
               with:
+                  fetch-depth: 1
                   sparse-checkout: |
                       .github/
                       rust/
+                      docker/
                       docker-compose.dev.yml
                       docker-compose.base.yml
                   sparse-checkout-cone-mode: false

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -23,6 +23,11 @@ jobs:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
             - uses: actions/checkout@v4
+              with:
+                  sparse-checkout: |
+                      .github/
+                      rust/
+                  sparse-checkout-cone-mode: false
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
               with:
@@ -122,6 +127,13 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               if: needs.changes.outputs.rust == 'true'
+              with:
+                  sparse-checkout: |
+                      .github/
+                      rust/
+                      docker-compose.dev.yml
+                      docker-compose.base.yml
+                  sparse-checkout-cone-mode: false
 
             - name: Setup main repo and dependencies
               if: needs.changes.outputs.rust == 'true'


### PR DESCRIPTION
## Summary
Adds sparse-checkout configuration to Backend CI, Frontend CI, and Rust CI workflows to reduce checkout time and disk usage.

## Changes

**Backend CI** - Django test job only (migration checks skip optimization as they switch refs)
- Exclude: rust/, livestream/, frontend/src/
- Include: Minimal frontend artifacts (dist/, public/, schema.json)

**Frontend CI** - All 5 checkout steps
- Exclude: posthog/ backend, ee/ backend, rust/, livestream/, most of common/
- Include: frontend/, ee/frontend/, common/esbuilder/, products TS/TSX

**Rust CI** - Changes and test jobs
- Include: rust/, .github/, docker-compose files only
- Build/lint/shear already had sparse-checkout

## Rationale

Based on https://depot.dev/blog/why-organizations-have-slow-actions-checkout

Backend/Frontend CI run on every PR with 50+ parallel jobs. Sparse checkout reduces file writes and working tree size even if network transfer is similar.

## Test plan
CI will validate changes work correctly