### PR TITLE
fix(experiments): funnel chart - use custom_name if set

### DIFF
--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -51,7 +51,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
         if (sessionData) {
             openModal({
                 sessionData,
-                stepName: step.name,
+                stepName: step.custom_name || step.name,
                 variant: variantKey,
             })
         }

--- a/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
@@ -44,7 +44,7 @@ export function StepLegend({ step, stepIndex, showTime }: StepLegendProps): JSX.
     return (
         <div className="StepLegend">
             <LemonRow icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />}>
-                <span title={step.name}>{step.custom_name || step.name}</span>
+                <span title={step.custom_name || step.name}>{step.custom_name || step.name}</span>
             </LemonRow>
             <LemonRow icon={<IconTrendingFlat />} status="success" style={{ color: 'unset' }}>
                 <Tooltip


### PR DESCRIPTION
## Problem

Funnel charts currently uses only the event name and not the custom name if set.

## Changes

Use custom_name if set.

## How did you test this code?

- **NB**: not tested as my local env is broken atm!
