### PR TITLE
feat(array): send $product_signal event on issue creation

### DIFF
--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -293,6 +293,7 @@ fn create_product_signal_event(issue: &Issue, timestamp: &DateTime<Utc>) -> Clic
         project_id: None,
         event: "$product_signal".to_string(),
         distinct_id: "team".to_string(),
+        properties: Some(properties_json),
         person_id: None,
         timestamp: timestamp_str,
         created_at: now_str,


### PR DESCRIPTION
NOTE: I have not written any rust before, Claude helped me a lot with this, it might be completely wrong

## Problem

For new issues, we want a product signal to consume for tasks.

## Changes

Create a `$product_signal` event when a new issue is created to be consumed by the tasks product.

## How did you test this code?

Added some unit tests. I don't know how to test this well locally.