### PR TITLE
feat(migration-analysis): add info message when skipping operations on new tables

### DIFF
--- a/posthog/management/migration_analysis/analyzer.py
+++ b/posthog/management/migration_analysis/analyzer.py
@@ -88,6 +88,13 @@ class RiskAnalyzer:
         # Check PostHog policies
         policy_violations = self.check_policies(migration)
 
+        # Build info messages
+        info_messages = []
+        if self.newly_created_models:
+            info_messages.append(
+                "ℹ️  Skipped operations on newly created tables (empty tables don't cause lock contention)."
+            )
+
         return MigrationRisk(
             path=path,
             app=migration.app_label,
@@ -95,6 +102,7 @@ class RiskAnalyzer:
             operations=operation_risks,
             combination_risks=combination_risks,
             policy_violations=policy_violations,
+            info_messages=info_messages,
         )
 
     def _is_safe_on_new_table(self, op, risk: OperationRisk) -> bool:

--- a/posthog/management/migration_analysis/formatters.py
+++ b/posthog/management/migration_analysis/formatters.py
@@ -90,6 +90,10 @@ class ConsoleTreeFormatter(RiskFormatter):
         for idx, op_risk in enumerate(risk.operations):
             lines.extend(self._format_operation(idx, op_risk, risk))
 
+        # Format info messages
+        if risk.info_messages:
+            lines.extend(self._format_info_messages(risk.info_messages))
+
         # Format policy violations
         if risk.policy_violations:
             lines.extend(self._format_policy_violations(risk.policy_violations))
@@ -136,6 +140,18 @@ class ConsoleTreeFormatter(RiskFormatter):
             lines.append(f"{prefix}   {details_str}")
         else:
             lines.append(f"{prefix}└─ {op_number} {icon} {op_risk.type}: {op_risk.reason}")
+
+        return lines
+
+    def _format_info_messages(self, messages: list[str]) -> list[str]:
+        """Format informational messages."""
+        lines = []
+        lines.append("  │")
+        lines.append("  └──> ℹ️  INFO:")
+
+        for message in messages:
+            wrapped = textwrap.fill(message, width=72, initial_indent="       ", subsequent_indent="       ")
+            lines.append(wrapped)
 
         return lines
 

--- a/posthog/management/migration_analysis/models.py
+++ b/posthog/management/migration_analysis/models.py
@@ -48,6 +48,7 @@ class MigrationRisk:
     operations: list[OperationRisk]
     combination_risks: list[str] = field(default_factory=list)
     policy_violations: list[str] = field(default_factory=list)  # PostHog-specific coding policies
+    info_messages: list[str] = field(default_factory=list)  # Informational messages (not warnings)
 
     @property
     def max_score(self) -> int:

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -803,6 +803,9 @@ class TestCombinationRisks:
         assert migration_risk.operations[0].type == "CreateModel"
         assert migration_risk.level == RiskLevel.SAFE
         assert len(migration_risk.combination_risks) == 0
+        # Should have info message about skipped operations
+        assert len(migration_risk.info_messages) == 1
+        assert "Skipped operations on newly created tables" in migration_risk.info_messages[0]
 
     def test_create_model_with_add_constraint_safe(self):
         """AddConstraint on newly created table should be filtered out (safe, not shown in PR)"""


### PR DESCRIPTION
## Problem

When AddIndex/AddConstraint operations are skipped on newly created tables (implemented in #39354), there's no transparency about what happened. Reviewers might wonder why indexes/constraints don't appear in the PR comment.

## Solution

Add informational message when operations are skipped on newly created tables:

```
ℹ️  Skipped operations on newly created tables (empty tables don't cause lock contention).
```

Follows existing architectural pattern (like `combination_risks` and `policy_violations`) by adding `info_messages` field to `MigrationRisk` model.

## Changes

- Add `info_messages` field to MigrationRisk dataclass
- Set info message in `analyze_migration()` when newly created models exist
- Display info messages in formatter (after operations, before warnings)
- Add test to verify info message appears

## Example Output

```
posthog.0874_add_schema_models
  │  └─ #1 ✅ CreateModel: Creating new table is safe
  │     model: SchemaPropertyGroup
  │  └─ #2 ✅ CreateModel: Creating new table is safe
  │     model: EventSchema
  │
  └──> ℹ️  INFO:
       ℹ️  Skipped operations on newly created tables (empty tables 
       don't cause lock contention).
```

## Test plan

All 52 tests pass including new test verifying info message appears.