### PR TITLE
chore(kafka-deduplicator): adjust default checkpoint configs

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -49,7 +49,7 @@ impl Default for CheckpointConfig {
     fn default() -> Self {
         Self {
             // NOTE! production & local dev defaults can be overridden in top-level config.rs
-            //or env vars; assume these defaults are only applied as-is in unit tests and CI
+            // or env vars; assume these defaults are only applied as-is in unit tests and CI
             checkpoint_interval: Duration::from_secs(300), // 5 minutes (TBD)
             cleanup_interval: Duration::from_secs(1320),   // 22 minutes (TBD)
             local_checkpoint_dir: "./checkpoints".to_string(),
@@ -58,7 +58,7 @@ impl Default for CheckpointConfig {
             full_upload_interval: 0, // TODO: always full checkpoints until we impl incremental
             aws_region: "us-east-1".to_string(),
             max_local_checkpoints: 10,
-            max_checkpoint_retention_hours: 72,
+            max_checkpoint_retention_hours: 6,
             max_concurrent_checkpoints: 3,
             checkpoint_gate_interval: Duration::from_millis(200),
             checkpoint_worker_shutdown_timeout: Duration::from_secs(10),

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -58,7 +58,7 @@ impl Default for CheckpointConfig {
             full_upload_interval: 0, // TODO: always full checkpoints until we impl incremental
             aws_region: "us-east-1".to_string(),
             max_local_checkpoints: 10,
-            max_checkpoint_retention_hours: 6,
+            max_checkpoint_retention_hours: 2,
             max_concurrent_checkpoints: 3,
             checkpoint_gate_interval: Duration::from_millis(200),
             checkpoint_worker_shutdown_timeout: Duration::from_secs(10),

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -94,16 +94,16 @@ pub struct Config {
     pub port: u16,
 
     // Checkpoint configuration - integrated from checkpoint::config
-    #[envconfig(default = "900")] // 15 minutes in seconds
+    #[envconfig(default = "1800")] // 30 minutes in seconds
     pub checkpoint_interval_secs: u64,
 
-    #[envconfig(default = "1680")] // 28 minutes in seconds
+    #[envconfig(default = "900")] // 15 minutes in seconds
     pub checkpoint_cleanup_interval_secs: u64,
 
-    #[envconfig(default = "72")] // 72 hours
+    #[envconfig(default = "4")] // 4 hours
     pub max_checkpoint_retention_hours: u32,
 
-    #[envconfig(default = "3")]
+    #[envconfig(default = "8")]
     pub max_concurrent_checkpoints: usize,
 
     #[envconfig(default = "200")]
@@ -112,7 +112,7 @@ pub struct Config {
     #[envconfig(default = "10")]
     pub checkpoint_worker_shutdown_timeout_secs: u64,
 
-    #[envconfig(default = "5")]
+    #[envconfig(default = "2")]
     pub max_local_checkpoints: usize,
 
     #[envconfig(default = "/tmp/checkpoints")]

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -100,7 +100,7 @@ pub struct Config {
     #[envconfig(default = "900")] // 15 minutes in seconds
     pub checkpoint_cleanup_interval_secs: u64,
 
-    #[envconfig(default = "4")] // 4 hours
+    #[envconfig(default = "2")] // 2 hours
     pub max_checkpoint_retention_hours: u32,
 
     #[envconfig(default = "8")]


### PR DESCRIPTION
## Problem
Locally-stored recent checkpoints are eating too much disk space.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adjusts checkpoint configs to perform more in parallel, retain fewer recent snapshots, and adjust snapshot interval. To be paired with related change to horizontally scale the service, making each pod responsible for less partitions/stores/checkpoints

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
