### PR TITLE
feat(array): product signals event type

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1049,6 +1049,31 @@
             "label": "Person profile processing flag",
             "system": true
         },
+        "$product_signal_description": {
+            "description": "A detailed description of the product signal and what action may be required.",
+            "examples": ["A new error type was detected affecting 15% of users in the checkout flow"],
+            "label": "Product signal description"
+        },
+        "$product_signal_severity": {
+            "description": "The severity level of the product signal.",
+            "examples": ["low", "medium", "high", "critical"],
+            "label": "Product signal severity"
+        },
+        "$product_signal_source": {
+            "description": "The PostHog product that generated this signal.",
+            "examples": ["error_tracking", "product_analytics"],
+            "label": "Product signal source"
+        },
+        "$product_signal_title": {
+            "description": "A brief title describing the product signal.",
+            "examples": ["New error in checkout flow", "Funnel drop-off detected"],
+            "label": "Product signal title"
+        },
+        "$product_signal_type": {
+            "description": "The type of product signal being reported.",
+            "examples": ["new_issue", "funnel_anomoly"],
+            "label": "Product signal type"
+        },
         "$python_runtime": {
             "description": "The Python runtime that was used to capture the event.",
             "examples": ["CPython"],
@@ -1854,6 +1879,11 @@
         "$pageview": {
             "description": "When a user loads (or reloads) a page.",
             "label": "Pageview"
+        },
+        "$product_signal": {
+            "description": "Internal signals representing actionable product issues detected by PostHog analysis systems.",
+            "ignored_in_assistant": true,
+            "label": "Product signal"
         },
         "$rageclick": {
             "description": "A user has rapidly and repeatedly clicked in a single place.",
@@ -3231,6 +3261,31 @@
             "description": "The setting from an SDK to control whether an event has person processing enabled",
             "label": "Person profile processing flag",
             "system": true
+        },
+        "$product_signal_description": {
+            "description": "A detailed description of the product signal and what action may be required.",
+            "examples": ["A new error type was detected affecting 15% of users in the checkout flow"],
+            "label": "Product signal description"
+        },
+        "$product_signal_severity": {
+            "description": "The severity level of the product signal.",
+            "examples": ["low", "medium", "high", "critical"],
+            "label": "Product signal severity"
+        },
+        "$product_signal_source": {
+            "description": "The PostHog product that generated this signal.",
+            "examples": ["error_tracking", "product_analytics"],
+            "label": "Product signal source"
+        },
+        "$product_signal_title": {
+            "description": "A brief title describing the product signal.",
+            "examples": ["New error in checkout flow", "Funnel drop-off detected"],
+            "label": "Product signal title"
+        },
+        "$product_signal_type": {
+            "description": "The type of product signal being reported.",
+            "examples": ["new_issue", "funnel_anomoly"],
+            "label": "Product signal type"
         },
         "$python_runtime": {
             "description": "The Python runtime that was used to capture the event.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1071,7 +1071,7 @@
         },
         "$product_signal_type": {
             "description": "The type of product signal being reported.",
-            "examples": ["new_issue", "funnel_anomoly"],
+            "examples": ["new_issue", "funnel_conversion_rate_change"],
             "label": "Product signal type"
         },
         "$python_runtime": {
@@ -3284,7 +3284,7 @@
         },
         "$product_signal_type": {
             "description": "The type of product signal being reported.",
-            "examples": ["new_issue", "funnel_anomoly"],
+            "examples": ["new_issue", "funnel_conversion_rate_change"],
             "label": "Product signal type"
         },
         "$python_runtime": {

--- a/frontend/src/taxonomy/taxonomy.tsx
+++ b/frontend/src/taxonomy/taxonomy.tsx
@@ -130,6 +130,13 @@ export const POSTHOG_EVENT_PROMOTED_PROPERTIES = {
     $pageleave: ['$current_url', 'title', '$referrer'],
     $groupidentify: ['$group_type', '$group_key', '$group_set'],
     $screen: ['$screen_name'],
+    $product_signal: [
+        '$product_signal_type',
+        '$product_signal_severity',
+        '$product_signal_title',
+        '$product_signal_source',
+        '$product_signal_description',
+    ],
     $web_vitals: [
         '$web_vitals_FCP_value',
         '$web_vitals_CLS_value',

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -48,6 +48,20 @@ class AvailableFeature(StrEnum):
     AUDIT_LOGS = "audit_logs"
 
 
+# When adding a new product, ensure the enum value matches the ProductKey value in frontend/src/types.ts
+class Product(StrEnum):
+    PRODUCT_ANALYTICS = "product_analytics"
+    SESSION_REPLAY = "session_replay"
+    FEATURE_FLAGS = "feature_flags"
+    EXPERIMENTS = "experiments"
+    SURVEYS = "surveys"
+    DATA_WAREHOUSE = "data_warehouse"
+    ERROR_TRACKING = "error_tracking"
+    WEB_ANALYTICS = "web_analytics"
+    REVENUE_ANALYTICS = "revenue_analytics"
+    MARKETING_ANALYTICS = "marketing_analytics"
+
+
 TREND_FILTER_TYPE_ACTIONS = "actions"
 TREND_FILTER_TYPE_EVENTS = "events"
 TREND_FILTER_TYPE_DATA_WAREHOUSE = "data_warehouse"

--- a/posthog/product_signals/__init__.py
+++ b/posthog/product_signals/__init__.py
@@ -1,0 +1,9 @@
+from .schema import ProductSignal, ProductSignalException, ProductSignalSeverity, ProductSignalSource, ProductSignalType
+
+__all__ = [
+    "ProductSignal",
+    "ProductSignalException",
+    "ProductSignalSeverity",
+    "ProductSignalSource",
+    "ProductSignalType",
+]

--- a/posthog/product_signals/__init__.py
+++ b/posthog/product_signals/__init__.py
@@ -1,9 +1,8 @@
-from .schema import ProductSignal, ProductSignalException, ProductSignalSeverity, ProductSignalSource, ProductSignalType
+from .schema import ProductSignal, ProductSignalException, ProductSignalSeverity, ProductSignalType
 
 __all__ = [
     "ProductSignal",
     "ProductSignalException",
     "ProductSignalSeverity",
-    "ProductSignalSource",
     "ProductSignalType",
 ]

--- a/posthog/product_signals/schema.py
+++ b/posthog/product_signals/schema.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Optional
+
+import structlog
+
+from posthog.api.capture import capture_internal
+
+logger = structlog.get_logger(__name__)
+
+
+class ProductSignalSeverity(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ProductSignalType(StrEnum):
+    NEW_ISSUE = "new_issue"
+    FUNNEL_ANOMOLY = "funnel_anomoly"
+
+
+class ProductSignalSource(StrEnum):
+    ERROR_TRACKING = "error_tracking"
+    PRODUCT_ANALYTICS = "product_analytics"
+
+
+class ProductSignalException(Exception):
+    def __init__(self, signal: "ProductSignal") -> None:
+        super().__init__(
+            f"ProductSignalException: {signal.signal_type.value} [{signal.severity.value}] - {signal.title}"
+        )
+        self.signal_type = signal.signal_type
+        self.severity = signal.severity
+        self.title = signal.title
+        self.description = signal.description
+        self.source = signal.source
+        self.distinct_id = signal.distinct_id
+        self.metadata = signal.metadata
+        self.timestamp = signal.timestamp
+
+
+@dataclass
+class ProductSignal:
+    signal_type: ProductSignalType
+    severity: ProductSignalSeverity
+    title: str
+    source: ProductSignalSource
+    distinct_id: str
+    description: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    timestamp: Optional[datetime] = None
+
+    def to_event_properties(self) -> dict[str, Any]:
+        props = {
+            **self.metadata,
+            "$product_signal_type": self.signal_type.value,
+            "$product_signal_severity": self.severity.value,
+            "$product_signal_title": self.title,
+            "$product_signal_source": self.source.value,
+        }
+
+        if self.description:
+            props["$product_signal_description"] = self.description
+
+        return props
+
+    @staticmethod
+    def create(
+        team_token: str,
+        signal: "ProductSignal",
+        distinct_id: str,
+    ) -> None:
+        timestamp = signal.timestamp or datetime.now()
+
+        try:
+            capture_internal(
+                token=team_token,
+                event_name="$product_signal",
+                event_source="product_signals",
+                timestamp=timestamp,
+                distinct_id=distinct_id,
+                properties=signal.to_event_properties(),
+                process_person_profile=False,
+            )
+        except Exception as e:
+            raise ProductSignalException(signal) from e

--- a/posthog/product_signals/schema.py
+++ b/posthog/product_signals/schema.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 import structlog
 
 from posthog.api.capture import capture_internal
+from posthog.constants import Product
 from posthog.exceptions_capture import capture_exception
 
 logger = structlog.get_logger(__name__)
@@ -20,12 +21,7 @@ class ProductSignalSeverity(StrEnum):
 
 class ProductSignalType(StrEnum):
     NEW_ISSUE = "new_issue"
-    FUNNEL_ANOMOLY = "funnel_anomoly"
-
-
-class ProductSignalSource(StrEnum):
-    ERROR_TRACKING = "error_tracking"
-    PRODUCT_ANALYTICS = "product_analytics"
+    FUNNEL_CONVERSION_RATE_CHANGE = "funnel_conversion_rate_change"
 
 
 class ProductSignalException(Exception):
@@ -49,7 +45,7 @@ class ProductSignal:
     signal_type: ProductSignalType
     severity: ProductSignalSeverity
     title: str
-    source: ProductSignalSource
+    source: Product
     distinct_id: str
     description: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/posthog/product_signals/schema.py
+++ b/posthog/product_signals/schema.py
@@ -17,6 +17,7 @@ class ProductSignalSeverity(StrEnum):
     MEDIUM = "medium"
     HIGH = "high"
     CRITICAL = "critical"
+    UNKNOWN = "unknown"
 
 
 class ProductSignalType(StrEnum):

--- a/posthog/product_signals/schema.py
+++ b/posthog/product_signals/schema.py
@@ -69,9 +69,26 @@ class ProductSignal:
     @staticmethod
     def create(
         team_token: str,
-        signal: "ProductSignal",
         distinct_id: str,
+        signal_type: ProductSignalType,
+        severity: ProductSignalSeverity,
+        title: str,
+        source: Product,
+        description: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        timestamp: Optional[datetime] = None,
     ) -> None:
+        signal = ProductSignal(
+            signal_type=signal_type,
+            severity=severity,
+            title=title,
+            source=source,
+            distinct_id=distinct_id,
+            description=description,
+            metadata=metadata or {},
+            timestamp=timestamp,
+        )
+
         timestamp = signal.timestamp or datetime.now()
 
         try:

--- a/posthog/product_signals/test_schema.py
+++ b/posthog/product_signals/test_schema.py
@@ -71,19 +71,14 @@ class TestProductSignal(BaseTest):
     def test_create_signal_success(self, mock_capture_internal):
         mock_capture_internal.return_value = None
 
-        signal = ProductSignal(
+        ProductSignal.create(
+            team_token="test_token",
+            distinct_id="team_123",
             signal_type=ProductSignalType.NEW_ISSUE,
             severity=ProductSignalSeverity.HIGH,
             title="Test Signal",
-            description="Test description",
             source=Product.ERROR_TRACKING,
-            distinct_id="team_123",
-        )
-
-        ProductSignal.create(
-            team_token="test_token",
-            signal=signal,
-            distinct_id="team_123",
+            description="Test description",
         )
 
         mock_capture_internal.assert_called_once()
@@ -103,19 +98,15 @@ class TestProductSignal(BaseTest):
         mock_capture_internal.return_value = None
 
         custom_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
-        signal = ProductSignal(
+
+        ProductSignal.create(
+            team_token="test_token",
+            distinct_id="team_456",
             signal_type=ProductSignalType.FUNNEL_CONVERSION_RATE_CHANGE,
             severity=ProductSignalSeverity.MEDIUM,
             title="Funnel Drop",
             source=Product.PRODUCT_ANALYTICS,
-            distinct_id="team_456",
             timestamp=custom_timestamp,
-        )
-
-        ProductSignal.create(
-            team_token="test_token",
-            signal=signal,
-            distinct_id="team_456",
         )
 
         call_kwargs = mock_capture_internal.call_args.kwargs
@@ -125,22 +116,17 @@ class TestProductSignal(BaseTest):
     def test_create_signal_with_metadata(self, mock_capture_internal):
         mock_capture_internal.return_value = None
 
-        signal = ProductSignal(
+        ProductSignal.create(
+            team_token="test_token",
+            distinct_id="team_789",
             signal_type=ProductSignalType.NEW_ISSUE,
             severity=ProductSignalSeverity.CRITICAL,
             title="Critical Bug",
             source=Product.ERROR_TRACKING,
-            distinct_id="team_789",
             metadata={
                 "error_count": 42,
                 "first_seen": "2024-01-01T00:00:00Z",
             },
-        )
-
-        ProductSignal.create(
-            team_token="test_token",
-            signal=signal,
-            distinct_id="team_789",
         )
 
         call_kwargs = mock_capture_internal.call_args.kwargs
@@ -152,18 +138,13 @@ class TestProductSignal(BaseTest):
     def test_create_signal_captures_exception_on_error(self, mock_capture_internal, mock_capture_exception):
         mock_capture_internal.side_effect = Exception("Capture failed")
 
-        signal = ProductSignal(
+        ProductSignal.create(
+            team_token="test_token",
+            distinct_id="team_123",
             signal_type=ProductSignalType.NEW_ISSUE,
             severity=ProductSignalSeverity.HIGH,
             title="Test Signal",
             source=Product.ERROR_TRACKING,
-            distinct_id="team_123",
-        )
-
-        ProductSignal.create(
-            team_token="test_token",
-            signal=signal,
-            distinct_id="team_123",
         )
 
         mock_capture_exception.assert_called_once()

--- a/posthog/product_signals/test_schema.py
+++ b/posthog/product_signals/test_schema.py
@@ -1,0 +1,210 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.product_signals.schema import (
+    ProductSignal,
+    ProductSignalException,
+    ProductSignalSeverity,
+    ProductSignalSource,
+    ProductSignalType,
+)
+
+
+class TestProductSignal(BaseTest):
+    def test_to_event_properties_basic(self):
+        signal = ProductSignal(
+            signal_type=ProductSignalType.NEW_ISSUE,
+            severity=ProductSignalSeverity.HIGH,
+            title="Test Issue",
+            description="Test description",
+            source=ProductSignalSource.ERROR_TRACKING,
+            distinct_id="team_123",
+        )
+
+        props = signal.to_event_properties()
+
+        assert props["$product_signal_type"] == "new_issue"
+        assert props["$product_signal_severity"] == "high"
+        assert props["$product_signal_title"] == "Test Issue"
+        assert props["$product_signal_source"] == "error_tracking"
+        assert props["$product_signal_description"] == "Test description"
+
+    def test_to_event_properties_without_description(self):
+        signal = ProductSignal(
+            signal_type=ProductSignalType.FUNNEL_ANOMOLY,
+            severity=ProductSignalSeverity.MEDIUM,
+            title="Test Issue",
+            source=ProductSignalSource.PRODUCT_ANALYTICS,
+            distinct_id="team_456",
+        )
+
+        props = signal.to_event_properties()
+
+        assert "$product_signal_description" not in props
+        assert props["$product_signal_type"] == "funnel_anomoly"
+        assert props["$product_signal_severity"] == "medium"
+
+    def test_to_event_properties_with_metadata(self):
+        signal = ProductSignal(
+            signal_type=ProductSignalType.NEW_ISSUE,
+            severity=ProductSignalSeverity.CRITICAL,
+            title="Critical Error",
+            source=ProductSignalSource.ERROR_TRACKING,
+            distinct_id="team_789",
+            metadata={
+                "error_id": "err_123",
+                "affected_users": 150,
+                "url": "https://example.com/checkout",
+            },
+        )
+
+        props = signal.to_event_properties()
+
+        assert props["error_id"] == "err_123"
+        assert props["affected_users"] == 150
+        assert props["url"] == "https://example.com/checkout"
+        assert props["$product_signal_type"] == "new_issue"
+
+    @patch("posthog.product_signals.schema.capture_internal")
+    def test_create_signal_success(self, mock_capture_internal):
+        mock_capture_internal.return_value = None
+
+        signal = ProductSignal(
+            signal_type=ProductSignalType.NEW_ISSUE,
+            severity=ProductSignalSeverity.HIGH,
+            title="Test Signal",
+            description="Test description",
+            source=ProductSignalSource.ERROR_TRACKING,
+            distinct_id="team_123",
+        )
+
+        ProductSignal.create(
+            team_token="test_token",
+            signal=signal,
+            distinct_id="team_123",
+        )
+
+        mock_capture_internal.assert_called_once()
+        call_kwargs = mock_capture_internal.call_args.kwargs
+
+        assert call_kwargs["token"] == "test_token"
+        assert call_kwargs["event_name"] == "$product_signal"
+        assert call_kwargs["event_source"] == "product_signals"
+        assert call_kwargs["distinct_id"] == "team_123"
+        assert call_kwargs["process_person_profile"] is False
+        assert call_kwargs["properties"]["$product_signal_type"] == "new_issue"
+        assert call_kwargs["properties"]["$product_signal_severity"] == "high"
+        assert call_kwargs["properties"]["$product_signal_title"] == "Test Signal"
+
+    @patch("posthog.product_signals.schema.capture_internal")
+    def test_create_signal_with_timestamp(self, mock_capture_internal):
+        mock_capture_internal.return_value = None
+
+        custom_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        signal = ProductSignal(
+            signal_type=ProductSignalType.FUNNEL_ANOMOLY,
+            severity=ProductSignalSeverity.MEDIUM,
+            title="Funnel Drop",
+            source=ProductSignalSource.PRODUCT_ANALYTICS,
+            distinct_id="team_456",
+            timestamp=custom_timestamp,
+        )
+
+        ProductSignal.create(
+            team_token="test_token",
+            signal=signal,
+            distinct_id="team_456",
+        )
+
+        call_kwargs = mock_capture_internal.call_args.kwargs
+        assert call_kwargs["timestamp"] == custom_timestamp
+
+    @patch("posthog.product_signals.schema.capture_internal")
+    def test_create_signal_with_metadata(self, mock_capture_internal):
+        mock_capture_internal.return_value = None
+
+        signal = ProductSignal(
+            signal_type=ProductSignalType.NEW_ISSUE,
+            severity=ProductSignalSeverity.CRITICAL,
+            title="Critical Bug",
+            source=ProductSignalSource.ERROR_TRACKING,
+            distinct_id="team_789",
+            metadata={
+                "error_count": 42,
+                "first_seen": "2024-01-01T00:00:00Z",
+            },
+        )
+
+        ProductSignal.create(
+            team_token="test_token",
+            signal=signal,
+            distinct_id="team_789",
+        )
+
+        call_kwargs = mock_capture_internal.call_args.kwargs
+        assert call_kwargs["properties"]["error_count"] == 42
+        assert call_kwargs["properties"]["first_seen"] == "2024-01-01T00:00:00Z"
+
+    @patch("posthog.product_signals.schema.capture_internal")
+    def test_create_signal_raises_exception_on_error(self, mock_capture_internal):
+        mock_capture_internal.side_effect = Exception("Capture failed")
+
+        signal = ProductSignal(
+            signal_type=ProductSignalType.NEW_ISSUE,
+            severity=ProductSignalSeverity.HIGH,
+            title="Test Signal",
+            source=ProductSignalSource.ERROR_TRACKING,
+            distinct_id="team_123",
+        )
+
+        with self.assertRaises(ProductSignalException) as context:
+            ProductSignal.create(
+                team_token="test_token",
+                signal=signal,
+                distinct_id="team_123",
+            )
+
+        exception = context.exception
+        assert exception.signal_type == ProductSignalType.NEW_ISSUE
+        assert exception.severity == ProductSignalSeverity.HIGH
+        assert exception.title == "Test Signal"
+        assert "new_issue" in str(exception)
+        assert "high" in str(exception)
+        assert "Test Signal" in str(exception)
+
+
+class TestProductSignalException(BaseTest):
+    def test_exception_captures_signal_data(self):
+        signal = ProductSignal(
+            signal_type=ProductSignalType.FUNNEL_ANOMOLY,
+            severity=ProductSignalSeverity.CRITICAL,
+            title="Test Exception",
+            description="Test description",
+            source=ProductSignalSource.PRODUCT_ANALYTICS,
+            distinct_id="team_999",
+            metadata={"key": "value"},
+        )
+
+        exception = ProductSignalException(signal)
+
+        assert exception.signal_type == ProductSignalType.FUNNEL_ANOMOLY
+        assert exception.severity == ProductSignalSeverity.CRITICAL
+        assert exception.title == "Test Exception"
+        assert exception.description == "Test description"
+        assert exception.distinct_id == "team_999"
+        assert exception.metadata == {"key": "value"}
+
+    def test_exception_message_format(self):
+        signal = ProductSignal(
+            signal_type=ProductSignalType.NEW_ISSUE,
+            severity=ProductSignalSeverity.LOW,
+            title="Low Priority Signal",
+            source=ProductSignalSource.ERROR_TRACKING,
+            distinct_id="team_100",
+        )
+
+        exception = ProductSignalException(signal)
+
+        assert str(exception) == "ProductSignalException: new_issue [low] - Low Priority Signal"

--- a/posthog/product_signals/test_schema.py
+++ b/posthog/product_signals/test_schema.py
@@ -3,11 +3,11 @@ from datetime import UTC, datetime
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from posthog.constants import Product
 from posthog.product_signals.schema import (
     ProductSignal,
     ProductSignalException,
     ProductSignalSeverity,
-    ProductSignalSource,
     ProductSignalType,
 )
 
@@ -19,7 +19,7 @@ class TestProductSignal(BaseTest):
             severity=ProductSignalSeverity.HIGH,
             title="Test Issue",
             description="Test description",
-            source=ProductSignalSource.ERROR_TRACKING,
+            source=Product.ERROR_TRACKING,
             distinct_id="team_123",
         )
 
@@ -33,17 +33,17 @@ class TestProductSignal(BaseTest):
 
     def test_to_event_properties_without_description(self):
         signal = ProductSignal(
-            signal_type=ProductSignalType.FUNNEL_ANOMOLY,
+            signal_type=ProductSignalType.FUNNEL_CONVERSION_RATE_CHANGE,
             severity=ProductSignalSeverity.MEDIUM,
             title="Test Issue",
-            source=ProductSignalSource.PRODUCT_ANALYTICS,
+            source=Product.PRODUCT_ANALYTICS,
             distinct_id="team_456",
         )
 
         props = signal.to_event_properties()
 
         assert "$product_signal_description" not in props
-        assert props["$product_signal_type"] == "funnel_anomoly"
+        assert props["$product_signal_type"] == "funnel_conversion_rate_change"
         assert props["$product_signal_severity"] == "medium"
 
     def test_to_event_properties_with_metadata(self):
@@ -51,7 +51,7 @@ class TestProductSignal(BaseTest):
             signal_type=ProductSignalType.NEW_ISSUE,
             severity=ProductSignalSeverity.CRITICAL,
             title="Critical Error",
-            source=ProductSignalSource.ERROR_TRACKING,
+            source=Product.ERROR_TRACKING,
             distinct_id="team_789",
             metadata={
                 "error_id": "err_123",
@@ -76,7 +76,7 @@ class TestProductSignal(BaseTest):
             severity=ProductSignalSeverity.HIGH,
             title="Test Signal",
             description="Test description",
-            source=ProductSignalSource.ERROR_TRACKING,
+            source=Product.ERROR_TRACKING,
             distinct_id="team_123",
         )
 
@@ -104,10 +104,10 @@ class TestProductSignal(BaseTest):
 
         custom_timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
         signal = ProductSignal(
-            signal_type=ProductSignalType.FUNNEL_ANOMOLY,
+            signal_type=ProductSignalType.FUNNEL_CONVERSION_RATE_CHANGE,
             severity=ProductSignalSeverity.MEDIUM,
             title="Funnel Drop",
-            source=ProductSignalSource.PRODUCT_ANALYTICS,
+            source=Product.PRODUCT_ANALYTICS,
             distinct_id="team_456",
             timestamp=custom_timestamp,
         )
@@ -129,7 +129,7 @@ class TestProductSignal(BaseTest):
             signal_type=ProductSignalType.NEW_ISSUE,
             severity=ProductSignalSeverity.CRITICAL,
             title="Critical Bug",
-            source=ProductSignalSource.ERROR_TRACKING,
+            source=Product.ERROR_TRACKING,
             distinct_id="team_789",
             metadata={
                 "error_count": 42,
@@ -156,7 +156,7 @@ class TestProductSignal(BaseTest):
             signal_type=ProductSignalType.NEW_ISSUE,
             severity=ProductSignalSeverity.HIGH,
             title="Test Signal",
-            source=ProductSignalSource.ERROR_TRACKING,
+            source=Product.ERROR_TRACKING,
             distinct_id="team_123",
         )
 
@@ -179,18 +179,18 @@ class TestProductSignal(BaseTest):
 class TestProductSignalException(BaseTest):
     def test_exception_captures_signal_data(self):
         signal = ProductSignal(
-            signal_type=ProductSignalType.FUNNEL_ANOMOLY,
+            signal_type=ProductSignalType.FUNNEL_CONVERSION_RATE_CHANGE,
             severity=ProductSignalSeverity.CRITICAL,
             title="Test Exception",
             description="Test description",
-            source=ProductSignalSource.PRODUCT_ANALYTICS,
+            source=Product.PRODUCT_ANALYTICS,
             distinct_id="team_999",
             metadata={"key": "value"},
         )
 
         exception = ProductSignalException(signal)
 
-        assert exception.signal_type == ProductSignalType.FUNNEL_ANOMOLY
+        assert exception.signal_type == ProductSignalType.FUNNEL_CONVERSION_RATE_CHANGE
         assert exception.severity == ProductSignalSeverity.CRITICAL
         assert exception.title == "Test Exception"
         assert exception.description == "Test description"
@@ -202,7 +202,7 @@ class TestProductSignalException(BaseTest):
             signal_type=ProductSignalType.NEW_ISSUE,
             severity=ProductSignalSeverity.LOW,
             title="Low Priority Signal",
-            source=ProductSignalSource.ERROR_TRACKING,
+            source=Product.ERROR_TRACKING,
             distinct_id="team_100",
         )
 

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -549,7 +549,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 08:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$product_signal', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback']
   GROUP BY team_id
   '''
 # ---
@@ -561,7 +561,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 08:00:00'
     AND timestamp < '2022-01-10 16:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$product_signal', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback']
   GROUP BY team_id
   '''
 # ---
@@ -573,7 +573,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 16:00:00'
     AND timestamp < '2022-01-10 23:59:59'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$product_signal', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback']
   GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -482,6 +482,7 @@ def get_teams_with_billable_event_count_in_period(
         "survey shown",
         "survey dismissed",
         "$exception",
+        "$product_signal",
         *AI_EVENTS,
     ]
 

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1999,7 +1999,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$product_signal_type": {
             "label": "Product signal type",
             "description": "The type of product signal being reported.",
-            "examples": ["new_issue", "funnel_anomoly"],
+            "examples": ["new_issue", "funnel_conversion_rate_change"],
         },
         "$product_signal_severity": {
             "label": "Product signal severity",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -213,6 +213,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Exception",
             "description": "An unexpected error or unhandled exception in your application.",
         },
+        "$product_signal": {
+            "label": "Product signal",
+            "description": "Internal signals representing actionable product issues detected by PostHog analysis systems.",
+            "ignored_in_assistant": True,
+        },
         "$web_vitals": {
             "label": "Web vitals",
             "description": "Automatically captured web vitals data.",
@@ -1990,6 +1995,31 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "CSP Policy version",
             "description": "The version of the CSP policy. Must be provided in the report URL.",
             "examples": ["1.0"],
+        },
+        "$product_signal_type": {
+            "label": "Product signal type",
+            "description": "The type of product signal being reported.",
+            "examples": ["new_issue", "funnel_anomoly"],
+        },
+        "$product_signal_severity": {
+            "label": "Product signal severity",
+            "description": "The severity level of the product signal.",
+            "examples": ["low", "medium", "high", "critical"],
+        },
+        "$product_signal_title": {
+            "label": "Product signal title",
+            "description": "A brief title describing the product signal.",
+            "examples": ["New error in checkout flow", "Funnel drop-off detected"],
+        },
+        "$product_signal_source": {
+            "label": "Product signal source",
+            "description": "The PostHog product that generated this signal.",
+            "examples": ["error_tracking", "product_analytics"],
+        },
+        "$product_signal_description": {
+            "label": "Product signal description",
+            "description": "A detailed description of the product signal and what action may be required.",
+            "examples": ["A new error type was detected affecting 15% of users in the checkout flow"],
         },
     },
     "numerical_event_properties": {},


### PR DESCRIPTION
## Problem

We want a way for products to emit signals when we detect changes in their product.

These are different from something like alerts in that they should be emitted by products whenever there is a significant change. Examples of a signal include:

- A funnel conversion rate changes significantly
- An experiment reaches statistical significance
- An issue is affecting an increasing number of users

The goal of these product signals is to create a noisy stream of events which we can consume to create meaningful tasks for the array product.


## Changes

Added a new event type $product_signal, and given it some default properties.

This event type is stored in the events table (not in the internal events table) because we may want users to be able to take actions on signals,to analyze them using product analytics, or to be able to see them in the Activity tab.

Since these events will be generated internally, they should not be billed for, so we exclude them from billing.

## How did you test this code?

Added some unit tests.