### PR TITLE
feat(customers): Create notebook node to display usage metrics

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -1,0 +1,72 @@
+import { useValues } from 'kea'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { NodeKind, UsageMetric, UsageMetricsQueryResponse } from '~/queries/schema/schema-general'
+
+import {
+    UsageMetricCard,
+    UsageMetricCardSkeleton,
+} from 'products/customer_analytics/frontend/components/UsageMetricCard'
+
+import { NotebookNodeProps, NotebookNodeType } from '../types'
+import { createPostHogWidgetNode } from './NodeWrapper'
+import { notebookNodeLogic } from './notebookNodeLogic'
+
+const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAttributes>): JSX.Element | null => {
+    const { expanded } = useValues(notebookNodeLogic)
+    const { personId } = attributes
+    const logic = dataNodeLogic({
+        query: {
+            kind: NodeKind.UsageMetricsQuery,
+            person_id: personId,
+        },
+        key: personId,
+    })
+    const { response, responseLoading, responseError } = useValues(logic)
+
+    if (!expanded) {
+        return null
+    }
+
+    if (responseLoading) {
+        return <UsageMetricCardSkeleton />
+    }
+
+    if (responseError) {
+        return <div className="text-danger text-center p-4">Failed to load usage metrics</div>
+    }
+
+    const queryResponse = response as UsageMetricsQueryResponse | undefined
+    const results = (queryResponse?.results ?? []) as UsageMetric[]
+    const hasResults = results.length > 0
+
+    if (!hasResults) {
+        return <div className="text-muted text-center p-4">No usage metrics available</div>
+    }
+
+    return (
+        <div className="@container">
+            <div className="grid grid-cols-1 @md:grid-cols-2 @xl:grid-cols-4 gap-4 p-4">
+                {results.map((metric) => (
+                    <UsageMetricCard key={metric.id} metric={metric} />
+                ))}
+            </div>
+        </div>
+    )
+}
+
+type NotebookNodeUsageMetricsAttributes = {
+    personId: string
+}
+
+export const NotebookNodeUsageMetrics = createPostHogWidgetNode<NotebookNodeUsageMetricsAttributes>({
+    nodeType: NotebookNodeType.UsageMetrics,
+    titlePlaceholder: 'Usage',
+    Component,
+    resizeable: false,
+    expandable: true,
+    startExpanded: true,
+    attributes: {
+        personId: {},
+    },
+})

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -42,6 +42,7 @@ import { NotebookNodeRecording } from '../Nodes/NotebookNodeRecording'
 import { NotebookNodeReplayTimestamp } from '../Nodes/NotebookNodeReplayTimestamp'
 import { NotebookNodeSurvey } from '../Nodes/NotebookNodeSurvey'
 import { NotebookNodeTaskCreate } from '../Nodes/NotebookNodeTaskCreate'
+import { NotebookNodeUsageMetrics } from '../Nodes/NotebookNodeUsageMetrics'
 import { FloatingSuggestions } from '../Suggestions/FloatingSuggestions'
 import { insertionSuggestionsLogic } from '../Suggestions/insertionSuggestionsLogic'
 import { NotebookEditor } from '../types'
