### PR TITLE
fix(flags): Maintain blast radius associations

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -415,12 +415,13 @@ export function FeatureFlagReleaseConditions({
                                     )}
                                 />
                                 of <b>{aggregationTargetName}</b> in this set. Will match approximately{' '}
-                                {affectedUsers[index] !== undefined ? (
+                                {group.sort_key && affectedUsers[group.sort_key] !== undefined ? (
                                     <b>
                                         {`${
-                                            computeBlastRadiusPercentage(group.rollout_percentage, index).toPrecision(
-                                                2
-                                            ) * 1
+                                            computeBlastRadiusPercentage(
+                                                group.rollout_percentage,
+                                                group.sort_key
+                                            ).toPrecision(2) * 1
                                             // Multiplying by 1 removes trailing zeros after the decimal
                                             // point added by toPrecision
                                         }% `}
@@ -429,7 +430,7 @@ export function FeatureFlagReleaseConditions({
                                     <Spinner className="mr-1" />
                                 )}{' '}
                                 {(() => {
-                                    const affectedUserCount = affectedUsers[index]
+                                    const affectedUserCount = group.sort_key ? affectedUsers[group.sort_key] : undefined
                                     if (
                                         affectedUserCount !== undefined &&
                                         affectedUserCount >= 0 &&

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -1,4 +1,5 @@
 import { expectLogic } from 'kea-test-utils'
+import { v4 as uuidv4 } from 'uuid'
 
 import api from 'lib/api'
 
@@ -14,6 +15,10 @@ import {
 
 import { featureFlagReleaseConditionsLogic } from './featureFlagReleaseConditionsLogic'
 
+jest.mock('uuid', () => ({
+    v4: jest.fn(),
+}))
+
 function generateFeatureFlagFilters(
     groups: FeatureFlagGroupType[],
     multivariate?: MultivariateFlagOptions
@@ -23,9 +28,20 @@ function generateFeatureFlagFilters(
 
 describe('the feature flag release conditions logic', () => {
     let logic: ReturnType<typeof featureFlagReleaseConditionsLogic.build>
+    let nextUuid: string
 
     beforeEach(() => {
         initKeaTests()
+
+        jest.clearAllMocks()
+
+        nextUuid = 'A'
+        ;(uuidv4 as jest.Mock).mockImplementation(() => {
+            const uuid = nextUuid
+            nextUuid = String.fromCharCode(nextUuid.charCodeAt(0) + 1)
+            return uuid
+        })
+
         logic = featureFlagReleaseConditionsLogic({
             id: '1234',
             filters: generateFeatureFlagFilters([
@@ -66,6 +82,7 @@ describe('the feature flag release conditions logic', () => {
                         ],
                         rollout_percentage: 50,
                         variant: null,
+                        sort_key: 'A',
                     },
                 ]),
             })
@@ -74,7 +91,7 @@ describe('the feature flag release conditions logic', () => {
             })
                 .toDispatchActions(['calculateBlastRadius', 'setAffectedUsers', 'setTotalUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 120 },
+                    affectedUsers: { A: 120 },
                     totalUsers: 2000,
                 })
         })
@@ -85,7 +102,7 @@ describe('the feature flag release conditions logic', () => {
 
             logic = featureFlagReleaseConditionsLogic({
                 filters: generateFeatureFlagFilters([
-                    { properties: [], rollout_percentage: 86, variant: null },
+                    { properties: [], rollout_percentage: 86, variant: null, sort_key: 'A' },
                     {
                         properties: [
                             {
@@ -97,6 +114,7 @@ describe('the feature flag release conditions logic', () => {
                         ],
                         rollout_percentage: 50,
                         variant: null,
+                        sort_key: 'B',
                     },
                     {
                         properties: [
@@ -109,6 +127,7 @@ describe('the feature flag release conditions logic', () => {
                         ],
                         rollout_percentage: 75,
                         variant: null,
+                        sort_key: 'C',
                     },
                     {
                         properties: [
@@ -121,6 +140,7 @@ describe('the feature flag release conditions logic', () => {
                         ],
                         rollout_percentage: 86,
                         variant: null,
+                        sort_key: 'D',
                     },
                 ]),
             })
@@ -135,27 +155,27 @@ describe('the feature flag release conditions logic', () => {
             })
                 .toDispatchActions(['setAffectedUsers', 'setAffectedUsers', 'setAffectedUsers', 'setAffectedUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: undefined, 1: undefined, 2: undefined, 3: undefined },
+                    affectedUsers: { A: undefined, B: undefined, C: undefined, D: undefined },
                     totalUsers: null,
                 })
                 .toDispatchActions(['setAffectedUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 140, 1: undefined, 2: undefined, 3: undefined },
+                    affectedUsers: { A: 140, B: undefined, C: undefined, D: undefined },
                     totalUsers: null,
                 })
                 .toDispatchActions(['setAffectedUsers', 'setTotalUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 140, 1: 240 },
+                    affectedUsers: { A: 140, B: 240 },
                     totalUsers: 2002,
                 })
                 .toDispatchActions(['setAffectedUsers', 'setTotalUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 140, 1: 240, 2: 500 },
+                    affectedUsers: { A: 140, B: 240, C: 500 },
                     totalUsers: 2000,
                 })
                 .toDispatchActions(['setAffectedUsers', 'setTotalUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 140, 1: 240, 2: 500, 3: 750 },
+                    affectedUsers: { A: 140, B: 240, C: 500, D: 750 },
                     totalUsers: 2001,
                 })
         })
@@ -166,7 +186,6 @@ describe('the feature flag release conditions logic', () => {
                 .mockReturnValueOnce(Promise.resolve({ users_affected: 248, total_users: 2000 }))
                 .mockReturnValueOnce(Promise.resolve({ users_affected: 496, total_users: 2000 }))
 
-            logic?.unmount()
             logic = featureFlagReleaseConditionsLogic({
                 id: '5678',
                 filters: generateFeatureFlagFilters([
@@ -174,6 +193,7 @@ describe('the feature flag release conditions logic', () => {
                         properties: [],
                         rollout_percentage: 50,
                         variant: null,
+                        sort_key: 'A',
                     },
                 ]),
             })
@@ -194,7 +214,7 @@ describe('the feature flag release conditions logic', () => {
                 // third call is to set the affected users for the updateConditionSet action
                 .toDispatchActions(['setAffectedUsers', 'setAffectedUsers', 'setAffectedUsers', 'setTotalUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 124 },
+                    affectedUsers: { A: 124 },
                     totalUsers: 2000,
                 })
 
@@ -210,23 +230,24 @@ describe('the feature flag release conditions logic', () => {
             })
                 .toDispatchActions(['setAffectedUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: undefined },
+                    affectedUsers: { A: undefined },
                     totalUsers: 2000,
                 })
                 .toDispatchActions(['setAffectedUsers', 'setTotalUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 248 },
+                    affectedUsers: { A: 248 },
                     totalUsers: 2000,
                 })
 
             // Add another condition set
             await expectLogic(logic, () => {
+                nextUuid = 'B'
                 logic.actions.addConditionSet()
             })
                 .toDispatchActions(['setAffectedUsers'])
                 .toMatchValues({
                     // expect the new empty condition set to initialize affected users to be same as total users
-                    affectedUsers: { 0: 248, 1: 2000 },
+                    affectedUsers: { A: 248, B: 2000 },
                     totalUsers: 2000,
                 })
                 .toNotHaveDispatchedActions(['setTotalUsers'])
@@ -244,7 +265,7 @@ describe('the feature flag release conditions logic', () => {
             })
                 .toDispatchActions(['setAffectedUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 248, 1: undefined },
+                    affectedUsers: { A: 248, B: undefined },
                     totalUsers: 2000,
                 })
                 .toNotHaveDispatchedActions(['setTotalUsers'])
@@ -262,12 +283,12 @@ describe('the feature flag release conditions logic', () => {
             })
                 .toDispatchActions(['setAffectedUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 248, 1: undefined },
+                    affectedUsers: { A: 248, B: undefined },
                     totalUsers: 2000,
                 })
                 .toDispatchActions(['setAffectedUsers', 'setTotalUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 248, 1: 496 },
+                    affectedUsers: { A: 248, B: 496 },
                     totalUsers: 2000,
                 })
 
@@ -275,64 +296,61 @@ describe('the feature flag release conditions logic', () => {
             await expectLogic(logic, () => {
                 logic.actions.removeConditionSet(0)
             })
-                .toDispatchActions(['setAffectedUsers'])
+                .toNotHaveDispatchedActions(['setAffectedUsers'])
                 .toMatchValues({
-                    affectedUsers: { 0: 496, 1: 496 },
-                })
-                .toDispatchActions(['setAffectedUsers'])
-                .toMatchValues({
-                    affectedUsers: { 0: 496, 1: undefined },
+                    affectedUsers: { A: 248, B: 496 },
                 })
         })
 
         it('computes blast radius percentages accurately', async () => {
-            logic.actions.setAffectedUsers(0, 100)
-            logic.actions.setAffectedUsers(1, 200)
-            logic.actions.setAffectedUsers(2, 346)
+            logic.actions.setAffectedUsers('A', 100)
+            logic.actions.setAffectedUsers('B', 200)
+            logic.actions.setAffectedUsers('C', 346)
             logic.actions.setTotalUsers(1000)
 
-            expect(logic.values.computeBlastRadiusPercentage(20, 0)).toBeCloseTo(2, 2)
-            expect(logic.values.computeBlastRadiusPercentage(33, 0)).toBeCloseTo(3.3, 2)
+            expect(logic.values.computeBlastRadiusPercentage(20, 'A')).toBeCloseTo(2, 2)
+            expect(logic.values.computeBlastRadiusPercentage(33, 'A')).toBeCloseTo(3.3, 2)
 
-            expect(logic.values.computeBlastRadiusPercentage(50, 1)).toBeCloseTo(10, 2)
-            expect(logic.values.computeBlastRadiusPercentage(100, 1)).toBeCloseTo(20, 2)
+            expect(logic.values.computeBlastRadiusPercentage(50, 'B')).toBeCloseTo(10, 2)
+            expect(logic.values.computeBlastRadiusPercentage(100, 'B')).toBeCloseTo(20, 2)
 
-            expect(logic.values.computeBlastRadiusPercentage(100, 2)).toBeCloseTo(34.6, 2)
-            expect(logic.values.computeBlastRadiusPercentage(67, 2)).toBeCloseTo(23.182, 2)
+            expect(logic.values.computeBlastRadiusPercentage(100, 'C')).toBeCloseTo(34.6, 2)
+            expect(logic.values.computeBlastRadiusPercentage(67, 'C')).toBeCloseTo(23.182, 2)
         })
 
         it('computes blast radius percentages accurately with missing information', async () => {
-            logic.actions.setAffectedUsers(0, -1)
-            logic.actions.setAffectedUsers(1, undefined)
-            logic.actions.setAffectedUsers(2, 25)
+            logic.actions.setAffectedUsers('A', -1)
+            logic.actions.setAffectedUsers('B', undefined)
+            logic.actions.setAffectedUsers('C', 25)
             // total users is null as well
 
-            expect(logic.values.computeBlastRadiusPercentage(20, 0)).toBeCloseTo(20, 2)
-            expect(logic.values.computeBlastRadiusPercentage(33, 0)).toBeCloseTo(33, 2)
+            expect(logic.values.computeBlastRadiusPercentage(20, 'A')).toBeCloseTo(20, 2)
+            expect(logic.values.computeBlastRadiusPercentage(33, 'A')).toBeCloseTo(33, 2)
 
-            expect(logic.values.computeBlastRadiusPercentage(50, 1)).toBeCloseTo(50, 2)
-            expect(logic.values.computeBlastRadiusPercentage(100, 1)).toBeCloseTo(100, 2)
+            expect(logic.values.computeBlastRadiusPercentage(50, 'B')).toBeCloseTo(50, 2)
+            expect(logic.values.computeBlastRadiusPercentage(100, 'B')).toBeCloseTo(100, 2)
 
-            expect(logic.values.computeBlastRadiusPercentage(100, 2)).toBeCloseTo(100, 2)
-            expect(logic.values.computeBlastRadiusPercentage(10, 2)).toBeCloseTo(10, 2)
+            expect(logic.values.computeBlastRadiusPercentage(100, 'C')).toBeCloseTo(100, 2)
+            expect(logic.values.computeBlastRadiusPercentage(10, 'C')).toBeCloseTo(10, 2)
 
             logic.actions.setTotalUsers(100)
-            expect(logic.values.computeBlastRadiusPercentage(67, 0)).toBeCloseTo(67, 2)
+            expect(logic.values.computeBlastRadiusPercentage(67, 'A')).toBeCloseTo(67, 2)
             // total users is defined but affected users is not. UI side should handle not showing the result in this case
             // and computation resolves to rollout percentage
-            expect(logic.values.computeBlastRadiusPercentage(75, 1)).toEqual(75)
-            expect(logic.values.computeBlastRadiusPercentage(100, 2)).toBeCloseTo(25, 2)
+            expect(logic.values.computeBlastRadiusPercentage(75, 'B')).toEqual(75)
+            expect(logic.values.computeBlastRadiusPercentage(100, 'C')).toBeCloseTo(25, 2)
         })
 
         describe('API calls', () => {
             beforeEach(() => {
-                jest.spyOn(api, 'create')
-
                 logic?.unmount()
+
+                jest.spyOn(api, 'create').mockClear()
+
                 logic = featureFlagReleaseConditionsLogic({
                     id: '12345',
                     filters: generateFeatureFlagFilters([
-                        { properties: [], rollout_percentage: undefined, variant: null },
+                        { properties: [], rollout_percentage: undefined, variant: null, sort_key: 'A' },
                         {
                             properties: [
                                 {
@@ -344,6 +362,7 @@ describe('the feature flag release conditions logic', () => {
                             ],
                             rollout_percentage: undefined,
                             variant: null,
+                            sort_key: 'B',
                         },
                         {
                             properties: [
@@ -356,6 +375,7 @@ describe('the feature flag release conditions logic', () => {
                             ],
                             rollout_percentage: undefined,
                             variant: null,
+                            sort_key: 'C',
                         },
                     ]),
                 })
@@ -374,11 +394,11 @@ describe('the feature flag release conditions logic', () => {
                         'setTotalUsers',
                     ])
                     .toMatchValues({
-                        affectedUsers: { 0: 120, 1: 120, 2: 120 },
+                        affectedUsers: { A: 120, B: 120, C: 120 },
                         totalUsers: 2000,
                     })
 
-                expect(api.create).toHaveBeenCalledTimes(4)
+                expect(api.create).toHaveBeenCalledTimes(3)
 
                 await expectLogic(logic, () => {
                     logic.actions.updateConditionSet(0, 20, undefined, undefined)
@@ -393,7 +413,7 @@ describe('the feature flag release conditions logic', () => {
                 }).toNotHaveDispatchedActions(['setAffectedUsers', 'setTotalUsers'])
 
                 // no extra calls when changing rollout percentage
-                expect(api.create).toHaveBeenCalledTimes(4)
+                expect(api.create).toHaveBeenCalledTimes(3)
             })
         })
     })
@@ -507,25 +527,6 @@ describe('the feature flag release conditions logic', () => {
                     sort_key: 'A',
                 },
             ])
-        })
-
-        it('preserves affected user calculations when reordering', () => {
-            const filters = generateFeatureFlagFilters([
-                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'A' },
-                { properties: [], rollout_percentage: 75, variant: null, sort_key: 'B' },
-                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'C' },
-            ])
-            logic.actions.setFilters(filters)
-
-            for (let i = 0; i < 3; i++) {
-                logic.actions.setAffectedUsers(i, i * 100)
-            }
-
-            logic.actions.moveConditionSetDown(0)
-            expect(logic.values.affectedUsers).toEqual({ 0: 100, 1: 0, 2: 200 })
-
-            logic.actions.moveConditionSetUp(1)
-            expect(logic.values.affectedUsers).toEqual({ 0: 0, 1: 100, 2: 200 })
         })
     })
 

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -18,7 +18,7 @@ import { v4 as uuidv4 } from 'uuid'
 import api from 'lib/api'
 import { isEmptyProperty } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType, TaxonomicFilterProps } from 'lib/components/TaxonomicFilter/types'
-import { objectsEqual, range } from 'lib/utils'
+import { objectsEqual } from 'lib/utils'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -43,23 +43,6 @@ function moveConditionSet<T>(groups: T[], index: number, newIndex: number): T[] 
     return updatedGroups
 }
 
-// Helper function to swap affected users between two indices
-function swapAffectedUsers(
-    affectedUsers: Record<number, number | undefined>,
-    actions: { setAffectedUsers: (index: number, count?: number) => void },
-    fromIndex: number,
-    toIndex: number
-): void {
-    if (!(fromIndex in affectedUsers) || !(toIndex in affectedUsers)) {
-        return
-    }
-
-    const fromCount = affectedUsers[fromIndex]
-    const toCount = affectedUsers[toIndex]
-    actions.setAffectedUsers(toIndex, fromCount)
-    actions.setAffectedUsers(fromIndex, toCount)
-}
-
 // TODO: Type onChange errors properly
 export interface FeatureFlagReleaseConditionsLogicProps {
     filters: FeatureFlagFilters
@@ -70,7 +53,11 @@ export interface FeatureFlagReleaseConditionsLogicProps {
     isSuper?: boolean
 }
 
-function ensureSortKeys(filters: FeatureFlagFilters): FeatureFlagFilters {
+export type FeatureFlagGroupTypeWithSortKey = FeatureFlagGroupType & { sort_key: string }
+
+function ensureSortKeys(
+    filters: FeatureFlagFilters
+): FeatureFlagFilters & { groups: FeatureFlagGroupTypeWithSortKey[] } {
     return {
         ...filters,
         groups: filters.groups.map((group: FeatureFlagGroupType) => ({
@@ -111,7 +98,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             newVariant,
             newDescription,
         }),
-        setAffectedUsers: (index: number, count?: number) => ({ index, count }),
+        setAffectedUsers: (sortKey: string, count?: number) => ({ sortKey, count }),
         setTotalUsers: (count: number) => ({ count }),
         calculateBlastRadius: true,
         loadAllFlagKeys: (flagIds: string[]) => ({ flagIds }),
@@ -125,15 +112,17 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         filters: {
             setFilters: (_, { filters }) => {
                 // Only assign sort_keys to groups that don't have one
-                const groupsWithKeys = filters.groups.map((group: FeatureFlagGroupType) => {
-                    if (group.sort_key) {
-                        return group
+                const groupsWithKeys = filters.groups.map(
+                    (group: FeatureFlagGroupType): FeatureFlagGroupTypeWithSortKey => {
+                        if (group.sort_key) {
+                            return group as FeatureFlagGroupTypeWithSortKey
+                        }
+                        return {
+                            ...group,
+                            sort_key: uuidv4(),
+                        }
                     }
-                    return {
-                        ...group,
-                        sort_key: uuidv4(),
-                    }
-                })
+                )
 
                 return { ...filters, groups: groupsWithKeys }
             },
@@ -205,12 +194,11 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 if (!state) {
                     return state
                 }
-                const groups = state.groups.concat([
-                    {
-                        ...state.groups[index],
-                        sort_key: uuidv4(),
-                    },
-                ])
+                const newGroup: FeatureFlagGroupTypeWithSortKey = {
+                    ...state.groups[index],
+                    sort_key: uuidv4(),
+                }
+                const groups: FeatureFlagGroupTypeWithSortKey[] = [...state.groups, newGroup]
                 return { ...state, groups }
             },
             moveConditionSetDown: (state, { index }) => {
@@ -227,11 +215,11 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             },
         },
         affectedUsers: [
-            { 0: undefined } as Record<number, number | undefined>,
+            {} as Record<string, number | undefined>,
             {
-                setAffectedUsers: (state, { index, count }) => ({
+                setAffectedUsers: (state, { sortKey, count }) => ({
                     ...state,
-                    [index]: count,
+                    [sortKey]: count,
                 }),
             },
         ],
@@ -266,14 +254,23 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         },
         duplicateConditionSet: async ({ index }, breakpoint) => {
             await breakpoint(1000) // in ms
-            const valueForSourceCondition = values.affectedUsers[index]
-            const newIndex = values.filters.groups.length - 1
-            actions.setAffectedUsers(newIndex, valueForSourceCondition)
+            const sourceSortKey = values.filters.groups[index].sort_key
+            const valueForSourceCondition = sourceSortKey ? values.affectedUsers[sourceSortKey] : undefined
+            const newGroup = values.filters.groups[values.filters.groups.length - 1]
+            actions.setAffectedUsers(newGroup.sort_key, valueForSourceCondition)
         },
         updateConditionSet: async ({ index, newProperties }, breakpoint) => {
+            const group: FeatureFlagGroupTypeWithSortKey | undefined = values.filters.groups[index]
+            if (!group) {
+                console.warn('Tried to update condition set at invalid index', index)
+                return
+            }
+
+            const { sort_key: sortKey } = group
+
             if (newProperties) {
                 // properties have changed, so we'll have to re-fetch affected users
-                actions.setAffectedUsers(index, undefined)
+                actions.setAffectedUsers(sortKey, undefined)
 
                 // Add any new flag IDs from the updated properties
                 const newFlagIds = newProperties.flatMap((property) =>
@@ -298,60 +295,56 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     group_type_index: values.filters?.aggregation_group_type_index ?? null,
                 }
             )
-            actions.setAffectedUsers(index, response.users_affected)
+
+            actions.setAffectedUsers(sortKey, response.users_affected)
             actions.setTotalUsers(response.total_users)
         },
         addConditionSet: () => {
-            actions.setAffectedUsers(values.filters.groups.length - 1, values.totalUsers || -1)
-        },
-        removeConditionSet: ({ index }) => {
-            const previousLength = Object.keys(values.affectedUsers).length
-            range(index, previousLength).map((idx) => {
-                const count = previousLength - 1 === idx ? undefined : values.affectedUsers[idx + 1]
-                actions.setAffectedUsers(idx, count)
-            })
+            const newGroup = values.filters.groups[values.filters.groups.length - 1]
+            if (newGroup.sort_key) {
+                actions.setAffectedUsers(newGroup.sort_key, values.totalUsers || -1)
+            }
         },
         setAggregationGroupTypeIndex: () => {
             actions.calculateBlastRadius()
         },
         calculateBlastRadius: async () => {
-            const usersAffected: Promise<UserBlastRadiusType>[] = []
+            const usersAffectedPromises: Promise<{ result: UserBlastRadiusType; sortKey: string }>[] = []
 
-            values.filters?.groups?.forEach((condition, index) => {
-                actions.setAffectedUsers(index, undefined)
+            values.filters.groups.forEach((condition: FeatureFlagGroupTypeWithSortKey) => {
+                const { sort_key: sortKey } = condition
+                actions.setAffectedUsers(sortKey, undefined)
 
                 const properties = condition.properties
+                let responsePromise: Promise<UserBlastRadiusType>
                 if (!properties || properties.some(isEmptyProperty)) {
                     // don't compute for incomplete conditions
-                    usersAffected.push(Promise.resolve({ users_affected: -1, total_users: -1 }))
+                    responsePromise = Promise.resolve({ users_affected: -1, total_users: -1 })
                 } else if (properties.length === 0) {
                     // Request total users for empty condition sets
-                    const responsePromise = api.create(
+                    responsePromise = api.create(
                         `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
                         {
                             condition: { properties: [] },
                             group_type_index: values.filters?.aggregation_group_type_index ?? null,
                         }
                     )
-
-                    usersAffected.push(responsePromise)
                 } else {
-                    const responsePromise = api.create(
+                    responsePromise = api.create(
                         `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
                         {
                             condition,
                             group_type_index: values.filters?.aggregation_group_type_index ?? null,
                         }
                     )
-
-                    usersAffected.push(responsePromise)
                 }
+                usersAffectedPromises.push(responsePromise.then((result) => ({ result, sortKey })))
             })
 
-            const results = await Promise.all(usersAffected)
-            // Create action for all users affected
-            results.forEach((result, index) => {
-                actions.setAffectedUsers(index, result.users_affected)
+            const results = await Promise.all(usersAffectedPromises)
+
+            results.forEach(({ result, sortKey }) => {
+                actions.setAffectedUsers(sortKey, result.users_affected)
                 if (result.total_users !== -1) {
                     actions.setTotalUsers(result.total_users)
                 }
@@ -426,12 +419,6 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 actions.setFlagKeysLoading(false)
             }
         },
-        moveConditionSetUp: ({ index }) => {
-            swapAffectedUsers(values.affectedUsers, actions, index, index - 1)
-        },
-        moveConditionSetDown: ({ index }) => {
-            swapAffectedUsers(values.affectedUsers, actions, index, index + 1)
-        },
     })),
     selectors({
         // Get the appropriate groups based on isSuper
@@ -504,7 +491,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         ],
         computeBlastRadiusPercentage: [
             (s) => [s.affectedUsers, s.totalUsers],
-            (affectedUsers, totalUsers) => (rolloutPercentage, index) => {
+            (affectedUsers, totalUsers) => (rolloutPercentage, sortKey) => {
                 let effectiveRolloutPercentage = rolloutPercentage
                 if (
                     rolloutPercentage === undefined ||
@@ -515,10 +502,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 }
 
                 if (
-                    affectedUsers[index] === -1 ||
+                    affectedUsers[sortKey] === -1 ||
                     totalUsers === -1 ||
                     !totalUsers ||
-                    affectedUsers[index] === undefined
+                    affectedUsers[sortKey] === undefined
                 ) {
                     return effectiveRolloutPercentage
                 }
@@ -528,7 +515,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     effectiveTotalUsers = 1
                 }
 
-                return effectiveRolloutPercentage * ((affectedUsers[index] ?? 0) / effectiveTotalUsers)
+                return effectiveRolloutPercentage * ((affectedUsers[sortKey] ?? 0) / effectiveTotalUsers)
             },
         ],
         getFlagKey: [


### PR DESCRIPTION
## Problem

When moving a condition set as a blast radius is calculating, the affected user count would no longer be assigned to the old index. This would cause numbers for a given condition set to be incorrect, as they'd be out of sync.

This change decouples the affected user counts from the index, instead opting to use the stable sort_key.

## How did you test this code?

Tested locally + existing tests have been updated and are passing.
