### PR TITLE
refactor: Fix churn calculation for revenue analytics

### DIFF
--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_metrics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_metrics_query_runner.py
@@ -334,7 +334,10 @@ class RevenueAnalyticsMetricsQueryRunner(RevenueAnalyticsQueryRunner[RevenueAnal
                         distinct=True,
                         args=[
                             ast.Field(chain=[RevenueAnalyticsSubscriptionView.get_generic_view_alias(), "id"]),
-                            self._period_eq_expr(ast.Field(chain=["ended_at"]), ast.Field(chain=["period_start"])),
+                            self._period_eq_expr(
+                                ast.Field(chain=["ended_at"]),
+                                self._add_period_expr(ast.Field(chain=["period_start"]), -1),
+                            ),
                         ],
                     ),
                 ),
@@ -368,7 +371,7 @@ class RevenueAnalyticsMetricsQueryRunner(RevenueAnalyticsQueryRunner[RevenueAnal
                             ast.CompareOperation(
                                 op=ast.CompareOperationOp.Eq,
                                 left=ast.Field(chain=["churned_subscription_count"]),
-                                right=ast.Field(chain=["subscription_count"]),
+                                right=ast.Field(chain=["prev_subscription_count"]),
                             ),
                         ]
                     ),

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_metrics_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_metrics_query_runner.ambr
@@ -19,11 +19,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -127,11 +127,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT NULL AS id,
@@ -214,11 +214,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -323,11 +323,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -461,11 +461,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -618,11 +618,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -779,11 +779,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -887,11 +887,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -1024,11 +1024,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -1132,11 +1132,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -1269,11 +1269,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -1386,11 +1386,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -1528,11 +1528,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -1636,11 +1636,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -1773,11 +1773,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -1882,11 +1882,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -2020,11 +2020,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -2129,11 +2129,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -2267,11 +2267,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -2386,11 +2386,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -2530,11 +2530,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -2648,11 +2648,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM
@@ -2791,11 +2791,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, equals(toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')), period_start)) AS revenue
      FROM
        (SELECT subscription_id AS id,
@@ -2909,11 +2909,11 @@
             countIf(DISTINCT revenue_analytics_subscription.id, and(ifNull(lessOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0), or(isNull(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), ifNull(greaterOrEquals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), 0)))) AS prev_subscription_count,
             countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.started_at, 'UTC')))
                                                                        and isNull(period_start))) AS new_subscription_count,
-            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), period_start), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
-                                                                       and isNull(period_start))) AS churned_subscription_count,
+            countIf(DISTINCT revenue_analytics_subscription.id, ifNull(equals(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')), date_add(period_start, toIntervalMonth(-1))), isNull(toStartOfMonth(toTimeZone(revenue_analytics_subscription.ended_at, 'UTC')))
+                                                                       and isNull(date_add(period_start, toIntervalMonth(-1))))) AS churned_subscription_count,
             and(ifNull(equals(prev_subscription_count, 0), 0), ifNull(greater(subscription_count, 0), 0)) AS is_new_customer,
-            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, subscription_count), isNull(churned_subscription_count)
-                                                                          and isNull(subscription_count))) AS is_churned_customer,
+            and(ifNull(greater(churned_subscription_count, 0), 0), ifNull(equals(churned_subscription_count, prev_subscription_count), isNull(churned_subscription_count)
+                                                                          and isNull(prev_subscription_count))) AS is_churned_customer,
             sumIf(revenue_analytics_revenue_item.amount, ifNull(equals(toStartOfMonth(revenue_analytics_revenue_item.timestamp), period_start), isNull(toStartOfMonth(revenue_analytics_revenue_item.timestamp))
                                                                 and isNull(period_start))) AS revenue
      FROM

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_metrics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_analytics_metrics_query_runner.py
@@ -367,7 +367,7 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "label": "Churned Subscription Count | stripe.posthog_test",
                     "days": ALL_MONTHS_DAYS,
                     "labels": ALL_MONTHS_LABELS,
