### PR TITLE
feat(customers): Display metric trend

### DIFF
--- a/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.test.ts
+++ b/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.test.ts
@@ -12,7 +12,7 @@ import { initKeaTests } from '~/test/init'
 import { topBarSettingsButtonLogic } from './topBarSettingsButtonLogic'
 
 const groupsScene = (): any => ({
-    scene: { component: () => null, logic: null, settingSectionId: 'environment-crm' },
+    scene: { component: () => null, logic: null, settingSectionId: 'environment-customer-analytics' },
 })
 const personsScene = (): any => ({
     scene: { component: () => null, logic: null, settingSectionId: 'environment-product-analytics' },
@@ -24,7 +24,7 @@ const scenes: Record<string, () => any> = {
 }
 
 describe('topBarSettingsButtonLogic', () => {
-    describe('loadedSceneSettingsSectionId selector for environment-crm', () => {
+    describe('loadedSceneSettingsSectionId selector for environment-customer-analytics', () => {
         let logic: ReturnType<typeof topBarSettingsButtonLogic.build>
         let sceneLogicInstance: ReturnType<typeof sceneLogic.build>
 
@@ -43,17 +43,17 @@ describe('topBarSettingsButtonLogic', () => {
             sceneLogicInstance?.unmount()
         })
 
-        it('returns environment-crm when CRM feature flag is enabled', async () => {
+        it('returns environment-customer-analytics when CRM feature flag is enabled', async () => {
             featureFlagLogic.actions.setFeatureFlags([], {
                 [FEATURE_FLAGS.CRM_ITERATION_ONE]: true,
             })
 
             await expectLogic(logic).toMatchValues({
-                loadedSceneSettingsSectionId: 'environment-crm',
+                loadedSceneSettingsSectionId: 'environment-customer-analytics',
             })
         })
 
-        it('returns undefined when CRM feature flag is disabled for environment-crm', async () => {
+        it('returns undefined when CRM feature flag is disabled for environment-customer-analytics', async () => {
             featureFlagLogic.actions.setFeatureFlags([], {
                 [FEATURE_FLAGS.CRM_ITERATION_ONE]: false,
             })

--- a/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.ts
+++ b/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.ts
@@ -32,7 +32,10 @@ export const topBarSettingsButtonLogic = kea<topBarSettingsButtonLogicType>([
                 const settingSectionId = activeLoadedScene?.settingSectionId
 
                 // Only show CRM settings button when the feature flag is enabled
-                if (settingSectionId === 'environment-crm' && !featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
+                if (
+                    settingSectionId === 'environment-customer-analytics' &&
+                    !featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]
+                ) {
                     return undefined
                 }
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -2205,3 +2205,12 @@ export function getRelativeNextPath(nextPath: string | null | undefined, locatio
         return null
     }
 }
+
+export const formatPercentage = (x: number, options?: { precise?: boolean }): string => {
+    if (options?.precise) {
+        return (x / 100).toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 1 })
+    } else if (x >= 1000) {
+        return humanFriendlyLargeNumber(x) + '%'
+    }
+    return (x / 100).toLocaleString(undefined, { style: 'percent', maximumSignificantDigits: 2 })
+}

--- a/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
+++ b/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
@@ -7,7 +7,7 @@ import { LemonBanner, LemonButton, LemonSkeleton, LemonTag } from '@posthog/lemo
 import { getColorVar } from 'lib/colors'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
-import { humanFriendlyDuration, humanFriendlyLargeNumber, isNotNil, range } from 'lib/utils'
+import { formatPercentage, humanFriendlyDuration, humanFriendlyLargeNumber, isNotNil, range } from 'lib/utils'
 import { DEFAULT_CURRENCY, getCurrencySymbol } from 'lib/utils/geography/currency'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -240,15 +240,6 @@ const OverviewItemCell = ({
             </div>
         </Tooltip>
     )
-}
-
-const formatPercentage = (x: number, options?: { precise?: boolean }): string => {
-    if (options?.precise) {
-        return (x / 100).toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 1 })
-    } else if (x >= 1000) {
-        return humanFriendlyLargeNumber(x) + '%'
-    }
-    return (x / 100).toLocaleString(undefined, { style: 'percent', maximumSignificantDigits: 2 })
 }
 
 const formatUnit = (x: number, options?: { precise?: boolean }): string => {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -26358,6 +26358,9 @@
         "UsageMetric": {
             "additionalProperties": false,
             "properties": {
+                "change_from_previous_pct": {
+                    "type": ["number", "null"]
+                },
                 "display": {
                     "$ref": "#/definitions/UsageMetricDisplay"
                 },
@@ -26373,11 +26376,23 @@
                 "name": {
                     "type": "string"
                 },
+                "previous": {
+                    "type": "number"
+                },
                 "value": {
                     "type": "number"
                 }
             },
-            "required": ["id", "name", "value", "format", "display", "interval"],
+            "required": [
+                "id",
+                "name",
+                "value",
+                "previous",
+                "change_from_previous_pct",
+                "format",
+                "display",
+                "interval"
+            ],
             "type": "object"
         },
         "UsageMetricDisplay": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4113,6 +4113,8 @@ export interface UsageMetric {
     id: string
     name: string
     value: number
+    previous: number
+    change_from_previous_pct: number | null
     format: UsageMetricFormat
     display: UsageMetricDisplay
     interval: integer

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -169,5 +169,5 @@ export function GroupsScene(): JSX.Element {
 export const scene: SceneExport = {
     component: GroupsScene,
     logic: groupsSceneLogic,
-    settingSectionId: 'environment-crm',
+    settingSectionId: 'environment-customer-analytics',
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -1,4 +1,7 @@
-import { useValues } from 'kea'
+import { BindLogic, useValues } from 'kea'
+
+import { UsageMetricsConfig } from 'scenes/settings/environment/UsageMetricsConfig'
+import { usageMetricsConfigLogic } from 'scenes/settings/environment/usageMetricsConfigLogic'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind, UsageMetric, UsageMetricsQueryResponse } from '~/queries/schema/schema-general'
@@ -8,7 +11,7 @@ import {
     UsageMetricCardSkeleton,
 } from 'products/customer_analytics/frontend/components/UsageMetricCard'
 
-import { NotebookNodeProps, NotebookNodeType } from '../types'
+import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
 import { createPostHogWidgetNode } from './NodeWrapper'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
@@ -55,6 +58,16 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     )
 }
 
+const Settings = ({ attributes }: NotebookNodeAttributeProperties<NotebookNodeUsageMetricsAttributes>): JSX.Element => {
+    return (
+        <div className="p-2">
+            <BindLogic logic={usageMetricsConfigLogic} props={{ logicKey: attributes.nodeId }}>
+                <UsageMetricsConfig />
+            </BindLogic>
+        </div>
+    )
+}
+
 type NotebookNodeUsageMetricsAttributes = {
     personId: string
 }
@@ -63,6 +76,8 @@ export const NotebookNodeUsageMetrics = createPostHogWidgetNode<NotebookNodeUsag
     nodeType: NotebookNodeType.UsageMetrics,
     titlePlaceholder: 'Usage',
     Component,
+    Settings,
+    settingsIcon: 'gear',
     resizeable: false,
     expandable: true,
     startExpanded: true,

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -33,7 +33,6 @@ import { AccessControlLevel, AccessControlResourceType, Realm } from '~/types'
 
 import { IntegrationsList } from '../../lib/integrations/IntegrationsList'
 import { AutocaptureSettings, WebVitalsAutocaptureSettings } from './environment/AutocaptureSettings'
-import { CRMUsageMetricsConfig } from './environment/CRMUsageMetricsConfig'
 import { CSPReportingSettings } from './environment/CSPReportingSettings'
 import { CorrelationConfig } from './environment/CorrelationConfig'
 import { DataAttributes } from './environment/DataAttributes'
@@ -73,6 +72,7 @@ import {
     WebSnippet,
 } from './environment/TeamSettings'
 import { ProjectAccountFiltersSetting } from './environment/TestAccountFiltersConfig'
+import { UsageMetricsConfig } from './environment/UsageMetricsConfig'
 import { WebAnalyticsEnablePreAggregatedTables } from './environment/WebAnalyticsAPISetting'
 import { WebhookIntegration } from './environment/WebhookIntegration'
 import { Invites } from './organization/Invites'
@@ -163,6 +163,25 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'dead-clicks-autocapture',
                 title: 'Dead clicks autocapture',
                 component: <DeadClicksAutocaptureSettings />,
+            },
+        ],
+    },
+    {
+        level: 'environment',
+        id: 'environment-customer-analytics',
+        title: 'Customer analytics',
+        flag: 'CRM_ITERATION_ONE',
+        settings: [
+            {
+                id: 'group-analytics',
+                title: 'Group analytics',
+                component: <GroupAnalyticsConfig />,
+            },
+            {
+                id: 'crm-usage-metrics',
+                title: 'Usage metrics',
+                component: <UsageMetricsConfig />,
+                flag: 'CRM_USAGE_METRICS',
             },
         ],
     },
@@ -354,25 +373,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 title: 'New query engine',
                 component: <WebAnalyticsEnablePreAggregatedTables />,
                 flag: 'WEB_ANALYTICS_API',
-            },
-        ],
-    },
-    {
-        level: 'environment',
-        id: 'environment-crm',
-        title: 'CRM',
-        flag: 'CRM_ITERATION_ONE',
-        settings: [
-            {
-                id: 'group-analytics',
-                title: 'Group analytics',
-                component: <GroupAnalyticsConfig />,
-            },
-            {
-                id: 'crm-usage-metrics',
-                title: 'Usage metrics',
-                component: <CRMUsageMetricsConfig />,
-                flag: 'CRM_USAGE_METRICS',
             },
         ],
     },

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
-import { Form, capitalizeFirstLetter } from 'kea-forms'
+import { Form } from 'kea-forms'
 
-import { IconEllipsis, IconPlus } from '@posthog/icons'
+import { IconEllipsis, IconPlusSmall } from '@posthog/icons'
 import {
     LemonButton,
     LemonDialog,
@@ -17,14 +17,12 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { LemonField } from 'lib/lemon-ui/LemonField'
-import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
-import { groupsModel } from '~/models/groupsModel'
 import { AnyPropertyFilter, EntityTypes, FilterType } from '~/types'
 
-import { UsageMetric, crmUsageMetricsConfigLogic } from './crmUsageMetricsConfigLogic'
+import { UsageMetric, usageMetricsConfigLogic } from './usageMetricsConfigLogic'
 
 function sanitizeFilters(filters?: FilterType): FilterType {
     if (!filters) {
@@ -45,9 +43,9 @@ function sanitizeFilters(filters?: FilterType): FilterType {
     return sanitized
 }
 
-function CRMUsageMetricsTable(): JSX.Element {
-    const { usageMetrics, usageMetricsLoading } = useValues(crmUsageMetricsConfigLogic)
-    const { removeUsageMetric } = useActions(crmUsageMetricsConfigLogic)
+function UsageMetricsTable(): JSX.Element {
+    const { usageMetrics, usageMetricsLoading } = useValues(usageMetricsConfigLogic)
+    const { removeUsageMetric } = useActions(usageMetricsConfigLogic)
 
     const columns: LemonTableColumns<UsageMetric> = [
         {
@@ -85,19 +83,19 @@ function CRMUsageMetricsTable(): JSX.Element {
                                         title: 'Edit usage metric',
                                         description: (
                                             <div>
-                                                <CRMUsageMetricsForm metric={metric} />
+                                                <UsageMetricsForm metric={metric} />
                                             </div>
                                         ),
                                         primaryButton: {
                                             htmlType: 'submit',
                                             children: 'Save',
-                                            'data-attr': 'update-crm-usage-metric',
+                                            'data-attr': 'update-usage-metric',
                                             form: 'usageMetric',
                                         },
                                         secondaryButton: {
                                             htmlType: 'button',
                                             children: 'Cancel',
-                                            'data-attr': 'cancel-update-crm-usage-metric',
+                                            'data-attr': 'cancel-update-usage-metric',
                                         },
                                     })
                                 },
@@ -132,12 +130,12 @@ function CRMUsageMetricsTable(): JSX.Element {
     return <LemonTable columns={columns} dataSource={usageMetrics} loading={usageMetricsLoading} />
 }
 
-interface CRMUsageMetricsFormProps {
+interface UsageMetricsFormProps {
     metric?: UsageMetric
 }
 
-function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element {
-    const { resetUsageMetric, setIsEditing, setUsageMetricValues } = useActions(crmUsageMetricsConfigLogic)
+function UsageMetricsForm({ metric }: UsageMetricsFormProps): JSX.Element {
+    const { resetUsageMetric, setIsEditing, setUsageMetricValues } = useActions(usageMetricsConfigLogic)
 
     if (metric) {
         setUsageMetricValues(metric)
@@ -155,7 +153,7 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
     ]
 
     return (
-        <Form id="usageMetric" logic={crmUsageMetricsConfigLogic} formKey="usageMetric" enableFormOnSubmit>
+        <Form id="usageMetric" logic={usageMetricsConfigLogic} formKey="usageMetric" enableFormOnSubmit>
             <div className="flex flex-col gap-2">
                 <div className="grid grid-cols-2 gap-2">
                     <LemonField name="name" label="Name" help="This will be the title of the column in group list">
@@ -238,7 +236,7 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
                                             }
                                             onChange(newValue)
                                         }}
-                                        pageKey="CRMUsageMetricsConfig"
+                                        pageKey="UsageMetricsConfig"
                                     />
                                     <TestAccountFilterSwitch
                                         checked={currentFilters?.filter_test_accounts ?? false}
@@ -258,17 +256,13 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
                         <div className="flex gap-2 mt-2">
                             <LemonButton
                                 type="primary"
-                                data-attr="save-crm-usage-metric"
+                                data-attr="save-usage-metric"
                                 htmlType="submit"
                                 form="usageMetric"
                             >
                                 Save
                             </LemonButton>
-                            <LemonButton
-                                type="secondary"
-                                data-attr="cancel-crm-usage-metric"
-                                onClick={handleCancelForm}
-                            >
+                            <LemonButton type="secondary" data-attr="cancel-usage-metric" onClick={handleCancelForm}>
                                 Cancel
                             </LemonButton>
                         </div>
@@ -279,44 +273,29 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
     )
 }
 
-export function CRMUsageMetricsConfig(): JSX.Element {
-    const { isEditing, currentGroupTypeIndex, availableGroupTypes } = useValues(crmUsageMetricsConfigLogic)
-    const { setIsEditing, resetUsageMetric, setCurrentGroupTypeIndex } = useActions(crmUsageMetricsConfigLogic)
-    const { aggregationLabel } = useValues(groupsModel)
+export function UsageMetricsConfig(): JSX.Element {
+    const { isEditing } = useValues(usageMetricsConfigLogic)
+    const { setIsEditing, resetUsageMetric } = useActions(usageMetricsConfigLogic)
 
     const handleAddMetric = (): void => {
         resetUsageMetric()
         setIsEditing(true)
     }
 
-    const tabs = availableGroupTypes.map((groupType) => ({
-        key: groupType.group_type_index.toString(),
-        label: capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural),
-        content: (
-            <div className="flex flex-col gap-2">
+    return (
+        <>
+            <p>
+                Choose which events matter for each metric: API calls, feature adoption, session frequency, error rates
+                to identify expansion opportunities and churn risk based on real customer behavior.
+            </p>
+            <div className="flex flex-col gap-2 items-start">
                 {!isEditing && (
-                    <LemonButton onClick={handleAddMetric} icon={<IconPlus />}>
+                    <LemonButton onClick={handleAddMetric} icon={<IconPlusSmall />}>
                         Add metric
                     </LemonButton>
                 )}
-                {isEditing ? <CRMUsageMetricsForm /> : <CRMUsageMetricsTable />}
+                {isEditing ? <UsageMetricsForm /> : <UsageMetricsTable />}
             </div>
-        ),
-    }))
-
-    if (availableGroupTypes.length === 0) {
-        return <div>No group types available</div>
-    }
-
-    return (
-        <>
-            Choose which events matter for each metric: API calls, feature adoption, session frequency, error rates to
-            identify expansion opportunities and churn risk based on real customer behavior.
-            <LemonTabs
-                activeKey={currentGroupTypeIndex.toString()}
-                onChange={(key) => setCurrentGroupTypeIndex(parseInt(key, 10))}
-                tabs={tabs}
-            />
         </>
     )
 }

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -18,6 +18,7 @@ export type SettingLevelId = (typeof SettingLevelIds)[number]
 export type SettingSectionId =
     | 'environment-details'
     | 'environment-autocapture'
+    | 'environment-customer-analytics'
     | 'environment-product-analytics'
     | 'environment-revenue-analytics'
     | 'environment-marketing-analytics'
@@ -27,7 +28,6 @@ export type SettingSectionId =
     | 'environment-feature-flags'
     | 'environment-error-tracking'
     | 'environment-csp-reporting'
-    | 'environment-crm'
     | 'environment-max'
     | 'environment-integrations'
     | 'environment-activity-logs'

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5284,11 +5284,13 @@ class UsageMetric(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    change_from_previous_pct: Optional[float] = None
     display: UsageMetricDisplay
     format: UsageMetricFormat
     id: str
     interval: int
     name: str
+    previous: float
     value: float
 
 

--- a/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
+++ b/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
@@ -1,21 +1,31 @@
 # serializer version: 1
 # name: TestUsageMetricsQueryRunner.test_complex_event_filter
   '''
-  SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-         'Test metric' AS name,
-         'numeric' AS format,
-         'number' AS display,
-         7 AS interval,
-         count(*) AS value
-  FROM events
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event')))
+  SELECT id AS id,
+         name AS name,
+         format AS format,
+         display AS display,
+         interval AS interval,
+         value AS value,
+         previous AS previous,
+         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
+  FROM
+    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
+            'Test metric' AS name,
+            'numeric' AS format,
+            'number' AS display,
+            7 AS interval,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))) AS value,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))) AS previous
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event'))))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -30,24 +40,44 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_group_metric
   '''
-  SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-         'Test metric' AS name,
-         'numeric' AS format,
-         'number' AS display,
-         7 AS interval,
-         count(*) AS value
-  FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event'))
+  SELECT id AS id,
+         name AS name,
+         format AS format,
+         display AS display,
+         interval AS interval,
+         value AS value,
+         previous AS previous,
+         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
+  FROM
+    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
+            'Test metric' AS name,
+            'numeric' AS format,
+            'number' AS display,
+            7 AS interval,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))) AS value,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')))) AS previous
+     FROM events
+     WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
   LIMIT 100
   UNION ALL
-  SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
-         'Another test metric' AS name,
-         'currency' AS format,
-         'sparkline' AS display,
-         30 AS interval,
-         count(*) AS value
-  FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event'))
+  SELECT id AS id,
+         name AS name,
+         format AS format,
+         display AS display,
+         interval AS interval,
+         value AS value,
+         previous AS previous,
+         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
+  FROM
+    (SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
+            'Another test metric' AS name,
+            'currency' AS format,
+            'sparkline' AS display,
+            30 AS interval,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))) AS value,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')))) AS previous
+     FROM events
+     WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event')))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -83,21 +113,31 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_metric_interval
   '''
-  SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-         'Test metric' AS name,
-         'numeric' AS format,
-         'number' AS display,
-         7 AS interval,
-         count(*) AS value
-  FROM events
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event'))
+  SELECT id AS id,
+         name AS name,
+         format AS format,
+         display AS display,
+         interval AS interval,
+         value AS value,
+         previous AS previous,
+         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
+  FROM
+    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
+            'Test metric' AS name,
+            'numeric' AS format,
+            'number' AS display,
+            7 AS interval,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))) AS value,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))) AS previous
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -133,38 +173,58 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_person_metric
   '''
-  SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-         'Test metric' AS name,
-         'numeric' AS format,
-         'number' AS display,
-         7 AS interval,
-         count(*) AS value
-  FROM events
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event'))
+  SELECT id AS id,
+         name AS name,
+         format AS format,
+         display AS display,
+         interval AS interval,
+         value AS value,
+         previous AS previous,
+         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
+  FROM
+    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
+            'Test metric' AS name,
+            'numeric' AS format,
+            'number' AS display,
+            7 AS interval,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))) AS value,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))) AS previous
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
   LIMIT 100
   UNION ALL
-  SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
-         'Another test metric' AS name,
-         'currency' AS format,
-         'sparkline' AS display,
-         30 AS interval,
-         count(*) AS value
-  FROM events
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event'))
+  SELECT id AS id,
+         name AS name,
+         format AS format,
+         display AS display,
+         interval AS interval,
+         value AS value,
+         previous AS previous,
+         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
+  FROM
+    (SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
+            'Another test metric' AS name,
+            'currency' AS format,
+            'sparkline' AS display,
+            30 AS interval,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))) AS value,
+            countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))) AS previous
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event')))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
+++ b/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
@@ -97,7 +97,9 @@
          NULL AS format,
          NULL AS display,
          NULL AS interval,
