### PR TITLE
fix: accidental static string

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -140,8 +140,8 @@ export function AuthorizedUrlList({
                                             tooltip={
                                                 type === AuthorizedUrlListType.TOOLBAR_URLS ||
                                                 type === AuthorizedUrlListType.WEB_ANALYTICS
-                                                    ? 'Launch toolbar'
-                                                    : 'Launch url'
+                                                    ? 'Open the toolbar on this page'
+                                                    : 'Open the browser at this page'
                                             }
                                             center
                                             data-attr="toolbar-open"

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -813,7 +813,7 @@ function RecordingTriggersSummary({ selectedPlatform }: { selectedPlatform: 'web
                   {
                       enabled: hasSampling,
                       label: 'Sampling',
-                      detail: hasSampling ? `numericSampleRate%` : null,
+                      detail: hasSampling ? `${numericSampleRate}%` : null,
                   },
                   {
                       enabled: hasMinDuration,

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -490,7 +490,7 @@ export function ReplayAuthorizedDomains(): JSX.Element {
                 Domains and wildcard subdomains are allowed (e.g. <code>https://*.example.com</code>). However,
                 wildcarded top-level domains cannot be used (for security reasons).
             </p>
-            <AuthorizedUrlList type={AuthorizedUrlListType.RECORDING_DOMAINS} showLaunch={true} allowAdd={false} />
+            <AuthorizedUrlList type={AuthorizedUrlListType.RECORDING_DOMAINS} showLaunch={false} allowAdd={false} />
         </div>
     )
 }


### PR DESCRIPTION
should have been a templated string, but wasn't

<img width="480" height="75" alt="image" src="https://github.com/user-attachments/assets/dc77edb1-4ea9-40e2-bddc-b3c83b42d90a" />


ah, and fix how the launch button is presented in the authorised url list