### PR TITLE
fix: prevent invalid from_plan_key error when switching plans

### DIFF
--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -30,7 +30,8 @@ export const BillingProductAddonActions = ({
     buttonSize,
     ctaTextOverride,
 }: BillingProductAddonActionsProps): JSX.Element => {
-    const { billing, billingError, currentPlatformAddon, unusedPlatformAddonAmount } = useValues(billingLogic)
+    const { billing, billingError, currentPlatformAddon, unusedPlatformAddonAmount, switchPlanLoading } =
+        useValues(billingLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const {
         currentAndUpgradePlans,
@@ -61,9 +62,10 @@ export const BillingProductAddonActions = ({
                     <LemonButton
                         fullWidth
                         disabledReason={
-                            isDataPipelinesDeprecated
+                            (switchPlanLoading ? 'Switching plans...' : undefined) ||
+                            (isDataPipelinesDeprecated
                                 ? `Data pipelines have moved to new, usage-based pricing with generous free allowance, and old ingestion-based pricing ended on ${DATA_PIPELINES_CUTOFF_DATE}.`
-                                : undefined
+                                : undefined)
                         }
                         onClick={() => {
                             setSurveyResponse('$survey_response_1', addon.type)
@@ -215,6 +217,7 @@ export const BillingProductAddonActions = ({
                 overlay={
                     <LemonButton
                         fullWidth
+                        disabledReason={switchPlanLoading ? 'Switching plans...' : undefined}
                         onClick={() => {
                             reportBillingAddonPlanSwitchStarted(currentPlatformAddon.type, addon.type, 'downgrade')
                             showConfirmDowngradeModal()
@@ -244,6 +247,7 @@ export const BillingProductAddonActions = ({
 
                 <LemonButton
                     type="primary"
+                    disabledReason={switchPlanLoading ? 'Switching plans...' : undefined}
                     onClick={() => {
                         reportBillingAddonPlanSwitchStarted(currentPlatformAddon.type, addon.type, 'upgrade')
                         showConfirmUpgradeModal()

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -569,8 +569,7 @@ export const billingLogic = kea<billingLogicType>([
                 if (!currentPlatformAddon || !timeTotalInSeconds) {
                     return 0
                 }
-                const currentPlan = currentPlatformAddon.plans?.[0]
-                const unitAmount = parseFloat(currentPlan?.unit_amount_usd || '0')
+                const unitAmount = parseFloat(currentPlatformAddon.current_amount_usd || '0')
                 const ratio = Math.max(0, Math.min(1, timeRemainingInSeconds / timeTotalInSeconds))
                 const amount = unitAmount * ratio
                 return Math.round(amount * 100) / 100

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -665,9 +665,12 @@ export const billingProductLogic = kea<billingProductLogicType>([
             if (!upgradePlan || !currentPlatformAddon) {
                 return
             }
+            const currentPlanKey =
+                currentPlatformAddon.plans?.find((p) => p.current_plan)?.plan_key ||
+                currentPlatformAddon.plans?.[0]?.plan_key
             actions.switchFlatrateSubscriptionPlan({
                 from_product_key: String(currentPlatformAddon.type),
-                from_plan_key: String(currentPlatformAddon.plans?.[0]?.plan_key),
+                from_plan_key: String(currentPlanKey || ''),
                 to_product_key: props.product.type,
                 to_plan_key: String(upgradePlan.plan_key),
             })
@@ -678,9 +681,12 @@ export const billingProductLogic = kea<billingProductLogicType>([
             if (!targetPlan || !currentPlatformAddon) {
                 return
             }
+            const currentPlanKey =
+                currentPlatformAddon.plans?.find((p) => p.current_plan)?.plan_key ||
+                currentPlatformAddon.plans?.[0]?.plan_key
             actions.switchFlatrateSubscriptionPlan({
                 from_product_key: String(currentPlatformAddon.type),
-                from_plan_key: String(currentPlatformAddon.plans?.[0]?.plan_key),
+                from_plan_key: String(currentPlanKey || ''),
                 to_product_key: props.product.type,
                 to_plan_key: String(targetPlan.plan_key),
             })

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -670,7 +670,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 currentPlatformAddon.plans?.[0]?.plan_key
             actions.switchFlatrateSubscriptionPlan({
                 from_product_key: String(currentPlatformAddon.type),
-                from_plan_key: String(currentPlanKey || ''),
+                from_plan_key: String(currentPlanKey),
                 to_product_key: props.product.type,
                 to_plan_key: String(upgradePlan.plan_key),
             })
@@ -686,7 +686,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 currentPlatformAddon.plans?.[0]?.plan_key
             actions.switchFlatrateSubscriptionPlan({
                 from_product_key: String(currentPlatformAddon.type),
-                from_plan_key: String(currentPlanKey || ''),
+                from_plan_key: String(currentPlanKey),
                 to_product_key: props.product.type,
                 to_plan_key: String(targetPlan.plan_key),
             })


### PR DESCRIPTION
## Problem
When a plan switch is loading, other addon action buttons remain active. 
Although the modal's Cancel button is disabled, if the user refreshes the page or navigates using browser history before the loading completes, an `Unknown plan key for from_product` error may occur.

Exception: https://us.posthog.com/project/2/error_tracking/0199d5fa-3279-7b81-b32e-93bcee3874ee

## Changes
- Added disabled state to "Remove add-on", "Downgrade", and "Upgrade" buttons while any subscription plan switch is loading and billing hasn't reloaded yet. 
- Fixed how `from_plan_key` is determined (using current plan, not the first one) - more reliable and also could have caused the error

## How did you test this code?
Manually:
Basic flow works correctly (current plan is properly identified)
Other action buttons become disabled while `switchPlanLoading`

<img width="415" height="382" alt="Screenshot 2025-10-13 at 14 21 39" src="https://github.com/user-attachments/assets/ab7e5c2d-ed87-408d-87ce-82a0d22ef90a" />