### PR TITLE
refactor: Include warning on feature previews page when can't load them

### DIFF
--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -23,5 +23,9 @@ declare global {
         }
         IMPERSONATED_SESSION?: boolean
         POSTHOG_JS_UUID_VERSION?: string
+
+        // These are used to track global errors across the app.
+        // Can be used to determine whether we should show warnings in different places in the app.
+        POSTHOG_GLOBAL_ERRORS?: Record<string, boolean>
     }
 }

--- a/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
+++ b/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
@@ -11,9 +11,10 @@ import { Label } from 'lib/ui/Label/Label'
 
 import { EnrichedEarlyAccessFeature, featurePreviewsLogic } from './featurePreviewsLogic'
 
+const hasPosthogJsFailedToLoadFeaturePreviews = (): boolean => !!window.POSTHOG_GLOBAL_ERRORS?.onFeatureFlagsLoadError
+
 // Feature previews can be linked to by using hash in the url
 // example external link: https://app.posthog.com/settings/user-feature-previews#llm-analytics
-
 export function FeaturePreviews(): JSX.Element {
     const { earlyAccessFeatures, rawEarlyAccessFeaturesLoading } = useValues(featurePreviewsLogic)
     const { loadEarlyAccessFeatures } = useActions(featurePreviewsLogic)
@@ -23,6 +24,7 @@ export function FeaturePreviews(): JSX.Element {
     const conceptFeatures = earlyAccessFeatures.filter((f) => f.stage === 'concept')
     const disabledConceptFeatureCount = conceptFeatures.filter((f) => !f.enabled).length
     const betaFeatures = earlyAccessFeatures.filter((f) => f.stage === 'beta')
+    const failedToLoadFeaturePreviews = earlyAccessFeatures.length === 0 && hasPosthogJsFailedToLoadFeaturePreviews()
 
     return (
         <div className="flex flex-col gap-y-8">
@@ -34,6 +36,25 @@ export function FeaturePreviews(): JSX.Element {
                         Note that toggling these features will enable it for your account only. Each individual user in
                         your organization will need to enable it separately.
                     </LemonBanner>
+
+                    {failedToLoadFeaturePreviews && (
+                        <LemonBanner type="warning" className="mb-4">
+                            <div className="flex flex-col gap-2">
+                                <span>
+                                    We couldn't load our internal feature flags. This could be due to the presence of
+                                    adblockers running in your browser or due to a network issue (e.g. slow wifi).
+                                </span>
+                                <span className="italic">
+                                    Note: If you use feature flags for your app, you can avoid this issue for your users
+                                    by using a{' '}
+                                    <Link to="https://posthog.com/docs/advanced/proxy" target="_blank">
+                                        reverse proxy
+                                    </Link>
+                                    .
+                                </span>
+                            </div>
+                        </LemonBanner>
+                    )}
                 </div>
                 <div className="flex flex-col flex-1 gap-2 overflow-y-auto">
                     {rawEarlyAccessFeaturesLoading ? (

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -79,6 +79,10 @@ export function loadPostHogJS(): void {
             }
 
             posthog.capture('onFeatureFlags error')
+
+            // Track that we failed to load feature flags
+            window.POSTHOG_GLOBAL_ERRORS ||= {}
+            window.POSTHOG_GLOBAL_ERRORS['onFeatureFlagsLoadError'] = true
         })
     } else {
         posthog.init('fake_token', {


### PR DESCRIPTION
We are now setting a global flag to detect whether we failed to load our early access feature flags. We used to display a global toast but that was too cumbersome; let's now use it only where it actually matters.

<img width="924" height="334" alt="image" src="https://github.com/user-attachments/assets/6dc32133-1d4c-417e-9ff5-ae78ceeb6419" />
