### PR TITLE
chore: tag all AI runner queries with Product=MAX_AI

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -23,7 +23,14 @@ from posthog.clickhouse.client.connection import (
 )
 from posthog.clickhouse.client.escape import substitute_params
 from posthog.clickhouse.client.tracing import trace_clickhouse_query_decorator
-from posthog.clickhouse.query_tagging import AccessMethod, Feature, QueryTags, get_query_tag_value, get_query_tags
+from posthog.clickhouse.query_tagging import (
+    AccessMethod,
+    Feature,
+    Product,
+    QueryTags,
+    get_query_tag_value,
+    get_query_tags,
+)
 from posthog.cloud_utils import is_cloud
 from posthog.errors import ch_error_type, wrap_query_error
 from posthog.exceptions import ClickHouseAtCapacity
@@ -185,6 +192,9 @@ def sync_execute(
 
     # update tags if inside temporal (should not)
     update_query_tags_with_temporal_info()
+
+    if tags.product == Product.MAX_AI or tags.service_name == "temporal-worker-max-ai":
+        ch_user = ClickHouseUser.MAX_AI
 
     while True:
         settings = {

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -27,6 +27,7 @@ class Product(StrEnum):
     REPLAY = "replay"
     SESSION_SUMMARY = "session_summary"
     WAREHOUSE = "warehouse"
+    EXPERIMENTS = "experiments"
 
 
 class Feature(StrEnum):

--- a/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
@@ -14,6 +14,7 @@ from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.property import action_to_expr
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql_queries.ai.utils import TaxonomyCacheMixin
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models import Action
@@ -37,14 +38,15 @@ class EventTaxonomyQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[EventTax
         query = self.to_query()
         hogql = to_printed_hogql(query, self.team)
 
-        response = execute_hogql_query(
-            query_type="EventTaxonomyQuery",
-            query=query,
-            team=self.team,
-            timings=self.timings,
-            modifiers=self.modifiers,
-            limit_context=self.limit_context,
-        )
+        with tags_context(product=Product.MAX_AI):
+            response = execute_hogql_query(
+                query_type="EventTaxonomyQuery",
+                query=query,
+                team=self.team,
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
 
         results: list[EventTaxonomyItem] = []
         for prop, sample_values, sample_count in response.results:

--- a/posthog/hogql_queries/ai/trace_query_runner.py
+++ b/posthog/hogql_queries/ai/trace_query_runner.py
@@ -22,6 +22,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
@@ -57,7 +58,7 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
         super().__init__(*args, **kwargs)
 
     def _calculate(self):
-        with self.timings.measure("trace_query_hogql_execute"):
+        with self.timings.measure("trace_query_hogql_execute"), tags_context(product=Product.MAX_AI):
             query_result = execute_hogql_query(
                 query=self.to_query(),
                 placeholders={

--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -22,6 +22,7 @@ from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -64,7 +65,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
         )
 
     def _calculate(self):
-        with self.timings.measure("traces_query_hogql_execute"):
+        with self.timings.measure("traces_query_hogql_execute"), tags_context(product=Product.MAX_AI):
             # Calculate max number of events needed with current offset and limit
             limit_value = self.query.limit if self.query.limit else 100
             offset_value = self.query.offset if self.query.offset else 0

--- a/posthog/hogql_queries/ai/traces_query_runner_v2.py
+++ b/posthog/hogql_queries/ai/traces_query_runner_v2.py
@@ -24,6 +24,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -68,7 +69,7 @@ class TracesQueryRunnerV2(AnalyticsQueryRunner[TracesQueryResponse]):
 
     def _get_trace_ids(self) -> tuple[list[str], datetime | None, datetime | None]:
         """Execute a separate query to get relevant trace IDs and their time range."""
-        with self.timings.measure("traces_query_trace_ids_execute"):
+        with self.timings.measure("traces_query_trace_ids_execute"), tags_context(product=Product.MAX_AI):
             # Calculate max number of events needed with current offset and limit
             limit_value = self.query.limit if self.query.limit else 100
             offset_value = self.query.offset if self.query.offset else 0
@@ -140,7 +141,7 @@ class TracesQueryRunnerV2(AnalyticsQueryRunner[TracesQueryResponse]):
         # Create a narrowed date range if we have timestamps
         narrowed_date_range = self._create_narrowed_date_range(min_timestamp, max_timestamp)
 
-        with self.timings.measure("traces_query_hogql_execute"):
+        with self.timings.measure("traces_query_hogql_execute"), tags_context(product=Product.MAX_AI):
             query_result = self.paginator.execute_hogql_query(
                 query=self._to_query_with_trace_ids(trace_ids),
                 placeholders={

--- a/posthog/hogql_queries/ai/vector_search_query_runner.py
+++ b/posthog/hogql_queries/ai/vector_search_query_runner.py
@@ -10,6 +10,7 @@ from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql_queries.ai.utils import TaxonomyCacheMixin
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 
@@ -25,14 +26,15 @@ class VectorSearchQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[VectorSea
         query = self.to_query()
         hogql = to_printed_hogql(query, self.team)
 
-        response = execute_hogql_query(
-            query_type="VectorSearchQuery",
-            query=query,
-            team=self.team,
-            timings=self.timings,
-            modifiers=self.modifiers,
-            limit_context=self.limit_context,
-        )
+        with tags_context(product=Product.MAX_AI):
+            response = execute_hogql_query(
+                query_type="VectorSearchQuery",
+                query=query,
+                team=self.team,
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
 
         results: list[VectorSearchResponseItem] = []
         for id, distance in response.results:

--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -19,7 +19,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import Product, tag_queries
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.experiments import MULTIPLE_VARIANT_KEY
 from posthog.hogql_queries.experiments.exposure_query_logic import (
@@ -154,6 +154,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                 experiment_id=self.query.experiment_id,
                 experiment_name=self.query.experiment_name,
                 experiment_feature_flag_key=self.feature_flag_key,
+                product=Product.EXPERIMENTS,
             )
 
             # Set limit to avoid being cut-off by the default 100 rows limit


### PR DESCRIPTION
1. For all AI query runners set tag product=Product.MAX_AI
2. If running inside max temporal worker or product is MAX_AI use ClickHouseUser.MAX_AI (it missing it fallbacks back to default)