### PR TITLE
chore(cdp): spread out pod termination more evenly

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -330,8 +330,8 @@ export function getDefaultConfig(): PluginsServerConfig {
 
         // Pod termination
         POD_TERMINATION_ENABLED: false,
-        POD_TERMINATION_BASE_TIMEOUT_MINUTES: 60, // Default: 1 hour
-        POD_TERMINATION_JITTER_MINUTES: 15, // Default: 15 minutes
+        POD_TERMINATION_BASE_TIMEOUT_MINUTES: 30, // Default: 30 minutes
+        POD_TERMINATION_JITTER_MINUTES: 60, // Default: 1 hour, so timeout is between 30 minutes and 1h30m
     }
 }
 


### PR DESCRIPTION
## Problem

Pod termination timer from https://github.com/PostHog/posthog/pull/39195/files is working as expected, but as shown below the timeouts are not particularly well spread out, especially across all 70-80 pods in US. This seems to lead to a more significant downgrade in fleet size roughly every 60 min, which causes our lag warning alert to trigger hourly:
https://posthog.slack.com/archives/C07CR2K1H6G/p1759867073194779

<img width="383" height="377" alt="Screenshot 2025-10-07 at 3 05 27 PM" src="https://github.com/user-attachments/assets/af332c62-314c-4f7c-96d8-5a577963b688" />

## Changes

Spreads out the termination times across 60 minutes instead of 15

## How did you test this code?

n/a, just integer config value change
