### PR TITLE
feat(llma): add custom model pricing

### DIFF
--- a/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -352,7 +352,7 @@ exports[`IngestionConsumer typical event processing ai event 1`] = `
       "person_mode": "full",
       "person_properties": "{"$current_url":"http://localhost:8000","$creator_event_uuid":"<REPLACED-UUID-1>","$initial_current_url":"http://localhost:8000"}",
       "project_id": 2,
-      "properties": "{"$current_url":"http://localhost:8000","$ai_model":"gpt-4","$ai_provider":"openai","$ai_input_tokens":100,"$ai_output_tokens":50,"$ip":"127.0.0.1","$set":{"$current_url":"http://localhost:8000"},"$set_once":{"$initial_current_url":"http://localhost:8000"},"$ai_model_cost_used":"gpt-4","$ai_cost_model_source":"primary","$ai_input_cost_usd":0.003,"$ai_output_cost_usd":0.003,"$ai_total_cost_usd":0.006}",
+      "properties": "{"$current_url":"http://localhost:8000","$ai_model":"gpt-4","$ai_provider":"openai","$ai_input_tokens":100,"$ai_output_tokens":50,"$ip":"127.0.0.1","$set":{"$current_url":"http://localhost:8000"},"$set_once":{"$initial_current_url":"http://localhost:8000"},"$ai_input_cost_usd":0.003,"$ai_output_cost_usd":0.003,"$ai_total_cost_usd":0.006,"$ai_model_cost_used":"gpt-4","$ai_cost_model_source":"primary"}",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.000",
       "uuid": "<REPLACED-UUID-1>",

--- a/plugin-server/src/ingestion/ai-costs/cost-model-matching.ts
+++ b/plugin-server/src/ingestion/ai-costs/cost-model-matching.ts
@@ -10,6 +10,7 @@ const SPECIAL_COST_MODELS = ['gemini-2.5-pro-preview']
 export enum CostModelSource {
     Primary = 'primary',
     Backup = 'backup',
+    Custom = 'custom',
 }
 
 export interface CostModelResult {

--- a/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
+++ b/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
@@ -454,7 +454,7 @@ describe('processAiEvent()', () => {
             expect(result.properties!.$ai_output_cost_usd).toBeCloseTo(0.1, 6)
             expect(result.properties!.$ai_total_cost_usd).toBeCloseTo(0.2, 6)
             expect(result.properties!.$ai_model_cost_used).toBe('custom')
-            expect(result.properties!.$ai_cost_model_source).toBe('custom')
+            expect(result.properties!.$ai_cost_model_source).toBe(CostModelSource.Custom)
         })
 
         it('uses custom pricing even when model is unknown', () => {

--- a/plugin-server/src/ingestion/ai-costs/process-ai-event.ts
+++ b/plugin-server/src/ingestion/ai-costs/process-ai-event.ts
@@ -3,7 +3,7 @@ import bigDecimal from 'js-big-decimal'
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { logger } from '../../utils/logger'
-import { findCostFromModel, getNewModelName, requireSpecialCost } from './cost-model-matching'
+import { CostModelSource, findCostFromModel, getNewModelName, requireSpecialCost } from './cost-model-matching'
 import { calculateInputCost } from './input-costs'
 import { calculateOutputCost } from './output-costs'
 import { ModelRow } from './providers/types'
@@ -111,7 +111,7 @@ const processCost = (event: PluginEvent) => {
         setCostsOnEvent(event, customCost)
 
         event.properties['$ai_model_cost_used'] = 'custom'
-        event.properties['$ai_cost_model_source'] = 'custom'
+        event.properties['$ai_cost_model_source'] = CostModelSource.Custom
 
         return event
     }


### PR DESCRIPTION
## Problem

When users encounter problems with the LLM cost calculation on our side, they can't really do anything about it.

Some users might also have custom model pricing with their LLM provider. They might also use some models that are not public, or that we don't support for the cost calculation yet.

## Changes

This gives the users four event properties that they can set to represent the pricing for their LLM generations:

- `$ai_input_token_price`: price per input token (required)
- `$ai_output_token_price`: price per output token (required)
- `$ai_cache_read_token_price`: price per cached token read (optional)
- `$ai_cache_write_token_price`: price per cached token write (optional)

## How did you test this code?

Automated tests and manually.

## Changelog: (features only) Is this feature complete?

Users can now force LLM Analytics' cost calculation to use a particular price per token by sending properties like `$ai_input_token_price`, `$ai_output_token_price`, `$ai_cache_read_token_price`, and `$ai_cache_write_token_price`.
