### PR TITLE
fix(person): Fix person splitting not showing results

### DIFF
--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -886,6 +886,121 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             matching_row = next(row for row in pdis2 if row[0] == person.uuid)
             self.assertEqual(matching_row, (person.uuid, person.distinct_ids[0], 0))
 
+    def test_split_person_overrides_delete_version(self):
+        """
+        Test that split person correctly sets version to override deleted persons.
+
+        When a person is deleted, the delete event uses version + 100 (e.g., version 100).
+        When splitting, the new person should use version + 101 (e.g., version 101) to ensure
+        ClickHouse sees the split person as more recent than the delete event.
+        """
+        from posthog.models.person.missing_person import uuidFromDistinctId
+        from posthog.models.person.util import delete_person
+
+        # Create person A with UUID derived from the distinct_id (same UUID that split will use)
+        person_a_uuid = uuidFromDistinctId(self.team.pk, "deleted_user")
+        person_a = Person.objects.create(
+            team=self.team,
+            uuid=person_a_uuid,
+            version=0,
+        )
+        PersonDistinctId.objects.create(
+            team=self.team,
+            person=person_a,
+            distinct_id="deleted_user",
+            version=0,
+        )
+        create_person(
+            team_id=self.team.pk,
+            uuid=str(person_a.uuid),
+            version=0,
+            sync=True,
+        )
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="deleted_user",
+            person_id=str(person_a.uuid),
+            version=0,
+            sync=True,
+        )
+
+        # Delete person A (this creates a delete event with version 100 = 0 + 100)
+        delete_person(person_a, sync=True)
+        person_a.delete()
+
+        # Create person B with a different distinct_id (will also have version 0 by default)
+        person_b = _create_person(
+            team=self.team,
+            distinct_ids=["active_user"],
+            immediate=True,
+        )
+
+        # Manually add the deleted distinct_id to person B (simulating a merge scenario)
+        # This would happen in a real scenario where events come in for the deleted distinct_id
+        PersonDistinctId.objects.create(
+            team=self.team,
+            person=person_b,
+            distinct_id="deleted_user",
+            version=2,
+        )
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="deleted_user",
+            person_id=str(person_b.uuid),
+            version=2,
+            sync=True,
+        )
+
+        # Now person_b has both "active_user" and "deleted_user"
+        person_b.refresh_from_db()
+        self.assertEqual(set(person_b.distinct_ids), {"active_user", "deleted_user"})
+
+        # Split person B
+        response = self.client.post("/api/person/{}/split/".format(person_b.uuid)).json()
+        self.assertTrue(response["success"])
+
+        # Verify ClickHouse has the correct state
+        ch_persons = sync_execute(
+            """
+            SELECT id, version, is_deleted
+            FROM person
+            FINAL
+            WHERE team_id = %(team_id)s AND id IN (
+                SELECT DISTINCT person_id
+                FROM person_distinct_id2
+                FINAL
+                WHERE team_id = %(team_id)s AND distinct_id = 'deleted_user'
+            )
+            ORDER BY version DESC
+            """,
+            {"team_id": self.team.pk},
+        )
+
+        # Should have exactly one person (the split creates a new one with version 101)
+        self.assertEqual(len(ch_persons), 1)
+        _, version, is_deleted = ch_persons[0]
+
+        # The split person should have version 101 (person_b version 0 + 101)
+        # which is higher than the delete version 100 (person_a version 0 + 100)
+        self.assertEqual(version, 101)
+        self.assertEqual(is_deleted, 0)
+
+        # Verify person_distinct_id2 for the deleted_user distinct_id
+        ch_pdis = sync_execute(
+            """
+            SELECT person_id, distinct_id, version, is_deleted
+            FROM person_distinct_id2
+            FINAL
+            WHERE team_id = %(team_id)s AND distinct_id = 'deleted_user'
+            """,
+            {"team_id": self.team.pk},
+        )
+
+        self.assertEqual(len(ch_pdis), 1)
+        _, pdi_distinct_id, _, pdi_is_deleted = ch_pdis[0]
+        self.assertEqual(pdi_distinct_id, "deleted_user")
+        self.assertEqual(pdi_is_deleted, 0)
+
     @freeze_time("2021-08-25T22:09:14.252Z")
     def test_patch_user_property_activity(self):
         person = _create_person(

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -106,11 +106,16 @@ class Person(models.Model):
                         uuid=uuidFromDistinctId(self.team_id, distinct_id),
                         team_id=self.team_id,
                         defaults={
-                            "version": original_person_version + 1,
+                            # Set version higher than delete events (which use version + 100).
+                            # Keep in sync with: posthog/models/person/util.py:222 (_delete_person)
+                            # and plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
+                            "version": original_person_version + 101,
                         },
                     )
                     pdi.person_id = str(person.id)
