### PR TITLE
fix: group recordings by s3 key and run deletes in parallel

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -3,7 +3,7 @@ import uuid
 import asyncio
 import builtins
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, List, Optional, TypeVar, Union, cast  # noqa: UP035
 
 from django.db.models import Prefetch
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 from statshog.defaults.django import statsd
+from temporalio import common
 
 from posthog.hogql.constants import CSV_EXPORT_LIMIT
 
@@ -879,6 +880,10 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 input,
                 id=workflow_id,
                 task_queue=SESSION_REPLAY_TASK_QUEUE,
+                retry_policy=common.RetryPolicy(
+                    maximum_attempts=2,
+                    initial_interval=timedelta(minutes=1),
+                ),
             )
         )
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 from typing import Optional, cast
 from uuid import uuid4
 
@@ -20,6 +21,7 @@ from django.utils import timezone
 
 from flaky import flaky
 from rest_framework import status
+from temporalio import common
 
 import posthog.models.person.deletion
 from posthog.clickhouse.client import sync_execute
@@ -409,6 +411,13 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                     ),
                     id=f"delete-recordings-with-person-{person.uuid}-1234",
                     task_queue=SESSION_REPLAY_TASK_QUEUE,
+                    retry_policy=common.RetryPolicy(
+                        initial_interval=timedelta(seconds=60),
+                        backoff_coefficient=2.0,
+                        maximum_interval=None,
+                        maximum_attempts=2,
+                        non_retryable_error_types=None,
+                    ),
                 )
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
@@ -443,6 +452,13 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                     ),
                     id=f"delete-recordings-with-person-{person.uuid}-1234",
                     task_queue=SESSION_REPLAY_TASK_QUEUE,
+                    retry_policy=common.RetryPolicy(
+                        initial_interval=timedelta(seconds=60),
+                        backoff_coefficient=2.0,
+                        maximum_interval=None,
+                        maximum_attempts=2,
+                        non_retryable_error_types=None,
+                    ),
                 )
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)

--- a/posthog/temporal/delete_recordings/__init__.py
+++ b/posthog/temporal/delete_recordings/__init__.py
@@ -1,5 +1,6 @@
 from posthog.temporal.delete_recordings.activities import (
     delete_recording_blocks,
+    group_recording_blocks,
     load_recording_blocks,
     load_recordings_with_person,
 )
@@ -14,4 +15,5 @@ ACTIVITIES = [
     load_recording_blocks,
     delete_recording_blocks,
     load_recordings_with_person,
+    group_recording_blocks,
 ]