-         NULL AS value
+         NULL AS value,
+         NULL AS previous,
+         NULL AS change_from_previous_pct
   WHERE 0
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -157,7 +159,9 @@
          NULL AS format,
          NULL AS display,
          NULL AS interval,
-         NULL AS value
+         NULL AS value,
+         NULL AS previous,
+         NULL AS change_from_previous_pct
   WHERE 0
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,

--- a/products/customer_analytics/backend/hogql_queries/test/test_usage_metrics_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/test/test_usage_metrics_query_runner.py
@@ -242,7 +242,7 @@ class TestUsageMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         with freeze_time(timezone.now() - timedelta(days=8)):
-            # These should not count
+            # These should not count in `value`, but should count in `previous`
             for _ in range(3):
                 _create_event(
                     event="metric_event",
@@ -252,7 +252,7 @@ class TestUsageMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 )
 
         with freeze_time(timezone.now() - timedelta(days=7)):
-            # These should count, as date_from check is gte
+            # These should count in `value` only, as date_from check is gte and `previous` check is lt
             for _ in range(2):
                 _create_event(
                     event="metric_event",
@@ -279,6 +279,8 @@ class TestUsageMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], str(metric.id))
         self.assertEqual(results[0]["value"], 4.0)
+        self.assertEqual(results[0]["previous"], 3.0)
+        self.assertEqual(results[0]["change_from_previous_pct"], 33.33333333333333)
 
     @freeze_time("2025-10-09T12:11:00")
     @snapshot_clickhouse_queries

