### PR TITLE
feat: add flag to show upgrade to managed accts

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -252,8 +252,9 @@ export const FEATURE_FLAGS = {
     ACTIVE_HOURS_HEATMAP: 'active-hours-heatmap', // owner: @jabahamondes #team-web-analytics
     CALENDAR_HEATMAP_INSIGHT: 'calendar-heatmap-insight', // owner: @jabahamondes #team-web-analytics
     WEB_ANALYTICS_MARKETING: 'marketing-analytics', // owner: @jabahamondes #team-web-analytics
-    BILLING_FORECASTING_ISSUES: 'billing-forecasting-issues', // owner: @pato
+    BILLING_FORECASTING_ISSUES: 'billing-forecasting-issues', // owner: @pato #team-billing
     STARTUP_PROGRAM_INTENT: 'startup-program-intent', // owner: @pawel-cebula #team-billing
+    SHOW_UPGRADE_TO_MANAGED_ACCOUNT: 'show-upgrade-to-managed-account', // owner: @pawel-cebula #team-billing
     SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES: 'web-analytics-pre-aggregated-tables', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_FRUSTRATING_PAGES_TILE: 'web-analytics-frustrating-pages-tile', // owner: @lricoy #team-web-analytics
     ALWAYS_QUERY_BLOCKING: 'always-query-blocking', // owner: @timgl

--- a/frontend/src/scenes/billing/BillingHero.tsx
+++ b/frontend/src/scenes/billing/BillingHero.tsx
@@ -4,6 +4,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { Link } from '@posthog/lemon-ui'
 
 import { BillingUpgradeCTA } from 'lib/components/BillingUpgradeCTA'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import { BillingPlan, BillingProductV2Type, StartupProgramLabel } from '~/types'
 
@@ -159,12 +160,13 @@ export const BillingHero = ({ product }: { product: BillingProductV2Type }): JSX
     const { scrollToProduct } = useActions(billingLogic)
     const { isPlanComparisonModalOpen, billingProductLoading } = useValues(billingProductLogic({ product }))
     const { toggleIsPlanComparisonModalOpen } = useActions(billingProductLogic({ product }))
+    const showUpgradeToManagedAccount = useFeatureFlag('SHOW_UPGRADE_TO_MANAGED_ACCOUNT')
 
     if (!billingPlan) {
         return null
     }
 
-    const showUpgradeOptions = billingPlan === BillingPlan.Free && !isManagedAccount
+    const showUpgradeOptions = billingPlan === BillingPlan.Free && (!isManagedAccount || showUpgradeToManagedAccount)
     const copyVariation =
         (startupProgramLabelCurrent ? BADGE_CONFIG[startupProgramLabelCurrent] : BADGE_CONFIG[billingPlan]) ||
         BADGE_CONFIG[BillingPlan.Paid]

--- a/frontend/src/scenes/billing/BillingHero.tsx
+++ b/frontend/src/scenes/billing/BillingHero.tsx
@@ -4,7 +4,6 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { Link } from '@posthog/lemon-ui'
 
 import { BillingUpgradeCTA } from 'lib/components/BillingUpgradeCTA'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import { BillingPlan, BillingProductV2Type, StartupProgramLabel } from '~/types'
@@ -161,7 +160,7 @@ export const BillingHero = ({ product }: { product: BillingProductV2Type }): JSX
     const { scrollToProduct } = useActions(billingLogic)
     const { isPlanComparisonModalOpen, billingProductLoading } = useValues(billingProductLogic({ product }))
     const { toggleIsPlanComparisonModalOpen } = useActions(billingProductLogic({ product }))
-    const showUpgradeToManagedAccount = useFeatureFlag(FEATURE_FLAGS.SHOW_UPGRADE_TO_MANAGED_ACCOUNT)
+    const showUpgradeToManagedAccount = useFeatureFlag('SHOW_UPGRADE_TO_MANAGED_ACCOUNT')
 
     if (!billingPlan) {
         return null

--- a/frontend/src/scenes/billing/BillingHero.tsx
+++ b/frontend/src/scenes/billing/BillingHero.tsx
@@ -4,6 +4,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { Link } from '@posthog/lemon-ui'
 
 import { BillingUpgradeCTA } from 'lib/components/BillingUpgradeCTA'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import { BillingPlan, BillingProductV2Type, StartupProgramLabel } from '~/types'
@@ -160,7 +161,7 @@ export const BillingHero = ({ product }: { product: BillingProductV2Type }): JSX
     const { scrollToProduct } = useActions(billingLogic)
     const { isPlanComparisonModalOpen, billingProductLoading } = useValues(billingProductLogic({ product }))
     const { toggleIsPlanComparisonModalOpen } = useActions(billingProductLogic({ product }))
-    const showUpgradeToManagedAccount = useFeatureFlag('SHOW_UPGRADE_TO_MANAGED_ACCOUNT')
+    const showUpgradeToManagedAccount = useFeatureFlag(FEATURE_FLAGS.SHOW_UPGRADE_TO_MANAGED_ACCOUNT)
 
     if (!billingPlan) {
         return null


### PR DESCRIPTION
## Problem

We hide upgrade options on billing page to managed accounts as it can be confusing for sales-led customers, however, in some cases managed accounts decide to go with pay-as-you-go rather than annual plan and we need to allow them to upgrade.

More context here: https://posthog.slack.com/archives/C08UUFAKSFM/p1760098100688809?thread_ts=1759942554.262889&cid=C08UUFAKSFM

## Changes

Adds [show-upgrade-to-managed-account](https://us.posthog.com/project/2/feature_flags/214548) feature flag that can be toggled for orgs to show upgrade option to them even if they're managed.

## How did you test this code?

Manually
