### PR TITLE
chore(ux): new tab items get tree functionality

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -11,8 +11,6 @@ import {
     IconShortcut,
 } from '@posthog/icons'
 
-import { linkToLogic } from 'lib/components/FileSystem/LinkTo/linkToLogic'
-import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
 import { dayjs } from 'lib/dayjs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
@@ -21,43 +19,23 @@ import { TreeNodeDisplayIcon } from 'lib/lemon-ui/LemonTree/LemonTreeUtils'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture/ProfilePicture'
 import { Tooltip } from 'lib/lemon-ui/Tooltip/Tooltip'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import {
-    ContextMenuGroup,
-    ContextMenuItem,
-    ContextMenuSeparator,
-    ContextMenuSub,
-    ContextMenuSubContent,
-    ContextMenuSubTrigger,
-} from 'lib/ui/ContextMenu/ContextMenu'
-import {
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuSeparator,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
-} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { ContextMenuGroup, ContextMenuItem } from 'lib/ui/ContextMenu/ContextMenu'
+import { DropdownMenuGroup } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { cn } from 'lib/utils/css-classes'
 import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
-import { openDeleteGroupTypeDialog } from 'scenes/settings/environment/GroupAnalyticsConfig'
 
-import { DashboardsMenuItems } from '~/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
-import { NewMenu } from '~/layout/panel-layout/menus/NewMenu'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
-import { groupAnalyticsConfigLogic } from '~/scenes/settings/environment/groupAnalyticsConfigLogic'
 import { UserBasicType } from '~/types'
 
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
 import { TreeFiltersDropdownMenu } from './TreeFiltersDropdownMenu'
 import { TreeSearchField } from './TreeSearchField'
 import { TreeSortDropdownMenu } from './TreeSortDropdownMenu'
-import { BrowserLikeMenuItems } from './menus/BrowserLikeMenuItems'
-import { ProductAnalyticsMenuItems } from './menus/ProductAnalyticsMenuItems'
-import { SessionReplayMenuItems } from './menus/SessionReplayMenuItems'
+import { MenuItems } from './menus/MenuItems'
 import { projectTreeLogic } from './projectTreeLogic'
