### PR TITLE
chore: change task processing workflow timeouts

### DIFF
--- a/products/tasks/backend/services/sandbox_agent.py
+++ b/products/tasks/backend/services/sandbox_agent.py
@@ -90,7 +90,7 @@ class SandboxAgent:
         return f"export ANTHROPIC_API_KEY={settings.ANTHROPIC_API_KEY} && node /scripts/runAgent.mjs --taskId {task_id} --workflowId {workflow_id} --repositoryPath {repo_path}"
 
     def _get_setup_command(self, repo_path: str) -> str:
-        return f"export ANTHROPIC_API_KEY={settings.ANTHROPIC_API_KEY} && claude --dangerously-skip-permissions -p '{SETUP_REPOSITORY_PROMPT.format(cwd=repo_path, repository=repo_path)}' --max-turns 20"
+        return f"export ANTHROPIC_API_KEY={settings.ANTHROPIC_API_KEY} && claude --dangerously-skip-permissions -p '{SETUP_REPOSITORY_PROMPT.format(cwd=repo_path, repository=repo_path)}' --max-turns 3"  # TODO: Increase max turns after testing
 
     async def destroy(self) -> None:
         await self.sandbox.destroy()

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -131,7 +131,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         return await workflow.execute_activity(
             get_task_details,
             task_id,
-            start_to_close_timeout=timedelta(seconds=30),
+            start_to_close_timeout=timedelta(minutes=2),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
@@ -144,7 +144,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         check_result = await workflow.execute_activity(
             check_snapshot_exists_for_repository,
             check_input,
-            start_to_close_timeout=timedelta(seconds=30),
+            start_to_close_timeout=timedelta(minutes=2),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
@@ -163,8 +163,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         return await workflow.execute_activity(
             get_sandbox_for_setup,
             get_sandbox_input,
-            start_to_close_timeout=timedelta(minutes=10),
-            retry_policy=RetryPolicy(maximum_attempts=2),
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
     async def _clone_repository_in_sandbox(self, sandbox_id: str) -> None:
@@ -179,7 +179,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             clone_repository,
             clone_input,
             start_to_close_timeout=timedelta(minutes=10),
-            retry_policy=RetryPolicy(maximum_attempts=2),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
     async def _setup_repository_in_sandbox(self, sandbox_id: str) -> None:
@@ -192,8 +192,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         await workflow.execute_activity(
             setup_repository,
             setup_repo_input,
-            start_to_close_timeout=timedelta(minutes=15),
-            retry_policy=RetryPolicy(maximum_attempts=1),
+            start_to_close_timeout=timedelta(minutes=60),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
     async def _snapshot_sandbox(self, sandbox_id: str) -> str:
@@ -208,7 +208,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         return await workflow.execute_activity(
             create_snapshot,
             snapshot_input,
-            start_to_close_timeout=timedelta(minutes=25),
+            start_to_close_timeout=timedelta(minutes=20),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
@@ -249,7 +249,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             create_sandbox_from_snapshot,
             create_sandbox_input,
             start_to_close_timeout=timedelta(minutes=5),
-            retry_policy=RetryPolicy(maximum_attempts=2),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
     async def _inject_github_token(self, sandbox_id: str) -> None:
@@ -262,7 +262,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         await workflow.execute_activity(
             inject_github_token,
             inject_token_input,
-            start_to_close_timeout=timedelta(minutes=5),
+            start_to_close_timeout=timedelta(minutes=2),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
@@ -275,7 +275,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         return await workflow.execute_activity(
             inject_personal_api_key,
             inject_key_input,
-            start_to_close_timeout=timedelta(minutes=5),
+            start_to_close_timeout=timedelta(minutes=2),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
@@ -284,7 +284,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             await workflow.execute_activity(
                 cleanup_personal_api_key,
                 personal_api_key_id,
-                start_to_close_timeout=timedelta(minutes=5),
+                start_to_close_timeout=timedelta(minutes=10),
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
         except Exception as e:
@@ -301,8 +301,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         return await workflow.execute_activity(
             execute_task_in_sandbox,
             execute_input,
-            start_to_close_timeout=timedelta(minutes=30),
-            retry_policy=RetryPolicy(maximum_attempts=1),
+            start_to_close_timeout=timedelta(minutes=60),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
     async def _track_workflow_event(self, event_name: str, properties: dict) -> None:
@@ -314,6 +314,6 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         await workflow.execute_activity(
             track_workflow_event,
             track_input,
-            start_to_close_timeout=timedelta(seconds=10),
+            start_to_close_timeout=timedelta(minutes=2),
             retry_policy=RetryPolicy(maximum_attempts=1),
         )


### PR DESCRIPTION
## Problem

Some of the workflow timeouts were not long enough.

## Changes

Increases timeouts for repo setup and task execution to 60m
