### PR TITLE
feat(flags): Port `local_evaluation` endpoint to Rust

### DIFF
--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.schema import EventsQuery
@@ -303,6 +304,21 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
             user=self.user,
             secure_value="pbkdf2_sha256$260000$posthog_personal_api_key$dUOOjl6bYdigHd+QfhYzN6P2vM01ZbFROS8dm9KRK7Y=",
         )
+
+    @parameterized.expand(
+        [
+            ("sha256", None, "sha256$45af89b510a3279a817f851de5d3f95b73485d58ec2672a39e52d8aeeb014059"),
+            ("pbkdf2", 1, "pbkdf2_sha256$1$posthog_personal_api_key$vzzA4fHFTiUipScUeDJ4+NjuXwAWWu2AFRbk/JUs6Ck="),
+            (
+                "pbkdf2",
+                260000,
+                "pbkdf2_sha256$260000$posthog_personal_api_key$eeRy21dbVoEzYND0NVLfjXxgNeO67SeBRrwQr6bbhK4=",
+            ),
+        ]
+    )
+    def test_hash_key_values(self, algorithm, iterations, expected_hash):
+        result = hash_key_value("test_key_12345", algorithm, iterations=iterations)
+        assert result == expected_hash
 
     def test_no_key(self):
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/")

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2826,6 +2826,7 @@ dependencies = [
  "common-cookieless",
  "common-database",
  "common-geoip",
+ "common-hypercache",
  "common-metrics",
  "common-redis",
  "common-types",
@@ -2833,6 +2834,7 @@ dependencies = [
  "envconfig",
  "futures",
  "health",
+ "hex",
  "json5",
  "limiters",
  "md5",
@@ -2841,6 +2843,7 @@ dependencies = [
  "opentelemetry 0.22.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.22.1",
+ "pbkdf2",
  "percent-encoding",
  "petgraph",
  "rand 0.8.5",
@@ -2853,6 +2856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2",
  "sqlx",
  "strum 0.26.3",
  "test-case",
@@ -5368,6 +5372,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5381,6 +5396,8 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -34,11 +34,15 @@ serde_json = { workspace = true }
 json5 = "0.4"
 thiserror = { workspace = true }
 sha1 = "0.10.6"
+sha2 = "0.10.8"
+pbkdf2 = { version = "0.12.2", features = ["simple"] }
+hex = "0.4.3"
 regex.workspace = true
 base64.workspace = true
 sqlx = { workspace = true, features = ["rust_decimal"] }
 uuid = { workspace = true }
 common-compression = { path = "../common/compression" }
+common-hypercache = { path = "../common/hypercache" }
 common-alloc = { path = "../common/alloc" }
 strum = { version = "0.26", features = ["derive"] }
 health = { path = "../common/health" }

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -39,7 +39,7 @@ pub async fn validate_secret_api_token(state: &AppState, token: &str) -> Result<
     let pg_reader: PostgresReader = state.database_pools.non_persons_reader.clone();
     let token_str = token.to_string();
 
-    team_operations::fetch_team_with_redis_fallback(
+    team_operations::fetch_team_from_redis_with_fallback(
         state.redis_reader.clone(),
         state.redis_writer.clone(),
         token,

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -216,17 +216,10 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
             let scoped_organizations: Option<Vec<String>> =
                 row.try_get("scoped_organizations").ok();
 
-            // Get the team's organization_id (from cache or database)
-            let team_organization_id = match team.organization_id {
-                Some(org_id) => org_id,
-                None => {
-                    // Old cache entry without organization_id - fetch it from database
-                    sqlx::query_scalar("SELECT organization_id FROM posthog_team WHERE id = $1")
-                        .bind(team.id)
-                        .fetch_one(&mut *conn)
-                        .await?
-                }
-            };
+            // Get the team's organization_id (guaranteed to be present)
+            let team_organization_id = team
+                .organization_id
+                .expect("organization_id should always be present");
             let team_organization_id_str = team_organization_id.to_string();
 
             // Check organization access:

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -216,9 +216,17 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
             let scoped_organizations: Option<Vec<String>> =
                 row.try_get("scoped_organizations").ok();
 
-            // Fetch the team's organization_id
-            let (_, team_organization_id) =
-                Team::from_pg_by_id_with_organization(pg_reader.clone(), team.id).await?;
+            // Get the team's organization_id (from cache or database)
+            let team_organization_id = match team.organization_id {
+                Some(org_id) => org_id,
+                None => {
+                    // Old cache entry without organization_id - fetch it from database
+                    sqlx::query_scalar("SELECT organization_id FROM posthog_team WHERE id = $1")
+                        .bind(team.id)
+                        .fetch_one(&mut *conn)
+                        .await?
+                }
+            };
             let team_organization_id_str = team_organization_id.to_string();
 
             // Check organization access:

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -1,0 +1,385 @@
+use crate::{
+    api::errors::FlagError,
+    router::State as AppState,
+    team::{team_models::Team, team_operations},
+};
+use axum::http::HeaderMap;
+use common_database::PostgresReader;
+use tracing::{debug, warn};
+
+/// Token prefix constants
+const SECRET_TOKEN_PREFIX: &str = "phs_";
+
+/// Extracts bearer token from Authorization header
+pub fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("authorization")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
+/// Extracts team secret API token from Authorization header only
+/// Only tokens starting with SECRET_TOKEN_PREFIX are considered secret API tokens
+pub fn extract_team_secret_token(headers: &HeaderMap) -> Option<String> {
+    extract_bearer_token(headers).filter(|token| token.starts_with(SECRET_TOKEN_PREFIX))
+}
+
+/// Extracts personal API key from Authorization header
+pub fn extract_personal_api_key(headers: &HeaderMap) -> Result<Option<String>, FlagError> {
+    // If it's not a team token (doesn't start with SECRET_TOKEN_PREFIX), treat as personal API key
+    Ok(extract_bearer_token(headers).filter(|token| !token.starts_with(SECRET_TOKEN_PREFIX)))
+}
+
+/// Validates team secret API token and returns Team object
+pub async fn validate_secret_api_token(state: &AppState, token: &str) -> Result<Team, FlagError> {
+    debug!("Validating team token");
+
+    let pg_reader: PostgresReader = state.database_pools.non_persons_reader.clone();
+    let token_str = token.to_string();
+
+    team_operations::fetch_team_with_redis_fallback(
+        state.redis_reader.clone(),
+        state.redis_writer.clone(),
+        token,
+        || async move {
+            Team::from_pg_by_secret_token(pg_reader, &token_str)
+                .await
+                .map_err(|_| FlagError::TokenValidationError)
+        },
+    )
+    .await
+}
+
+/// Validates that a secret API token matches the specified team
+/// Returns Ok(()) if the token belongs to the team, Err otherwise
+pub async fn validate_secret_api_token_for_team(
+    state: &AppState,
+    token: &str,
+    expected_team_id: i32,
+) -> Result<(), FlagError> {
+    debug!(
+        expected_team_id = expected_team_id,
+        "Validating secret API token for team"
+    );
+
+    // Fetch the team using the secret token
+    let pg_reader: PostgresReader = state.database_pools.non_persons_reader.clone();
+    let team = Team::from_pg_by_secret_token(pg_reader, token)
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "Secret API token not found");
+            FlagError::SecretApiTokenInvalid
+        })?;
+
+    // Verify the team ID matches
+    if team.id != expected_team_id {
+        warn!(
+            secret_token_team_id = team.id,
+            expected_team_id = expected_team_id,
+            "Secret API token belongs to a different team"
+        );
+        return Err(FlagError::SecretApiTokenInvalid);
+    }
+
+    debug!(team_id = team.id, "Secret API token validated successfully");
+
+    Ok(())
+}
+
+/// Hash a personal API key value using legacy PBKDF2 mode
+/// Ported from PostHog's `hash_key_value` function in `posthog/models/personal_api_key.py`
+fn hash_legacy_pbkdf2_key(value: &str, iterations: u32) -> String {
+    use pbkdf2::pbkdf2_hmac;
+    use sha2::Sha256;
+
+    let salt = b"posthog_personal_api_key";
+
+    // Compute PBKDF2-HMAC-SHA256 hash
+    let mut hash = [0u8; 32]; // 256 bits / 8 = 32 bytes
+    pbkdf2_hmac::<Sha256>(value.as_bytes(), salt, iterations, &mut hash);
+
+    // Encode hash in base64 and format like Django: pbkdf2_sha256$iterations$salt$hash
+    let hash_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash);
+    format!(
+        "pbkdf2_sha256${}${}${}",
+        iterations,
+        String::from_utf8_lossy(salt),
+        hash_b64
+    )
+}
+
+/// Hash a personal API key value using the specified mode
+/// Ported from PostHog's `hash_key_value` function in `posthog/models/personal_api_key.py`
+fn hash_personal_api_key(value: &str, mode: &str, iterations: Option<u32>) -> String {
+    use sha2::{Digest, Sha256};
+
+    match mode {
+        // Current simple hashing mode
+        "sha256" => {
+            if iterations.is_some() {
+                panic!("Iterations must not be provided when using simple hashing mode");
+            }
+
+            // Inspiration on why no salt:
+            // https://github.com/jazzband/django-rest-knox/issues/188
+            let mut hasher = Sha256::new();
+            hasher.update(value.as_bytes());
+            let result = hasher.finalize();
+            format!("sha256${}", hex::encode(result))
+        }
+        // Legacy PBKDF2 mode
+        "pbkdf2" => {
+            let iterations = iterations.expect("Iterations must be provided for pbkdf2 mode");
+            hash_legacy_pbkdf2_key(value, iterations)
+        }
+        _ => panic!("Unsupported hashing mode: {mode}"),
+    }
+}
+
+/// Validates personal API key with feature flag scopes for a specific team
+/// Returns Ok(()) if the personal API key has access to the specified team
+pub async fn validate_personal_api_key_with_scopes_for_team(
+    state: &AppState,
+    key: &str,
+    team: &Team,
+) -> Result<(), FlagError> {
+    use sqlx::Row;
+
+    debug!(team_id = team.id, "Validating personal API key for team");
+
+    // Try all hashing modes to find the key
+    let modes_to_try = vec![
+        ("sha256", None),
+        ("pbkdf2", Some(260000)),
+        ("pbkdf2", Some(390000)),
+    ];
+
+    let pg_reader: PostgresReader = state.database_pools.non_persons_reader.clone();
+    let mut conn = pg_reader.get_connection().await?;
+
+    for (mode, iterations) in modes_to_try {
+        let secure_value = hash_personal_api_key(key, mode, iterations);
+
+        // Query for PersonalAPIKey with scope validation
+        // The key must:
+        // 1. Have an active user
+        // 2. Have either no scopes (full access) OR have feature_flag:read or feature_flag:write scopes
+        let query = r#"
+            SELECT
+                pak.id as key_id,
+                pak.scopes,
+                pak.scoped_teams,
+                pak.scoped_organizations,
+                u.id as user_id,
+                u.is_active as user_is_active,
+                u.current_organization_id as user_organization_id
+            FROM posthog_personalapikey pak
+            INNER JOIN posthog_user u ON pak.user_id = u.id
+            WHERE pak.secure_value = $1
+              AND u.is_active = true
+              AND (
+                  pak.scopes IS NULL
+                  OR pak.scopes = '{*}'
+                  OR 'feature_flag:read' = ANY(pak.scopes)
+                  OR 'feature_flag:write' = ANY(pak.scopes)
+              )
+        "#;
+
+        let row_result = sqlx::query(query)
+            .bind(&secure_value)
+            .fetch_optional(&mut *conn)
+            .await?;
+
+        if let Some(row) = row_result {
+            // Validate scoped_teams restriction
+            let scoped_teams: Option<Vec<i32>> = row.try_get("scoped_teams").ok();
+            if let Some(ref teams) = scoped_teams {
+                if !teams.is_empty() && !teams.contains(&team.id) {
+                    warn!(
+                        team_id = team.id,
+                        scoped_teams = ?teams,
+                        "Personal API key does not have access to this team"
+                    );
+                    return Err(FlagError::PersonalApiKeyInvalid(
+                        "Authorization header".to_string(),
+                    ));
+                }
+            }
+
+            // Validate organization access (MANDATORY)
+            // Personal API keys can only access teams in organizations where the user is a member,
+            // unless explicitly scoped to specific organizations via scoped_organizations
+            let user_id: i32 = row.get("user_id");
+            let user_organization_id: uuid::Uuid = row.get("user_organization_id");
+            let scoped_organizations: Option<Vec<String>> =
+                row.try_get("scoped_organizations").ok();
+
+            // Fetch the team's organization_id
+            let (_, team_organization_id) =
+                Team::from_pg_by_id_with_organization(pg_reader.clone(), team.id).await?;
+            let team_organization_id_str = team_organization_id.to_string();
+
+            // Check organization access:
+            // - If scoped_organizations has entries: team's org must be in the list
+            // - Otherwise (NULL or empty): user must be a member of the team's org
+            let has_org_access = match scoped_organizations.as_ref() {
+                Some(orgs) if !orgs.is_empty() => orgs.contains(&team_organization_id_str),
+                _ => {
+                    // Check if user is a member of the team's organization
+                    let is_member: bool = sqlx::query_scalar(
+                        "SELECT EXISTS(SELECT 1 FROM posthog_organizationmembership WHERE user_id = $1 AND organization_id = $2)"
+                    )
+                    .bind(user_id)
+                    .bind(team_organization_id)
+                    .fetch_one(&mut *conn)
+                    .await?;
+                    is_member
+                }
+            };
+
+            if !has_org_access {
+                warn!(
+                    user_organization_id = %user_organization_id,
+                    team_organization_id = %team_organization_id_str,
+                    scoped_organizations = ?scoped_organizations,
+                    "Personal API key does not have access to this organization"
+                );
+                return Err(FlagError::PersonalApiKeyInvalid(
+                    "Authorization header".to_string(),
+                ));
+            }
+
+            debug!(
+                user_id = user_id,
+                team_id = team.id,
+                user_organization_id = %user_organization_id,
+                team_organization_id = %team_organization_id_str,
+                scoped_teams = ?scoped_teams,
+                scoped_organizations = ?scoped_organizations,
+                "Personal API key validated successfully with org membership check"
+            );
+
+            return Ok(());
+        }
+    }
+
+    warn!("Personal API key not found or doesn't have required scopes");
+    Err(FlagError::PersonalApiKeyInvalid(
+        "Authorization header".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn test_extract_team_secret_token_from_header() {
+        use axum::http::HeaderMap;
+
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer phs_123456789".parse().unwrap());
+
+        let result = extract_team_secret_token(&headers);
+        assert_eq!(result, Some("phs_123456789".to_string()));
+    }
+
+    #[test]
+    fn test_extract_team_secret_token_requires_phs_prefix() {
+        use axum::http::HeaderMap;
+
+        let mut headers = HeaderMap::new();
+        // Personal API key (phx_*) should not be extracted as secret token
+        headers.insert("authorization", "Bearer phx_personal_key".parse().unwrap());
+
+        let result = extract_team_secret_token(&headers);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_personal_api_key() {
+        use axum::http::HeaderMap;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            "Bearer phx_personal_key_123".parse().unwrap(),
+        );
+
+        let result = extract_personal_api_key(&headers).unwrap();
+        assert_eq!(result, Some("phx_personal_key_123".to_string()));
+
+        // Should not extract team tokens (phs_*)
+        headers.insert("authorization", "Bearer phs_team_token".parse().unwrap());
+        let result = extract_personal_api_key(&headers).unwrap();
+        assert_eq!(result, None);
+    }
+
+    // Ported from PostHog's `test_hash_key_values` function in `posthog/api/test/test_personal_api_keys.py`
+    #[rstest]
+    #[case(
+        "sha256",
+        None,
+        "sha256$45af89b510a3279a817f851de5d3f95b73485d58ec2672a39e52d8aeeb014059"
+    )]
+    #[case(
+        "pbkdf2",
+        Some(1),
+        "pbkdf2_sha256$1$posthog_personal_api_key$vzzA4fHFTiUipScUeDJ4+NjuXwAWWu2AFRbk/JUs6Ck="
+    )]
+    #[case("pbkdf2", Some(260000), "pbkdf2_sha256$260000$posthog_personal_api_key$eeRy21dbVoEzYND0NVLfjXxgNeO67SeBRrwQr6bbhK4=")]
+    fn test_hash_personal_api_key(
+        #[case] algorithm: &str,
+        #[case] iterations: Option<u32>,
+        #[case] expected_hash: &str,
+    ) {
+        let result = hash_personal_api_key("test_key_12345", algorithm, iterations);
+        assert_eq!(result, expected_hash);
+    }
+
+    #[test]
+    #[should_panic(expected = "Iterations must be provided for pbkdf2 mode")]
+    fn test_hash_personal_api_key_pbkdf2_requires_iterations() {
+        hash_personal_api_key("test_key", "pbkdf2", None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Iterations must not be provided when using simple hashing mode")]
+    fn test_hash_personal_api_key_sha256_forbids_iterations() {
+        hash_personal_api_key("test_key", "sha256", Some(100));
+    }
+
+    #[test]
+    fn test_extract_bearer_token() {
+        use axum::http::HeaderMap;
+
+        // Test valid bearer token
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer my_token_123".parse().unwrap());
+        let result = extract_bearer_token(&headers);
+        assert_eq!(result, Some("my_token_123".to_string()));
+
+        // Test with extra whitespace
+        headers.insert("authorization", "Bearer   my_token_456  ".parse().unwrap());
+        let result = extract_bearer_token(&headers);
+        assert_eq!(result, Some("my_token_456".to_string()));
+
+        // Test missing Bearer prefix
+        headers.insert("authorization", "my_token_789".parse().unwrap());
+        let result = extract_bearer_token(&headers);
+        assert_eq!(result, None);
+
+        // Test empty token
+        headers.insert("authorization", "Bearer ".parse().unwrap());
+        let result = extract_bearer_token(&headers);
+        assert_eq!(result, None);
+
+        // Test no authorization header
+        let empty_headers = HeaderMap::new();
+        let result = extract_bearer_token(&empty_headers);
+        assert_eq!(result, None);
+    }
+}

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -1,11 +1,23 @@
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::response::{IntoResponse, Json, Response};
 use common_cookieless::CookielessManagerError;
 use common_database::{extract_timeout_type, is_timeout_error, CustomDatabaseError};
+use common_hypercache::HyperCacheError;
 use common_redis::CustomRedisError;
+use serde::Serialize;
 use thiserror::Error;
 
 use crate::utils::graph_utils::DependencyType;
+
+/// Structured error response matching Django REST Framework's format
+#[derive(Debug, Serialize)]
+pub struct AuthenticationErrorResponse {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub code: String,
+    pub detail: String,
+    pub attr: Option<String>,
+}
 
 #[derive(Error, Debug)]
 pub enum ClientFacingError {
@@ -37,6 +49,12 @@ pub enum FlagError {
     NoTokenError,
     #[error("API key is not valid")]
     TokenValidationError,
+    #[error("Personal API key found in request {0} is invalid")]
+    PersonalApiKeyInvalid(String),
+    #[error("Secret API token is invalid")]
+    SecretApiTokenInvalid,
+    #[error("No authentication credentials provided")]
+    NoAuthenticationProvided,
     #[error("Row not found in postgres")]
     RowNotFound,
     #[error("failed to parse redis cache data")]
@@ -67,6 +85,10 @@ pub enum FlagError {
     PropertiesNotInCache,
     #[error("Static cohort matches not cached")]
     StaticCohortMatchesNotCached,
+    #[error("Cache miss - data not found in cache")]
+    CacheMiss,
+    #[error("Failed to parse data")]
+    DataParsingError,
     #[error(transparent)]
     CookielessError(#[from] CookielessManagerError),
 }
@@ -138,6 +160,33 @@ impl IntoResponse for FlagError {
             }
             FlagError::TokenValidationError => {
                 (StatusCode::UNAUTHORIZED, "The provided API key is invalid or has expired. Please check your API key and try again.".to_string())
+            }
+            FlagError::PersonalApiKeyInvalid(source) => {
+                let response = AuthenticationErrorResponse {
+                    error_type: "authentication_error".to_string(),
+                    code: "authentication_failed".to_string(),
+                    detail: format!("Personal API key found in request {source} is invalid."),
+                    attr: None,
+                };
+                return (StatusCode::UNAUTHORIZED, Json(response)).into_response();
+            }
+            FlagError::SecretApiTokenInvalid => {
+                let response = AuthenticationErrorResponse {
+                    error_type: "authentication_error".to_string(),
+                    code: "authentication_failed".to_string(),
+                    detail: "Secret API token is invalid.".to_string(),
+                    attr: None,
+                };
+                return (StatusCode::UNAUTHORIZED, Json(response)).into_response();
+            }
+            FlagError::NoAuthenticationProvided => {
+                let response = AuthenticationErrorResponse {
+                    error_type: "authentication_error".to_string(),
+                    code: "not_authenticated".to_string(),
+                    detail: "Authentication credentials were not provided.".to_string(),
+                    attr: None,
+                };
+                return (StatusCode::UNAUTHORIZED, Json(response)).into_response();
             }
             FlagError::RedisDataParsingError => {
                 tracing::error!("Data parsing error: {:?}", self);
@@ -228,6 +277,14 @@ impl IntoResponse for FlagError {
             FlagError::StaticCohortMatchesNotCached => {
                 (StatusCode::BAD_REQUEST, "Static cohort matches not cached. Please check your distinct_id and try again.".to_string())
             }
+            FlagError::CacheMiss => {
+                tracing::error!("Cache miss - required data not found in cache");
+                (StatusCode::SERVICE_UNAVAILABLE, "Required data not found in cache. This is likely a temporary issue. Please try again later.".to_string())
+            }
+            FlagError::DataParsingError => {
+                tracing::error!("Failed to parse data");
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse internal data. This is likely a temporary issue. Please try again later.".to_string())
+            }
             FlagError::CookielessError(err) => {
                 match err {
                     // 400 Bad Request errors - client-side issues
@@ -302,6 +359,21 @@ impl From<sqlx::Error> for FlagError {
                 } else {
                     FlagError::DatabaseError(e, None)
                 }
+            }
+        }
+    }
+}
+
+impl From<HyperCacheError> for FlagError {
+    fn from(e: HyperCacheError) -> Self {
+        match e {
+            HyperCacheError::CacheMiss => FlagError::CacheMiss,
+            HyperCacheError::Redis(redis_error) => FlagError::from(redis_error),
+            HyperCacheError::S3(_) => FlagError::CacheMiss,
+            HyperCacheError::Json(_) => FlagError::DataParsingError,
+            HyperCacheError::Compression(_) => FlagError::DataParsingError,
+            HyperCacheError::Timeout(_) => {
+                FlagError::TimeoutError(Some("cache_timeout".to_string()))
             }
         }
     }

--- a/rust/feature-flags/src/api/local_evaluation.rs
+++ b/rust/feature-flags/src/api/local_evaluation.rs
@@ -1,0 +1,196 @@
+use crate::{
+    api::{auth, errors::FlagError},
+    router::State as AppState,
+    team::{team_models::Team, team_operations},
+};
+use axum::{
+    debug_handler,
+    extract::{Query, State},
+    http::{HeaderMap, Method, StatusCode},
+    response::{IntoResponse, Json, Response},
+};
+use common_hypercache::{CacheSource, HyperCacheConfig, HyperCacheReader, KeyType};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{info, warn};
+
+/// Response for local evaluation endpoint
+/// This is returned as raw JSON from cache to avoid deserialization overhead
+pub type LocalEvaluationResponse = Value;
+
+/// Query parameters for the local evaluation endpoint
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LocalEvaluationQueryParams {
+    /// Team API token - required to specify which team's flags to return
+    pub token: String,
+}
+
+/// Local evaluation endpoint handler
+///
+/// This endpoint provides flag definitions for client-side evaluation.
+///
+/// **HTTP Method:** GET only (HEAD and OPTIONS also supported)
+///
+/// **Required Query Parameter:**
+/// - `token`: Team API token (e.g., `phc_...`) - specifies which team's flags to return
+///
+/// **Authentication Methods (one required via Authorization header):**
+/// 1. Team secret API tokens (secret_api_token, secret_api_token_backup)
+/// 2. Personal API keys with feature_flag:read or feature_flag:write scopes
+///
+/// The authentication must have access to the team specified by the token parameter.
+///
+/// **Response:**
+/// The response is retrieved directly from Redis cache using Django's cache keys.
+/// No database fallback is provided - if the cache is empty, an error is returned.
+/// The response always includes cohort definitions.
+#[debug_handler]
+pub async fn flags_definitions(
+    State(state): State<AppState>,
+    Query(params): Query<LocalEvaluationQueryParams>,
+    headers: HeaderMap,
+    method: Method,
+) -> Result<Response, FlagError> {
+    info!(
+        method = %method,
+        token = %params.token,
+        "Processing local evaluation request (always includes cohorts)"
+    );
+
+    // Only GET is supported for this read-only endpoint
+    // HEAD and OPTIONS are handled for HTTP compliance
+    if method != Method::GET {
+        return Ok(handle_non_get_method(&method));
+    }
+
+    // Fetch team using the token from query parameter
+    let team = fetch_team_by_token(&state, &params.token).await?;
+
+    // Authenticate against the specified team
+    authenticate_local_evaluation(&state, &team, &headers).await?;
+
+    // Retrieve cached response from HyperCache (always with cohorts)
+    let cached_response = get_from_cache(&state, &team).await?;
+
+    Ok(Json(cached_response).into_response())
+}
+
+/// Handles non-GET HTTP methods (HEAD, OPTIONS, and unsupported methods)
+fn handle_non_get_method(method: &Method) -> Response {
+    match *method {
+        Method::HEAD => (
+            StatusCode::OK,
+            [("content-type", "application/json")],
+            axum::body::Body::empty(),
+        )
+            .into_response(),
+        Method::OPTIONS => {
+            (StatusCode::NO_CONTENT, [("allow", "GET, OPTIONS, HEAD")]).into_response()
+        }
+        _ => (
+            StatusCode::METHOD_NOT_ALLOWED,
+            [("allow", "GET, OPTIONS, HEAD")],
+        )
+            .into_response(),
+    }
+}
+
+/// Fetches a team by its API token
+/// Tries Redis cache first, then falls back to PostgreSQL
+async fn fetch_team_by_token(state: &AppState, token: &str) -> Result<Team, FlagError> {
+    let pg_reader = state.database_pools.non_persons_reader.clone();
+    let token_str = token.to_string();
+
+    team_operations::fetch_team_with_redis_fallback(
+        state.redis_reader.clone(),
+        state.redis_writer.clone(),
+        token,
+        || async move {
+            Team::from_pg(pg_reader, &token_str)
+                .await
+                .map_err(|_| FlagError::TokenValidationError)
+        },
+    )
+    .await
+}
+
+/// Retrieves the cached response using HyperCache (Redis + S3 fallback)
+///
+/// Always uses the cache with cohorts included to match Django's behavior and ensure
+/// consistency across all clients accessing the same team's data. The cohorts are required
+/// for proper local evaluation of flags that depend on cohort membership.
+async fn get_from_cache(
+    state: &AppState,
+    team: &Team,
+) -> Result<LocalEvaluationResponse, FlagError> {
+    // Configure HyperCache to use the flags_with_cohorts.json cache key
+    // This ensures we always return cohort definitions along with flag definitions
+    let hypercache_config = HyperCacheConfig::new(
+        "feature_flags".to_string(),
+        "flags_with_cohorts.json".to_string(),
+        state.config.object_storage_region.clone(),
+        state.config.object_storage_bucket.clone(),
+    );
+
+    // Set S3 endpoint if configured
+    let mut config = hypercache_config;
+    if !state.config.object_storage_endpoint.is_empty() {
+        config.s3_endpoint = Some(state.config.object_storage_endpoint.clone());
+    }
+
+    // Create HyperCacheReader with the Redis client from state
+    let hypercache_reader = HyperCacheReader::new(state.redis_reader.clone(), config)
+        .await
+        .map_err(|e| {
+            warn!(team_id = team.id, error = %e, "Failed to create HyperCacheReader");
+            FlagError::CacheMiss
+        })?;
+
+    // Use KeyType::team() to generate the proper cache key
+    let team_key = KeyType::team(team.clone());
+
+    // Try to get data from cache (Redis first, then S3 fallback)
+    let (data, source) = hypercache_reader.get_with_source(&team_key).await?;
+
+    let source_name = match source {
+        CacheSource::Redis => "Redis",
+        CacheSource::S3 => "S3",
+    };
+    info!(
+        team_id = team.id,
+        source = source_name,
+        "Cache hit for local evaluation (with cohorts)"
+    );
+
+    Ok(data)
+}
+
+/// Authenticates local evaluation requests using team secret API tokens or personal API keys
+///
+/// Validates that the authentication credential has access to the specified team.
+///
+/// Supports two authentication methods:
+/// 1. Team secret API tokens (secret_api_token, secret_api_token_backup) from Authorization header
+/// 2. Personal API keys with feature_flag:read or feature_flag:write scopes
+///
+/// Priority: Secret API tokens take precedence over personal API keys when both are provided.
+///
+/// Returns Ok(()) if authentication succeeds, Err otherwise
+async fn authenticate_local_evaluation(
+    state: &AppState,
+    team: &Team,
+    headers: &HeaderMap,
+) -> Result<(), FlagError> {
+    // Try team secret token first (from Authorization header only)
+    // Secret tokens have priority over personal API keys
+    if let Some(token) = auth::extract_team_secret_token(headers) {
+        return auth::validate_secret_api_token_for_team(state, &token, team.id).await;
+    }
+
+    // Try personal API key (with scope validation)
+    if let Some(key) = auth::extract_personal_api_key(headers)? {
+        return auth::validate_personal_api_key_with_scopes_for_team(state, &key, team).await;
+    }
+
+    Err(FlagError::NoAuthenticationProvided)
+}

--- a/rust/feature-flags/src/api/local_evaluation.rs
+++ b/rust/feature-flags/src/api/local_evaluation.rs
@@ -101,7 +101,7 @@ async fn fetch_team_by_token(state: &AppState, token: &str) -> Result<Team, Flag
     let pg_reader = state.database_pools.non_persons_reader.clone();
     let token_str = token.to_string();
 
-    team_operations::fetch_team_with_redis_fallback(
+    team_operations::fetch_team_from_redis_with_fallback(
         state.redis_reader.clone(),
         state.redis_writer.clone(),
         token,

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -1,3 +1,5 @@
+pub mod auth;
 pub mod endpoint;
 pub mod errors;
+pub mod local_evaluation;
 pub mod types;

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -138,6 +138,16 @@ pub struct Config {
     #[envconfig(default = "")]
     pub redis_reader_url: String,
 
+    // S3 configuration for HyperCache fallback
+    #[envconfig(default = "posthog")]
+    pub object_storage_bucket: String,
+
+    #[envconfig(default = "us-east-1")]
+    pub object_storage_region: String,
+
+    #[envconfig(default = "")]
+    pub object_storage_endpoint: String,
+
     #[envconfig(default = "")]
     pub redis_writer_url: String,
 
@@ -313,6 +323,9 @@ impl Config {
             otel_sampling_rate: 1.0,
             otel_service_name: "posthog-feature-flags".to_string(),
             otel_log_level: Level::ERROR,
+            object_storage_bucket: "posthog".to_string(),
+            object_storage_region: "us-east-1".to_string(),
+            object_storage_endpoint: "".to_string(),
         }
     }
 

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -251,6 +251,7 @@ mod tests {
             api_token: "test-token".to_string(),
             project_id: 1,
             uuid: Uuid::new_v4(),
+            organization_id: None,
             autocapture_opt_out: None,
             autocapture_exceptions_opt_in: None,
             autocapture_web_vitals_opt_in: None,

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -19,7 +19,7 @@ use tower_http::{
 };
 
 use crate::{
-    api::endpoint,
+    api::{endpoint, local_evaluation},
     cohorts::cohort_cache_manager::CohortCacheManager,
     config::{Config, TeamIdCollection},
     metrics::utils::team_id_label_filter,
@@ -87,6 +87,14 @@ where
     let flags_router = Router::new()
         .route("/flags", any(endpoint::flags))
         .route("/flags/", any(endpoint::flags))
+        .route(
+            "/flags/definitions",
+            any(local_evaluation::flags_definitions),
+        )
+        .route(
+            "/flags/definitions/",
+            any(local_evaluation::flags_definitions),
+        )
         .route("/decide", any(endpoint::flags))
         .route("/decide/", any(endpoint::flags))
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency));

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -16,6 +16,7 @@ pub struct Team {
     /// Thanks to this default-base approach, we avoid invalidating the whole cache needlessly.
     pub project_id: ProjectId,
     pub uuid: Uuid,
+    pub organization_id: Option<Uuid>,
     pub autocapture_opt_out: Option<bool>,
     pub autocapture_exceptions_opt_in: Option<bool>,
     pub autocapture_web_vitals_opt_in: Option<bool>,

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -4,7 +4,94 @@ use crate::{
 };
 use common_database::PostgresReader;
 use common_redis::Client as RedisClient;
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
+use tracing::{debug, warn};
+
+/// Fetches a team from Redis cache with PostgreSQL fallback
+///
+/// This helper consolidates the common pattern of:
+/// 1. Try Redis cache first
+/// 2. On cache miss, fetch from PostgreSQL using the provided lookup function
+/// 3. Update Redis cache on successful database fetch
+/// 4. Return the team
+///
+/// # Arguments
+/// * `redis_reader` - Redis client for cache reads
+/// * `redis_writer` - Redis client for cache writes
+/// * `token` - Token to use for cache key lookup
+/// * `db_lookup` - Async function to fetch team from PostgreSQL on cache miss
+pub async fn fetch_team_with_redis_fallback<F, Fut>(
+    redis_reader: Arc<dyn RedisClient + Send + Sync>,
+    redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    token: &str,
+    db_lookup: F,
+) -> Result<Team, FlagError>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<Team, FlagError>>,
+{
+    // Try to get team from cache first
+    match Team::from_redis(redis_reader, token).await {
+        Ok(team) => {
+            debug!(team_id = team.id, "Found team in Redis cache");
+            Ok(team)
+        }
+        Err(e) => {
+            debug!(error = %e, "Team not found in Redis cache");
+            // Fallback to database using provided lookup function
+            match db_lookup().await {
+                Ok(team) => {
+                    debug!(team_id = team.id, "Found team in PostgreSQL");
+                    // Update Redis cache for next time
+                    if let Err(e) = Team::update_redis_cache(redis_writer, &team).await {
+                        warn!(team_id = team.id, error = %e, "Failed to update Redis cache");
+                    }
+                    Ok(team)
+                }
+                Err(e) => {
+                    warn!(error = %e, "Team not found in PostgreSQL");
+                    Err(e)
+                }
+            }
+        }
+    }
+}
+
+/// SQL fragment for selecting all Team columns
+const TEAM_COLUMNS: &str = "
+    id,
+    uuid,
+    name,
+    api_token,
+    project_id,
+    cookieless_server_hash_mode,
+    timezone,
+    autocapture_opt_out,
+    autocapture_exceptions_opt_in,
+    autocapture_web_vitals_opt_in,
+    capture_performance_opt_in,
+    capture_console_log_opt_in,
+    session_recording_opt_in,
+    inject_web_apps,
+    surveys_opt_in,
+    heatmaps_opt_in,
+    capture_dead_clicks,
+    flags_persistence_default,
+    session_recording_sample_rate,
+    session_recording_minimum_duration_milliseconds,
+    autocapture_web_vitals_allowed_metrics,
+    autocapture_exceptions_errors_to_ignore,
+    session_recording_linked_flag,
+    session_recording_network_payload_capture_config,
+    session_recording_masking_config,
+    session_replay_config,
+    survey_config,
+    session_recording_url_trigger_config,
+    session_recording_url_blocklist_config,
+    session_recording_event_trigger_config,
+    session_recording_trigger_match_type_config,
+    recording_domains
+";
 
 impl Team {
     /// Validates a token, and returns a team if it exists.
@@ -84,47 +171,68 @@ impl Team {
     pub async fn from_pg(client: PostgresReader, token: &str) -> Result<Team, FlagError> {
         let mut conn = client.get_connection().await?;
 
-        let query = "SELECT 
-            id, 
-            uuid,
-            name, 
-            api_token, 
-            project_id, 
-            cookieless_server_hash_mode, 
-            timezone,
-            autocapture_opt_out,
-            autocapture_exceptions_opt_in,
-            autocapture_web_vitals_opt_in,
-            capture_performance_opt_in,
-            capture_console_log_opt_in,
-            session_recording_opt_in,
-            inject_web_apps,
-            surveys_opt_in,
-            heatmaps_opt_in,
-            capture_dead_clicks,
-            flags_persistence_default,
-            session_recording_sample_rate,
-            session_recording_minimum_duration_milliseconds,
-            autocapture_web_vitals_allowed_metrics,
-            autocapture_exceptions_errors_to_ignore,
-            session_recording_linked_flag,
-            session_recording_network_payload_capture_config,
-            session_recording_masking_config,
-            session_replay_config,
-            survey_config,
-            session_recording_url_trigger_config,
-            session_recording_url_blocklist_config,
-            session_recording_event_trigger_config,
-            session_recording_trigger_match_type_config,
-            recording_domains
-        FROM posthog_team 
-        WHERE api_token = $1";
-        let row = sqlx::query_as::<_, Team>(query)
+        let query = format!("SELECT {TEAM_COLUMNS} FROM posthog_team WHERE api_token = $1");
+        let row = sqlx::query_as::<_, Team>(&query)
             .bind(token)
             .fetch_one(&mut *conn)
             .await?;
 
         Ok(row)
+    }
+
+    pub async fn from_pg_by_secret_token(
+        client: PostgresReader,
+        token: &str,
+    ) -> Result<Team, FlagError> {
+        let mut conn = client.get_connection().await?;
+
+        let query = format!(
+            "SELECT {TEAM_COLUMNS} FROM posthog_team WHERE secret_api_token = $1 OR secret_api_token_backup = $1"
+        );
+        let row = sqlx::query_as::<_, Team>(&query)
+            .bind(token)
+            .fetch_one(&mut *conn)
+            .await?;
+
+        Ok(row)
+    }
+
+    pub async fn from_pg_by_id(client: PostgresReader, team_id: i32) -> Result<Team, FlagError> {
+        let mut conn = client.get_connection().await?;
+
+        let query = format!("SELECT {TEAM_COLUMNS} FROM posthog_team WHERE id = $1");
+        let row = sqlx::query_as::<_, Team>(&query)
+            .bind(team_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+        Ok(row)
+    }
+
+    /// Fetches a team by ID along with its organization_id in a single query.
+    /// Used when organization_id is needed for validation (e.g., Personal API Key scoped_organizations).
+    pub async fn from_pg_by_id_with_organization(
+        client: PostgresReader,
+        team_id: i32,
+    ) -> Result<(Team, sqlx::types::Uuid), FlagError> {
+        use sqlx::{FromRow, Row};
+
+        let mut conn = client.get_connection().await?;
+
+        let query =
+            format!("SELECT {TEAM_COLUMNS}, organization_id FROM posthog_team WHERE id = $1");
+        let row = sqlx::query(&query)
+            .bind(team_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+        // Parse the Team using FromRow trait
+        let team = Team::from_row(&row)?;
+
+        // Extract organization_id separately
+        let organization_id: sqlx::types::Uuid = row.try_get("organization_id")?;
+
+        Ok((team, organization_id))
     }
 }
 

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -20,7 +20,7 @@ use tracing::{debug, warn};
 /// * `redis_writer` - Redis client for cache writes
 /// * `token` - Token to use for cache key lookup
 /// * `db_lookup` - Async function to fetch team from PostgreSQL on cache miss
-pub async fn fetch_team_with_redis_fallback<F, Fut>(
+pub async fn fetch_team_from_redis_with_fallback<F, Fut>(
     redis_reader: Arc<dyn RedisClient + Send + Sync>,
     redis_writer: Arc<dyn RedisClient + Send + Sync>,
     token: &str,

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -242,65 +242,38 @@ pub async fn setup_invalid_pg_client() -> Arc<dyn Client + Send + Sync> {
     Arc::new(MockPgClient)
 }
 
-pub async fn insert_new_team_in_pg(
-    persons_client: Arc<dyn Client + Send + Sync>,
-    non_persons_client: Arc<dyn Client + Send + Sync>,
-    team_id: Option<i32>,
-) -> Result<Team, Error> {
-    const ORG_ID: &str = "019026a4be8000005bf3171d00629163";
+/// Inserts an organization if it doesn't exist
+/// If slug is not provided, generates one from the org_id
+async fn insert_organization_if_not_exists(
+    conn: &mut PoolConnection<Postgres>,
+    org_id: &str,
+    slug: Option<&str>,
+) -> Result<(), Error> {
+    let org_slug = match slug {
+        Some(s) => s.to_string(),
+        None => format!("test-org-{}", &org_id[..8]),
+    };
 
-    // Create new organization from scratch (in non-persons database)
-    let mut conn = non_persons_client.get_connection().await?;
-    sqlx::query(r#"INSERT INTO posthog_organization
+    sqlx::query(
+        r#"INSERT INTO posthog_organization
         (id, name, slug, created_at, updated_at, plugins_access_level, for_internal_metrics, is_member_join_email_enabled, enforce_2fa, is_hipaa, customer_id, available_product_features, personalization, setup_section_2_completed, domain_whitelist, members_can_use_personal_api_keys, allow_publicly_shared_resources)
         VALUES
-        ($1::uuid, 'Test Organization', 'test-organization', '2024-06-17 14:40:49.298579+00:00', '2024-06-17 14:40:49.298593+00:00', 9, false, true, NULL, false, NULL, '{}', '{}', true, '{}', true, true)
-        ON CONFLICT DO NOTHING"#)
-        .bind(ORG_ID)
-        .execute(&mut *conn)
-        .await?;
-
-    // Create team model
-    let id = match team_id {
-        Some(value) => value,
-        None => rand::thread_rng().gen_range(0..10_000_000),
-    };
-    let token = random_string("phc_", 12);
-    let team = Team {
-        id,
-        project_id: id as i64,
-        name: "Test Team".to_string(),
-        api_token: token.clone(),
-        cookieless_server_hash_mode: 0,
-        timezone: "UTC".to_string(),
-        ..Default::default()
-    };
-    let uuid = Uuid::now_v7();
-
-    let mut non_persons_conn = non_persons_client.get_connection().await?;
-
-    // Insert a project for the team (in non-persons database)
-    let res = sqlx::query(
-        r#"INSERT INTO posthog_project
-        (id, organization_id, name, created_at) VALUES
-        ($1, $2::uuid, $3, '2024-06-17 14:40:51.332036+00:00')"#,
+        ($1::uuid, 'Test Organization', $2, '2024-06-17 14:40:49.298579+00:00', '2024-06-17 14:40:49.298593+00:00', 9, false, true, NULL, false, NULL, '{}', '{}', true, '{}', true, true)
+        ON CONFLICT DO NOTHING"#,
     )
-    .bind(team.project_id)
-    .bind(ORG_ID)
-    .bind(&team.name)
-    .execute(&mut *non_persons_conn)
+    .bind(org_id)
+    .bind(&org_slug)
+    .execute(&mut **conn)
     .await?;
-    assert_eq!(res.rows_affected(), 1);
 
-    // Insert a team with the correct team-project relationship (in non-persons database)
-    let res = sqlx::query(
-        r#"INSERT INTO posthog_team
-        (id, uuid, organization_id, project_id, api_token, name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical, cookieless_server_hash_mode, base_currency, session_recording_retention_period, web_analytics_pre_aggregated_tables_enabled) VALUES
-        ($1, $2, $3::uuid, $4, $5, $6, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]', $7, 'USD', '30d', false)"#
-    ).bind(team.id).bind(uuid).bind(ORG_ID).bind(team.project_id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode).execute(&mut *non_persons_conn).await?;
-    assert_eq!(res.rows_affected(), 1);
+    Ok(())
+}
 
-    // Insert group type mappings (in persons database)
+/// Inserts group type mappings for a team in the persons database
+async fn insert_team_group_mappings(
+    persons_client: Arc<dyn Client + Send + Sync>,
+    team: &Team,
+) -> Result<(), Error> {
     let mut persons_conn = persons_client.get_connection().await?;
     let group_types = vec![
         ("project", 0),
@@ -325,6 +298,62 @@ pub async fn insert_new_team_in_pg(
         .await?;
         assert_eq!(res.rows_affected(), 1);
     }
+
+    Ok(())
+}
+
+pub async fn insert_new_team_in_pg(
+    persons_client: Arc<dyn Client + Send + Sync>,
+    non_persons_client: Arc<dyn Client + Send + Sync>,
+    team_id: Option<i32>,
+    org_id: Option<&str>,
+) -> Result<Team, Error> {
+    let org_id = org_id.unwrap_or("019026a4be8000005bf3171d00629163");
+
+    // Create team model
+    let id = match team_id {
+        Some(value) => value,
+        None => rand::thread_rng().gen_range(0..10_000_000),
+    };
+    let token = random_string("phc_", 12);
+    let team = Team {
+        id,
+        project_id: id as i64,
+        name: "Test Team".to_string(),
+        api_token: token.clone(),
+        cookieless_server_hash_mode: 0,
+        timezone: "UTC".to_string(),
+        ..Default::default()
+    };
+
+    // Insert organization and project
+    let mut non_persons_conn = non_persons_client.get_connection().await?;
+    insert_organization_if_not_exists(&mut non_persons_conn, org_id, None).await?;
+
+    let uuid = Uuid::now_v7();
+    let res = sqlx::query(
+        r#"INSERT INTO posthog_project
+        (id, organization_id, name, created_at) VALUES
+        ($1, $2::uuid, $3, '2024-06-17 14:40:51.332036+00:00')"#,
+    )
+    .bind(team.project_id)
+    .bind(org_id)
+    .bind(&team.name)
+    .execute(&mut *non_persons_conn)
+    .await?;
+    assert_eq!(res.rows_affected(), 1);
+
+    // Insert team without secret tokens
+    let res = sqlx::query(
+        r#"INSERT INTO posthog_team
+        (id, uuid, organization_id, project_id, api_token, name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical, cookieless_server_hash_mode, base_currency, session_recording_retention_period, web_analytics_pre_aggregated_tables_enabled) VALUES
+        ($1, $2, $3::uuid, $4, $5, $6, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]', $7, 'USD', '30d', false)"#
+    ).bind(team.id).bind(uuid).bind(org_id).bind(team.project_id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode).execute(&mut *non_persons_conn).await?;
+    assert_eq!(res.rows_affected(), 1);
+
+    // Insert group type mappings
+    insert_team_group_mappings(persons_client, &team).await?;
+
     Ok(team)
 }
 
@@ -763,20 +792,22 @@ pub struct TestContext {
     pub persons_writer: Arc<dyn Client + Send + Sync>,
     pub non_persons_reader: Arc<dyn Client + Send + Sync>,
     pub non_persons_writer: Arc<dyn Client + Send + Sync>,
+    config: Config,
 }
 
 impl TestContext {
     pub async fn new(config: Option<&Config>) -> Self {
-        let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
+        let config = config.unwrap_or(&DEFAULT_TEST_CONFIG).clone();
 
-        let (persons_reader, non_persons_reader) = setup_dual_pg_readers(Some(config)).await;
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(Some(config)).await;
+        let (persons_reader, non_persons_reader) = setup_dual_pg_readers(Some(&config)).await;
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(Some(&config)).await;
 
         Self {
             persons_reader,
             persons_writer,
             non_persons_reader,
             non_persons_writer,
+            config,
         }
     }
 
@@ -794,6 +825,21 @@ impl TestContext {
             self.persons_writer.clone(),
             self.non_persons_writer.clone(),
             team_id,
+            None,
+        )
+        .await
+    }
+
+    pub async fn insert_new_team_with_org(
+        &self,
+        team_id: Option<i32>,
+        org_id: &str,
+    ) -> Result<Team, Error> {
+        insert_new_team_in_pg(
+            self.persons_writer.clone(),
+            self.non_persons_writer.clone(),
+            team_id,
+            Some(org_id),
         )
         .await
     }
@@ -926,5 +972,295 @@ impl TestContext {
         distinct_id: &str,
     ) -> Result<PersonId, Error> {
         get_person_id_by_distinct_id(self.persons_reader.clone(), team_id, distinct_id).await
+    }
+
+    /// Creates a user with configurable options
+    pub async fn create_user_with_options(
+        &self,
+        email: &str,
+        org_id: &uuid::Uuid,
+        team_id: Option<i32>,
+        is_active: bool,
+    ) -> Result<i32, Error> {
+        let mut conn = self.non_persons_writer.get_connection().await?;
+        let user_uuid = uuid::Uuid::new_v4();
+
+        let user_id: i32 = if let Some(team_id) = team_id {
+            sqlx::query(
+                "INSERT INTO posthog_user (
+                    password, last_login, email, first_name, last_name, is_active, is_staff, date_joined,
+                    events_column_config, current_organization_id, current_team_id, uuid
+                 )
+                 VALUES ('', NULL, $1, 'Test', 'User', $2, false, NOW(), '{\"active\": \"DEFAULT\"}'::jsonb, $3, $4, $5)
+                 RETURNING id",
+            )
+            .bind(email)
+            .bind(is_active)
+            .bind(org_id)
+            .bind(team_id)
+            .bind(user_uuid)
+            .fetch_one(&mut *conn)
+            .await?
+            .get(0)
+        } else {
+            sqlx::query(
+                "INSERT INTO posthog_user (
+                    password, last_login, email, first_name, last_name, is_active, is_staff, date_joined,
+                    events_column_config, current_organization_id, current_team_id, uuid
+                 )
+                 VALUES ('', NULL, $1, 'Test', 'User', $2, false, NOW(), '{\"active\": \"DEFAULT\"}'::jsonb, $3, NULL, $4)
+                 RETURNING id",
+            )
+            .bind(email)
+            .bind(is_active)
+            .bind(org_id)
+            .bind(user_uuid)
+            .fetch_one(&mut *conn)
+            .await?
+            .get(0)
+        };
+
+        Ok(user_id)
+    }
+
+    /// Creates an active user with a team (common case)
+    pub async fn create_user(
+        &self,
+        email: &str,
+        org_id: &uuid::Uuid,
+        team_id: i32,
+    ) -> Result<i32, Error> {
+        self.create_user_with_options(email, org_id, Some(team_id), true)
+            .await
+    }
+
+    /// Creates a personal API key with hashed value (SHA256 mode)
+    pub async fn create_personal_api_key(
+        &self,
+        user_id: i32,
+        label: &str,
+        scopes: Vec<&str>,
+        scoped_teams: Option<Vec<i32>>,
+        scoped_organizations: Option<Vec<String>>,
+    ) -> Result<(String, String), Error> {
+        // Generate unique PAK ID and value
+        let pak_id = format!("test_pak_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let api_key_value = format!("phx_{}", &uuid::Uuid::new_v4().to_string()[..12]);
+
+        // Hash the key using SHA256
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(api_key_value.as_bytes());
+        let hash_result = hasher.finalize();
+        let secure_value = format!("sha256${}", hex::encode(hash_result));
+
+        let mut conn = self.non_persons_writer.get_connection().await?;
+
+        // Convert scopes to Vec<String>
+        let scopes_vec: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
+
+        let mut query = sqlx::QueryBuilder::new(
+            "INSERT INTO posthog_personalapikey (id, user_id, label, secure_value, created_at, scopes",
+        );
+
+        if scoped_teams.is_some() {
+            query.push(", scoped_teams");
+        }
+        if scoped_organizations.is_some() {
+            query.push(", scoped_organizations");
+        }
+
+        query.push(") VALUES (");
+        query.push_bind(&pak_id);
+        query.push(", ");
+        query.push_bind(user_id);
+        query.push(", ");
+        query.push_bind(label);
+        query.push(", ");
+        query.push_bind(&secure_value);
+        query.push(", NOW(), ");
+        query.push_bind(&scopes_vec);
+
+        if let Some(teams) = scoped_teams {
+            query.push(", ");
+            query.push_bind(teams);
+        }
+        if let Some(orgs) = scoped_organizations {
+            query.push(", ");
+            query.push_bind(orgs);
+        }
+
+        query.push(")");
+
+        query.build().execute(&mut *conn).await?;
+
+        Ok((pak_id, api_key_value))
+    }
+
+    /// Creates a team with both public token and secret API token
+    /// Optionally accepts a backup secret token
+    pub async fn create_team_with_secret_token(
+        &self,
+        public_token: Option<&str>,
+        secret_token: Option<&str>,
+        backup_secret_token: Option<&str>,
+    ) -> Result<(Team, String, Option<String>), Error> {
+        // Generate unique tokens if not provided
+        let public_token = public_token
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| random_string("phc_", 12));
+        let secret_token = secret_token
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| random_string("phs_", 12));
+        let backup_secret_token = backup_secret_token.map(|s| s.to_string());
+
+        const ORG_ID: &str = "019026a4be8000005bf3171d00629163";
+
+        // Create team model
+        let id = rand::thread_rng().gen_range(0..10_000_000);
+        let team = Team {
+            id,
+            project_id: id as i64,
+            name: "Test Team".to_string(),
+            api_token: public_token.clone(),
+            cookieless_server_hash_mode: 0,
+            timezone: "UTC".to_string(),
+            ..Default::default()
+        };
+
+        // Insert organization and project
+        let mut conn = self.non_persons_writer.get_connection().await?;
+        insert_organization_if_not_exists(&mut conn, ORG_ID, None).await?;
+
+        let uuid = Uuid::now_v7();
+        let res = sqlx::query(
+            r#"INSERT INTO posthog_project
+            (id, organization_id, name, created_at) VALUES
+            ($1, $2::uuid, $3, '2024-06-17 14:40:51.332036+00:00')"#,
+        )
+        .bind(team.project_id)
+        .bind(ORG_ID)
+        .bind(&team.name)
+        .execute(&mut *conn)
+        .await?;
+        assert_eq!(res.rows_affected(), 1);
+
+        // Insert team with secret tokens
+        let mut query_str = String::from(
+            "INSERT INTO posthog_team (id, uuid, organization_id, project_id, api_token, secret_api_token"
+        );
+
+        // Add secret_api_token_backup column if provided
+        if backup_secret_token.is_some() {
+            query_str.push_str(", secret_api_token_backup");
+        }
+
+        query_str.push_str(", name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical, cookieless_server_hash_mode, base_currency, session_recording_retention_period, web_analytics_pre_aggregated_tables_enabled) VALUES ($1, $2, $3::uuid, $4, $5, $6");
+
+        // Add backup token parameter placeholder if provided
+        if backup_secret_token.is_some() {
+            query_str.push_str(", $7");
+            query_str.push_str(", $8, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '[\"data-attr\"]', false, false, '[]', '[]', '[]', '[]', '[]', $9, 'USD', '30d', false)");
+        } else {
+            query_str.push_str(", $7, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '[\"data-attr\"]', false, false, '[]', '[]', '[]', '[]', '[]', $8, 'USD', '30d', false)");
+        }
+
+        let mut query = sqlx::query(&query_str)
+            .bind(team.id)
+            .bind(uuid)
+            .bind(ORG_ID)
+            .bind(team.project_id)
+            .bind(&team.api_token)
+            .bind(&secret_token);
+
+        if let Some(ref backup) = backup_secret_token {
+            query = query.bind(backup);
+        }
+
+        query = query
+            .bind(&team.name)
+            .bind(team.cookieless_server_hash_mode);
+
+        let res = query.execute(&mut *conn).await?;
+        assert_eq!(res.rows_affected(), 1);
+
+        // Insert group type mappings
+        insert_team_group_mappings(self.persons_writer.clone(), &team).await?;
+
+        Ok((team, secret_token, backup_secret_token))
+    }
+
+    /// Populates the HyperCache with flag definitions for local_evaluation endpoint
+    /// Uses the same cache key format that Django's cache warming uses
+    pub async fn populate_local_evaluation_cache(
+        &self,
+        redis: Arc<dyn RedisClientTrait + Send + Sync>,
+        team_id: i32,
+    ) -> Result<(), Error> {
+        // Cache key format: posthog:1:cache/teams/{team_id}/feature_flags/flags_with_cohorts.json
+        let cache_key =
+            format!("posthog:1:cache/teams/{team_id}/feature_flags/flags_with_cohorts.json");
+
+        // Create minimal valid flag definitions response
+        let flags_data = json!({
+            "flags": [],
+            "group_type_mapping": {},
+            "cohorts": {}
+        });
+
+        let payload = serde_json::to_string(&flags_data)?;
+
+        redis
+            .set(cache_key, payload)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to set cache: {}", e))?;
+
+        Ok(())
+    }
+
+    /// Gets the organization_id for a team by querying the project table
+    pub async fn get_organization_id_for_team(&self, team: &Team) -> Result<uuid::Uuid, Error> {
+        let mut conn = self.non_persons_reader.get_connection().await?;
+        let org_id: uuid::Uuid =
+            sqlx::query_scalar("SELECT organization_id FROM posthog_project WHERE id = $1")
+                .bind(team.project_id)
+                .fetch_one(&mut *conn)
+                .await?;
+        Ok(org_id)
+    }
+
+    /// Simplified helper to populate cache for a team
+    /// Handles Redis client setup internally
+    pub async fn populate_cache_for_team(&self, team_id: i32) -> Result<(), Error> {
+        let redis_client = setup_redis_client(Some(self.config.redis_url.clone())).await;
+        self.populate_local_evaluation_cache(redis_client, team_id)
+            .await
+    }
+
+    /// Generates a unique test email address with an optional prefix
+    pub fn generate_test_email(prefix: &str) -> String {
+        let unique_id = &uuid::Uuid::new_v4().to_string()[..8];
+        format!("{prefix}_{unique_id}@posthog.com")
+    }
+
+    /// Adds a user to an organization with a specified membership level
+    pub async fn add_user_to_organization(
+        &self,
+        user_id: i32,
+        org_id: &uuid::Uuid,
+        level: i16,
+    ) -> Result<(), Error> {
+        let mut conn = self.non_persons_writer.get_connection().await?;
+        sqlx::query(
+            "INSERT INTO posthog_organizationmembership (id, organization_id, user_id, level, joined_at, updated_at)
+             VALUES ($1, $2, $3, $4, NOW(), NOW())",
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(org_id)
+        .bind(user_id)
+        .bind(level)
+        .execute(&mut *conn)
+        .await?;
+        Ok(())
     }
 }

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -31,6 +31,7 @@ impl ServerHandle {
         ServerHandle { addr, shutdown }
     }
 
+    #[allow(dead_code)]
     pub async fn for_config_with_mock_redis(
         config: Config,
         limited_tokens: Vec<String>,
@@ -237,6 +238,7 @@ impl ServerHandle {
         ServerHandle { addr, shutdown }
     }
 
+    #[allow(dead_code)]
     pub async fn send_flags_request<T: Into<reqwest::Body>>(
         &self,
         body: T,
@@ -265,6 +267,7 @@ impl ServerHandle {
             .expect("failed to send request")
     }
 
+    #[allow(dead_code)]
     pub async fn send_invalid_header_for_flags_request<T: Into<reqwest::Body>>(
         &self,
         body: T,
@@ -286,6 +289,7 @@ impl Drop for ServerHandle {
     }
 }
 
+#[allow(dead_code)]
 async fn liveness_loop(handle: health::HealthHandle) {
     loop {
         handle.report_healthy().await;

--- a/rust/feature-flags/tests/test_local_evaluation.rs
+++ b/rust/feature-flags/tests/test_local_evaluation.rs
@@ -1,0 +1,1034 @@
+mod common;
+
+#[tokio::test]
+async fn test_hypercache_config_generation() {
+    use common_hypercache::{HyperCacheConfig, KeyType};
+    use common_types::TeamIdentifier;
+
+    // Create a test team that implements TeamIdentifier
+    #[derive(Debug, Clone)]
+    struct TestTeam {
+        id: i32,
+        token: String,
+    }
+
+    impl TeamIdentifier for TestTeam {
+        fn team_id(&self) -> i32 {
+            self.id
+        }
+
+        fn api_token(&self) -> &str {
+            &self.token
+        }
+    }
+
+    let test_team = TestTeam {
+        id: 123,
+        token: "test_token".to_string(),
+    };
+
+    // Test that HyperCache configurations generate correct cache keys matching Django format
+    let config_with_cohorts = HyperCacheConfig::new(
+        "feature_flags".to_string(),
+        "flags_with_cohorts.json".to_string(),
+        "us-east-1".to_string(),
+        "test-bucket".to_string(),
+    );
+
+    let config_without_cohorts = HyperCacheConfig::new(
+        "feature_flags".to_string(),
+        "flags_without_cohorts.json".to_string(),
+        "us-east-1".to_string(),
+        "test-bucket".to_string(),
+    );
+
+    let team_key = KeyType::team(test_team.clone());
+
+    // Test Redis cache key generation (includes posthog:1: prefix)
+    let redis_key_with_cohorts = config_with_cohorts.get_redis_cache_key(&team_key);
+    assert_eq!(
+        redis_key_with_cohorts,
+        "posthog:1:cache/teams/123/feature_flags/flags_with_cohorts.json"
+    );
+
+    let redis_key_without_cohorts = config_without_cohorts.get_redis_cache_key(&team_key);
+    assert_eq!(
+        redis_key_without_cohorts,
+        "posthog:1:cache/teams/123/feature_flags/flags_without_cohorts.json"
+    );
+
+    // Test S3 cache key generation (no prefix, matches Django object_storage)
+    let s3_key_with_cohorts = config_with_cohorts.get_s3_cache_key(&team_key);
+    assert_eq!(
+        s3_key_with_cohorts,
+        "cache/teams/123/feature_flags/flags_with_cohorts.json"
+    );
+
+    let s3_key_without_cohorts = config_without_cohorts.get_s3_cache_key(&team_key);
+    assert_eq!(
+        s3_key_without_cohorts,
+        "cache/teams/123/feature_flags/flags_without_cohorts.json"
+    );
+}
+
+#[tokio::test]
+async fn test_local_evaluation_endpoint_exists() {
+    use feature_flags::config::Config;
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint exists and returns some response (even if unauthorized)
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token=any_token",
+            server.addr
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    // Should return 401 Unauthorized when no authentication is provided
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn test_personal_api_key_authentication_no_key() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+    use serde_json::Value;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create a real team so we pass the token validation
+    let team = context.insert_new_team(None).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 401 when no API key is provided
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body_text = response.text().await.unwrap();
+
+    assert_eq!(status, 401);
+
+    // Verify the response body matches Django's format
+    let body: Value = serde_json::from_str(&body_text).unwrap();
+    assert_eq!(body["type"], "authentication_error");
+    assert_eq!(body["code"], "not_authenticated");
+    assert_eq!(
+        body["detail"],
+        "Authentication credentials were not provided."
+    );
+    assert_eq!(body["attr"], Value::Null);
+}
+
+#[tokio::test]
+async fn test_personal_api_key_authentication_invalid_key() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+    use serde_json::Value;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create a real team so we pass the token validation
+    let team = context.insert_new_team(None).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 401 when an invalid API key is provided
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", "Bearer phx_invalid_key_12345")
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body_text = response.text().await.unwrap();
+
+    assert_eq!(status, 401);
+
+    // Verify the response body matches Django's format
+    let body: Value = serde_json::from_str(&body_text).unwrap();
+    assert_eq!(body["type"], "authentication_error");
+    assert_eq!(body["code"], "authentication_failed");
+    assert_eq!(
+        body["detail"],
+        "Personal API key found in request Authorization header is invalid."
+    );
+    assert_eq!(body["attr"], Value::Null);
+}
+
+#[tokio::test]
+async fn test_personal_api_key_authentication_valid_key_with_scopes() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team, user, and personal API key using helpers
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let user_email = feature_flags::utils::test_utils::TestContext::generate_test_email("test_pak");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(user_id, "Test PAK", vec!["feature_flag:read"], None, None)
+        .await
+        .unwrap();
+
+    // Populate cache to avoid 503 errors
+    context.populate_cache_for_team(team.id).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 200 when a valid API key with proper scopes is provided
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Response body: {}",
+        response.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_personal_api_key_authentication_without_feature_flag_scopes() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team, user, and personal API key with different scope
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let user_email =
+        feature_flags::utils::test_utils::TestContext::generate_test_email("test_no_scopes");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK No Scopes",
+            vec!["insight:read"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 401 when API key doesn't have feature_flag scopes
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn test_personal_api_key_authentication_inactive_user() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    // Create INACTIVE user using helper (is_active = false)
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_inactive_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user_with_options(&user_email, &org_id, Some(team.id), false)
+        .await
+        .unwrap();
+
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Inactive",
+            vec!["feature_flag:read"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 401 when user is inactive
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn test_secret_api_token_authentication_valid_token() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team with secret API token using helper
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // Populate cache to avoid 503 errors
+    context.populate_cache_for_team(team.id).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 200 when a valid secret API token is provided
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Response body: {}",
+        response.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_secret_api_token_authentication_invalid_token() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+    use serde_json::Value;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create a real team so we pass the token validation
+    let team = context.insert_new_team(None).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 401 when an invalid secret token is provided
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", "Bearer phs_invalid_secret_token_xyz")
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body_text = response.text().await.unwrap();
+
+    assert_eq!(status, 401);
+
+    // Verify the response body matches Django's format
+    let body: Value = serde_json::from_str(&body_text).unwrap();
+    assert_eq!(body["type"], "authentication_error");
+    assert_eq!(body["code"], "authentication_failed");
+    assert_eq!(body["detail"], "Secret API token is invalid.");
+    assert_eq!(body["attr"], Value::Null);
+}
+
+#[tokio::test]
+async fn test_missing_token_parameter() {
+    use feature_flags::config::Config;
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 400 when token parameter is missing
+    let response = client
+        .get(format!("http://{}/flags/definitions", server.addr))
+        .header("Authorization", "Bearer phs_test_token")
+        .send()
+        .await
+        .unwrap();
+
+    // Should return 400 Bad Request when token parameter is missing
+    assert_eq!(response.status(), 400);
+}
+
+#[tokio::test]
+async fn test_token_mismatch_secret_token_for_different_team() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create two teams with secret tokens
+    let (team1, _secret1, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    let (_team2, secret2, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test: Use team1's public token but team2's secret token - should fail
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret2}"))
+        .send()
+        .await
+        .unwrap();
+
+    // Should return 401 because the secret token doesn't match the team
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn test_personal_api_key_with_scoped_teams_allowed() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team using helper (creates org, project, and team)
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_scoped_teams_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+
+    // Create personal API key with scoped_teams restriction that includes our team
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Scoped Teams",
+            vec!["feature_flag:read"],
+            Some(vec![team.id]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Populate cache to avoid 503 errors
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_local_evaluation_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Should succeed because the team is in the scoped_teams list
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = response.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "Should authenticate when team is in scoped_teams. Response body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_personal_api_key_with_scoped_teams_denied() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_denied_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+
+    // Create personal API key with scoped_teams restriction that excludes our team
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Denied",
+            vec!["feature_flag:read"],
+            Some(vec![99999]), // Different team ID
+            None,
+        )
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Should fail because the team is not in the scoped_teams list
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        401,
+        "Should deny access when team is not in scoped_teams"
+    );
+}
+
+#[tokio::test]
+async fn test_personal_api_key_with_scoped_organizations_allowed() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_org_allowed_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+
+    // Create personal API key with scoped_organizations restriction that includes our org
+    let org_id_str = org_id.to_string();
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Org Allowed",
+            vec!["feature_flag:read"],
+            None,
+            Some(vec![org_id_str]),
+        )
+        .await
+        .unwrap();
+
+    // Populate cache to avoid 503 errors
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_local_evaluation_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Should succeed because the organization is in the scoped_organizations list
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = response.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "Should authenticate when organization is in scoped_organizations. Response body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_personal_api_key_with_scoped_organizations_denied() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team using helper (creates org, project, and team)
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_org_denied_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+
+    // Create personal API key with scoped_organizations restriction that excludes our org
+    let different_org_id = uuid::Uuid::new_v4().to_string();
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Org Denied",
+            vec!["feature_flag:read"],
+            None,
+            Some(vec![different_org_id]), // Different organization ID
+        )
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Should fail because the organization is not in the scoped_organizations list
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        401,
+        "Should deny access when organization is not in scoped_organizations"
+    );
+}
+
+#[tokio::test]
+async fn test_cache_miss_returns_503() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+    use serde_json::Value;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team with secret API token
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // DO NOT populate cache - we want to test cache miss behavior
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Request should return 503 when cache is empty
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body_text = response.text().await.unwrap();
+
+    assert_eq!(
+        status, 503,
+        "Should return 503 on cache miss. Body: {body_text}"
+    );
+
+    // Verify the response body has proper error format (if JSON)
+    if let Ok(body) = serde_json::from_str::<Value>(&body_text) {
+        assert_eq!(body["type"], "server_error");
+        assert_eq!(body["code"], "service_unavailable");
+        assert!(
+            body["detail"]
+                .as_str()
+                .unwrap()
+                .contains("Required data not found in cache"),
+            "Error message should mention cache miss"
+        );
+    } else {
+        // If not JSON, verify the error message mentions cache
+        assert!(
+            body_text.contains("Required data not found in cache"),
+            "Body should mention cache miss. Got: {body_text}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_personal_api_key_with_all_access_scopes() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team, user, and personal API key with {*} (all access) scopes
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_all_access_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+
+    // Create PAK with {*} scope (all access)
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(user_id, "Test PAK All Access", vec!["*"], None, None)
+        .await
+        .unwrap();
+
+    // Populate cache to avoid 503 errors
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_local_evaluation_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 200 when PAK has all access
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Response body: {}",
+        response.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_personal_api_key_with_feature_flag_write_scope() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team, user, and personal API key with feature_flag:write scope
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_write_scope_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+
+    // Create PAK with feature_flag:write scope (write includes read access)
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Write Scope",
+            vec!["feature_flag:write"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Populate cache to avoid 503 errors
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_local_evaluation_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test that the endpoint returns 200 with feature_flag:write scope
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Should succeed with feature_flag:write scope. Response body: {}",
+        response.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_backup_secret_api_token_authentication() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create a team with both secret_api_token and secret_api_token_backup using helper
+    let backup_token_value = feature_flags::utils::test_utils::random_string("phs_backup_", 12);
+    let (team, _secret_token, backup_secret_token) = context
+        .create_team_with_secret_token(None, None, Some(&backup_token_value))
+        .await
+        .unwrap();
+
+    // Populate cache to avoid 503 errors
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_local_evaluation_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Test that the backup secret token works
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header(
+            "Authorization",
+            format!("Bearer {}", backup_secret_token.unwrap()),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Should authenticate with backup secret token. Response body: {}",
+        response.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_invalid_project_api_key() {
+    use feature_flags::config::Config;
+    use reqwest;
+    use serde_json::Value;
+
+    let config = Config::default_test_config();
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // Test with an explicitly invalid token (not just missing, but actually wrong)
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token=phc_definitely_invalid_token_12345",
+            server.addr
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body_text = response.text().await.unwrap();
+
+    assert_eq!(
+        status, 401,
+        "Should return 401 for invalid token. Body: {body_text}"
+    );
+
+    // Verify the response body format (if JSON)
+    if let Ok(body) = serde_json::from_str::<Value>(&body_text) {
+        assert_eq!(body["type"], "authentication_error");
+        assert_eq!(body["code"], "not_authenticated");
+    } else {
+        // If not JSON, verify the error message mentions invalid API key
+        assert!(
+            body_text.contains("API key is invalid") || body_text.contains("expired"),
+            "Body should mention invalid API key. Got: {body_text}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_secret_token_takes_priority_over_personal_api_key() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create two teams with different data
+    let (team1, secret_token1, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    let team2 = context.insert_new_team(None).await.unwrap();
+    let org_id2 = context.get_organization_id_for_team(&team2).await.unwrap();
+
+    // Create PAK for team2
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_priority_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id2, team2.id)
+        .await
+        .unwrap();
+
+    let (_pak_id, _personal_key) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Priority",
+            vec!["feature_flag:read"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Populate cache for team1 only
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_local_evaluation_cache(redis_client, team1.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Provide BOTH authentication methods:
+    // - Secret token for team1 (in Authorization header - phs_ prefix)
+    // - Personal API key for team2 (phx_ prefix)
+    // Expected: Secret token takes priority, so we get team1's data
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token1}"))
+        .send()
+        .await
+        .unwrap();
+
+    // Should succeed with team1's secret token (200 status)
+    // If PAK was tried first, it would fail because PAK belongs to team2
+    assert_eq!(
+        response.status(),
+        200,
+        "Should authenticate with secret token when both auth methods provided. Response body: {}",
+        response.text().await.unwrap()
+    );
+}

--- a/rust/feature-flags/tests/test_personal_api_key_scopes.rs
+++ b/rust/feature-flags/tests/test_personal_api_key_scopes.rs
@@ -1,0 +1,581 @@
+mod common;
+
+use feature_flags::config::DEFAULT_TEST_CONFIG;
+use feature_flags::utils::test_utils::TestContext;
+use uuid::Uuid;
+
+/// Helper: Clean up test data (PAK, organization memberships, and user)
+async fn cleanup_test_data(ctx: &TestContext, pak_id: String, user_id: i32) {
+    let mut conn = ctx.get_non_persons_connection().await.unwrap();
+    sqlx::query("DELETE FROM posthog_personalapikey WHERE id = $1")
+        .bind(pak_id)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM posthog_organizationmembership WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM posthog_user WHERE id = $1")
+        .bind(user_id)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_personal_api_key_scoped_teams_allowed() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create two teams
+    let team1 = ctx.insert_new_team(None).await.unwrap();
+    let _team2 = ctx.insert_new_team(None).await.unwrap();
+
+    let org_id = ctx.get_organization_id_for_team(&team1).await.unwrap();
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org_id, Some(team1.id), true)
+        .await
+        .unwrap();
+    ctx.add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(
+            user_id,
+            "Test PAK",
+            vec!["feature_flag:read"],
+            Some(vec![team1.id]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team1 (allowed)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate when accessing allowed team"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_scoped_organizations_allowed() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create a team
+    let team = ctx.insert_new_team(None).await.unwrap();
+
+    let org_id = ctx.get_organization_id_for_team(&team).await.unwrap();
+    let org_id_str = org_id.to_string();
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org_id, Some(team.id), true)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(
+            user_id,
+            "Test PAK",
+            vec!["feature_flag:read"],
+            None,
+            Some(vec![org_id_str]),
+        )
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team in allowed organization
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate when accessing team in allowed organization"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_unrestricted_teams_null() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create two teams
+    let team1 = ctx.insert_new_team(None).await.unwrap();
+    let team2 = ctx.insert_new_team(None).await.unwrap();
+
+    let org_id = ctx.get_organization_id_for_team(&team1).await.unwrap();
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org_id, Some(team1.id), true)
+        .await
+        .unwrap();
+    ctx.add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(user_id, "Test PAK", vec!["feature_flag:read"], None, None)
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team1 (should be allowed - NULL means all teams)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate when scoped_teams is NULL (unrestricted)"
+    );
+
+    // Test accessing team2 (should also be allowed - NULL means all teams)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team2.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate for any team when scoped_teams is NULL"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_unrestricted_teams_empty_array() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create two teams
+    let team1 = ctx.insert_new_team(None).await.unwrap();
+    let team2 = ctx.insert_new_team(None).await.unwrap();
+
+    let org_id = ctx.get_organization_id_for_team(&team1).await.unwrap();
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org_id, Some(team1.id), true)
+        .await
+        .unwrap();
+    ctx.add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(
+            user_id,
+            "Test PAK",
+            vec!["feature_flag:read"],
+            Some(vec![]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team1 (should be allowed - empty array means all teams)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate when scoped_teams is empty array (unrestricted)"
+    );
+
+    // Test accessing team2 (should also be allowed - empty array means all teams)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team2.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate for any team when scoped_teams is empty array"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_unrestricted_organizations_null() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create teams in two different orgs
+    let team1 = ctx.insert_new_team(None).await.unwrap();
+    let team2 = ctx.insert_new_team(None).await.unwrap();
+
+    let org_id = ctx.get_organization_id_for_team(&team1).await.unwrap();
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org_id, Some(team1.id), true)
+        .await
+        .unwrap();
+    ctx.add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(
+            user_id,
+            "Test PAK - Org Unrestricted",
+            vec!["feature_flag:read"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team1 (should be allowed - NULL means all orgs)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate when scoped_organizations is NULL (unrestricted)"
+    );
+
+    // Test accessing team2 in different org (should also be allowed - NULL means all orgs)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team2.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate for any org when scoped_organizations is NULL"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_mixed_scopes_both_valid() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create a team
+    let team = ctx.insert_new_team(None).await.unwrap();
+
+    let org_id = ctx.get_organization_id_for_team(&team).await.unwrap();
+    let org_id_str = org_id.to_string();
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org_id, Some(team.id), true)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(
+            user_id,
+            "Test PAK - Mixed Scopes",
+            vec!["feature_flag:read"],
+            Some(vec![team.id]),
+            Some(vec![org_id_str.clone()]),
+        )
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team (should be allowed - both scopes match)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate when both scoped_teams and scoped_organizations match"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_mixed_scopes_team_valid_org_invalid() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create two teams in different organizations
+    let org1_id = Uuid::new_v4();
+    let org2_id = Uuid::new_v4();
+    let team1 = ctx
+        .insert_new_team_with_org(None, &org1_id.to_string())
+        .await
+        .unwrap();
+    let _team2 = ctx
+        .insert_new_team_with_org(None, &org2_id.to_string())
+        .await
+        .unwrap();
+
+    let org2_id_str = org2_id.to_string();
+
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org1_id, Some(team1.id), true)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(
+            user_id,
+            "Test PAK - Mixed Invalid",
+            vec!["feature_flag:read"],
+            Some(vec![team1.id]),
+            Some(vec![org2_id_str.clone()]),
+        )
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team1 (should be denied - org doesn't match)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        401,
+        "Should return 401 when scoped_organizations doesn't match team's org"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_user_without_current_team() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create a team for organization context
+    let team = ctx.insert_new_team(None).await.unwrap();
+
+    let org_id = ctx.get_organization_id_for_team(&team).await.unwrap();
+
+    // Create a user WITHOUT current_team_id
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org_id, None, true)
+        .await
+        .unwrap();
+    ctx.add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(
+            user_id,
+            "Test PAK - No Team",
+            vec!["feature_flag:read"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test authentication succeeds but cache miss returns 503
+    // (Users without current_team_id can still authenticate if they're in the org)
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        503,
+        "Should return 503 on cache miss (auth succeeds for users without current_team_id)"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}
+
+#[tokio::test]
+async fn test_personal_api_key_user_member_of_multiple_orgs() {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let ctx = TestContext::new(Some(&config)).await;
+
+    // Create two organizations with teams
+    let org1_id = Uuid::new_v4();
+    let org2_id = Uuid::new_v4();
+    let team1 = ctx
+        .insert_new_team_with_org(None, &org1_id.to_string())
+        .await
+        .unwrap();
+    let team2 = ctx
+        .insert_new_team_with_org(None, &org2_id.to_string())
+        .await
+        .unwrap();
+
+    // Create a user with current_organization_id set to org1
+    let user_email = format!("test_{}@example.com", Uuid::new_v4());
+    let user_id = ctx
+        .create_user_with_options(&user_email, &org1_id, Some(team1.id), true)
+        .await
+        .unwrap();
+
+    // Add user as member of BOTH organizations
+    ctx.add_user_to_organization(user_id, &org1_id, 15)
+        .await
+        .unwrap();
+    ctx.add_user_to_organization(user_id, &org2_id, 15)
+        .await
+        .unwrap();
+
+    // Create personal API key with no scopes (unrestricted)
+    let (pak_id, secure_value) = ctx
+        .create_personal_api_key(user_id, "Test PAK", vec!["feature_flag:read"], None, None)
+        .await
+        .unwrap();
+
+    // Start server
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let client = reqwest::Client::new();
+
+    // Test accessing team2 in org2
+    // User is a member of org2, even though current_organization_id is org1
+    // This should SUCCEED because the user is a member of org2
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team2.api_token
+        ))
+        .header("Authorization", format!("Bearer {secure_value}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        401,
+        "Should authenticate when user is a member of the team's org, even if current_organization_id differs"
+    );
+
+    cleanup_test_data(&ctx, pak_id, user_id).await;
+}


### PR DESCRIPTION
## Problem

Most requests to `/local_evaluation` should be completely resolved from the cache. We already return flag definitions from the cache. We plan to use HyperCache to handle authentication as well.

But before we do that, we want a lightweight service to serve up local_evaluation. This PR is step 1 in that.

## Changes

Adds a new `/flags/definitions` endpoint to serve up feature flag definitions used by SDK clients to implement local evaluation of feature flags.

This leverages the `HyperCache` to return flag definitions. This does not use `HyperCache` for authentication yet. That'll come in a follow-up.

## How did you test this code?

Unit Tests
Manual Tests

__No Access__
- [x] Invalid PAT
- [x] Valid PAT, but wrong org scope
- [x] Valid PAT, but wrong team scope
- [x] Valid PAT, but wrong feature scope
- [x] Invalid secret api token
- [x] Valid secret api token, but wrong team
- [x] Valid PAT, all access, but user not in org
- [x] Invalid project api key (?token)

__Successful Access__
- [x] Valid PAT - org: All Access, scopes: All Access (default org)
- [x] Valid PAT - org: All Access, scopes: All Access (another org the user has access to)
- [x] Valid PAT - project: All Access, scopes: All Access (default project)
- [x] Valid PAT - project: All Access, scopes: All Access (another project the user has access to)
- [x] Valid PAT, specific teams:
- [x] Valid PAT, scoped team, proper scope
- [x] Valid PAT, scoped org, proper feature scope `feature_flag:read`
- [x] Valid PAT, scoped org, proper feature scope `feature_flag:write`
- [x] Valid secret api token
- [x] Valid backup secret api token
- [x] Cache miss correct response

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Important Context

1. This introduces a new endpoint, but nobody is calling it yet, so it's relatively safe in that regard.
2. It does not handle cache misses yet. That'll come in a follow-up.
3. It does not use Hypercache for auth yet. That's coming later.
