### PR TITLE
feat(experiments): redirecting draft experiments to the new create form.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -4,12 +4,13 @@ import { useState } from 'react'
 import { LemonTabs } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { WebExperimentImplementationDetails } from 'scenes/experiments/WebExperimentImplementationDetails'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import type { CachedExperimentQueryResponse } from '~/queries/schema/schema-general'
 import { LegacyExperimentInfo } from '~/scenes/experiments/legacy/LegacyExperimentInfo'
-import { ActivityScope } from '~/types'
+import { ActivityScope, ProgressStatus } from '~/types'
 
 import { ExperimentImplementationDetails } from '../ExperimentImplementationDetails'
 import { ExperimentMetricModal } from '../Metrics/ExperimentMetricModal'
@@ -29,7 +30,9 @@ import {
     ResultsInsightInfoBanner,
     ResultsQuery,
 } from '../components/ResultsBreakdown'
+import { CreateExperiment } from '../create/CreateExperiment'
 import { experimentLogic } from '../experimentLogic'
+import { getExperimentStatus } from '../experimentsLogic'
 import { isLegacyExperiment, isLegacyExperimentQuery, removeMetricFromOrderingArray } from '../utils'
 import { DistributionModal, DistributionTable } from './DistributionTable'
 import { ExperimentHeader } from './ExperimentHeader'
