### PR TITLE
fix(flags): Don't log span events in production

### DIFF
--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -76,9 +76,6 @@ async fn main() {
 
     let log_layer = {
         let base_layer = fmt::layer()
-            .with_span_events(
-                FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
-            )
             .with_target(true)
             .with_thread_ids(true)
             .with_level(true);
@@ -86,6 +83,13 @@ async fn main() {
         if debug {
             // Development: Pretty colored output (like Django's ConsoleRenderer(colors=DEBUG))
             base_layer
+                .with_span_events(
+                    FmtSpan::NEW
+                        | FmtSpan::CLOSE
+                        | FmtSpan::ENTER
+                        | FmtSpan::EXIT
+                        | FmtSpan::ACTIVE,
+                )
                 .with_ansi(true)
                 .with_filter(EnvFilter::from_default_env())
                 .boxed()


### PR DESCRIPTION
## Problem

The feature flags service is logging every span event, causing us to log way too much (we have ~10x more logs than Contour).

## Changes

I've removed the configuration that logs span events and moved it to enable in debug only.
