### PR TITLE
fix: copy assets on configure server instead of build start

### DIFF
--- a/frontend/vite-public-assets-plugin.ts
+++ b/frontend/vite-public-assets-plugin.ts
@@ -108,7 +108,8 @@ function copyPublicAssets(): void {
 export function publicAssetsPlugin(): Plugin {
     return {
         name: 'public-assets-copy',
-        buildStart() {
+        configureServer() {
+            // Copy assets when dev server starts
             deleteAssetsFiles()
             copyPublicAssets()
         },


### PR DESCRIPTION
## Problem
Vite was copying assets only on `build`... we don't use `build`, so this meant new devs/ installs weren't getting assets correctly. I'm not sure if this truly fixes @pauldambra's issue, but let's try it.
 
## Changes
Move vite copy assets function to run on server start (not build)

## How did you test this code?
Ran dev server, assets copied successfully 