-                    "data": [0, 0, 0, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0],
+                    "data": [0, 0, 0, 0, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
                     "breakdown": {
                         "property": "stripe.posthog_test",
                         "kind": "Churned Subscription Count",
@@ -412,7 +412,7 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "label": "Churned Customer Count | stripe.posthog_test",
                     "days": ALL_MONTHS_DAYS,
                     "labels": ALL_MONTHS_LABELS,
-                    "data": [0, 0, 0, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0],
+                    "data": [0, 0, 0, 0, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
                     "breakdown": {
                         "property": "stripe.posthog_test",
                         "kind": "Churned Customer Count",
@@ -469,15 +469,15 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                         None,
                         None,
                         None,
-                        Decimal("536.7876254634"),
-                        Decimal("20.4450263351"),
+                        None,
+                        Decimal("6.8150087777"),
+                        Decimal("20.445026333"),
                         None,
                         None,
                         None,
                         None,
                         None,
                         None,
-                        0,
                         0,
                         0,
                         0,
@@ -495,6 +495,26 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 },
             ],
         )
+
+        # Assert that `previous_subscription_count` + `new_subscription_count` - `churned_subscription_count` = `subscription_count`
+        for subscription_count, prev_subscription_count, new_subscription_count, churned_subscription_count in zip(
+            results[0]["data"][1:],
+            results[0]["data"][:-1],
+            results[1]["data"][1:],
+            results[2]["data"][1:],
+        ):
+            self.assertEqual(
+                subscription_count, prev_subscription_count + new_subscription_count - churned_subscription_count
+            )
+
+        # Same for customer count
+        for customer_count, prev_customer_count, new_customer_count, churned_customer_count in zip(
+            results[3]["data"][1:],
+            results[3]["data"][:-1],
+            results[4]["data"][1:],
+            results[5]["data"][1:],
+        ):
+            self.assertEqual(customer_count, prev_customer_count + new_customer_count - churned_customer_count)
 
     def test_with_data_and_date_range(self):
         results = self._run_revenue_analytics_metrics_query(
@@ -542,7 +562,7 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "label": "Churned Subscription Count | stripe.posthog_test",
                     "days": days,
                     "labels": labels,
-                    "data": [0, 3, 1, 0],
+                    "data": [0, 0, 3, 1],
                     "breakdown": {
                         "property": "stripe.posthog_test",
                         "kind": "Churned Subscription Count",
@@ -587,7 +607,7 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "label": "Churned Customer Count | stripe.posthog_test",
                     "days": days,
                     "labels": labels,
-                    "data": [0, 3, 1, 0],
+                    "data": [0, 0, 3, 1],
                     "breakdown": {
                         "property": "stripe.posthog_test",
                         "kind": "Churned Customer Count",
@@ -622,7 +642,7 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "label": "LTV | stripe.posthog_test",
                     "days": days,
                     "labels": labels,
-                    "data": [None, Decimal("536.7876254634"), Decimal("20.4450263351"), None],
+                    "data": [None, None, Decimal("6.8150087777"), Decimal("20.445026333")],
                     "breakdown": {
                         "property": "stripe.posthog_test",
                         "kind": "LTV",
@@ -841,37 +861,37 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 ([0, 0, None, None, None, None, None], "LTV | stripe.posthog_test - Product C"),
                 ([0, 0, 0, 1, 1, 1, 1], "Subscription Count | stripe.posthog_test - Product D"),
                 ([0, 0, 0, 1, 0, 0, 0], "New Subscription Count | stripe.posthog_test - Product D"),
-                ([0, 0, 0, 0, 0, 0, 1], "Churned Subscription Count | stripe.posthog_test - Product D"),
+                ([0, 0, 0, 0, 0, 0, 0], "Churned Subscription Count | stripe.posthog_test - Product D"),
                 ([0, 0, 0, 1, 1, 1, 1], "Customer Count | stripe.posthog_test - Product D"),
                 ([0, 0, 0, 1, 0, 0, 0], "New Customer Count | stripe.posthog_test - Product D"),
-                ([0, 0, 0, 0, 0, 0, 1], "Churned Customer Count | stripe.posthog_test - Product D"),
+                ([0, 0, 0, 0, 0, 0, 0], "Churned Customer Count | stripe.posthog_test - Product D"),
                 (
                     [0, 0, 0, Decimal("85.47825"), Decimal("85.47825"), Decimal("83.16695"), 0],
                     "ARPU | stripe.posthog_test - Product D",
                 ),
-                ([0, 0, 0, None, None, None, 0], "LTV | stripe.posthog_test - Product D"),
+                ([0, 0, 0, None, None, None, None], "LTV | stripe.posthog_test - Product D"),
                 ([0, 0, 0, 1, 1, 1, 1], "Subscription Count | stripe.posthog_test - Product E"),
                 ([0, 0, 0, 1, 0, 0, 0], "New Subscription Count | stripe.posthog_test - Product E"),
-                ([0, 0, 0, 0, 0, 0, 1], "Churned Subscription Count | stripe.posthog_test - Product E"),
+                ([0, 0, 0, 0, 0, 0, 0], "Churned Subscription Count | stripe.posthog_test - Product E"),
                 ([0, 0, 0, 1, 1, 1, 1], "Customer Count | stripe.posthog_test - Product E"),
                 ([0, 0, 0, 1, 0, 0, 0], "New Customer Count | stripe.posthog_test - Product E"),
-                ([0, 0, 0, 0, 0, 0, 1], "Churned Customer Count | stripe.posthog_test - Product E"),
+                ([0, 0, 0, 0, 0, 0, 0], "Churned Customer Count | stripe.posthog_test - Product E"),
                 (
                     [0, 0, 0, Decimal("273.57025"), Decimal("273.57025"), Decimal("43.82703"), 0],
                     "ARPU | stripe.posthog_test - Product E",
                 ),
-                ([0, 0, 0, None, None, None, 0], "LTV | stripe.posthog_test - Product E"),
+                ([0, 0, 0, None, None, None, None], "LTV | stripe.posthog_test - Product E"),
                 ([0, 0, 0, 1, 1, 1, 1], "Subscription Count | stripe.posthog_test - Product F"),
                 ([0, 0, 0, 1, 0, 0, 0], "New Subscription Count | stripe.posthog_test - Product F"),
-                ([0, 0, 0, 0, 0, 0, 1], "Churned Subscription Count | stripe.posthog_test - Product F"),
+                ([0, 0, 0, 0, 0, 0, 0], "Churned Subscription Count | stripe.posthog_test - Product F"),
                 ([0, 0, 0, 1, 1, 1, 1], "Customer Count | stripe.posthog_test - Product F"),
                 ([0, 0, 0, 1, 0, 0, 0], "New Customer Count | stripe.posthog_test - Product F"),
-                ([0, 0, 0, 0, 0, 0, 1], "Churned Customer Count | stripe.posthog_test - Product F"),
+                ([0, 0, 0, 0, 0, 0, 0], "Churned Customer Count | stripe.posthog_test - Product F"),
                 (
                     [0, 0, 0, Decimal("668.67503"), Decimal("668.67503"), Decimal("1459.02008"), 0],
                     "ARPU | stripe.posthog_test - Product F",
                 ),
-                ([0, 0, 0, None, None, None, 0], "LTV | stripe.posthog_test - Product F"),
+                ([0, 0, 0, None, None, None, None], "LTV | stripe.posthog_test - Product F"),
             ],
         )
 
@@ -1052,15 +1072,16 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         ).results
 
         self.assertEqual(len(results), 8)
+
         self.assertEqual(
             [result["data"] for result in results],
             [
                 [0, 1, 1, 1, 2, 0, 0],  # Subscription Count
                 [0, 1, 1, 0, 1, 0, 0],  # New Subscription Count
-                [0, 1, 0, 0, 2, 0, 0],  # Churned Subscription Count
+                [0, 0, 1, 0, 0, 2, 0],  # Churned Subscription Count
                 [0, 1, 1, 1, 1, 0, 0],  # Customer Count
                 [0, 1, 1, 0, 0, 0, 0],  # New Customer Count
-                [0, 1, 0, 0, 1, 0, 0],  # Churned Customer Count
+                [0, 0, 1, 0, 0, 1, 0],  # Churned Customer Count
                 [
                     0,
                     Decimal("33.0414"),
@@ -1070,9 +1091,29 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     0,
                     0,
                 ],  # ARPU
-                [0, Decimal("33.0414"), None, None, Decimal("66.1083336037"), 0, 0],  # LTV
+                [0, None, Decimal("5.5629321819"), None, None, 0, 0],  # LTV
             ],
         )
+
+        # Assert that `previous_subscription_count` + `new_subscription_count` - `churned_subscription_count` = `subscription_count`
+        for subscription_count, prev_subscription_count, new_subscription_count, churned_subscription_count in zip(
+            results[0]["data"][1:],
+            results[0]["data"][:-1],
+            results[1]["data"][1:],
+            results[2]["data"][1:],
+        ):
+            self.assertEqual(
+                subscription_count, prev_subscription_count + new_subscription_count - churned_subscription_count
+            )
+
+        # Same for customer count
+        for customer_count, prev_customer_count, new_customer_count, churned_customer_count in zip(
+            results[3]["data"][1:],
+            results[3]["data"][:-1],
+            results[4]["data"][1:],
+            results[5]["data"][1:],
+        ):
+            self.assertEqual(customer_count, prev_customer_count + new_customer_count - churned_customer_count)
 
         # Then, update the team to use the after_dropoff_period subscriptionDropoffMode
         event_item = REVENUE_ANALYTICS_CONFIG_SAMPLE_EVENT.model_copy(
@@ -1097,10 +1138,10 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             [
                 [0, 1, 2, 1, 2, 2, 0],  # Subscription Count
                 [0, 1, 1, 0, 1, 0, 0],  # New Subscription Count
-                [0, 0, 1, 0, 0, 2, 0],  # Churned Subscription Count
+                [0, 0, 0, 1, 0, 0, 2],  # Churned Subscription Count
                 [0, 1, 2, 1, 1, 1, 0],  # Customer Count
                 [0, 1, 1, 0, 0, 0, 0],  # New Customer Count
-                [0, 0, 1, 0, 0, 1, 0],  # Churned Customer Count
+                [0, 0, 0, 1, 0, 0, 1],  # Churned Customer Count
                 [
                     0,
                     Decimal("33.0414"),
@@ -1110,6 +1151,6 @@ class TestRevenueAnalyticsMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     0,
                     0,
                 ],  # ARPU
-                [0, None, Decimal("5.5629321818"), None, None, 0, 0],  # LTV
+                [0, None, None, Decimal("11.2552348796"), None, None, 0],  # LTV
             ],
         )


### PR DESCRIPTION
Previously, we'd count the churn on the month the customer's subscription ended. This caused a small problem because we'd reflect new subscriptions/customers immediately on the same month/day it started, but we'd only decrease it from the active subscription/customer count the next day (because the subscription was active on that day!)

This meant that when looking at a chart of active/new/churned subscriptions, that's how it would look:

```
Active:  10  11  11  11  10  10
New:      0   1   0   0   0   0
Churned:  0   0   0   1   0   0
```

You can see how someone churns on the 4th day, but it's only decreased from active subscriptions on the next day. I believe the chart should look as follows, which prompted the change here

```
Active:  10  11  11  11  10  10
New:      0   1   0   0   0   0
Churned:  0   0   0   0   1   0
```

See the last row, it's now only churned on the 5th day, following the decrease in the first row on the 5th day.

This could also be solved in a different way, by decreasing the number of active subscriptions on the 4th day. This could easily be achieved if Clickhouse included a `toEndOfPeriod` function, but alas, it doesn't.

I'm checking with @minekansu whether this change makes any sense or not: https://posthog.slack.com/archives/C08JLPPRA3B/p1760049633524699