-import { calculateMovePath, joinPath, splitPath } from './utils'
+import { calculateMovePath } from './utils'
 
 export interface ProjectTreeProps {
     logicKey?: string // key override?
@@ -80,10 +58,7 @@ export function ProjectTree({
     showRecents,
 }: ProjectTreeProps): JSX.Element {
     const [uniqueKey] = useState(() => `project-tree-${counter++}`)
-    const { viableItems, shortcutNonFolderPaths } = useValues(projectTreeDataLogic)
-    const { deleteShortcut, addShortcutItem } = useActions(projectTreeDataLogic)
-    const { groupTypes } = useValues(groupAnalyticsConfigLogic)
-    const { deleteGroupType } = useActions(groupAnalyticsConfigLogic)
+    const { viableItems } = useValues(projectTreeDataLogic)
     const projectTreeLogicProps = { key: logicKey ?? uniqueKey, root }
     const {
         fullFileSystemFiltered,
@@ -94,11 +69,9 @@ export function ProjectTree({
         searchTerm,
         searchResults,
         checkedItems,
-        checkedItemsCount,
         checkedItemCountNumeric,
         scrollTargetId,
         editingItemId,
-        checkedItemsArray,
         treeTableColumnSizes,
         treeTableTotalWidth,
         sortMethod: projectSortMethod,
@@ -108,7 +81,6 @@ export function ProjectTree({
     const {
         createFolder,
         rename,
-        deleteItem,
         moveItem,
         toggleFolderOpen,
         setLastViewedId,
@@ -117,8 +89,6 @@ export function ProjectTree({
         loadFolder,
         onItemChecked,
         moveCheckedItems,
-        linkCheckedItems,
-        assureVisibility,
         clearScrollTarget,
         setEditingItemId,
         setSortMethod,
@@ -126,8 +96,6 @@ export function ProjectTree({
         setSelectMode,
         setSearchTerm,
     } = useActions(projectTreeLogic(projectTreeLogicProps))
-    const { openMoveToModal } = useActions(moveToLogic)
-    const { openLinkToModal } = useActions(linkToLogic)
 
     const { setPanelTreeRef, resetPanelLayout } = useActions(panelLayoutLogic)
     const { mainContentRef } = useValues(panelLayoutLogic)
@@ -206,285 +174,6 @@ export function ProjectTree({
         }
 
         return false
-    }
-
-    // Merge duplicate menu code for both context and dropdown menus
-    const renderMenuItems = (item: TreeDataItem, type: 'context' | 'dropdown'): JSX.Element => {
-        // Determine the separator component based on MenuItem type
-        const MenuItem = type === 'context' ? ContextMenuItem : DropdownMenuItem
-        const MenuSeparator = type === 'context' ? ContextMenuSeparator : DropdownMenuSeparator
-        const MenuSub = type === 'context' ? ContextMenuSub : DropdownMenuSub
-        const MenuSubTrigger = type === 'context' ? ContextMenuSubTrigger : DropdownMenuSubTrigger
-        const MenuSubContent = type === 'context' ? ContextMenuSubContent : DropdownMenuSubContent
-
-        const showSelectMenuItems = root === 'project://' && item.record?.path && !item.disableSelect && !onlyTree
-
-        // Show product menu items if the item is a product or shortcut (and the item is a product, products have 1 slash in the href)
-        const showProductMenuItems =
-            root === 'products://' ||
-            (root === 'shortcuts://' && item.record?.href && item.record.href.split('/').length - 1 === 1)
-
-        // Note: renderMenuItems() is called often, so we're using custom components to isolate logic and network requests
-        const productMenu =
-            showProductMenuItems && item.name === 'Product analytics' ? (
-                <>
-                    <ProductAnalyticsMenuItems
-                        MenuItem={MenuItem}
-                        MenuSeparator={MenuSeparator}
-                        onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
-                    />
-                    <MenuSeparator />
-                </>
-            ) : showProductMenuItems && item.name === 'Session replay' ? (
-                <>
-                    <SessionReplayMenuItems
-                        MenuItem={MenuItem}
-                        MenuSub={MenuSub}
-                        MenuSubTrigger={MenuSubTrigger}
-                        MenuSubContent={MenuSubContent}
-                        MenuSeparator={MenuSeparator}
-                        onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
-                    />
-                    <MenuSeparator />
-                </>
-            ) : showProductMenuItems && item.name === 'Dashboards' ? (
-                <>
-                    <DashboardsMenuItems
-                        MenuItem={MenuItem}
-                        MenuSub={MenuSub}
-                        MenuSubTrigger={MenuSubTrigger}
-                        MenuSubContent={MenuSubContent}
-                        MenuSeparator={MenuSeparator}
-                        onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
-                    />
-                    <MenuSeparator />
-                </>
-            ) : null
-
-        const isItemAFolder = item.record?.type === 'folder'
-        const itemShortcutPath = joinPath([splitPath(item.record?.path).pop() ?? 'Unnamed'])
-        const isItemAlreadyInShortcut = !isItemAFolder && shortcutNonFolderPaths.has(itemShortcutPath)
-        return (
-            <>
-                {productMenu}
-                {showSelectMenuItems ? (
-                    <>
-                        <MenuItem
-                            asChild
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                onItemChecked(item.id, !checkedItems[item.id], false)
-                            }}
-                            data-attr="tree-item-menu-select-button"
-                        >
-                            <ButtonPrimitive menuItem>{checkedItems[item.id] ? 'Deselect' : 'Select'}</ButtonPrimitive>
-                        </MenuItem>
-                        <MenuSeparator />
-                    </>
-                ) : null}
-
-                {item.record?.path && item.record?.type !== 'folder' && item.record?.href ? (
-                    <>
-                        <BrowserLikeMenuItems
-                            href={item.record?.href}
-                            MenuItem={MenuItem}
-                            resetPanelLayout={resetPanelLayout}
-                        />
-                        <MenuSeparator />
-                    </>
-                ) : null}
-
-                {checkedItemCountNumeric > 0 && item.record?.type === 'folder' ? (
-                    <>
-                        <MenuItem
-                            asChild
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                moveCheckedItems(item?.record?.path)
-                            }}
-                            data-attr="tree-item-menu-move-checked-items-button"
-                        >
-                            <ButtonPrimitive menuItem>
-                                Move {checkedItemsCount} selected item{checkedItemsCount === '1' ? '' : 's'} here
-                            </ButtonPrimitive>
-                        </MenuItem>
-                        <MenuItem
-                            asChild
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                linkCheckedItems(item?.record?.path)
-                            }}
-                            data-attr="tree-item-menu-create-shortcut-button"
-                        >
-                            <ButtonPrimitive menuItem>
-                                Create {checkedItemsCount} shortcut{checkedItemsCount === '1' ? '' : 's'} here
-                            </ButtonPrimitive>
-                        </MenuItem>
-                        <MenuSeparator />
-                    </>
-                ) : null}
-
-                {(item.record?.protocol === 'project://' && item.record?.type === 'folder') ||
-                item.id?.startsWith('project-folder-empty/') ? (
-                    <>
-                        <MenuSub key="new">
-                            <MenuSubTrigger asChild data-attr="tree-item-menu-open-new-menu-button">
-                                <ButtonPrimitive menuItem>
-                                    New...
-                                    <IconChevronRight className="ml-auto size-3" />
-                                </ButtonPrimitive>
-                            </MenuSubTrigger>
-                            <MenuSubContent>
-                                <NewMenu type={type} item={item} createFolder={createFolder} />
-                            </MenuSubContent>
-                        </MenuSub>
-                        <MenuSeparator />
-                    </>
-                ) : null}
-                {item.record?.path ? (
-                    root === 'shortcuts://' ? (
-                        item.id.startsWith('shortcuts://') || item.id.startsWith('shortcuts/') ? (
-                            <MenuItem
-                                asChild
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    item.record && deleteShortcut(item.record?.id)
-                                }}
-                                data-attr="tree-item-menu-remove-from-shortcuts-button"
-                            >
-                                <ButtonPrimitive menuItem>Remove from shortcuts</ButtonPrimitive>
-                            </MenuItem>
-                        ) : null
-                    ) : isItemAlreadyInShortcut ? (
-                        <MenuItem asChild disabled={true} data-attr="tree-item-menu-add-to-shortcuts-disabled-button">
-                            <ButtonPrimitive menuItem disabled={true}>
-                                Already in shortcuts panel
-                            </ButtonPrimitive>
-                        </MenuItem>
-                    ) : (
-                        <MenuItem
-                            asChild
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                item.record && addShortcutItem(item.record as FileSystemEntry)
-                            }}
-                            data-attr="tree-item-menu-add-to-shortcuts-button"
-                        >
-                            <ButtonPrimitive menuItem>Add to shortcuts panel</ButtonPrimitive>
-                        </MenuItem>
-                    )
-                ) : null}
-
-                {item.id.startsWith('project/') || item.id.startsWith('project://') ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e: any) => {
-                            e.stopPropagation()
-                            if (
-                                checkedItemsArray.length > 0 &&
-                                checkedItemsArray.find(({ id }) => id === item.record?.id)
-                            ) {
-                                openMoveToModal(checkedItemsArray)
-                            } else {
-                                openMoveToModal([item.record as unknown as FileSystemEntry])
-                            }
-                        }}
-                    >
-                        <ButtonPrimitive menuItem>Move to...</ButtonPrimitive>
-                    </MenuItem>
-                ) : null}
-
-                {(item.id.startsWith('project/') || item.id.startsWith('project://')) &&
-                item.record?.type !== 'folder' ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e: any) => {
-                            e.stopPropagation()
-                            if (
-                                checkedItemsArray.length > 0 &&
-                                checkedItemsArray.find(({ id }) => id === item.record?.id)
-                            ) {
-                                openLinkToModal(checkedItemsArray)
-                            } else {
-                                openLinkToModal([item.record as unknown as FileSystemEntry])
-                            }
-                        }}
-                    >
-                        <ButtonPrimitive menuItem>Create shortcut in...</ButtonPrimitive>
-                    </MenuItem>
-                ) : null}
-
-                {item.record?.path && item.record?.type === 'folder' ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            setEditingItemId(item.id)
-                        }}
-                        data-attr="tree-item-menu-rename-button"
-                    >
-                        <ButtonPrimitive menuItem>Rename</ButtonPrimitive>
-                    </MenuItem>
-                ) : null}
-
-                {item.record?.path && item.record?.shortcut ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            assureVisibility({ type: item.record?.type, ref: item.record?.ref })
-                        }}
-                        data-attr="tree-item-menu-show-original-button"
-                    >
-                        <ButtonPrimitive menuItem>Show original</ButtonPrimitive>
-                    </MenuItem>
-                ) : null}
-
-                {item.record?.shortcut ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
-                        }}
-                        data-attr="tree-item-menu-delete-shortcut-button"
-                    >
-                        <ButtonPrimitive menuItem>Delete shortcut</ButtonPrimitive>
-                    </MenuItem>
-                ) : item.record?.path && item.record?.type === 'folder' ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
-                        }}
-                        data-attr="tree-item-menu-delete-folder-button"
-                    >
-                        <ButtonPrimitive menuItem>Delete folder</ButtonPrimitive>
-                    </MenuItem>
-                ) : root === 'persons://' && item.record?.category === 'Groups' && item.record?.href ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            const href = item.record?.href as string
-                            const groupTypeIndex = parseInt(href.match(/\/groups\/(\d+)/)?.[1] || '0', 10)
-                            const groupType = Array.from(groupTypes.values()).find(
-                                (gt) => gt.group_type_index === groupTypeIndex
-                            )
-
-                            openDeleteGroupTypeDialog({
-                                onConfirm: () => deleteGroupType(groupTypeIndex),
-                                groupTypeName: groupType?.group_type || item.name || 'group type',
-                            })
-                        }}
-                        data-attr="tree-item-menu-delete-group-button"
-                    >
-                        <ButtonPrimitive menuItem>Delete group type</ButtonPrimitive>
-                    </MenuItem>
-                ) : null}
-            </>
-        )
     }
 
     const tree = (
@@ -603,7 +292,7 @@ export function ProjectTree({
 
                 return (
                     <ContextMenuGroup className="group/colorful-product-icons colorful-product-icons-true">
-                        {renderMenuItems(item, 'context')}
+                        <MenuItems item={item} type="context" root={root} onlyTree={onlyTree} logicKey={logicKey} />
                     </ContextMenuGroup>
                 )
             }}
@@ -614,7 +303,7 @@ export function ProjectTree({
 
                 return (
                     <DropdownMenuGroup className="group/colorful-product-icons colorful-product-icons-true">
-                        {renderMenuItems(item, 'dropdown')}
+                        <MenuItems item={item} type="dropdown" root={root} onlyTree={onlyTree} logicKey={logicKey} />
                     </DropdownMenuGroup>
                 )
             }}

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.tsx
@@ -1,3 +1,4 @@
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -42,6 +43,7 @@ export function BrowserLikeMenuItems({
                 onClick={(e) => {
                     e.stopPropagation()
                     void navigator.clipboard.writeText(document.location.origin + href)
+                    lemonToast.success('Link copied to clipboard')
                 }}
                 data-attr="tree-item-menu-copy-link-button"
             >

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
@@ -246,7 +246,7 @@ export function MenuItems({
             {item.id.startsWith('project/') || item.id.startsWith('project://') ? (
                 <MenuItem
                     asChild
-                    onClick={(e: any) => {
+                    onClick={(e: React.MouseEvent<HTMLElement>) => {
                         e.stopPropagation()
                         if (
                             checkedItemsArray.length > 0 &&
@@ -265,7 +265,7 @@ export function MenuItems({
             {(item.id.startsWith('project/') || item.id.startsWith('project://')) && item.record?.type !== 'folder' ? (
                 <MenuItem
                     asChild
-                    onClick={(e: any) => {
+                    onClick={(e: React.MouseEvent<HTMLElement>) => {
                         e.stopPropagation()
                         if (
                             checkedItemsArray.length > 0 &&

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
@@ -1,0 +1,355 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconChevronRight } from '@posthog/icons'
+
+import { linkToLogic } from 'lib/components/FileSystem/LinkTo/linkToLogic'
+import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
+import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import {
+    ContextMenuItem,
+    ContextMenuSeparator,
+    ContextMenuSub,
+    ContextMenuSubContent,
+    ContextMenuSubTrigger,
+} from 'lib/ui/ContextMenu/ContextMenu'
+import {
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
+} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { openDeleteGroupTypeDialog } from 'scenes/settings/environment/GroupAnalyticsConfig'
+import { groupAnalyticsConfigLogic } from 'scenes/settings/environment/groupAnalyticsConfigLogic'
+
+import { FileSystemEntry } from '~/queries/schema/schema-general'
+
+import { NewMenu } from '../../menus/NewMenu'
+import { panelLayoutLogic } from '../../panelLayoutLogic'
+import { projectTreeDataLogic } from '../projectTreeDataLogic'
+import { projectTreeLogic } from '../projectTreeLogic'
+import { joinPath, splitPath } from '../utils'
+import { BrowserLikeMenuItems } from './BrowserLikeMenuItems'
+import { DashboardsMenuItems } from './DashboardsMenuItems'
+import { ProductAnalyticsMenuItems } from './ProductAnalyticsMenuItems'
+import { SessionReplayMenuItems } from './SessionReplayMenuItems'
+
+interface MenuItemsProps {
+    item: TreeDataItem
+    type: 'context' | 'dropdown'
+    root?: string
+    onlyTree?: boolean
+    logicKey?: string
+    showSelectMenuOption?: boolean
+}
+
+let counter = 0
+
+export function MenuItems({
+    item,
+    type,
+    root,
+    onlyTree,
+    logicKey,
+    showSelectMenuOption = true,
+}: MenuItemsProps): JSX.Element {
+    const [uniqueKey] = useState(() => `project-tree-${counter++}`)
+    const { shortcutNonFolderPaths } = useValues(projectTreeDataLogic)
+    const { deleteShortcut, addShortcutItem } = useActions(projectTreeDataLogic)
+    const { groupTypes } = useValues(groupAnalyticsConfigLogic)
+    const { deleteGroupType } = useActions(groupAnalyticsConfigLogic)
+    const projectTreeLogicProps = { key: logicKey ?? uniqueKey, root }
+    const { checkedItems, checkedItemsCount, checkedItemCountNumeric, checkedItemsArray } = useValues(
+        projectTreeLogic(projectTreeLogicProps)
+    )
+    const {
+        createFolder,
+        deleteItem,
+        onItemChecked,
+        moveCheckedItems,
+        linkCheckedItems,
+        assureVisibility,
+        setEditingItemId,
+    } = useActions(projectTreeLogic(projectTreeLogicProps))
+    const { openMoveToModal } = useActions(moveToLogic)
+    const { openLinkToModal } = useActions(linkToLogic)
+
+    const { resetPanelLayout } = useActions(panelLayoutLogic)
+
+    const MenuItem = type === 'context' ? ContextMenuItem : DropdownMenuItem
+    const MenuSeparator = type === 'context' ? ContextMenuSeparator : DropdownMenuSeparator
+    const MenuSub = type === 'context' ? ContextMenuSub : DropdownMenuSub
+    const MenuSubTrigger = type === 'context' ? ContextMenuSubTrigger : DropdownMenuSubTrigger
+    const MenuSubContent = type === 'context' ? ContextMenuSubContent : DropdownMenuSubContent
+
+    const showSelectMenuItems =
+        root === 'project://' && item.record?.path && !item.disableSelect && !onlyTree && showSelectMenuOption
+
+    // Show product menu items if the item is a product or shortcut (and the item is a product, products have 1 slash in the href)
+    const showProductMenuItems =
+        root === 'products://' ||
+        (root === 'shortcuts://' && item.record?.href && item.record.href.split('/').length - 1 === 1)
+
+    // Note: renderMenuItems() is called often, so we're using custom components to isolate logic and network requests
+    const productMenu =
+        showProductMenuItems && item.name === 'Product analytics' ? (
+            <>
+                <ProductAnalyticsMenuItems
+                    MenuItem={MenuItem}
+                    MenuSeparator={MenuSeparator}
+                    onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
+                />
+                <MenuSeparator />
+            </>
+        ) : showProductMenuItems && item.name === 'Session replay' ? (
+            <>
+                <SessionReplayMenuItems
+                    MenuItem={MenuItem}
+                    MenuSub={MenuSub}
+                    MenuSubTrigger={MenuSubTrigger}
+                    MenuSubContent={MenuSubContent}
+                    MenuSeparator={MenuSeparator}
+                    onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
+                />
+                <MenuSeparator />
+            </>
+        ) : showProductMenuItems && item.name === 'Dashboards' ? (
+            <>
+                <DashboardsMenuItems
+                    MenuItem={MenuItem}
+                    MenuSub={MenuSub}
+                    MenuSubTrigger={MenuSubTrigger}
+                    MenuSubContent={MenuSubContent}
+                    MenuSeparator={MenuSeparator}
+                    onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
+                />
+                <MenuSeparator />
+            </>
+        ) : null
+
+    const isItemAFolder = item.record?.type === 'folder'
+    const itemShortcutPath = joinPath([splitPath(item.record?.path).pop() ?? 'Unnamed'])
+    const isItemAlreadyInShortcut = !isItemAFolder && shortcutNonFolderPaths.has(itemShortcutPath)
+    return (
+        <>
+            {productMenu}
+            {showSelectMenuItems ? (
+                <>
+                    <MenuItem
+                        asChild
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            onItemChecked(item.id, !checkedItems[item.id], false)
+                        }}
+                        data-attr="tree-item-menu-select-button"
+                    >
+                        <ButtonPrimitive menuItem>{checkedItems[item.id] ? 'Deselect' : 'Select'}</ButtonPrimitive>
+                    </MenuItem>
+                    <MenuSeparator />
+                </>
+            ) : null}
+
+            {item.record?.path && item.record?.type !== 'folder' && item.record?.href ? (
+                <>
+                    <BrowserLikeMenuItems
+                        href={item.record?.href}
+                        MenuItem={MenuItem}
+                        resetPanelLayout={resetPanelLayout}
+                    />
+                    <MenuSeparator />
+                </>
+            ) : null}
+
+            {checkedItemCountNumeric > 0 && item.record?.type === 'folder' ? (
+                <>
+                    <MenuItem
+                        asChild
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            moveCheckedItems(item?.record?.path)
+                        }}
+                        data-attr="tree-item-menu-move-checked-items-button"
+                    >
+                        <ButtonPrimitive menuItem>
+                            Move {checkedItemsCount} selected item{checkedItemsCount === '1' ? '' : 's'} here
+                        </ButtonPrimitive>
+                    </MenuItem>
+                    <MenuItem
+                        asChild
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            linkCheckedItems(item?.record?.path)
+                        }}
+                        data-attr="tree-item-menu-create-shortcut-button"
+                    >
+                        <ButtonPrimitive menuItem>
+                            Create {checkedItemsCount} shortcut{checkedItemsCount === '1' ? '' : 's'} here
+                        </ButtonPrimitive>
+                    </MenuItem>
+                    <MenuSeparator />
+                </>
+            ) : null}
+
+            {(item.record?.protocol === 'project://' && item.record?.type === 'folder') ||
+            item.id?.startsWith('project-folder-empty/') ? (
+                <>
+                    <MenuSub key="new">
+                        <MenuSubTrigger asChild data-attr="tree-item-menu-open-new-menu-button">
+                            <ButtonPrimitive menuItem>
+                                New...
+                                <IconChevronRight className="ml-auto size-3" />
+                            </ButtonPrimitive>
+                        </MenuSubTrigger>
+                        <MenuSubContent>
+                            <NewMenu type={type} item={item} createFolder={createFolder} />
+                        </MenuSubContent>
+                    </MenuSub>
+                    <MenuSeparator />
+                </>
+            ) : null}
+            {item.record?.path ? (
+                root === 'shortcuts://' ? (
+                    item.id.startsWith('shortcuts://') || item.id.startsWith('shortcuts/') ? (
+                        <MenuItem
+                            asChild
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                item.record && deleteShortcut(item.record?.id)
+                            }}
+                            data-attr="tree-item-menu-remove-from-shortcuts-button"
+                        >
+                            <ButtonPrimitive menuItem>Remove from shortcuts</ButtonPrimitive>
+                        </MenuItem>
+                    ) : null
+                ) : isItemAlreadyInShortcut ? (
+                    <MenuItem asChild disabled={true} data-attr="tree-item-menu-add-to-shortcuts-disabled-button">
+                        <ButtonPrimitive menuItem disabled={true}>
+                            Already in shortcuts panel
+                        </ButtonPrimitive>
+                    </MenuItem>
+                ) : (
+                    <MenuItem
+                        asChild
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            item.record && addShortcutItem(item.record as FileSystemEntry)
+                        }}
+                        data-attr="tree-item-menu-add-to-shortcuts-button"
+                    >
+                        <ButtonPrimitive menuItem>Add to shortcuts panel</ButtonPrimitive>
+                    </MenuItem>
+                )
+            ) : null}
+
+            {item.id.startsWith('project/') || item.id.startsWith('project://') ? (
+                <MenuItem
+                    asChild
+                    onClick={(e: any) => {
+                        e.stopPropagation()
+                        if (
+                            checkedItemsArray.length > 0 &&
+                            checkedItemsArray.find(({ id }) => id === item.record?.id)
+                        ) {
+                            openMoveToModal(checkedItemsArray)
+                        } else {
+                            openMoveToModal([item.record as unknown as FileSystemEntry])
+                        }
+                    }}
+                >
+                    <ButtonPrimitive menuItem>Move to...</ButtonPrimitive>
+                </MenuItem>
+            ) : null}
+
+            {(item.id.startsWith('project/') || item.id.startsWith('project://')) && item.record?.type !== 'folder' ? (
+                <MenuItem
+                    asChild
+                    onClick={(e: any) => {
+                        e.stopPropagation()
+                        if (
+                            checkedItemsArray.length > 0 &&
+                            checkedItemsArray.find(({ id }) => id === item.record?.id)
+                        ) {
+                            openLinkToModal(checkedItemsArray)
+                        } else {
+                            openLinkToModal([item.record as unknown as FileSystemEntry])
+                        }
+                    }}
+                >
+                    <ButtonPrimitive menuItem>Create shortcut in...</ButtonPrimitive>
+                </MenuItem>
+            ) : null}
+
+            {item.record?.path && item.record?.type === 'folder' ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        setEditingItemId(item.id)
+                    }}
+                    data-attr="tree-item-menu-rename-button"
+                >
+                    <ButtonPrimitive menuItem>Rename</ButtonPrimitive>
+                </MenuItem>
+            ) : null}
+
+            {item.record?.path && item.record?.shortcut ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        assureVisibility({ type: item.record?.type, ref: item.record?.ref })
+                    }}
+                    data-attr="tree-item-menu-show-original-button"
+                >
+                    <ButtonPrimitive menuItem>Show original</ButtonPrimitive>
+                </MenuItem>
+            ) : null}
+
+            {item.record?.shortcut ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
+                    }}
+                    data-attr="tree-item-menu-delete-shortcut-button"
+                >
+                    <ButtonPrimitive menuItem>Delete shortcut</ButtonPrimitive>
+                </MenuItem>
+            ) : item.record?.path && item.record?.type === 'folder' ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        deleteItem(item.record as unknown as FileSystemEntry, logicKey ?? uniqueKey)
+                    }}
+                    data-attr="tree-item-menu-delete-folder-button"
+                >
+                    <ButtonPrimitive menuItem>Delete folder</ButtonPrimitive>
+                </MenuItem>
+            ) : root === 'persons://' && item.record?.category === 'Groups' && item.record?.href ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        const href = item.record?.href as string
+                        const groupTypeIndex = parseInt(href.match(/\/groups\/(\d+)/)?.[1] || '0', 10)
+                        const groupType = Array.from(groupTypes.values()).find(
+                            (gt) => gt.group_type_index === groupTypeIndex
+                        )
+
+                        openDeleteGroupTypeDialog({
+                            onConfirm: () => deleteGroupType(groupTypeIndex),
+                            groupTypeName: groupType?.group_type || item.name || 'group type',
+                        })
+                    }}
+                    data-attr="tree-item-menu-delete-group-button"
+                >
+                    <ButtonPrimitive menuItem>Delete group type</ButtonPrimitive>
+                </MenuItem>
+            ) : null}
+        </>
+    )
+}

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -222,11 +222,10 @@ function SceneTabComponent({ tab, className, isDragging }: SceneTabProps): JSX.E
                     hasSideActionRight
                     className={cn(
                         'w-full',
-                        'relative p-0.5 flex flex-row items-center gap-1 rounded-tr rounded-tl border border-transparent',
+                        'relative py-0.5 pl-2 pr-5 flex flex-row items-center gap-1 rounded-tr rounded-tl border border-transparent',
                         tab.active
                             ? 'rounded-bl-none rounded-br-none cursor-default text-primary bg-primary border-primary'
                             : 'cursor-pointer text-secondary bg-transparent hover:bg-surface-primary hover:text-primary-hover z-20',
-                        canRemoveTab ? 'pl-2 pr-1' : 'px-3',
                         'focus:outline-none',
                         className
                     )}

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef } from 'react'
 
