### PR TITLE
feat: capture user deleted event

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1040,7 +1040,8 @@ class TestUserAPI(APIBaseTest):
         response = self.client.delete(f"/api/users/@me/")
         assert response.status_code == status.HTTP_409_CONFLICT
 
-    def test_can_delete_user_with_no_organization_memberships(self):
+    @patch("posthoganalytics.capture")
+    def test_can_delete_user_with_no_organization_memberships(self, mock_capture):
         user = self._create_user("noactiveorgmemberships@posthog.com", password="test")
 
         self.client.force_login(user)
@@ -1056,6 +1057,12 @@ class TestUserAPI(APIBaseTest):
         response = self.client.delete(f"/api/users/@me/")
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not User.objects.filter(uuid=user.uuid).exists()
+
+        mock_capture.assert_called_once_with(
+            distinct_id=user.distinct_id,
+            event="user account deleted",
+            properties=mock.ANY,
+        )
 
     def test_cannot_delete_another_user_with_no_org_memberships(self):
         user = self._create_user("deleteanotheruser@posthog.com", password="test")

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -52,7 +52,7 @@ from posthog.auth import (
 )
 from posthog.constants import PERMITTED_FORUM_DOMAINS
 from posthog.email import is_email_available
-from posthog.event_usage import report_user_updated, report_user_verified_email
+from posthog.event_usage import report_user_deleted_account, report_user_updated, report_user_verified_email
 from posthog.helpers.two_factor_session import set_two_factor_verified_in_session
 from posthog.middleware import get_impersonated_session_expires_at
 from posthog.models import Dashboard, Team, User, UserScenePersonalisation
@@ -445,8 +445,6 @@ class UserViewSet(
         }
 
     def perform_destroy(self, user: User) -> None:
-        from posthog.event_usage import report_user_deleted_account
-
         report_user_deleted_account(user)
         super().perform_destroy(user)
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -444,6 +444,12 @@ class UserViewSet(
             "user_permissions": UserPermissions(cast(User, self.request.user)),
         }
 
+    def perform_destroy(self, user: User) -> None:
+        from posthog.event_usage import report_user_deleted_account
+
+        report_user_deleted_account(user)
+        super().perform_destroy(user)
+
     @action(methods=["POST"], detail=False, permission_classes=[AllowAny])
     def verify_email(self, request, **kwargs):
         token = request.data["token"] if "token" in request.data else None

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -286,6 +286,7 @@ def report_user_deleted_account(user: User):
         event="user account deleted",
         properties=user.get_analytics_metadata(),
     )
+    posthoganalytics.flush()
 
 
 def groups(organization: Optional[Organization] = None, team: Optional[Team] = None):

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -278,6 +278,16 @@ def report_organization_deleted(user: User, organization: Organization):
     )
 
 
+def report_user_deleted_account(user: User):
+    if not user.distinct_id:
+        return
+    posthoganalytics.capture(
+        distinct_id=user.distinct_id,
+        event="user account deleted",
+        properties=user.get_analytics_metadata(),
+    )
+
+
 def groups(organization: Optional[Organization] = None, team: Optional[Team] = None):
     result = {"instance": SITE_URL}
     if organization is not None:


### PR DESCRIPTION
## Problem
Users continue receiving emails after deleting account, we need an event to automatically unsubscribe in Customer.io. 

## Changes
Added `user account deleted` event, similar to how we handle `organization deleted`

## How did you test this code?
Integration test + manually
