### PR TITLE
fix: show upgrade/dowgrade actions for customers on Teams

### DIFF
--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -336,9 +336,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                     return false
                 }
 
-                // Check if they are subscribed to another add-on that is not a legacy add-on
-                // This is because if they are on a legacy add-on, we want them to be able to move to a new add-on.
-                return parentProduct.addons.some((a: BillingProductV2AddonType) => a.subscribed && !a.legacy_product)
+                return parentProduct.addons.some((a: BillingProductV2AddonType) => a.subscribed)
             },
         ],
         customLimitUsd: [


### PR DESCRIPTION
## Problem
On the billing page for customers on legacy Teams plan, "Add" actions are currently shown on other addon cards. It should show downgrade/upgrade instead. 

## Changes
Removed the check in `isSubscribedToAnotherAddon` that ignored legacy addons. Before, it was needed so users could switch from Teams using "Add" action.
| Before | After |
|:------:|:------:|
| <img src="https://github.com/user-attachments/assets/63531e1b-ac39-471a-9dcd-eb92fbfa74fe" width="400"/> | <img src="https://github.com/user-attachments/assets/ac02e83f-ced4-4e2a-92ce-96ad7bc43161" width="400"/> |



## How did you test this code?
Locally, tested that upgrade/downgrade from teams to another addon works. 