### PR TITLE
fix(docker): docker base should use main db for plugin persons

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -289,7 +289,6 @@ services:
         restart: on-failure
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
-            PERSONS_DATABASE_URL: 'postgres://posthog:posthog@persons_db:5432/posthog_persons'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
             CLICKHOUSE_HOST: 'clickhouse'

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -289,6 +289,7 @@ services:
         restart: on-failure
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
             CLICKHOUSE_HOST: 'clickhouse'

--- a/posthog/person_db_router.py
+++ b/posthog/person_db_router.py
@@ -78,6 +78,6 @@ class PersonDBRouter:
         return db != "persons_db_writer"
 
     def is_persons_model(self, app_label, model_name):
-        # only route posthog app modlels, not auth.Group (there is a name clash between posthog_group
+        # only route posthog app models, not auth.Group (there is a name clash between posthog_group
         # and Django's auth_group
         return app_label == "posthog" and model_name in PERSONS_DB_MODELS


### PR DESCRIPTION
## Problem

Accidentally changed the docker compose base file to point to the wrong spot 

## Changes

Change the plugins server in docker-compose base to point to the main database as a persons database url

## How did you test this code?

Tested locally, by running ./bin/start and generating demo data


<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