--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -108,7 +108,7 @@ async def group_recording_blocks(input: RecordingWithBlocks) -> list[list[Record
             base_key = urlunparse((scheme, netloc, path, None, None, None))
             block_map[base_key].append(block)
 
-        block_groups: list[list[RecordingBlock]] = block_map.values()
+        block_groups: list[list[RecordingBlock]] = list(block_map.values())
 
         logger.info(f"Grouped {block_count} blocks into {len(block_groups)} groups")
         return block_groups

--- a/posthog/temporal/delete_recordings/types.py
+++ b/posthog/temporal/delete_recordings/types.py
@@ -4,14 +4,14 @@ from posthog.session_recordings.session_recording_v2_service import RecordingBlo
 
 
 @dataclass(frozen=True)
-class RecordingInput:
+class Recording:
     session_id: str
     team_id: int
 
 
 @dataclass(frozen=True)
-class DeleteRecordingBlocksInput:
-    recording: RecordingInput
+class RecordingWithBlocks:
+    recording: Recording
     blocks: list[RecordingBlock]
 
 

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 import structlog
 from asgiref.sync import async_to_sync
+from temporalio import common
 from temporalio.client import (
     Client,
     Schedule,
@@ -167,6 +168,9 @@ async def create_enforce_max_replay_retention_schedule(client: Client):
             EnforceMaxReplayRetentionInput(dry_run=False),
             id="enforce-max-replay-retention-schedule",
             task_queue=SESSION_REPLAY_TASK_QUEUE,
+            retry_policy=common.RetryPolicy(
+                maximum_attempts=1,
+            ),
         ),
         spec=ScheduleSpec(
             calendars=[

--- a/posthog/temporal/tests/delete_recordings/test_workflows.py
+++ b/posthog/temporal/tests/delete_recordings/test_workflows.py
@@ -10,11 +10,8 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
 from posthog.session_recordings.session_recording_v2_service import RecordingBlock
-from posthog.temporal.delete_recordings.types import (
-    DeleteRecordingBlocksInput,
-    RecordingInput,
-    RecordingsWithPersonInput,
-)
+from posthog.temporal.delete_recordings.activities import group_recording_blocks
+from posthog.temporal.delete_recordings.types import Recording, RecordingsWithPersonInput, RecordingWithBlocks
 from posthog.temporal.delete_recordings.workflows import DeleteRecordingsWithPersonWorkflow, DeleteRecordingWorkflow
 
 
@@ -27,27 +24,37 @@ async def test_delete_recording_workflow():
             RecordingBlock(
                 start_time=datetime.now(),
                 end_time=datetime.now() + timedelta(hours=3),
-                url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6",
+                url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6?range=bytes=12269307-12294780",
             ),
             RecordingBlock(
                 start_time=datetime.now() + timedelta(hours=4),
                 end_time=datetime.now() + timedelta(hours=6),
-                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a",
+                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=81788204-81793010",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() + timedelta(hours=4),
+                end_time=datetime.now() + timedelta(hours=6),
+                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=2790658-2800843",
             ),
         ],
     }
 
+    EXPECTED_GROUPS = [
+        [TEST_SESSIONS[TEST_SESSION_ID][0]],
+        [TEST_SESSIONS[TEST_SESSION_ID][1], TEST_SESSIONS[TEST_SESSION_ID][2]],
+    ]
+
     @activity.defn(name="load-recording-blocks")
-    async def load_recording_blocks_mocked(input: RecordingInput) -> list[RecordingBlock]:
+    async def load_recording_blocks_mocked(input: Recording) -> list[RecordingBlock]:
         assert input.session_id == TEST_SESSION_ID
         assert input.team_id == TEST_TEAM_ID
         return TEST_SESSIONS[TEST_SESSION_ID]
 
     @activity.defn(name="delete-recording-blocks")
-    async def delete_recording_blocks_mocked(input: DeleteRecordingBlocksInput) -> None:
+    async def delete_recording_blocks_mocked(input: RecordingWithBlocks) -> None:
         assert input.recording.session_id == TEST_SESSION_ID
         assert input.recording.team_id == TEST_TEAM_ID
-        assert input.blocks == TEST_SESSIONS[TEST_SESSION_ID]
+        assert input.blocks in EXPECTED_GROUPS
         TEST_SESSIONS[input.recording.session_id] = []  # Delete recording blocks
 
     task_queue_name = str(uuid.uuid4())
@@ -56,12 +63,12 @@ async def test_delete_recording_workflow():
             env.client,
             task_queue=task_queue_name,
             workflows=[DeleteRecordingWorkflow],
-            activities=[load_recording_blocks_mocked, delete_recording_blocks_mocked],
+            activities=[load_recording_blocks_mocked, delete_recording_blocks_mocked, group_recording_blocks],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
             await env.client.execute_workflow(
                 DeleteRecordingWorkflow.run,
-                RecordingInput(session_id=TEST_SESSION_ID, team_id=TEST_TEAM_ID),
+                Recording(session_id=TEST_SESSION_ID, team_id=TEST_TEAM_ID),
                 id=str(uuid.uuid4()),
                 task_queue=task_queue_name,
             )
@@ -79,37 +86,62 @@ async def test_delete_recording_with_person_workflow():
             RecordingBlock(
                 start_time=datetime.now(),
                 end_time=datetime.now() + timedelta(hours=3),
-                url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6",
+                url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6?range=bytes=12269307-12294780",
             ),
             RecordingBlock(
                 start_time=datetime.now() + timedelta(hours=4),
                 end_time=datetime.now() + timedelta(hours=6),
-                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a",
+                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=81788204-81793010",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() + timedelta(hours=4),
+                end_time=datetime.now() + timedelta(hours=6),
+                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=2790658-2800843",
             ),
         ],
         "791244f2-2569-4ed9-a448-d5a6e35471cd": [
             RecordingBlock(
                 start_time=datetime.now(),
                 end_time=datetime.now() + timedelta(hours=10),
-                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994",
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=12269307-12294780",
             ),
             RecordingBlock(
                 start_time=datetime.now() + timedelta(hours=12),
                 end_time=datetime.now() + timedelta(hours=14),
-                url="s3://test_bucket/session_recordings/90d/1756117702805-183ced947c057852",
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=81788204-81793010",
             ),
         ],
         "3d2b505b-3a0e-48fd-89ab-6eb65a08e915": [
             RecordingBlock(
                 start_time=datetime.now(),
                 end_time=datetime.now() + timedelta(hours=23),
-                url="s3://test_bucket/session_recordings/30d/1756117708699-28b991ee5019274d",
+                url="s3://test_bucket/session_recordings/30d/1756117708699-28b991ee5019274d?range=bytes=81788204-81793010",
             ),
             RecordingBlock(
                 start_time=datetime.now() + timedelta(hours=24),
                 end_time=datetime.now() + timedelta(hours=26),
-                url="s3://test_bucket/session_recordings/30d/1756117711878-61ed9e32ebf3e27a",
+                url="s3://test_bucket/session_recordings/30d/1756117711878-61ed9e32ebf3e27a?range=bytes=2790658-2800843",
             ),
+        ],
+    }
+
+    EXPECTED_GROUPS = {
+        "1c6c32da-0518-4a83-a513-eb2595c33b66": [
+            [TEST_SESSIONS["1c6c32da-0518-4a83-a513-eb2595c33b66"][0]],
+            [
+                TEST_SESSIONS["1c6c32da-0518-4a83-a513-eb2595c33b66"][1],
+                TEST_SESSIONS["1c6c32da-0518-4a83-a513-eb2595c33b66"][2],
+            ],
+        ],
+        "791244f2-2569-4ed9-a448-d5a6e35471cd": [
+            [
+                TEST_SESSIONS["791244f2-2569-4ed9-a448-d5a6e35471cd"][0],
+                TEST_SESSIONS["791244f2-2569-4ed9-a448-d5a6e35471cd"][1],
+            ],
+        ],
+        "3d2b505b-3a0e-48fd-89ab-6eb65a08e915": [
+            [TEST_SESSIONS["3d2b505b-3a0e-48fd-89ab-6eb65a08e915"][0]],
+            [TEST_SESSIONS["3d2b505b-3a0e-48fd-89ab-6eb65a08e915"][1]],
         ],
     }
 
