### PR TITLE
fix: use HQL names for tables in person query

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -176,10 +176,10 @@ export const personsLogic = kea<personsLogicType>([
                             SELECT
                                 pdi2.distinct_id,
                                 argMax(pdi2.person_id, pdi2.version) AS person_id
-                            FROM person_distinct_id2 pdi2
+                            FROM raw_person_distinct_ids pdi2
                             WHERE pdi2.distinct_id IN (
                                     SELECT distinct_id
-                                    FROM person_distinct_id2
+                                    FROM raw_person_distinct_ids
                                     WHERE person_id = {id}
                                 )
                             GROUP BY pdi2.distinct_id


### PR DESCRIPTION
## Problem
fix for this issue
https://posthog.slack.com/archives/C09LH9BDEJC/p1760139078515279

table name was incorrect for HQL
