### PR TITLE
fix(ci): Use correct token for update-bot-ips flow

### DIFF
--- a/.github/workflows/update-bot-ips.yml
+++ b/.github/workflows/update-bot-ips.yml
@@ -41,7 +41,7 @@ jobs:
               if: steps.check-changes.outputs.changes == 'true'
               uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v5
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   commit-message: 'Update bot IPs from GoodBots repository'
                   title: '🤖 Update bot IPs from GoodBots repository'
                   body: |


### PR DESCRIPTION
## Problem

Currently this job fails
```
  /usr/bin/git push --force-with-lease origin create-pull-request/patch:refs/heads/create-pull-request/patch
  remote: Permission to PostHog/posthog.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/PostHog/posthog/': The requested URL returned error: 403
  Error: The process '/usr/bin/git' failed with exit code 128
```

## Changes

Switch to a token that should have sufficient permissions to do this

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
