### PR TITLE
fix(insights): Creating alert on user path/retention causes a crash

### DIFF
--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -220,7 +220,7 @@ export function EditAlertModal({
                                                                   } (${formula})`,
                                                                   value: index,
                                                               }))
-                                                            : alertSeries?.map(
+                                                            : (alertSeries?.map(
                                                                   ({ custom_name, name, event }, index) => ({
                                                                       label: isBreakdownValid
                                                                           ? 'any breakdown value'
@@ -229,7 +229,7 @@ export function EditAlertModal({
                                                                             }`,
                                                                       value: isBreakdownValid ? 0 : index,
                                                                   })
-                                                              )
+                                                              ) ?? [])
                                                     }
                                                     disabledReason={
                                                         isBreakdownValid &&

--- a/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
@@ -10,7 +10,7 @@ import { ProfileBubbles } from 'lib/lemon-ui/ProfilePicture'
 import { pluralize } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
-import { AlertState, InsightThresholdType, NodeKind } from '~/queries/schema/schema-general'
+import { AlertState, InsightThresholdType } from '~/queries/schema/schema-general'
 import { InsightShortId } from '~/types'
 
 import { InsightAlertsLogicProps, insightAlertsLogic } from '../insightAlertsLogic'
@@ -67,7 +67,7 @@ export function AlertListItem({ alert, onClick }: AlertListItemProps): JSX.Eleme
 interface ManageAlertsModalProps extends InsightAlertsLogicProps {
     isOpen: boolean
     insightShortId: InsightShortId
-    insightQueryKind: NodeKind
+    canCreateAlertForInsight: boolean
     onClose?: () => void
 }
 
@@ -76,8 +76,6 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
     const logic = insightAlertsLogic(props)
 
     const { alerts } = useValues(logic)
-
-    const { insightQueryKind } = props
 
     return (
         <LemonModal onClose={props.onClose} isOpen={props.isOpen} width={600} simple title="">
@@ -122,8 +120,9 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
                     type="primary"
                     onClick={() => push(urls.insightAlert(props.insightShortId, 'new'))}
                     disabledReason={
-                        (insightQueryKind === NodeKind.PathsQuery && `Cannot create an alert for paths query`) ||
-                        (insightQueryKind === NodeKind.RetentionQuery && `Cannot create an alert for retention query`)
+                        !props.canCreateAlertForInsight
+                            ? 'Alerts are only available for trends. Change the insight representation to add alerts.'
+                            : undefined
                     }
                 >
                     New alert

--- a/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
@@ -10,7 +10,7 @@ import { ProfileBubbles } from 'lib/lemon-ui/ProfilePicture'
 import { pluralize } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
-import { AlertState, InsightThresholdType } from '~/queries/schema/schema-general'
+import { AlertState, InsightThresholdType, NodeKind } from '~/queries/schema/schema-general'
 import { InsightShortId } from '~/types'
 
 import { InsightAlertsLogicProps, insightAlertsLogic } from '../insightAlertsLogic'
@@ -67,6 +67,7 @@ export function AlertListItem({ alert, onClick }: AlertListItemProps): JSX.Eleme
 interface ManageAlertsModalProps extends InsightAlertsLogicProps {
     isOpen: boolean
     insightShortId: InsightShortId
+    insightQueryKind: NodeKind
     onClose?: () => void
 }
 
@@ -75,6 +76,8 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
     const logic = insightAlertsLogic(props)
 
     const { alerts } = useValues(logic)
+
+    const { insightQueryKind } = props
 
     return (
         <LemonModal onClose={props.onClose} isOpen={props.isOpen} width={600} simple title="">
@@ -115,7 +118,14 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
             </LemonModal.Content>
 
             <LemonModal.Footer>
-                <LemonButton type="primary" onClick={() => push(urls.insightAlert(props.insightShortId, 'new'))}>
+                <LemonButton
+                    type="primary"
+                    onClick={() => push(urls.insightAlert(props.insightShortId, 'new'))}
+                    disabledReason={
+                        (insightQueryKind === NodeKind.PathsQuery && `Cannot create an alert for paths query`) ||
+                        (insightQueryKind === NodeKind.RetentionQuery && `Cannot create an alert for retention query`)
+                    }
+                >
                     New alert
                 </LemonButton>
                 <LemonButton type="secondary" onClick={props.onClose}>

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -188,6 +188,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             insightLogicProps={insightLogicProps}
                             insightId={insight.id as number}
                             insightShortId={insight.short_id as InsightShortId}
+                            insightQueryKind={insightQuery.kind}
                         />
                     )}
 

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -6,7 +6,7 @@ import { IconCode2, IconInfo, IconPencil, IconPeople, IconShare, IconTrash, Icon
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
-import { insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
+import { areAlertsSupportedForInsight, insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
 import { EditAlertModal } from 'lib/components/Alerts/views/EditAlertModal'
 import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
@@ -141,6 +141,8 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     const siteUrl = preflight?.site_url || window.location.origin
 
+    const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
+
     async function handleDuplicateInsight(): Promise<void> {
         // We do not want to duplicate the dashboard filters that might be included in this insight
         // Ideally we would store those separately and be able to remove them on duplicate or edit, but current we merge them
@@ -188,7 +190,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             insightLogicProps={insightLogicProps}
                             insightId={insight.id as number}
                             insightShortId={insight.short_id as InsightShortId}
-                            insightQueryKind={insightQuery.kind}
+                            canCreateAlertForInsight={canCreateAlertForInsight}
                         />
                     )}
 


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/39177

The crash occurs when `formulaNodes` is empty or undefined and `alertSeries` is undefined.

## Changes

1) Added a fallback array to prevent the crash
2) Disable the new alert button when the insight is `user path` or `retention` kind 


https://github.com/user-attachments/assets/52d953bc-3f5e-4b5f-a917-e599bad0fbe5

<img width="856" height="522" alt="Screenshot 2025-10-10 at 7 37 24 AM" src="https://github.com/user-attachments/assets/47ac8f5a-a4b4-4f75-9cae-8fc762db71b1" />


## How did you test this code?

1) Go to a user path insight
2) Click on the triple dot menu on the top right corner
3) Click on `Alerts`

You should see that you can't click on `New Alert`