### PR TITLE
fix(feature flag): Point user to variant key error when they try to save with incorrect inputs

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -913,6 +913,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
         hasExperiment,
         isDraftExperiment,
         properties,
+        variantErrors,
     } = useValues(featureFlagLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const { hasAvailableFeature } = useValues(userLogic)
@@ -1146,6 +1147,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                             intent_context: ProductIntentContext.FEATURE_FLAG_VIEW_RECORDINGS,
                                         })
                                     }}
+                                    variantErrors={variantErrors}
                                 />
                             </SceneSection>
                         </>
@@ -1464,6 +1466,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                             },
                                         })
                                     }}
+                                    variantErrors={variantErrors}
                                 />
                             </SceneSection>
                         </>

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -28,7 +28,7 @@ import { ScheduledChangeOperationType, ScheduledChangeType } from '~/types'
 import { FeatureFlagReleaseConditions } from './FeatureFlagReleaseConditions'
 import { FeatureFlagVariantsForm } from './FeatureFlagVariantsForm'
 import { groupFilters } from './FeatureFlags'
-import { featureFlagLogic, variantKeyToIndexFeatureFlagPayloads } from './featureFlagLogic'
+import { featureFlagLogic, validateFeatureFlagKey, variantKeyToIndexFeatureFlagPayloads } from './featureFlagLogic'
 
 export const DAYJS_FORMAT = 'MMMM DD, YYYY h:mm A'
 
@@ -326,6 +326,9 @@ export default function FeatureFlagSchedule(): JSX.Element {
                                                 }
                                                 setSchedulePayload(null, null, null, currentVariants, newPayloads)
                                             }}
