### PR TITLE
fix: caddy defaults should not have quotes

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -17,7 +17,7 @@ services:
                 {
                 ${CADDY_TLS_BLOCK:-}
                 }
-                ${CADDY_HOST:-'http://localhost:8000'} {
+                ${CADDY_HOST:-http://localhost:8000} {
                     @replay-capture {
                         path /s
                         path /s/


### PR DESCRIPTION
turns out caddy env defaults shouldn't have quotes 🤷 

https://caddyserver.com/docs/caddyfile/concepts#environment-variables