### PR TITLE
chore(capture): add metric label for rerouted overflow

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -267,7 +267,8 @@ impl KafkaSink {
                         headers.set_force_disable_person_processing(true);
                         counter!(
                             "capture_events_rerouted_overflow",
-                            &[("reason", "force_limited")]
+                            "reason" => "force_limited",
+                            "key" => event_key.to_string()
                         )
                         .increment(1);
                         (&self.overflow_topic, None)
@@ -275,7 +276,8 @@ impl KafkaSink {
                     OverflowLimiterResult::Limited => {
                         counter!(
                             "capture_events_rerouted_overflow",
-                            &[("reason", "rate_limited")]
+                            "reason" => "rate_limited",
+                            "key" => event_key.to_string()
                         )
                         .increment(1);
                         if self.partition.as_ref().unwrap().should_preserve_locality() {


### PR DESCRIPTION
## Problem

Currently we don't know which keys we are rate or forcibly limiting. Since the cardinality of these is pretty low, we should add them as metric labels

## Changes

- Added event `key` label to `capture_events_rerouted_overflow` metric