+                                            variantErrors={displayVariants.map(({ key: variantKey }) => ({
+                                                key: validateFeatureFlagKey(variantKey),
+                                            }))}
                                         />
                                     </div>
                                 )

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -92,6 +92,15 @@ export default function FeatureFlagSchedule(): JSX.Element {
 
     const scheduleFilters = { ...schedulePayload.filters, aggregation_group_type_index: aggregationGroupTypeIndex }
 
+    const { variants: displayVariants, payloads: displayPayloads } = getScheduledVariantsPayloads(
+        featureFlag,
+        schedulePayload
+    )
+
+    const variantErrors = displayVariants.map(({ key: variantKey }) => ({
+        key: validateFeatureFlagKey(variantKey),
+    }))
+
     const columns: LemonTableColumns<ScheduledChangeType> = [
         {
             title: 'Change',
@@ -266,9 +275,6 @@ export default function FeatureFlagSchedule(): JSX.Element {
                         {scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants &&
                             featureFlags[FEATURE_FLAGS.SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE] &&
                             (() => {
-                                const { variants: displayVariants, payloads: displayPayloads } =
-                                    getScheduledVariantsPayloads(featureFlag, schedulePayload)
-
                                 return (
                                     <div className="border rounded p-4">
                                         <FeatureFlagVariantsForm
@@ -326,9 +332,7 @@ export default function FeatureFlagSchedule(): JSX.Element {
                                                 }
                                                 setSchedulePayload(null, null, null, currentVariants, newPayloads)
                                             }}
-                                            variantErrors={displayVariants.map(({ key: variantKey }) => ({
-                                                key: validateFeatureFlagKey(variantKey),
-                                            }))}
+                                            variantErrors={variantErrors}
                                         />
                                     </div>
                                 )
@@ -342,7 +346,9 @@ export default function FeatureFlagSchedule(): JSX.Element {
                                         ? 'Select the scheduled date and time'
                                         : hasFormErrors(schedulePayloadErrors)
                                           ? 'Fix release condition errors'
-                                          : undefined
+                                          : variantErrors.some((error) => error.key != null)
+                                            ? 'Fix schedule variant changes errors'
+                                            : undefined
                                 }
                             >
                                 Schedule

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -346,7 +346,8 @@ export default function FeatureFlagSchedule(): JSX.Element {
                                         ? 'Select the scheduled date and time'
                                         : hasFormErrors(schedulePayloadErrors)
                                           ? 'Fix release condition errors'
-                                          : variantErrors.some((error) => error.key != null)
+                                          : scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants &&
+                                              variantErrors.some((error) => error.key != null)
                                             ? 'Fix schedule variant changes errors'
                                             : undefined
                                 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
@@ -4,11 +4,14 @@ import { IconBalance, IconPlus, IconRewindPlay, IconTrash } from '@posthog/icons
 import { LemonButton, LemonDivider, LemonInput } from '@posthog/lemon-ui'
 
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { LemonField } from 'lib/lemon-ui/LemonField'
 import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { alphabet } from 'lib/utils'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
 
 import { FeatureFlagGroupType, MultivariateFlagVariant } from '~/types'
+
+import { VariantError } from './featureFlagLogic'
 
 export interface FeatureFlagVariantsFormProps {
     variants: MultivariateFlagVariant[]
@@ -24,6 +27,7 @@ export interface FeatureFlagVariantsFormProps {
     onViewRecordings?: (variantKey: string) => void
     onVariantChange?: (index: number, field: 'key' | 'name' | 'rollout_percentage', value: any) => void
     onPayloadChange?: (index: number, value: any) => void
+    variantErrors: VariantError[]
 }
 
 export function focusVariantKeyField(index: number): void {
@@ -47,6 +51,7 @@ export function FeatureFlagVariantsForm({
     onViewRecordings,
     onVariantChange,
     onPayloadChange,
+    variantErrors,
 }: FeatureFlagVariantsFormProps): JSX.Element {
     const variantRolloutSum = variants.reduce((sum, variant) => sum + (variant.rollout_percentage || 0), 0)
     const areVariantRolloutsValid = variantRolloutSum === 100
@@ -147,19 +152,21 @@ export function FeatureFlagVariantsForm({
                         <Lettermark name={alphabet[index]} color={LettermarkColor.Gray} />
                     </div>
                     <div className="col-span-4">
-                        <LemonInput
-                            data-attr="feature-flag-variant-key"
-                            data-key-index={index.toString()}
-                            className="ph-ignore-input"
-                            placeholder={`example-variant-${index + 1}`}
-                            autoComplete="off"
-                            autoCapitalize="off"
-                            autoCorrect="off"
-                            spellCheck={false}
-                            disabled={!canEditVariant(index)}
-                            value={variant.key}
-                            onChange={(value) => onVariantChange?.(index, 'key', value)}
-                        />
+                        <LemonField.Pure error={variantErrors[index]?.key}>
+                            <LemonInput
+                                data-attr="feature-flag-variant-key"
+                                data-key-index={index.toString()}
+                                className="ph-ignore-input"
+                                placeholder={`example-variant-${index + 1}`}
+                                autoComplete="off"
+                                autoCapitalize="off"
+                                autoCorrect="off"
+                                spellCheck={false}
+                                disabled={!canEditVariant(index)}
+                                value={variant.key}
+                                onChange={(value) => onVariantChange?.(index, 'key', value)}
+                            />
+                        </LemonField.Pure>
                     </div>
                     <div className="col-span-6">
                         <LemonInput

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
@@ -148,7 +148,7 @@ export function FeatureFlagVariantsForm({
             </div>
             {variants.map((variant: MultivariateFlagVariant, index: number) => (
                 <div key={index} className="VariantFormList__row grid gap-2">
-                    <div className="flex items-center justify-center">
+                    <div className="flex mt-2 justify-center">
                         <Lettermark name={alphabet[index]} color={LettermarkColor.Gray} />
                     </div>
                     <div className="col-span-4">
@@ -224,7 +224,7 @@ export function FeatureFlagVariantsForm({
                             )}
                         </div>
                     </div>
-                    <div className="flex items-center justify-center">
+                    <div className="flex justify-center items-start mt-1.5">
                         {variants.length > 1 && onRemoveVariant && (
                             <LemonButton
                                 icon={<IconTrash />}

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1455,7 +1455,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             (s) => [s.featureFlag],
             (featureFlag: FeatureFlagType) => {
                 return featureFlag?.filters?.groups?.flatMap((g) => g.properties ?? []) ?? []
-            }
+            },
         ],
         variantErrors: [
             (s) => [s.variants],

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -79,6 +79,10 @@ export type ScheduleFlagPayload = Pick<FeatureFlagType, 'filters' | 'active'> & 
     payloads?: Record<string, any>
 }
 
+export type VariantError = {
+    key: string | undefined
+}
+
 const getDefaultRollbackCondition = (): FeatureFlagRollbackConditions => ({
     operator: 'gt',
     threshold_type: RolloutConditionType.Sentry,
@@ -1451,6 +1455,15 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             (s) => [s.featureFlag],
             (featureFlag: FeatureFlagType) => {
                 return featureFlag?.filters?.groups?.flatMap((g) => g.properties ?? []) ?? []
+            }
+        ],
+        variantErrors: [
+            (s) => [s.variants],
+            (variants) => {
+                const errors: VariantError[] = variants.map(({ key: variantKey }: MultivariateFlagVariant) => ({
+                    key: validateFeatureFlagKey(variantKey),
+                }))
+                return errors
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/39464

## Changes

1) Added a selector to figure whether the variant keys are valid
2) Included a `LemonField` as a parent of the `LemonInput` of variant key to display the error
3) Adjusted the styling so that the delete icon and the alphabet mark dont look out of place when there is an error

When saving an existing feature flag (same behavior as creating a new flag):

https://github.com/user-attachments/assets/2eb60006-eed9-4613-bd9b-fca5f129d544




When trying to create a variant schedule:


https://github.com/user-attachments/assets/af49773c-9b49-49d9-bcdd-0003555343b5


## How did you test this code?

Locally:
1. Create a new flag
2. Set the `Served value` as `multi variant`
3. Set one of the variant keys to `Variant A`
4. Try to save, you should see that the page scrolls to the variant key section and you should see the error below the input.
