### PR TITLE
chore(dev): apply DJ012 and RUF005 ruff rules

### DIFF
--- a/ee/hogai/graph/inkeep_docs/nodes.py
+++ b/ee/hogai/graph/inkeep_docs/nodes.py
@@ -60,7 +60,7 @@ class InkeepDocsNode(RootNode):  # Inheriting from RootNode to use the same mess
         )
         if last_human_message_index is not None:
             messages = messages[: last_human_message_index + 1]
-        return [system_prompt] + messages[-29:]
+        return [system_prompt, *messages[-29:]]
 
     def _get_model(self):  # type: ignore
         return MaxChatOpenAI(

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -603,7 +603,7 @@ class FeatureFlagSerializer(
         # Check for cycles using DFS
         def has_cycle(flag_key, path):
             if flag_key in path:
-                cycle_path = path[path.index(flag_key) :] + [flag_key]
+                cycle_path = [*path[path.index(flag_key) :], flag_key]
                 cycle_display = " → ".join(cycle_path)
                 raise serializers.ValidationError(f"Circular dependency detected: {cycle_display}")
 

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -33,7 +33,7 @@ QUERY_WAIT_TIME = Histogram(
     "query_wait_time_seconds",
     "Time from query creation to pick-up",
     labelnames=["team", "mode"],
-    buckets=Histogram.DEFAULT_BUCKETS[2:-1] + (20, 30, 60, 120, 300, 600, float("inf")),
+    buckets=(*Histogram.DEFAULT_BUCKETS[2:-1], 20, 30, 60, 120, 300, 600, float("inf")),
 )
 
 QUERY_PROCESS_TIME = Histogram(

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -688,7 +688,7 @@ def map_virtual_properties(e: ast.Expr):
         and e.chain[-1].startswith("$virt")
     ):
         # we pretend virtual properties are regular properties, but they should map to the same field directly on the parent table
-        return ast.Field(chain=e.chain[:-2] + [e.chain[-1]])
+        return ast.Field(chain=[*e.chain[:-2], e.chain[-1]])
     return e
 
 

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -122,6 +122,10 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
     def __str__(self):
         return self.name or self.derived_name or self.short_id
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._original_query = self.query
+
     def save(self, *args, **kwargs) -> None:
         # generate query metadata if needed
         if self._state.adding or self.query != self._original_query or self.query_metadata is None:
@@ -140,10 +144,6 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
                 )
                 capture_exception(e)
         super().save(*args, **kwargs)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._original_query = self.query
 
     @classmethod
     def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Insight"]:

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -97,6 +97,10 @@ class Subscription(models.Model):
     created_by = models.ForeignKey("User", on_delete=models.SET_NULL, null=True, blank=True)
     deleted = models.BooleanField(default=False)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._rrule = self.rrule
+
     def save(self, *args, **kwargs) -> None:
         # Only if the schedule has changed do we update the next delivery date
         if not self.id or str(self._rrule) != str(self.rrule):
@@ -104,10 +108,6 @@ class Subscription(models.Model):
             if "update_fields" in kwargs:
                 kwargs["update_fields"].append("next_delivery_date")
         super().save(*args, **kwargs)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._rrule = self.rrule
 
     @property
     def rrule(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,8 +279,6 @@ ignore = [
     "UP007",
     "UP032",
     # Temporarily ignored after ruff 0.14.0 upgrade - require careful review/testing
-    "DJ012",  # Django model method ordering - style preference
-    "RUF005", # List concatenation to unpacking - minor perf optimization
     "UP045",  # Type annotation simplification - needs mypy verification
     "UP046",  # PEP 695 type parameters for classes - may affect mypy
     "UP047",  # PEP 695 type parameters for functions - may affect mypy
@@ -289,11 +287,9 @@ select = [
     "B",
     "C4",
     "C9",
-    "DJ012",
     "E",
     "F",
     "I",
-    "RUF005",
     "RUF013",
     "RUF015",
     "RUF019",


### PR DESCRIPTION
## Summary

Stacked on #39545 - applies two ruff rules that were temporarily ignored after the 0.14.0 upgrade.

## Changes

**DJ012: Django model method ordering**
- Enforces Django style guide: magic methods before custom methods
- Fixed 3 violations:
  - `Insight`: moved `__init__` before `save()`
  - `Subscription`: moved `__init__` before `save()`
  - `FileSystemSyncMixin`: moved `__init_subclass__` before all custom methods

**RUF005: List concatenation to unpacking**
- Minor perf optimization: `[a] + b` → `[a, *b]`
- Applied 4 auto-fixes across codebase

## Files changed

8 files total:
- 3 Django models (method reordering)
- 4 files with list unpacking optimizations
- 1 config file (removed rules from ignore list)

All changes are safe, no mypy impact.