### PR TITLE
refactor(flags): count query in user blast radius calculation

### DIFF
--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -169,6 +169,52 @@ class PersonQuery:
             },
         )
 
+    def get_uniq_count(self) -> tuple[str, dict]:
+        """
+        Returns a simplified query that counts unique person IDs using uniq(id).
+        This is more efficient than the full get_query() for counting purposes.
+        Ignores prefiltering optimizations and is_deleted checks for simplicity.
+        """
+        (
+            _,
+            person_filters_finalization_condition,
+            person_filters_params,
+        ) = self._get_person_filter_clauses()
+        (
+            multiple_cohorts_condition,
+            multiple_cohorts_params,
+        ) = self._get_multiple_cohorts_clause()
+        single_cohort_join, single_cohort_params = self._get_fast_single_cohort_clause()
+        (
+            _,
+            search_finalization_condition,
+            search_params,
+        ) = self._get_search_clauses()
+        distinct_id_condition, distinct_id_params = self._get_distinct_id_clause()
+        email_condition, email_params = self._get_email_clause()
+
+        return (
+            f"""
+            SELECT uniq(id)
+            FROM person
+            {single_cohort_join}
+            WHERE team_id = %(team_id)s
+            {multiple_cohorts_condition}
+            {email_condition}
+            {person_filters_finalization_condition} {search_finalization_condition}
+            {distinct_id_condition}
+            """,
+            {
+                **person_filters_params,
+                **single_cohort_params,
+                **search_params,
+                **distinct_id_params,
+                **email_params,
+                **multiple_cohorts_params,
+                "team_id": self._team_id,
+            },
+        )
+
     @property
     def fields(self) -> list[ColumnName]:
         "Returns person table fields this query exposes"


### PR DESCRIPTION
## Problem

When editing a flag, some requests to `user_blast_radius` are timing out for a customer with >200M records in the person table in ClickHouse.

Context:
https://posthoghelp.zendesk.com/agent/tickets/39534 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41702)

## Changes

- Created new method to count person without filtering `is_deleted` and without INNER queries
- Protected by `blast-radius-uniq-count` feature flag

Original query:
```
SELECT count(1)
FROM
  (SELECT id
   FROM person
   WHERE team_id = <id>
     AND id IN
       (SELECT id
        FROM person
        WHERE team_id = <id>
          AND (has(['Argentina', 'Japan', 'South Korea', 'Myanmar', 'Philippines', 'Thailand'], "alias_pmat__geoip_country_name")))
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND (has(['Argentina', 'Japan', 'South Korea', 'Myanmar', 'Philippines', 'Thailand'], argMax(person."alias_pmat__geoip_country_name", version))))
SETTINGS optimize_aggregation_in_order = 1
```

New query:
```
select uniq(id) from person where team_id = <id>
          AND (has(['Argentina', 'Japan', 'South Korea', 'Myanmar', 'Philippines', 'Thailand'], "alias_pmat__geoip_country_name"))
```

The count is not precise, but it is only used to be an estimate. 

## How did you test this code?

- Manual