### PR TITLE
fix(experiments): Saved metric creation redirects to metrics

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -99,7 +99,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
                 lemonToast.success('Shared metric created successfully')
                 actions.reportExperimentSharedMetricCreated(response as SharedMetric)
                 actions.loadSharedMetrics()
-                router.actions.push(`/experiments/shared-metrics/${response.id}`)
+                router.actions.push('/experiments?tab=shared-metrics')
             }
         },
         updateSharedMetric: async () => {


### PR DESCRIPTION
## Problem
When creating a shared metric and saving it, we stay in the form, which is weird UX.

## Changes
On successful creation, redirect to the saved metrics list, which is already what we're doing on saved metric update.