### PR TITLE
fix(blobby): rate limit on events instead of msgs

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -92,7 +92,7 @@ export class SessionBatchRecorder {
         const teamId = message.team.teamId
         const teamSessionKey = `${teamId}$${sessionId}`
 
-        const isAllowed = this.rateLimiter.handleEvent(teamSessionKey, partition)
+        const isAllowed = this.rateLimiter.handleMessage(teamSessionKey, partition, message.message)
 
         if (!isAllowed) {
             logger.debug('🔁', 'session_batch_recorder_event_rate_limited', {


### PR DESCRIPTION
## Problem

Rate limiter counted Kafka messages instead of actual events.

## Changes

Switches the counting to events.

## How did you test this code?

Updated the tests.

