### PR TITLE
fix(myke): remove token from event properties

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -434,9 +434,8 @@ describe.each([
                 expect(invocationGlobals[0].event.properties).toEqual({
                     $current_url: 'https://posthog.com',
                     $lib_version: '1.0.0',
-                    token: undefined,
                 })
-                expect(invocationGlobals[0].event.properties.token).toBeUndefined()
+                expect(invocationGlobals[0].event.properties).not.toHaveProperty('token')
             })
         })
     })

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -67,7 +67,7 @@ export function convertToHogFunctionInvocationGlobals(
         : clickHouseTimestampToISO(event.timestamp)
 
     // Remove token to prevent sending to third-party services
-    const { token, ...propertiesWithoutToken } = properties
+    delete properties.token
 
     const context: HogFunctionInvocationGlobals = {
         project: {
@@ -80,7 +80,7 @@ export function convertToHogFunctionInvocationGlobals(
             event: event.event!,
             elements_chain: event.elements_chain,
             distinct_id: event.distinct_id,
-            properties: propertiesWithoutToken,
+            properties: properties,
             timestamp: eventTimestamp,
             url: `${projectUrl}/events/${encodeURIComponent(event.uuid)}/${encodeURIComponent(eventTimestamp)}`,
         },
@@ -124,7 +124,7 @@ export function convertInternalEventToHogFunctionInvocationGlobals(
     }
 
     // Remove token to prevent sending to third-party services
-    const { token, ...propertiesWithoutToken } = properties
+    delete properties.token
 
     const context: HogFunctionInvocationGlobals = {
         project: {
@@ -137,7 +137,7 @@ export function convertInternalEventToHogFunctionInvocationGlobals(
             event: data.event.event,
             elements_chain: '', // Not applicable but left here for compatibility
             distinct_id: data.event.distinct_id,
-            properties: propertiesWithoutToken,
+            properties: properties,
             timestamp: data.event.timestamp,
             url: data.event.url ?? '',
         },

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -66,6 +66,9 @@ export function convertToHogFunctionInvocationGlobals(
         ? event.timestamp
         : clickHouseTimestampToISO(event.timestamp)
 
+    // Remove token to prevent sending to third-party services
+    const { token, ...propertiesWithoutToken } = properties
+
     const context: HogFunctionInvocationGlobals = {
         project: {
             id: team.id,
@@ -77,7 +80,7 @@ export function convertToHogFunctionInvocationGlobals(
             event: event.event!,
             elements_chain: event.elements_chain,
             distinct_id: event.distinct_id,
-            properties: { ...properties, token: undefined }, // Remove token to prevent sending to third-party services
+            properties: propertiesWithoutToken,
             timestamp: eventTimestamp,
             url: `${projectUrl}/events/${encodeURIComponent(event.uuid)}/${encodeURIComponent(eventTimestamp)}`,
         },
@@ -120,6 +123,9 @@ export function convertInternalEventToHogFunctionInvocationGlobals(
         delete properties.exception_props
     }
 
+    // Remove token to prevent sending to third-party services
+    const { token, ...propertiesWithoutToken } = properties
+
     const context: HogFunctionInvocationGlobals = {
         project: {
             id: team.id,
@@ -131,7 +137,7 @@ export function convertInternalEventToHogFunctionInvocationGlobals(
             event: data.event.event,
             elements_chain: '', // Not applicable but left here for compatibility
             distinct_id: data.event.distinct_id,
-            properties: { ...properties, token: undefined }, // Remove token to prevent sending it to third-party services
+            properties: propertiesWithoutToken,
             timestamp: data.event.timestamp,
             url: data.event.url ?? '',
         },

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -77,7 +77,7 @@ export function convertToHogFunctionInvocationGlobals(
             event: event.event!,
             elements_chain: event.elements_chain,
             distinct_id: event.distinct_id,
-            properties,
+            properties: { ...properties, token: undefined }, // Remove token to prevent sending to third-party services
             timestamp: eventTimestamp,
             url: `${projectUrl}/events/${encodeURIComponent(event.uuid)}/${encodeURIComponent(eventTimestamp)}`,
         },
@@ -131,7 +131,7 @@ export function convertInternalEventToHogFunctionInvocationGlobals(
             event: data.event.event,
             elements_chain: '', // Not applicable but left here for compatibility
             distinct_id: data.event.distinct_id,
-            properties: properties,
+            properties: { ...properties, token: undefined }, // Remove token to prevent sending it to third-party services
             timestamp: data.event.timestamp,
             url: data.event.url ?? '',
         },


### PR DESCRIPTION
## Problem

we dont want to send tokens downstream and just remove them entirely from the properties

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- removed token from event properties 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added test 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
