### PR TITLE
chore(cdp): shorten base pod termination timeout

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -339,8 +339,8 @@ export function getDefaultConfig(): PluginsServerConfig {
 
         // Pod termination
         POD_TERMINATION_ENABLED: false,
-        POD_TERMINATION_BASE_TIMEOUT_MINUTES: 30, // Default: 30 minutes
-        POD_TERMINATION_JITTER_MINUTES: 45, // Default: 45 hour, so timeout is between 30 minutes and 1h15m
+        POD_TERMINATION_BASE_TIMEOUT_MINUTES: 15, // Default: 15 minutes
+        POD_TERMINATION_JITTER_MINUTES: 45, // Default: 45 minutes, so timeout is between 15 minutes and 60 minutes
     }
 }
 


### PR DESCRIPTION
## Problem

Context: https://posthog.slack.com/archives/C07CR2K1H6G/p1760371606147689?thread_ts=1760371379.268279&cid=C07CR2K1H6G


## Changes

Modifying timeout range from 30m-1h15m to 15-60m
