### PR TITLE
feat(flags): Notify when a flag uses unsupported regex

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -96,6 +96,7 @@ import {
 import { AnalysisTab } from './FeatureFlagAnalysisTab'
 import { FeatureFlagAutoRollback } from './FeatureFlagAutoRollout'
 import { FeatureFlagCodeExample } from './FeatureFlagCodeExample'
+import { FeatureFlagConditionWarning } from './FeatureFlagConditionWarning'
 import { FeatureFlagEvaluationTags } from './FeatureFlagEvaluationTags'
 import FeatureFlagProjects from './FeatureFlagProjects'
 import { FeatureFlagReleaseConditions } from './FeatureFlagReleaseConditions'
@@ -565,6 +566,7 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
                                         id={`${featureFlag.id}`}
                                         filters={featureFlag.filters}
                                         onChange={setFeatureFlagFilters}
+                                        evaluationRuntime={featureFlag.evaluation_runtime}
                                     />
                                     <SceneDivider />
                                 </>
@@ -910,6 +912,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
         hasEncryptedPayloadBeenSaved,
         hasExperiment,
         isDraftExperiment,
+        properties,
     } = useValues(featureFlagLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const { hasAvailableFeature } = useValues(userLogic)
@@ -987,6 +990,10 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
         <SceneContent>
             {readOnly ? (
                 <>
+                    <FeatureFlagConditionWarning
+                        properties={properties}
+                        evaluationRuntime={featureFlag.evaluation_runtime}
+                    />
                     <div className="flex flex-col">
                         <div className="grid grid-cols-8">
                             <div className="col-span-2 card-secondary">Status</div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagConditionWarning.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagConditionWarning.tsx
@@ -1,0 +1,31 @@
+import { useValues } from 'kea'
+
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+
+import { AnyPropertyFilter, FeatureFlagEvaluationRuntime } from '~/types'
+
+import { featureFlagConditionWarningLogic } from './featureFlagConditionWarningLogic'
+
+export interface FeatureFlagConditionWarningProps {
+    evaluationRuntime?: FeatureFlagEvaluationRuntime
+    properties: AnyPropertyFilter[]
+    className?: string
+}
+
+export function FeatureFlagConditionWarning({
+    properties,
+    className,
+    evaluationRuntime = FeatureFlagEvaluationRuntime.ALL,
+}: FeatureFlagConditionWarningProps): JSX.Element | null {
+    const { warning } = useValues(featureFlagConditionWarningLogic({ properties, evaluationRuntime }))
+
+    if (!warning) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="warning" className={className}>
+            {warning}
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -25,6 +25,7 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { IconArrowDown, IconArrowUp, IconErrorOutline, IconOpenInNew, IconSubArrowRight } from 'lib/lemon-ui/icons'
 import { capitalizeFirstLetter, dateFilterToText, dateStringToComponents, humanFriendlyNumber } from 'lib/utils'
+import { FeatureFlagConditionWarning } from 'scenes/feature-flags/FeatureFlagConditionWarning'
 import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
@@ -89,6 +90,7 @@ export function FeatureFlagReleaseConditions({
     nonEmptyFeatureFlagVariants,
     showTrashIconWithOneCondition = false,
     removedLastConditionCallback,
+    evaluationRuntime,
 }: FeatureFlagReleaseConditionsLogicProps & {
     hideMatchOptions?: boolean
     isSuper?: boolean
@@ -112,6 +114,7 @@ export function FeatureFlagReleaseConditions({
         totalUsers,
         filtersTaxonomicOptions,
         aggregationTargetName,
+        properties,
     } = useValues(releaseConditionsLogic)
 
     const {
@@ -263,6 +266,13 @@ export function FeatureFlagReleaseConditions({
                                 Learn more about how to make feature flags available instantly.
                             </Link>
                         </LemonBanner>
+                    )}
+                    {!readOnly && (
+                        <FeatureFlagConditionWarning
+                            properties={properties}
+                            evaluationRuntime={evaluationRuntime}
+                            className="mt-3 mb-3"
+                        />
                     )}
                     {readOnly ? (
                         <>

--- a/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.test.ts
@@ -63,6 +63,12 @@ describe('featureFlagConditionWarningLogic', () => {
                     operator: PropertyOperator.Regex,
                     value: '^[a-z]+@posthog\\.com$',
                 },
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(?=test)', // lookahead pattern escaped
+                },
             ]
 
             const logic = featureFlagConditionWarningLogic({

--- a/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.test.ts
@@ -67,7 +67,7 @@ describe('featureFlagConditionWarningLogic', () => {
                     key: 'email',
                     type: PropertyFilterType.Person,
                     operator: PropertyOperator.Regex,
-                    value: '(?=test)', // lookahead pattern escaped
+                    value: '\\(?=test\\)', // lookahead pattern escaped
                 },
             ]
 

--- a/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.test.ts
@@ -1,0 +1,439 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+import { AnyPropertyFilter, FeatureFlagEvaluationRuntime, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { featureFlagConditionWarningLogic } from './featureFlagConditionWarningLogic'
+
+describe('featureFlagConditionWarningLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    describe('server runtime', () => {
+        it('returns no warning for server evaluation', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(?=test)',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.SERVER,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+    })
+
+    describe('client runtime - no unsupported features', () => {
+        it('returns no warning when no regex properties exist', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Exact,
+                    value: 'test@posthog.com',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+
+        it('returns no warning for regex without unsupported features', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '^[a-z]+@posthog\\.com$',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+
+        it('returns no warning for empty properties', () => {
+            const logic = featureFlagConditionWarningLogic({
+                properties: [],
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+    })
+
+    describe('client runtime - lookahead detection', () => {
+        it('detects positive lookahead (?=)', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 'test(?=@posthog)',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning:
+                    'This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (lookahead).',
+            })
+        })
+
+        it('detects negative lookahead (?!)', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 'posthog(?!\\.org)',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning:
+                    'This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (lookahead).',
+            })
+        })
+    })
+
+    describe('client runtime - lookbehind detection', () => {
+        it('detects positive lookbehind (?<=)', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(?<=@)posthog',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning:
+                    'This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (lookbehind).',
+            })
+        })
+
+        it('detects negative lookbehind (?<!)', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(?<!admin@)posthog',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning:
+                    'This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (lookbehind).',
+            })
+        })
+    })
+
+    describe('client runtime - backreference detection', () => {
+        it('detects backreferences \\1 through \\9', () => {
+            const testCases = ['(\\w+)\\1', '(a)(b)\\2', 'repeat(\\w+)word\\1again', '(x)(y)(z)\\3', 'test\\9']
+
+            testCases.forEach((value) => {
+                const properties: AnyPropertyFilter[] = [
+                    {
+                        key: 'text',
+                        type: PropertyFilterType.Person,
+                        operator: PropertyOperator.Regex,
+                        value,
+                    },
+                ]
+
+                const logic = featureFlagConditionWarningLogic({
+                    properties,
+                    evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+                })
+                logic.mount()
+
+                expectLogic(logic).toMatchValues({
+                    warning:
+                        'This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (backreferences).',
+                })
+
+                logic.unmount()
+            })
+        })
+
+        it('does not detect \\0 as backreference', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'text',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 'test\\0',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+    })
+
+    describe('client runtime - multiple unsupported features', () => {
+        it('reports all unsupported features when multiple exist', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'text',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(?=test)(?<=@)(\\w+)\\1',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            const warning = logic.values.warning as string
+            expect(warning).toContain('This flag cannot be evaluated in client environments')
+            expect(warning).toContain('lookahead')
+            expect(warning).toContain('lookbehind')
+            expect(warning).toContain('backreferences')
+        })
+
+        it('reports features from multiple properties', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 'test(?=@)',
+                },
+                {
+                    key: 'name',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(?<=prefix)name',
+                },
+                {
+                    key: 'text',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(\\w+)\\1',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            const warning = logic.values.warning as string
+            expect(warning).toContain('lookahead')
+            expect(warning).toContain('lookbehind')
+            expect(warning).toContain('backreferences')
+        })
+    })
+
+    describe('client runtime - mixed property operators', () => {
+        it('only checks regex operators', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Exact,
+                    value: '(?=test)',
+                },
+                {
+                    key: 'name',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.IContains,
+                    value: '(?<=prefix)',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+
+        it('detects unsupported features only in regex properties', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Exact,
+                    value: '(?=safe)',
+                },
+                {
+                    key: 'text',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 'test(?=@)',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning:
+                    'This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (lookahead).',
+            })
+        })
+    })
+
+    describe('ALL runtime', () => {
+        it('behaves like client runtime', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 'test(?=@)',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.ALL,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning:
+                    'This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (lookahead).',
+            })
+        })
+    })
+
+    describe('edge cases', () => {
+        it('handles regex patterns that look like but are not unsupported features', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'text',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 'plain text with \\d digits',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+
+        it('handles complex regex with groups but no backreferences', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: '(test|prod)@(posthog|example)\\.(com|org)',
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+
+        it('converts value to string before checking', () => {
+            const properties: AnyPropertyFilter[] = [
+                {
+                    key: 'number',
+                    type: PropertyFilterType.Person,
+                    operator: PropertyOperator.Regex,
+                    value: 123,
+                },
+            ]
+
+            const logic = featureFlagConditionWarningLogic({
+                properties,
+                evaluationRuntime: FeatureFlagEvaluationRuntime.CLIENT,
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                warning: undefined,
+            })
+        })
+    })
+})

--- a/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.ts
@@ -11,6 +11,10 @@ export interface FeatureFlagConditionWarningLogicProps {
     evaluationRuntime: FeatureFlagEvaluationRuntime
 }
 
+const REGEX_LOOKAHEAD = /(?<!\\)\(\?[=!]/ // (?= or (?!
+const REGEX_LOOKBEHIND = /(?<!\\)\(\?<[=!]/ //  or (?<!
+const REGEX_BACKREFERENCE = /(?<!\\)\\[1-9]/ // \1 through \9
+
 export const featureFlagConditionWarningLogic = kea<featureFlagConditionWarningLogicType>([
     path(['scenes', 'feature-flags', 'featureFlagConditionWarningLogic']),
     props({} as FeatureFlagConditionWarningLogicProps),
@@ -29,18 +33,15 @@ export const featureFlagConditionWarningLogic = kea<featureFlagConditionWarningL
                     if (isPropertyFilterWithOperator(property) && property.operator === 'regex') {
                         const pattern = String(property.value)
 
-                        // Check for lookahead assertions: (?= or (?!
-                        if (pattern.includes('(?=') || pattern.includes('(?!')) {
+                        if (REGEX_LOOKAHEAD.test(pattern)) {
                             unsupportedFeatures.add('lookahead')
                         }
 
-                        // Check for lookbehind assertions: (?<= or (?<!
-                        if (pattern.includes('(?<=') || pattern.includes('(?<!')) {
+                        if (REGEX_LOOKBEHIND.test(pattern)) {
                             unsupportedFeatures.add('lookbehind')
                         }
 
-                        // Check for backreferences: \1 through \9
-                        if (/\\[1-9]/.test(pattern)) {
+                        if (REGEX_BACKREFERENCE.test(pattern)) {
                             unsupportedFeatures.add('backreferences')
                         }
                     }

--- a/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagConditionWarningLogic.ts
@@ -1,0 +1,55 @@
+import { kea, key, path, props, selectors } from 'kea'
+
+import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
+
+import { AnyPropertyFilter, FeatureFlagEvaluationRuntime } from '~/types'
+
+import type { featureFlagConditionWarningLogicType } from './featureFlagConditionWarningLogicType'
+
+export interface FeatureFlagConditionWarningLogicProps {
+    properties: AnyPropertyFilter[]
+    evaluationRuntime: FeatureFlagEvaluationRuntime
+}
+
+export const featureFlagConditionWarningLogic = kea<featureFlagConditionWarningLogicType>([
+    path(['scenes', 'feature-flags', 'featureFlagConditionWarningLogic']),
+    props({} as FeatureFlagConditionWarningLogicProps),
+    key((props) => JSON.stringify(props.properties)),
+
+    selectors({
+        warning: [
+            (_, p) => [p.properties, p.evaluationRuntime],
+            (properties: AnyPropertyFilter[], evaluationRuntime: FeatureFlagEvaluationRuntime): string | undefined => {
+                if (evaluationRuntime === FeatureFlagEvaluationRuntime.SERVER) {
+                    return
+                }
+
+                const unsupportedFeatures = new Set<string>()
+                properties.forEach((property) => {
+                    if (isPropertyFilterWithOperator(property) && property.operator === 'regex') {
+                        const pattern = String(property.value)
+
+                        // Check for lookahead assertions: (?= or (?!
+                        if (pattern.includes('(?=') || pattern.includes('(?!')) {
+                            unsupportedFeatures.add('lookahead')
+                        }
+
+                        // Check for lookbehind assertions: (?<= or (?<!
+                        if (pattern.includes('(?<=') || pattern.includes('(?<!')) {
+                            unsupportedFeatures.add('lookbehind')
+                        }
+
+                        // Check for backreferences: \1 through \9
+                        if (/\\[1-9]/.test(pattern)) {
+                            unsupportedFeatures.add('backreferences')
+                        }
+                    }
+                })
+
+                return unsupportedFeatures.size > 0
+                    ? `This flag cannot be evaluated in client environments. Release conditions contain unsupported regex patterns (${Array.from(unsupportedFeatures).join(', ')}).`
+                    : undefined
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1404,6 +1404,12 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 return !experiment?.start_date
             },
         ],
+        properties: [
+            (s) => [s.featureFlag],
+            (featureFlag: FeatureFlagType) => {
+                return featureFlag?.filters?.groups?.flatMap((g) => g.properties ?? []) ?? []
+            },
+        ],
     }),
     urlToAction(({ actions, props, values }) => ({
         [urls.featureFlag(props.id ?? 'new')]: (_, searchParams, ___, { method }) => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -24,6 +24,7 @@ import { projectLogic } from 'scenes/projectLogic'
 import { groupsModel } from '~/models/groupsModel'
 import {
     AnyPropertyFilter,
+    FeatureFlagEvaluationRuntime,
     FeatureFlagFilters,
     FeatureFlagGroupType,
     GroupTypeIndex,
@@ -51,6 +52,7 @@ export interface FeatureFlagReleaseConditionsLogicProps {
     onChange?: (filters: FeatureFlagFilters, errors: any) => void
     nonEmptyFeatureFlagVariants?: MultivariateFlagVariant[]
     isSuper?: boolean
+    evaluationRuntime?: FeatureFlagEvaluationRuntime
 }
 
 export type FeatureFlagGroupTypeWithSortKey = FeatureFlagGroupType & { sort_key: string }
@@ -538,6 +540,12 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                             property.type === PropertyFilterType.Flag && property.key ? [property.key] : []
                         ) || []
                 ) || [],
+        ],
+        properties: [
+            (s) => [s.filterGroups],
+            (filterGroups: FeatureFlagGroupType[]) => {
+                return filterGroups?.flatMap((g) => g.properties ?? []) ?? []
+            },
         ],
     }),
     propsChanged(({ props, values, actions }) => {


### PR DESCRIPTION
## Problem

Flags which may be resolved remotely via the flags service cannot use look-ahead, look-behind or back-references. The `regex` crate does not support these.

The number of unsupported regex features is small enough that client-side validation is preferred. Otherwise, we'd likely need to persist a value on the flag indicating whether or not the flags service can parse the regex for user feedback.

When using evaluation environments, this warning is disabled for server flags.

Closes https://github.com/PostHog/posthog/issues/37428

## Changes

<img width="789" height="810" alt="image" src="https://github.com/user-attachments/assets/c30b2220-90d0-4e21-82f9-01cb4cc7bf07" />

<img width="606" height="742" alt="image" src="https://github.com/user-attachments/assets/116f3003-8b59-4935-b473-7075ec90b6e3" />

## How did you test this code?

I've tested locally and added additional tests for the warning notice logic.
