### PR TITLE
chore(ux): update preflightLogic from webpack to vite

### DIFF
--- a/frontend/src/scenes/PreflightCheck/preflightLogic.test.ts
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.test.ts
@@ -80,7 +80,7 @@ describe('preflightLogic', () => {
                         },
                         {
                             id: 'frontend',
-                            name: 'Frontend build · Webpack',
+                            name: 'Frontend build · Vite',
                             status: 'validated',
                         },
                         {
@@ -144,7 +144,7 @@ describe('preflightLogic', () => {
                         },
                         {
                             id: 'frontend',
-                            name: 'Frontend build · Webpack',
+                            name: 'Frontend build · Vite',
                             status: 'validated',
                         },
                         {

--- a/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
@@ -133,7 +133,7 @@ export const preflightLogic = kea<preflightLogicType>([
                     },
                     {
                         id: 'frontend',
-                        name: 'Frontend build · Webpack',
+                        name: 'Frontend build · Vite',
                         status: 'validated', // Always validated if we're showing the preflight check
                     },
                     {


### PR DESCRIPTION
## Problem
It says webpack for preflight frontend, I think this is old and needs to be updated

<img width="449" height="176" alt="image" src="https://github.com/user-attachments/assets/db4749f0-759f-43f2-8191-ed552be31d91" />
