### PR TITLE
feat: Round timings object to ms

### DIFF
--- a/posthog/hogql/timings.py
+++ b/posthog/hogql/timings.py
@@ -42,7 +42,8 @@ class HogQLTimings:
     def to_dict(self) -> dict[str, float]:
         timings = {**self.timings}
         for key, start in reversed(self._timing_starts.items()):
-            timings[key] = timings.get(key, 0.0) + (perf_counter() - start)
+            value = timings.get(key, 0.0) + (perf_counter() - start)
+            timings[key] = round(value, 3)  # round to milliseconds, we don't need to store more precision than that
         return timings
 
     def to_list(self, back_out_stack=True) -> list[QueryTiming]:

--- a/posthog/hogql/timings.py
+++ b/posthog/hogql/timings.py
@@ -3,6 +3,8 @@ from time import perf_counter
 
 from posthog.schema import QueryTiming
 
+TIMING_DECIMAL_PLACES = 3  # round to milliseconds
+
 
 # Not thread safe.
 # See trends_query_runner for an example of how to use for multithreaded queries
@@ -42,11 +44,11 @@ class HogQLTimings:
     def to_dict(self) -> dict[str, float]:
         timings = {**self.timings}
         for key, start in reversed(self._timing_starts.items()):
-            value = timings.get(key, 0.0) + (perf_counter() - start)
-            timings[key] = round(value, 3)  # round to milliseconds, we don't need to store more precision than that
+            timings[key] = round(timings.get(key, 0.0) + (perf_counter() - start), TIMING_DECIMAL_PLACES)
         return timings
 
     def to_list(self, back_out_stack=True) -> list[QueryTiming]:
         return [
-            QueryTiming(k=key, t=time) for key, time in (self.to_dict() if back_out_stack else self.timings).items()
+            QueryTiming(k=key, t=round(time, TIMING_DECIMAL_PLACES))
+            for key, time in (self.to_dict() if back_out_stack else self.timings).items()
         ]


### PR DESCRIPTION
## Problem

The timings object can get pretty large, especially when all these floats are JSON encoded

<img width="294" height="471" alt="Screenshot 2025-10-09 at 14 01 09" src="https://github.com/user-attachments/assets/cf043359-5051-42e1-8010-918db3aad152" />

Let's round off all those extra digits we don't really need. Anything <1ms is not really interesting here.

<img width="542" height="674" alt="Screenshot 2025-10-09 at 14 16 08" src="https://github.com/user-attachments/assets/6d0f0d17-d2f8-4122-853e-eff7ba0e6bc4" />

## Changes

Round timings to 3 decimal places

## How did you test this code?

n/a but see the screenshots

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