-                    pdi.version = (pdi.version or 0) + 1
+                    # Set distinct_id version higher than delete events (which use pdi.version + 100).
+                    # This ensures the split distinct_id overrides any deleted distinct_id.
+                    pdi.version = (pdi.version or 0) + 101
                     pdi.save(update_fields=["version", "person_id"])
 
                 from posthog.models.person.util import create_person, create_person_distinct_id

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -219,7 +219,11 @@ def _delete_person(
     create_person(
         uuid=str(uuid),
         team_id=team_id,
-        version=version + 100,  # keep in sync with deletePerson in plugin-server/src/utils/db/db.ts
+        # Version + 100 ensures delete takes precedence over normal updates.
+        # Keep in sync with:
+        # - plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
+        # - posthog/models/person/person.py:112 (split_person uses version + 101 to override deletes)
+        version=version + 100,
         created_at=created_at,
         is_deleted=True,
         sync=sync,


### PR DESCRIPTION
> [!NOTE]
> I personally don't like this solution for the issue, but it works and it's safe and allows us to have the split person functionality running until we address the tech debt created by the solutions implemented to deal with race conditions between updates from the plugin-server and Django concerning person deletions

## Problem

When splitting persons that were previously merged, the split persons incorrectly appear as deleted in ClickHouse queries. This happens due to an interaction between person merging, deletion, and splitting logic.

### Background

When persons are deleted (including during merge operations), we use `version + 100` for both the person and distinct_id records ([introduced in #10688](https://github.com/PostHog/posthog/pull/10688) to address [#10538](https://github.com/PostHog/posthog/issues/10538)). This ensures delete operations take precedence over concurrent normal updates.

 ### Reproduction Steps

  1. **Initial state**: 3 separate persons
     - `user_001` → Person(uuid_1, version=0)
     - `user_002` → Person(uuid_2, version=0)
     - `user_003` → Person(uuid_3, version=0)

  2. **After merging all into uuid_1**:
     - uuid_1: version=50, is_deleted=0 (after updates)
     - uuid_2: version=**100**, is_deleted=**1** (deleted with version + 100)
     - uuid_3: version=**100**, is_deleted=**1** (deleted with version + 100)

  3. **After splitting the merged person**:
     - uuid_2 gets recreated with version=**51**, is_deleted=0
     - But ClickHouse FINAL sees version 100 (deleted) as more recent than version 51 (active)

This means split persons don't appear in query results because ClickHouse's `argMax(*, version)` picks the deleted record (version 100) over the split record (version 51).

## Solution

This PR fixes Bug #1 by ensuring split persons use `version + 101` for both person and distinct_id records, making them always appear more recent than delete records (version + 100). 

$\color{Red}\Huge{\textbf{Important}}$: While the previous solution only impacted the version on the kafka topic, this PR changes the postgres data, minimizing discrepancies between postgres and CH data.

 ### Changes

  - **Person version**: `original_person_version + 101` (was `+ 1`)
  - **Distinct ID version**: `(pdi.version or 0) + 101` (was `+ 1`)
  - Added cross-reference comments between delete and split code
  - Added comprehensive test `test_split_person_overrides_delete_version`

  ## Technical Debt Notice

 **This is a workaround on top of an existing workaround**. The version + 100 pattern was itself introduced as a hack to handle race conditions during deletion. Now we're adding version + 101 to override that.

  **This approach is fragile** because:
  - It relies on magic number offsets (+100, +101) that are easy to break
  - It does not solve the core issue, which is that deletion is adding 100 to the version when generating a kafka message creating a drift between Postgres and CH

  For now, this unblocks the immediate issue, but **we should create a follow-up ticket to redesign this properly**.

  ## Testing

  - All existing person split tests pass
  - New test validates split overrides delete in ClickHouse
  - Verified persons appear correctly after split operations
