### PR TITLE
fix: Add logic key to useIssueQueryContext

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
@@ -28,7 +28,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttribute
     const { personId } = attributes
     const { dateRange, filterTestAccounts, filterGroup, searchQuery } = useValues(issueFiltersLogic({ logicKey }))
     const { assignee, orderBy, orderDirection, status } = useValues(issueQueryOptionsLogic({ logicKey }))
-    const context = useIssueQueryContext()
+    const context = useIssueQueryContext(logicKey)
     const query = errorTrackingQuery({
         orderBy,
         status,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
@@ -30,7 +30,10 @@ import { IssueListTitleColumn, IssueListTitleHeader } from 'products/error_track
 import { useSparklineData } from 'products/error_tracking/frontend/hooks/use-sparkline-data'
 import { bulkSelectLogic } from 'products/error_tracking/frontend/logics/bulkSelectLogic'
 import { issuesDataNodeLogic } from 'products/error_tracking/frontend/logics/issuesDataNodeLogic'
-import { errorTrackingSceneLogic } from 'products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic'
+import {
+    ERROR_TRACKING_SCENE_LOGIC_KEY,
+    errorTrackingSceneLogic,
+} from 'products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic'
 import { ERROR_TRACKING_LISTING_RESOLUTION } from 'products/error_tracking/frontend/utils'
 
 const VolumeColumn: QueryContextColumnComponent = (props) => {
@@ -95,8 +98,8 @@ const defaultColumns: Record<string, QueryContextColumn> = {
     volume: { align: 'right', renderTitle: VolumeColumnHeader, render: VolumeColumn },
 }
 
-export const useIssueQueryContext = (): QueryContext => {
-    const { orderBy } = useValues(issueQueryOptionsLogic)
+export const useIssueQueryContext = (logicKey: string): QueryContext => {
+    const { orderBy } = useValues(issueQueryOptionsLogic({ logicKey }))
 
     const columns = useMemo(() => {
         const columns = { ...defaultColumns }
@@ -125,7 +128,7 @@ export function IssuesList(): JSX.Element {
     const { orderBy } = useValues(issueQueryOptionsLogic)
     const { query } = useValues(errorTrackingSceneLogic)
     const { openSupportForm } = useActions(supportLogic)
-    const context = useIssueQueryContext()
+    const context = useIssueQueryContext(ERROR_TRACKING_SCENE_LOGIC_KEY)
 
     return (
         <BindLogic logic={issuesDataNodeLogic} props={{ key: insightVizDataNodeKey(insightProps) }}>


### PR DESCRIPTION
## Problem
We were calling `useIssueQueryContext` in `NotebookNodeIssues`. The thing is that `useIssueQueryContext` gets values from `issueQueryOptionsLogic`, which requires a `key`. 

This was not a problem for `IssuesList`, as we're binding the logics in the scene component, but it errored out when in `NotebookNodeIssues`.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Added a `logicKey` param to `useIssueQueryContext`
	- In `IssuesList`, pass in the same logic key that is bound in `ErrorTrackingScene`
	- In `NotebookNodeIssues`, pass in the same key that is used in `Settings`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Screenshot of the error
<img width="885" height="551" alt="image" src="https://github.com/user-attachments/assets/7ec84bbd-0af2-4e51-b753-a08220133224" />

## How did you test this code?
Made sure that the query + filters + options are working both for the notebook node and error tracking scene
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
