### PR TITLE
chore: adding persons db to the minimal dev start configuration.

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -43,10 +43,16 @@ procs:
             bin/check_postgres_up posthog && \
             bin/start-rust-service feature-flags
 
+    migrate-postgres:
+        shell: 'bin/check_postgres_up && python manage.py migrate' # This takes ~10 s
+
     migrate-clickhouse:
         # These migrations are not in the `backend` service, because they typically aren't blocking for backend startup,
         # but unfortunately they DO take 10-30 s just to check if there's any migration to run (haven't profiled why)
         shell: 'bin/check_kafka_clickhouse_up && python manage.py migrate_clickhouse'
+
+    migrate-persons-db:
+        shell: 'bin/check_persons_db_up && cd rust && DATABASE_URL=postgres://posthog:posthog@localhost:5434/posthog_persons sqlx migrate run --source persons_migrations'
 
     storybook:
         shell: 'pnpm --filter=@posthog/storybook install && pnpm run storybook'

--- a/docker-compose.dev-minimal.yml
+++ b/docker-compose.dev-minimal.yml
@@ -82,6 +82,23 @@ services:
         # and eventually kills postgres, these settings aim to stop that happening.
         # They are only for DEV and should not be used in production.
         command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000 -c max_prepared_transactions=10
+    persons_db:
+        extends:
+            file: docker-compose.base.yml
+            service: db
+        ports:
+            - '5434:5432'
+        environment:
+            POSTGRES_USER: posthog
+            POSTGRES_DB: posthog_persons
+            POSTGRES_PASSWORD: posthog
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U posthog -d posthog_persons']
+            interval: 5s
+            timeout: 5s
+        volumes:
+            - persons-db:/var/lib/postgresql/data
+        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000 -c max_prepared_transactions=10
     redis:
         extends:
             file: docker-compose.base.yml
@@ -167,3 +184,5 @@ services:
 
 volumes:
     redpanda-data:
+    persons-db:
+        driver: local


### PR DESCRIPTION
## Problem

When starting a local development environment with `bin/start --minimal`, the Django app fails because the `persons_db` service is missing at port `5434`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add the `persons_db` service to the minimal docker, and the migrations check to the minimal mprocs file.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/c2491027-fc2e-4510-8ec4-442f2159c0c8)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
