### PR TITLE
feat(experiments): Regular metrics recalc time + refactor

### DIFF
--- a/dags/experiment_regular_metrics_timeseries.py
+++ b/dags/experiment_regular_metrics_timeseries.py
@@ -8,7 +8,7 @@ This module defines:
 """
 
 import json
-from datetime import datetime, time
+from datetime import datetime
 from typing import Any, Union
 from zoneinfo import ZoneInfo
 
@@ -27,16 +27,13 @@ from posthog.schema import (
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.models.experiment import Experiment, ExperimentMetricResult
-from posthog.models.team import Team
 
 from dags.common import JobOwners
-
-# =============================================================================
-# Configuration
-# =============================================================================
-
-# Default hour (UTC) for experiment recalculation when team has no specific time set
-DEFAULT_EXPERIMENT_RECALCULATION_HOUR = 2  # 02:00 UTC
+from dags.experiments import (
+    _parse_partition_key,
+    discover_experiment_metric_partitions,
+    schedule_experiment_metric_partitions,
+)
 
 # Create dynamic partitions definition for regular metric combinations
 EXPERIMENT_REGULAR_METRICS_PARTITIONS_NAME = "experiment_regular_metrics"
@@ -47,59 +44,6 @@ experiment_regular_metrics_partitions_def = dagster.DynamicPartitionsDefinition(
 # =============================================================================
 # Asset
 # =============================================================================
-
-
-def _get_experiment_regular_metrics_timeseries(
-    context: dagster.SensorEvaluationContext,
-) -> list[tuple[int, str, str, dict[str, Any]]]:
-    """
-    Discover active experiment-regular metric combinations from the database.
-
-    Each combination will become a dynamic partition for the experiment_regular_metrics_timeseries asset.
-
-    Args:
-        context: Dagster context for logging to UI.
-
-    Returns:
-        List of tuples containing (experiment_id, metric_uuid, fingerprint, metric_dict)
-        for all valid experiment-regular metric combinations that should be processed.
-    """
-    experiment_metrics = []
-
-    # Query experiments that are eligible for timeseries analysis (running experiments only)
-    experiments = Experiment.objects.filter(
-        deleted=False,
-        stats_config__timeseries=True,
-        start_date__isnull=False,
-        end_date__isnull=True,
-    ).exclude(
-        # Exclude if both metrics and metrics_secondary are empty or null
-        Q(metrics__isnull=True) | Q(metrics=[]),
-        Q(metrics_secondary__isnull=True) | Q(metrics_secondary=[]),
-    )
-
-    for experiment in experiments:
-        # Extract regular metrics from metrics and metrics_secondary fields
-        all_metrics = (experiment.metrics or []) + (experiment.metrics_secondary or [])
-
-        for metric in all_metrics:
-            # Skip if metric doesn't have a UUID (shouldn't happen but being safe)
-            metric_uuid = metric.get("uuid")
-            if not metric_uuid:
-                context.log.warning(f"Metric in experiment {experiment.id} has no UUID, skipping")
-                continue
-
-            # Compute fingerprint for this metric in context of this experiment
-            fingerprint = compute_metric_fingerprint(
-                metric,
-                experiment.start_date,
-                experiment.stats_config,
-                experiment.exposure_criteria,
-            )
-
-            experiment_metrics.append((experiment.id, metric_uuid, fingerprint, metric))
-
-    return experiment_metrics
 
 
 def _remove_step_sessions_from_experiment_result(result: ExperimentQueryResponse) -> ExperimentQueryResponse:
@@ -114,25 +58,6 @@ def _remove_step_sessions_from_experiment_result(result: ExperimentQueryResponse
             variant.step_sessions = None
 
     return result
-
-
-def _parse_partition_key(partition_key: str) -> tuple[int, str, str]:
-    """
-    Parse partition key to extract experiment ID, metric UUID, and fingerprint.
-
-    The partition key format is: experiment_{id}_metric_{uuid}_{fingerprint}
-    """
-    parts = partition_key.split("_")
-    if len(parts) != 5 or parts[0] != "experiment" or parts[2] != "metric":
-        raise ValueError(f"Invalid partition key format: {partition_key}")
-
-    try:
-        experiment_id = int(parts[1])
-        metric_uuid = parts[3]
-        fingerprint = parts[4]
-        return experiment_id, metric_uuid, fingerprint
-    except ValueError as e:
-        raise ValueError(f"Failed to parse partition key {partition_key}: {e}")
 
 
 @dagster.asset(
@@ -284,6 +209,60 @@ def experiment_regular_metrics_timeseries(context: dagster.AssetExecutionContext
 # Job and automation for regular metrics timeseries calculation
 # =============================================================================
 
+
+def _get_experiment_regular_metrics_timeseries(
+    context: dagster.SensorEvaluationContext,
+) -> list[tuple[int, str, str]]:
+    """
+    Discover active experiment-regular metric combinations from the database.
+
+    Each combination will become a dynamic partition for the experiment_regular_metrics_timeseries asset.
+
+    Args:
+        context: Dagster context for logging to UI.
+
+    Returns:
+        List of tuples containing (experiment_id, metric_uuid, fingerprint)
+        for all valid experiment-regular metric combinations that should be processed.
+    """
+    experiment_metrics = []
+
+    # Query experiments that are eligible for timeseries analysis (running experiments only)
+    experiments = Experiment.objects.filter(
+        deleted=False,
+        stats_config__timeseries=True,
+        start_date__isnull=False,
+        end_date__isnull=True,
+    ).exclude(
+        # Exclude if both metrics and metrics_secondary are empty or null
+        Q(metrics__isnull=True) | Q(metrics=[]),
+        Q(metrics_secondary__isnull=True) | Q(metrics_secondary=[]),
+    )
+
+    for experiment in experiments:
+        # Extract regular metrics from metrics and metrics_secondary fields
+        all_metrics = (experiment.metrics or []) + (experiment.metrics_secondary or [])
+
+        for metric in all_metrics:
+            # Skip if metric doesn't have a UUID (shouldn't happen but being safe)
+            metric_uuid = metric.get("uuid")
+            if not metric_uuid:
+                context.log.warning(f"Metric in experiment {experiment.id} has no UUID, skipping")
+                continue
+
+            # Compute fingerprint for this metric in context of this experiment
+            fingerprint = compute_metric_fingerprint(
+                metric,
+                experiment.start_date,
+                experiment.stats_config,
+                experiment.exposure_criteria,
+            )
+
+            experiment_metrics.append((experiment.id, metric_uuid, fingerprint))
+
+    return experiment_metrics
+
+
 experiment_regular_metrics_timeseries_job = dagster.define_asset_job(
     name="experiment_regular_metrics_timeseries_job",
     selection=[experiment_regular_metrics_timeseries],
@@ -304,54 +283,12 @@ def experiment_regular_metrics_timeseries_discovery_sensor(context: dagster.Sens
     analysis. When new combinations are found, it creates dynamic partitions for the
     experiment_regular_metrics_timeseries asset and triggers processing only for the new partitions.
     """
