### PR TITLE
chore(kafka-deduplicator): more descriptive config key name

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -25,17 +25,19 @@ pub struct CheckpointConfig {
     /// AWS region for S3
     pub aws_region: String,
 
-    /// Maximum number of local checkpoints to keep around *per partition*
-    pub max_local_checkpoints: usize,
+    /// Maximum number of local checkpoint attempts to keep around *per partition*
+    pub checkpoints_per_partition: usize,
 
-    /// Maximum number of hours for which any local checkpoint is retained
+    /// Maximum number of hours any local checkpoint attempt should be retained
     pub max_checkpoint_retention_hours: u32,
 
-    /// Maximum number of concurrent checkpoints to perform
+    /// Maximum number of concurrent checkpoint attempts to perform on a single node.
+    /// NOTE: checkpoint attempts are unique to a given partition; no two for the same
+    /// partition can be in-flight at the same time
     pub max_concurrent_checkpoints: usize,
 
-    /// How often to attempt to check if a slot is available
-    /// when max_concurrent_checkpoints slots are occupied
+    /// Polling interval to check if a concurrent checkpoint attempt slot
+    /// has become available when max_concurrent_checkpoints slots are occupied
     pub checkpoint_gate_interval: Duration,
 
     /// Timeout for checkpoint worker graceful shutdown (applied in CheckpointManager::stop)
@@ -57,7 +59,7 @@ impl Default for CheckpointConfig {
             s3_key_prefix: "deduplication-checkpoints".to_string(),
             full_upload_interval: 0, // TODO: always full checkpoints until we impl incremental
             aws_region: "us-east-1".to_string(),
-            max_local_checkpoints: 10,
+            checkpoints_per_partition: 5,
             max_checkpoint_retention_hours: 2,
             max_concurrent_checkpoints: 3,
             checkpoint_gate_interval: Duration::from_millis(200),

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -519,12 +519,13 @@ impl CheckpointManager {
 
         // iterate on each group, sort by timestamp dir, and eliminate the oldest N
         for checkpoint_dirs in paths_by_parent.values_mut() {
-            if checkpoint_dirs.len() > config.max_local_checkpoints {
+            if checkpoint_dirs.len() > config.checkpoints_per_partition {
                 // sort by timestamp dir
                 checkpoint_dirs.sort_by(|a, b| a.file_name().unwrap().cmp(b.file_name().unwrap()));
 
                 // eliminate the oldest N snapshots from each /topic/partition group
-                let checkpoints_to_remove = checkpoint_dirs.len() - config.max_local_checkpoints;
+                let checkpoints_to_remove =
+                    checkpoint_dirs.len() - config.checkpoints_per_partition;
                 for checkpoint_dir in checkpoint_dirs.iter().take(checkpoints_to_remove) {
                     let checkpoint_path = checkpoint_dir.to_string_lossy().to_string();
 
@@ -1023,7 +1024,7 @@ mod tests {
             checkpoint_interval: Duration::from_secs(120),
             cleanup_interval: Duration::from_millis(50),
             max_checkpoint_retention_hours: 0,
-            max_local_checkpoints: 100, // don't come near this limit for this test!
+            checkpoints_per_partition: 100, // don't come near this limit for this test!
             local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
             ..Default::default()
         };
@@ -1091,7 +1092,7 @@ mod tests {
             checkpoint_interval: Duration::from_secs(120),
             cleanup_interval: Duration::from_millis(50),
             max_checkpoint_retention_hours: 24, // don't come near this limit for this test!
-            max_local_checkpoints: 0,           // scorched earth
+            checkpoints_per_partition: 0,       // scorched earth
             local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
             ..Default::default()
         };
@@ -1216,8 +1217,7 @@ mod tests {
         let config = CheckpointConfig {
             checkpoint_interval: Duration::from_millis(100),
             cleanup_interval: Duration::from_secs(120),
-            max_local_checkpoints: 3,
-
+            checkpoints_per_partition: 3,
             local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
             ..Default::default()
         };

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -85,7 +85,7 @@ impl KafkaDeduplicatorService {
             s3_key_prefix: config.s3_key_prefix.clone(),
             full_upload_interval: config.checkpoint_full_upload_interval,
             aws_region: config.aws_region.clone(),
-            max_local_checkpoints: config.checkpoints_per_partition,
+            checkpoints_per_partition: config.checkpoints_per_partition,
             max_checkpoint_retention_hours: config.max_checkpoint_retention_hours,
             max_concurrent_checkpoints: config.max_concurrent_checkpoints,
             checkpoint_gate_interval: config.checkpoint_gate_interval(),


### PR DESCRIPTION
## Problem
Cleaning up a bit more cruft as we sort out why config overrides aren't applying in deduplicator as expected
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Rename config key and update call site refs
* Misc. comment cleanup
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; deploy observation is next 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