@@ -137,6 +138,7 @@ export function Editor(): JSX.Element {
         NotebookNodeTaskCreate,
         NotebookNodeLLMTrace,
         NotebookNodeIssues,
+        NotebookNodeUsageMetrics,
     ]
 
     if (hasCollapsibleSections) {

--- a/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
@@ -31,6 +31,7 @@ export const fromNodeTypeToLabel: Omit<
     [NotebookNodeType.TaskCreate]: 'Task suggestions',
     [NotebookNodeType.LLMTrace]: 'LLM traces',
     [NotebookNodeType.Issues]: 'Issues',
+    [NotebookNodeType.UsageMetrics]: 'Usage metrics',
 }
 
 export function ContainsTypeFilters({

--- a/frontend/src/scenes/notebooks/types.ts
+++ b/frontend/src/scenes/notebooks/types.ts
@@ -59,6 +59,7 @@ export enum NotebookNodeType {
     TaskCreate = 'ph-task-create',
     LLMTrace = 'ph-llm-trace',
     Issues = 'ph-issues',
+    UsageMetrics = 'ph-usage-metrics',
 }
 
 export type NotebookNodeResource = {

--- a/frontend/src/scenes/notebooks/utils.ts
+++ b/frontend/src/scenes/notebooks/utils.ts
@@ -62,6 +62,7 @@ export const textContent = (node: RichContentNode): string => {
         [NotebookNodeType.Embed]: customOrTitleSerializer,
         [NotebookNodeType.Latex]: customOrTitleSerializer,
         [NotebookNodeType.TaskCreate]: customOrTitleSerializer,
+        [NotebookNodeType.UsageMetrics]: customOrTitleSerializer,
     }
 
     return getText(node, {

--- a/frontend/src/scenes/persons/PersonFeedCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonFeedCanvas.tsx
@@ -24,6 +24,7 @@ const PersonFeedCanvas = ({ person }: PersonFeedCanvasProps): JSX.Element => {
             initialContent={{
                 type: 'doc',
                 content: [
+                    { type: 'ph-usage-metrics', attrs: { personId: id, nodeId: uuid() } },
                     {
                         type: 'ph-person-feed',
                         attrs: {

--- a/products/customer_analytics/frontend/components/UsageMetricCard.tsx
+++ b/products/customer_analytics/frontend/components/UsageMetricCard.tsx
@@ -1,0 +1,38 @@
+import { LemonCard, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
+
+import { humanFriendlyCurrency, humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
+
+import { UsageMetric } from '~/queries/schema/schema-general'
+
+export const UsageMetricCard = ({ metric }: { metric: UsageMetric }): JSX.Element => {
+    const formatValue = (): string => {
+        if (metric.format === 'currency') {
+            return humanFriendlyCurrency(metric.value)
+        }
+        return humanFriendlyLargeNumber(metric.value)
+    }
+
+    return (
+        <LemonCard hoverEffect={false} className="p-4 flex-1 max-w-[300px]">
+            <div className="text-sm font-semibold text-muted-alt mb-1">{metric.name}</div>
+            <Tooltip title={humanFriendlyNumber(metric.value)}>
+                <div className="text-3xl font-bold text-primary my-2 truncate">{formatValue()}</div>
+            </Tooltip>
+            <div className="text-xs text-muted">Last {metric.interval} days</div>
+        </LemonCard>
+    )
+}
+
+export const UsageMetricCardSkeleton = (): JSX.Element => (
+    <div className="@container">
+        <div className="grid grid-cols-1 @md:grid-cols-2 @xl:grid-cols-4 gap-4 p-4">
+            {[1, 2, 3].map((i) => (
+                <LemonCard key={i} className="p-4">
+                    <LemonSkeleton className="h-4 bg-border rounded w-24 mb-2" />
+                    <LemonSkeleton className="h-8 bg-border rounded w-32 my-2" />
+                    <LemonSkeleton className="h-3 bg-border rounded w-20" />
+                </LemonCard>
+            ))}
+        </div>
+    </div>
+)


### PR DESCRIPTION
## Problem
We've built the [query runner](https://github.com/PostHog/posthog/pull/39426), so now we need to display the data.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Part of https://github.com/PostHog/posthog/issues/39179
## Changes
- Create component to display usage metrics
- Create notebook node to display usage metrics in notebooks

UI is not final, I think it will likely grow similar to Web Analytics tiles. It is also very basic: we're not showing trends from previous period, clicking doesn't do anything, etc.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

### Loading state
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/bd8f3ab6-8b79-421d-8543-039c996becce" />

### Empty state
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/83f84a17-e905-40ab-8b0c-17b665187bfe" />

### Loaded state
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/b6216573-a1a3-49d3-b74d-79622edcb479" />

### Error state
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/6a0581ef-daae-48f7-a75e-c1fa0fa15127" />

### Tooltip in metric value
To see the actual value when it is formatted/abbreviated
<img width="448" height="296" alt="image" src="https://github.com/user-attachments/assets/b02d061b-caf4-48c3-8e7a-7c0ebe5fefc9" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
