### PR TITLE
fix: Make the search keys filterable for the lemon autocomplete

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSearchableSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSearchableSelect.tsx
@@ -16,6 +16,7 @@ import {
 
 export interface LemonSearchableSelectPropsBase<T> extends LemonSelectPropsBase<T> {
     searchPlaceholder?: string
+    searchKeys?: string[]
 }
 
 export interface LemonSearchableSelectPropsClearable<T>
@@ -70,13 +71,17 @@ function filterStructure<T>(
     return matchedOptions.has(item) ? item : null
 }
 
-function filterOptions<T>(options: LemonSelectOptions<T>, searchTerm: string): LemonSelectOptions<T> {
+function filterOptions<T>(
+    options: LemonSelectOptions<T>,
+    searchTerm: string,
+    searchKeys: string[] = ['label']
+): LemonSelectOptions<T> {
     if (!searchTerm) {
         return options
     }
 
     const flatOptions = flattenOptions(options)
-    const fuse = new Fuse(flatOptions, { keys: ['label'], threshold: 0.3 })
+    const fuse = new Fuse(flatOptions, { keys: searchKeys, threshold: 0.3 })
     const matchedOptions = new Set(fuse.search(searchTerm).map((result) => result.item))
 
     return options.map((item) => filterStructure(item, matchedOptions)).filter(Boolean) as LemonSelectOptions<T>
@@ -84,6 +89,7 @@ function filterOptions<T>(options: LemonSelectOptions<T>, searchTerm: string): L
 
 export function LemonSearchableSelect<T extends string | number | boolean | null>({
     searchPlaceholder,
+    searchKeys = ['label'],
     onChange,
     onSelect,
     ...selectProps
@@ -91,8 +97,8 @@ export function LemonSearchableSelect<T extends string | number | boolean | null
     const [searchTerm, setSearchTerm] = useState('')
 
     const filteredOptions = useMemo(() => {
-        return filterOptions(selectProps.options, searchTerm)
-    }, [selectProps.options, searchTerm])
+        return filterOptions(selectProps.options, searchTerm, searchKeys)
+    }, [selectProps.options, searchTerm, searchKeys])
 
     // Add search input as first menu item
     const optionsWithSearch = useMemo(() => {

--- a/frontend/src/scenes/audit-logs/DetailFilters.tsx
+++ b/frontend/src/scenes/audit-logs/DetailFilters.tsx
@@ -377,6 +377,7 @@ export const DetailFilters = (): JSX.Element => {
                 options={fieldOptions}
                 placeholder="Add filter"
                 searchPlaceholder="Search fields..."
+                searchKeys={['value']}
                 icon={<IconPlus />}
                 size="small"
                 className="w-[200px]"


### PR DESCRIPTION
## Problem

- Autocomplete on the detail filters doesnt work as the item labels are `divs` and it doesn't know how to search in those.

## Changes

- Add the ability to the Lemon autocomplete to set custom search keys, `value` in this case.
