### PR TITLE
fix: use temporal metric meter for prometheus metrics

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -6,6 +6,8 @@ import structlog
 import posthoganalytics
 from celery import shared_task
 from prometheus_client import Counter
+from temporalio import activity, workflow
+from temporalio.common import MetricCounter, MetricMeter
 
 from posthog import settings
 from posthog.exceptions_capture import capture_exception
@@ -24,6 +26,7 @@ from ee.tasks.subscriptions.subscription_utils import generate_assets, generate_
 
 logger = structlog.get_logger(__name__)
 
+# Prometheus metrics for Celery workers (web/worker pods)
 SUBSCRIPTION_QUEUED = Counter(
     "subscription_queued",
     "A subscription was queued for delivery",
@@ -39,6 +42,50 @@ SUBSCRIPTION_FAILURE = Counter(
     "A subscription failed to send",
     labelnames=["destination", "execution_path"],
 )
+
+
+# Temporal metrics for temporal workers
+def get_metric_meter() -> MetricMeter:
+    """Get metric meter for the current context (activity or workflow)."""
+    if activity.in_activity():
+        return activity.metric_meter()
+    elif workflow.in_workflow():
+        return workflow.metric_meter()
+    else:
+        raise RuntimeError("Not within workflow or activity context")
+
+
+def get_subscription_queued_metric(destination: str, execution_path: str) -> MetricCounter:
+    return (
+        get_metric_meter()
+        .with_additional_attributes({"destination": destination, "execution_path": execution_path})
+        .create_counter(
+            "subscription_queued",
+            "A subscription was queued for delivery",
+        )
+    )
+
+
+def get_subscription_success_metric(destination: str, execution_path: str) -> MetricCounter:
+    return (
+        get_metric_meter()
+        .with_additional_attributes({"destination": destination, "execution_path": execution_path})
+        .create_counter(
+            "subscription_send_success",
+            "A subscription was sent successfully",
+        )
+    )
+
+
+def get_subscription_failure_metric(destination: str, execution_path: str) -> MetricCounter:
+    return (
+        get_metric_meter()
+        .with_additional_attributes({"destination": destination, "execution_path": execution_path})
+        .create_counter(
+            "subscription_send_failure",
+            "A subscription failed to send",
+        )
+    )
 
 
 async def deliver_subscription_report_async(
@@ -91,7 +138,7 @@ async def deliver_subscription_report_async(
 
     if subscription.target_type == "email":
         logger.info("deliver_subscription_report_async.sending_email", subscription_id=subscription_id)
-        SUBSCRIPTION_QUEUED.labels(destination="email", execution_path="temporal").inc()
+        get_subscription_queued_metric("email", "temporal").add(1)
 
         # Send emails
         emails = subscription.target_value.split(",")
@@ -119,9 +166,9 @@ async def deliver_subscription_report_async(
                 logger.info(
                     "deliver_subscription_report_async.email_sent", subscription_id=subscription_id, email=email
                 )
-                SUBSCRIPTION_SUCCESS.labels(destination="email", execution_path="temporal").inc()
+                get_subscription_success_metric("email", "temporal").add(1)
             except Exception as e:
-                SUBSCRIPTION_FAILURE.labels(destination="email", execution_path="temporal").inc()
+                get_subscription_failure_metric("email", "temporal").add(1)
                 logger.error(
                     "deliver_subscription_report_async.email_failed",
                     subscription_id=subscription.id,
@@ -134,7 +181,7 @@ async def deliver_subscription_report_async(
 
     elif subscription.target_type == "slack":
         logger.info("deliver_subscription_report_async.sending_slack", subscription_id=subscription_id)
-        SUBSCRIPTION_QUEUED.labels(destination="slack", execution_path="temporal").inc()
+        get_subscription_queued_metric("slack", "temporal").add(1)
 
         try:
             logger.info("deliver_subscription_report_async.loading_slack_integration", subscription_id=subscription_id)
@@ -144,7 +191,7 @@ async def deliver_subscription_report_async(
 
             if not integration:
                 logger.error("deliver_subscription_report_async.no_slack_integration", subscription_id=subscription_id)
-                SUBSCRIPTION_FAILURE.labels(destination="slack", execution_path="temporal").inc()
+                get_subscription_failure_metric("slack", "temporal").add(1)
                 return
 
             logger.info("deliver_subscription_report_async.sending_slack_message", subscription_id=subscription_id)
@@ -156,9 +203,9 @@ async def deliver_subscription_report_async(
                 is_new_subscription=is_new_subscription_target,
             )
             logger.info("deliver_subscription_report_async.slack_sent", subscription_id=subscription_id)
-            SUBSCRIPTION_SUCCESS.labels(destination="slack", execution_path="temporal").inc()
+            get_subscription_success_metric("slack", "temporal").add(1)
         except Exception as e:
-            SUBSCRIPTION_FAILURE.labels(destination="slack", execution_path="temporal").inc()
+            get_subscription_failure_metric("slack", "temporal").add(1)
             logger.error(
                 "deliver_subscription_report_async.slack_failed",
                 subscription_id=subscription.id,

--- a/ee/tasks/test/subscriptions/test_generate_assets_async.py
+++ b/ee/tasks/test/subscriptions/test_generate_assets_async.py
@@ -30,6 +30,7 @@ async def mock_export_asset():
     with (
         patch("ee.tasks.subscriptions.subscription_utils.exporter.export_asset_direct", side_effect=set_content),
         patch("ee.tasks.subscriptions.subscription_utils.get_metric_meter", MagicMock()),
+        patch("ee.tasks.subscriptions.get_metric_meter", MagicMock()),
     ):
         yield
 

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -47,6 +47,7 @@ async def subscriptions_worker(temporal_client: Client):
         yield  # allow the test to run while the worker is active
 
 
+@patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("ee.tasks.subscriptions.send_slack_subscription_report")
 @patch("ee.tasks.subscriptions.send_email_subscription_report")
 @patch("ee.tasks.subscriptions.generate_assets_async")
@@ -56,6 +57,7 @@ async def test_subscription_delivery_scheduling(
     mock_gen_assets: MagicMock,
     mock_send_email: MagicMock,
     mock_send_slack: MagicMock,
+    mock_metric_meter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,
@@ -145,6 +147,7 @@ async def test_subscription_delivery_scheduling(
     assert delivered_sub_ids == {subscriptions[0].id, subscriptions[1].id}
 
 
+@patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("posthoganalytics.feature_enabled", return_value=True)
 @patch("ee.tasks.subscriptions.get_slack_integration_for_team", return_value=None)
 @patch("ee.tasks.subscriptions.send_email_subscription_report")
@@ -155,6 +158,7 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
     mock_gen_assets: MagicMock,
     mock_send_email: MagicMock,
     mock_send_slack: MagicMock,
+    mock_metric_meter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,
@@ -205,6 +209,7 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
     assert mock_send_email.call_count == 0 and mock_send_slack.call_count == 0
 
 
+@patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("posthoganalytics.feature_enabled", return_value=True)
 @patch("ee.tasks.subscriptions.send_email_subscription_report")
 @patch("ee.tasks.subscriptions.generate_assets_async")
@@ -212,6 +217,7 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
 async def test_handle_subscription_value_change_email(
     mock_gen_assets: MagicMock,
     mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,
@@ -269,6 +275,7 @@ async def test_handle_subscription_value_change_email(
     ]
 
 
+@patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("posthoganalytics.feature_enabled", return_value=True)
 @patch("ee.tasks.subscriptions.get_slack_integration_for_team", return_value=None)
 @patch("ee.tasks.subscriptions.generate_assets_async")
@@ -276,6 +283,7 @@ async def test_handle_subscription_value_change_email(
 async def test_deliver_subscription_report_slack(
     mock_gen_assets: MagicMock,
     mock_send_slack: MagicMock,
+    mock_metric_meter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We aren't getting some Prometheus metrics for Temporal subscriptions.

## Changes

Same as https://github.com/PostHog/posthog/pull/39414 but for metrics I missed. 


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
