### PR TITLE
chore(experiments): hide targeting and experiment type panels.

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -37,6 +37,12 @@ type CreateExperimentProps = Partial<{
     draftExperiment: Experiment
 }>
 
+/**
+ * temporary setup. We may want to put this behind a feature flag for testing.
+ */
+const SHOW_EXPERIMENT_TYPE_PANEL = false
+const SHOW_TARGETING_PANEL = false
+
 export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JSX.Element => {
     const { HogfettiComponent } = useHogfetti({ count: 100, duration: 3000 })
 
@@ -106,16 +112,20 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                         }}
                         className="bg-surface-primary"
                         panels={[
-                            {
-                                key: 'experiment-type',
-                                header: 'Experiment type',
-                                content: (
-                                    <ExperimentTypePanel
-                                        experiment={experiment}
-                                        setExperimentType={(type) => setExperimentValue('type', type)}
-                                    />
-                                ),
-                            },
+                            ...(SHOW_EXPERIMENT_TYPE_PANEL
+                                ? [
+                                      {
+                                          key: 'experiment-type',
+                                          header: 'Experiment type',
+                                          content: (
+                                              <ExperimentTypePanel
+                                                  experiment={experiment}
+                                                  setExperimentType={(type) => setExperimentValue('type', type)}
+                                              />
+                                          ),
+                                      },
+                                  ]
+                                : []),
                             {
                                 key: 'experiment-variants',
                                 header: 'Feature flag & variants',
@@ -136,15 +146,19 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                     />
                                 ),
                             },
-                            {
-                                key: 'experiment-targeting',
-                                header: 'Targeting',
-                                content: (
-                                    <div className="p-4">
-                                        <span>Targeting Panel Goes Here</span>
-                                    </div>
-                                ),
-                            },
+                            ...(SHOW_TARGETING_PANEL
+                                ? [
+                                      {
+                                          key: 'experiment-targeting',
+                                          header: 'Targeting',
+                                          content: (
+                                              <div className="p-4">
+                                                  <span>Targeting Panel Goes Here</span>
+                                              </div>
+                                          ),
+                                      },
+                                  ]
+                                : []),
                             {
                                 key: 'experiment-exposure',
                                 header: 'Exposure criteria',


### PR DESCRIPTION
## Problem

When creating an experiment, the existing backend doesn't support targeting groups.

https://github.com/PostHog/posthog/blob/5ff3546c84fa71a34eef603e8aec850b1653b1a6/ee/clickhouse/views/experiments.py#L251-L256

And, we don't have a separate UI for no-code experiments.

So, to maintain feature parity and focus solely on UX changes, it makes sense to hide those two panels...

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adding two boolean constants to act as flags to hide those two panels selectively. We can refactor this to use feature flags if we want to experiment with adding the fields.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/ee1f4361-cdad-49af-b8f2-cadda829ed17)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
