### PR TITLE
fix: remove hogql codeowners rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 # If a file is set here, then PRs will require that team's approval to get that code merged.
-
-posthog/hogql/** @PostHog/hogql


### PR DESCRIPTION
We don't do this anywhere else, I don't think it makes sense