### PR TITLE
feat: Move condition sets while calculating

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -320,6 +320,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_UNIFIED_CREATE_FORM: 'experiments-unified-create-form', // owner: @rodrigoi #team-experiments
     TARGETED_PRODUCT_UPSELL: 'targeted-product-upsell', // owner: @raquelmsmith
     COHORT_CALCULATION_HISTORY: 'cohort-calculation-history', // owner: @gustavo #team-feature-flags
+    FEATURE_FLAG_MOVE_CONDITIONS_WHILE_CALCULATING: 'feature-flag-move-conditions-while-calculating', // owner: @luke-belton #team-support
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -320,7 +320,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_UNIFIED_CREATE_FORM: 'experiments-unified-create-form', // owner: @rodrigoi #team-experiments
     TARGETED_PRODUCT_UPSELL: 'targeted-product-upsell', // owner: @raquelmsmith
     COHORT_CALCULATION_HISTORY: 'cohort-calculation-history', // owner: @gustavo #team-feature-flags
-    FEATURE_FLAG_MOVE_CONDITIONS_WHILE_CALCULATING: 'feature-flag-move-conditions-while-calculating', // owner: @luke-belton #team-support
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -13,9 +13,7 @@ import { EditableField } from 'lib/components/EditableField/EditableField'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { INSTANTLY_AVAILABLE_PROPERTIES } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
 import { GroupsAccessStatus, groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -131,7 +129,6 @@ export function FeatureFlagReleaseConditions({
         useValues(featureFlagLogic)
 
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
-    const canMoveConditionsWhileCalculating = useFeatureFlag('FEATURE_FLAG_MOVE_CONDITIONS_WHILE_CALCULATING')
 
     const featureFlagVariants = nonEmptyFeatureFlagVariants || nonEmptyVariants
 
@@ -202,11 +199,7 @@ export function FeatureFlagReleaseConditions({
                                             disabledReason={
                                                 index === filterGroups.length - 1
                                                     ? 'Cannot move last condition set down'
-                                                    : !canMoveConditionsWhileCalculating &&
-                                                        (affectedUsers[index] === undefined ||
-                                                            affectedUsers[index + 1] === undefined)
-                                                      ? 'Cannot move condition sets while calculating affected users'
-                                                      : null
+                                                    : null
                                             }
                                             onClick={() => moveConditionSetDown(index)}
                                         />
@@ -215,15 +208,7 @@ export function FeatureFlagReleaseConditions({
                                             icon={<IconArrowUp />}
                                             noPadding
                                             tooltip="Move condition set up in precedence"
-                                            disabledReason={
-                                                index === 0
-                                                    ? 'Cannot move first condition set up'
-                                                    : !canMoveConditionsWhileCalculating &&
-                                                        (affectedUsers[index] === undefined ||
-                                                            affectedUsers[index - 1] === undefined)
-                                                      ? 'Cannot move condition sets while calculating affected users'
-                                                      : null
-                                            }
+                                            disabledReason={index === 0 ? 'Cannot move first condition set up' : null}
                                             onClick={() => moveConditionSetUp(index)}
                                         />
                                     </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -13,7 +13,9 @@ import { EditableField } from 'lib/components/EditableField/EditableField'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { INSTANTLY_AVAILABLE_PROPERTIES } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
 import { GroupsAccessStatus, groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -129,6 +131,7 @@ export function FeatureFlagReleaseConditions({
         useValues(featureFlagLogic)
 
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
+    const canMoveConditionsWhileCalculating = useFeatureFlag('FEATURE_FLAG_MOVE_CONDITIONS_WHILE_CALCULATING')
 
     const featureFlagVariants = nonEmptyFeatureFlagVariants || nonEmptyVariants
 
@@ -199,8 +202,9 @@ export function FeatureFlagReleaseConditions({
                                             disabledReason={
                                                 index === filterGroups.length - 1
                                                     ? 'Cannot move last condition set down'
-                                                    : affectedUsers[index] === undefined ||
-                                                        affectedUsers[index + 1] === undefined
+                                                    : !canMoveConditionsWhileCalculating &&
+                                                        (affectedUsers[index] === undefined ||
+                                                            affectedUsers[index + 1] === undefined)
                                                       ? 'Cannot move condition sets while calculating affected users'
                                                       : null
                                             }
@@ -214,8 +218,9 @@ export function FeatureFlagReleaseConditions({
                                             disabledReason={
                                                 index === 0
                                                     ? 'Cannot move first condition set up'
-                                                    : affectedUsers[index] === undefined ||
-                                                        affectedUsers[index - 1] === undefined
+                                                    : !canMoveConditionsWhileCalculating &&
+                                                        (affectedUsers[index] === undefined ||
+                                                            affectedUsers[index - 1] === undefined)
                                                       ? 'Cannot move condition sets while calculating affected users'
                                                       : null
                                             }


### PR DESCRIPTION
## Problem

To [unblock a customer](https://posthog.slack.com/archives/C0386ASS3TN/p1760004130760669?thread_ts=1759922782.331509&cid=C0386ASS3TN), allow flag conditions to be moved even while the blast radius is calculating.