### PR TITLE
fix: enable replay in onboarding when intent is shown

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -143,17 +143,18 @@ const sessionReplayOnboardingToggle = (
     currentTeam: TeamType | TeamPublicType | null,
     selectedProducts: ProductKey[]
 ): ProductConfigOption => {
+    const userDecision =
+        currentTeam?.session_recording_opt_in ||
+        selectedProducts.includes(ProductKey.SESSION_REPLAY) ||
+        currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.SESSION_REPLAY)
+
     return {
         title: 'Enable session recordings',
         description: `Turn on session recordings and watch how users experience your app. We will also turn on console log and network performance recording. You can change these settings any time in the settings panel.`,
         teamProperty: 'session_recording_opt_in',
         // TRICKY: if someone has shown secondary (or tertiary or...) product intent for replay we want to include it as enabled
         // particularly while we're not taking people through every product onboarding they showed interest in
-        value:
-            (currentTeam?.session_recording_opt_in ||
-                selectedProducts.includes(ProductKey.SESSION_REPLAY) ||
-                currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.SESSION_REPLAY)) ??
-            false,
+        value: userDecision ?? false,
         type: 'toggle',
         visible: true,
     }

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -17,7 +17,14 @@ import { getMaskingConfigFromLevel, getMaskingLevelFromConfig } from 'scenes/ses
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { AvailableFeature, OnboardingStepKey, ProductKey, type SessionRecordingMaskingLevel } from '~/types'
+import {
+    AvailableFeature,
+    OnboardingStepKey,
+    ProductKey,
+    type SessionRecordingMaskingLevel,
+    TeamPublicType,
+    TeamType,
+} from '~/types'
 
 import { OnboardingInviteTeammates } from './OnboardingInviteTeammates'
 import { OnboardingProductConfiguration } from './OnboardingProductConfiguration'
