### PR TITLE
refactor(experiments): metric source modal for create form

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -264,18 +264,7 @@ export function ExperimentView(): JSX.Element {
 
                     {usesNewQueryRunner ? (
                         <>
-                            <MetricSourceModal isSecondary={true} />
-                            <MetricSourceModal isSecondary={false} />
-                        </>
-                    ) : (
-                        <>
-                            <LegacyMetricSourceModal experimentId={experimentId} isSecondary={true} />
-                            <LegacyMetricSourceModal experimentId={experimentId} isSecondary={false} />
-                        </>
-                    )}
-
-                    {usesNewQueryRunner ? (
-                        <>
+                            <MetricSourceModal />
                             <ExperimentMetricModal
                                 experimentId={experimentId}
                                 onSave={(metric, context) => {
@@ -323,6 +312,8 @@ export function ExperimentView(): JSX.Element {
                         </>
                     ) : (
                         <>
+                            <LegacyMetricSourceModal experimentId={experimentId} isSecondary={true} />
+                            <LegacyMetricSourceModal experimentId={experimentId} isSecondary={false} />
                             <LegacyMetricModal experimentId={experimentId} isSecondary={true} />
                             <LegacyMetricModal experimentId={experimentId} isSecondary={false} />
                         </>

--- a/frontend/src/scenes/experiments/Metrics/AddMetricButton.tsx
+++ b/frontend/src/scenes/experiments/Metrics/AddMetricButton.tsx
@@ -1,0 +1,25 @@
+import { useActions } from 'kea'
+
+import { IconPlus } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+
+import type { MetricContext } from './experimentMetricModalLogic'
+import { metricSourceModalLogic } from './metricSourceModalLogic'
+
+export const AddMetricButton = ({ metricContext }: { metricContext: MetricContext }): JSX.Element => {
+    const { openMetricSourceModal } = useActions(metricSourceModalLogic)
+
+    return (
+        <LemonButton
+            icon={<IconPlus />}
+            type="secondary"
+            size="xsmall"
+            onClick={() => {
+                openMetricSourceModal(metricContext)
+            }}
+        >
+            Add {metricContext.type} metric
+        </LemonButton>
+    )
+}

--- a/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
@@ -3,31 +3,24 @@ import { useActions, useValues } from 'kea'
 import { LemonModal } from '@posthog/lemon-ui'
 
 import { modalsLogic } from '../modalsLogic'
-import { METRIC_CONTEXTS, experimentMetricModalLogic } from './experimentMetricModalLogic'
+import { experimentMetricModalLogic } from './experimentMetricModalLogic'
+import { metricSourceModalLogic } from './metricSourceModalLogic'
 
-export function MetricSourceModal({ isSecondary }: { isSecondary?: boolean }): JSX.Element {
-    const {
-        closePrimaryMetricSourceModal,
-        closeSecondaryMetricSourceModal,
-        openPrimarySharedMetricModal,
-        openSecondarySharedMetricModal,
-    } = useActions(modalsLogic)
-    const { isPrimaryMetricSourceModalOpen, isSecondaryMetricSourceModalOpen } = useValues(modalsLogic)
-
-    const isOpen = isSecondary ? isSecondaryMetricSourceModalOpen : isPrimaryMetricSourceModalOpen
-    const closeCurrentModal = isSecondary ? closeSecondaryMetricSourceModal : closePrimaryMetricSourceModal
-    const openSharedMetricModal = isSecondary ? openSecondarySharedMetricModal : openPrimarySharedMetricModal
+export const MetricSourceModal = (): JSX.Element => {
+    const { isModalOpen, context } = useValues(metricSourceModalLogic)
+    const { closeMetricSourceModal } = useActions(metricSourceModalLogic)
 
     const { openExperimentMetricModal } = useActions(experimentMetricModalLogic)
+    const { openPrimarySharedMetricModal, openSecondarySharedMetricModal } = useActions(modalsLogic)
 
     return (
-        <LemonModal isOpen={isOpen} onClose={closeCurrentModal} width={1000} title="Choose metric source">
+        <LemonModal isOpen={isModalOpen} onClose={closeMetricSourceModal} width={1000} title="Choose metric source">
             <div className="flex gap-4 mb-4">
                 <div
                     className="flex-1 cursor-pointer p-4 rounded border hover:border-accent"
                     onClick={() => {
-                        closeCurrentModal()
-                        openExperimentMetricModal(METRIC_CONTEXTS[isSecondary ? 'secondary' : 'primary'])
+                        closeMetricSourceModal()
+                        openExperimentMetricModal(context)
                     }}
                 >
                     <div className="font-semibold">
@@ -40,8 +33,10 @@ export function MetricSourceModal({ isSecondary }: { isSecondary?: boolean }): J
                 <div
                     className="flex-1 cursor-pointer p-4 rounded border hover:border-accent"
                     onClick={() => {
-                        closeCurrentModal()
-                        openSharedMetricModal(null)
+                        closeMetricSourceModal()
+                        context.type === 'primary'
+                            ? openPrimarySharedMetricModal(null)
+                            : openSecondarySharedMetricModal(null)
                     }}
                 >
                     <div className="font-semibold">

--- a/frontend/src/scenes/experiments/Metrics/metricSourceModalLogic.tsx
+++ b/frontend/src/scenes/experiments/Metrics/metricSourceModalLogic.tsx
@@ -1,0 +1,31 @@
+import { kea } from 'kea'
+import { actions, path, reducers } from 'kea'
+
+import { METRIC_CONTEXTS, MetricContext } from './experimentMetricModalLogic'
+import type { metricSourceModalLogicType } from './metricSourceModalLogicType'
+
+export const metricSourceModalLogic = kea<metricSourceModalLogicType>([
+    path(['scenes', 'experiments', 'create', 'metricSourceModalLogic']),
+
+    actions({
+        openMetricSourceModal: (context: MetricContext) => ({ context }),
+        closeMetricSourceModal: true,
+    }),
+
+    reducers({
+        isModalOpen: [
+            false,
+            {
+                openMetricSourceModal: () => true,
+                closeMetricSourceModal: () => false,
+            },
+        ],
+        context: [
+            METRIC_CONTEXTS.primary as MetricContext,
+            {
+                openMetricSourceModal: (_, { context }) => context,
+                closeMetricSourceModal: () => METRIC_CONTEXTS.primary,
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -4,13 +4,14 @@ import { IconInfo, IconList } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { IconAreaChart } from 'lib/lemon-ui/icons'
+import { AddMetricButton } from 'scenes/experiments/Metrics/AddMetricButton'
+import { METRIC_CONTEXTS } from 'scenes/experiments/Metrics/experimentMetricModalLogic'
 
 import type { ExperimentMetric } from '~/queries/schema/schema-general'
 
 import { experimentLogic } from '../../experimentLogic'
 import { modalsLogic } from '../../modalsLogic'
 import { MetricsReorderModal } from '../MetricsReorderModal'
-import { AddPrimaryMetric, AddSecondaryMetric } from '../shared/AddMetric'
 import { HowToReadTooltip } from './HowToReadTooltip'
 import { MetricsTable } from './MetricsTable'
 import { ResultDetails } from './ResultDetails'
@@ -101,7 +102,9 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                     <div className="ml-auto">
                         {metrics.length > 0 && (
                             <div className="mb-2 mt-4 justify-end flex gap-2">
-                                {isSecondary ? <AddSecondaryMetric /> : <AddPrimaryMetric />}
+                                <AddMetricButton
+                                    metricContext={isSecondary ? METRIC_CONTEXTS.secondary : METRIC_CONTEXTS.primary}
+                                />
                                 {metrics.length > 1 && (
                                     <LemonButton
                                         type="secondary"
@@ -155,7 +158,9 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                                     : 'Primary metrics represent the main goal of the experiment and directly measure if your hypothesis was successful.'}
                             </p>
                         </div>
-                        {isSecondary ? <AddSecondaryMetric /> : <AddPrimaryMetric />}
+                        <AddMetricButton
+                            metricContext={isSecondary ? METRIC_CONTEXTS.secondary : METRIC_CONTEXTS.primary}
+                        />
                     </div>
                 </div>
             )}

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -18,8 +18,6 @@ import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import type { Experiment } from '~/types'
 
-import { MetricSourceModal } from '../Metrics/MetricSourceModal'
-import { MetricsReorderModal } from '../MetricsView/MetricsReorderModal'
 import { ExperimentTypePanel } from './ExperimentTypePanel'
 import { ExposureCriteriaPanel } from './ExposureCriteriaPanel'
 import { VariantsPanel } from './VariantsPanel'
@@ -188,12 +186,6 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                     <span>Sidebar Checklist Goes Here</span>
                 </div>
             </div>
-
-            {/* Metric Modals */}
-            <MetricSourceModal isSecondary={false} />
-            <MetricSourceModal isSecondary={true} />
-            <MetricsReorderModal isSecondary={false} />
-            <MetricsReorderModal isSecondary={true} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

We need to reuse the `MetricSourceModal` component on the create experiment form.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We apply the same refactoring rules we used in the `ExperimentMetricModal` component to allow a single instance of the modal for both primary and secondary, and isolated state management on a new Kea logic. We also added a new `AddMetricButton` that is context-aware. We preserve the original components for the _legacy view_.

There are no feature changes. Modals behave the same.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/bedcceb9-45d4-4a40-82ae-25aa4a650448)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
