### PR TITLE
feat(err): cymbal support for persons db

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -75,6 +75,7 @@ case "$RS_SVC" in
     export FRAME_CACHE_TTL_SECONDS=1
     export BIND_PORT=3302 # HACK! avoid local-dev clash with property-defs-rs port
     export ALLOW_INTERNAL_IPS="true"
+    export PERSONS_URL=postgres://posthog:posthog@localhost:5434/posthog_persons
     ;;
 
   embedding-worker)

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -85,7 +85,7 @@ impl AppContext {
         let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
         let persons_options = options.clone();
         let posthog_pool = options.connect(&config.database_url).await?;
-        let persons_pool = persons_options.connect(&config.database_url).await?;
+        let persons_pool = persons_options.connect(&config.persons_url).await?;
 
         let s3_client = aws_sdk_s3::Client::from_conf(get_aws_config(config).await);
         let s3_client = S3Client::new(s3_client);

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -41,7 +41,8 @@ pub struct AppContext {
     pub kafka_consumer: SingleTopicConsumer,
     pub transactional_producer: Mutex<TransactionalProducer<KafkaContext>>,
     pub immediate_producer: FutureProducer<KafkaContext>,
-    pub pool: PgPool,
+    pub posthog_pool: PgPool,
+    pub persons_pool: PgPool,
     pub catalog: Catalog,
     pub resolver: Resolver,
     pub config: Config,
@@ -82,7 +83,9 @@ impl AppContext {
             create_kafka_producer(&config.kafka, kafka_immediate_liveness).await?;
 
         let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
-        let pool = options.connect(&config.database_url).await?;
+        let persons_options = options.clone();
+        let posthog_pool = options.connect(&config.database_url).await?;
+        let persons_pool = persons_options.connect(&config.database_url).await?;
 
         let s3_client = aws_sdk_s3::Client::from_conf(get_aws_config(config).await);
         let s3_client = S3Client::new(s3_client);
@@ -98,12 +101,12 @@ impl AppContext {
         let smp_chunk = ChunkIdFetcher::new(
             smp,
             s3_client.clone(),
-            pool.clone(),
+            posthog_pool.clone(),
             config.object_storage_bucket.clone(),
         );
         let smp_saving = Saving::new(
             smp_chunk,
-            pool.clone(),
+            posthog_pool.clone(),
             s3_client.clone(),
             config.object_storage_bucket.clone(),
             config.ss_prefix.clone(),
@@ -119,7 +122,7 @@ impl AppContext {
         let hmp_chunk = ChunkIdFetcher::new(
             hmp,
             s3_client.clone(),
-            pool.clone(),
+            posthog_pool.clone(),
             config.object_storage_bucket.clone(),
         );
         let hmp_caching = Caching::new(hmp_chunk, ss_cache.clone());
@@ -170,7 +173,8 @@ impl AppContext {
             kafka_consumer,
             transactional_producer: Mutex::new(transactional_producer),
             immediate_producer,
-            pool,
+            posthog_pool,
+            persons_pool,
             catalog,
             resolver,
             config: config.clone(),

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -50,6 +50,9 @@ pub struct Config {
     #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog")]
     pub database_url: String,
 
+    #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog")]
+    pub persons_url: String,
+
     // Rust service connect directly to postgres, not via pgbouncer, so we keep this low
     #[envconfig(default = "4")]
     pub max_pg_connections: u32,

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -261,7 +261,7 @@ pub async fn resolve_issue(
     event_timestamp: DateTime<Utc>,
     event_properties: FingerprintedErrProps,
 ) -> Result<Issue, UnhandledError> {
-    let mut conn = context.pool.acquire().await?;
+    let mut conn = context.posthog_pool.acquire().await?;
     // Fast path - just fetch the issue directly, and then reopen it if needed
     let existing_issue =
         Issue::load_by_fingerprint(&mut *conn, team_id, &event_properties.fingerprint.value)

--- a/rust/cymbal/src/pipeline/exception/stack_processing.rs
+++ b/rust/cymbal/src/pipeline/exception/stack_processing.rs
@@ -59,7 +59,7 @@ pub async fn do_stack_processing(
                     metrics::counter!(FRAME_RESOLUTION).increment(1);
                     let res = context
                         .resolver
-                        .resolve(&frame, team_id, &context.pool, &context.catalog)
+                        .resolve(&frame, team_id, &context.posthog_pool, &context.catalog)
                         .await;
                     context.worker_liveness.report_healthy().await;
                     res
@@ -114,7 +114,7 @@ pub async fn do_stack_processing(
             .team_id;
 
         let mut conn = context
-            .pool
+            .posthog_pool
             .acquire()
             .await
             .map_err(|e| (index, e.into()))?;

--- a/rust/cymbal/src/pipeline/group.rs
+++ b/rust/cymbal/src/pipeline/group.rs
@@ -35,7 +35,7 @@ pub async fn map_group_types(
 
         let group_type_mappings = context
             .team_manager
-            .get_group_types(&context.pool, event.team_id)
+            .get_group_types(&context.persons_pool, event.team_id)
             .await
             .map_err(|e| (i, e))?;
 

--- a/rust/cymbal/src/pipeline/person.rs
+++ b/rust/cymbal/src/pipeline/person.rs
@@ -39,7 +39,7 @@ pub async fn add_person_properties(
         let m_distinct_id = distinct_id.clone();
         let team_id = event.team_id;
         let fut = async move {
-            let res = Person::from_distinct_id(&m_context.pool, team_id, &m_distinct_id)
+            let res = Person::from_distinct_id(&m_context.persons_pool, team_id, &m_distinct_id)
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to fetch person {}, {:?}", m_distinct_id, e);
@@ -51,8 +51,12 @@ pub async fn add_person_properties(
                 Err(sqlx::Error::ColumnDecode { .. }) => {
                     // If we failed to decode the person properties, we just put an empty property set on
                     // the event, so e.g. counting exceptions by person still works
-                    Person::from_distinct_id_no_props(&m_context.pool, team_id, &m_distinct_id)
-                        .await
+                    Person::from_distinct_id_no_props(
+                        &m_context.persons_pool,
+                        team_id,
+                        &m_distinct_id,
+                    )
+                    .await
                 }
                 Err(e) => Err(e),
             }

--- a/rust/cymbal/src/teams.rs
+++ b/rust/cymbal/src/teams.rs
@@ -169,7 +169,12 @@ pub async fn do_team_lookups(
 
         let m_ctx = context.clone();
         let m_token = token.clone();
-        let fut = async move { m_ctx.team_manager.get_team(&m_ctx.pool, &m_token).await };
+        let fut = async move {
+            m_ctx
+                .team_manager
+                .get_team(&m_ctx.posthog_pool, &m_token)
+                .await
+        };
         let lookup = WithIndices {
             indices: vec![index],
             inner: tokio::spawn(fut),


### PR DESCRIPTION
I don't _love_ this - if we expected it to stick around for more than a quarter or two, I'd argue for branded pools instead (e.g. `pub struct PersonPool(PgPool)`) or a more complete solution, but a combination of the ingestion folks planning a persons API as the future, and the short notice (they're shipping the split tomorrow, whoops) makes me feel this'll do.

As above, if we expected this to stick around long-term, flags and cymbal ought to share code more here, I'm fairly certain we do almost identical things, and I bet this oversight would have been caught earlier if we did.