### PR TITLE
fix(migration-analysis): skip AddIndex/AddConstraint on newly created tables

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -105,3 +105,7 @@ ee/session_recordings/**/*.py @PostHog/team-replay
 # Own everything in mobile replay (all file types)
 
 ee/frontend/mobile-replay @PostHog/team-replay
+
+# DevEx
+
+posthog/management/migration_analysis/ @PostHog/DevEx

--- a/posthog/management/migration_analysis/analyzer.py
+++ b/posthog/management/migration_analysis/analyzer.py
@@ -54,10 +54,20 @@ class RiskAnalyzer:
     }
 
     def analyze_migration(self, migration, path: str) -> MigrationRisk:
+        # Collect newly created models for this migration
+        self.newly_created_models = {
+            op.name for op in migration.operations if op.__class__.__name__ == "CreateModel" and hasattr(op, "name")
+        }
+
         operation_risks = []
 
         for op in migration.operations:
             risk = self.analyze_operation(op)
+
+            # Skip AddIndex/AddConstraint on newly created tables - they're safe
+            if self._is_safe_on_new_table(op, risk):
+                continue
+
             operation_risks.append(risk)
 
             # Recursively analyze database_operations in SeparateDatabaseAndState
@@ -86,6 +96,13 @@ class RiskAnalyzer:
             combination_risks=combination_risks,
             policy_violations=policy_violations,
         )
+
+    def _is_safe_on_new_table(self, op, risk: OperationRisk) -> bool:
+        """Check if operation is safe because it's on a newly created table."""
+        if risk.type not in ["AddIndex", "AddConstraint"]:
+            return False
+        model_name = risk.details.get("model") or getattr(op, "model_name", None)
+        return model_name in self.newly_created_models
 
     def analyze_operation(self, op) -> OperationRisk:
         op_type = op.__class__.__name__

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -779,3 +779,94 @@ class TestCombinationRisks:
         # Should not have DDL isolation combination risk for safe concurrent operations
         ddl_warnings = [r for r in migration_risk.combination_risks if "DDL" in r and "isolation" in r]
         assert len(ddl_warnings) == 0, f"Should not warn about DDL isolation for CONCURRENTLY: {ddl_warnings}"
+
+    def test_create_model_with_add_index_safe(self):
+        """AddIndex on newly created table should be filtered out (safe, not shown in PR)"""
+        mock_migration = MagicMock()
+        mock_migration.app_label = "test"
+        mock_migration.name = "0001_create_new_table"
+        mock_migration.atomic = True
+
+        # Non-concurrent index that would normally be score 4
+        index = MagicMock()
+        index.concurrent = False
+
+        mock_migration.operations = [
+            create_mock_operation(migrations.CreateModel, name="NewTable", fields=[]),
+            create_mock_operation(migrations.AddIndex, model_name="NewTable", index=index),
+        ]
+
+        migration_risk = self.analyzer.analyze_migration(mock_migration, "test/migrations/0001_create_new_table.py")
+
+        # AddIndex on new table should be filtered out (not shown in operations)
+        assert len(migration_risk.operations) == 1  # Only CreateModel
+        assert migration_risk.operations[0].type == "CreateModel"
+        assert migration_risk.level == RiskLevel.SAFE
+        assert len(migration_risk.combination_risks) == 0
+
+    def test_create_model_with_add_constraint_safe(self):
+        """AddConstraint on newly created table should be filtered out (safe, not shown in PR)"""
+        mock_migration = MagicMock()
+        mock_migration.app_label = "test"
+        mock_migration.name = "0001_create_new_table"
+        mock_migration.atomic = True
+
+        mock_migration.operations = [
+            create_mock_operation(migrations.CreateModel, name="NewTable", fields=[]),
+            create_mock_operation(migrations.AddConstraint, model_name="NewTable"),
+        ]
+
+        migration_risk = self.analyzer.analyze_migration(mock_migration, "test/migrations/0001_create_new_table.py")
+
+        # AddConstraint on new table should be filtered out (not shown in operations)
+        assert len(migration_risk.operations) == 1  # Only CreateModel
+        assert migration_risk.operations[0].type == "CreateModel"
+        assert migration_risk.level == RiskLevel.SAFE
+        assert len(migration_risk.combination_risks) == 0
+
+    def test_create_model_with_multiple_indexes_no_warning(self):
+        """Multiple indexes on newly created table should be filtered out (no combination warning)"""
+        mock_migration = MagicMock()
+        mock_migration.app_label = "test"
+        mock_migration.name = "0001_create_new_table"
+        mock_migration.atomic = True
+
+        index1 = MagicMock()
+        index1.concurrent = False
+        index2 = MagicMock()
+        index2.concurrent = False
+
+        mock_migration.operations = [
+            create_mock_operation(migrations.CreateModel, name="NewTable", fields=[]),
+            create_mock_operation(migrations.AddIndex, model_name="NewTable", index=index1),
+            create_mock_operation(migrations.AddIndex, model_name="NewTable", index=index2),
+        ]
+
+        migration_risk = self.analyzer.analyze_migration(mock_migration, "test/migrations/0001_create_new_table.py")
+
+        # Both indexes should be filtered out (not shown in operations)
+        assert len(migration_risk.operations) == 1  # Only CreateModel
+        assert migration_risk.operations[0].type == "CreateModel"
+        assert migration_risk.level == RiskLevel.SAFE
+        # Should NOT trigger "multiple indexes" warning
+        assert len(migration_risk.combination_risks) == 0
+
+    def test_add_index_on_existing_table_still_risky(self):
+        """AddIndex on existing table (without CreateModel) should still be risky"""
+        mock_migration = MagicMock()
+        mock_migration.app_label = "test"
+        mock_migration.name = "0002_add_index_existing"
+        mock_migration.atomic = True
+
+        index = MagicMock()
+        index.concurrent = False
+
+        mock_migration.operations = [
+            create_mock_operation(migrations.AddIndex, model_name="ExistingTable", index=index),
+        ]
+
+        migration_risk = self.analyzer.analyze_migration(mock_migration, "test/migrations/0002_add_index_existing.py")
+
+        # Index on existing table should still be score 4
+        assert migration_risk.operations[0].score == 4
+        assert migration_risk.level == RiskLevel.BLOCKED


### PR DESCRIPTION
## Problem

Migrations that create new tables and immediately add indexes/constraints were incorrectly flagged as BLOCKED. For example, PR #39288 creates 3 new tables with indexes and constraints, but these operations are safe because:
- Tables are empty (no data to index or validate)
- No existing code knows about these tables (no lock contention)
- Index creation on empty table is instant
- Constraint validation on empty table is instant

## Solution

Filter out AddIndex and AddConstraint operations on newly created tables at the entry point in `analyze_migration()`. These operations no longer appear in PR comments since they are safe and don't need review.

Added `_is_safe_on_new_table()` helper method to centralize the logic.

## Changes

- Add helper method to check if operation is on newly created table
- Skip AddIndex/AddConstraint on new tables before adding to operation_risks
- Update tests to verify operations are filtered out
- Add DevEx team as soft codeowner for migration analysis

## Result

PR #39288 and similar migrations will now show SAFE status instead of BLOCKED.

## Test plan

All 52 tests pass including new tests for:
- CreateModel + AddIndex filtered out
- CreateModel + AddConstraint filtered out  
- CreateModel + multiple indexes filtered out
- AddIndex on existing table still flagged as risky