### PR TITLE
fix(migrations): handle case-insensitive model name matching in risk analyzer

### DIFF
--- a/posthog/management/migration_analysis/analyzer.py
+++ b/posthog/management/migration_analysis/analyzer.py
@@ -54,9 +54,11 @@ class RiskAnalyzer:
     }
 
     def analyze_migration(self, migration, path: str) -> MigrationRisk:
-        # Collect newly created models for this migration
+        # Collect newly created models for this migration (normalized to lowercase for case-insensitive matching)
         self.newly_created_models = {
-            op.name for op in migration.operations if op.__class__.__name__ == "CreateModel" and hasattr(op, "name")
+            op.name.lower()
+            for op in migration.operations
+            if op.__class__.__name__ == "CreateModel" and hasattr(op, "name")
         }
 
         operation_risks = []
@@ -110,6 +112,8 @@ class RiskAnalyzer:
         if risk.type not in ["AddIndex", "AddConstraint"]:
             return False
         model_name = risk.details.get("model") or getattr(op, "model_name", None)
+        if model_name:
+            model_name = model_name.lower()
         return model_name in self.newly_created_models
 
     def analyze_operation(self, op) -> OperationRisk:
@@ -121,7 +125,18 @@ class RiskAnalyzer:
         if analyzer:
             return analyzer.analyze(op)
 
-        # Fallback for unknown operation types
+        # Fallback for unscored operation types
+        # Check if it's a known Django operation
+        is_django_operation = op.__class__.__module__.startswith("django.db.migrations.operations")
+
+        if is_django_operation:
+            return OperationRisk(
+                type=op_type,
+                score=2,
+                reason=f"Unscored Django operation: {op_type} (needs manual review)",
+                details={},
+            )
+
         return OperationRisk(
             type=op_type,
             score=2,


### PR DESCRIPTION
Fixes incorrect blocking of migrations that add indexes/constraints to newly created tables.

## Problem

Operations on newly created tables (AddIndex/AddConstraint) were incorrectly flagged as risky in PR #39288.

Root cause: Two bugs in the analyzer:
1. `AddIndexAnalyzer` and `AddConstraintAnalyzer` weren't populating `model_name` in details dict
2. Case-sensitivity mismatch: CreateModel uses capitalized names (`SchemaPropertyGroup`) while AddIndex/AddConstraint use lowercase (`schemapropertygroup`)

## Solution

- Populate model field in AddIndex/AddConstraint analyzers
- Normalize model names to lowercase for case-insensitive comparison
- Enhanced tests to use real Django naming patterns

## Test Plan

- Verified on actual migration 0876 from PR #39288 - now correctly shows as "Safe" instead of "Blocked"
- All tests pass

## Before

```
**Summary:** 0 Safe | 0 Needs Review | 1 Blocked

## ❌ Blocked
posthog.0876_add_schema_models
  └─ #4 ❌ AddIndex: Non-concurrent index creation locks table
  └─ #5 ⚠️ AddConstraint: Adding constraint may lock table
  ...
```

## After

```
**Summary:** 1 Safe | 0 Needs Review | 0 Blocked

## ✅ Safe
posthog.0876_add_schema_models
  └─ #1 ✅ CreateModel
  └─ #2 ✅ CreateModel
  └─ #3 ✅ CreateModel
  │
  └──> ℹ️  INFO:
       ℹ️  Skipped operations on newly created tables
```