### PR TITLE
feat: use disk to hold blocks while deleting recording data

### DIFF
--- a/posthog/storage/session_recording_v2_object_storage.py
+++ b/posthog/storage/session_recording_v2_object_storage.py
@@ -363,7 +363,11 @@ class SessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
 
     def download_file(self, key: str, filename: str) -> None:
         try:
-            self.aws_client.download_file(self.bucket, filename, key)
+            self.aws_client.download_file(
+                Bucket=self.bucket,
+                Key=key,
+                Filename=filename,
+            )
         except Exception as e:
             logger.exception(
                 "session_recording_v2_object_storage.download_file_failed",
@@ -375,7 +379,11 @@ class SessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
 
     def upload_file(self, key: str, filename: str) -> None:
         try:
-            self.aws_client.upload_file(filename, self.bucket, key)
+            self.aws_client.upload_file(
+                Bucket=self.bucket,
+                Key=key,
+                Filename=filename,
+            )
         except Exception as e:
             logger.exception(
                 "session_recording_v2_object_storage.upload_file_failed",

--- a/posthog/storage/session_recording_v2_object_storage.py
+++ b/posthog/storage/session_recording_v2_object_storage.py
@@ -28,6 +28,14 @@ class FileFetchError(Exception):
     pass
 
 
+class FileDownloadError(Exception):
+    pass
+
+
+class FileUploadError(Exception):
+    pass
+
+
 class SessionRecordingV2ObjectStorageBase(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read_bytes(self, key: str, first_byte: int, last_byte: int) -> bytes | None:
@@ -79,6 +87,14 @@ class SessionRecordingV2ObjectStorageBase(metaclass=abc.ABCMeta):
     def is_lts_enabled(self) -> bool:
         pass
 
+    @abc.abstractmethod
+    def download_file(self, key: str, filename: str) -> None:
+        pass
+
+    @abc.abstractmethod
+    def upload_file(self, key: str, filename: str) -> None:
+        pass
+
 
 class UnavailableSessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
     def read_bytes(self, key: str, first_byte: int, last_byte: int) -> bytes | None:
@@ -113,6 +129,12 @@ class UnavailableSessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorage
 
     def is_lts_enabled(self) -> bool:
         return False
+
+    def download_file(self, key: str, filename: str) -> None:
+        raise FileDownloadError("Storage not available")
+
+    def upload_file(self, key: str, filename: str) -> None:
+        raise FileUploadError("Storage not available")
 
 
 class SessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
@@ -339,6 +361,30 @@ class SessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
     def is_lts_enabled(self) -> bool:
         return bool(settings.SESSION_RECORDING_V2_S3_LTS_PREFIX)
 
+    def download_file(self, key: str, filename: str) -> None:
+        try:
+            self.aws_client.download_file(self.bucket, filename, key)
+        except Exception as e:
+            logger.exception(
+                "session_recording_v2_object_storage.download_file_failed",
+                bucket=self.bucket,
+                key=key,
+                error=e,
+            )
+            raise FileDownloadError(f"Failed to download file: {str(e)}")
+
+    def upload_file(self, key: str, filename: str) -> None:
+        try:
+            self.aws_client.upload_file(filename, self.bucket, key)
+        except Exception as e:
+            logger.exception(
+                "session_recording_v2_object_storage.upload_file_failed",
+                bucket=self.bucket,
+                key=key,
+                error=e,
+            )
+            raise FileUploadError(f"Failed to upload file: {str(e)}")
+
 
 class AsyncSessionRecordingV2ObjectStorage:
     def __init__(self, aws_client, bucket: str) -> None:
@@ -562,6 +608,30 @@ class AsyncSessionRecordingV2ObjectStorage:
 
     def is_lts_enabled(self) -> bool:
         return bool(settings.SESSION_RECORDING_V2_S3_LTS_PREFIX)
+
+    async def download_file(self, key: str, filename: str) -> None:
+        try:
+            await self.aws_client.download_file(self.bucket, filename, key)
+        except Exception as e:
+            logger.exception(
+                "async_session_recording_v2_object_storage.download_file_failed",
+                bucket=self.bucket,
+                key=key,
+                error=e,
+            )
+            raise FileDownloadError(f"Failed to download file: {str(e)}")
+
+    async def upload_file(self, key: str, filename: str) -> None:
+        try:
+            await self.aws_client.upload_file(filename, self.bucket, key)
+        except Exception as e:
+            logger.exception(
+                "async_session_recording_v2_object_storage.upload_file_failed",
+                bucket=self.bucket,
+                key=key,
+                error=e,
+            )
+            raise FileUploadError(f"Failed to upload file: {str(e)}")
 
 
 _client: SessionRecordingV2ObjectStorageBase = UnavailableSessionRecordingV2ObjectStorage()

--- a/posthog/storage/test/test_session_recording_v2_object_storage.py
+++ b/posthog/storage/test/test_session_recording_v2_object_storage.py
@@ -330,9 +330,7 @@ class TestAsyncSessionRecordingV2Storage(APIBaseTest):
         ]
     )
     @patch("posthog.storage.session_recording_v2_object_storage.aioboto3")
-    async def test_throws_runtimeerror_if_required_settings_missing(
-        self, settings_override, patched_aioboto3
-    ) -> None:
+    async def test_throws_runtimeerror_if_required_settings_missing(self, settings_override, patched_aioboto3) -> None:
         with self.settings(**settings_override):
             client_mock = MagicMock(AsyncContextManager)
             patched_aioboto3.Session.return_value.client = client_mock

--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -146,6 +146,7 @@ async def delete_recording_blocks(input: RecordingWithBlocks) -> None:
             block_length = end_byte - start_byte + 1
             key = path.lstrip("/")
 
+            tmpfile = None
             try:
                 _, tmpfile = mkstemp()
 
@@ -170,7 +171,8 @@ async def delete_recording_blocks(input: RecordingWithBlocks) -> None:
                 logger.warning(f"Failed to upload block at {block.url}, skipping...")
                 block_deleted_error_counter += 1
             finally:
-                os.remove(tmpfile)
+                if tmpfile is not None:
+                    os.remove(tmpfile)
 
     get_block_deleted_counter().add(block_deleted_counter)
     get_block_deleted_error_counter().add(block_deleted_error_counter)

--- a/posthog/temporal/tests/delete_recordings/test_overwrite.py
+++ b/posthog/temporal/tests/delete_recordings/test_overwrite.py
@@ -1,0 +1,41 @@
+import os
+from tempfile import mkstemp
+
+import pytest
+
+from posthog.temporal.delete_recordings.activities import overwrite_block
+
+
+@pytest.mark.parametrize("buffer_size", [1, 64, 1024, 2048])
+@pytest.mark.parametrize(
+    "start_byte,block_length,input_buffer,expected_output_buffer",
+    [
+        (0, 5, bytearray(b"\x01" * 5 + b"\x02" * 5 + b"\x03" * 5), bytearray(b"\x00" * 5 + b"\x02" * 5 + b"\x03" * 5)),
+        (5, 5, bytearray(b"\x01" * 5 + b"\x02" * 5 + b"\x03" * 5), bytearray(b"\x01" * 5 + b"\x00" * 5 + b"\x03" * 5)),
+        (10, 5, bytearray(b"\x01" * 5 + b"\x02" * 5 + b"\x03" * 5), bytearray(b"\x01" * 5 + b"\x02" * 5 + b"\x00" * 5)),
+        (0, 15, bytearray(b"\x01" * 5 + b"\x02" * 5 + b"\x03" * 5), bytearray(b"\x00" * 15)),
+        (
+            150,
+            500,
+            bytearray(b"\x01" * 150 + b"\x02" * 500 + b"\x03" * 5),
+            bytearray(b"\x01" * 150 + b"\x00" * 500 + b"\x03" * 5),
+        ),
+        (0, 655, bytearray(b"\x01" * 150 + b"\x02" * 500 + b"\x03" * 5), bytearray(b"\x00" * 655)),
+    ],
+)
+def test_overwrite_block(
+    start_byte: int, block_length: int, buffer_size: int, input_buffer: bytearray, expected_output_buffer: bytearray
+):
+    _, tmpfile = mkstemp()
+
+    with open(tmpfile, "wb") as fp:
+        fp.write(input_buffer)
+
+    overwrite_block(tmpfile, start_byte, block_length, buffer_size)
+
+    with open(tmpfile, "rb") as fp:
+        output_buffer = bytearray(fp.read())
+
+    assert output_buffer == expected_output_buffer
+
+    os.remove(tmpfile)


### PR DESCRIPTION
The Temporal workflows for deleting recordings are frequently causing the worker to run out-of-memory. Due to the high variance in batch file sizes on S3 the memory consumption for these workflows is highly irregular.

This PR changes the delete-recording-blocks activity to use the filesystem to hold data while overwriting blocks, instead of holding it in memory. This should make the memory consumption very predictable (and low).