### PR TITLE
fix: fewer snapshots at once maybe?

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
@@ -215,7 +215,7 @@ export const snapshotDataLogic = kea<snapshotDataLogicType>([
                     }) || []
 
                 if (nextSourcesToLoad.length > 0) {
-                    return actions.loadSnapshotsForSource(nextSourcesToLoad.slice(0, 30))
+                    return actions.loadSnapshotsForSource(nextSourcesToLoad.slice(0, 15))
                 }
 
                 if (!props.blobV2PollingDisabled) {

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -963,6 +963,9 @@ class SessionRecordingViewSet(
         with timer("get_recording"):
             recording: SessionRecording = self.get_object()
 
+        trace.get_current_span().set_attribute("team_id", self.team_id)
+        trace.get_current_span().set_attribute("session_id", str(recording.session_id))
+
         if not SessionReplayEvents().exists(session_id=str(recording.session_id), team=self.team):
             raise exceptions.NotFound("Recording not found")
 


### PR DESCRIPTION
let's do two things here

1) maybe very large recordings can't decompress 30 blocks at once, we don't let other people load more than 20, strip it back

2) let's tag snapshot traces more