### PR TITLE
fix(flags): bugs in release conditions of flags UI

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -81,6 +81,7 @@ export interface LemonSelectPropsBase<T>
     menu?: Pick<LemonMenuProps, 'className' | 'closeParentPopoverOnClickInside'>
     visible?: LemonDropdownProps['visible']
     startVisible?: LemonDropdownProps['startVisible']
+    truncateText?: { maxWidthClass: string }
 }
 
 export interface LemonSelectPropsClearable<T> extends LemonSelectPropsBase<T> {
@@ -119,6 +120,7 @@ export function LemonSelect<T extends string | number | boolean | null>({
     renderButtonContent,
     visible,
     startVisible,
+    truncateText,
     ...buttonProps
 }: LemonSelectProps<T>): JSX.Element {
     const [items, allLeafOptions] = useMemo(
@@ -173,7 +175,13 @@ export function LemonSelect<T extends string | number | boolean | null>({
                 tooltip={activeLeaf?.tooltip}
                 {...buttonProps}
             >
-                <span className="flex flex-1">
+                <span
+                    className={
+                        truncateText
+                            ? `block w-full overflow-hidden text-ellipsis whitespace-nowrap ${truncateText.maxWidthClass}`
+                            : 'flex flex-1'
+                    }
+                >
                     {renderButtonContent
                         ? renderButtonContent(activeLeaf)
                         : activeLeaf

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -476,6 +476,7 @@ export function FeatureFlagReleaseConditions({
                                                 value: variant.key,
                                             }))}
                                             data-attr="feature-flags-variant-override-select"
+                                            truncateText={{ maxWidthClass: 'max-w-[7rem]' }}
                                         />
                                     </div>
                                 </div>

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -339,6 +339,11 @@ describe('the feature flag release conditions logic', () => {
             // and computation resolves to rollout percentage
             expect(logic.values.computeBlastRadiusPercentage(75, 'B')).toEqual(75)
             expect(logic.values.computeBlastRadiusPercentage(100, 'C')).toBeCloseTo(25, 2)
+
+            logic.actions.setTotalUsers(500_000_000)
+            logic.actions.setAffectedUsers('A', 249_999_000)
+            expect(logic.values.computeBlastRadiusPercentage(100, 'A')).toEqual(49.9998)
+            expect(logic.values.computeBlastRadiusPercentage(5, 'C')).toEqual(0)
         })
 
         describe('API calls', () => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -515,7 +515,11 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     effectiveTotalUsers = 1
                 }
 
-                return effectiveRolloutPercentage * ((affectedUsers[sortKey] ?? 0) / effectiveTotalUsers)
+                return (
+                    Math.round(
+                        effectiveRolloutPercentage * ((affectedUsers[sortKey] ?? 0) / effectiveTotalUsers) * 1000000
+                    ) / 1000000
+                )
             },
         ],
         getFlagKey: [


### PR DESCRIPTION
## Problem

1. Percentages too small becoming scientific notations
2. UI doesn't handle variants with big keys properly.

<img width="397" height="114" alt="image" src="https://github.com/user-attachments/assets/8130aff7-5c13-4478-a585-15de05fecd58" />

## Changes

1. Limited percentages to 6 digits after decimal point
2. Applied text-ellipsis to variant selector.

<img width="571" height="312" alt="image" src="https://github.com/user-attachments/assets/09735b95-9033-4297-adeb-88b76fa5923e" />

## How did you test this code?

- Manual
- Unit tests