### PR TITLE
fix(experiments): Update text in link to feature flag modal

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -494,8 +494,7 @@ const SelectExistingFeatureFlagModal = ({
             <div className="deprecated-space-y-2">
                 <div className="text-muted mb-2 max-w-xl">
                     Select an existing multivariate feature flag to use with this experiment. The feature flag must use
-                    multiple variants with <code>'control'</code> as the first, and not be associated with an existing
-                    experiment.
+                    multiple variants with <code>'control'</code> as the first.
                 </div>
                 {filtersSection}
                 <LemonTable

--- a/frontend/src/scenes/experiments/create/SelectExistingFeatureFlagModal.tsx
+++ b/frontend/src/scenes/experiments/create/SelectExistingFeatureFlagModal.tsx
@@ -44,8 +44,7 @@ export const SelectExistingFeatureFlagModal = ({
             <div className="deprecated-space-y-2">
                 <div className="text-muted mb-2 max-w-xl">
                     Select an existing multivariate feature flag to use with this experiment. The feature flag must use
-                    multiple variants with <code>'control'</code> as the first, and not be associated with an existing
-                    experiment.
+                    multiple variants with <code>'control'</code> as the first.
                 </div>
                 {filtersSection}
                 <LemonTable


### PR DESCRIPTION


## Problem

Experiments can now link itself to flags associated to other experiments based on https://github.com/PostHog/posthog/pull/31005.

The text in the modal communicates otherwise:

<img width="890" height="517" alt="Screenshot 2025-10-13 at 4 27 10 PM" src="https://github.com/user-attachments/assets/b2560f2f-a26b-4ede-8dda-660d0fb0a593" />


## Changes

<img width="841" height="458" alt="Screenshot 2025-10-13 at 4 21 16 PM" src="https://github.com/user-attachments/assets/15363d8c-06eb-4922-85d7-bcbb807bbd83" />


## How did you test this code?

Locally:
1) Go to the experiment creation page: http://localhost:8010/project/2/experiments/new
2) Click on `Link to existing feature flag`
3) A modal should pop out and you should see that the updated text

