### PR TITLE
fix: Revert "fix(flags): Added if check and return error for filters with empty groups fix#38896"

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -401,12 +401,6 @@ class FeatureFlagSerializer(
             # mypy cannot tell that self.instance is a FeatureFlag
             return self.instance.filters
 
-        groups = filters.get("groups", [])
-        if isinstance(groups, list) and len(groups) == 0:
-            raise serializers.ValidationError(
-                "Feature flag filters must contain at least one condition set. Empty 'groups' array is not allowed."
-            )
-
         aggregation_group_type_index = filters.get("aggregation_group_type_index", None)
 
         def properties_all_match(predicate):


### PR DESCRIPTION
Reverts PostHog/posthog#39110

Tests are failing, reverting while investigating.

Context:
https://posthog.slack.com/archives/C09ADEV3AJD/p1760369128463549?thread_ts=1760366822.862389&cid=C09ADEV3AJD