### PR TITLE
chore(ci): upgrade setup-uv action to v7.1.0

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -47,7 +47,6 @@ jobs:
               with:
                   enable-cache: true
                   version: 0.8.19
-                  pyproject-file: 'pyproject.toml'
 
             - name: Install python dependencies
               shell: bash

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -43,7 +43,7 @@ jobs:
                   python-version-file: 'pyproject.toml'
 
             - name: Install uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -126,7 +126,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19
@@ -571,7 +571,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv-tests
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19
@@ -842,7 +842,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv-async
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -85,7 +85,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -318,7 +318,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -70,7 +70,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19
@@ -175,7 +175,7 @@ jobs:
                   python-version-file: 'pyproject.toml'
             - name: Install uv
               id: setup-uv-hogql-python
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -149,7 +149,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -62,7 +62,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -161,7 +161,7 @@ jobs:
             - name: Install uv
               id: setup-uv
               if: needs.changes.outputs.rust == 'true'
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -44,7 +44,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+              uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.8.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ RUN apt-get update && \
     "pkg-config" \
     && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install uv~=0.7.0 --no-cache-dir && \
+    pip install uv==0.8.19 --no-cache-dir && \
     UV_PROJECT_ENVIRONMENT=/python-runtime uv sync --frozen --no-dev --no-cache --compile-bytecode --no-binary-package lxml --no-binary-package xmlsec
 
 ENV PATH=/python-runtime/bin:$PATH \

--- a/Dockerfile.ai-evals
+++ b/Dockerfile.ai-evals
@@ -31,7 +31,7 @@ COPY pyproject.toml uv.lock docker-compose.base.yml docker-compose.dev.yml ./
 
 # Install python deps
 RUN rm -rf /var/lib/apt/lists/* && \
-pip install uv~=0.7.0 --no-cache-dir && \
+pip install uv==0.8.19 --no-cache-dir && \
 UV_PROJECT_ENVIRONMENT=/python-runtime uv sync --frozen --no-cache --compile-bytecode \
 --no-binary-package lxml --no-binary-package xmlsec
 


### PR DESCRIPTION
Upgrade setup-uv GitHub Action from v5.4.1 to v7.1.0 for latest improvements.

## Changes

- Update `astral-sh/setup-uv` action to v7.1.0 across all CI workflows
- Remove deprecated `pyproject-file` input from ci-ai.yml (replaced by auto-detection in v6.0.0)

## Why

Addresses review comment on #39558. The v6.x and v7.x series bring significant improvements.

**v6.0.0 (Breaking)**
- Removed `pyproject-file` and `uv-file` inputs (replaced with `working-directory` and auto-detection)
- Removed automatic venv activation with `python-version` (now explicit via `activate-environment`)
- Better default `cache-dependency-glob` covering 99.5% of use cases
- Self-hosted runners use default UV cache dir instead of RUNNER_TEMP

**v7.0.0 (Breaking)**
- Switched to node24 runtime (all PostHog runners support this)
- Removed deprecated `server-url` input (not used in this repo)
- Better UV_CACHE_DIR handling and config file detection
- Faster cache pruning with `--ci --force` flag
- Respects UV_NO_MODIFY_PATH

**v7.1.0**
- Support for resolution-strategy input
- Exposes venv path in outputs when using activate-environment
- Python install caching
- Windows PATH improvements

## Impact

Breaking changes don't affect this repo:
- All runners (ubuntu-latest, ubuntu-24.04, depot-*) support node24
- We don't use deprecated inputs (server-url, pyproject-file now removed)
- We don't use venv activation feature

## Test plan

CI workflows will run with the upgraded action.