### PR TITLE
chore(messaging): enable SES-backed email in messaging

### DIFF
--- a/products/messaging/frontend/Campaigns/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/messaging/frontend/Campaigns/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -14,16 +14,15 @@ import { useHogFlowStep } from '../steps/HogFlowSteps'
 import { HogFlowAction } from '../types'
 
 export const ACTION_NODES_TO_SHOW: CreateActionType[] = [
-    // TODO: Re-enable email action once we have full SES support
-    // {
-    //     type: 'function_email',
-    //     name: 'Email',
-    //     description: 'Send an email to the user.',
-    //     config: {
-    //         template_id: 'template-email',
-    //         inputs: {},
-    //     },
-    // },
+    {
+        type: 'function_email',
+        name: 'Email',
+        description: 'Send an email to the user.',
+        config: {
+            template_id: 'template-email',
+            inputs: {},
+        },
+    },
     {
         type: 'function_sms',
         name: 'SMS',

--- a/products/messaging/frontend/Channels/EmailSetup/emailSetupModalLogic.ts
+++ b/products/messaging/frontend/Channels/EmailSetup/emailSetupModalLogic.ts
@@ -42,7 +42,7 @@ export const emailSetupModalLogic = kea<emailSetupModalLogicType>([
     forms(({ actions }) => ({
         emailSender: {
             defaults: {
-                provider: 'mailjet',
+                provider: 'ses',
                 email: '',
                 name: '',
             } as EmailSenderFormType,

--- a/products/messaging/frontend/Channels/MessageChannels.tsx
+++ b/products/messaging/frontend/Channels/MessageChannels.tsx
@@ -3,7 +3,6 @@ import { useActions, useValues } from 'kea'
 import { LemonSkeleton } from '@posthog/lemon-ui'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { EmailIntegrationsList } from 'lib/integrations/EmailIntegrationsList'
 import { IntegrationsList } from 'lib/integrations/IntegrationsList'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -17,7 +16,6 @@ export function MessageChannels(): JSX.Element {
     const { setupModalOpen, integrations, integrationsLoading, setupModalType, selectedIntegration } =
         useValues(integrationsLogic)
     const { openSetupModal, closeSetupModal } = useActions(integrationsLogic)
-    const hasMessagingSesFeatureFlag = useFeatureFlag('MESSAGING_SES')
 
     const allMessagingIntegrations =
         integrations?.filter((integration) => MESSAGING_CHANNEL_TYPES.includes(integration.kind as ChannelType)) ?? []
@@ -51,7 +49,7 @@ export function MessageChannels(): JSX.Element {
                         isEmpty
                     />
                 )}
-                {hasMessagingSesFeatureFlag && <EmailIntegrationsList />}
+                <EmailIntegrationsList />
                 <IntegrationsList titleText="" onlyKinds={MESSAGING_CHANNEL_TYPES.filter((type) => type !== 'email')} />
             </div>
         </>

--- a/products/messaging/frontend/MessagingScene.tsx
+++ b/products/messaging/frontend/MessagingScene.tsx
@@ -93,7 +93,6 @@ export function MessagingScene(): JSX.Element {
     const { openNewCategoryModal } = useActions(optOutCategoriesLogic)
 
     const hasMessagingFeatureFlag = useFeatureFlag('MESSAGING')
-    const hasMessagingSesFeatureFlag = useFeatureFlag('MESSAGING_SES')
 
     if (!hasMessagingFeatureFlag) {
         return (
@@ -107,16 +106,15 @@ export function MessagingScene(): JSX.Element {
     }
 
     const newChannelMenuItems: LemonMenuItems = [
-        hasMessagingSesFeatureFlag
-            ? {
-                  label: (
-                      <div className="flex gap-1 items-center">
-                          <IconLetter /> Email
-                      </div>
-                  ),
-                  onClick: () => openSetupModal(undefined, 'email'),
-              }
-            : null,
+        {
+            label: (
+                <div className="flex gap-1 items-center">
+                    <IconLetter /> Email
+                </div>
+            ),
+            onClick: () => openSetupModal(undefined, 'email'),
+        },
+
         {
             label: (
                 <div className="flex gap-1 items-center">
@@ -137,7 +135,7 @@ export function MessagingScene(): JSX.Element {
             ),
             onClick: () => openSetupModal(undefined, 'twilio'),
         },
-    ].filter(Boolean)
+    ]
 
     const tabs: LemonTab<MessagingSceneTab>[] = [
         {
@@ -150,18 +148,16 @@ export function MessagingScene(): JSX.Element {
                 </>
             ),
         },
-        hasMessagingSesFeatureFlag
-            ? {
-                  label: 'Library',
-                  key: 'library',
-                  content: (
-                      <>
-                          <p>Create and manage messages</p>
-                          <MessageTemplatesTable />
-                      </>
-                  ),
-              }
-            : null,
+        {
+            label: 'Library',
+            key: 'library',
+            content: (
+                <>
+                    <p>Create and manage messages</p>
+                    <MessageTemplatesTable />
+                </>
+            ),
+        },
         {
             label: 'Channels',
             key: 'channels',
@@ -172,7 +168,7 @@ export function MessagingScene(): JSX.Element {
             key: 'opt-outs',
             content: <OptOutScene />,
         },
-    ].filter(Boolean) as LemonTab<MessagingSceneTab>[]
+    ]
 
     return (
         <SceneContent className="messaging">


### PR DESCRIPTION
## Problem

This PR is basically a revert of https://github.com/PostHog/posthog/pull/38938/files

## Changes

- Show native email action in workflow editor
- Show email in the "Channels" tab
- Show Templates tab again

## How did you test this code?

Ensured features showing back up as expected locally