### PR TITLE
chore(max): Remove Zendesk ticket creation for Max AI feedback

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -37,7 +37,6 @@ import {
 } from 'lib/components/Cards/InsightCard/InsightDetails'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { NotFound } from 'lib/components/NotFound'
-import { supportLogic } from 'lib/components/Support/supportLogic'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { pluralize } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -984,7 +983,6 @@ function RetriableFailureActions(): JSX.Element {
 function SuccessActions({ retriable }: { retriable: boolean }): JSX.Element {
     const { traceId } = useValues(maxThreadLogic)
     const { retryLastMessage } = useActions(maxThreadLogic)
-    const { submitZendeskTicket } = useActions(supportLogic)
     const { user } = useValues(userLogic)
 
     const [rating, setRating] = useState<'good' | 'bad' | null>(null)
@@ -1003,24 +1001,11 @@ function SuccessActions({ retriable }: { retriable: boolean }): JSX.Element {
     }
 
     function submitFeedback(): void {
-        if (!feedback || !traceId || !user) {
+        if (!feedback || !traceId) {
             return // Input is empty
         }
         posthog.captureTraceFeedback(traceId, feedback)
         setFeedbackInputStatus('submitted')
-        // Also create a support ticket for thumbs down feedback, for the support hero to see
-        submitZendeskTicket({
-            name: user.first_name,
-            email: user.email,
-            kind: 'feedback',
-            target_area: 'max-ai',
-            severity_level: 'medium',
-            message: [
-                feedback,
-                '\nℹ️ This ticket was created automatically when a user gave thumbs down feedback to Max AI.',
-                `Trace: https://us.posthog.com/project/2/llm-analytics/traces/${traceId}`,
-            ].join('\n'),
-        })
     }
 
     return (


### PR DESCRIPTION
## Summary
- stop invoking the support logic from the Max AI thread UI when users leave negative feedback
- keep feedback capture limited to telemetry without creating Zendesk tickets automatically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fd40dd4c832cbf23e85293f56294