### PR TITLE
fix: Revert "feat(logs): add new logs query optimization to fix read in order bug"

### DIFF
--- a/posthog/hogql/database/schema/logs.py
+++ b/posthog/hogql/database/schema/logs.py
@@ -25,10 +25,6 @@ class LogsTable(Table):
         "instrumentation_scope": StringDatabaseField(name="instrumentation_scope", nullable=False),
         "event_name": StringDatabaseField(name="event_name", nullable=False),
         "service_name": StringDatabaseField(name="service_name", nullable=False),
-        # internal fields for query optimization
-        # TODO: hide/block in hogql
-        "_part_starting_offset": IntegerDatabaseField(name="_part_starting_offset", nullable=True),
-        "_part_offset": IntegerDatabaseField(name="_part_offset", nullable=True),
     }
 
     def to_printed_clickhouse(self, context):

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -123,45 +123,83 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
         return LogsQueryResponse(results=results, **self.paginator.response_params())
 
     def to_query(self) -> ast.SelectQuery:
-        # utilize a hack to fix read_in_order_optimization not working correctly
-        # from: https://github.com/ClickHouse/ClickHouse/pull/82478/
-        query = self.paginator.paginate(
-            parse_select("""
-                SELECT _part_starting_offset+_part_offset from logs
-            """)
+        query = parse_select(
+            """
+            SELECT
+            uuid,
+            hex(trace_id),
+            hex(span_id),
+            body,
+            attributes,
+            timestamp,
+            observed_timestamp,
+            severity_text,
+            severity_number,
+            severity_text as level,
+            resource_attributes,
+            instrumentation_scope,
+            event_name
+            FROM logs, time_bucket_cte
+        """
         )
         assert isinstance(query, ast.SelectQuery)
         order_dir = "ASC" if self.query.orderBy == "earliest" else "DESC"
+        min_or_max_if = "minIf" if order_dir == "ASC" else "maxIf"
+        limit_ast = ast.Constant(value=(self.query.limit or 999) + (self.query.offset or 0) + 1)
 
-        query.where = ast.And(exprs=[self.where()])
-        query.order_by = [
-            parse_order_expr("team_id"),
-            parse_order_expr(f"toUnixTimestamp(timestamp) {order_dir}"),
-            parse_order_expr(f"timestamp {order_dir}"),
-        ]
-
-        final_query = parse_select(
-            """
+        # clickhouse is sadly not smart enough to realise it doesn't need to scan 10 million rows
+        # to fetch the first 1000 results. We use this fancy subquery which gives us time bracket between which we are
+        # guaranteed to have at least {limit} results - we don't need to scan outside this range.
+        count_query = parse_select(
+            f"""
             SELECT
-                uuid,
-                hex(trace_id),
-                hex(span_id),
-                body,
-                attributes,
-                timestamp,
-                observed_timestamp,
-                severity_text,
-                severity_number,
-                severity_text as level,
-                resource_attributes,
-                instrumentation_scope,
-                event_name
-            FROM logs where (_part_starting_offset+_part_offset) in (select 1)
-        """
+                arraySort([{min_or_max_if}(time_bucket, cumulative_count == 0) + toIntervalMinute({{offset_desc}}), {min_or_max_if}(time_bucket, cumulative_count == {{limit}}) + toIntervalMinute({{offset_asc}})]) AS time_buckets
+            FROM
+            (
+                WITH cumulative_counts AS
+                    (
+                        SELECT
+                            toStartOfInterval(timestamp, toIntervalMinute(10)) AS time_bucket,
+                            count() AS count,
+                            min2(sum(count()) OVER (ORDER BY time_bucket {order_dir} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), {{limit}}) AS cumulative_count
+                        FROM logs
+                        GROUP BY time_bucket
+                    )
+                SELECT time_bucket, cumulative_count
+                FROM cumulative_counts
+                WHERE cumulative_count == 0 or cumulative_count == {{limit}}
+                UNION ALL
+                SELECT toStartOfInterval({{date_from}}, toIntervalMinute(10)) AS time_bucket, {{max_limit}} AS cumulative_count
+                UNION ALL
+                SELECT toStartOfInterval({{date_to}}, toIntervalMinute(10)) AS time_bucket, {{min_limit}} AS cumulative_count
+            )
+        """,
+            placeholders={
+                "limit": limit_ast,
+                "offset_desc": ast.Constant(value=10 if order_dir == "DESC" else 0),
+                "offset_asc": ast.Constant(value=10 if order_dir == "ASC" else 0),
+                "min_limit": limit_ast if order_dir == "ASC" else ast.Constant(value=0),
+                "max_limit": limit_ast if order_dir == "DESC" else ast.Constant(value=0),
+                "date_from": ast.Constant(value=self.query_date_range.date_from()),
+                "date_to": ast.Constant(value=self.query_date_range.date_to()),
+            },
         )
-        assert isinstance(final_query, ast.SelectQuery)
-        final_query.where.right = query  # type: ignore
-        return final_query
+
+        # this query always parses the same so safe to ignore typing
+        count_query.select_from.table.initial_select_query.ctes["cumulative_counts"].expr.where = self.where()  # type: ignore
+        query.ctes = {"time_bucket_cte": ast.CTE(name="time_buckets", cte_type="column", expr=count_query)}
+
+        query.where = ast.And(
+            exprs=[
+                self.where(),
+                parse_expr("timestamp >= time_bucket_cte[1]"),
+                parse_expr("timestamp < time_bucket_cte[2]"),
+            ]
+        )
+        query.order_by = [
+            parse_order_expr(f"toUnixTimestamp(timestamp) {order_dir}"),
+        ]
+        return query
 
     def where(self):
         exprs: list[ast.Expr] = [


### PR DESCRIPTION
Reverts PostHog/posthog#39406

Pretty sure this made things slower in the end, will look into it when I'm back but revert for now 