### PR TITLE
chore(flags): add debug metrics to help identify writer pool timeouts

### DIFF
--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -110,13 +110,7 @@ impl DatabasePools {
         // Log whether pools are actually separate or aliased
         let pools_are_separate = config.is_persons_db_routing_enabled();
         if pools_are_separate {
-            info!(
-                persons_read_url = &config.get_persons_read_database_url()
-                    [..20.min(config.get_persons_read_database_url().len())],
-                persons_write_url = &config.get_persons_write_database_url()
-                    [..20.min(config.get_persons_write_database_url().len())],
-                "Using separate persons database pools"
-            );
+            info!("Using separate persons database pools");
         } else {
             info!("Persons pools are aliased to non-persons pools (persons DB routing disabled)");
         }

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -4,6 +4,7 @@ use common_database::{get_pool_with_config, PoolConfig};
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
+use tracing::info;
 
 /// Direct database pool access for different operation types
 #[derive(Clone)]
@@ -94,6 +95,31 @@ impl DatabasePools {
         } else {
             non_persons_writer.clone()
         };
+
+        // Log pool configuration at startup
+        info!(
+            max_connections = config.max_pg_connections,
+            acquire_timeout_secs = config.acquire_timeout_secs,
+            idle_timeout_secs = config.idle_timeout_secs,
+            max_lifetime_secs = config.max_lifetime_secs,
+            test_before_acquire = config.test_before_acquire.0,
+            persons_routing_enabled = config.is_persons_db_routing_enabled(),
+            "Database pool configuration"
+        );
+
+        // Log whether pools are actually separate or aliased
+        let pools_are_separate = config.is_persons_db_routing_enabled();
+        if pools_are_separate {
+            info!(
+                persons_read_url = &config.get_persons_read_database_url()
+                    [..20.min(config.get_persons_read_database_url().len())],
+                persons_write_url = &config.get_persons_write_database_url()
+                    [..20.min(config.get_persons_write_database_url().len())],
+                "Using separate persons database pools"
+            );
+        } else {
+            info!("Persons pools are aliased to non-persons pools (persons DB routing disabled)");
+        }
 
         Ok(DatabasePools {
             non_persons_reader,

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -25,9 +25,11 @@ use crate::{
     cohorts::cohort_models::CohortId,
     flags::flag_models::FeatureFlagId,
     metrics::consts::{
-        FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_DB_CONNECTION_TIME,
-        FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
-        FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME, FLAG_PERSON_QUERY_TIME,
+        FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_CONNECTION_HOLD_TIME,
+        FLAG_DB_CONNECTION_TIME, FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME,
+        FLAG_GROUP_QUERY_TIME, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
+        FLAG_PERSON_QUERY_TIME, FLAG_POOL_UTILIZATION_GAUGE,
+        FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER,
     },
     properties::{
         property_matching::match_property,
@@ -685,8 +687,8 @@ async fn try_set_feature_flag_hash_key_overrides(
 
     // Query 1: Get all person data - person_ids + existing overrides + validation (person pool)
     let person_data_query = r#"
-            SELECT DISTINCT 
-                p.person_id, 
+            SELECT DISTINCT
+                p.person_id,
                 p.distinct_id,
                 existing.feature_flag_key
             FROM posthog_persondistinctid p
@@ -699,7 +701,7 @@ async fn try_set_feature_flag_hash_key_overrides(
 
     // Query 2: Get all active feature flags with experience continuity (non-person pool)
     let flags_query = r#"
-            SELECT flag.key 
+            SELECT flag.key
             FROM posthog_featureflag flag
             JOIN posthog_team team ON flag.team_id = team.id
             WHERE team.project_id = $1
@@ -936,6 +938,7 @@ async fn try_should_write_hash_key_override(
     project_id: ProjectId,
 ) -> Result<bool, FlagError> {
     const QUERY_TIMEOUT: Duration = Duration::from_millis(1000);
+    let operation_start = Instant::now();
 
     // Query 1: Get person_ids and existing overrides from person pool in one shot
     let person_data_query = r#"
@@ -959,14 +962,48 @@ async fn try_should_write_hash_key_override(
     "#;
 
     let result = timeout(QUERY_TIMEOUT, async {
+        // Log pool states before attempting connections
+        let persons_reader_stats = router.get_persons_reader().get_pool_stats();
+        let non_persons_reader_stats = router.get_non_persons_reader().get_pool_stats();
+
+        if let (Some(pr_stats), Some(npr_stats)) = (&persons_reader_stats, &non_persons_reader_stats) {
+            let pr_utilization = (pr_stats.size - pr_stats.num_idle as u32) as f64 / pr_stats.size as f64;
+            let npr_utilization = (npr_stats.size - npr_stats.num_idle as u32) as f64 / npr_stats.size as f64;
+
+            if pr_utilization > 0.8 || npr_utilization > 0.8 {
+                warn!(
+                    team_id = %team_id,
+                    distinct_ids = ?distinct_ids,
+                    persons_reader_pool_size = pr_stats.size,
+                    persons_reader_idle = pr_stats.num_idle,
+                    persons_reader_utilization_pct = pr_utilization * 100.0,
+                    non_persons_reader_pool_size = npr_stats.size,
+                    non_persons_reader_idle = npr_stats.num_idle,
+                    non_persons_reader_utilization_pct = npr_utilization * 100.0,
+                    "High pool utilization before should_write_hash_key_override"
+                );
+            }
+
+            common_metrics::gauge(
+                FLAG_POOL_UTILIZATION_GAUGE,
+                &[("pool".to_string(), "persons_reader".to_string())],
+                pr_utilization,
+            );
+            common_metrics::gauge(
+                FLAG_POOL_UTILIZATION_GAUGE,
+                &[("pool".to_string(), "non_persons_reader".to_string())],
+                npr_utilization,
+            );
+        }
+
         // Get connection from persons pool for person data
         let persons_labels = [
             ("pool".to_string(), "persons_reader".to_string()),
             (
                 "operation".to_string(),
-                "should_write_hash_key_override".to_string(),
-            ),
+                "should_write_hash_key_override".to_string()),
         ];
+        let persons_conn_start = Instant::now();
         let persons_conn_timer =
             common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &persons_labels);
         let mut persons_conn = router
@@ -975,6 +1012,16 @@ async fn try_should_write_hash_key_override(
             .await
             .map_err(FlagError::from)?;
         persons_conn_timer.fin();
+        let persons_conn_acquisition_time = persons_conn_start.elapsed();
+
+        if persons_conn_acquisition_time > Duration::from_millis(100) {
+            warn!(
+                team_id = %team_id,
+                pool = "persons_reader",
+                acquisition_ms = persons_conn_acquisition_time.as_millis(),
+                "Slow connection acquisition from persons_reader pool"
+            );
+        }
 
         // Step 1: Get person data and existing overrides
         let person_query_labels = [
@@ -1016,6 +1063,15 @@ async fn try_should_write_hash_key_override(
                 "should_write_hash_key_override".to_string(),
             ),
         ];
+
+        // Log that we're holding one connection while acquiring another
+        info!(
+            team_id = %team_id,
+            persons_conn_held_ms = persons_conn_start.elapsed().as_millis(),
+            "Acquiring non_persons_reader connection while holding persons_reader connection"
+        );
+
+        let non_persons_conn_start = Instant::now();
         let non_persons_conn_timer =
             common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &non_persons_labels);
         let mut non_persons_conn = router
@@ -1024,6 +1080,17 @@ async fn try_should_write_hash_key_override(
             .await
             .map_err(FlagError::from)?;
         non_persons_conn_timer.fin();
+        let non_persons_conn_acquisition_time = non_persons_conn_start.elapsed();
+
+        if non_persons_conn_acquisition_time > Duration::from_millis(100) {
+            warn!(
+                team_id = %team_id,
+                pool = "non_persons_reader",
+                acquisition_ms = non_persons_conn_acquisition_time.as_millis(),
+                persons_conn_held_ms = persons_conn_start.elapsed().as_millis(),
+                "Slow connection acquisition from non_persons_reader pool while holding persons_reader connection"
+            );
+        }
         let flags_labels = [
             (
                 "query".to_string(),
@@ -1048,16 +1115,85 @@ async fn try_should_write_hash_key_override(
             }
         }
 
+        // Record how long both connections were held
+        common_metrics::histogram(
+            FLAG_CONNECTION_HOLD_TIME,
+            &[
+                ("pool".to_string(), "persons_reader".to_string()),
+                ("operation".to_string(), "should_write_check".to_string()),
+            ],
+            persons_conn_start.elapsed().as_millis() as f64,
+        );
+
         Ok::<bool, FlagError>(false) // All flags have overrides
     })
     .await;
 
+    let total_operation_time = operation_start.elapsed();
+
     match result {
-        Ok(Ok(flags_present)) => Ok(flags_present),
-        Ok(Err(e)) => Err(e),
+        Ok(Ok(flags_present)) => {
+            if total_operation_time > Duration::from_millis(500) {
+                warn!(
+                    team_id = %team_id,
+                    distinct_ids = ?distinct_ids,
+                    operation_ms = total_operation_time.as_millis(),
+                    result = flags_present,
+                    "Slow should_write_hash_key_override operation completed"
+                );
+            }
+            Ok(flags_present)
+        }
+        Ok(Err(e)) => {
+            tracing::error!(
+                team_id = %team_id,
+                distinct_ids = ?distinct_ids,
+                operation_ms = total_operation_time.as_millis(),
+                error = ?e,
+                "should_write_hash_key_override failed with error"
+            );
+            Err(e)
+        }
         Err(_) => {
-            // Handle timeout
-            Err(FlagError::TimeoutError(None))
+            // Capture all pool states on timeout
+            let persons_reader_stats = router.get_persons_reader().get_pool_stats();
+            let non_persons_reader_stats = router.get_non_persons_reader().get_pool_stats();
+            let persons_writer_stats = router.get_persons_writer().get_pool_stats();
+            let non_persons_writer_stats = router.get_non_persons_writer().get_pool_stats();
+
+            tracing::error!(
+                team_id = %team_id,
+                distinct_ids = ?distinct_ids,
+                timeout_after_ms = QUERY_TIMEOUT.as_millis(),
+                operation_elapsed_ms = total_operation_time.as_millis(),
+                persons_reader_pool = ?persons_reader_stats,
+                non_persons_reader_pool = ?non_persons_reader_stats,
+                persons_writer_pool = ?persons_writer_stats,
+                non_persons_writer_pool = ?non_persons_writer_stats,
+                "should_write_hash_key_override timed out - capturing all pool states"
+            );
+
+            // Emit metrics for timeout with pool states
+            if let Some(stats) = persons_writer_stats {
+                common_metrics::inc(
+                    FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER,
+                    &[
+                        (
+                            "writer_pool_busy".to_string(),
+                            (stats.num_idle == 0).to_string(),
+                        ),
+                        (
+                            "writer_utilization_pct".to_string(),
+                            ((((stats.size - stats.num_idle as u32) as f64 / stats.size as f64)
+                                * 100.0) as i64)
+                                .to_string(),
+                        ),
+                    ],
+                    1,
+                );
+            }
+
+            Err(FlagError::TimeoutError(Some("query_timeout".to_string())))
         }
     }
 }

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -47,3 +47,12 @@ pub const FLAG_DB_CONNECTION_TIME: &str = "flags_db_connection_time";
 
 // Flag request kludges (to see how often we have to massage our request data to be able to parse it)
 pub const FLAG_REQUEST_KLUDGE_COUNTER: &str = "flags_request_kludge_total";
+
+// New diagnostic metrics for pool exhaustion investigation
+pub const FLAG_POOL_UTILIZATION_GAUGE: &str = "flags_pool_utilization_ratio";
+pub const FLAG_CONNECTION_HOLD_TIME: &str = "flags_connection_hold_time_ms";
+pub const FLAG_CONNECTION_QUEUE_DEPTH_GAUGE: &str = "flags_connection_queue_depth";
+pub const FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER: &str =
+    "flags_reader_timeout_with_writer_state_total";
+pub const FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER: &str =
+    "flags_experience_continuity_requests_total";


### PR DESCRIPTION
## Background

The Rust feature flags service is experiencing intermittent timeouts with pool_timeout errors on the reader database pools, even though these pools point to read replicas that are not under load. The puzzling
 behavior is that these timeouts correlate with write load spikes on the primary database, despite the reader and writer pools being completely separate with different connection URLs.

## Problem We're Trying to Solve

Core Question: Why do reader pool timeouts occur when only the writer database is under load, given that reader pools connect to unloaded read replicas?

## Existing Metrics Gaps

Our current metrics only track:
- Query execution times
- Overall request latency
- Success/failure counts
- Basic timeout counts

### What's missing:
- Pool utilization visibility - We can't see how full the connection pools are at any point
- Connection hold patterns - No visibility into how long connections are held by operations
- Cross-pool correlation - Can't correlate reader timeouts with writer pool states
- Timeout context - When timeouts occur, we lose critical diagnostic information about pool states

## New Metrics & Logging Added

1. Pool Utilization Gauge (flags_pool_utilization_ratio)

- Purpose: Real-time visibility into connection pool saturation
- Labels: pool (persons_reader, non_persons_reader, etc.)
- Range: 0.0 to 1.0 (0% to 100% utilized)
- Why it helps: Identifies if pools are actually exhausted or if the timeout has another cause

2. Connection Hold Time Histogram (flags_connection_hold_time_ms)

- Purpose: Tracks how long operations hold database connections
- Labels: operation (e.g., should_write_hash_key_override)
- Why it helps: Identifies operations that might be hoarding connections and starving other requests

3. Reader Timeout with Writer State Counter (flags_reader_timeout_with_writer_state_total)

- Purpose: Specifically tracks when reader pools timeout while capturing writer pool state
- Labels: writer_pool_busy (true/false), writer_utilization_pct (0-100)
- Why it helps: Directly tests the hypothesis that writer pool exhaustion somehow affects reader pools

4. Experience Continuity Counter (flags_experience_continuity_requests_total)

- Purpose: Tracks how often experience continuity features are evaluated
- Labels: flag_key, team_id
- Why it helps: The try_should_write_hash_key_override function acquires multiple connections and may be a bottleneck

5. Enhanced Timeout Error Logging

When a timeout occurs, we now capture and log:
- All four pool states (persons/non-persons × reader/writer)
- Current utilization percentages
- Number of idle connections
- Pool sizes
- Correlation with writer pool exhaustion

## Expected Insights

These metrics will help us determine:

1. Is it actual pool exhaustion? The utilization gauge will show if pools are really at 100% when timeouts occur
2. Is there a connection leak? Hold time metrics will reveal if connections are being held too long
3. Is there cross-pool interference? The correlation counter will prove/disprove if writer load actually impacts readers
4. What's the real bottleneck? Detailed timeout logs will show exact pool states at failure time

## Next Steps

Once deployed, I'll write some grafana queries to monitor these metrics during the next write load spike to:

- Confirm whether reader pools are actually exhausted (utilization = 100%)
- Check if connection hold times spike during issues
- Verify if writer pool state correlates with reader timeouts
- Identify which specific operations are involved

This diagnostic instrumentation is temporary and can be simplified once we identify the root cause.