### PR TITLE
fix: Add disposables plugin to toolbar

### DIFF
--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -13,6 +13,7 @@ import { windowValuesPlugin } from 'kea-window-values'
 import type { PostHog } from 'posthog-js'
 import { createRoot } from 'react-dom/client'
 
+import { disposablesPlugin } from '~/kea-disposables'
 import { ToolbarApp } from '~/toolbar/ToolbarApp'
 import { ToolbarParams } from '~/types'
 
@@ -26,6 +27,7 @@ interface InitKeaProps {
 const initKeaInToolbar = ({ routerHistory, routerLocation, beforePlugins }: InitKeaProps = {}): void => {
     const plugins = [
         ...(beforePlugins || []),
+        disposablesPlugin,
         localStoragePlugin(),
         windowValuesPlugin({ window: window }),
         routerPlugin({


### PR DESCRIPTION
## Problem

The toolbar stopped appearing. It was missing the disposables plugin.

## How did you test this code?

Tested locally before and after this change, toolbar is back in working order.

