### PR TITLE
fix(kafka-deduplicator): Publish PotentialDeduplicate messages

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,7 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
-            - 'jose-sequeira/publish-potential-duplicates-kafka-dedup'
+
 jobs:
     build:
         name: build ${{ matrix.image }}

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,7 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
-            - 'jose-sequeira/duplicates-producer'
+            - 'jose-sequeira/publish-potential-duplicates-kafka-dedup'
 jobs:
     build:
         name: build ${{ matrix.image }}

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -752,6 +752,15 @@ impl MessageProcessor for DeduplicationProcessor {
 }
 
 impl DeduplicationProcessor {
+    /// Determine if an event should be published to the duplicate events topic
+    fn should_publish_event(&self, result: &DeduplicationResult) -> bool {
+        matches!(
+            result,
+            DeduplicationResult::ConfirmedDuplicate(_, _, _, _)
+                | DeduplicationResult::PotentialDuplicate(_, _, _)
+        )
+    }
+
     /// Publish duplicate event to the duplicate events topic
     async fn publish_duplicate_event(
         &self,
@@ -762,7 +771,7 @@ impl DeduplicationProcessor {
         metrics: &MetricsHelper,
     ) -> Result<()> {
         // Only publish for actual duplicates (not New or Skipped)
-        if !deduplication_result.is_duplicate() {
+        if !self.should_publish_event(deduplication_result) {
             return Ok(());
         }
 

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -771,7 +771,7 @@ impl DeduplicationProcessor {
         metrics: &MetricsHelper,
     ) -> Result<()> {
         // Only publish for actual duplicates (not New or Skipped)
-        if self.should_publish_event(deduplication_result) {
+        if !self.should_publish_event(deduplication_result) {
             return Ok(());
         }
 

--- a/rust/kafka-deduplicator/src/deduplication_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_processor.rs
@@ -771,7 +771,7 @@ impl DeduplicationProcessor {
         metrics: &MetricsHelper,
     ) -> Result<()> {
         // Only publish for actual duplicates (not New or Skipped)
-        if !self.should_publish_event(deduplication_result) {
+        if self.should_publish_event(deduplication_result) {
             return Ok(());
         }
 


### PR DESCRIPTION
## Problem

We're only publishing `ConfirmedDuplicate` events, we should also publish `PotentialDuplicate` events to the duplicate topic

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
