### PR TITLE
fix(llma): trace not found due to bad starting timestamp

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -56,6 +56,7 @@ import {
     formatLLMUsage,
     getEventType,
     getSessionID,
+    getTraceTimestamp,
     hasSessionID,
     isLLMTraceEvent,
     normalizeMessages,
@@ -367,7 +368,7 @@ const TreeNode = React.memo(function TraceNode({
             <Link
                 to={urls.llmAnalyticsTrace(topLevelTrace.id, {
                     event: item.id,
-                    timestamp: removeMilliseconds(topLevelTrace.createdAt),
+                    timestamp: getTraceTimestamp(topLevelTrace.createdAt),
                     ...(searchQuery?.trim() && { search: searchQuery }),
                 })}
                 className={classNames(

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -14,7 +14,7 @@ import { isTracesQuery } from '~/queries/utils'
 
 import { LLMMessageDisplay } from './ConversationDisplay/ConversationMessagesDisplay'
 import { llmAnalyticsLogic } from './llmAnalyticsLogic'
-import { formatLLMCost, formatLLMLatency, formatLLMUsage, normalizeMessages, removeMilliseconds } from './utils'
+import { formatLLMCost, formatLLMLatency, formatLLMUsage, getTraceTimestamp, normalizeMessages } from './utils'
 
 export function LLMAnalyticsTraces(): JSX.Element {
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(llmAnalyticsLogic)
@@ -88,7 +88,7 @@ const IDColumn: QueryContextColumnComponent = ({ record }) => {
             <Tooltip title={row.id}>
                 <Link
                     className="ph-no-capture"
-                    to={urls.llmAnalyticsTrace(row.id, { timestamp: removeMilliseconds(row.createdAt) })}
+                    to={urls.llmAnalyticsTrace(row.id, { timestamp: getTraceTimestamp(row.createdAt) })}
                 >
                     {row.id.slice(0, 4)}...{row.id.slice(-4)}
                 </Link>
@@ -103,7 +103,7 @@ const TraceNameColumn: QueryContextColumnComponent = ({ record }) => {
         <strong>
             <Link
                 className="ph-no-capture"
-                to={urls.llmAnalyticsTrace(row.id, { timestamp: removeMilliseconds(row.createdAt) })}
+                to={urls.llmAnalyticsTrace(row.id, { timestamp: getTraceTimestamp(row.createdAt) })}
             >
                 {row.traceName || '–'}
             </Link>

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -500,6 +500,10 @@ export function removeMilliseconds(timestamp: string): string {
     return dayjs(timestamp).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
 }
 
+export function getTraceTimestamp(timestamp: string): string {
+    return dayjs(timestamp).utc().subtract(5, 'minutes').format('YYYY-MM-DDTHH:mm:ss[Z]')
+}
+
 export function formatLLMEventTitle(event: LLMTrace | LLMTraceEvent): string {
     if (isLLMTraceEvent(event)) {
         if (event.event === '$ai_generation') {


### PR DESCRIPTION
## Problem

Many users (especially those with high LLM events volumes) are getting a "Trace not found" when clicking on a trace from the traces list.

I suspect that the timestamp used in the URL, to optimize the query fetching the trace, is incorrectly truncated, and it's causing this issue.

## Changes

This removes five minutes from it, to make sure that the trace is found. Back then, there was no bloom filter on the materialized trace ID, but now there is. This shouldn't noticeably impact query performance. With the bloom filter, we might even be able to remove this optimization, but I decided to leave it still, for now.

If this doesn't fix the bug completely, I'll remove this optimization.

## How did you test this code?

Manually.