@@ -120,16 +152,16 @@ async def test_delete_recording_with_person_workflow():
         return list(TEST_SESSIONS.keys())
 
     @activity.defn(name="load-recording-blocks")
-    async def load_recording_blocks_mocked(input: RecordingInput) -> list[RecordingBlock]:
+    async def load_recording_blocks_mocked(input: Recording) -> list[RecordingBlock]:
         assert input.session_id in TEST_SESSIONS
         assert input.team_id == TEST_TEAM_ID
         return TEST_SESSIONS[input.session_id]
 
     @activity.defn(name="delete-recording-blocks")
-    async def delete_recording_blocks_mocked(input: DeleteRecordingBlocksInput) -> None:
+    async def delete_recording_blocks_mocked(input: RecordingWithBlocks) -> None:
         assert input.recording.session_id in TEST_SESSIONS
         assert input.recording.team_id == TEST_TEAM_ID
-        assert input.blocks == TEST_SESSIONS[input.recording.session_id]
+        assert input.blocks in EXPECTED_GROUPS[input.recording.session_id]
         TEST_SESSIONS[input.recording.session_id] = []  # Delete recording blocks
 
     task_queue_name = str(uuid.uuid4())
@@ -142,6 +174,7 @@ async def test_delete_recording_with_person_workflow():
                 load_recording_blocks_mocked,
                 delete_recording_blocks_mocked,
                 load_recordings_with_person_mocked,
+                group_recording_blocks,
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):


### PR DESCRIPTION
We group by base key to avoid multiple deletes attempting to zero out parts of a file at the same time.