-import { IconSearch, IconSidePanel } from '@posthog/icons'
+import { IconEllipsis, IconSearch, IconSidePanel } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 
@@ -9,17 +9,25 @@ import { SceneDashboardChoiceModal } from 'lib/components/SceneDashboardChoice/S
 import { sceneDashboardChoiceModalLogic } from 'lib/components/SceneDashboardChoice/sceneDashboardChoiceModalLogic'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { Link } from 'lib/lemon-ui/Link'
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ButtonGroupPrimitive, ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ContextMenu, ContextMenuContent, ContextMenuGroup, ContextMenuTrigger } from 'lib/ui/ContextMenu/ContextMenu'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuTrigger,
+} from 'lib/ui/DropdownMenu/DropdownMenu'
 import { ListBox, ListBoxHandle } from 'lib/ui/ListBox/ListBox'
 import { TabsPrimitive, TabsPrimitiveList, TabsPrimitiveTrigger } from 'lib/ui/TabsPrimitive/TabsPrimitive'
 import { cn } from 'lib/utils/css-classes'
 import { maxLogic } from 'scenes/max/maxLogic'
-import { NEW_TAB_CATEGORY_ITEMS, newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
+import { NEW_TAB_CATEGORY_ITEMS, NewTabTreeDataItem, newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
+import { MenuItems } from '~/layout/panel-layout/ProjectTree/menus/MenuItems'
 import { SidePanelTab } from '~/types'
 
 export const scene: SceneExport = {
@@ -35,6 +43,18 @@ const getCategoryDisplayName = (category: string): string => {
         recents: 'Recents',
     }
     return displayNames[category] || category
+}
+
+// Helper function to convert NewTabTreeDataItem to TreeDataItem for menu usage
+const convertToTreeDataItem = (item: NewTabTreeDataItem): NewTabTreeDataItem => {
+    return {
+        ...item,
+        record: {
+            ...item.record,
+            href: item.href,
+            path: item.name, // Use name as path for menu compatibility
+        },
+    }
 }
 
 export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homepage' } = {}): JSX.Element {
@@ -203,7 +223,18 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                         </div>
                     ) : (
                         <div className="grid grid-cols-1 @md/main-content:grid-cols-2 @xl/main-content:grid-cols-3 @2xl/main-content:grid-cols-4 gap-4 group/colorful-product-icons colorful-product-icons-true">
-                            {filteredItemsGrid.map(({ category, types }, columnIndex) => (
+                            {Object.entries(
+                                filteredItemsGrid.reduce(
+                                    (acc, item) => {
+                                        if (!acc[item.category]) {
+                                            acc[item.category] = []
+                                        }
+                                        acc[item.category].push(item)
+                                        return acc
+                                    },
+                                    {} as Record<string, typeof filteredItemsGrid>
+                                )
+                            ).map(([category, items], columnIndex) => (
                                 <div
                                     className={cn('mb-8', {
                                         'col-span-4': selectedCategory !== 'all',
@@ -226,40 +257,88 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                         </div>
                                     </div>
                                     <div className="flex flex-col gap-2">
-                                        {category === 'recents' && types.length === 0 ? (
+                                        {category === 'recents' && items.length === 0 ? (
                                             // Special handling for empty project items
                                             <div className="flex flex-col gap-2 text-tertiary text-balance">
                                                 {isSearching ? 'Searching...' : 'No results found'}
                                             </div>
                                         ) : (
-                                            types.map((qt, index) => (
+                                            items.map((item, index) => (
                                                 // If we have filtered results set virtual focus to first item
                                                 <ListBox.Item
-                                                    key={index}
+                                                    key={item.id}
                                                     asChild
                                                     focusFirst={filteredItemsGrid.length > 0 && index === 0}
                                                     row={index}
                                                     column={columnIndex}
                                                 >
-                                                    <Link
-                                                        to={qt.href}
-                                                        className={cn('w-full @sm/main-content:w-auto')}
-                                                        buttonProps={{
-                                                            size: 'base',
-                                                        }}
-                                                    >
-                                                        <span className="text-sm">{qt.icon ?? qt.name[0]}</span>
-                                                        <span className="text-sm truncate text-primary">
-                                                            {search ? (
-                                                                <SearchHighlightMultiple
-                                                                    string={qt.name}
-                                                                    substring={search}
-                                                                />
-                                                            ) : (
-                                                                qt.name
-                                                            )}
-                                                        </span>
-                                                    </Link>
+                                                    <ButtonGroupPrimitive className="group w-full">
+                                                        <ContextMenu>
+                                                            <ContextMenuTrigger asChild>
+                                                                <Link
+                                                                    to={item.href || '#'}
+                                                                    className="w-full"
+                                                                    buttonProps={{
+                                                                        size: 'base',
+                                                                        hasSideActionRight: true,
+                                                                    }}
+                                                                >
+                                                                    <span className="text-sm">
+                                                                        {item.icon ?? item.name[0]}
+                                                                    </span>
+                                                                    <span className="text-sm truncate text-primary">
+                                                                        {search ? (
+                                                                            <SearchHighlightMultiple
+                                                                                string={item.name}
+                                                                                substring={search}
+                                                                            />
+                                                                        ) : (
+                                                                            item.name
+                                                                        )}
+                                                                    </span>
+                                                                </Link>
+                                                            </ContextMenuTrigger>
+                                                            <ContextMenuContent loop className="max-w-[250px]">
+                                                                <ContextMenuGroup>
+                                                                    <MenuItems
+                                                                        item={convertToTreeDataItem(item)}
+                                                                        type="context"
+                                                                        root="project://"
+                                                                        onlyTree={false}
+                                                                        showSelectMenuOption={false}
+                                                                    />
+                                                                </ContextMenuGroup>
+                                                            </ContextMenuContent>
+                                                        </ContextMenu>
+                                                        <DropdownMenu>
+                                                            <DropdownMenuTrigger asChild>
+                                                                <ButtonPrimitive
+                                                                    size="xs"
+                                                                    iconOnly
+                                                                    isSideActionRight
+                                                                    className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100"
+                                                                >
+                                                                    <IconEllipsis className="size-3" />
+                                                                </ButtonPrimitive>
+                                                            </DropdownMenuTrigger>
+                                                            <DropdownMenuContent
+                                                                loop
+                                                                align="end"
+                                                                side="bottom"
+                                                                className="max-w-[250px]"
+                                                            >
+                                                                <DropdownMenuGroup>
+                                                                    <MenuItems
+                                                                        item={convertToTreeDataItem(item)}
+                                                                        type="dropdown"
+                                                                        root="project://"
+                                                                        onlyTree={false}
+                                                                        showSelectMenuOption={false}
+                                                                    />
+                                                                </DropdownMenuGroup>
+                                                            </DropdownMenuContent>
+                                                        </DropdownMenu>
+                                                    </ButtonGroupPrimitive>
                                                 </ListBox.Item>
                                             ))
                                         )}

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -225,6 +225,7 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                         <div className="grid grid-cols-1 @md/main-content:grid-cols-2 @xl/main-content:grid-cols-3 @2xl/main-content:grid-cols-4 gap-4 group/colorful-product-icons colorful-product-icons-true">
                             {Object.entries(groupedFilteredItems).map(([category, items], columnIndex) => {
                                 const typedItems = items as NewTabTreeDataItem[]
+                                const isFirstCategory = columnIndex === 0
                                 return (
                                     <div
                                         className={cn('mb-8', {
@@ -256,16 +257,20 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                             ) : (
                                                 typedItems.map((item, index) => (
                                                     // If we have filtered results set virtual focus to first item
-                                                    <ListBox.Item
-                                                        key={item.id}
-                                                        asChild
-                                                        focusFirst={filteredItemsGrid.length > 0 && index === 0}
-                                                        row={index}
-                                                        column={columnIndex}
-                                                    >
-                                                        <ButtonGroupPrimitive className="group w-full border-0">
-                                                            <ContextMenu>
-                                                                <ContextMenuTrigger asChild>
+                                                    <ButtonGroupPrimitive className="group w-full border-0">
+                                                        <ContextMenu>
+                                                            <ContextMenuTrigger asChild>
+                                                                <ListBox.Item
+                                                                    key={item.id}
+                                                                    asChild
+                                                                    focusFirst={
+                                                                        filteredItemsGrid.length > 0 &&
+                                                                        isFirstCategory &&
+                                                                        index === 0
+                                                                    }
+                                                                    row={index}
+                                                                    column={columnIndex}
+                                                                >
                                                                     <Link
                                                                         to={item.href || '#'}
                                                                         className="w-full"
@@ -288,49 +293,49 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                                                             )}
                                                                         </span>
                                                                     </Link>
-                                                                </ContextMenuTrigger>
-                                                                <ContextMenuContent loop className="max-w-[250px]">
-                                                                    <ContextMenuGroup>
-                                                                        <MenuItems
-                                                                            item={convertToTreeDataItem(item)}
-                                                                            type="context"
-                                                                            root="project://"
-                                                                            onlyTree={false}
-                                                                            showSelectMenuOption={false}
-                                                                        />
-                                                                    </ContextMenuGroup>
-                                                                </ContextMenuContent>
-                                                            </ContextMenu>
-                                                            <DropdownMenu>
-                                                                <DropdownMenuTrigger asChild>
-                                                                    <ButtonPrimitive
-                                                                        size="xs"
-                                                                        iconOnly
-                                                                        isSideActionRight
-                                                                        className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
-                                                                    >
-                                                                        <IconEllipsis className="size-3" />
-                                                                    </ButtonPrimitive>
-                                                                </DropdownMenuTrigger>
-                                                                <DropdownMenuContent
-                                                                    loop
-                                                                    align="end"
-                                                                    side="bottom"
-                                                                    className="max-w-[250px]"
+                                                                </ListBox.Item>
+                                                            </ContextMenuTrigger>
+                                                            <ContextMenuContent loop className="max-w-[250px]">
+                                                                <ContextMenuGroup>
+                                                                    <MenuItems
+                                                                        item={convertToTreeDataItem(item)}
+                                                                        type="context"
+                                                                        root="project://"
+                                                                        onlyTree={false}
+                                                                        showSelectMenuOption={false}
+                                                                    />
+                                                                </ContextMenuGroup>
+                                                            </ContextMenuContent>
+                                                        </ContextMenu>
+                                                        <DropdownMenu>
+                                                            <DropdownMenuTrigger asChild>
+                                                                <ButtonPrimitive
+                                                                    size="xs"
+                                                                    iconOnly
+                                                                    isSideActionRight
+                                                                    className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
                                                                 >
-                                                                    <DropdownMenuGroup>
-                                                                        <MenuItems
-                                                                            item={convertToTreeDataItem(item)}
-                                                                            type="dropdown"
-                                                                            root="project://"
-                                                                            onlyTree={false}
-                                                                            showSelectMenuOption={false}
-                                                                        />
-                                                                    </DropdownMenuGroup>
-                                                                </DropdownMenuContent>
-                                                            </DropdownMenu>
-                                                        </ButtonGroupPrimitive>
-                                                    </ListBox.Item>
+                                                                    <IconEllipsis className="size-3" />
+                                                                </ButtonPrimitive>
+                                                            </DropdownMenuTrigger>
+                                                            <DropdownMenuContent
+                                                                loop
+                                                                align="end"
+                                                                side="bottom"
+                                                                className="max-w-[250px]"
+                                                            >
+                                                                <DropdownMenuGroup>
+                                                                    <MenuItems
+                                                                        item={convertToTreeDataItem(item)}
+                                                                        type="dropdown"
+                                                                        root="project://"
+                                                                        onlyTree={false}
+                                                                        showSelectMenuOption={false}
+                                                                    />
+                                                                </DropdownMenuGroup>
+                                                            </DropdownMenuContent>
+                                                        </DropdownMenu>
+                                                    </ButtonGroupPrimitive>
                                                 ))
                                             )}
                                         </div>

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -46,7 +46,7 @@ const getCategoryDisplayName = (category: string): string => {
 }
 
 // Helper function to convert NewTabTreeDataItem to TreeDataItem for menu usage
-const convertToTreeDataItem = (item: NewTabTreeDataItem): NewTabTreeDataItem => {
+function convertToTreeDataItem(item: NewTabTreeDataItem): NewTabTreeDataItem {
     return {
         ...item,
         record: {

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -272,7 +272,7 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                                     row={index}
                                                     column={columnIndex}
                                                 >
-                                                    <ButtonGroupPrimitive className="group w-full">
+                                                    <ButtonGroupPrimitive className="group w-full border-none">
                                                         <ContextMenu>
                                                             <ContextMenuTrigger asChild>
                                                                 <Link

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -272,7 +272,7 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                                     row={index}
                                                     column={columnIndex}
                                                 >
-                                                    <ButtonGroupPrimitive className="group w-full border-none">
+                                                    <ButtonGroupPrimitive className="group w-full border-0">
                                                         <ContextMenu>
                                                             <ContextMenuTrigger asChild>
                                                                 <Link
@@ -316,7 +316,7 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                                                     size="xs"
                                                                     iconOnly
                                                                     isSideActionRight
-                                                                    className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100"
+                                                                    className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
                                                                 >
                                                                     <IconEllipsis className="size-3" />
                                                                 </ButtonPrimitive>

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -8,6 +8,7 @@ import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 import { SceneDashboardChoiceModal } from 'lib/components/SceneDashboardChoice/SceneDashboardChoiceModal'
 import { sceneDashboardChoiceModalLogic } from 'lib/components/SceneDashboardChoice/sceneDashboardChoiceModalLogic'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
+import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { Link } from 'lib/lemon-ui/Link'
 import { ButtonGroupPrimitive, ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ContextMenu, ContextMenuContent, ContextMenuGroup, ContextMenuTrigger } from 'lib/ui/ContextMenu/ContextMenu'
@@ -46,7 +47,7 @@ const getCategoryDisplayName = (category: string): string => {
 }
 
 // Helper function to convert NewTabTreeDataItem to TreeDataItem for menu usage
-function convertToTreeDataItem(item: NewTabTreeDataItem): NewTabTreeDataItem {
+function convertToTreeDataItem(item: NewTabTreeDataItem): TreeDataItem {
     return {
         ...item,
         record: {
@@ -60,9 +61,8 @@ function convertToTreeDataItem(item: NewTabTreeDataItem): NewTabTreeDataItem {
 export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homepage' } = {}): JSX.Element {
     const inputRef = useRef<HTMLInputElement>(null)
     const listboxRef = useRef<ListBoxHandle>(null)
-    const { filteredItemsGrid, search, selectedItem, categories, selectedCategory, isSearching } = useValues(
-        newTabSceneLogic({ tabId })
-    )
+    const { filteredItemsGrid, groupedFilteredItems, search, selectedItem, categories, selectedCategory, isSearching } =
+        useValues(newTabSceneLogic({ tabId }))
     const { mobileLayout } = useValues(navigationLogic)
     const { setQuestion, focusInput } = useActions(maxLogic)
     const { setSearch, setSelectedCategory } = useActions(newTabSceneLogic({ tabId }))
@@ -223,128 +223,120 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                         </div>
                     ) : (
                         <div className="grid grid-cols-1 @md/main-content:grid-cols-2 @xl/main-content:grid-cols-3 @2xl/main-content:grid-cols-4 gap-4 group/colorful-product-icons colorful-product-icons-true">
-                            {Object.entries(
-                                filteredItemsGrid.reduce(
-                                    (acc, item) => {
-                                        if (!acc[item.category]) {
-                                            acc[item.category] = []
-                                        }
-                                        acc[item.category].push(item)
-                                        return acc
-                                    },
-                                    {} as Record<string, typeof filteredItemsGrid>
-                                )
-                            ).map(([category, items], columnIndex) => (
-                                <div
-                                    className={cn('mb-8', {
-                                        'col-span-4': selectedCategory !== 'all',
-                                    })}
-                                    key={category}
-                                >
-                                    <div className="mb-4">
-                                        <div className="flex items-center gap-2">
-                                            <h3 className="mb-0 text-lg font-medium text-muted">
-                                                {search ? (
-                                                    <SearchHighlightMultiple
-                                                        string={getCategoryDisplayName(category)}
-                                                        substring={search}
-                                                    />
-                                                ) : (
-                                                    getCategoryDisplayName(category)
-                                                )}
-                                            </h3>
-                                            {category === 'recents' && isSearching && <Spinner size="small" />}
+                            {Object.entries(groupedFilteredItems).map(([category, items], columnIndex) => {
+                                const typedItems = items as NewTabTreeDataItem[]
+                                return (
+                                    <div
+                                        className={cn('mb-8', {
+                                            'col-span-4': selectedCategory !== 'all',
+                                        })}
+                                        key={category}
+                                    >
+                                        <div className="mb-4">
+                                            <div className="flex items-center gap-2">
+                                                <h3 className="mb-0 text-lg font-medium text-muted">
+                                                    {search ? (
+                                                        <SearchHighlightMultiple
+                                                            string={getCategoryDisplayName(category)}
+                                                            substring={search}
+                                                        />
+                                                    ) : (
+                                                        getCategoryDisplayName(category)
+                                                    )}
+                                                </h3>
+                                                {category === 'recents' && isSearching && <Spinner size="small" />}
+                                            </div>
+                                        </div>
+                                        <div className="flex flex-col gap-2">
+                                            {category === 'recents' && typedItems.length === 0 ? (
+                                                // Special handling for empty project items
+                                                <div className="flex flex-col gap-2 text-tertiary text-balance">
+                                                    {isSearching ? 'Searching...' : 'No results found'}
+                                                </div>
+                                            ) : (
+                                                typedItems.map((item, index) => (
+                                                    // If we have filtered results set virtual focus to first item
+                                                    <ListBox.Item
+                                                        key={item.id}
+                                                        asChild
+                                                        focusFirst={filteredItemsGrid.length > 0 && index === 0}
+                                                        row={index}
+                                                        column={columnIndex}
+                                                    >
+                                                        <ButtonGroupPrimitive className="group w-full border-0">
+                                                            <ContextMenu>
+                                                                <ContextMenuTrigger asChild>
+                                                                    <Link
+                                                                        to={item.href || '#'}
+                                                                        className="w-full"
+                                                                        buttonProps={{
+                                                                            size: 'base',
+                                                                            hasSideActionRight: true,
+                                                                        }}
+                                                                    >
+                                                                        <span className="text-sm">
+                                                                            {item.icon ?? item.name[0]}
+                                                                        </span>
+                                                                        <span className="text-sm truncate text-primary">
+                                                                            {search ? (
+                                                                                <SearchHighlightMultiple
+                                                                                    string={item.name}
+                                                                                    substring={search}
+                                                                                />
+                                                                            ) : (
+                                                                                item.name
+                                                                            )}
+                                                                        </span>
+                                                                    </Link>
+                                                                </ContextMenuTrigger>
+                                                                <ContextMenuContent loop className="max-w-[250px]">
+                                                                    <ContextMenuGroup>
+                                                                        <MenuItems
+                                                                            item={convertToTreeDataItem(item)}
+                                                                            type="context"
+                                                                            root="project://"
+                                                                            onlyTree={false}
+                                                                            showSelectMenuOption={false}
+                                                                        />
+                                                                    </ContextMenuGroup>
+                                                                </ContextMenuContent>
+                                                            </ContextMenu>
+                                                            <DropdownMenu>
+                                                                <DropdownMenuTrigger asChild>
+                                                                    <ButtonPrimitive
+                                                                        size="xs"
+                                                                        iconOnly
+                                                                        isSideActionRight
+                                                                        className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
+                                                                    >
+                                                                        <IconEllipsis className="size-3" />
+                                                                    </ButtonPrimitive>
+                                                                </DropdownMenuTrigger>
+                                                                <DropdownMenuContent
+                                                                    loop
+                                                                    align="end"
+                                                                    side="bottom"
+                                                                    className="max-w-[250px]"
+                                                                >
+                                                                    <DropdownMenuGroup>
+                                                                        <MenuItems
+                                                                            item={convertToTreeDataItem(item)}
+                                                                            type="dropdown"
+                                                                            root="project://"
+                                                                            onlyTree={false}
+                                                                            showSelectMenuOption={false}
+                                                                        />
+                                                                    </DropdownMenuGroup>
+                                                                </DropdownMenuContent>
+                                                            </DropdownMenu>
+                                                        </ButtonGroupPrimitive>
+                                                    </ListBox.Item>
+                                                ))
+                                            )}
                                         </div>
                                     </div>
-                                    <div className="flex flex-col gap-2">
-                                        {category === 'recents' && items.length === 0 ? (
-                                            // Special handling for empty project items
-                                            <div className="flex flex-col gap-2 text-tertiary text-balance">
-                                                {isSearching ? 'Searching...' : 'No results found'}
-                                            </div>
-                                        ) : (
-                                            items.map((item, index) => (
-                                                // If we have filtered results set virtual focus to first item
-                                                <ListBox.Item
-                                                    key={item.id}
-                                                    asChild
-                                                    focusFirst={filteredItemsGrid.length > 0 && index === 0}
-                                                    row={index}
-                                                    column={columnIndex}
-                                                >
-                                                    <ButtonGroupPrimitive className="group w-full border-0">
-                                                        <ContextMenu>
-                                                            <ContextMenuTrigger asChild>
-                                                                <Link
-                                                                    to={item.href || '#'}
-                                                                    className="w-full"
-                                                                    buttonProps={{
-                                                                        size: 'base',
-                                                                        hasSideActionRight: true,
-                                                                    }}
-                                                                >
-                                                                    <span className="text-sm">
-                                                                        {item.icon ?? item.name[0]}
-                                                                    </span>
-                                                                    <span className="text-sm truncate text-primary">
-                                                                        {search ? (
-                                                                            <SearchHighlightMultiple
-                                                                                string={item.name}
-                                                                                substring={search}
-                                                                            />
-                                                                        ) : (
-                                                                            item.name
-                                                                        )}
-                                                                    </span>
-                                                                </Link>
-                                                            </ContextMenuTrigger>
-                                                            <ContextMenuContent loop className="max-w-[250px]">
-                                                                <ContextMenuGroup>
-                                                                    <MenuItems
-                                                                        item={convertToTreeDataItem(item)}
-                                                                        type="context"
-                                                                        root="project://"
-                                                                        onlyTree={false}
-                                                                        showSelectMenuOption={false}
-                                                                    />
-                                                                </ContextMenuGroup>
-                                                            </ContextMenuContent>
-                                                        </ContextMenu>
-                                                        <DropdownMenu>
-                                                            <DropdownMenuTrigger asChild>
-                                                                <ButtonPrimitive
-                                                                    size="xs"
-                                                                    iconOnly
-                                                                    isSideActionRight
-                                                                    className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
-                                                                >
-                                                                    <IconEllipsis className="size-3" />
-                                                                </ButtonPrimitive>
-                                                            </DropdownMenuTrigger>
-                                                            <DropdownMenuContent
-                                                                loop
-                                                                align="end"
-                                                                side="bottom"
-                                                                className="max-w-[250px]"
-                                                            >
-                                                                <DropdownMenuGroup>
-                                                                    <MenuItems
-                                                                        item={convertToTreeDataItem(item)}
-                                                                        type="dropdown"
-                                                                        root="project://"
-                                                                        onlyTree={false}
-                                                                        showSelectMenuOption={false}
-                                                                    />
-                                                                </DropdownMenuGroup>
-                                                            </DropdownMenuContent>
-                                                        </DropdownMenu>
-                                                    </ButtonGroupPrimitive>
-                                                </ListBox.Item>
-                                            ))
-                                        )}
-                                    </div>
-                                </div>
-                            ))}
+                                )
+                            })}
                         </div>
                     )}
                 </div>

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -296,6 +296,21 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
             (s) => [s.filteredItemsGrid],
             (filteredItemsGrid): NewTabTreeDataItem[] => filteredItemsGrid,
         ],
+        groupedFilteredItems: [
+            (s) => [s.filteredItemsGrid],
+            (filteredItemsGrid: NewTabTreeDataItem[]): Record<string, NewTabTreeDataItem[]> => {
+                return filteredItemsGrid.reduce(
+                    (acc: Record<string, NewTabTreeDataItem[]>, item: NewTabTreeDataItem) => {
+                        if (!acc[item.category]) {
+                            acc[item.category] = []
+                        }
+                        acc[item.category].push(item)
+                        return acc
+                    },
+                    {} as Record<string, NewTabTreeDataItem[]>
+                )
+            },
+        ],
         selectedIndex: [
             (s) => [s.rawSelectedIndex, s.filteredItemsList],
             (rawSelectedIndex, filteredItemsList): number | null => {


### PR DESCRIPTION
## Problem
New tab scene items were not very functional

![2025-10-07 15 13 19](https://github.com/user-attachments/assets/ddf7eb55-5d33-49a9-bb93-238d3cc56aa2)
![2025-10-07 15 14 22](https://github.com/user-attachments/assets/a2ce07cb-783e-4034-8774-f8e5b57d7c1e)


## Changes
* Make the items an extended version of `TreeDataItem`
* Enable context/dropdown menus to match Trees
* Move context/dropdown menu items into new file (Project tree also using it)
    * added prop to explicitly hide "select" from menus (new tab scene sets this to hide as selecting here doesn't make sense) 
* Fix bug where tab name didn't truncate for X button (BONUS)

## How did you test this code?
- Arrows left/right/up/down in new tab items still work ✅ 
- Enter on active new tab items work ✅ 
- Add to shortcuts in new tab menu works ✅  
- Open in new tab menu item works ✅ 
- Project tree menu items all work as expected
    - selecting ✅ 
    - shortcuts ✅ 
    - move to etc ✅ 