@@ -206,6 +209,17 @@ export function ExperimentView(): JSX.Element {
     const { closeExperimentMetricModal } = useActions(experimentMetricModalLogic)
 
     const [activeTabKey, setActiveTabKey] = useState<string>('metrics')
+
+    /**
+     * this is temporary, for testing purposes only.
+     * this has to be migrated into a scene with a proper path, and paramsToProps
+     * so it works seamlesly with the toolbar and tab bar navigation.
+     */
+    const isUnifiedCreateFormEnabled = useFeatureFlag('EXPERIMENTS_UNIFIED_CREATE_FORM', 'test')
+
+    if (!experimentLoading && getExperimentStatus(experiment) === ProgressStatus.Draft && isUnifiedCreateFormEnabled) {
+        return <CreateExperiment draftExperiment={experiment} />
+    }
 
     return (
         <SceneContent>

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -33,11 +33,11 @@ const LemonFieldError = ({ error }: { error: string }): JSX.Element => {
     )
 }
 
-type CreateExerimentProps = Partial<{
+type CreateExperimentProps = Partial<{
     draftExperiment: Experiment
 }>
 
-export const CreateExperiment = ({ draftExperiment }: CreateExerimentProps): JSX.Element => {
+export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JSX.Element => {
     const { HogfettiComponent } = useHogfetti({ count: 100, duration: 3000 })
 
     const { experiment, experimentErrors } = useValues(createExperimentLogic({ experiment: draftExperiment }))

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -16,6 +16,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import type { Experiment } from '~/types'
 
 import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { MetricsReorderModal } from '../MetricsView/MetricsReorderModal'
@@ -32,11 +33,15 @@ const LemonFieldError = ({ error }: { error: string }): JSX.Element => {
     )
 }
 
-export const CreateExperiment = (): JSX.Element => {
+type CreateExerimentProps = Partial<{
+    draftExperiment: Experiment
+}>
+
+export const CreateExperiment = ({ draftExperiment }: CreateExerimentProps): JSX.Element => {
     const { HogfettiComponent } = useHogfetti({ count: 100, duration: 3000 })
 
-    const { experiment, experimentErrors } = useValues(createExperimentLogic)
-    const { setExperimentValue } = useActions(createExperimentLogic)
+    const { experiment, experimentErrors } = useValues(createExperimentLogic({ experiment: draftExperiment }))
+    const { setExperimentValue } = useActions(createExperimentLogic({ experiment: draftExperiment }))
 
     const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
 

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
@@ -319,6 +319,127 @@ describe('createExperimentLogic', () => {
         })
     })
 
+    describe('experiment prop initialization', () => {
+        it('defaults to NEW_EXPERIMENT when no prop is provided', async () => {
+            const defaultLogic = createExperimentLogic()
+            defaultLogic.mount()
+
+            await expectLogic(defaultLogic).toMatchValues({
+                experiment: partial({
+                    id: 'new',
+                    name: '',
+                    description: '',
+                    type: 'product',
+                }),
+            })
+
+            defaultLogic.unmount()
+        })
+
+        it('uses provided experiment prop as default', async () => {
+            const existingExperiment: Experiment = {
+                ...NEW_EXPERIMENT,
+                id: 123,
+                name: 'Existing Experiment',
+                description: 'Existing hypothesis',
+                type: 'web',
+                feature_flag_key: 'existing-flag',
+            }
+
+            const propsLogic = createExperimentLogic({ experiment: existingExperiment })
+            propsLogic.mount()
+
+            await expectLogic(propsLogic).toMatchValues({
+                experiment: partial({
+                    id: 123,
+                    name: 'Existing Experiment',
+                    description: 'Existing hypothesis',
+                    type: 'web',
+                    feature_flag_key: 'existing-flag',
+                }),
+            })
+
+            propsLogic.unmount()
+        })
+
+        it('resetExperiment resets to NEW_EXPERIMENT when no prop provided', async () => {
+            const defaultLogic = createExperimentLogic()
+            defaultLogic.mount()
+
+            await expectLogic(defaultLogic, () => {
+                defaultLogic.actions.setExperiment({
+                    ...NEW_EXPERIMENT,
+                    name: 'Changed Name',
+                    description: 'Changed Description',
+                })
+            })
+                .toDispatchActions(['setExperiment'])
+                .toMatchValues({
+                    experiment: partial({
+                        name: 'Changed Name',
+                        description: 'Changed Description',
+                    }),
+                })
+
+            await expectLogic(defaultLogic, () => {
+                defaultLogic.actions.resetExperiment()
+            })
+                .toDispatchActions(['resetExperiment'])
+                .toMatchValues({
+                    experiment: partial({
+                        id: 'new',
+                        name: '',
+                        description: '',
+                    }),
+                })
+
+            defaultLogic.unmount()
+        })
+
+        it('resetExperiment resets to provided experiment prop', async () => {
+            const existingExperiment: Experiment = {
+                ...NEW_EXPERIMENT,
+                id: 456,
+                name: 'Original Experiment',
+                description: 'Original hypothesis',
+                type: 'web',
+            }
+
+            const propsLogic = createExperimentLogic({ experiment: existingExperiment })
+            propsLogic.mount()
+
+            await expectLogic(propsLogic, () => {
+                propsLogic.actions.setExperiment({
+                    ...existingExperiment,
+                    name: 'Modified Name',
+                    description: 'Modified Description',
+                })
+            })
+                .toDispatchActions(['setExperiment'])
+                .toMatchValues({
+                    experiment: partial({
+                        name: 'Modified Name',
+                        description: 'Modified Description',
+                    }),
+                })
+
+            await expectLogic(propsLogic, () => {
+                propsLogic.actions.resetExperiment()
+            })
+                .toDispatchActions(['resetExperiment'])
+                .toMatchValues({
+                    experiment: partial({
+                        id: 456,
+                        name: 'Original Experiment',
+                        description: 'Original hypothesis',
+                        type: 'web',
+                    }),
+                })
+
+            propsLogic.unmount()
+        })
+    })
+
     describe('feature flag integration', () => {
         it('includes feature flag key in experiment submission', async () => {
             await expectLogic(logic, () => {

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, listeners, path, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { forms } from 'kea-forms'
 import { router } from 'kea-router'
 
@@ -18,9 +18,14 @@ import { ProductKey } from '~/types'
 import { NEW_EXPERIMENT } from '../constants'
 import type { createExperimentLogicType } from './createExperimentLogicType'
 
+type CreateExperimentLogicProps = Partial<{
+    experiment: Experiment
+}>
+
 export const createExperimentLogic = kea<createExperimentLogicType>([
-    key(() => 'create-experiment'),
-    path(['scenes', 'experiments', 'create', 'createExperimentLogic']),
+    props({} as CreateExperimentLogicProps),
+    key((props) => props.experiment?.id || 'create-experiment'),
+    path((key) => ['scenes', 'experiments', 'create', 'createExperimentLogic', key]),
     connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
         actions: [
@@ -32,10 +37,10 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             ['addProductIntent'],
         ],
     })),
-    forms(({ actions }) => ({
+    forms(({ actions, props }) => ({
         experiment: {
             options: { showErrorsOnTouch: true },
-            defaults: { ...NEW_EXPERIMENT } as Experiment,
+            defaults: (props.experiment ?? { ...NEW_EXPERIMENT }) as Experiment,
             errors: ({ name, description }: Experiment) => ({
                 name: !name ? 'Name is required' : undefined,
                 description: !description ? 'Hypothesis is required' : undefined,
@@ -50,14 +55,13 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
         createExperiment: () => ({}),
         createExperimentSuccess: true,
     })),
-    reducers(() => ({
+    reducers(({ props }) => ({
         experiment: [
-            { ...NEW_EXPERIMENT } as Experiment & { feature_flag_filters?: FeatureFlagFilters },
-            { persist: true },
+            (props.experiment ?? { ...NEW_EXPERIMENT }) as Experiment & { feature_flag_filters?: FeatureFlagFilters },
             {
                 setExperiment: (_, { experiment }) => experiment,
                 updateFeatureFlagKey: (state, { key }) => ({ ...state, feature_flag_key: key }),
-                resetExperiment: () => ({ ...NEW_EXPERIMENT }),
+                resetExperiment: () => props.experiment ?? { ...NEW_EXPERIMENT },
             },
         ],
     })),

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -18,7 +18,7 @@ import { ProductKey } from '~/types'
 import { NEW_EXPERIMENT } from '../constants'
 import type { createExperimentLogicType } from './createExperimentLogicType'
 
-type CreateExperimentLogicProps = Partial<{
+export type CreateExperimentLogicProps = Partial<{
     experiment: Experiment
 }>
 


### PR DESCRIPTION
## Problem

Pre-launch _draft_ experiments are treated as regular experiments, and loaded using the experiment view. This complicates the process of creating and launching experiments.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Termporarily, until we confirm if this new form is better, we are returning a `CreateExperiment` when loading the `ExperimentView` for a _draft_ experiment.
We should plug this into the scene infrastructure to play nicely with the tab bar.

| New form for _draft_ experiments |
| - |
| ![edit draft](https://github.com/user-attachments/assets/43970d44-9615-42b9-9086-0de9b96f613c) |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/*.test.tsx
```

![cat-type-small](https://github.com/user-attachments/assets/c54999a2-6e0b-4bd2-8cf6-4ac08f4a2b35)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
