### PR TITLE
fix: emit prom metrics for subscriptions

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -53,9 +53,21 @@ SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
 
 
 # Temporal metrics for temporal workers
+def get_metric_meter():
+    """Get metric meter for the current context (activity or workflow)."""
+    from temporalio import workflow
+
+    if activity.in_activity():
+        return activity.metric_meter()
+    elif workflow.in_workflow():
+        return workflow.metric_meter()
+    else:
+        raise RuntimeError("Not within workflow or activity context")
+
+
 def get_asset_generation_duration_metric(execution_path: str):
     return (
-        activity.metric_meter()
+        get_metric_meter()
         .with_additional_attributes({"execution_path": execution_path})
         .create_histogram_timedelta(
             "subscription_asset_generation_duration",
@@ -66,7 +78,7 @@ def get_asset_generation_duration_metric(execution_path: str):
 
 def get_asset_generation_timeout_metric(execution_path: str):
     return (
-        activity.metric_meter()
+        get_metric_meter()
         .with_additional_attributes({"execution_path": execution_path})
         .create_counter(
             "subscription_asset_generation_timeout",

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -1,3 +1,4 @@
+import time
 import asyncio
 import datetime
 from typing import Union
@@ -6,7 +7,8 @@ from django.conf import settings
 
 import structlog
 from celery import chain
-from prometheus_client import Counter, Histogram
+from prometheus_client import Histogram
+from temporalio import activity
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
@@ -41,6 +43,7 @@ def _get_failed_asset_info(assets: list[ExportedAsset], resource: Union[Subscrip
     }
 
 
+# Prometheus metrics for Celery workers (web/worker pods)
 SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
     "subscription_asset_generation_duration_seconds",
     "Time spent generating assets for a subscription",
@@ -48,11 +51,28 @@ SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
     buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
 )
 
-SUBSCRIPTION_ASSET_GENERATION_TIMEOUT_COUNTER = Counter(
-    "subscription_asset_generation_timeout_total",
-    "Number of times asset generation timed out during subscription delivery",
-    labelnames=["execution_path"],
-)
+
+# Temporal metrics for temporal workers
+def get_asset_generation_duration_metric(execution_path: str):
+    return (
+        activity.metric_meter()
+        .with_additional_attributes({"execution_path": execution_path})
+        .create_histogram_timedelta(
+            "subscription_asset_generation_duration",
+            "Time spent generating assets for a subscription",
+        )
+    )
+
+
+def get_asset_generation_timeout_metric(execution_path: str):
+    return (
+        activity.metric_meter()
+        .with_additional_attributes({"execution_path": execution_path})
+        .create_counter(
+            "subscription_asset_generation_timeout",
+            "Number of times asset generation timed out during subscription delivery",
+        )
+    )
 
 
 def generate_assets(
@@ -112,7 +132,8 @@ async def generate_assets_async(
     This function requires "created_by", "insight", "dashboard", "team" be prefetched on the resource
     """
     logger.info("generate_assets_async.starting", resource_id=getattr(resource, "id", None))
-    with SUBSCRIPTION_ASSET_GENERATION_TIMER.labels(execution_path="temporal").time():
+    start_time = time.time()
+    try:
         if resource.dashboard:
             # Fetch tiles asynchronously
             dashboard = resource.dashboard  # Capture reference for lambda
@@ -202,7 +223,7 @@ async def generate_assets_async(
                 team_id=resource.team_id,
             )
         except TimeoutError:
-            SUBSCRIPTION_ASSET_GENERATION_TIMEOUT_COUNTER.labels(execution_path="temporal").inc()
+            get_asset_generation_timeout_metric("temporal").add(1)
 
             # Get failure info for logging
             failure_info = _get_failed_asset_info(assets, resource)
@@ -218,3 +239,6 @@ async def generate_assets_async(
             # Continue with partial results - some assets may not have content
 
         return insights, assets
+    finally:
+        duration = datetime.timedelta(seconds=time.time() - start_time)
+        get_asset_generation_duration_metric("temporal").record(duration)

--- a/ee/tasks/test/subscriptions/test_generate_assets_async.py
+++ b/ee/tasks/test/subscriptions/test_generate_assets_async.py
@@ -27,7 +27,10 @@ async def mock_export_asset():
         asset.content = b"fake image data"
         asset.save()
 
-    with patch("ee.tasks.subscriptions.subscription_utils.exporter.export_asset_direct", side_effect=set_content):
+    with (
+        patch("ee.tasks.subscriptions.subscription_utils.exporter.export_asset_direct", side_effect=set_content),
+        patch("ee.tasks.subscriptions.subscription_utils.get_metric_meter", MagicMock()),
+    ):
         yield
 
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We weren't getting Prometheus metrics for subscriptions running on Temporal because the subscription code was using Python's prometheus_client library (Counter, Histogram) instead of Temporal's built-in metric system (activity.metric_meter()). 

Python prometheus_client metrics need a separate HTTP server to be exposed, but the temporal worker only exposes Temporal SDK metrics via its PrometheusConfig on port 6738.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Switch to Temporal's metric system (like batch exports) so that metrics are automatically exposed through the existing Temporal Prometheus endpoint.

Batch exports code: 
https://github.com/PostHog/posthog/blob/bf7d2126297f09a28549e4aa8e200486c12dc1f4/products/batch_exports/backend/temporal/metrics.py#L23-L24

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I will verify metrics are emitted in prod

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
