### PR TITLE
fix(django): rms cross-database query on org deletes

### DIFF
--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -16,7 +16,7 @@ actions_that_require_current_team = [
 def delete_bulky_postgres_data(team_ids: list[int]):
     "Efficiently delete large tables for teams from postgres. Using normal CASCADE delete here can time out"
 
-    from posthog.models.cohort import CohortPeople
+    from posthog.models.cohort import Cohort, CohortPeople
     from posthog.models.error_tracking import ErrorTrackingIssueFingerprintV2
     from posthog.models.feature_flag.feature_flag import FeatureFlagHashKeyOverride
     from posthog.models.insight_caching_state import InsightCachingState
@@ -27,7 +27,12 @@ def delete_bulky_postgres_data(team_ids: list[int]):
     _raw_delete(EarlyAccessFeature.objects.filter(team_id__in=team_ids))
     _raw_delete(PersonDistinctId.objects.filter(team_id__in=team_ids))
     _raw_delete(ErrorTrackingIssueFingerprintV2.objects.filter(team_id__in=team_ids))
-    _raw_delete(CohortPeople.objects.filter(cohort__team_id__in=team_ids))
+
+    # Get cohort_ids from the default database first to avoid cross-database join
+    # CohortPeople is in persons_db, Cohort is in default db
+    cohort_ids = list(Cohort.objects.filter(team_id__in=team_ids).values_list("id", flat=True))
+    _raw_delete(CohortPeople.objects.filter(cohort_id__in=cohort_ids))
+
     _raw_delete(FeatureFlagHashKeyOverride.objects.filter(team_id__in=team_ids))
     _raw_delete(Person.objects.filter(team_id__in=team_ids))
     _raw_delete(InsightCachingState.objects.filter(team_id__in=team_ids))


### PR DESCRIPTION
## Problem

Organization deletes created a table join between cohort and cohortpeople. This is a cross database join with two separate databases.

## Changes

First look up all cohort ids with the team id filter, then make the delete cohort people query with the list of cohort ids.

## How did you test this code?

Unit tests cover the delete functionality.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
