### PR TITLE
feat(kafka-deduplicator): add structured logging for production deploy envs only

### DIFF
--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { workspace = true }
 tokio-util = { version = "0.7.16", features = ["rt"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -158,15 +158,27 @@ async fn main() -> Result<()> {
         .context("Failed to load configuration from environment variables. Please check your environment setup.")?;
 
     // Initialize tracing with structured output similar to feature-flags
-    let log_layer = fmt::layer()
-        .with_span_events(
-            FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
-        )
-        .with_target(true)
-        .with_thread_ids(true)
-        .with_level(true)
-        .with_ansi(false)
-        .with_filter(EnvFilter::from_default_env());
+    let log_layer = {
+        let base = fmt::layer()
+            .with_span_events(
+                FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
+            )
+            .with_target(true)
+            .with_thread_ids(true)
+            .with_level(true);
+
+        if config.otel_log_level == tracing::Level::DEBUG {
+            // local dev: pretty-print output to console
+            base.with_ansi(true)
+                .with_filter(EnvFilter::from_default_env())
+                .boxed()
+        } else {
+            // production: use JSON format Loki/Grafana can extract useful filter tags from
+            base.json()
+                .with_filter(EnvFilter::from_default_env())
+                .boxed()
+        }
+    };
 
     // OpenTelemetry layer if configured
     let otel_layer = if let Some(ref otel_url) = config.otel_url {

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -160,18 +160,18 @@ async fn main() -> Result<()> {
     // Initialize tracing with structured output similar to feature-flags
     let log_layer = {
         let base = fmt::layer()
-            .with_span_events(
-                FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
-            )
             .with_target(true)
             .with_thread_ids(true)
             .with_level(true);
 
         if config.otel_log_level == tracing::Level::DEBUG {
             // local dev: pretty-print output to console
-            base.with_ansi(true)
-                .with_filter(EnvFilter::from_default_env())
-                .boxed()
+            base.with_span_events(
+                FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
+            )
+            .with_ansi(true)
+            .with_filter(EnvFilter::from_default_env())
+            .boxed()
         } else {
             // production: use JSON format Loki/Grafana can extract useful filter tags from
             base.json()


### PR DESCRIPTION
## Problem
We should be able to use supported field extraction and filtering capabilities when reviewing production logs for our Rust services.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Wire up JSON output for production
* Wire up pretty-print std output for local dev

**Note**: this will probably require a bit of tuning/iteration - just a start to have a look at how this works. Inspired by some similar changes in `posthog-feature-flags` svc config

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
