### PR TITLE
feat: support force disable person processing

### DIFF
--- a/plugin-server/src/ingestion/cookieless/cookieless-manager.test.ts
+++ b/plugin-server/src/ingestion/cookieless/cookieless-manager.test.ts
@@ -454,7 +454,7 @@ describe('CookielessManager', () => {
 
                 // Dropped events are not returned in the response array
                 expect(result.event).toBeUndefined()
-                expect(result.headers).toEqual({})
+                expect(result.headers).toEqual({ force_disable_person_processing: false })
             })
         })
 
@@ -597,7 +597,7 @@ describe('CookielessManager', () => {
 
                 // Dropped events are not returned in the response array
                 expect(result.event).toBeUndefined()
-                expect(result.headers).toEqual({})
+                expect(result.headers).toEqual({ force_disable_person_processing: false })
             })
             it('should preserve headers when passing through non-cookieless events', async () => {
                 const testHeaders = {

--- a/plugin-server/src/ingestion/cookieless/cookieless-manager.test.ts
+++ b/plugin-server/src/ingestion/cookieless/cookieless-manager.test.ts
@@ -280,7 +280,12 @@ describe('CookielessManager', () => {
 
         async function processEvent(
             event: PipelineEvent,
-            headers: { token?: string; distinct_id?: string; timestamp?: string } = {}
+            headers: {
+                token?: string
+                distinct_id?: string
+                timestamp?: string
+                force_disable_person_processing: boolean
+            } = { force_disable_person_processing: false }
         ): Promise<PipelineEvent | undefined> {
             const response = await hub.cookielessManager.doBatch([{ event, team, message, headers }])
             expect(response.length).toBe(1)
@@ -290,17 +295,29 @@ describe('CookielessManager', () => {
 
         async function processEventWithHeaders(
             event: PipelineEvent,
-            headers: { token?: string; distinct_id?: string; timestamp?: string }
+            headers: {
+                token?: string
+                distinct_id?: string
+                timestamp?: string
+                force_disable_person_processing: boolean
+            }
         ): Promise<{
             event: PipelineEvent | undefined
-            headers: { token?: string; distinct_id?: string; timestamp?: string }
+            headers: {
+                token?: string
+                distinct_id?: string
+                timestamp?: string
+                force_disable_person_processing: boolean
+            }
         }> {
             const response = await hub.cookielessManager.doBatch([{ event, team, message, headers }])
             expect(response.length).toBe(1)
             const result = response[0]
             return {
                 event: isOkResult(result) ? result.value.event : undefined,
-                headers: isOkResult(result) ? result.value.headers || {} : {},
+                headers: isOkResult(result)
+                    ? result.value.headers || { force_disable_person_processing: false }
+                    : { force_disable_person_processing: false },
             }
         }
 
@@ -401,6 +418,7 @@ describe('CookielessManager', () => {
                     token: 'test-token',
                     distinct_id: 'test-distinct-id',
                     timestamp: '1234567890',
+                    force_disable_person_processing: false,
                 }
 
                 const result = await processEventWithHeaders(event, testHeaders)
@@ -414,6 +432,7 @@ describe('CookielessManager', () => {
                     token: 'test-token',
                     distinct_id: 'test-distinct-id',
                     timestamp: '1234567890',
+                    force_disable_person_processing: false,
                 }
 
                 const result = await processEventWithHeaders(nonCookielessEvent, testHeaders)
@@ -427,6 +446,7 @@ describe('CookielessManager', () => {
                     token: 'test-token',
                     distinct_id: 'test-distinct-id',
                     timestamp: '1234567890',
+                    force_disable_person_processing: false,
                 }
 
                 // Test with alias event which should be dropped
@@ -570,6 +590,7 @@ describe('CookielessManager', () => {
                     token: 'test-token',
                     distinct_id: 'test-distinct-id',
                     timestamp: '1234567890',
+                    force_disable_person_processing: false,
                 }
 
                 const result = await processEventWithHeaders(event, testHeaders)
@@ -583,6 +604,7 @@ describe('CookielessManager', () => {
                     token: 'test-token',
                     distinct_id: 'test-distinct-id',
                     timestamp: '1234567890',
+                    force_disable_person_processing: false,
                 }
 
                 const result = await processEventWithHeaders(nonCookielessEvent, testHeaders)

--- a/plugin-server/src/ingestion/event-preprocessing/apply-drop-events-restrictions.test.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/apply-drop-events-restrictions.test.ts
@@ -22,6 +22,7 @@ describe('createApplyDropRestrictionsStep', () => {
             headers: {
                 token: 'valid-token-123',
                 distinct_id: 'user-456',
+                force_disable_person_processing: false,
             },
         }
         jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(false)
@@ -38,6 +39,7 @@ describe('createApplyDropRestrictionsStep', () => {
             headers: {
                 token: 'blocked-token-abc',
                 distinct_id: 'blocked-user-def',
+                force_disable_person_processing: false,
             },
         }
         jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(true)
@@ -67,7 +69,9 @@ describe('createApplyDropRestrictionsStep', () => {
     it('should handle empty headers', async () => {
         const input = {
             message: {} as any,
-            headers: {},
+            headers: {
+                force_disable_person_processing: false,
+            },
         }
         jest.mocked(eventIngestionRestrictionManager.shouldDropEvent).mockReturnValue(false)
 

--- a/plugin-server/src/ingestion/event-preprocessing/apply-force-overflow-restrictions.test.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/apply-force-overflow-restrictions.test.ts
@@ -29,6 +29,7 @@ describe('createApplyForceOverflowRestrictionsStep', () => {
             headers: {
                 token: 'valid-token-123',
                 distinct_id: 'user-456',
+                force_disable_person_processing: false,
             },
         }
 
@@ -48,6 +49,7 @@ describe('createApplyForceOverflowRestrictionsStep', () => {
             headers: {
                 token: 't-xyz',
                 distinct_id: 'd-1',
+                force_disable_person_processing: false,
             },
         }
 
@@ -69,6 +71,7 @@ describe('createApplyForceOverflowRestrictionsStep', () => {
             headers: {
                 token: 't-abc',
                 distinct_id: 'd-2',
+                force_disable_person_processing: false,
             },
         }
 
@@ -105,7 +108,9 @@ describe('createApplyForceOverflowRestrictionsStep', () => {
     it('handles empty headers', async () => {
         const input = {
             message: {} as any,
-            headers: {},
+            headers: {
+                force_disable_person_processing: false,
+            },
         }
         jest.mocked(eventIngestionRestrictionManager.shouldForceOverflow).mockReturnValue(false)
 
@@ -130,6 +135,7 @@ describe('createApplyForceOverflowRestrictionsStep', () => {
             headers: {
                 token: 'test-token',
                 distinct_id: 'test-user',
+                force_disable_person_processing: false,
             },
         }
 

--- a/plugin-server/src/ingestion/event-preprocessing/drop-exception-events.test.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/drop-exception-events.test.ts
@@ -21,6 +21,7 @@ describe('createDropExceptionEventsStep', () => {
                         token: 'token123',
                         distinct_id: 'user123',
                         timestamp: '2021-01-01T00:00:00Z',
+                        force_disable_person_processing: false,
                     },
                 },
             }
@@ -46,6 +47,7 @@ describe('createDropExceptionEventsStep', () => {
                         token: 'token123',
                         distinct_id: 'user123',
                         timestamp: '2021-01-01T00:00:00Z',
+                        force_disable_person_processing: false,
                     },
                 },
             }
@@ -71,6 +73,7 @@ describe('createDropExceptionEventsStep', () => {
                         token: 'token123',
                         distinct_id: 'user123',
                         timestamp: '2021-01-01T00:00:00Z',
+                        force_disable_person_processing: false,
                     },
                 },
             }
@@ -96,6 +99,7 @@ describe('createDropExceptionEventsStep', () => {
                         token: 'token123',
                         distinct_id: 'user123',
                         timestamp: '2021-01-01T00:00:00Z',
+                        force_disable_person_processing: false,
                     },
                 },
             }
@@ -121,6 +125,7 @@ describe('createDropExceptionEventsStep', () => {
                         token: 'token123',
                         distinct_id: 'user123',
                         timestamp: '2021-01-01T00:00:00Z',
+                        force_disable_person_processing: false,
                     },
                 },
             }
@@ -146,6 +151,7 @@ describe('createDropExceptionEventsStep', () => {
                         token: 'token123',
                         distinct_id: 'user123',
                         timestamp: '2021-01-01T00:00:00Z',
+                        force_disable_person_processing: false,
                     },
                 },
             }

--- a/plugin-server/src/ingestion/event-preprocessing/validate-event-uuid.test.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/validate-event-uuid.test.ts
@@ -38,7 +38,9 @@ describe('createValidateEventUuidStep', () => {
                 person_processing_opt_out: false,
             } as any,
             message: {} as any,
-            headers: {},
+            headers: {
+                force_disable_person_processing: false,
+            },
         }
 
         step = createValidateEventUuidStep(mockHub)

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -91,6 +91,7 @@ const createIncomingEventsWithTeam = (events: PipelineEvent[], team: Team): Inco
             headers: {
                 token: e.token || '',
                 distinct_id: e.distinct_id || '',
+                force_disable_person_processing: false,
             },
         })
     )
@@ -710,6 +711,7 @@ describe('IngestionConsumer', () => {
                         token: team.api_token,
                         distinct_id: event.distinct_id || '',
                         timestamp: (Date.now() + index * 1000).toString(),
+                        force_disable_person_processing: false,
                     },
                 }
             })
@@ -723,12 +725,14 @@ describe('IngestionConsumer', () => {
                 token: team.api_token,
                 distinct_id: 'distinct-id-1',
                 timestamp: expect.any(String),
+                force_disable_person_processing: false,
             })
 
             expect(batches[`${team.api_token}:distinct-id-2`].events[0].headers).toEqual({
                 token: team.api_token,
                 distinct_id: 'distinct-id-2',
                 timestamp: expect.any(String),
+                force_disable_person_processing: false,
             })
 
             // Verify the timestamp values are different

--- a/plugin-server/src/kafka/consumer.test.ts
+++ b/plugin-server/src/kafka/consumer.test.ts
@@ -464,12 +464,12 @@ describe('parseKafkaHeaders', () => {
 describe('parseEventHeaders', () => {
     it('should return empty object when headers is undefined', () => {
         const result = parseEventHeaders(undefined)
-        expect(result).toEqual({})
+        expect(result).toEqual({ force_disable_person_processing: false })
     })
 
     it('should return empty object when headers is empty array', () => {
         const result = parseEventHeaders([])
-        expect(result).toEqual({})
+        expect(result).toEqual({ force_disable_person_processing: false })
     })
 
     it('should parse token header only', () => {
@@ -477,6 +477,7 @@ describe('parseEventHeaders', () => {
         const result = parseEventHeaders(headers)
         expect(result).toEqual({
             token: 'test-token',
+            force_disable_person_processing: false,
         })
     })
 
@@ -485,6 +486,7 @@ describe('parseEventHeaders', () => {
         const result = parseEventHeaders(headers)
         expect(result).toEqual({
             distinct_id: 'user-123',
+            force_disable_person_processing: false,
         })
     })
 
@@ -493,6 +495,7 @@ describe('parseEventHeaders', () => {
         const result = parseEventHeaders(headers)
         expect(result).toEqual({
             timestamp: '1234567890',
+            force_disable_person_processing: false,
         })
     })
 
@@ -509,6 +512,7 @@ describe('parseEventHeaders', () => {
             token: 'test-token',
             distinct_id: 'user-123',
             timestamp: '1234567890',
+            force_disable_person_processing: false,
         })
     })
 
@@ -523,6 +527,7 @@ describe('parseEventHeaders', () => {
             token: 'test-token',
             distinct_id: 'user-123',
             timestamp: '1234567890',
+            force_disable_person_processing: false,
         })
     })
 
@@ -539,6 +544,7 @@ describe('parseEventHeaders', () => {
         expect(result).toEqual({
             token: 'test-token',
             distinct_id: 'user-123',
+            force_disable_person_processing: false,
         })
     })
 
@@ -555,6 +561,7 @@ describe('parseEventHeaders', () => {
             token: '',
             distinct_id: '',
             timestamp: '',
+            force_disable_person_processing: false,
         })
     })
 
@@ -569,6 +576,7 @@ describe('parseEventHeaders', () => {
         expect(result).toEqual({
             token: 'second-token',
             distinct_id: 'second-id',
+            force_disable_person_processing: false,
         })
     })
 
@@ -584,6 +592,7 @@ describe('parseEventHeaders', () => {
         expect(result).toEqual({
             token: 'test-token',
             timestamp: '1234567890',
+            force_disable_person_processing: false,
         })
     })
 
@@ -599,6 +608,7 @@ describe('parseEventHeaders', () => {
         expect(result).toEqual({
             token: 'test-token',
             timestamp: '1234567890',
+            force_disable_person_processing: false,
         })
     })
 
@@ -607,6 +617,7 @@ describe('parseEventHeaders', () => {
         const result = parseEventHeaders(headers)
         expect(result).toEqual({
             event: '$pageview',
+            force_disable_person_processing: false,
         })
     })
 
@@ -615,6 +626,7 @@ describe('parseEventHeaders', () => {
         const result = parseEventHeaders(headers)
         expect(result).toEqual({
             uuid: '123e4567-e89b-12d3-a456-426614174000',
+            force_disable_person_processing: false,
         })
     })
 
@@ -635,6 +647,7 @@ describe('parseEventHeaders', () => {
             timestamp: '1234567890',
             event: '$pageview',
             uuid: '123e4567-e89b-12d3-a456-426614174000',
+            force_disable_person_processing: false,
         })
     })
 
@@ -655,6 +668,7 @@ describe('parseEventHeaders', () => {
             distinct_id: 'user-123',
             event: 'custom_event',
             uuid: 'uuid-value',
+            force_disable_person_processing: false,
         })
     })
 
@@ -671,6 +685,7 @@ describe('parseEventHeaders', () => {
             token: 'test-token',
             event: '',
             uuid: '',
+            force_disable_person_processing: false,
         })
     })
 })

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -830,7 +830,9 @@ export const parseEventHeaders = (headers?: MessageHeader[]): EventHeaders => {
     // Kafka headers come from librdkafka as an array of objects with keys value pairs per header.
     // We extract the specific headers we care about into a structured format.
 
-    const result: EventHeaders = {}
+    const result: EventHeaders = {
+        force_disable_person_processing: false,
+    }
 
     headers?.forEach((header) => {
         Object.keys(header).forEach((key) => {
@@ -845,12 +847,21 @@ export const parseEventHeaders = (headers?: MessageHeader[]): EventHeaders => {
                 result.event = value
             } else if (key === 'uuid') {
                 result.uuid = value
+            } else if (key === 'force_disable_person_processing') {
+                result.force_disable_person_processing = value === 'true'
             }
         })
     })
 
     // Track comprehensive header status metrics
-    const trackedHeaders = ['token', 'distinct_id', 'timestamp', 'event', 'uuid'] as const
+    const trackedHeaders = [
+        'token',
+        'distinct_id',
+        'timestamp',
+        'event',
+        'uuid',
+        'force_disable_person_processing',
+    ] as const
     trackedHeaders.forEach((header) => {
         const status = result[header] ? 'present' : 'absent'
         kafkaHeaderStatusCounter.labels(header, status).inc()

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1356,6 +1356,7 @@ export interface EventHeaders {
     timestamp?: string
     event?: string
     uuid?: string
+    force_disable_person_processing: boolean
 }
 
 export interface IncomingEvent {

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -18,7 +18,8 @@ export async function processPersonsStep(
     team: Team,
     timestamp: DateTime,
     processPerson: boolean,
-    personStoreBatch: PersonsStoreForBatch
+    personStoreBatch: PersonsStoreForBatch,
+    forceDisablePersonProcessing: boolean = false
 ): Promise<PipelineResult<[PluginEvent, Person, Promise<void>]>> {
     const context = new PersonContext(
         event,
@@ -35,7 +36,8 @@ export async function processPersonsStep(
     const processor = new PersonEventProcessor(
         context,
         new PersonPropertyService(context),
-        new PersonMergeService(context)
+        new PersonMergeService(context),
+        forceDisablePersonProcessing
     )
     const [result, kafkaAck] = await processor.processEvent()
 

--- a/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
@@ -32,6 +32,7 @@ describe('compareTimestamps', () => {
     it('should handle missing event timestamp with headers without throwing', () => {
         const headers: EventHeaders = {
             timestamp: '1672574400000', // 2023-01-01T12:00:00Z
+            force_disable_person_processing: false,
         }
 
         expect(() => {
@@ -43,6 +44,7 @@ describe('compareTimestamps', () => {
         const headers: EventHeaders = {
             token: 'test-token',
             distinct_id: 'test-id',
+            force_disable_person_processing: false,
             // timestamp is missing
         }
 
@@ -54,6 +56,7 @@ describe('compareTimestamps', () => {
     it('should handle invalid timestamp header without throwing', () => {
         const headers: EventHeaders = {
             timestamp: 'not-a-number',
+            force_disable_person_processing: false,
         }
 
         expect(() => {
@@ -66,6 +69,7 @@ describe('compareTimestamps', () => {
         const timestampMs = DateTime.fromISO(timestamp).toMillis()
         const headers: EventHeaders = {
             timestamp: timestampMs.toString(),
+            force_disable_person_processing: false,
         }
 
         expect(() => {
@@ -79,6 +83,7 @@ describe('compareTimestamps', () => {
         const differentTimestampMs = timestampMs + 5000 // 5 seconds difference
         const headers: EventHeaders = {
             timestamp: differentTimestampMs.toString(),
+            force_disable_person_processing: false,
         }
 
         expect(() => {
@@ -98,6 +103,7 @@ describe('compareTimestamps', () => {
     it('should use default context when not provided', () => {
         const headers: EventHeaders = {
             timestamp: '1672574400000', // 2023-01-01T12:00:00Z
+            force_disable_person_processing: false,
         }
 
         expect(() => {
@@ -111,6 +117,7 @@ describe('compareTimestamps', () => {
         const timestampMs = DateTime.fromRFC2822(timestamp).toMillis()
         const headers: EventHeaders = {
             timestamp: timestampMs.toString(),
+            force_disable_person_processing: false,
         }
 
         expect(() => {
@@ -121,6 +128,7 @@ describe('compareTimestamps', () => {
     it('should work without optional parameters', () => {
         const headers: EventHeaders = {
             timestamp: '1672574400000',
+            force_disable_person_processing: false,
         }
 
         expect(() => {
@@ -142,7 +150,7 @@ describe('compareTimestamps', () => {
         ]
 
         testCases.forEach(({ timestamp, header }) => {
-            const headers: EventHeaders = { timestamp: header }
+            const headers: EventHeaders = { timestamp: header, force_disable_person_processing: false }
 
             expect(() => {
                 compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context')
@@ -155,6 +163,7 @@ describe('compareTimestamps', () => {
         const timestampMs = DateTime.fromISO(timestamp).toMillis() + 1000 // 1 second difference
         const headers: EventHeaders = {
             timestamp: timestampMs.toString(),
+            force_disable_person_processing: false,
         }
 
         compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context', 1.0)
@@ -167,6 +176,7 @@ describe('compareTimestamps', () => {
         const timestampMs = DateTime.fromISO(timestamp).toMillis() + 1000 // 1 second difference
         const headers: EventHeaders = {
             timestamp: timestampMs.toString(),
+            force_disable_person_processing: false,
         }
 
         compareTimestamps(timestamp, headers, 123, 'test-uuid', 'test-context', 0.0)
@@ -177,6 +187,7 @@ describe('compareTimestamps', () => {
     it('should always log parse error when sample rate is 1.0', () => {
         const headers: EventHeaders = {
             timestamp: 'invalid-timestamp',
+            force_disable_person_processing: false,
         }
 
         compareTimestamps('invalid-date-format', headers, 123, 'test-uuid', 'test-context', 1.0)
@@ -187,6 +198,7 @@ describe('compareTimestamps', () => {
     it('should never log parse error when sample rate is 0.0', () => {
         const headers: EventHeaders = {
             timestamp: 'invalid-timestamp',
+            force_disable_person_processing: false,
         }
 
         compareTimestamps('invalid-date-format', headers, 123, 'test-uuid', 'test-context', 0.0)
@@ -204,6 +216,7 @@ describe('compareTimestamps', () => {
         const timestampMs = DateTime.fromISO(timestamp).toMillis() + 1000
         const headers: EventHeaders = {
             timestamp: timestampMs.toString(),
+            force_disable_person_processing: false,
         }
 
         try {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -120,6 +120,7 @@ exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
         "personUpdateCache": {},
         "updateLatencyPerDistinctIdSeconds": {},
       },
+      false,
     ],
   ],
   [


### PR DESCRIPTION
## Problem

We want to completely switch off person processing for events manually forced to overflow.

## Changes

Reads the `force_disable_person_processing` header and disables personless processing for events with the header set to true.

## How did you test this code?

Added new tests
