### PR TITLE
fix(myke): send heartbeat for temporal workflows

### DIFF
--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -271,7 +271,9 @@ async def process_condition_batch_activity(inputs: ProcessConditionBatchInputs) 
                         ch_user=ClickHouseUser.COHORTS,
                         workload=Workload.OFFLINE,
                     )
-                    # Send heartbeat after database operation to prevent timeout
+
+                # Send heartbeat every 1000 conditions to prevent timeout
+                if idx % 1000 == 0:
                     temporalio.activity.heartbeat()
 
             except Exception as e:

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -271,6 +271,8 @@ async def process_condition_batch_activity(inputs: ProcessConditionBatchInputs) 
                         ch_user=ClickHouseUser.COHORTS,
                         workload=Workload.OFFLINE,
                     )
+                    # Send heartbeat after database operation to prevent timeout
+                    temporalio.activity.heartbeat()
 
             except Exception as e:
                 logger.exception(


### PR DESCRIPTION
## Problem

we are timing out due to not sending hearbeats

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

send heartbeats after clickhouse queries that take potentially longer

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
