### PR TITLE
fix(migration-analysis): Improve PostgreSQL pattern recognition

### DIFF
--- a/posthog/management/migration_analysis/analyzer.py
+++ b/posthog/management/migration_analysis/analyzer.py
@@ -199,6 +199,14 @@ class RiskAnalyzer:
         if not categorizer.runsql_ops or getattr(migration, "atomic", True):
             return []
 
+        # Skip INFO warning if all RunSQL operations are safe CONCURRENTLY operations
+        all_safe_concurrent = all(
+            op_risk.score == 1 and "CONCURRENTLY" in str(op_risk.details.get("sql", "")).upper()
+            for _, op_risk in categorizer.runsql_ops
+        )
+        if all_safe_concurrent:
+            return []  # No need to warn about atomic=False for safe concurrent operations
+
         return ["⚠️  INFO: Migration is marked atomic=False. Ensure data migrations handle failures correctly."]
 
     def check_policies(self, migration) -> list[str]:

--- a/posthog/management/migration_analysis/analyzer.py
+++ b/posthog/management/migration_analysis/analyzer.py
@@ -149,7 +149,7 @@ class RiskAnalyzer:
         schema_refs = categorizer.format_operation_refs(categorizer.schema_ops)
 
         return [
-            f"⚠️  WARNING: {runpython_refs} + {schema_refs}    "
+            f"❌ BLOCKED: {runpython_refs} + {schema_refs}    "
             "RunPython data migration combined with schema changes. "
             "Data migrations can hold locks during execution, especially on large tables. "
             "Split into separate migrations: 1) schema changes, 2) data migration."
@@ -163,7 +163,7 @@ class RiskAnalyzer:
         ddl_refs = categorizer.format_operation_refs(categorizer.ddl_ops)
 
         return [
-            f"⚠️  WARNING: {ddl_refs} mixed with other operations    "
+            f"❌ BLOCKED: {ddl_refs} mixed with other operations    "
             "RunSQL with DDL (CREATE INDEX/ALTER TABLE) should be isolated in their own migration "
             "to avoid lock conflicts."
         ]
@@ -176,7 +176,7 @@ class RiskAnalyzer:
         high_risk_refs = categorizer.format_operation_refs(categorizer.high_risk_ops)
 
         return [
-            f"⚠️  WARNING: Multiple high-risk operations in one migration: {high_risk_refs}    "
+            f"❌ BLOCKED: Multiple high-risk operations in one migration: {high_risk_refs}    "
             "Each high-risk operation (score 4+) should be isolated to make rollback easier and reduce deployment risk. "
             "Consider splitting into separate migrations."
         ]
@@ -189,7 +189,7 @@ class RiskAnalyzer:
         index_refs = categorizer.format_operation_refs(categorizer.addindex_ops)
 
         return [
-            f"⚠️  WARNING: Multiple index creations in one migration: {index_refs}    "
+            f"❌ BLOCKED: Multiple index creations in one migration: {index_refs}    "
             "Creating multiple indexes can cause I/O overload and extended lock times. "
             "Consider splitting into separate migrations to reduce system load."
         ]

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -593,7 +593,7 @@ class TestCombinationRisks:
         combination_risks = self.analyzer.check_operation_combinations(mock_migration, operation_risks)
 
         assert len(combination_risks) > 0
-        assert any("WARNING" in warning or "DDL" in warning for warning in combination_risks)
+        assert any("BLOCKED" in warning or "DDL" in warning for warning in combination_risks)
 
     def test_runsql_concurrent_index_no_ddl_warning(self):
         """CREATE INDEX CONCURRENTLY should NOT trigger DDL isolation warning"""

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -429,7 +429,7 @@ class TestRunSQLOperations:
         # Score 3 when IF NOT EXISTS is missing (still NEEDS_REVIEW, not BLOCKED)
         assert risk.score == 3
         assert risk.level == RiskLevel.NEEDS_REVIEW
-        assert "if not exists" in risk.guidance.lower()
+        assert risk.guidance is not None and "if not exists" in risk.guidance.lower()
 
     def test_run_sql_drop_index_with_if_exists(self):
         """Test DROP INDEX without CONCURRENTLY but with IF EXISTS - still risky but idempotent."""

--- a/posthog/management/migration_analysis/utils.py
+++ b/posthog/management/migration_analysis/utils.py
@@ -80,6 +80,11 @@ class OperationCategorizer:
 
         sql_upper = str(op_risk.details.get("sql", "")).upper() if op_risk.details else ""
 
+        # Skip categorization for safe CONCURRENTLY operations
+        # These are non-blocking and don't need DDL isolation warnings
+        if "CONCURRENTLY" in sql_upper and "INDEX" in sql_upper:
+            return  # Don't categorize as DDL or DML
+
         # Use word boundaries to avoid false positives like UPDATE_TIME matching UPDATE
         for kw in self.DML_KEYWORDS:
             if re.search(r"\b" + re.escape(kw) + r"\b", sql_upper):

--- a/posthog/management/migration_analysis/utils.py
+++ b/posthog/management/migration_analysis/utils.py
@@ -1,6 +1,10 @@
 """Utility classes and functions for migration analysis."""
 
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from posthog.management.migration_analysis.models import OperationRisk
 
 
 class VolatileFunctionDetector:
@@ -47,15 +51,15 @@ class OperationCategorizer:
     DML_KEYWORDS = ["UPDATE", "DELETE", "INSERT"]
     DDL_KEYWORDS = ["CREATE INDEX", "ALTER TABLE", "ADD COLUMN"]
 
-    def __init__(self, operation_risks: list):
+    def __init__(self, operation_risks: list["OperationRisk"]):
         self.operation_risks = operation_risks
-        self.dml_ops: list[tuple[int, object]] = []
-        self.ddl_ops: list[tuple[int, object]] = []
-        self.schema_ops: list[tuple[int, object]] = []
-        self.runsql_ops: list[tuple[int, object]] = []
-        self.runpython_ops: list[tuple[int, object]] = []
-        self.addindex_ops: list[tuple[int, object]] = []
-        self.high_risk_ops: list[tuple[int, object]] = []
+        self.dml_ops: list[tuple[int, OperationRisk]] = []
+        self.ddl_ops: list[tuple[int, OperationRisk]] = []
+        self.schema_ops: list[tuple[int, OperationRisk]] = []
+        self.runsql_ops: list[tuple[int, OperationRisk]] = []
+        self.runpython_ops: list[tuple[int, OperationRisk]] = []
+        self.addindex_ops: list[tuple[int, OperationRisk]] = []
+        self.high_risk_ops: list[tuple[int, OperationRisk]] = []
         self._categorize()
 
     def _categorize(self):
@@ -133,6 +137,6 @@ class OperationCategorizer:
     def has_multiple_high_risk(self) -> bool:
         return len(self.high_risk_ops) > 1
 
-    def format_operation_refs(self, ops: list[tuple[int, object]]) -> str:
+    def format_operation_refs(self, ops: list[tuple[int, "OperationRisk"]]) -> str:
         """Format operation references like '#3 RunSQL, #5 AddField'."""
-        return ", ".join(f"#{idx+1} {getattr(op, 'type', 'Unknown')}" for idx, op in ops)
+        return ", ".join(f"#{idx+1} {op.type}" for idx, op in ops)


### PR DESCRIPTION
Fixes false positives where migrations using the correct safe patterns were getting blocked or over-warned.

**Main fix:**
SeparateDatabaseAndState + CREATE INDEX CONCURRENTLY was getting blocked due to combination risk escalation. This is the recommended safe pattern but analyzer was treating CONCURRENTLY as problematic DDL.

**Root cause:**
- RunSQL analyzer gave score 2 (needs review) for all CONCURRENTLY operations
- DDL categorizer included them in ddl_ops
- Combination checker triggered DDL isolation warning
- Any combination risk auto-escalates to BLOCKED

**Changes:**

Fixed CONCURRENTLY scoring - now score 1 (safe) for CREATE/DROP/REINDEX INDEX CONCURRENTLY

Added safe pattern recognition:
- ADD CONSTRAINT ... NOT VALID - score 1, validates new rows only
- VALIDATE CONSTRAINT - score 2, slow but allows reads/writes  
- DROP CONSTRAINT - score 1 (CASCADE gets score 3)
- COMMENT ON / SET STATISTICS - score 0, metadata only

IF NOT EXISTS / IF EXISTS handling:
- Missing these bumps score by 1 to encourage idempotency
- CONCURRENTLY ops: 1→2 when missing
- Non-concurrent ops: 2→3 when missing
- Not blocking, just nudging toward better practice

Before: CREATE INDEX CONCURRENTLY in SeparateDatabaseAndState → BLOCKED
After: CREATE INDEX CONCURRENTLY IF NOT EXISTS in SeparateDatabaseAndState → SAFE

Tests added for all new patterns (48 total tests passing)