-    try:
-        current_experiment_metrics = _get_experiment_regular_metrics_timeseries(context)
-        if not current_experiment_metrics:
-            context.log.debug("No experiment-regular metrics found for timeseries analysis")
-            return dagster.SkipReason("No experiments with regular metrics found")
-
-        # Generate partition keys in format: experiment_{id}_metric_{uuid}_{fingerprint}
-        current_partition_keys = [
-            f"experiment_{exp_id}_metric_{metric_uuid}_{fingerprint}"
-            for exp_id, metric_uuid, fingerprint, _ in current_experiment_metrics
-        ]
-
-        # Check which partitions are new
-        existing_partitions = set(context.instance.get_dynamic_partitions(EXPERIMENT_REGULAR_METRICS_PARTITIONS_NAME))
-        new_partitions = [key for key in current_partition_keys if key not in existing_partitions]
-
-        # Build response
-        run_requests = []
-        dynamic_partitions_requests = []
-
-        if new_partitions:
-            context.log.info(
-                f"Discovered {len(new_partitions)} new experiment-regular metric combinations for timeseries analysis"
-            )
-            # Add new partitions
-            dynamic_partitions_requests.append(
-                experiment_regular_metrics_partitions_def.build_add_request(new_partitions)
-            )
-            # Create run requests for new partitions only
-            run_requests = [
-                dagster.RunRequest(
-                    run_key=f"sensor_{partition_key}_{context.cursor or 'initial'}",
-                    partition_key=partition_key,
-                )
-                for partition_key in new_partitions
-            ]
-        else:
-            context.log.debug("No new experiment-regular metrics discovered for timeseries analysis")
-            return dagster.SkipReason("No new regular metric experiments to process")
-
-        return dagster.SensorResult(
-            run_requests=run_requests,
-            dynamic_partitions_requests=dynamic_partitions_requests,
-        )
-
-    except Exception as e:
-        context.log.exception("Failed to discover regular metric experiments")
-        return dagster.SkipReason(f"Failed to discover regular metric experiments: {e}")
+    return discover_experiment_metric_partitions(
+        context=context,
+        partition_name=EXPERIMENT_REGULAR_METRICS_PARTITIONS_NAME,
+        partitions_def=experiment_regular_metrics_partitions_def,
+        get_metrics_fn=_get_experiment_regular_metrics_timeseries,
+    )
 
 
 @dagster.schedule(
@@ -365,63 +302,7 @@ def experiment_regular_metrics_timeseries_refresh_schedule(context: dagster.Sche
     This schedule runs hourly and reprocesses experiment-regular metric combinations
     for teams scheduled at the current hour.
     """
-    try:
-        current_hour = context.scheduled_execution_time.hour
-        target_time = time(current_hour, 0, 0)
-
-        # Build time filter for teams
-        if current_hour == DEFAULT_EXPERIMENT_RECALCULATION_HOUR:
-            # At default hour, include teams with NULL (not set) or explicitly set to this hour
-            time_filter = Q(experiment_recalculation_time=target_time) | Q(experiment_recalculation_time__isnull=True)
-        else:
-            # At other hours, only include teams explicitly set to this hour
-            time_filter = Q(experiment_recalculation_time=target_time)
-
-        # Get all experiments from teams scheduled at this hour
-        target_experiment_ids = set(
-            Experiment.objects.filter(
-                deleted=False,
-                stats_config__timeseries=True,
-                start_date__isnull=False,
-                end_date__isnull=True,
-                team__in=Team.objects.filter(time_filter),
-            ).values_list("id", flat=True)
-        )
-
-        if not target_experiment_ids:
-            return dagster.SkipReason(f"No experiments found for teams scheduled at {current_hour}:00 UTC")
-
-        all_partitions = list(context.instance.get_dynamic_partitions(EXPERIMENT_REGULAR_METRICS_PARTITIONS_NAME))
-
-        if not all_partitions:
-            return dagster.SkipReason("No experiment regular metrics partitions exist")
-
-        # Filter to only partitions for target experiments
-        partitions_to_run = []
-        for partition_key in all_partitions:
-            try:
-                experiment_id, _, _ = _parse_partition_key(partition_key)
-                if experiment_id in target_experiment_ids:
-                    partitions_to_run.append(partition_key)
-            except ValueError:
-                context.log.warning(f"Skipping partition with invalid key format: {partition_key}")
-                continue
-
-        if not partitions_to_run:
-            return dagster.SkipReason(f"No metrics to process for teams at {current_hour}:00 UTC")
-
-        context.log.info(
-            f"Scheduling refresh for {len(partitions_to_run)} partitions for teams at {current_hour}:00 UTC"
-        )
-
-        return [
-            dagster.RunRequest(
-                run_key=f"scheduled_{partition_key}_{context.scheduled_execution_time.strftime('%Y%m%d_%H')}",
-                partition_key=partition_key,
-            )
-            for partition_key in partitions_to_run
-        ]
-
-    except Exception as e:
-        context.log.exception("Failed to schedule regular metrics refresh")
-        return dagster.SkipReason(f"Failed to schedule regular metrics refresh: {e}")
+    return schedule_experiment_metric_partitions(
+        context=context,
+        partition_name=EXPERIMENT_REGULAR_METRICS_PARTITIONS_NAME,
+    )

--- a/dags/experiment_saved_metrics_timeseries.py
+++ b/dags/experiment_saved_metrics_timeseries.py
@@ -12,8 +12,6 @@ from datetime import datetime
 from typing import Any, Union
 from zoneinfo import ZoneInfo
 
-from django.db import connection
-
 import dagster
 
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
@@ -23,6 +21,11 @@ from posthog.hogql_queries.experiments.experiment_query_runner import Experiment
 from posthog.models.experiment import Experiment, ExperimentMetricResult
 
 from dags.common import JobOwners
+from dags.experiments import (
+    _parse_partition_key,
+    discover_experiment_metric_partitions,
+    schedule_experiment_metric_partitions,
+)
 
 # =============================================================================
 # Dynamic Partitions Setup
@@ -37,71 +40,6 @@ experiment_saved_metrics_partitions_def = dagster.DynamicPartitionsDefinition(
 # =============================================================================
 # Asset
 # =============================================================================
-
-
-def _get_experiment_saved_metrics_timeseries(context: dagster.SensorEvaluationContext) -> list[tuple[int, str, str]]:
-    """
-    Discover active experiment-saved metric combinations from the database.
-
-    Each combination will become a dynamic partition for the experiment_saved_metrics_timeseries asset.
-
-    Args:
-        context: Dagster context for logging to UI.
-
-    Returns:
-        List of tuples containing (experiment_id, metric_uuid, fingerprint)
-        for all valid experiment-saved metric combinations that should be processed.
-    """
-    experiment_saved_metrics = []
-
-    # Query experiments that are eligible for timeseries analysis (running experiments only)
-    experiments = Experiment.objects.filter(
-        deleted=False,
-        stats_config__timeseries=True,
-        start_date__isnull=False,
-        end_date__isnull=True,
-    ).prefetch_related("experimenttosavedmetric_set__saved_metric")
-
-    for experiment in experiments:
-        # Get all saved metrics linked to this experiment
-        for exp_to_saved_metric in experiment.experimenttosavedmetric_set.all():
-            saved_metric = exp_to_saved_metric.saved_metric
-
-            # Compute fingerprint for this saved metric in context of this experiment
-            fingerprint = compute_metric_fingerprint(
-                saved_metric.query,
-                experiment.start_date,
-                experiment.stats_config,
-                experiment.exposure_criteria,
-            )
-
-            metric_uuid = saved_metric.query.get("uuid")
-            if not metric_uuid:
-                context.log.warning(f"Saved metric {saved_metric.id} has no UUID in query, skipping")
-                continue
-
-            experiment_saved_metrics.append((experiment.id, metric_uuid, fingerprint))
-
-    return experiment_saved_metrics
-
-
-def _parse_saved_metric_timeseries_partition_key(partition_key: str) -> tuple[int, str, str]:
-    """
-    Parse partition key to extract experiment ID, metric UUID, and fingerprint.
-
-    The partition key format is: experiment_{id}_metric_{uuid}_{fingerprint}
-    """
-    parts = partition_key.split("_")
-    if len(parts) < 5 or parts[0] != "experiment" or parts[2] != "metric":
-        raise ValueError(f"Invalid partition key format: {partition_key}")
-
-    try:
-        experiment_id = int(parts[1])
-        metric_uuid = parts[3]
-        fingerprint = parts[4]
-        return experiment_id, metric_uuid, fingerprint
-    except ValueError as e:
-        raise ValueError(f"Failed to parse partition key {partition_key}: {e}")
 
 
 @dagster.asset(
@@ -121,7 +59,7 @@ def experiment_saved_metrics_timeseries(context: dagster.AssetExecutionContext) 
     if not context.partition_key:
         raise dagster.Failure("This asset must be run with a partition key")
 
-    experiment_id, metric_uuid, fingerprint = _parse_saved_metric_timeseries_partition_key(context.partition_key)
+    experiment_id, metric_uuid, fingerprint = _parse_partition_key(context.partition_key)
 
     context.log.info(
         f"Computing timeseries results for experiment {experiment_id}, metric {metric_uuid}, fingerprint {fingerprint}"
@@ -256,6 +194,53 @@ def experiment_saved_metrics_timeseries(context: dagster.AssetExecutionContext) 
 # Job and automation for saved metrics timeseries calculation
 # =============================================================================
 
+
+def _get_experiment_saved_metrics_timeseries(context: dagster.SensorEvaluationContext) -> list[tuple[int, str, str]]:
+    """
+    Discover active experiment-saved metric combinations from the database.
+
+    Each combination will become a dynamic partition for the experiment_saved_metrics_timeseries asset.
+
+    Args:
+        context: Dagster context for logging to UI.
+
+    Returns:
+        List of tuples containing (experiment_id, metric_uuid, fingerprint)
+        for all valid experiment-saved metric combinations that should be processed.
+    """
+    experiment_saved_metrics = []
+
+    # Query experiments that are eligible for timeseries analysis (running experiments only)
+    experiments = Experiment.objects.filter(
+        deleted=False,
+        stats_config__timeseries=True,
+        start_date__isnull=False,
+        end_date__isnull=True,
+    ).prefetch_related("experimenttosavedmetric_set__saved_metric")
+
+    for experiment in experiments:
+        # Get all saved metrics linked to this experiment
+        for exp_to_saved_metric in experiment.experimenttosavedmetric_set.all():
+            saved_metric = exp_to_saved_metric.saved_metric
+
+            # Compute fingerprint for this saved metric in context of this experiment
+            fingerprint = compute_metric_fingerprint(
+                saved_metric.query,
+                experiment.start_date,
+                experiment.stats_config,
+                experiment.exposure_criteria,
+            )
+
+            metric_uuid = saved_metric.query.get("uuid")
+            if not metric_uuid:
+                context.log.warning(f"Saved metric {saved_metric.id} has no UUID in query, skipping")
+                continue
+
+            experiment_saved_metrics.append((experiment.id, metric_uuid, fingerprint))
+
+    return experiment_saved_metrics
+
+
 experiment_saved_metrics_timeseries_job = dagster.define_asset_job(
     name="experiment_saved_metrics_timeseries_job",
     selection=[experiment_saved_metrics_timeseries],
@@ -276,85 +261,26 @@ def experiment_saved_metrics_timeseries_discovery_sensor(context: dagster.Sensor
     analysis. When new combinations are found, it creates dynamic partitions for the
     experiment_saved_metrics_timeseries asset and triggers processing only for the new partitions.
     """
-    try:
-        connection.close()  # Reset connection
-
-        current_experiment_saved_metrics = _get_experiment_saved_metrics_timeseries(context)
-        if not current_experiment_saved_metrics:
-            context.log.debug("No experiment-saved metrics found for timeseries analysis")
-            return dagster.SkipReason("No experiments with saved metrics found")
-
-        # Generate partition keys in format: experiment_{id}_metric_{uuid}_{fingerprint}
-        current_partition_keys = [
-            f"experiment_{exp_id}_metric_{metric_uuid}_{fingerprint}"
-            for exp_id, metric_uuid, fingerprint in current_experiment_saved_metrics
-        ]
-
-        # Check which partitions are new
-        existing_partitions = set(context.instance.get_dynamic_partitions(EXPERIMENT_SAVED_METRICS_PARTITIONS_NAME))
-        new_partitions = [key for key in current_partition_keys if key not in existing_partitions]
-
-        # Build response
-        run_requests = []
-        dynamic_partitions_requests = []
-
-        if new_partitions:
-            context.log.info(
-                f"Discovered {len(new_partitions)} new experiment-saved metric combinations for timeseries analysis"
-            )
-            # Add new partitions
-            dynamic_partitions_requests.append(
-                experiment_saved_metrics_partitions_def.build_add_request(new_partitions)
-            )
-            # Create run requests for new partitions only
-            run_requests = [
-                dagster.RunRequest(
-                    run_key=f"sensor_{partition_key}_{context.cursor or 'initial'}",
-                    partition_key=partition_key,
-                )
-                for partition_key in new_partitions
-            ]
-        else:
-            context.log.debug("No new experiment-saved metrics discovered for timeseries analysis")
-            return dagster.SkipReason("No new saved metric experiments to process")
-
-        return dagster.SensorResult(
-            run_requests=run_requests,
-            dynamic_partitions_requests=dynamic_partitions_requests,
-        )
-
-    except Exception as e:
-        context.log.exception("Failed to discover saved metric experiments")
-        raise dagster.Failure(f"Sensor failed: {e}")
+    return discover_experiment_metric_partitions(
+        context=context,
+        partition_name=EXPERIMENT_SAVED_METRICS_PARTITIONS_NAME,
+        partitions_def=experiment_saved_metrics_partitions_def,
+        get_metrics_fn=_get_experiment_saved_metrics_timeseries,
+    )
 
 
 @dagster.schedule(
     job=experiment_saved_metrics_timeseries_job,
-    cron_schedule="0 2 * * *",  # Daily at 02:00 UTC
+    cron_schedule="0 * * * *",  # Every hour at minute 0
     execution_timezone="UTC",
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
 )
 def experiment_saved_metrics_timeseries_refresh_schedule(context: dagster.ScheduleEvaluationContext):
     """
-    This schedule runs daily and reprocesses all known experiment-saved metric combinations.
+    This schedule runs hourly and reprocesses experiment-saved metric combinations
+    for teams scheduled at the current hour.
     """
-    try:
-        connection.close()  # Reset connection
-
-        existing_partitions = list(context.instance.get_dynamic_partitions(EXPERIMENT_SAVED_METRICS_PARTITIONS_NAME))
-
-        if not existing_partitions:
-            return dagster.SkipReason("No experiment saved metrics partitions exist")
-
-        context.log.info(f"Scheduling full refresh for {len(existing_partitions)} saved metrics partitions")
-        return [
-            dagster.RunRequest(
-                run_key=f"saved_metrics_refresh_{partition_key}_{context.scheduled_execution_time.strftime('%Y%m%d')}",
-                partition_key=partition_key,
-            )
-            for partition_key in existing_partitions
-        ]
-
-    except Exception as e:
-        context.log.exception("Failed to schedule saved metrics refresh")
-        raise dagster.Failure(f"Schedule failed: {e}")
+    return schedule_experiment_metric_partitions(
+        context=context,
+        partition_name=EXPERIMENT_SAVED_METRICS_PARTITIONS_NAME,
+    )

--- a/dags/experiments.py
+++ b/dags/experiments.py
@@ -1,0 +1,188 @@
+"""
+Shared utilities for experiment-related Dagster schedules and sensors.
+"""
+
+from datetime import time
+
+from django.db import connection
+from django.db.models import Q
+
+import dagster
+
+from posthog.models.experiment import Experiment
+from posthog.models.team import Team
+
+# Default hour (UTC) for experiment recalculation when team has no specific time set
+DEFAULT_EXPERIMENT_RECALCULATION_HOUR = 2  # 02:00 UTC
+
+
+def _parse_partition_key(partition_key: str) -> tuple[int, str, str]:
+    """
+    Parse partition key to extract experiment ID, metric UUID, and fingerprint.
+
+    The partition key format is: experiment_{id}_metric_{uuid}_{fingerprint}
+    """
+    parts = partition_key.split("_")
+    if len(parts) < 5 or parts[0] != "experiment" or parts[2] != "metric":
+        raise ValueError(f"Invalid partition key format: {partition_key}")
+
+    try:
+        experiment_id = int(parts[1])
+        metric_uuid = parts[3]
+        fingerprint = parts[4]
+        return experiment_id, metric_uuid, fingerprint
+    except ValueError as e:
+        raise ValueError(f"Failed to parse partition key {partition_key}: {e}")
+
+
+def schedule_experiment_metric_partitions(
+    context: dagster.ScheduleEvaluationContext,
+    partition_name: str,
+) -> list[dagster.RunRequest] | dagster.SkipReason:
+    """
+    Get experiment partitions that should run at the current scheduled hour based on team settings.
+
+    This function filters experiments by their team's configured recalculation time and returns
+    RunRequests for the matching partitions.
+
+    Args:
+        context: Dagster schedule evaluation context
+        partition_name: Name of the dynamic partition set (e.g., "experiment_regular_metrics")
+
+    Returns:
+        List of RunRequests for partitions to process, or SkipReason if none found
+    """
+    try:
+        connection.close()  # Reset connection
+
+        current_hour = context.scheduled_execution_time.hour
+        target_time = time(current_hour, 0, 0)
+
+        # Build time filter for teams
+        if current_hour == DEFAULT_EXPERIMENT_RECALCULATION_HOUR:
+            # At default hour, include teams with NULL (not set) or explicitly set to this hour
+            time_filter = Q(experiment_recalculation_time=target_time) | Q(experiment_recalculation_time__isnull=True)
+        else:
+            # At other hours, only include teams explicitly set to this hour
+            time_filter = Q(experiment_recalculation_time=target_time)
+
+        # Get all experiments from teams scheduled at this hour
+        target_experiment_ids = set(
+            Experiment.objects.filter(
+                deleted=False,
+                stats_config__timeseries=True,
+                start_date__isnull=False,
+                end_date__isnull=True,
+                team__in=Team.objects.filter(time_filter),
+            ).values_list("id", flat=True)
+        )
+
+        if not target_experiment_ids:
+            return dagster.SkipReason(f"No experiments found for teams scheduled at {current_hour}:00 UTC")
+
+        all_partitions = list(context.instance.get_dynamic_partitions(partition_name))
+
+        if not all_partitions:
+            return dagster.SkipReason(f"No {partition_name} partitions exist")
+
+        # Filter to only partitions for target experiments
+        partitions_to_run = []
+        for partition_key in all_partitions:
+            try:
+                experiment_id, _, _ = _parse_partition_key(partition_key)
+                if experiment_id in target_experiment_ids:
+                    partitions_to_run.append(partition_key)
+            except ValueError:
+                context.log.warning(f"Skipping partition with invalid key format: {partition_key}")
+                continue
+
+        if not partitions_to_run:
+            return dagster.SkipReason(f"No partitions to process for teams at {current_hour}:00 UTC")
+
+        context.log.info(
+            f"Scheduling refresh for {len(partitions_to_run)} partitions from {partition_name} for teams at {current_hour}:00 UTC"
+        )
+
+        return [
+            dagster.RunRequest(
+                run_key=f"scheduled_{partition_key}_{context.scheduled_execution_time.strftime('%Y%m%d_%H')}",
+                partition_key=partition_key,
+            )
+            for partition_key in partitions_to_run
+        ]
+
+    except Exception as e:
+        context.log.exception(f"Failed to schedule refresh for {partition_name}")
+        raise dagster.Failure(f"Failed to schedule refresh for {partition_name}: {e}")
+
+
+def discover_experiment_metric_partitions(
+    context: dagster.SensorEvaluationContext,
+    partition_name: str,
+    partitions_def: dagster.DynamicPartitionsDefinition,
+    get_metrics_fn,
+) -> dagster.SensorResult | dagster.SkipReason:
+    """
+    Automatically discover new experiment-metric combinations and trigger timeseries calculation.
+
+    This function continuously monitors for new experiments or metrics that need timeseries
+    analysis. When new combinations are found, it creates dynamic partitions and triggers
+    processing only for the new partitions.
+
+    Args:
+        context: Dagster sensor evaluation context
+        partition_name: Name of the dynamic partition set (e.g., "experiment_regular_metrics")
+        partitions_def: Dynamic partitions definition object
+        get_metrics_fn: Function to get current experiment-metric combinations
+
+    Returns:
+        SensorResult with run requests and partition requests, or SkipReason if none found
+    """
+    try:
+        connection.close()  # Reset connection
+
+        current_experiment_metrics = get_metrics_fn(context)
+        if not current_experiment_metrics:
+            context.log.debug(f"No {partition_name} found for timeseries analysis")
+            return dagster.SkipReason(f"No experiments with {partition_name} found")
+
+        # Generate partition keys in format: experiment_{id}_metric_{uuid}_{fingerprint}
+        current_partition_keys = [
+            f"experiment_{exp_id}_metric_{metric_uuid}_{fingerprint}"
+            for exp_id, metric_uuid, fingerprint in current_experiment_metrics
+        ]
+
+        # Check which partitions are new
+        existing_partitions = set(context.instance.get_dynamic_partitions(partition_name))
+        new_partitions = [key for key in current_partition_keys if key not in existing_partitions]
+
+        # Build response
+        run_requests = []
+        dynamic_partitions_requests = []
+
+        if new_partitions:
+            context.log.info(
+                f"Discovered {len(new_partitions)} new {partition_name} combinations for timeseries analysis"
+            )
+            # Add new partitions
+            dynamic_partitions_requests.append(partitions_def.build_add_request(new_partitions))
+            # Create run requests for new partitions only
+            run_requests = [
+                dagster.RunRequest(
+                    run_key=f"sensor_{partition_key}_{context.cursor or 'initial'}",
+                    partition_key=partition_key,
+                )
+                for partition_key in new_partitions
+            ]
+        else:
+            context.log.debug(f"No new {partition_name} discovered for timeseries analysis")
+            return dagster.SkipReason(f"No new {partition_name} to process")
+
+        return dagster.SensorResult(
+            run_requests=run_requests,
+            dynamic_partitions_requests=dynamic_partitions_requests,
+        )
+
+    except Exception as e:
+        context.log.exception(f"Failed to discover {partition_name} experiments")
+        raise dagster.Failure(f"Failed to discover {partition_name} experiments: {e}")

--- a/dags/experiments.py
+++ b/dags/experiments.py
@@ -9,11 +9,27 @@ from django.db.models import Q
 
 import dagster
 
+from posthog.schema import ExperimentQueryResponse
+
 from posthog.models.experiment import Experiment
 from posthog.models.team import Team
 
 # Default hour (UTC) for experiment recalculation when team has no specific time set
 DEFAULT_EXPERIMENT_RECALCULATION_HOUR = 2  # 02:00 UTC
+
+
+def remove_step_sessions_from_experiment_result(result: ExperimentQueryResponse) -> ExperimentQueryResponse:
+    """
+    Remove step_sessions values from experiment results to reduce API response size.
+    """
+    if result.baseline is not None:
+        result.baseline.step_sessions = None
+
+    if result.variant_results is not None:
+        for variant in result.variant_results:
+            variant.step_sessions = None
+
+    return result
 
 
 def _parse_partition_key(partition_key: str) -> tuple[int, str, str]:

--- a/dags/tests/test_experiment_saved_metrics_timeseries_schedule.py
+++ b/dags/tests/test_experiment_saved_metrics_timeseries_schedule.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 import dagster
 
 from posthog.models import Organization, Team, User
-from posthog.models.experiment import Experiment
+from posthog.models.experiment import Experiment, ExperimentSavedMetric, ExperimentToSavedMetric
 from posthog.models.feature_flag import FeatureFlag
 
-from dags.experiment_regular_metrics_timeseries import experiment_regular_metrics_timeseries_refresh_schedule
+from dags.experiment_saved_metrics_timeseries import experiment_saved_metrics_timeseries_refresh_schedule
 from dags.experiments import _parse_partition_key
 
 
@@ -37,6 +37,13 @@ class TestScheduleIntegration(BaseTest):
         team.save()
         user = User.objects.create(email="test@example.com")
 
+        # Create saved metrics
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=team,
+            name="Test Saved Metric",
+            query={"kind": "ExperimentMetric", "metric_type": "mean", "uuid": "saved_metric_uuid"},
+        )
+
         # Create different types of experiments - only the valid one should be processed
         flag_ended = FeatureFlag.objects.create(team=team, key="flag-ended", created_by=user)
         exp_ended = Experiment.objects.create(
@@ -46,8 +53,8 @@ class TestScheduleIntegration(BaseTest):
             start_date=datetime.datetime.now(),
             end_date=datetime.datetime.now(),  # Has end date - should be excluded
             stats_config={"timeseries": True},
-            metrics=[{"uuid": "metric1", "metric_type": "mean"}],
         )
+        ExperimentToSavedMetric.objects.create(experiment=exp_ended, saved_metric=saved_metric)
 
         flag_no_timeseries = FeatureFlag.objects.create(team=team, key="flag-no-ts", created_by=user)
         exp_no_timeseries = Experiment.objects.create(
@@ -56,8 +63,8 @@ class TestScheduleIntegration(BaseTest):
             feature_flag=flag_no_timeseries,
             start_date=datetime.datetime.now(),
             stats_config={"timeseries": False},  # Timeseries disabled - should be excluded
-            metrics=[{"uuid": "metric2", "metric_type": "mean"}],
         )
+        ExperimentToSavedMetric.objects.create(experiment=exp_no_timeseries, saved_metric=saved_metric)
 
         flag_valid = FeatureFlag.objects.create(team=team, key="flag-valid", created_by=user)
         exp_valid = Experiment.objects.create(
@@ -66,22 +73,22 @@ class TestScheduleIntegration(BaseTest):
             feature_flag=flag_valid,
             start_date=datetime.datetime.now(),
             stats_config={"timeseries": True},  # This one should be included
-            metrics=[{"uuid": "metric3", "metric_type": "mean"}],
         )
+        ExperimentToSavedMetric.objects.create(experiment=exp_valid, saved_metric=saved_metric)
 
         context = dagster.build_schedule_context(scheduled_execution_time=datetime.datetime(2024, 1, 15, 10, 0))
 
         # The schedule needs to check what partitions exist in Dagster's database.
         # We don't have Dagster's infrastructure in tests, so we mock just this part.
-        # Everything else (finding orgs, experiments, filtering by time) uses real data.
+        # Everything else (finding teams, experiments, filtering by time) uses real data.
 
-        valid_partition = f"experiment_{exp_valid.id}_metric_metric3_fingerprint"
+        valid_partition = f"experiment_{exp_valid.id}_metric_saved_metric_uuid_fingerprint"
         mock_instance = MagicMock()
         mock_instance.get_dynamic_partitions = Mock(
             return_value=[
                 valid_partition,
-                f"experiment_{exp_ended.id}_metric_metric1_fingerprint",  # Should be filtered out
-                f"experiment_{exp_no_timeseries.id}_metric_metric2_fingerprint",  # Should be filtered out
+                f"experiment_{exp_ended.id}_metric_saved_metric_uuid_fingerprint",  # Should be filtered out
+                f"experiment_{exp_no_timeseries.id}_metric_saved_metric_uuid_fingerprint",  # Should be filtered out
             ]
         )
 
@@ -89,7 +96,7 @@ class TestScheduleIntegration(BaseTest):
             mock_connection.close = Mock()
             with patch.object(type(context), "instance", new_callable=PropertyMock) as mock_instance_prop:
                 mock_instance_prop.return_value = mock_instance
-                result = experiment_regular_metrics_timeseries_refresh_schedule(context)
+                result = experiment_saved_metrics_timeseries_refresh_schedule(context)
 
         # Should only return RunRequest for the valid experiment
         assert isinstance(result, list)
@@ -109,7 +116,7 @@ class TestScheduleIntegration(BaseTest):
 
         with patch("dags.experiments.connection") as mock_connection:
             mock_connection.close = Mock()
-            result = experiment_regular_metrics_timeseries_refresh_schedule(context)
+            result = experiment_saved_metrics_timeseries_refresh_schedule(context)
 
         assert isinstance(result, dagster.SkipReason)
         assert "No experiments found for teams scheduled at 14:00 UTC" in str(result)


### PR DESCRIPTION
## Changes
- Same as https://github.com/PostHog/posthog/pull/39080 but for regular metrics
- Refactored scheduling and sensor logic between regular and saved metrics to eliminate duplication

## How did you test this code?
- Tests pass
- Simulating a scheduled run in Dagster UI for a specific time works

<img width="1092" height="457" alt="image" src="https://github.com/user-attachments/assets/22e86c84-7a93-4a86-8525-915b38c8c81e" />