### PR TITLE
feat(ux): Add searching persons to new tab scene

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -320,6 +320,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_UNIFIED_CREATE_FORM: 'experiments-unified-create-form', // owner: @rodrigoi #team-experiments
     TARGETED_PRODUCT_UPSELL: 'targeted-product-upsell', // owner: @raquelmsmith
     COHORT_CALCULATION_HISTORY: 'cohort-calculation-history', // owner: @gustavo #team-feature-flags
+    DATA_IN_NEW_TAB_SCENE: 'data-in-new-tab-scene', // owner: @adamleithp #team-platform-ux
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -243,7 +243,7 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                 return (
                                     <div
                                         className={cn('mb-8', {
-                                            'col-span-4': selectedCategory !== 'all',
+                                            'col-span-4': selectedCategory !== 'all' || specialSearchMode === 'person',
                                         })}
                                         key={category}
                                     >

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -42,6 +42,7 @@ const getCategoryDisplayName = (category: string): string => {
         'apps-tools': 'Apps / Tools',
         'data-management': 'Data management',
         recents: 'Recents',
+        persons: 'Persons',
     }
     return displayNames[category] || category
 }
@@ -112,7 +113,7 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                         <div className="flex justify-between items-center relative text-xs font-medium overflow-hidden py-1 px-1.5 border-x border-b rounded-b backdrop-blur-sm bg-[var(--glass-bg-3000)]">
                             {specialSearchMode === 'person' ? (
                                 <span>
-                                    <span className="text-tertiary">Search person by ID or email</span>
+                                    <span className="text-tertiary">Search persons by ID, email, or properties</span>
                                 </span>
                             ) : (
                                 <span>
@@ -121,9 +122,9 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                         <ButtonPrimitive
                                             size="xxs"
                                             className="text-xs"
-                                            onClick={() => setSearch('/person john')}
+                                            onClick={() => setSearch('/persons john')}
                                         >
-                                            /person john
+                                            /persons john
                                         </ButtonPrimitive>
                                     </ListBox.Item>
                                     <span className="text-tertiary">or</span>
@@ -259,7 +260,9 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                                         getCategoryDisplayName(category)
                                                     )}
                                                 </h3>
-                                                {category === 'recents' && isSearching && <Spinner size="small" />}
+                                                {(category === 'recents' || category === 'persons') && isSearching && (
+                                                    <Spinner size="small" />
+                                                )}
                                             </div>
                                             {(() => {
                                                 const categoryInfo = categories.find((c) => c.key === category)
@@ -273,94 +276,98 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                             })()}
                                         </div>
                                         <div className="flex flex-col gap-2">
-                                            {category === 'recents' && typedItems.length === 0 ? (
-                                                // Special handling for empty project items
+                                            {(category === 'recents' || category === 'persons') &&
+                                            typedItems.filter((item) => item.id !== 'persons-placeholder').length ===
+                                                0 ? (
+                                                // Special handling for empty project items and persons
                                                 <div className="flex flex-col gap-2 text-tertiary text-balance">
                                                     {isSearching ? 'Searching...' : 'No results found'}
                                                 </div>
                                             ) : (
-                                                typedItems.map((item, index) => (
-                                                    // If we have filtered results set virtual focus to first item
-                                                    <ButtonGroupPrimitive className="group w-full border-0">
-                                                        <ContextMenu>
-                                                            <ContextMenuTrigger asChild>
-                                                                <ListBox.Item
-                                                                    key={item.id}
-                                                                    asChild
-                                                                    focusFirst={
-                                                                        filteredItemsGrid.length > 0 &&
-                                                                        isFirstCategory &&
-                                                                        index === 0
-                                                                    }
-                                                                    row={index}
-                                                                    column={columnIndex}
-                                                                >
-                                                                    <Link
-                                                                        to={item.href || '#'}
-                                                                        className="w-full"
-                                                                        buttonProps={{
-                                                                            size: 'base',
-                                                                            hasSideActionRight: true,
-                                                                        }}
+                                                typedItems
+                                                    .filter((item) => item.id !== 'persons-placeholder')
+                                                    .map((item, index) => (
+                                                        // If we have filtered results set virtual focus to first item
+                                                        <ButtonGroupPrimitive className="group w-full border-0">
+                                                            <ContextMenu>
+                                                                <ContextMenuTrigger asChild>
+                                                                    <ListBox.Item
+                                                                        key={item.id}
+                                                                        asChild
+                                                                        focusFirst={
+                                                                            filteredItemsGrid.length > 0 &&
+                                                                            isFirstCategory &&
+                                                                            index === 0
+                                                                        }
+                                                                        row={index}
+                                                                        column={columnIndex}
                                                                     >
-                                                                        <span className="text-sm">
-                                                                            {item.icon ?? item.name[0]}
-                                                                        </span>
-                                                                        <span className="text-sm truncate text-primary">
-                                                                            {search ? (
-                                                                                <SearchHighlightMultiple
-                                                                                    string={item.name}
-                                                                                    substring={search}
-                                                                                />
-                                                                            ) : (
-                                                                                item.name
-                                                                            )}
-                                                                        </span>
-                                                                    </Link>
-                                                                </ListBox.Item>
-                                                            </ContextMenuTrigger>
-                                                            <ContextMenuContent loop className="max-w-[250px]">
-                                                                <ContextMenuGroup>
-                                                                    <MenuItems
-                                                                        item={convertToTreeDataItem(item)}
-                                                                        type="context"
-                                                                        root="project://"
-                                                                        onlyTree={false}
-                                                                        showSelectMenuOption={false}
-                                                                    />
-                                                                </ContextMenuGroup>
-                                                            </ContextMenuContent>
-                                                        </ContextMenu>
-                                                        <DropdownMenu>
-                                                            <DropdownMenuTrigger asChild>
-                                                                <ButtonPrimitive
-                                                                    size="xs"
-                                                                    iconOnly
-                                                                    isSideActionRight
-                                                                    className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
+                                                                        <Link
+                                                                            to={item.href || '#'}
+                                                                            className="w-full"
+                                                                            buttonProps={{
+                                                                                size: 'base',
+                                                                                hasSideActionRight: true,
+                                                                            }}
+                                                                        >
+                                                                            <span className="text-sm">
+                                                                                {item.icon ?? item.name[0]}
+                                                                            </span>
+                                                                            <span className="text-sm truncate text-primary">
+                                                                                {search ? (
+                                                                                    <SearchHighlightMultiple
+                                                                                        string={item.name}
+                                                                                        substring={search}
+                                                                                    />
+                                                                                ) : (
+                                                                                    item.displayName || item.name
+                                                                                )}
+                                                                            </span>
+                                                                        </Link>
+                                                                    </ListBox.Item>
+                                                                </ContextMenuTrigger>
+                                                                <ContextMenuContent loop className="max-w-[250px]">
+                                                                    <ContextMenuGroup>
+                                                                        <MenuItems
+                                                                            item={convertToTreeDataItem(item)}
+                                                                            type="context"
+                                                                            root="project://"
+                                                                            onlyTree={false}
+                                                                            showSelectMenuOption={false}
+                                                                        />
+                                                                    </ContextMenuGroup>
+                                                                </ContextMenuContent>
+                                                            </ContextMenu>
+                                                            <DropdownMenu>
+                                                                <DropdownMenuTrigger asChild>
+                                                                    <ButtonPrimitive
+                                                                        size="xs"
+                                                                        iconOnly
+                                                                        isSideActionRight
+                                                                        className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
+                                                                    >
+                                                                        <IconEllipsis className="size-3" />
+                                                                    </ButtonPrimitive>
+                                                                </DropdownMenuTrigger>
+                                                                <DropdownMenuContent
+                                                                    loop
+                                                                    align="end"
+                                                                    side="bottom"
+                                                                    className="max-w-[250px]"
                                                                 >
-                                                                    <IconEllipsis className="size-3" />
-                                                                </ButtonPrimitive>
-                                                            </DropdownMenuTrigger>
-                                                            <DropdownMenuContent
-                                                                loop
-                                                                align="end"
-                                                                side="bottom"
-                                                                className="max-w-[250px]"
-                                                            >
-                                                                <DropdownMenuGroup>
-                                                                    <MenuItems
-                                                                        item={convertToTreeDataItem(item)}
-                                                                        type="dropdown"
-                                                                        root="project://"
-                                                                        onlyTree={false}
-                                                                        showSelectMenuOption={false}
-                                                                    />
-                                                                </DropdownMenuGroup>
-                                                            </DropdownMenuContent>
-                                                        </DropdownMenu>
-                                                    </ButtonGroupPrimitive>
-                                                ))
+                                                                    <DropdownMenuGroup>
+                                                                        <MenuItems
+                                                                            item={convertToTreeDataItem(item)}
+                                                                            type="dropdown"
+                                                                            root="project://"
+                                                                            onlyTree={false}
+                                                                            showSelectMenuOption={false}
+                                                                        />
+                                                                    </DropdownMenuGroup>
+                                                                </DropdownMenuContent>
+                                                            </DropdownMenu>
+                                                        </ButtonGroupPrimitive>
+                                                    ))
                                             )}
                                         </div>
                                     </div>

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -1,8 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef } from 'react'
 
-import { IconEllipsis, IconSearch } from '@posthog/icons'
-import { Spinner } from '@posthog/lemon-ui'
+import { IconInfo, IconSearch } from '@posthog/icons'
 import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 
 import { SceneDashboardChoiceModal } from 'lib/components/SceneDashboardChoice/SceneDashboardChoiceModal'
@@ -10,28 +9,18 @@ import { sceneDashboardChoiceModalLogic } from 'lib/components/SceneDashboardCho
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
-import { Link } from 'lib/lemon-ui/Link'
-import { ButtonGroupPrimitive, ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { ContextMenu, ContextMenuContent, ContextMenuGroup, ContextMenuTrigger } from 'lib/ui/ContextMenu/ContextMenu'
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuTrigger,
-} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ListBox, ListBoxHandle } from 'lib/ui/ListBox/ListBox'
 import { TabsPrimitive, TabsPrimitiveList, TabsPrimitiveTrigger } from 'lib/ui/TabsPrimitive/TabsPrimitive'
