### PR TITLE
fix: make sure metadata query fails for expired recordings

### DIFF
--- a/ee/hogai/session_summaries/session/input_data.py
+++ b/ee/hogai/session_summaries/session/input_data.py
@@ -22,7 +22,7 @@ def get_team(team_id: int) -> Team:
 def get_session_metadata(session_id: str, team_id: int, local_reads_prod: bool = False) -> RecordingMetadata:
     events_obj = SessionReplayEvents()
     if not local_reads_prod:
-        session_metadata = events_obj.get_metadata(session_id=str(session_id), team_id=team_id)
+        session_metadata = events_obj.get_metadata(session_id=str(session_id), team=get_team(team_id))
     else:
         session_metadata = _get_production_session_metadata_locally(events_obj, session_id, team_id)
     if not session_metadata:

--- a/ee/hogai/session_summaries/tests/test_summarize_session.py
+++ b/ee/hogai/session_summaries/tests/test_summarize_session.py
@@ -71,7 +71,7 @@ class TestSummarizeSession:
         ):
             with pytest.raises(ValueError, match=f"No session metadata found for session_id {mock_session_id}"):
                 await get_session_data_from_db(session_id=mock_session_id, team_id=mock_team.id, local_reads_prod=False)
-            mock_get_db_metadata.assert_called_once_with(session_id=mock_session_id, team_id=mock_team.id)
+            mock_get_db_metadata.assert_called_once_with(session_id=mock_session_id, team=mock_team)
 
     def test_prepare_data_no_events_returns_error_data(
         self, mock_team: MagicMock, mock_raw_metadata: dict[str, Any], mock_session_id: str

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -76,7 +76,7 @@ class SessionRecording(UUIDTModel):
         else:
             # Try to load from Clickhouse
             metadata = SessionReplayEvents().get_metadata(
-                team_id=self.team.pk,
+                team=self.team,
                 session_id=self.session_id,
                 recording_start_time=self.start_time,
             )

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -66,7 +66,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         )
 
     def test_get_metadata(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="1", team_id=self.team.id)
+        metadata = SessionReplayEvents().get_metadata(session_id="1", team=self.team)
         assert metadata == {
             "active_seconds": 25.0,
             "block_first_timestamps": [],
@@ -88,7 +88,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         }
 
     def test_get_metadata_with_block(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="2", team_id=self.team.id)
+        metadata = SessionReplayEvents().get_metadata(session_id="2", team=self.team)
         assert metadata == {
             "active_seconds": 1.234,
             "start_time": self.base_time,
@@ -110,7 +110,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         }
 
     def test_get_metadata_with_multiple_blocks(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="3", team_id=self.team.id)
+        metadata = SessionReplayEvents().get_metadata(session_id="3", team=self.team)
         assert metadata == {
             "active_seconds": 2.345,
             "start_time": self.base_time + relativedelta(seconds=1),
@@ -138,18 +138,18 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         }
 
     def test_get_nonexistent_metadata(self) -> None:
-        metadata = SessionReplayEvents().get_metadata(session_id="not a session", team_id=self.team.id)
+        metadata = SessionReplayEvents().get_metadata(session_id="not a session", team=self.team)
         assert metadata is None
 
     def test_get_metadata_does_not_leak_between_teams(self) -> None:
         another_team = Team.objects.create(organization=self.organization, name="Another Team")
-        metadata = SessionReplayEvents().get_metadata(session_id="1", team_id=another_team.id)
+        metadata = SessionReplayEvents().get_metadata(session_id="1", team=another_team)
         assert metadata is None
 
     def test_get_metadata_filters_by_date(self) -> None:
         metadata = SessionReplayEvents().get_metadata(
             session_id="1",
-            team_id=self.team.id,
+            team=self.team,
             recording_start_time=self.base_time + relativedelta(days=2),
         )
         assert metadata is None
@@ -157,7 +157,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
     def test_get_group_metadata(self) -> None:
         metadata_dict = SessionReplayEvents().get_group_metadata(
             session_ids=["1", "2"],
-            team_id=self.team.id,
+            team_id=self.team,
         )
         assert len(metadata_dict) == 2
         assert metadata_dict["1"] == {
@@ -202,7 +202,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
     def test_get_group_metadata_handles_nonexistent_sessions(self) -> None:
         metadata_dict = SessionReplayEvents().get_group_metadata(
             session_ids=["1", "nonexistent", "3"],
-            team_id=self.team.id,
+            team_id=self.team,
         )
         assert len(metadata_dict) == 3
         assert metadata_dict["1"] is not None

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -157,7 +157,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
     def test_get_group_metadata(self) -> None:
         metadata_dict = SessionReplayEvents().get_group_metadata(
             session_ids=["1", "2"],
-            team_id=self.team,
+            team=self.team,
         )
         assert len(metadata_dict) == 2
         assert metadata_dict["1"] == {
@@ -202,7 +202,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
     def test_get_group_metadata_handles_nonexistent_sessions(self) -> None:
         metadata_dict = SessionReplayEvents().get_group_metadata(
             session_ids=["1", "nonexistent", "3"],
-            team_id=self.team,
+            team=self.team,
         )
         assert len(metadata_dict) == 3
         assert metadata_dict["1"] is not None

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -133,7 +133,7 @@ async def fetch_session_batch_events_activity(
     # Disable thread-sensitive as we can get metadata for lots of sessions here
     metadata_dict = await database_sync_to_async(SessionReplayEvents().get_group_metadata, thread_sensitive=False)(
         session_ids=session_ids_to_fetch,
-        team_id=inputs.team_id,
+        team=team,
         recordings_min_timestamp=datetime.fromisoformat(inputs.min_timestamp_str),
         recordings_max_timestamp=datetime.fromisoformat(inputs.max_timestamp_str),
     )


### PR DESCRIPTION
Actually check if a recording is expired and return a NotFound error if so.