### PR TITLE
chore(messaging): remove hardcoded SES_REGION value to fix EU

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -334,7 +334,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SES_ENDPOINT: isTestEnv() || isDevEnv() ? 'http://localhost:4566' : '',
         SES_ACCESS_KEY_ID: isTestEnv() || isDevEnv() ? 'test' : '',
         SES_SECRET_ACCESS_KEY: isTestEnv() || isDevEnv() ? 'test' : '',
-        SES_REGION: '',
+        SES_REGION: isTestEnv() || isDevEnv() ? 'us-east-1' : '',
 
         // Pod termination
         POD_TERMINATION_ENABLED: false,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -334,7 +334,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SES_ENDPOINT: isTestEnv() || isDevEnv() ? 'http://localhost:4566' : '',
         SES_ACCESS_KEY_ID: isTestEnv() || isDevEnv() ? 'test' : '',
         SES_SECRET_ACCESS_KEY: isTestEnv() || isDevEnv() ? 'test' : '',
-        SES_REGION: 'us-east-1',
+        SES_REGION: '',
 
         // Pod termination
         POD_TERMINATION_ENABLED: false,


### PR DESCRIPTION
## Problem

We're currently hitting an `ConfigurationSetDoesNotExist` error only in EU because of this hardcoded us-central-1 region value. Setting it to a falsey value `''` should allow the SDK to fall back to the AWS role that the service has active.
