### PR TITLE
chore(flox): upgrade uv to 0.8.19

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -10,7 +10,7 @@ version = 1
 # the `[install]` section.
 [install]
 # Python - Python itself is installed on activation via `uv sync`
-uv = { pkg-path = "uv", pkg-group = "uv", version = "0.7.8" }
+uv = { pkg-path = "uv", pkg-group = "uv", version = "0.8.19" }
 xmlsec = { pkg-path = "xmlsec", version = "1.3.6" }
 freetds = { pkg-path = "freetds" } # For pymssql
 # Node


### PR DESCRIPTION
## Summary

Upgrade uv from 0.7.8 to 0.8.19 in the flox environment to support Python 3.12.11 installation.

## Context

uv 0.7.8 was released May 24, 2025, before python-build-standalone added Python 3.12.11 (June 4, 2025). This causes `uv sync` to fail for developers who don't have Python 3.12.11 already installed via system package managers (homebrew, pyenv, etc).

As documented in the [uv Python versions guide](https://docs.astral.sh/uv/concepts/python-versions/):

> The available Python versions are frozen for each uv release. To install new Python versions, you may need upgrade uv.

> As Python does not publish official distributable CPython binaries, uv instead uses pre-built distributions from the Astral `python-build-standalone` project.

uv 0.8.19 (released Sept 19, 2025) includes Python 3.12.11 in its registry, allowing the flox environment to be fully self-contained.

Note: 0.8.19 is the latest version available in flox. uv 0.9.x versions are not yet in the flox package registry.

## Changes

- Bump uv from 0.7.8 to 0.8.19 in `.flox/env/manifest.toml`

## Breaking changes reviewed

- manylinux_2_17 → manylinux_2_28: No impact (Python version pinned)
- uv venv prompts: No impact (only affects interactive usage)

## Test plan

- [x] Verify flox activation succeeds with new uv version
- [x] Verify `uv sync` works for developers without system Python 3.12.11