### PR TITLE
fix(feature flag): Variant schedule should not allow rollout that doesn't add up to 100

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -344,7 +344,8 @@ export default function FeatureFlagSchedule(): JSX.Element {
                                         ? 'Select the scheduled date and time'
                                         : hasFormErrors(schedulePayloadErrors)
                                           ? 'Fix release condition errors'
-                                          : !areVariantRolloutsValid
+                                          : scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants &&
+                                              !areVariantRolloutsValid
                                             ? `Percentage rollouts for variants must sum to 100 (currently ${variantRolloutSum}).`
                                             : undefined
                                 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -92,6 +92,14 @@ export default function FeatureFlagSchedule(): JSX.Element {
 
     const scheduleFilters = { ...schedulePayload.filters, aggregation_group_type_index: aggregationGroupTypeIndex }
 
+    const { variants: displayVariants, payloads: displayPayloads } = getScheduledVariantsPayloads(
+        featureFlag,
+        schedulePayload
+    )
+
+    const variantRolloutSum = displayVariants.reduce((sum, variant) => sum + (variant.rollout_percentage || 0), 0)
+    const areVariantRolloutsValid = variantRolloutSum === 100
+
     const columns: LemonTableColumns<ScheduledChangeType> = [
         {
             title: 'Change',
@@ -266,9 +274,6 @@ export default function FeatureFlagSchedule(): JSX.Element {
                         {scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants &&
                             featureFlags[FEATURE_FLAGS.SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE] &&
                             (() => {
-                                const { variants: displayVariants, payloads: displayPayloads } =
-                                    getScheduledVariantsPayloads(featureFlag, schedulePayload)
-
                                 return (
                                     <div className="border rounded p-4">
                                         <FeatureFlagVariantsForm
@@ -339,7 +344,9 @@ export default function FeatureFlagSchedule(): JSX.Element {
                                         ? 'Select the scheduled date and time'
                                         : hasFormErrors(schedulePayloadErrors)
                                           ? 'Fix release condition errors'
-                                          : undefined
+                                          : !areVariantRolloutsValid
+                                            ? `Percentage rollouts for variants must sum to 100 (currently ${variantRolloutSum}).`
+                                            : undefined
                                 }
                             >
                                 Schedule


### PR DESCRIPTION
## Problem

While the error is shown, the `Schedule` button can be clicked:


https://github.com/user-attachments/assets/b9db82f4-8fb8-408d-8a43-ab22bfff7627



## Changes

Disable the button when the total rollout is not 100:


https://github.com/user-attachments/assets/3842148d-bd8f-42f8-b845-1ff6e9ed5b3d



## How did you test this code?

Locally:
1. Go an existing flag that is multivariant and click on the `Schedule` tab
2. Change the update type to `Update variant` and add a schedule date
3. Update the variant(s) such that the total roll out is not 100

You should see that the `schedule` button is disabled 
