### PR TITLE
fix(person): Fix person transaction django routing

### DIFF
--- a/posthog/models/person/__init__.py
+++ b/posthog/models/person/__init__.py
@@ -1,3 +1,3 @@
-from .person import Person, PersonDistinctId, PersonOverride, PersonOverrideMapping
+from .person import Person, PersonDistinctId, PersonlessDistinctId, PersonOverride, PersonOverrideMapping
 
-__all__ = ["Person", "PersonDistinctId", "PersonOverride", "PersonOverrideMapping"]
+__all__ = ["Person", "PersonDistinctId", "PersonOverride", "PersonOverrideMapping", "PersonlessDistinctId"]

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from django.db import connections, models, transaction
+from django.db import connections, models, router, transaction
 from django.db.models import F, Q
 
 from posthog.models.utils import UUIDT
@@ -100,8 +100,8 @@ class Person(models.Model):
 
         for distinct_id in distinct_ids:
             if not distinct_id == main_distinct_id:
-                # Use the same database as the Person model (handles persons_db_writer routing in production)
-                with transaction.atomic(using=self._state.db or "default"):
+                db_alias = router.db_for_write(PersonDistinctId) or "default"
+                with transaction.atomic(using=db_alias):
                     pdi = PersonDistinctId.objects.select_for_update().get(person=self, distinct_id=distinct_id)
                     person, _ = Person.objects.get_or_create(
                         uuid=uuidFromDistinctId(self.team_id, distinct_id),

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -100,7 +100,8 @@ class Person(models.Model):
 
         for distinct_id in distinct_ids:
             if not distinct_id == main_distinct_id:
-                with transaction.atomic():
+                # Use the same database as the Person model (handles persons_db_writer routing in production)
+                with transaction.atomic(using=self._state.db or "default"):
                     pdi = PersonDistinctId.objects.select_for_update().get(person=self, distinct_id=distinct_id)
                     person, _ = Person.objects.get_or_create(
                         uuid=uuidFromDistinctId(self.team_id, distinct_id),


### PR DESCRIPTION
## Problem

Since last Friday, we are using in the US env a separate persons database (routed in Django via PersonDBRouter), I detected person splitting operations were failing with the error:

`TransactionManagementError: select_for_update cannot be used outside of a transaction.`

We were using Django's `transaction.atomic()` with no parameters, which creates transactions on the default database. However, when the PersonDBRouter is active, queries on Person, PersonDistinctId, and PersonlessDistinctId models are routed to persons_db_writer. This mismatch causes queries that require transactions (like `select_for_update`()) to fail.
