### PR TITLE
feat(blobby): add session rate limiting

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -272,6 +272,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_V2_REPLAY_EVENTS_KAFKA_TOPIC: 'clickhouse_session_replay_events',
         SESSION_RECORDING_V2_CONSOLE_LOG_ENTRIES_KAFKA_TOPIC: 'log_entries',
         SESSION_RECORDING_V2_CONSOLE_LOG_STORE_SYNC_BATCH_LIMIT: 1000,
+        SESSION_RECORDING_V2_MAX_EVENTS_PER_SESSION_PER_BATCH: Number.MAX_SAFE_INTEGER,
         // in both the PostHog cloud environment and development
         // we want this metadata switchover to be in blob ingestion v2 mode
         // hobby installs will set this metadata value to a datetime

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -148,6 +148,7 @@ export class SessionRecordingIngester {
         this.sessionBatchManager = new SessionBatchManager({
             maxBatchSizeBytes: this.config.SESSION_RECORDING_MAX_BATCH_SIZE_KB * 1024,
             maxBatchAgeMs: this.config.SESSION_RECORDING_MAX_BATCH_AGE_MS,
+            maxEventsPerSessionPerBatch: this.config.SESSION_RECORDING_V2_MAX_EVENTS_PER_SESSION_PER_BATCH,
             offsetManager,
             fileStorage: this.fileStorage,
             metadataStore,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
@@ -58,6 +58,16 @@ export class SessionBatchMetrics {
         help: 'Total number of bytes written to S3',
     })
 
+    private static readonly sessionsRateLimited = new Counter({
+        name: 'recording_blob_ingestion_v2_sessions_rate_limited_total',
+        help: 'Number of sessions that were rate limited',
+    })
+
+    private static readonly eventsRateLimited = new Counter({
+        name: 'recording_blob_ingestion_v2_events_rate_limited_total',
+        help: 'Number of events that were rate limited',
+    })
+
     public static incrementBatchesFlushed(): void {
         this.batchesFlushed.inc()
     }
@@ -101,5 +111,13 @@ export class SessionBatchMetrics {
 
     public static incrementS3BytesWritten(bytes: number): void {
         this.s3BytesWritten.inc(bytes)
+    }
+
+    public static incrementSessionsRateLimited(count: number = 1): void {
+        this.sessionsRateLimited.inc(count)
+    }
+
+    public static incrementEventsRateLimited(count: number = 1): void {
+        this.eventsRateLimited.inc(count)
     }
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.test.ts
@@ -59,6 +59,7 @@ describe('SessionBatchManager', () => {
         manager = new SessionBatchManager({
             maxBatchSizeBytes: 100,
             maxBatchAgeMs: 1000,
+            maxEventsPerSessionPerBatch: Number.MAX_SAFE_INTEGER,
             offsetManager: mockOffsetManager,
             fileStorage: mockFileStorage,
             metadataStore: mockMetadataStore,
@@ -81,7 +82,8 @@ describe('SessionBatchManager', () => {
             mockFileStorage,
             mockMetadataStore,
             mockConsoleLogStore,
-            new Date('2025-01-02')
+            new Date('2025-01-02'),
+            Number.MAX_SAFE_INTEGER
         )
 
         const secondBatch = manager.getCurrentBatch()
@@ -146,6 +148,98 @@ describe('SessionBatchManager', () => {
             const batch = manager.getCurrentBatch()
             manager.discardPartitions([])
             expect(batch.discardPartition).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('rate limiting config', () => {
+        it('should pass maxEventsPerSessionPerBatch to new batches', () => {
+            manager = new SessionBatchManager({
+                maxBatchSizeBytes: 100,
+                maxBatchAgeMs: 1000,
+                maxEventsPerSessionPerBatch: 500,
+                offsetManager: mockOffsetManager,
+                fileStorage: mockFileStorage,
+                metadataStore: mockMetadataStore,
+                consoleLogStore: mockConsoleLogStore,
+                metadataSwitchoverDate: new Date('2025-01-02'),
+            })
+
+            expect(SessionBatchRecorder).toHaveBeenCalledWith(
+                mockOffsetManager,
+                mockFileStorage,
+                mockMetadataStore,
+                mockConsoleLogStore,
+                new Date('2025-01-02'),
+                500
+            )
+        })
+
+        it('should pass maxEventsPerSessionPerBatch to batches created after flush', async () => {
+            manager = new SessionBatchManager({
+                maxBatchSizeBytes: 100,
+                maxBatchAgeMs: 1000,
+                maxEventsPerSessionPerBatch: 250,
+                offsetManager: mockOffsetManager,
+                fileStorage: mockFileStorage,
+                metadataStore: mockMetadataStore,
+                consoleLogStore: mockConsoleLogStore,
+                metadataSwitchoverDate: new Date('2025-01-02'),
+            })
+
+            await manager.flush()
+
+            expect(SessionBatchRecorder).toHaveBeenLastCalledWith(
+                mockOffsetManager,
+                mockFileStorage,
+                mockMetadataStore,
+                mockConsoleLogStore,
+                new Date('2025-01-02'),
+                250
+            )
+        })
+
+        it('should handle maxEventsPerSessionPerBatch = 0', () => {
+            manager = new SessionBatchManager({
+                maxBatchSizeBytes: 100,
+                maxBatchAgeMs: 1000,
+                maxEventsPerSessionPerBatch: 0,
+                offsetManager: mockOffsetManager,
+                fileStorage: mockFileStorage,
+                metadataStore: mockMetadataStore,
+                consoleLogStore: mockConsoleLogStore,
+                metadataSwitchoverDate: new Date('2025-01-02'),
+            })
+
+            expect(SessionBatchRecorder).toHaveBeenCalledWith(
+                mockOffsetManager,
+                mockFileStorage,
+                mockMetadataStore,
+                mockConsoleLogStore,
+                new Date('2025-01-02'),
+                0
+            )
+        })
+
+        it('should handle maxEventsPerSessionPerBatch = MAX_SAFE_INTEGER', () => {
+            manager = new SessionBatchManager({
+                maxBatchSizeBytes: 100,
+                maxBatchAgeMs: 1000,
+                maxEventsPerSessionPerBatch: Number.MAX_SAFE_INTEGER,
+                offsetManager: mockOffsetManager,
+                fileStorage: mockFileStorage,
+                metadataStore: mockMetadataStore,
+                consoleLogStore: mockConsoleLogStore,
+                metadataSwitchoverDate: new Date('2025-01-02'),
+            })
+
+            expect(SessionBatchRecorder).toHaveBeenCalledWith(
+                mockOffsetManager,
+                mockFileStorage,
+                mockMetadataStore,
+                mockConsoleLogStore,
+                new Date('2025-01-02'),
+                Number.MAX_SAFE_INTEGER
+            )
         })
     })
 })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.ts
@@ -12,6 +12,8 @@ export interface SessionBatchManagerConfig {
     maxBatchSizeBytes: number
     /** Maximum age of a batch in milliseconds before it should be flushed */
     maxBatchAgeMs: number
+    /** Maximum number of events per session per batch before rate limiting */
+    maxEventsPerSessionPerBatch: number
     /** Manages Kafka offset tracking and commits */
     offsetManager: KafkaOffsetManager
     /** Handles writing session batch files to storage */
@@ -62,6 +64,7 @@ export class SessionBatchManager {
     private currentBatch: SessionBatchRecorder
     private readonly maxBatchSizeBytes: number
     private readonly maxBatchAgeMs: number
+    private readonly maxEventsPerSessionPerBatch: number
     private readonly offsetManager: KafkaOffsetManager
     private readonly fileStorage: SessionBatchFileStorage
     private readonly metadataStore: SessionMetadataStore
@@ -72,6 +75,7 @@ export class SessionBatchManager {
     constructor(config: SessionBatchManagerConfig) {
         this.maxBatchSizeBytes = config.maxBatchSizeBytes
         this.maxBatchAgeMs = config.maxBatchAgeMs
+        this.maxEventsPerSessionPerBatch = config.maxEventsPerSessionPerBatch
         this.offsetManager = config.offsetManager
         this.fileStorage = config.fileStorage
         this.metadataStore = config.metadataStore
@@ -83,7 +87,8 @@ export class SessionBatchManager {
             this.fileStorage,
             this.metadataStore,
             this.consoleLogStore,
-            this.metadataSwitchoverDate
+            this.metadataSwitchoverDate,
+            this.maxEventsPerSessionPerBatch
         )
         this.lastFlushTime = Date.now()
     }
@@ -106,7 +111,8 @@ export class SessionBatchManager {
             this.fileStorage,
             this.metadataStore,
             this.consoleLogStore,
-            this.metadataSwitchoverDate
+            this.metadataSwitchoverDate,
+            this.maxEventsPerSessionPerBatch
         )
         this.lastFlushTime = Date.now()
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -11,6 +11,7 @@ import { SessionBlockMetadata } from './session-block-metadata'
 import { SessionConsoleLogRecorder } from './session-console-log-recorder'
 import { SessionConsoleLogStore } from './session-console-log-store'
 import { SessionMetadataStore } from './session-metadata-store'
+import { SessionRateLimiter } from './session-rate-limiter'
 import { SnappySessionRecorder } from './snappy-session-recorder'
 
 /**
@@ -64,15 +65,18 @@ export class SessionBatchRecorder {
     private readonly partitionSizes = new Map<number, number>()
     private _size: number = 0
     private readonly batchId: string
+    private readonly rateLimiter: SessionRateLimiter
 
     constructor(
         private readonly offsetManager: KafkaOffsetManager,
         private readonly storage: SessionBatchFileStorage,
         private readonly metadataStore: SessionMetadataStore,
         private readonly consoleLogStore: SessionConsoleLogStore,
-        private readonly metadataSwitchoverDate: SessionRecordingV2MetadataSwitchoverDate
+        private readonly metadataSwitchoverDate: SessionRecordingV2MetadataSwitchoverDate,
+        maxEventsPerSessionPerBatch: number = Number.MAX_SAFE_INTEGER
     ) {
         this.batchId = uuidv7()
+        this.rateLimiter = new SessionRateLimiter(maxEventsPerSessionPerBatch)
         logger.debug('🔁', 'session_batch_recorder_created', { batchId: this.batchId })
     }
 
@@ -87,6 +91,46 @@ export class SessionBatchRecorder {
         const sessionId = message.message.session_id
         const teamId = message.team.teamId
         const teamSessionKey = `${teamId}$${sessionId}`
+
+        const isAllowed = this.rateLimiter.handleEvent(teamSessionKey, partition)
+
+        if (!isAllowed) {
+            logger.debug('🔁', 'session_batch_recorder_event_rate_limited', {
+                partition,
+                sessionId,
+                teamId,
+                eventCount: this.rateLimiter.getEventCount(teamSessionKey),
+                batchId: this.batchId,
+            })
+
+            if (!this.partitionSessions.has(partition)) {
+                this.offsetManager.trackOffset({
+                    partition: message.message.metadata.partition,
+                    offset: message.message.metadata.offset,
+                })
+                return 0
+            }
+
+            const sessions = this.partitionSessions.get(partition)!
+            const existingRecorders = sessions.get(teamSessionKey)
+
+            if (existingRecorders) {
+                sessions.delete(teamSessionKey)
+                logger.info('🔁', 'session_batch_recorder_deleted_rate_limited_session', {
+                    partition,
+                    sessionId,
+                    teamId,
+                    batchId: this.batchId,
+                })
+            }
+
+            this.offsetManager.trackOffset({
+                partition: message.message.metadata.partition,
+                offset: message.message.metadata.offset,
+            })
+
+            return 0
+        }
 
         if (!this.partitionSessions.has(partition)) {
             this.partitionSessions.set(partition, new Map())
@@ -155,6 +199,9 @@ export class SessionBatchRecorder {
                 partition,
                 partitionSize,
             })
+
+            this.rateLimiter.discardPartition(partition)
+
             this._size -= partitionSize
             this.partitionSizes.delete(partition)
             this.partitionSessions.delete(partition)
@@ -260,10 +307,11 @@ export class SessionBatchRecorder {
             SessionBatchMetrics.incrementEventsFlushed(totalEvents)
             SessionBatchMetrics.incrementBytesWritten(totalBytes)
 
-            // Clear sessions, partition sizes, and total size after successful flush
+            // Clear sessions, partition sizes, total size, and rate limiter state after successful flush
             this.partitionSessions.clear()
             this.partitionSizes.clear()
             this._size = 0
+            this.rateLimiter.clear()
 
             logger.info('🔁', 'session_batch_recorder_flushed', {
                 totalEvents,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-rate-limiter.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-rate-limiter.test.ts
@@ -1,0 +1,262 @@
+import { SessionRateLimiter } from './session-rate-limiter'
+
+jest.mock('./metrics', () => ({
+    SessionBatchMetrics: {
+        incrementSessionsRateLimited: jest.fn(),
+        incrementEventsRateLimited: jest.fn(),
+    },
+}))
+
+describe('SessionRateLimiter', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('handleEvent', () => {
+        it('should allow events up to the limit', () => {
+            const limiter = new SessionRateLimiter(3)
+            const sessionKey = 'team123$session456'
+
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            expect(limiter.getEventCount(sessionKey)).toBe(3)
+        })
+
+        it('should block events after limit is exceeded', () => {
+            const limiter = new SessionRateLimiter(2)
+            const sessionKey = 'team123$session456'
+
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+        })
+
+        it('should track multiple sessions independently', () => {
+            const limiter = new SessionRateLimiter(2)
+            const session1 = 'team123$session1'
+            const session2 = 'team123$session2'
+
+            expect(limiter.handleEvent(session1, 1)).toBe(true)
+            expect(limiter.handleEvent(session2, 1)).toBe(true)
+            expect(limiter.handleEvent(session1, 1)).toBe(true)
+            expect(limiter.handleEvent(session2, 1)).toBe(true)
+
+            expect(limiter.handleEvent(session1, 1)).toBe(false)
+            expect(limiter.handleEvent(session2, 1)).toBe(false)
+        })
+
+        it('should continue blocking after limit is hit', () => {
+            const limiter = new SessionRateLimiter(1)
+            const sessionKey = 'team123$session456'
+
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+        })
+
+        it('should allow unlimited events with MAX_SAFE_INTEGER', () => {
+            const limiter = new SessionRateLimiter(Number.MAX_SAFE_INTEGER)
+            const sessionKey = 'team123$session456'
+
+            for (let i = 0; i < 1000000; i++) {
+                expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            }
+            expect(limiter.getEventCount(sessionKey)).toBe(1000000)
+        })
+    })
+
+    describe('getEventCount', () => {
+        it('should return 0 for new session', () => {
+            const limiter = new SessionRateLimiter(10)
+            expect(limiter.getEventCount('team123$session456')).toBe(0)
+        })
+
+        it('should return current count for tracked session', () => {
+            const limiter = new SessionRateLimiter(10)
+            const sessionKey = 'team123$session456'
+
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.getEventCount(sessionKey)).toBe(1)
+
+            limiter.handleEvent(sessionKey, 1)
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.getEventCount(sessionKey)).toBe(3)
+        })
+
+        it('should increment count even after limit is hit', () => {
+            const limiter = new SessionRateLimiter(2)
+            const sessionKey = 'team123$session456'
+
+            limiter.handleEvent(sessionKey, 1)
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.getEventCount(sessionKey)).toBe(2)
+
+            limiter.handleEvent(sessionKey, 1)
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.getEventCount(sessionKey)).toBe(4)
+        })
+    })
+
+    describe('removeSession', () => {
+        it('should remove session tracking', () => {
+            const limiter = new SessionRateLimiter(10)
+            const sessionKey = 'team123$session456'
+
+            limiter.handleEvent(sessionKey, 1)
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.getEventCount(sessionKey)).toBe(2)
+
+            limiter.removeSession(sessionKey)
+            expect(limiter.getEventCount(sessionKey)).toBe(0)
+
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.getEventCount(sessionKey)).toBe(1)
+        })
+
+        it('should remove limited session status', () => {
+            const limiter = new SessionRateLimiter(1)
+            const sessionKey = 'team123$session456'
+
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+
+            limiter.removeSession(sessionKey)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+        })
+
+        it('should handle removing non-existent session', () => {
+            const limiter = new SessionRateLimiter(10)
+            expect(() => limiter.removeSession('nonexistent')).not.toThrow()
+        })
+    })
+
+    describe('clear', () => {
+        it('should clear all sessions', () => {
+            const limiter = new SessionRateLimiter(10)
+            const session1 = 'team123$session1'
+            const session2 = 'team123$session2'
+
+            limiter.handleEvent(session1, 1)
+            limiter.handleEvent(session1, 1)
+            limiter.handleEvent(session2, 1)
+
+            expect(limiter.getEventCount(session1)).toBe(2)
+            expect(limiter.getEventCount(session2)).toBe(1)
+
+            limiter.clear()
+
+            expect(limiter.getEventCount(session1)).toBe(0)
+            expect(limiter.getEventCount(session2)).toBe(0)
+        })
+
+        it('should clear limited session status', () => {
+            const limiter = new SessionRateLimiter(1)
+            const sessionKey = 'team123$session456'
+
+            limiter.handleEvent(sessionKey, 1)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+
+            limiter.clear()
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+        })
+    })
+
+    describe('edge cases', () => {
+        it('should handle limit of 0', () => {
+            const limiter = new SessionRateLimiter(0)
+            const sessionKey = 'team123$session456'
+
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+            expect(limiter.getEventCount(sessionKey)).toBe(1)
+        })
+
+        it('should handle limit of 1', () => {
+            const limiter = new SessionRateLimiter(1)
+            const sessionKey = 'team123$session456'
+
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(true)
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+        })
+
+        it('should handle many concurrent sessions', () => {
+            const limiter = new SessionRateLimiter(5)
+            const sessions = Array.from({ length: 100 }, (_, i) => `team123$session${i}`)
+
+            for (const session of sessions) {
+                for (let i = 0; i < 5; i++) {
+                    expect(limiter.handleEvent(session, 1)).toBe(true)
+                }
+                expect(limiter.handleEvent(session, 1)).toBe(false)
+            }
+        })
+    })
+
+    describe('discardPartition', () => {
+        it('should remove all sessions for a partition', () => {
+            const limiter = new SessionRateLimiter(10)
+            const session1 = 'team123$session1'
+            const session2 = 'team123$session2'
+            const session3 = 'team123$session3'
+
+            limiter.handleEvent(session1, 1)
+            limiter.handleEvent(session1, 1)
+            limiter.handleEvent(session2, 1)
+            limiter.handleEvent(session3, 2)
+
+            expect(limiter.getEventCount(session1)).toBe(2)
+            expect(limiter.getEventCount(session2)).toBe(1)
+            expect(limiter.getEventCount(session3)).toBe(1)
+
+            limiter.discardPartition(1)
+
+            expect(limiter.getEventCount(session1)).toBe(0)
+            expect(limiter.getEventCount(session2)).toBe(0)
+            expect(limiter.getEventCount(session3)).toBe(1)
+        })
+
+        it('should remove limited session status for partition', () => {
+            const limiter = new SessionRateLimiter(1)
+            const session1 = 'team123$session1'
+            const session2 = 'team123$session2'
+
+            limiter.handleEvent(session1, 1)
+            limiter.handleEvent(session1, 1)
+            limiter.handleEvent(session2, 2)
+            limiter.handleEvent(session2, 2)
+
+            expect(limiter.handleEvent(session1, 1)).toBe(false)
+            expect(limiter.handleEvent(session2, 2)).toBe(false)
+
+            limiter.discardPartition(1)
+
+            expect(limiter.handleEvent(session1, 1)).toBe(true)
+            expect(limiter.handleEvent(session2, 2)).toBe(false)
+        })
+
+        it('should handle discarding non-existent partition', () => {
+            const limiter = new SessionRateLimiter(10)
+            expect(() => limiter.discardPartition(999)).not.toThrow()
+        })
+
+        it('should allow session to restart on new partition after discard', () => {
+            const limiter = new SessionRateLimiter(2)
+            const sessionKey = 'team123$session456'
+
+            limiter.handleEvent(sessionKey, 1)
+            limiter.handleEvent(sessionKey, 1)
+            limiter.handleEvent(sessionKey, 1)
+
+            expect(limiter.handleEvent(sessionKey, 1)).toBe(false)
+
+            limiter.discardPartition(1)
+
+            limiter.handleEvent(sessionKey, 2)
+            limiter.handleEvent(sessionKey, 2)
+            expect(limiter.getEventCount(sessionKey)).toBe(2)
+            expect(limiter.handleEvent(sessionKey, 2)).toBe(false)
+        })
+    })
+})

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-rate-limiter.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-rate-limiter.ts
@@ -1,0 +1,84 @@
+import { SessionBatchMetrics } from './metrics'
+
+/**
+ * Rate limiter for session recordings
+ * Tracks event count per session and enforces a maximum events per batch limit
+ */
+export class SessionRateLimiter {
+    private readonly eventCounts = new Map<string, number>()
+    private readonly limitedSessions = new Set<string>()
+    private readonly sessionPartitions = new Map<string, number>()
+
+    constructor(private readonly maxEventsPerSession: number = Number.MAX_SAFE_INTEGER) {}
+
+    /**
+     * Handle an event for a session
+     * @param sessionKey - Unique session identifier (e.g., "teamId$sessionId")
+     * @param partition - Partition number for this event
+     * @returns true if event should be processed, false if rate limited
+     */
+    public handleEvent(sessionKey: string, partition: number): boolean {
+        const currentCount = this.eventCounts.get(sessionKey) ?? 0
+        const newCount = currentCount + 1
+
+        // Always increment the count and track partition
+        this.eventCounts.set(sessionKey, newCount)
+        this.sessionPartitions.set(sessionKey, partition)
+
+        if (this.limitedSessions.has(sessionKey)) {
+            SessionBatchMetrics.incrementEventsRateLimited()
+            return false
+        }
+
+        if (newCount > this.maxEventsPerSession) {
+            this.limitedSessions.add(sessionKey)
+            SessionBatchMetrics.incrementSessionsRateLimited()
+            SessionBatchMetrics.incrementEventsRateLimited()
+            return false
+        }
+
+        return true
+    }
+
+    /**
+     * Get current event count for a session
+     */
+    public getEventCount(sessionKey: string): number {
+        return this.eventCounts.get(sessionKey) ?? 0
+    }
+
+    /**
+     * Remove tracking for a session (used when partition is discarded)
+     */
+    public removeSession(sessionKey: string): void {
+        this.eventCounts.delete(sessionKey)
+        this.limitedSessions.delete(sessionKey)
+        this.sessionPartitions.delete(sessionKey)
+    }
+
+    /**
+     * Discard all sessions for a given partition
+     */
+    public discardPartition(partition: number): void {
+        const sessionsToRemove: string[] = []
+
+        for (const [sessionKey, sessionPartition] of this.sessionPartitions.entries()) {
+            if (sessionPartition === partition) {
+                sessionsToRemove.push(sessionKey)
+            }
+        }
+
+        for (const sessionKey of sessionsToRemove) {
+            this.removeSession(sessionKey)
+        }
+    }
+
+    /**
+     * Clear all rate limiting state
+     */
+    public clear(): void {
+        this.eventCounts.clear()
+        this.limitedSessions.clear()
+        this.sessionPartitions.clear()
+    }
+}

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -441,6 +441,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     SESSION_RECORDING_V2_REPLAY_EVENTS_KAFKA_TOPIC: string
     SESSION_RECORDING_V2_CONSOLE_LOG_ENTRIES_KAFKA_TOPIC: string
     SESSION_RECORDING_V2_CONSOLE_LOG_STORE_SYNC_BATCH_LIMIT: number
+    SESSION_RECORDING_V2_MAX_EVENTS_PER_SESSION_PER_BATCH: number
 
     // New: switchover flag for v2 session recording metadata
     SESSION_RECORDING_V2_METADATA_SWITCHOVER: string


### PR DESCRIPTION
## Problem

We're seeing some spammy sessions and we should just reject them.

## Changes

Adds a per-session limiter that limits the number of events per session per batch.

## How did you test this code?

Added tests for all affected classes.