@@ -132,6 +139,25 @@ const OnboardingWrapper = ({
     return currentOnboardingStep
 }
 
+const sessionReplayOnboardingToggle = (
+    currentTeam: TeamType | TeamPublicType | null,
+    selectedProducts: ProductKey[]
+): ProductConfigOption => {
+    return {
+        title: 'Enable session recordings',
+        description: `Turn on session recordings and watch how users experience your app. We will also turn on console log and network performance recording. You can change these settings any time in the settings panel.`,
+        teamProperty: 'session_recording_opt_in',
+        // TRICKY: if someone has shown secondary (or tertiary or...) product intent for replay we want to include it as enabled
+        // particularly while we're not taking people through every product onboarding they showed interest in
+        value:
+            currentTeam?.session_recording_opt_in ||
+            selectedProducts.includes(ProductKey.SESSION_REPLAY) ||
+            currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.SESSION_REPLAY) ||
+            false,
+        type: 'toggle',
+        visible: true,
+    }
+}
 const ProductAnalyticsOnboarding = (): JSX.Element => {
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -153,8 +179,8 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
     const options: ProductConfigOption[] = [
         {
             title: 'Autocapture frontend interactions',
-            description: `If you use our JavaScript, React Native or iOS libraries, we'll automagically 
-            capture frontend interactions like clicks, submits, and more. Fine-tune what you 
+            description: `If you use our JavaScript, React Native or iOS libraries, we'll automagically
+            capture frontend interactions like clicks, submits, and more. Fine-tune what you
             capture directly in your code snippet.`,
             teamProperty: 'autocapture_opt_out',
             value: !currentTeam?.autocapture_opt_out,
@@ -165,7 +191,7 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
         {
             title: 'Enable heatmaps',
             description: `If you use our JavaScript libraries, we can capture general clicks, mouse movements,
-                   and scrolling to create heatmaps. 
+                   and scrolling to create heatmaps.
                    No additional events are created, and you can disable this at any time.`,
             teamProperty: 'heatmaps_opt_in',
             value: currentTeam?.heatmaps_opt_in ?? true,
@@ -180,17 +206,7 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
             type: 'toggle',
             visible: true,
         },
-        {
-            title: 'Enable session recordings',
-            description: `Turn on session recordings and watch how users experience your app. We will also turn on console log and network performance recording. You can change these settings any time in the settings panel.`,
-            teamProperty: 'session_recording_opt_in',
-            // TRICKY: if someone has shown secondary product intent for replay we want to include it as enabled
-            // particularly while we're not taking people through every product onboarding they showed interest in
-            value:
-                (currentTeam?.session_recording_opt_in || selectedProducts.includes(ProductKey.SESSION_REPLAY)) ?? true,
-            type: 'toggle',
-            visible: true,
-        },
+        sessionReplayOnboardingToggle(currentTeam, selectedProducts),
         {
             title: 'Capture console logs',
             description: `Automatically enable console log capture`,
@@ -247,8 +263,8 @@ const WebAnalyticsOnboarding = (): JSX.Element => {
     const options: ProductConfigOption[] = [
         {
             title: 'Autocapture frontend interactions',
-            description: `If you use our JavaScript, React Native or iOS libraries, we'll automagically 
-            capture frontend interactions like clicks, submits, and more. Fine-tune what you 
+            description: `If you use our JavaScript, React Native or iOS libraries, we'll automagically
+            capture frontend interactions like clicks, submits, and more. Fine-tune what you
             capture directly in your code snippet.`,
             teamProperty: 'autocapture_opt_out',
             value: !currentTeam?.autocapture_opt_out,
@@ -259,7 +275,7 @@ const WebAnalyticsOnboarding = (): JSX.Element => {
         {
             title: 'Enable heatmaps',
             description: `If you use our JavaScript libraries, we can capture general clicks, mouse movements,
-                   and scrolling to create heatmaps. 
+                   and scrolling to create heatmaps.
                    No additional events are created, and you can disable this at any time.`,
             teamProperty: 'heatmaps_opt_in',
             value: currentTeam?.heatmaps_opt_in ?? true,
@@ -274,15 +290,7 @@ const WebAnalyticsOnboarding = (): JSX.Element => {
             type: 'toggle',
             visible: true,
         },
-        {
-            title: 'Enable session recordings',
-            description: `Turn on session recordings and watch how users experience your app. We will also turn on console log and network performance recording. You can change these settings any time in the settings panel.`,
-            teamProperty: 'session_recording_opt_in',
-            value:
-                (currentTeam?.session_recording_opt_in || selectedProducts.includes(ProductKey.SESSION_REPLAY)) ?? true,
-            type: 'toggle',
-            visible: true,
-        },
+        sessionReplayOnboardingToggle(currentTeam, selectedProducts),
         {
             title: 'Capture network performance',
             description: `Automatically enable network performance capture`,
@@ -314,7 +322,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
         {
             type: 'toggle',
             title: 'Capture console logs',
-            description: `Capture console logs as a part of user session recordings. 
+            description: `Capture console logs as a part of user session recordings.
                             Use the console logs alongside recordings to debug any issues with your app.`,
             teamProperty: 'capture_console_log_opt_in',
             value: currentTeam?.capture_console_log_opt_in ?? true,
@@ -361,7 +369,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
         configOptions.push({
             type: 'select',
             title: 'Minimum session duration (seconds)',
-            description: `Only record sessions that are longer than the specified duration. 
+            description: `Only record sessions that are longer than the specified duration.
                             Start with it low and increase it later if you're getting too many short sessions.`,
             teamProperty: 'session_recording_minimum_duration_milliseconds',
             value: currentTeam?.session_recording_minimum_duration_milliseconds || null,

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -150,9 +150,9 @@ const sessionReplayOnboardingToggle = (
         // TRICKY: if someone has shown secondary (or tertiary or...) product intent for replay we want to include it as enabled
         // particularly while we're not taking people through every product onboarding they showed interest in
         value:
-            currentTeam?.session_recording_opt_in ||
-            selectedProducts.includes(ProductKey.SESSION_REPLAY) ||
-            currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.SESSION_REPLAY) ||
+            (currentTeam?.session_recording_opt_in ||
+                selectedProducts.includes(ProductKey.SESSION_REPLAY) ||
+                currentTeam?.product_intents?.some((intent) => intent.product_type === ProductKey.SESSION_REPLAY)) ??
             false,
         type: 'toggle',
         visible: true,


### PR DESCRIPTION
i was running through onboarding locally and selected session replay as a secondary intent

when i hit the page with the toggles

the replay toggle was not enabled

i can't see why, but my friend claude suggested checking another thing to check...

tested and this change _i think_ makes sure it is enabled when it should be