### PR TITLE
fix(myke): fix broken hog functions filter byte code

### DIFF
--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -1,10 +1,11 @@
 import { BindLogic, actions, connect, kea, key, path, props, reducers, selectors, useActions, useValues } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
-import { LemonDivider } from '@posthog/lemon-ui'
+import { LemonDivider, Link } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
@@ -58,7 +59,10 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
     key(({ id, templateId }: HogFunctionConfigurationLogicProps) => id ?? templateId ?? 'new'),
     path((key) => ['scenes', 'hog-functions', 'hogFunctionSceneLogic', key]),
     connect((props: HogFunctionConfigurationLogicProps) => ({
-        values: [hogFunctionConfigurationLogic(props), ['configuration', 'type', 'loading', 'loaded']],
+        values: [
+            hogFunctionConfigurationLogic(props),
+            ['configuration', 'type', 'loading', 'loaded', 'teamHasCohortFilters', 'currentProjectId'],
+        ],
     })),
     actions({
         setCurrentTab: (tab: HogFunctionSceneTab) => ({ tab }),
@@ -290,7 +294,8 @@ function HogFunctionHeader(): JSX.Element {
 }
 
 export function HogFunctionScene(): JSX.Element {
-    const { currentTab, loading, loaded, logicProps, type } = useValues(hogFunctionSceneLogic)
+    const { currentTab, loading, loaded, logicProps, type, teamHasCohortFilters, currentProjectId } =
+        useValues(hogFunctionSceneLogic)
     const { setCurrentTab } = useActions(hogFunctionSceneLogic)
 
     const { id, templateId } = logicProps
@@ -351,6 +356,17 @@ export function HogFunctionScene(): JSX.Element {
         <SceneContent>
             <BindLogic logic={hogFunctionConfigurationLogic} props={logicProps}>
                 <HogFunctionHeader />
+                {teamHasCohortFilters && (
+                    <LemonBanner type="warning" className="mb-4">
+                        <strong>Warning:</strong> This function has "Filter out internal and test users" enabled, but
+                        your team's test account filters include cohorts. Cohorts cannot be used in real-time filters
+                        and may cause this function to fail. Please update your{' '}
+                        <Link to={`/project/${currentProjectId}/settings/project#internal-user-filtering`}>
+                            test account filters
+                        </Link>{' '}
+                        to use inline expressions instead of cohorts.
+                    </LemonBanner>
+                )}
                 <SceneDivider />
                 {templateId ? (
                     <HogFunctionConfiguration templateId={templateId} />

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -49,6 +49,7 @@ import {
     PropertyFilterType,
     PropertyGroupFilter,
     PropertyGroupFilterValue,
+    TeamType,
 } from '~/types'
 
 import { eventToHogFunctionContextId } from '../sub-templates/sub-templates'
@@ -296,6 +297,8 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             ['groupTypes'],
             userLogic,
             ['hasAvailableFeature'],
+            teamLogic,
+            ['currentTeam'],
         ],
     })),
     actions({
@@ -685,6 +688,19 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (s) => [s.hasAvailableFeature],
             (hasAvailableFeature) => {
                 return hasAvailableFeature(AvailableFeature.GROUP_ANALYTICS)
+            },
+        ],
+        teamHasCohortFilters: [
+            (s) => [s.currentTeam, s.configuration],
+            (currentTeam: TeamType | null, configuration: HogFunctionConfigurationType | null) => {
+                // Only show warning if filter_test_accounts is enabled AND team has cohort filters
+                const hasFilterTestAccountsEnabled = configuration?.filters?.filter_test_accounts === true
+                const teamHasCohorts =
+                    currentTeam?.test_account_filters?.some(
+                        (filter: AnyPropertyFilter) => filter.type === PropertyFilterType.Cohort
+                    ) || false
+
+                return hasFilterTestAccountsEnabled && teamHasCohorts
             },
         ],
         useMapping: [

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -58,8 +58,16 @@ export function HogFunctionFilters({
     showTriggerOptions?: boolean
 }): JSX.Element {
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { configuration, type, useMapping, filtersContainPersonProperties, oldFilters, newFilters, isLegacyPlugin } =
-        useValues(hogFunctionConfigurationLogic)
+    const {
+        configuration,
+        type,
+        useMapping,
+        filtersContainPersonProperties,
+        oldFilters,
+        newFilters,
+        isLegacyPlugin,
+        configurationErrors,
+    } = useValues(hogFunctionConfigurationLogic)
     const {
         setOldFilters,
         setNewFilters,
@@ -68,6 +76,7 @@ export function HogFunctionFilters({
         reportAIFiltersAccepted,
         reportAIFiltersRejected,
         reportAIFiltersPromptOpen,
+        setConfigurationManualErrors,
     } = useActions(hogFunctionConfigurationLogic)
 
     const isTransformation = type === 'transformation'
@@ -127,6 +136,14 @@ export function HogFunctionFilters({
                 embedded && 'p-2'
             )}
         >
+            {configurationErrors?.filters && (
+                <LemonBanner type="error" className="mb-2">
+                    <div className="space-y-1">
+                        <div>Failed to save: Filter configuration error</div>
+                        <div className="text-xs">{configurationErrors.filters}</div>
+                    </div>
+                </LemonBanner>
+            )}
             {showSourcePicker && (
                 <LemonField
                     name="filters"
@@ -173,6 +190,10 @@ export function HogFunctionFilters({
                     const onChange = (newValue: CyclotronJobFiltersType): void => {
                         if (oldFilters && newFilters) {
                             clearFiltersDiff()
+                        }
+                        // Clear any existing filter errors when the user changes filters
+                        if (configurationErrors?.filters) {
+                            setConfigurationManualErrors({ ...configurationErrors, filters: undefined })
                         }
                         _onChange(newValue)
                     }

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -58,16 +58,8 @@ export function HogFunctionFilters({
     showTriggerOptions?: boolean
 }): JSX.Element {
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const {
-        configuration,
-        type,
-        useMapping,
-        filtersContainPersonProperties,
-        oldFilters,
-        newFilters,
-        isLegacyPlugin,
-        configurationErrors,
-    } = useValues(hogFunctionConfigurationLogic)
+    const { configuration, type, useMapping, filtersContainPersonProperties, oldFilters, newFilters, isLegacyPlugin } =
+        useValues(hogFunctionConfigurationLogic)
     const {
         setOldFilters,
         setNewFilters,
@@ -76,7 +68,6 @@ export function HogFunctionFilters({
         reportAIFiltersAccepted,
         reportAIFiltersRejected,
         reportAIFiltersPromptOpen,
-        setConfigurationManualErrors,
     } = useActions(hogFunctionConfigurationLogic)
 
     const isTransformation = type === 'transformation'
@@ -136,14 +127,6 @@ export function HogFunctionFilters({
                 embedded && 'p-2'
             )}
         >
-            {configurationErrors?.filters && (
-                <LemonBanner type="error" className="mb-2">
-                    <div className="space-y-1">
-                        <div>Failed to save: Filter configuration error</div>
-                        <div className="text-xs">{configurationErrors.filters}</div>
-                    </div>
-                </LemonBanner>
-            )}
             {showSourcePicker && (
                 <LemonField
                     name="filters"
@@ -190,10 +173,6 @@ export function HogFunctionFilters({
                     const onChange = (newValue: CyclotronJobFiltersType): void => {
                         if (oldFilters && newFilters) {
                             clearFiltersDiff()
-                        }
-                        // Clear any existing filter errors when the user changes filters
-                        if (configurationErrors?.filters) {
-                            setConfigurationManualErrors({ ...configurationErrors, filters: undefined })
                         }
                         _onChange(newValue)
                     }

--- a/posthog/tasks/hog_functions.py
+++ b/posthog/tasks/hog_functions.py
@@ -72,7 +72,7 @@ def refresh_affected_hog_functions(team_id: Optional[int] = None, action_id: Opt
     updates = HogFunction.objects.bulk_update(successfully_compiled_hog_functions, ["filters", "updated_at"])
 
     reload_hog_functions_on_workers(
-        team_id=team_id, hog_function_ids=[str(hog_function.id) for hog_function in affected_hog_functions]
+        team_id=team_id, hog_function_ids=[str(hog_function.id) for hog_function in successfully_compiled_hog_functions]
     )
 
     return updates

--- a/posthog/tasks/hog_functions.py
+++ b/posthog/tasks/hog_functions.py
@@ -54,11 +54,22 @@ def refresh_affected_hog_functions(team_id: Optional[int] = None, action_id: Opt
 
     actions_by_id = {action.id: action for action in all_related_actions}
 
+    successfully_compiled_hog_functions = []
     for hog_function in affected_hog_functions:
-        hog_function.filters = compile_filters_bytecode(hog_function.filters, hog_function.team, actions_by_id)
-        hog_function.updated_at = timezone.now()
+        compiled_filters = compile_filters_bytecode(hog_function.filters, hog_function.team, actions_by_id)
 
-    updates = HogFunction.objects.bulk_update(affected_hog_functions, ["filters", "updated_at"])
+        # Only update if compilation succeeded (no bytecode_error)
+        if not compiled_filters.get("bytecode_error"):
+            hog_function.filters = compiled_filters
+            hog_function.updated_at = timezone.now()
+            successfully_compiled_hog_functions.append(hog_function)
+        else:
+            logger.warning(
+                f"Failed to compile filters for hog function {hog_function.id}: {compiled_filters.get('bytecode_error')}. "
+                "Keeping existing filters intact."
+            )
+
+    updates = HogFunction.objects.bulk_update(successfully_compiled_hog_functions, ["filters", "updated_at"])
 
     reload_hog_functions_on_workers(
         team_id=team_id, hog_function_ids=[str(hog_function.id) for hog_function in affected_hog_functions]


### PR DESCRIPTION
## Problem

1. Have no cohort in your _filter out internal and test users_ settings for your team 
2. create a hogfunction and enable the filter out functionality 
3. add a cohort to the team setting 
4. the hogfunction gets refreshed in the background rendering the bytecode as null because it has an error 
5. hogfunction fails now 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- in the background refresh we only update the filter byte code if it actually compiles and leave it unchanged if it does not 
- we show a banner with a link to the teams page when a team has a cohort in their team setting _and_ the hogfunction uses the filter 

![2025-10-10 16 49 44](https://github.com/user-attachments/assets/b1363855-5b5e-4590-979e-0cbc5356db17)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
