### PR TITLE
refactor: Standardize HogQL functions

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -72,7 +72,7 @@ def _initial_domain_type_expr() -> ast.Expr:
 if(
     {referring_domain} = '$direct',
     '$direct',
-    hogql_lookupDomainType({referring_domain})
+    lookupDomainType({referring_domain})
 )
 """
     )
@@ -287,14 +287,14 @@ def _initial_default_channel_rules_expr():
                 {gad_source} IS NOT NULL
             ),
             coalesce(
-                hogql_lookupPaidSourceType({source}),
+                lookupPaidSourceType({source}),
                 if(
                     match({campaign}, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
                     'Paid Shopping',
                     NULL
                 ),
-                hogql_lookupPaidMediumType({medium}),
-                hogql_lookupPaidSourceType({referring_domain}),
+                lookupPaidMediumType({medium}),
+                lookupPaidSourceType({referring_domain}),
                 multiIf (
                     {gad_source} = '1',
                     'Paid Search',
@@ -318,14 +318,14 @@ def _initial_default_channel_rules_expr():
             'Direct',
 
             coalesce(
-                hogql_lookupOrganicSourceType({source}),
+                lookupOrganicSourceType({source}),
                 if(
                     match({campaign}, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
                     'Organic Shopping',
                     NULL
                 ),
-                hogql_lookupOrganicMediumType({medium}),
-                hogql_lookupOrganicSourceType({referring_domain}),
+                lookupOrganicMediumType({medium}),
+                lookupOrganicSourceType({referring_domain}),
                 multiIf(
                     match({campaign}, '^(.*video.*)$'),
                     'Organic Video',

--- a/posthog/hogql/functions/embed_text.py
+++ b/posthog/hogql/functions/embed_text.py
@@ -10,11 +10,11 @@ def resolve_embed_text(team: Team | int | None, node: ast.Call) -> ast.Constant:
     args = node.args
 
     if team is None:
-        raise ValueError("embed_text() requires a team or team ID")
+        raise ValueError("embedText() requires a team or team ID")
     if len(args) < 1:
-        raise ValueError("embed_text() takes at least one argument")
+        raise ValueError("embedText() takes at least one argument")
     if len(args) > 2:
-        raise ValueError("embed_text() takes at most two arguments")
+        raise ValueError("embedText() takes at most two arguments")
 
     # mypy really goes crazy
     if not isinstance(team, Team):
@@ -26,9 +26,9 @@ def resolve_embed_text(team: Team | int | None, node: ast.Call) -> ast.Constant:
     model = args[1] if len(args) == 2 else None
 
     if not isinstance(text, ast.Constant) or not isinstance(text.value, str):
-        raise ValueError("embed_text() first argument must be a string literal")
+        raise ValueError("embedText() first argument must be a string literal")
     if model is not None and (not isinstance(model, ast.Constant) or not isinstance(model.value, str)):
-        raise ValueError("embed_text() second argument must be a string literal")
+        raise ValueError("embedText() second argument must be a string literal")
 
     response = generate_embedding(team_used, text.value, model.value if model else None)
 

--- a/posthog/hogql/functions/posthog.py
+++ b/posthog/hogql/functions/posthog.py
@@ -5,8 +5,8 @@ from .core import HogQLFunctionMeta
 HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "matchesAction": HogQLFunctionMeta("matchesAction", 1, 1),
     "sparkline": HogQLFunctionMeta("sparkline", 1, 1),
-    "recording_button": HogQLFunctionMeta("recording_button", 1, 2),
-    "explain_csp_report": HogQLFunctionMeta("explain_csp_report", 1, 1),
+    "recordingButton": HogQLFunctionMeta("recordingButton", 1, 2),
+    "explainCSPReport": HogQLFunctionMeta("explainCSPReport", 1, 1),
     # Allow case-insensitive matching since people might not know "SemVer" is the right capitalization
     "sortablesemver": HogQLFunctionMeta(
         "arrayMap(x -> toInt64OrZero(x),  splitByChar('.', extract(assumeNotNull({}), '(\\d+(\\.\\d+)+)')))",
@@ -15,13 +15,13 @@ HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         case_sensitive=False,
         signatures=[((StringType(),), ArrayType(item_type=IntegerType()))],
     ),
-    "embed_text": HogQLFunctionMeta("embed_text", 1, 2),
+    "embedText": HogQLFunctionMeta("embedText", 1, 2),
     # posthog/models/channel_type/sql.py and posthog/hogql/database/schema/channel_type.py
-    "hogql_lookupDomainType": HogQLFunctionMeta("hogql_lookupDomainType", 1, 1),
-    "hogql_lookupPaidSourceType": HogQLFunctionMeta("hogql_lookupPaidSourceType", 1, 1),
-    "hogql_lookupPaidMediumType": HogQLFunctionMeta("hogql_lookupPaidMediumType", 1, 1),
-    "hogql_lookupOrganicSourceType": HogQLFunctionMeta("hogql_lookupOrganicSourceType", 1, 1),
-    "hogql_lookupOrganicMediumType": HogQLFunctionMeta("hogql_lookupOrganicMediumType", 1, 1),
+    "lookupDomainType": HogQLFunctionMeta("lookupDomainType", 1, 1),
+    "lookupPaidSourceType": HogQLFunctionMeta("lookupPaidSourceType", 1, 1),
+    "lookupPaidMediumType": HogQLFunctionMeta("lookupPaidMediumType", 1, 1),
+    "lookupOrganicSourceType": HogQLFunctionMeta("lookupOrganicSourceType", 1, 1),
+    "lookupOrganicMediumType": HogQLFunctionMeta("lookupOrganicMediumType", 1, 1),
     # posthog/models/exchange_rate/sql.py
     # convertCurrency(from_currency, to_currency, amount, timestamp?)
     "convertCurrency": HogQLFunctionMeta(

--- a/posthog/hogql/functions/test/test_explain_csp_button.py
+++ b/posthog/hogql/functions/test/test_explain_csp_button.py
@@ -7,7 +7,7 @@ from posthog.hogql.query import execute_hogql_query
 class TestExplainCSPReport(BaseTest):
     def test_explain_csp_report(self):
         response = execute_hogql_query(
-            "select explain_csp_report({'violated_directive': 'script-src', 'original_policy': 'script-src https://example.com'})",
+            "select explainCSPReport({'violated_directive': 'script-src', 'original_policy': 'script-src https://example.com'})",
             self.team,
             pretty=False,
         )
@@ -38,5 +38,5 @@ class TestExplainCSPReport(BaseTest):
 
     def test_explain_csp_report_no_properties_error(self):
         with self.assertRaises(QueryError) as e:
-            execute_hogql_query(f"SELECT explain_csp_report()", self.team)
-        self.assertEqual(str(e.exception), "Function 'explain_csp_report' expects 1 argument, found 0")
+            execute_hogql_query(f"SELECT explainCSPReport()", self.team)
+        self.assertEqual(str(e.exception), "Function 'explainCSPReport' expects 1 argument, found 0")

--- a/posthog/hogql/functions/test/test_recording_button.py
+++ b/posthog/hogql/functions/test/test_recording_button.py
@@ -6,7 +6,7 @@ from posthog.hogql.query import execute_hogql_query
 
 class TestRecordingButton(BaseTest):
     def test_recording_button(self):
-        response = execute_hogql_query("select recording_button('12345-6789', 'active')", self.team, pretty=False)
+        response = execute_hogql_query("select recordingButton('12345-6789', 'active')", self.team, pretty=False)
         self.assertEqual(
             response.clickhouse,
             f"SELECT tuple(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s, %(hogql_val_3)s, %(hogql_val_4)s, %(hogql_val_5)s) LIMIT 100 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1",
@@ -22,5 +22,5 @@ class TestRecordingButton(BaseTest):
 
     def test_recording_button_error(self):
         with self.assertRaises(QueryError) as e:
-            execute_hogql_query(f"SELECT recording_button()", self.team)
-        self.assertEqual(str(e.exception), "Function 'recording_button' expects at least 1 argument, found 0")
+            execute_hogql_query(f"SELECT recordingButton()", self.team)
+        self.assertEqual(str(e.exception), "Function 'recordingButton' expects at least 1 argument, found 0")

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1392,21 +1392,21 @@ class _Printer(Visitor[str]):
             args = [self.visit(arg) for arg in node.args]
 
             if self.dialect == "clickhouse":
-                if node.name == "embed_text":
+                if node.name == "embedText":
                     return self.visit_constant(resolve_embed_text(self.context.team, node))
-                if node.name == "hogql_lookupDomainType":
+                elif node.name == "lookupDomainType":
                     channel_dict = get_channel_definition_dict()
                     return f"coalesce(dictGetOrNull('{channel_dict}', 'domain_type', (coalesce({args[0]}, ''), 'source')), dictGetOrNull('{channel_dict}', 'domain_type', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source')))"
-                elif node.name == "hogql_lookupPaidSourceType":
+                elif node.name == "lookupPaidSourceType":
                     channel_dict = get_channel_definition_dict()
                     return f"coalesce(dictGetOrNull('{channel_dict}', 'type_if_paid', (coalesce({args[0]}, ''), 'source')) , dictGetOrNull('{channel_dict}', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source')))"
-                elif node.name == "hogql_lookupPaidMediumType":
+                elif node.name == "lookupPaidMediumType":
                     channel_dict = get_channel_definition_dict()
                     return f"dictGetOrNull('{channel_dict}', 'type_if_paid', (coalesce({args[0]}, ''), 'medium'))"
-                elif node.name == "hogql_lookupOrganicSourceType":
+                elif node.name == "lookupOrganicSourceType":
                     channel_dict = get_channel_definition_dict()
                     return f"coalesce(dictGetOrNull('{channel_dict}', 'type_if_organic', (coalesce({args[0]}, ''), 'source')), dictGetOrNull('{channel_dict}', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source')))"
-                elif node.name == "hogql_lookupOrganicMediumType":
+                elif node.name == "lookupOrganicMediumType":
                     channel_dict = get_channel_definition_dict()
                     return f"dictGetOrNull('{channel_dict}', 'type_if_organic', (coalesce({args[0]}, ''), 'medium'))"
                 elif node.name == "convertCurrency":

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -513,9 +513,9 @@ class Resolver(CloningVisitor):
 
             if node.name == "sparkline":
                 return self.visit(sparkline(node=node, args=node.args))
-            if node.name == "recording_button":
+            if node.name == "recordingButton":
                 return self.visit(recording_button(node=node, args=node.args))
-            if node.name == "explain_csp_report":
+            if node.name == "explainCSPReport":
                 return self.visit(explain_csp_report(node=node, args=node.args))
             if node.name == "matchesAction":
                 events_alias, _ = self._get_events_table_current_scope()

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2133,7 +2133,7 @@ class TestPrinter(BaseTest):
 
     def test_lookup_domain_type(self):
         printed = self._print(
-            "select hogql_lookupDomainType('www.google.com') as domain from events",
+            "select lookupDomainType('www.google.com') as domain from events",
             settings=HogQLGlobalSettings(max_execution_time=10),
         )
         assert (
@@ -2149,7 +2149,7 @@ class TestPrinter(BaseTest):
 
     def test_lookup_paid_source_type(self):
         printed = self._print(
-            "select hogql_lookupPaidSourceType('google') as source from events",
+            "select lookupPaidSourceType('google') as source from events",
             settings=HogQLGlobalSettings(max_execution_time=10),
         )
         assert (
@@ -2165,7 +2165,7 @@ class TestPrinter(BaseTest):
 
     def test_lookup_paid_medium_type(self):
         printed = self._print(
-            "select hogql_lookupPaidMediumType('social') as medium from events",
+            "select lookupPaidMediumType('social') as medium from events",
             settings=HogQLGlobalSettings(max_execution_time=10),
         )
         assert (
@@ -2177,7 +2177,7 @@ class TestPrinter(BaseTest):
 
     def test_lookup_organic_source_type(self):
         printed = self._print(
-            "select hogql_lookupOrganicSourceType('google') as source  from events",
+            "select lookupOrganicSourceType('google') as source  from events",
             settings=HogQLGlobalSettings(max_execution_time=10),
         )
         assert (
@@ -2193,7 +2193,7 @@ class TestPrinter(BaseTest):
 
     def test_lookup_organic_medium_type(self):
         printed = self._print(
-            "select hogql_lookupOrganicMediumType('social') as medium from events",
+            "select lookupOrganicMediumType('social') as medium from events",
             settings=HogQLGlobalSettings(max_execution_time=10),
         )
         assert (

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -677,7 +677,7 @@ class TestResolver(BaseTest):
         )
         node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
 
-        node2 = self._select("select recording_button('12345', 'active')")
+        node2 = self._select("select recordingButton('12345', 'active')")
         node2 = cast(ast.SelectQuery, resolve_types(node2, self.context, dialect="clickhouse"))
         assert node == node2
 
@@ -688,7 +688,7 @@ class TestResolver(BaseTest):
         node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
 
         node2 = self._select(
-            "select explain_csp_report({'violated_directive': 'script-src', 'original_policy': 'script-src https://example.com'})"
+            "select explainCSPReport({'violated_directive': 'script-src', 'original_policy': 'script-src https://example.com'})"
         )
         node2 = cast(ast.SelectQuery, resolve_types(node2, self.context, dialect="clickhouse"))
         assert node == node2

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -62,7 +62,7 @@
   
   And lastly these are some HogQL specific functions:
   ```
-  ['matchesAction', 'sparkline', 'recording_button', 'explain_csp_report', 'sortablesemver', 'hogql_lookupDomainType', 'hogql_lookupPaidSourceType', 'hogql_lookupPaidMediumType', 'hogql_lookupOrganicSourceType', 'hogql_lookupOrganicMediumType', 'convertCurrency', 'getSurveyResponse', 'uniqueSurveySubmissionsFilter']
+  ['matchesAction', 'sparkline', 'recordingButton', 'explainCSPReport', 'sortablesemver', 'embedText', 'lookupDomainType', 'lookupPaidSourceType', 'lookupPaidMediumType', 'lookupOrganicSourceType', 'lookupOrganicMediumType', 'convertCurrency', 'getSurveyResponse', 'uniqueSurveySubmissionsFilter']
   ```
   
   You fix HogQL errors that may come from either HogQL resolver errors or clickhouse execution errors. You don't help with other knowledge.

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -62,7 +62,7 @@
   
   And lastly these are some HogQL specific functions:
   ```
-  ['matchesAction', 'sparkline', 'recording_button', 'explain_csp_report', 'sortablesemver', 'embed_text', 'hogql_lookupDomainType', 'hogql_lookupPaidSourceType', 'hogql_lookupPaidMediumType', 'hogql_lookupOrganicSourceType', 'hogql_lookupOrganicMediumType', 'convertCurrency', 'getSurveyResponse', 'uniqueSurveySubmissionsFilter']
+  ['matchesAction', 'sparkline', 'recording_button', 'explain_csp_report', 'sortablesemver', 'hogql_lookupDomainType', 'hogql_lookupPaidSourceType', 'hogql_lookupPaidMediumType', 'hogql_lookupOrganicSourceType', 'hogql_lookupOrganicMediumType', 'convertCurrency', 'getSurveyResponse', 'uniqueSurveySubmissionsFilter']
   ```
   
   You fix HogQL errors that may come from either HogQL resolver errors or clickhouse execution errors. You don't help with other knowledge.


### PR DESCRIPTION
Most of our HogQL functions follow `camelCase` with the exception of a handful of them, so let's standardize them all! 

~This is a breaking change since people might have these in their queries, but I don't know how to check whether this is gonna break something yet, might need some help with this.~ See [comment](https://github.com/PostHog/posthog/pull/39603#issuecomment-3399974439).
    
Also, I've removed the `hogql_` prefix from the channel type ones since we don't have that prefix anywhere else