### PR TITLE
fix(cdp): set group fetch to use read replica

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-webhooks.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-webhooks.ts
@@ -163,7 +163,8 @@ async function addGroupPropertiesToPostIngestionEvent(
             const group = await groupRepository.fetchGroup(
                 event.teamId as TeamId,
                 columnIndex as GroupTypeIndex,
-                groupKey
+                groupKey,
+                { useReadReplica: true }
             )
 
             const groupProperties = group ? group.group_properties : {}


### PR DESCRIPTION
## Problem

There is a fetch groups query in the cdp webhooks consumer that is a straight read and is not fetching for update. We should use the read replica for this query.

## Changes

Pass the useReadReplica option for the fetch group query

## How did you test this code?

Haven't tested this code, will only change anything in a production environment where we have read replicas

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
