### PR TITLE
fix(batch-import-worker): include job id on events

### DIFF
--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -152,6 +152,7 @@ fn create_group_identify_event(
     group_key: String,
     changes: GroupChanges,
     timestamp: chrono::DateTime<chrono::Utc>,
+    job_id: uuid::Uuid,
 ) -> Result<InternallyCapturedEvent, Error> {
     let event_uuid = Uuid::now_v7();
 
@@ -178,6 +179,10 @@ fn create_group_identify_event(
     properties.insert(
         "analytics_source".to_string(),
         Value::String("amplitude".to_string()),
+    );
+    properties.insert(
+        "$import_job_id".to_string(),
+        Value::String(job_id.to_string()),
     );
 
     let raw_event = RawEvent {
@@ -453,6 +458,10 @@ impl AmplitudeEvent {
                 "analytics_source".to_string(),
                 Value::String("amplitude".to_string()),
             );
+            properties.insert(
+                "$import_job_id".to_string(),
+                Value::String(context.job_id.to_string()),
+            );
 
             // Add groups to the regular event properties BEFORE creating RawEvent
             if !amp.groups.is_empty() {
@@ -545,6 +554,7 @@ impl AmplitudeEvent {
                                 changed_group.group_key,
                                 changed_group.changes,
                                 timestamp,
+                                context.job_id,
                             ) {
                                 Ok(group_event) => {
                                     events.push(group_event);
@@ -639,6 +649,7 @@ mod tests {
         TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(MockGroupCache::new()),
             import_events: true,
@@ -999,6 +1010,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(crate::cache::MockGroupCache::new()),
             import_events: true,
@@ -1074,6 +1086,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: cache.clone(),
             group_cache: Arc::new(crate::cache::MockGroupCache::new()),
             import_events: true,
@@ -1116,6 +1129,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(crate::cache::MockGroupCache::new()),
             import_events: true,
@@ -1155,6 +1169,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(crate::cache::MockGroupCache::new()),
             import_events: true,
@@ -1218,6 +1233,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(crate::cache::MockGroupCache::new()),
             import_events: true,
@@ -1274,6 +1290,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(crate::cache::MockGroupCache::new()),
             import_events: false, // Disabled
@@ -1327,6 +1344,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(MockGroupCache::new()),
             import_events: true,
@@ -1424,6 +1442,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: group_cache.clone(),
             import_events: true,
@@ -1498,6 +1517,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: group_cache.clone(),
             import_events: true,
@@ -1566,6 +1586,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(MockGroupCache::new()),
             import_events: true,
@@ -1629,6 +1650,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(MockGroupCache::new()),
             import_events: true,
@@ -1688,6 +1710,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(MockGroupCache::new()),
             import_events: true,
@@ -1738,6 +1761,7 @@ mod tests {
         let context = TransformContext {
             team_id: 123,
             token: "test_token".to_string(),
+            job_id: Uuid::now_v7(),
             identify_cache: Arc::new(MockIdentifyCache::new()),
             group_cache: Arc::new(MockGroupCache::new()),
             import_events: true,

--- a/rust/batch-import-worker/src/parse/content/captured.rs
+++ b/rust/batch-import-worker/src/parse/content/captured.rs
@@ -81,3 +81,58 @@ fn try_parse_to_num(value: Value) -> Value {
         _ => value,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn identity_transform(event: RawEvent) -> Result<Option<RawEvent>, Error> {
+        Ok(Some(event))
+    }
+
+    #[test]
+    fn test_job_id_in_captured_event() {
+        let test_job_id = Uuid::now_v7();
+
+        let mut properties = HashMap::new();
+        properties.insert("test_prop".to_string(), json!("test_value"));
+
+        let raw_event = RawEvent {
+            token: Some("test_token".to_string()),
+            distinct_id: Some(Value::String("user123".to_string())),
+            uuid: Some(Uuid::now_v7()),
+            event: "test_event".to_string(),
+            properties,
+            timestamp: Some("2023-10-15T14:30:00+00:00".to_string()),
+            set: None,
+            set_once: None,
+            offset: None,
+        };
+
+        let context = TransformContext {
+            team_id: 123,
+            token: "test_token".to_string(),
+            job_id: test_job_id,
+            identify_cache: std::sync::Arc::new(crate::cache::MockIdentifyCache::new()),
+            group_cache: std::sync::Arc::new(crate::cache::MockGroupCache::new()),
+            import_events: true,
+            generate_identify_events: false,
+            generate_group_identify_events: false,
+        };
+
+        let parser = captured_parse_fn(context, identity_transform);
+        let result = parser(raw_event).unwrap().unwrap();
+
+        assert_eq!(result.team_id, 123);
+        assert_eq!(result.inner.distinct_id, "user123");
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        assert_eq!(
+            data.properties.get("$import_job_id"),
+            Some(&json!(test_job_id.to_string()))
+        );
+        assert_eq!(data.properties.get("test_prop"), Some(&json!("test_value")));
+    }
+}

--- a/rust/batch-import-worker/src/parse/content/captured.rs
+++ b/rust/batch-import-worker/src/parse/content/captured.rs
@@ -17,6 +17,12 @@ pub fn captured_parse_fn(
 
         //TODO - HACK: relevant customer specifically asked for this, but it's not right in the general case
         raw.map_property("organization_id", try_parse_to_num);
+
+        raw.properties.insert(
+            "$import_job_id".to_string(),
+            Value::String(context.job_id.to_string()),
+        );
+
         let raw = raw;
 
         let Some(distinct_id) = raw.extract_distinct_id() else {

--- a/rust/batch-import-worker/src/parse/content/mixpanel.rs
+++ b/rust/batch-import-worker/src/parse/content/mixpanel.rs
@@ -236,3 +236,56 @@ fn add_source_data(
     );
     props
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn identity_transform(event: RawEvent) -> Result<Option<RawEvent>, Error> {
+        Ok(Some(event))
+    }
+
+    #[test]
+    fn test_job_id_in_mixpanel_event() {
+        let test_job_id = Uuid::now_v7();
+
+        let mx_event = MixpanelEvent {
+            event: "test_event".to_string(),
+            properties: MixpanelProperties {
+                timestamp: 1697379000,
+                distinct_id: Some("user123".to_string()),
+                other: HashMap::new(),
+            },
+        };
+
+        let context = TransformContext {
+            team_id: 123,
+            token: "test_token".to_string(),
+            job_id: test_job_id,
+            identify_cache: std::sync::Arc::new(crate::cache::MockIdentifyCache::new()),
+            group_cache: std::sync::Arc::new(crate::cache::MockGroupCache::new()),
+            import_events: true,
+            generate_identify_events: false,
+            generate_group_identify_events: false,
+        };
+
+        let parser =
+            MixpanelEvent::parse_fn(context, false, Duration::seconds(0), identity_transform);
+        let result = parser(mx_event).unwrap().unwrap();
+
+        let data: RawEvent = serde_json::from_str(&result.inner.data).unwrap();
+        assert_eq!(
+            data.properties.get("$import_job_id"),
+            Some(&json!(test_job_id.to_string()))
+        );
+        assert_eq!(
+            data.properties.get("historical_migration"),
+            Some(&json!(true))
+        );
+        assert_eq!(
+            data.properties.get("analytics_source"),
+            Some(&json!("mixpanel"))
+        );
+    }
+}

--- a/rust/batch-import-worker/src/parse/content/mixpanel.rs
+++ b/rust/batch-import-worker/src/parse/content/mixpanel.rs
@@ -75,7 +75,7 @@ impl MixpanelEvent {
             let properties = mx.properties.other;
             let properties = map_geoip_props(properties);
             let properties = remove_mp_props(properties);
-            let properties = add_source_data(properties);
+            let properties = add_source_data(properties, context.job_id);
 
             let raw_event = RawEvent {
                 token: Some(token.clone()),
@@ -221,11 +221,15 @@ fn remove_mp_props(mut props: HashMap<String, Value>) -> HashMap<String, Value> 
     props
 }
 
-fn add_source_data(mut props: HashMap<String, Value>) -> HashMap<String, Value> {
+fn add_source_data(mut props: HashMap<String, Value>, job_id: uuid::Uuid) -> HashMap<String, Value> {
     props.insert("historical_migration".to_string(), Value::Bool(true));
     props.insert(
         "analytics_source".to_string(),
         Value::String("mixpanel".to_string()),
+    );
+    props.insert(
+        "$import_job_id".to_string(),
+        Value::String(job_id.to_string()),
     );
     props
 }

--- a/rust/batch-import-worker/src/parse/content/mixpanel.rs
+++ b/rust/batch-import-worker/src/parse/content/mixpanel.rs
@@ -221,7 +221,10 @@ fn remove_mp_props(mut props: HashMap<String, Value>) -> HashMap<String, Value> 
     props
 }
 
-fn add_source_data(mut props: HashMap<String, Value>, job_id: uuid::Uuid) -> HashMap<String, Value> {
+fn add_source_data(
+    mut props: HashMap<String, Value>,
+    job_id: uuid::Uuid,
+) -> HashMap<String, Value> {
     props.insert("historical_migration".to_string(), Value::Bool(true));
     props.insert(
         "analytics_source".to_string(),

--- a/rust/batch-import-worker/src/parse/content/mod.rs
+++ b/rust/batch-import-worker/src/parse/content/mod.rs
@@ -23,6 +23,7 @@ pub enum ContentType {
 pub struct TransformContext {
     pub team_id: i32,
     pub token: String,
+    pub job_id: uuid::Uuid,
     pub identify_cache: Arc<dyn IdentifyCache>,
     pub group_cache: Arc<dyn GroupCache>,
     pub import_events: bool,

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -44,6 +44,7 @@ impl FormatConfig {
         let transform_context = TransformContext {
             team_id: model.team_id,
             token: context.get_token_for_team_id(model.team_id).await?,
+            job_id: model.id,
             identify_cache: context.identify_cache.clone(),
             group_cache: context.group_cache.clone(),
             import_events: model.import_config.import_events,


### PR DESCRIPTION
## Problem

If a customer receives duplicate events from Managed Migrations they have run, we'd like to be able to quickly understand if the duplicate came from the same batch import job. Then we'll be able to understand if the customer ran a job twice or if there is a bug in the import worker.

## Changes

Pass the job id to the event transformation/event parsing logic
Add the job id as a $import_job_id property on each event

## How did you test this code?

Unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