--- a/products/customer_analytics/frontend/components/UsageMetricCard.test.tsx
+++ b/products/customer_analytics/frontend/components/UsageMetricCard.test.tsx
@@ -78,7 +78,7 @@ describe('getTrendFromPercentageChange', () => {
 })
 
 describe('getMetricTooltip', () => {
-    const baseMetric = {
+    const baseMetric: UsageMetric = {
         id: 'revenue',
         name: 'Revenue',
         value: 50000,

--- a/products/customer_analytics/frontend/components/UsageMetricCard.test.tsx
+++ b/products/customer_analytics/frontend/components/UsageMetricCard.test.tsx
@@ -1,0 +1,177 @@
+import { IconTrending } from '@posthog/icons'
+
+import { getColorVar } from 'lib/colors'
+import { IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
+
+import { UsageMetric } from '~/queries/schema/schema-general'
+
+import { getMetricTooltip, getTrendFromPercentageChange } from './UsageMetricCard'
+
+describe('getTrendFromPercentageChange', () => {
+    it('returns undefined when change is null', () => {
+        const result = getTrendFromPercentageChange(null)
+        expect(result).toBeUndefined()
+    })
+
+    it('returns flat trend when change is 0', () => {
+        const result = getTrendFromPercentageChange(0)
+        expect(result).toEqual({
+            icon: IconTrendingFlat,
+            color: getColorVar('muted'),
+            tooltip: 'unchanged',
+        })
+    })
+
+    it('returns positive trend when change is positive', () => {
+        const result = getTrendFromPercentageChange(0.25)
+        expect(result).toEqual({
+            icon: IconTrending,
+            color: getColorVar('success'),
+            tooltip: 'increased by 0.25%',
+        })
+    })
+
+    it('returns positive trend with small percentage', () => {
+        const result = getTrendFromPercentageChange(0.05)
+        expect(result).toEqual({
+            icon: IconTrending,
+            color: getColorVar('success'),
+            tooltip: 'increased by 0.05%',
+        })
+    })
+
+    it('returns negative trend when change is negative', () => {
+        const result = getTrendFromPercentageChange(-0.15)
+        expect(result).toEqual({
+            icon: IconTrendingDown,
+            color: getColorVar('danger'),
+            tooltip: 'decreased by 0.15%',
+        })
+    })
+
+    it('returns negative trend with large percentage', () => {
+        const result = getTrendFromPercentageChange(-0.85)
+        expect(result).toEqual({
+            icon: IconTrendingDown,
+            color: getColorVar('danger'),
+            tooltip: 'decreased by 0.85%',
+        })
+    })
+
+    it('handles very small positive changes', () => {
+        const result = getTrendFromPercentageChange(0.001)
+        expect(result).toEqual({
+            icon: IconTrending,
+            color: getColorVar('success'),
+            tooltip: 'increased by 0.001%',
+        })
+    })
+
+    it('handles very small negative changes', () => {
+        const result = getTrendFromPercentageChange(-0.001)
+        expect(result).toEqual({
+            icon: IconTrendingDown,
+            color: getColorVar('danger'),
+            tooltip: 'decreased by 0.001%',
+        })
+    })
+})
+
+describe('getMetricTooltip', () => {
+    const baseMetric = {
+        id: 'revenue',
+        name: 'Revenue',
+        value: 50000,
+        previous: 40000,
+        change_from_previous_pct: 0.25,
+        interval: 30,
+        format: 'currency',
+        display: 'number',
+    }
+
+    it('returns basic tooltip when trend is undefined', () => {
+        const result = getMetricTooltip(baseMetric as UsageMetric, undefined)
+        expect(result).toBe('Revenue: 50,000')
+    })
+
+    it('returns basic tooltip when trend has no tooltip', () => {
+        const trend = {
+            icon: IconTrendingFlat,
+            color: getColorVar('muted'),
+            tooltip: null,
+        }
+        const result = getMetricTooltip(baseMetric as UsageMetric, trend)
+        expect(result).toBe('Revenue: 50,000')
+    })
+
+    it('returns full tooltip when trend has tooltip for increase', () => {
+        const trend = {
+            icon: IconTrending,
+            color: getColorVar('success'),
+            tooltip: 'increased by 0.25%',
+        }
+        const result = getMetricTooltip(baseMetric as UsageMetric, trend)
+        expect(result).toBe('Revenue: increased by 0.25%, to 50,000 from 40,000')
+    })
+
+    it('returns full tooltip when trend has tooltip for decrease', () => {
+        const metric: UsageMetric = {
+            ...baseMetric,
+            value: 35000,
+            previous: 40000,
+            change_from_previous_pct: -0.125,
+        }
+        const trend = {
+            icon: IconTrendingDown,
+            color: getColorVar('danger'),
+            tooltip: 'decreased by 0.125%',
+        }
+        const result = getMetricTooltip(metric, trend)
+        expect(result).toBe('Revenue: decreased by 0.125%, to 35,000 from 40,000')
+    })
+
+    it('returns full tooltip when trend has tooltip for unchanged', () => {
+        const metric: UsageMetric = {
+            ...baseMetric,
+            value: 40000,
+            previous: 40000,
+            change_from_previous_pct: 0,
+        }
+        const trend = {
+            icon: IconTrendingFlat,
+            color: getColorVar('muted'),
+            tooltip: 'unchanged',
+        }
+        const result = getMetricTooltip(metric, trend)
+        expect(result).toBe('Revenue: unchanged, to 40,000 from 40,000')
+    })
+
+    it('handles different metric names', () => {
+        const metric: UsageMetric = {
+            ...baseMetric,
+            name: 'Active Users',
+        }
+        const trend = {
+            icon: IconTrending,
+            color: getColorVar('success'),
+            tooltip: 'increased by 0.25%',
+        }
+        const result = getMetricTooltip(metric, trend)
+        expect(result).toBe('Active Users: increased by 0.25%, to 50,000 from 40,000')
+    })
+
+    it('handles large numbers', () => {
+        const metric: UsageMetric = {
+            ...baseMetric,
+            value: 1234567,
+            previous: 1000000,
+        }
+        const trend = {
+            icon: IconTrending,
+            color: getColorVar('success'),
+            tooltip: 'increased by 0.2345%',
+        }
+        const result = getMetricTooltip(metric, trend)
+        expect(result).toBe('Revenue: increased by 0.2345%, to 1,234,567 from 1,000,000')
+    })
+})

--- a/products/customer_analytics/frontend/components/UsageMetricCard.tsx
+++ b/products/customer_analytics/frontend/components/UsageMetricCard.tsx
@@ -1,6 +1,9 @@
+import { IconTrending } from '@posthog/icons'
 import { LemonCard, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
-import { humanFriendlyCurrency, humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
+import { getColorVar } from 'lib/colors'
+import { IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
+import { formatPercentage, humanFriendlyCurrency, humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
 
 import { UsageMetric } from '~/queries/schema/schema-general'
 
@@ -11,15 +14,52 @@ export const UsageMetricCard = ({ metric }: { metric: UsageMetric }): JSX.Elemen
         }
         return humanFriendlyLargeNumber(metric.value)
     }
+    let trend
+    if (metric.change_from_previous_pct === null) {
+        trend = undefined
+    } else if (metric.change_from_previous_pct === 0) {
+        trend = {
+            icon: IconTrendingFlat,
+            color: getColorVar('muted'),
+            tooltip: null,
+        }
+    } else if (metric.change_from_previous_pct > 0) {
+        trend = {
+            icon: IconTrending,
+            color: getColorVar('success'),
+            tooltip: `increased by ${formatPercentage(Math.abs(metric.change_from_previous_pct))}`,
+        }
+    } else if (metric.change_from_previous_pct < 0) {
+        trend = {
+            icon: IconTrendingDown,
+            color: getColorVar('danger'),
+            tooltip: `decreased by ${formatPercentage(Math.abs(metric.change_from_previous_pct))}`,
+        }
+    }
+
+    const tooltip =
+        trend && trend.tooltip
+            ? `${metric.name}: ${trend.tooltip}, to ${humanFriendlyNumber(metric.value)} from ${humanFriendlyNumber(metric.previous)}`
+            : `${metric.name}: ${humanFriendlyNumber(metric.value)}`
 
     return (
-        <LemonCard hoverEffect={false} className="p-4 flex-1 max-w-[300px]">
-            <div className="text-sm font-semibold text-muted-alt mb-1">{metric.name}</div>
-            <Tooltip title={humanFriendlyNumber(metric.value)}>
-                <div className="text-3xl font-bold text-primary my-2 truncate">{formatValue()}</div>
-            </Tooltip>
-            <div className="text-xs text-muted">Last {metric.interval} days</div>
-        </LemonCard>
+        <Tooltip title={tooltip}>
+            <div>
+                <LemonCard hoverEffect={false} className="p-4 flex flex-col flex-1 justify-between max-w-80 min-h-36 ">
+                    <div>
+                        <div className="text-sm font-semibold text-muted-alt mb-1">{metric.name}</div>
+                        <div className="text-3xl font-bold text-primary my-2 truncate">{formatValue()}</div>
+                    </div>
+                    {trend && metric?.change_from_previous_pct && (
+                        <div style={{ color: trend.color }}>
+                            <trend.icon color={trend.color} />
+                            {formatPercentage(metric.change_from_previous_pct)}
+                        </div>
+                    )}
+                    <div className="text-xs text-muted">Last {metric.interval} days</div>
+                </LemonCard>
+            </div>
+        </Tooltip>
     )
 }
 
@@ -27,7 +67,7 @@ export const UsageMetricCardSkeleton = (): JSX.Element => (
     <div className="@container">
         <div className="grid grid-cols-1 @md:grid-cols-2 @xl:grid-cols-4 gap-4 p-4">
             {[1, 2, 3].map((i) => (
-                <LemonCard key={i} className="p-4">
+                <LemonCard key={i} className="p-4 min-h-36">
                     <LemonSkeleton className="h-4 bg-border rounded w-24 mb-2" />
                     <LemonSkeleton className="h-8 bg-border rounded w-32 my-2" />
                     <LemonSkeleton className="h-3 bg-border rounded w-20" />


### PR DESCRIPTION
## Problem
We want to show how the metric is trending when compared to the previous period.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Part of https://github.com/PostHog/posthog/issues/39179
## Changes
- Calculate metric for previous period
- Display trend in metrics card
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Screenshots
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/997e0fd7-b113-48e8-89a5-868bcc53f294" />

<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/ca5b7ecc-d4e1-4a34-a9c4-09f56937bb14" />

<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/e80b430c-4784-48d5-99fc-1c4122d55604" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