-import { cn } from 'lib/utils/css-classes'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { NEW_TAB_CATEGORY_ITEMS, NewTabTreeDataItem, newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 
-import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
-import { MenuItems } from '~/layout/panel-layout/ProjectTree/menus/MenuItems'
 import { SidePanelTab } from '~/types'
 
+import { Results } from './components/Results'
 import { SearchHints } from './components/SearchHints'
 
 export const scene: SceneExport = {
@@ -39,7 +28,7 @@ export const scene: SceneExport = {
     logic: newTabSceneLogic,
 }
 
-const getCategoryDisplayName = (category: string): string => {
+export const getCategoryDisplayName = (category: string): string => {
     const displayNames: Record<string, string> = {
         'create-new': 'Create new',
         apps: 'Apps',
@@ -51,7 +40,7 @@ const getCategoryDisplayName = (category: string): string => {
 }
 
 // Helper function to convert NewTabTreeDataItem to TreeDataItem for menu usage
-function convertToTreeDataItem(item: NewTabTreeDataItem): TreeDataItem {
+export function convertToTreeDataItem(item: NewTabTreeDataItem): TreeDataItem {
     return {
         ...item,
         record: {
@@ -65,22 +54,12 @@ function convertToTreeDataItem(item: NewTabTreeDataItem): TreeDataItem {
 export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homepage' } = {}): JSX.Element {
     const inputRef = useRef<HTMLInputElement>(null)
     const listboxRef = useRef<ListBoxHandle>(null)
-    const {
-        filteredItemsGrid,
-        groupedFilteredItems,
-        search,
-        selectedItem,
-        categories,
-        selectedCategory,
-        isSearching,
-        specialSearchMode,
-        personSearchPagination,
-        personSearchResults,
-    } = useValues(newTabSceneLogic({ tabId }))
+    const { filteredItemsGrid, search, selectedItem, categories, selectedCategory, specialSearchMode } = useValues(
+        newTabSceneLogic({ tabId })
+    )
     const { mobileLayout } = useValues(navigationLogic)
     const { setQuestion, focusInput: focusMaxInput } = useActions(maxLogic)
     const { setSearch, setSelectedCategory } = useActions(newTabSceneLogic({ tabId }))
-    const newTabLogic = newTabSceneLogic({ tabId })
     const { openSidePanel } = useActions(sidePanelStateLogic)
     const { showSceneDashboardChoiceModal } = useActions(
         sceneDashboardChoiceModalLogic({ scene: Scene.ProjectHomepage })
@@ -178,19 +157,14 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                 innerClassName="pt-6"
                 styledScrollbars
             >
-                <div className="flex flex-col flex-1 max-w-[1200px] mx-auto w-full gap-4 px-3 @lg/main-content:px-8">
+                <div className="flex flex-col flex-1 max-w-[1200px] mx-auto w-full gap-4 px-4 @lg/main-content:px-8">
                     {filteredItemsGrid.length === 0 ? (
-                        <div className="flex flex-col gap-4">
-                            {selectedCategory === 'recents' ? (
-                                <div className="flex flex-col gap-2 text-center py-8">
-                                    <h3 className="text-lg font-medium text-muted">Search for project items</h3>
-                                    <p className="text-muted">
-                                        Try searching for cohorts, actions, experiments, dashboards, and more...
-                                    </p>
-                                </div>
-                            ) : (
-                                <div className="flex gap-1 items-center">
-                                    No results found,{' '}
+                        <div className="flex flex-col gap-4 px-2 py-2 bg-glass-bg-3000 rounded-lg">
+                            <div className="flex flex-col gap-1">
+                                <p className="text-tertiary mb-2">
+                                    <IconInfo /> No results found
+                                </p>
+                                <div className="flex gap-1">
                                     <ListBox.Item asChild className="list-none">
                                         <ButtonPrimitive size="sm" onClick={() => setSearch('')} variant="panel">
                                             Clear search
@@ -207,167 +181,11 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                         </ButtonPrimitive>
                                     </ListBox.Item>
                                 </div>
-                            )}
+                            </div>
                         </div>
                     ) : (
                         <div className="grid grid-cols-1 @md/main-content:grid-cols-2 @xl/main-content:grid-cols-3 @2xl/main-content:grid-cols-4 gap-4 group/colorful-product-icons colorful-product-icons-true">
-                            {Object.entries(groupedFilteredItems).map(([category, items], columnIndex) => {
-                                const typedItems = items as NewTabTreeDataItem[]
-                                const isFirstCategory = columnIndex === 0
-                                return (
-                                    <div
-                                        className={cn('mb-8', {
-                                            'col-span-4':
-                                                selectedCategory !== 'all' ||
-                                                (newTabSceneData && specialSearchMode === 'persons'),
-                                        })}
-                                        key={category}
-                                    >
-                                        <div className="mb-4">
-                                            <div className="flex items-baseline gap-2">
-                                                <h3 className="mb-0 text-lg font-medium text-secondary">
-                                                    {getCategoryDisplayName(category)}
-                                                </h3>
-                                                {newTabSceneData &&
-                                                    category === 'persons' &&
-                                                    personSearchResults.length > 0 && (
-                                                        <span className="text-xs text-tertiary">
-                                                            Showing first {personSearchResults.length} entries
-                                                        </span>
-                                                    )}
-                                                {(category === 'recents' ||
-                                                    (newTabSceneData && category === 'persons')) &&
-                                                    isSearching && <Spinner size="small" />}
-                                            </div>
-                                            {(() => {
-                                                const categoryInfo = categories.find((c) => c.key === category)
-                                                return (
-                                                    categoryInfo?.description && (
-                                                        <p className="text-xs text-tertiary mt-1 mb-0 min-h-8">
-                                                            {categoryInfo.description}
-                                                        </p>
-                                                    )
-                                                )
-                                            })()}
-                                        </div>
-                                        <div className="flex flex-col gap-2">
-                                            {(category === 'recents' || (newTabSceneData && category === 'persons')) &&
-                                            typedItems.filter((item) => item.id !== 'persons-placeholder').length ===
-                                                0 ? (
-                                                // Special handling for empty project items and persons
-                                                <div className="flex flex-col gap-2 text-tertiary text-balance">
-                                                    {isSearching ? 'Searching...' : 'No results found'}
-                                                </div>
-                                            ) : (
-                                                typedItems
-                                                    .filter((item) => item.id !== 'persons-placeholder')
-                                                    .map((item, index) => (
-                                                        // If we have filtered results set virtual focus to first item
-                                                        <ButtonGroupPrimitive className="group w-full border-0">
-                                                            <ContextMenu>
-                                                                <ContextMenuTrigger asChild>
-                                                                    <ListBox.Item
-                                                                        key={item.id}
-                                                                        asChild
-                                                                        focusFirst={
-                                                                            filteredItemsGrid.length > 0 &&
-                                                                            isFirstCategory &&
-                                                                            index === 0
-                                                                        }
-                                                                        row={index}
-                                                                        column={columnIndex}
-                                                                    >
-                                                                        <Link
-                                                                            to={item.href || '#'}
-                                                                            className="w-full"
-                                                                            buttonProps={{
-                                                                                size: 'base',
-                                                                                hasSideActionRight: true,
-                                                                            }}
-                                                                        >
-                                                                            <span className="text-sm">
-                                                                                {item.icon ?? item.name[0]}
-                                                                            </span>
-                                                                            <span className="text-sm truncate text-primary">
-                                                                                {search ? (
-                                                                                    <SearchHighlightMultiple
-                                                                                        string={item.name}
-                                                                                        substring={search}
-                                                                                    />
-                                                                                ) : (
-                                                                                    item.displayName || item.name
-                                                                                )}
-                                                                            </span>
-                                                                        </Link>
-                                                                    </ListBox.Item>
-                                                                </ContextMenuTrigger>
-                                                                <ContextMenuContent loop className="max-w-[250px]">
-                                                                    <ContextMenuGroup>
-                                                                        <MenuItems
-                                                                            item={convertToTreeDataItem(item)}
-                                                                            type="context"
-                                                                            root="project://"
-                                                                            onlyTree={false}
-                                                                            showSelectMenuOption={false}
-                                                                        />
-                                                                    </ContextMenuGroup>
-                                                                </ContextMenuContent>
-                                                            </ContextMenu>
-                                                            <DropdownMenu>
-                                                                <DropdownMenuTrigger asChild>
-                                                                    <ButtonPrimitive
-                                                                        size="xs"
-                                                                        iconOnly
-                                                                        isSideActionRight
-                                                                        className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
-                                                                    >
-                                                                        <IconEllipsis className="size-3" />
-                                                                    </ButtonPrimitive>
-                                                                </DropdownMenuTrigger>
-                                                                <DropdownMenuContent
-                                                                    loop
-                                                                    align="end"
-                                                                    side="bottom"
-                                                                    className="max-w-[250px]"
-                                                                >
-                                                                    <DropdownMenuGroup>
-                                                                        <MenuItems
-                                                                            item={convertToTreeDataItem(item)}
-                                                                            type="dropdown"
-                                                                            root="project://"
-                                                                            onlyTree={false}
-                                                                            showSelectMenuOption={false}
-                                                                        />
-                                                                    </DropdownMenuGroup>
-                                                                </DropdownMenuContent>
-                                                            </DropdownMenu>
-                                                        </ButtonGroupPrimitive>
-                                                    ))
-                                            )}
-                                            {newTabSceneData &&
-                                                category === 'persons' &&
-                                                personSearchPagination.hasMore && (
-                                                    <ListBox.Item asChild>
-                                                        <ButtonPrimitive
-                                                            variant="panel"
-                                                            onClick={() => {
-                                                                const searchTerm = search.startsWith('/persons ')
-                                                                    ? search.replace('/persons ', '')
-                                                                    : search
-                                                                newTabLogic.actions.loadMorePersonSearchResults({
-                                                                    searchTerm,
-                                                                })
-                                                            }}
-                                                            className="w-full mt-2"
-                                                        >
-                                                            Load more persons
-                                                        </ButtonPrimitive>
-                                                    </ListBox.Item>
-                                                )}
-                                        </div>
-                                    </div>
-                                )
-                            })}
+                            <Results tabId={tabId || ''} />
                         </div>
                     )}
                 </div>

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -223,7 +223,7 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                 return (
                                     <div
                                         className={cn('mb-8', {
-                                            'col-span-4': selectedCategory !== 'all' || specialSearchMode === 'person',
+                                            'col-span-4': selectedCategory !== 'all' || specialSearchMode === 'persons',
                                         })}
                                         key={category}
                                     >

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -39,7 +39,7 @@ export const scene: SceneExport = {
 const getCategoryDisplayName = (category: string): string => {
     const displayNames: Record<string, string> = {
         'create-new': 'Create new',
-        apps: 'Apps',
+        'apps-tools': 'Apps / Tools',
         'data-management': 'Data management',
         recents: 'Recents',
     }
@@ -61,8 +61,16 @@ function convertToTreeDataItem(item: NewTabTreeDataItem): TreeDataItem {
 export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homepage' } = {}): JSX.Element {
     const inputRef = useRef<HTMLInputElement>(null)
     const listboxRef = useRef<ListBoxHandle>(null)
-    const { filteredItemsGrid, groupedFilteredItems, search, selectedItem, categories, selectedCategory, isSearching } =
-        useValues(newTabSceneLogic({ tabId }))
+    const {
+        filteredItemsGrid,
+        groupedFilteredItems,
+        search,
+        selectedItem,
+        categories,
+        selectedCategory,
+        isSearching,
+        specialSearchMode,
+    } = useValues(newTabSceneLogic({ tabId }))
     const { mobileLayout } = useValues(navigationLogic)
     const { setQuestion, focusInput } = useActions(maxLogic)
     const { setSearch, setSelectedCategory } = useActions(newTabSceneLogic({ tabId }))
@@ -102,28 +110,34 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                     </ListBox.Item>
                     <div className="mx-1.5">
                         <div className="flex justify-between items-center relative text-xs font-medium overflow-hidden py-1 px-1.5 border-x border-b rounded-b backdrop-blur-sm bg-[var(--glass-bg-3000)]">
-                            <span>
-                                <span className="text-tertiary">Try:</span>
-                                <ListBox.Item asChild>
-                                    <ButtonPrimitive
-                                        size="xxs"
-                                        className="text-xs"
-                                        onClick={() => setSearch('New SQL query')}
-                                    >
-                                        New SQL query
-                                    </ButtonPrimitive>
-                                </ListBox.Item>
-                                <span className="text-tertiary">or</span>
-                                <ListBox.Item asChild>
-                                    <ButtonPrimitive
-                                        size="xxs"
-                                        className="text-xs"
-                                        onClick={() => setSearch('Experiment')}
-                                    >
-                                        Experiment
-                                    </ButtonPrimitive>
-                                </ListBox.Item>
-                            </span>
+                            {specialSearchMode === 'person' ? (
+                                <span>
+                                    <span className="text-tertiary">Search person by ID or email</span>
+                                </span>
+                            ) : (
+                                <span>
+                                    <span className="text-tertiary">Try:</span>
+                                    <ListBox.Item asChild>
+                                        <ButtonPrimitive
+                                            size="xxs"
+                                            className="text-xs"
+                                            onClick={() => setSearch('/person john')}
+                                        >
+                                            /person john
+                                        </ButtonPrimitive>
+                                    </ListBox.Item>
+                                    <span className="text-tertiary">or</span>
+                                    <ListBox.Item asChild>
+                                        <ButtonPrimitive
+                                            size="xxs"
+                                            className="text-xs"
+                                            onClick={() => setSearch('Experiment')}
+                                        >
+                                            Experiment
+                                        </ButtonPrimitive>
+                                    </ListBox.Item>
+                                </span>
+                            )}
                             <span className="text-primary flex gap-1 items-center">
                                 {/* if filtered results lenght is 0, this will be the first to focus */}
                                 <ListBox.Item asChild focusFirst={filteredItemsGrid.length === 0}>
@@ -247,6 +261,16 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                                 </h3>
                                                 {category === 'recents' && isSearching && <Spinner size="small" />}
                                             </div>
+                                            {(() => {
+                                                const categoryInfo = categories.find((c) => c.key === category)
+                                                return (
+                                                    categoryInfo?.description && (
+                                                        <p className="text-xs text-tertiary mt-1 mb-0 min-h-8">
+                                                            {categoryInfo.description}
+                                                        </p>
+                                                    )
+                                                )
+                                            })()}
                                         </div>
                                         <div className="flex flex-col gap-2">
                                             {category === 'recents' && typedItems.length === 0 ? (

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -73,10 +73,13 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
         selectedCategory,
         isSearching,
         specialSearchMode,
+        personSearchPagination,
+        personSearchResults,
     } = useValues(newTabSceneLogic({ tabId }))
     const { mobileLayout } = useValues(navigationLogic)
     const { setQuestion, focusInput: focusMaxInput } = useActions(maxLogic)
     const { setSearch, setSelectedCategory } = useActions(newTabSceneLogic({ tabId }))
+    const newTabLogic = newTabSceneLogic({ tabId })
     const { openSidePanel } = useActions(sidePanelStateLogic)
     const { showSceneDashboardChoiceModal } = useActions(
         sceneDashboardChoiceModalLogic({ scene: Scene.ProjectHomepage })
@@ -225,10 +228,15 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                         key={category}
                                     >
                                         <div className="mb-4">
-                                            <div className="flex items-center gap-2">
-                                                <h3 className="mb-0 text-lg font-medium text-muted">
+                                            <div className="flex items-baseline gap-2">
+                                                <h3 className="mb-0 text-lg font-medium text-secondary">
                                                     {getCategoryDisplayName(category)}
                                                 </h3>
+                                                {category === 'persons' && personSearchResults.length > 0 && (
+                                                    <span className="text-xs text-tertiary">
+                                                        Showing first {personSearchResults.length} entries
+                                                    </span>
+                                                )}
                                                 {(category === 'recents' || category === 'persons') && isSearching && (
                                                     <Spinner size="small" />
                                                 )}
@@ -337,6 +345,24 @@ export function NewTabScene({ tabId, source }: { tabId?: string; source?: 'homep
                                                             </DropdownMenu>
                                                         </ButtonGroupPrimitive>
                                                     ))
+                                            )}
+                                            {category === 'persons' && personSearchPagination.hasMore && (
+                                                <ListBox.Item asChild>
+                                                    <ButtonPrimitive
+                                                        variant="panel"
+                                                        onClick={() => {
+                                                            const searchTerm = search.startsWith('/persons ')
+                                                                ? search.replace('/persons ', '')
+                                                                : search
+                                                            newTabLogic.actions.loadMorePersonSearchResults({
+                                                                searchTerm,
+                                                            })
+                                                        }}
+                                                        className="w-full mt-2"
+                                                    >
+                                                        Load more persons
+                                                    </ButtonPrimitive>
+                                                </ListBox.Item>
                                             )}
                                         </div>
                                     </div>

--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -1,0 +1,318 @@
+import { useValues } from 'kea'
+
+import { IconEllipsis } from '@posthog/icons'
+import { Spinner } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { Link } from 'lib/lemon-ui/Link'
+import { ButtonGroupPrimitive, ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ContextMenu, ContextMenuContent, ContextMenuGroup, ContextMenuTrigger } from 'lib/ui/ContextMenu/ContextMenu'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuTrigger,
+} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { ListBox } from 'lib/ui/ListBox/ListBox'
+import { NewTabTreeDataItem, newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
+
+import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
+import { MenuItems } from '~/layout/panel-layout/ProjectTree/menus/MenuItems'
+
+import { convertToTreeDataItem, getCategoryDisplayName } from '../NewTabScene'
+
+function Category({
+    tabId,
+    items,
+    category,
+    columnIndex,
+}: {
+    tabId: string
+    items: NewTabTreeDataItem[]
+    category: string
+    columnIndex: number
+}): JSX.Element {
+    const typedItems = items as NewTabTreeDataItem[]
+    const isFirstCategory = columnIndex === 0
+    const newTabSceneData = useFeatureFlag('DATA_IN_NEW_TAB_SCENE')
+    const newTabLogic = newTabSceneLogic({ tabId })
+    const { filteredItemsGrid, search, categories, isSearching, personSearchPagination, personSearchResults } =
+        useValues(newTabSceneLogic({ tabId }))
+
+    return (
+        <div className="mb-8" key={category}>
+            <div className="mb-4">
+                <div className="flex items-baseline gap-2">
+                    <h3 className="mb-0 text-lg font-medium text-secondary">{getCategoryDisplayName(category)}</h3>
+                    {newTabSceneData && category === 'persons' && personSearchResults.length > 0 && (
+                        <span className="text-xs text-tertiary">
+                            Showing first {personSearchResults.length} entries
+                        </span>
+                    )}
+                    {(category === 'recents' || (newTabSceneData && category === 'persons')) && isSearching && (
+                        <Spinner size="small" />
+                    )}
+                </div>
+                {(() => {
+                    const categoryInfo = categories.find((c) => c.key === category)
+                    return (
+                        categoryInfo?.description && (
+                            <p className="text-xs text-tertiary mt-1 mb-0 min-h-8">{categoryInfo.description}</p>
+                        )
+                    )
+                })()}
+            </div>
+            <div className="flex flex-col gap-2">
+                {(category === 'recents' || (newTabSceneData && category === 'persons')) && typedItems.length === 0 ? (
+                    // Special handling for empty project items and persons
+                    <div className="flex flex-col gap-2 text-tertiary text-balance">
+                        {isSearching ? 'Searching...' : 'No results found'}
+                    </div>
+                ) : (
+                    typedItems.map((item, index) => (
+                        // If we have filtered results set virtual focus to first item
+                        <ButtonGroupPrimitive key={item.id} className="group w-full border-0">
+                            <ContextMenu>
+                                <ContextMenuTrigger asChild>
+                                    <ListBox.Item
+                                        asChild
+                                        focusFirst={filteredItemsGrid.length > 0 && isFirstCategory && index === 0}
+                                        row={index}
+                                        column={columnIndex}
+                                    >
+                                        <Link
+                                            to={item.href || '#'}
+                                            className="w-full"
+                                            buttonProps={{
+                                                size: 'base',
+                                                hasSideActionRight: true,
+                                            }}
+                                        >
+                                            <span className="text-sm">{item.icon ?? item.name[0]}</span>
+                                            <span className="text-sm truncate text-primary">
+                                                {search ? (
+                                                    <SearchHighlightMultiple string={item.name} substring={search} />
+                                                ) : (
+                                                    item.displayName || item.name
+                                                )}
+                                            </span>
+                                        </Link>
+                                    </ListBox.Item>
+                                </ContextMenuTrigger>
+                                <ContextMenuContent loop className="max-w-[250px]">
+                                    <ContextMenuGroup>
+                                        <MenuItems
+                                            item={convertToTreeDataItem(item)}
+                                            type="context"
+                                            root="project://"
+                                            onlyTree={false}
+                                            showSelectMenuOption={false}
+                                        />
+                                    </ContextMenuGroup>
+                                </ContextMenuContent>
+                            </ContextMenu>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <ButtonPrimitive
+                                        size="xs"
+                                        iconOnly
+                                        isSideActionRight
+                                        className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
+                                    >
+                                        <IconEllipsis className="size-3" />
+                                    </ButtonPrimitive>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent loop align="end" side="bottom" className="max-w-[250px]">
+                                    <DropdownMenuGroup>
+                                        <MenuItems
+                                            item={convertToTreeDataItem(item)}
+                                            type="dropdown"
+                                            root="project://"
+                                            onlyTree={false}
+                                            showSelectMenuOption={false}
+                                        />
+                                    </DropdownMenuGroup>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        </ButtonGroupPrimitive>
+                    ))
+                )}
+                {newTabSceneData && category === 'persons' && personSearchPagination.hasMore && (
+                    <ListBox.Item asChild>
+                        <ButtonPrimitive
+                            variant="panel"
+                            onClick={() => {
+                                const searchTerm = search.startsWith('/persons ')
+                                    ? search.replace('/persons ', '')
+                                    : search
+                                newTabLogic.actions.loadMorePersonSearchResults({
+                                    searchTerm,
+                                })
+                            }}
+                            className="w-full mt-2"
+                        >
+                            Load more persons
+                        </ButtonPrimitive>
+                    </ListBox.Item>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export function Results({ tabId }: { tabId: string }): JSX.Element {
+    const {
+        filteredItemsGrid,
+        groupedFilteredItems,
+        search,
+        categories,
+        selectedCategory,
+        isSearching,
+        specialSearchMode,
+        personSearchPagination,
+        personSearchResults,
+    } = useValues(newTabSceneLogic({ tabId }))
+    const newTabLogic = newTabSceneLogic({ tabId })
+    const newTabSceneData = useFeatureFlag('DATA_IN_NEW_TAB_SCENE')
+
+    const allCategories = Object.entries(groupedFilteredItems)
+
+    if (selectedCategory !== 'all' || (newTabSceneData && specialSearchMode === 'persons')) {
+        const categoryToShow = specialSearchMode === 'persons' ? 'persons' : selectedCategory
+        const items = groupedFilteredItems[categoryToShow] || []
+        const typedItems = items as NewTabTreeDataItem[]
+
+        return (
+            <div className="col-span-4 mb-8" key={categoryToShow}>
+                <div className="mb-4">
+                    <div className="flex items-baseline gap-2">
+                        <h3 className="mb-0 text-lg font-medium text-secondary">
+                            {getCategoryDisplayName(categoryToShow)}
+                        </h3>
+                        {newTabSceneData && categoryToShow === 'persons' && personSearchResults.length > 0 && (
+                            <span className="text-xs text-tertiary">
+                                Showing first {personSearchResults.length} entries
+                            </span>
+                        )}
+                        {(categoryToShow === 'recents' || (newTabSceneData && categoryToShow === 'persons')) &&
+                            isSearching && <Spinner size="small" />}
+                    </div>
+                    {(() => {
+                        const categoryInfo = categories.find((c) => c.key === categoryToShow)
+                        return (
+                            categoryInfo?.description && (
+                                <p className="text-xs text-tertiary mt-1 mb-0 min-h-8">{categoryInfo.description}</p>
+                            )
+                        )
+                    })()}
+                </div>
+                <div className="flex flex-col gap-2">
+                    {(categoryToShow === 'recents' || (newTabSceneData && categoryToShow === 'persons')) &&
+                    typedItems.length === 0 ? (
+                        // Special handling for empty project items and persons
+                        <div className="flex flex-col gap-2 text-tertiary text-balance">
+                            {isSearching ? 'Searching...' : 'No results found'}
+                        </div>
+                    ) : (
+                        typedItems.map((item, index) => (
+                            // If we have filtered results set virtual focus to first item
+                            <ButtonGroupPrimitive key={item.id} className="group w-full border-0">
+                                <ContextMenu>
+                                    <ContextMenuTrigger asChild>
+                                        <ListBox.Item
+                                            asChild
+                                            focusFirst={filteredItemsGrid.length > 0 && index === 0}
+                                            row={index}
+                                            column={0}
+                                        >
+                                            <Link
+                                                to={item.href || '#'}
+                                                className="w-full"
+                                                buttonProps={{
+                                                    size: 'base',
+                                                    hasSideActionRight: true,
+                                                }}
+                                            >
+                                                <span className="text-sm">{item.icon ?? item.name[0]}</span>
+                                                <span className="text-sm truncate text-primary">
+                                                    {search ? (
+                                                        <SearchHighlightMultiple
+                                                            string={item.name}
+                                                            substring={search}
+                                                        />
+                                                    ) : (
+                                                        item.displayName || item.name
+                                                    )}
+                                                </span>
+                                            </Link>
+                                        </ListBox.Item>
+                                    </ContextMenuTrigger>
+                                    <ContextMenuContent loop className="max-w-[250px]">
+                                        <ContextMenuGroup>
+                                            <MenuItems
+                                                item={convertToTreeDataItem(item)}
+                                                type="context"
+                                                root="project://"
+                                                onlyTree={false}
+                                                showSelectMenuOption={false}
+                                            />
+                                        </ContextMenuGroup>
+                                    </ContextMenuContent>
+                                </ContextMenu>
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <ButtonPrimitive
+                                            size="xs"
+                                            iconOnly
+                                            isSideActionRight
+                                            className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
+                                        >
+                                            <IconEllipsis className="size-3" />
+                                        </ButtonPrimitive>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent loop align="end" side="bottom" className="max-w-[250px]">
+                                        <DropdownMenuGroup>
+                                            <MenuItems
+                                                item={convertToTreeDataItem(item)}
+                                                type="dropdown"
+                                                root="project://"
+                                                onlyTree={false}
+                                                showSelectMenuOption={false}
+                                            />
+                                        </DropdownMenuGroup>
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </ButtonGroupPrimitive>
+                        ))
+                    )}
+                    {newTabSceneData && categoryToShow === 'persons' && personSearchPagination.hasMore && (
+                        <ListBox.Item asChild>
+                            <ButtonPrimitive
+                                variant="panel"
+                                onClick={() => {
+                                    const searchTerm = search.startsWith('/persons ')
+                                        ? search.replace('/persons ', '')
+                                        : search
+                                    newTabLogic.actions.loadMorePersonSearchResults({
+                                        searchTerm,
+                                    })
+                                }}
+                                className="w-full mt-2"
+                            >
+                                Load more persons
+                            </ButtonPrimitive>
+                        </ListBox.Item>
+                    )}
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <>
+            {allCategories.map(([category, items], columnIndex) => (
+                <Category tabId={tabId} items={items} category={category} columnIndex={columnIndex} key={category} />
+            ))}
+        </>
+    )
+}

--- a/frontend/src/scenes/new-tab/components/SearchHints.tsx
+++ b/frontend/src/scenes/new-tab/components/SearchHints.tsx
@@ -1,0 +1,113 @@
+import { IconSidePanel } from '@posthog/icons'
+
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ListBox } from 'lib/ui/ListBox/ListBox'
+
+import { SidePanelTab } from '~/types'
+
+import { SpecialSearchMode } from '../newTabSceneLogic'
+
+interface SearchHintsProps {
+    specialSearchMode: SpecialSearchMode
+    search: string
+    filteredItemsGridLength: number
+    setSearch: (search: string) => void
+    setQuestion: (question: string) => void
+    focusMaxInput: () => void
+    focusSearchInput: () => void
+    openSidePanel: (tab: SidePanelTab) => void
+}
+
+export function SearchHints({
+    specialSearchMode,
+    search,
+    filteredItemsGridLength,
+    setSearch,
+    setQuestion,
+    focusMaxInput,
+    focusSearchInput,
+    openSidePanel,
+}: SearchHintsProps): JSX.Element {
+    return (
+        <div className="flex justify-between items-center relative text-xs font-medium overflow-hidden py-1 px-1.5 border-x border-b rounded-b backdrop-blur-sm bg-[var(--glass-bg-3000)]">
+            {specialSearchMode === 'person' && search.trim() ? (
+                <span>
+                    <span className="text-tertiary mr-1">Try searching persons by:</span>
+                    <ListBox.Item asChild>
+                        <ButtonPrimitive
+                            size="xxs"
+                            className="text-xs -ml-1"
+                            onClick={() => {
+                                setSearch('/persons test@email.com')
+                                focusSearchInput()
+                            }}
+                        >
+                            email
+                        </ButtonPrimitive>
+                    </ListBox.Item>
+                    <span className="text-tertiary">or</span>
+                    <ListBox.Item asChild>
+                        <ButtonPrimitive
+                            size="xxs"
+                            className="text-xs"
+                            onClick={() => {
+                                setSearch('/persons some-id')
+                                focusSearchInput()
+                            }}
+                        >
+                            ID
+                        </ButtonPrimitive>
+                    </ListBox.Item>
+                </span>
+            ) : (
+                <span>
+                    <span className="text-tertiary">Try:</span>
+                    <ListBox.Item asChild>
+                        <ButtonPrimitive
+                            size="xxs"
+                            className="text-xs"
+                            onClick={() => {
+                                setSearch('/persons ')
+                                focusSearchInput()
+                            }}
+                        >
+                            /persons <span className="text-tertiary -ml-1">$email/id</span>
+                        </ButtonPrimitive>
+                    </ListBox.Item>
+                    <span className="text-tertiary">or</span>
+                    <ListBox.Item asChild>
+                        <ButtonPrimitive
+                            size="xxs"
+                            className="text-xs"
+                            onClick={() => {
+                                setSearch('Experiment')
+                                focusSearchInput()
+                            }}
+                        >
+                            Experiment
+                        </ButtonPrimitive>
+                    </ListBox.Item>
+                </span>
+            )}
+            <span className="text-primary flex gap-1 items-center">
+                {/* if filtered results length is 0, this will be the first to focus */}
+                <ListBox.Item asChild focusFirst={filteredItemsGridLength === 0}>
+                    <ButtonPrimitive
+                        size="xxs"
+                        onClick={() => {
+                            openSidePanel(SidePanelTab.Max)
+                            setSearch('')
+                            setQuestion(search)
+                            focusMaxInput()
+                        }}
+                        className="text-xs"
+                        tooltip="Hit enter to open Max!"
+                    >
+                        Ask Max!
+                        <IconSidePanel />
+                    </ButtonPrimitive>
+                </ListBox.Item>
+            </span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/new-tab/components/SearchHints.tsx
+++ b/frontend/src/scenes/new-tab/components/SearchHints.tsx
@@ -1,5 +1,6 @@
 import { IconSidePanel } from '@posthog/icons'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ListBox } from 'lib/ui/ListBox/ListBox'
 
@@ -28,6 +29,7 @@ export function SearchHints({
     focusSearchInput,
     openSidePanel,
 }: SearchHintsProps): JSX.Element {
+    const newTabSceneData = useFeatureFlag('DATA_IN_NEW_TAB_SCENE')
     return (
         <div className="flex justify-between items-center relative text-xs font-medium overflow-hidden py-1 px-1.5 border-x border-b rounded-b backdrop-blur-sm bg-[var(--glass-bg-3000)]">
             {specialSearchMode === 'persons' && search.trim() ? (
@@ -62,18 +64,34 @@ export function SearchHints({
             ) : (
                 <span>
                     <span className="text-tertiary">Try:</span>
-                    <ListBox.Item asChild>
-                        <ButtonPrimitive
-                            size="xxs"
-                            className="text-xs"
-                            onClick={() => {
-                                setSearch('/persons ')
-                                focusSearchInput()
-                            }}
-                        >
-                            /persons <span className="text-tertiary -ml-1">$email/id</span>
-                        </ButtonPrimitive>
-                    </ListBox.Item>
+
+                    {newTabSceneData ? (
+                        <ListBox.Item asChild>
+                            <ButtonPrimitive
+                                size="xxs"
+                                className="text-xs"
+                                onClick={() => {
+                                    setSearch('/persons ')
+                                    focusSearchInput()
+                                }}
+                            >
+                                /persons <span className="text-tertiary -ml-1">$email/id</span>
+                            </ButtonPrimitive>
+                        </ListBox.Item>
+                    ) : (
+                        <ListBox.Item asChild>
+                            <ButtonPrimitive
+                                size="xxs"
+                                className="text-xs"
+                                onClick={() => {
+                                    setSearch('New SQL query')
+                                    focusSearchInput()
+                                }}
+                            >
+                                New SQL query
+                            </ButtonPrimitive>
+                        </ListBox.Item>
+                    )}
                     <span className="text-tertiary">or</span>
                     <ListBox.Item asChild>
                         <ButtonPrimitive

--- a/frontend/src/scenes/new-tab/components/SearchHints.tsx
+++ b/frontend/src/scenes/new-tab/components/SearchHints.tsx
@@ -30,7 +30,7 @@ export function SearchHints({
 }: SearchHintsProps): JSX.Element {
     return (
         <div className="flex justify-between items-center relative text-xs font-medium overflow-hidden py-1 px-1.5 border-x border-b rounded-b backdrop-blur-sm bg-[var(--glass-bg-3000)]">
-            {specialSearchMode === 'person' && search.trim() ? (
+            {specialSearchMode === 'persons' && search.trim() ? (
                 <span>
                     <span className="text-tertiary mr-1">Try searching persons by:</span>
                     <ListBox.Item asChild>

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -254,12 +254,12 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         id: `person-${person.uuid}`,
                         name: `View this person ${displayName}`,
                         category: 'recents' as NEW_TAB_CATEGORY_ITEMS,
-                        href: urls.personByDistinctId(personId),
+                        href: urls.personByUUID(person.uuid),
                         icon: <IconPerson />,
                         record: {
                             type: 'person',
                             path: `Person: ${displayName}`,
-                            href: urls.personByDistinctId(personId),
+                            href: urls.personByUUID(person.uuid),
                         },
                     }
 

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -25,7 +25,7 @@ import { TreeDataItem } from '~/lib/lemon-ui/LemonTree/LemonTree'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 import { FileSystemIconType, FileSystemImport } from '~/queries/schema/schema-general'
-import { Breadcrumb, PersonType } from '~/types'
+import { PersonType } from '~/types'
 
 import type { newTabSceneLogicType } from './newTabSceneLogicType'
 
@@ -420,10 +420,6 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 )
             },
         ],
-        filteredItemsList: [
-            (s) => [s.filteredItemsGrid],
-            (filteredItemsGrid): NewTabTreeDataItem[] => filteredItemsGrid,
-        ],
         groupedFilteredItems: [
             (s) => [s.filteredItemsGrid],
             (filteredItemsGrid: NewTabTreeDataItem[]): Record<string, NewTabTreeDataItem[]> => {
@@ -440,25 +436,24 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
             },
         ],
         selectedIndex: [
-            (s) => [s.rawSelectedIndex, s.filteredItemsList],
-            (rawSelectedIndex, filteredItemsList): number | null => {
-                if (filteredItemsList.length === 0) {
+            (s) => [s.rawSelectedIndex, s.filteredItemsGrid],
+            (rawSelectedIndex, filteredItemsGrid): number | null => {
+                if (filteredItemsGrid.length === 0) {
                     return null
                 }
                 return (
-                    ((rawSelectedIndex % filteredItemsList.length) + filteredItemsList.length) %
-                    filteredItemsList.length
+                    ((rawSelectedIndex % filteredItemsGrid.length) + filteredItemsGrid.length) %
+                    filteredItemsGrid.length
                 )
             },
         ],
         selectedItem: [
-            (s) => [s.selectedIndex, s.filteredItemsList],
-            (selectedIndex, filteredItemsList): NewTabTreeDataItem | null =>
-                selectedIndex !== null && selectedIndex < filteredItemsList.length
-                    ? filteredItemsList[selectedIndex]
+            (s) => [s.selectedIndex, s.filteredItemsGrid],
+            (selectedIndex, filteredItemsGrid): NewTabTreeDataItem | null =>
+                selectedIndex !== null && selectedIndex < filteredItemsGrid.length
+                    ? filteredItemsGrid[selectedIndex]
                     : null,
         ],
-        breadcrumbs: [() => [], (): Breadcrumb[] => [{ key: 'new-tab', name: 'New tab', iconType: 'blank' }]],
     }),
     listeners(({ actions, values }) => ({
         onSubmit: () => {

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -22,8 +22,6 @@ import {
 import { SearchResults } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { splitPath } from '~/layout/panel-layout/ProjectTree/utils'
 import { TreeDataItem } from '~/lib/lemon-ui/LemonTree/LemonTree'
-import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
-import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 import { FileSystemIconType, FileSystemImport } from '~/queries/schema/schema-general'
 import { PersonType } from '~/types'
 
@@ -128,45 +126,10 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         return []
                     }
 
-                    const personsQuery: DataTableNode = {
-                        kind: NodeKind.DataTableNode,
-                        source: {
-                            kind: NodeKind.ActorsQuery,
-                            select: [...defaultDataTableColumns(NodeKind.ActorsQuery)],
-                            search: searchTerm.trim(),
-                        },
-                        full: true,
-                    }
-
-                    // Make direct API call to query endpoint with proper format
-                    const response = await api.create('api/projects/@current/query/', {
-                        query: personsQuery,
-                    })
+                    const response = await api.persons.list({ search: searchTerm.trim() })
                     breakpoint()
 
-                    // Parse the results - they come as nested arrays where first element is the person data
-
-                    const persons =
-                        response?.results?.map((row: any) => {
-                            const personData = row[0] // First element contains the person data
-                            const personId = row[1] // Second element is the ID
-                            const createdAt = row[2] // Third element is created_at
-
-                            const person: PersonType = {
-                                id: personId,
-                                uuid: personId,
-                                name: personData.display_name,
-                                distinct_ids: [personId],
-                                properties: {
-                                    email: personData.display_name,
-                                },
-                                created_at: createdAt,
-                            }
-
-                            return person
-                        }) || []
-
-                    return persons
+                    return response.results
                 },
             },
         ],

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -64,7 +64,6 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
     key((props) => props.tabId || 'default'),
     actions({
         setSearch: (search: string) => ({ search }),
-        setSearchImmediate: (search: string) => ({ search }),
         selectNext: true,
         selectPrevious: true,
         onSubmit: true,
@@ -175,7 +174,6 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
             '',
             {
                 setSearch: (_, { search }) => search,
-                setSearchImmediate: (_, { search }) => search,
             },
         ],
         selectedCategory: [

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -39,7 +39,6 @@ export interface NewTabTreeDataItem extends TreeDataItem {
 interface NewTabCategoryItem {
     key: NEW_TAB_CATEGORY_ITEMS
     label: string
-    description?: string
 }
 
 export type SpecialSearchMode = 'persons' | null
@@ -210,25 +209,22 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
             (s) => [s.featureFlags],
             (featureFlags): NewTabCategoryItem[] => {
                 const categories: NewTabCategoryItem[] = [
-                    { key: 'all', label: 'All', description: 'All items in PostHog' },
+                    { key: 'all', label: 'All' },
                     {
                         key: 'create-new',
                         label: 'Create new',
-                        description: 'Create new insights, queries, experiments, etc.',
                     },
-                    { key: 'apps', label: 'Apps', description: "All of PostHog's apps, tools, and features" },
+                    { key: 'apps', label: 'Apps' },
                     {
                         key: 'data-management',
                         label: 'Data management',
-                        description: 'Manage your data sources and destinations',
                     },
-                    { key: 'recents', label: 'Recents', description: 'Project-based recently accessed items' },
+                    { key: 'recents', label: 'Recents' },
                 ]
                 if (featureFlags[FEATURE_FLAGS.DATA_IN_NEW_TAB_SCENE]) {
                     categories.push({
                         key: 'persons',
                         label: 'Persons',
-                        description: 'Click to view a persons details on the persons page',
                     })
                 }
                 return categories
@@ -365,21 +361,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
 
                 const newTabSceneData = featureFlags[FEATURE_FLAGS.DATA_IN_NEW_TAB_SCENE]
 
-                // If in person search mode, ensure persons category always appears
+                // If in person search mode, return persons items (can be empty array)
                 if (newTabSceneData && specialSearchMode === 'persons') {
-                    // Always include at least an empty persons category to prevent layout shift
-                    if (personSearchItems.length === 0) {
-                        return [
-                            {
-                                id: 'persons-placeholder',
-                                name: '',
-                                category: 'persons' as NEW_TAB_CATEGORY_ITEMS,
-                                href: '',
-                                icon: null,
-                                record: { type: 'placeholder', path: '' },
-                            },
-                        ]
-                    }
                     return personSearchItems
                 }
 

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -35,7 +35,7 @@ export interface NewTabTreeDataItem extends TreeDataItem {
     flag?: string
 }
 
-export type SpecialSearchMode = 'person' | null
+export type SpecialSearchMode = 'persons' | null
 
 const PAGINATION_LIMIT = 20
 
@@ -226,7 +226,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
             (s) => [s.search, s.selectedCategory],
             (search: string, selectedCategory: NEW_TAB_CATEGORY_ITEMS): SpecialSearchMode => {
                 if (search.startsWith('/person') || selectedCategory === 'persons') {
-                    return 'person'
+                    return 'persons'
                 }
                 return null
             },
@@ -349,7 +349,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     .filter(({ flag }) => !flag || featureFlags[flag as keyof typeof featureFlags])
 
                 // If in person search mode, ensure persons category always appears
-                if (specialSearchMode === 'person') {
+                if (specialSearchMode === 'persons') {
                     // Always include at least an empty persons category to prevent layout shift
                     if (personSearchItems.length === 0) {
                         return [
@@ -409,7 +409,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 }
 
                 // For special search modes (like person search), skip the normal search filtering
-                if (specialSearchMode === 'person') {
+                if (specialSearchMode === 'persons') {
                     return filtered
                 }
 

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -152,11 +152,13 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                             const personId = row[1] // Second element is the ID
                             const createdAt = row[2] // Third element is created_at
 
-                            const person = {
+                            const person: PersonType = {
+                                id: personId,
                                 uuid: personId,
+                                name: personData.display_name,
                                 distinct_ids: [personId],
                                 properties: {
-                                    email: personData.display_name, // Use display_name as it's already formatted
+                                    email: personData.display_name,
                                 },
                                 created_at: createdAt,
                             }


### PR DESCRIPTION
## Problem
People want to search for people and other data

## Changes
* Add new category `persons`, which is triggered by clicking the tab or writing `/persons`
    * this enters "special search mode" for searching persons data
    * Move search hints into new component so that `persons` mode gets their own suggestions  
    * pagination (limit 20) with load more button
    * bonus: side actions dropdown/context on person result work (add to shortcuts etc) 🕺 
* Added category descriptions? I think this is nice to read something about what you're getting shown

---
![2025-10-09 13 31 14](https://github.com/user-attachments/assets/1b9395c0-fc3b-465e-bdad-0dcd58ae28be)
---
![2025-10-09 13 35 19](https://github.com/user-attachments/assets/d5f8e3fc-0524-405e-b501-5754c0d3535d)
---
![2025-10-09 15 28 58](https://github.com/user-attachments/assets/09598335-576c-4360-9da7-1b98e02bb996)
---
<img width="1034" height="434" alt="image" src="https://github.com/user-attachments/assets/98ea4ca8-24c4-4f30-a18a-85decc6538f9" />


## How did you test this code?
* Normal behaviour of:
    * apps, etc all work as expected (arrow keys, left right up down, searching etc) ✅ 
* clicking persons tab enters persons mode by injecting `/persons` at the front of the search term, 
* clicking off persons tab into others removes `/persons` from search
* searching people works by ID / email
* search is debounced so we don't hit the DB too much.


## Changelog: (features only) Is this feature complete?

Search for people/persons data right in the new tab page, moving toward searchable-all-the-things-from-one-spot
