### PR TITLE
chore: return membership changes to the job

### DIFF
--- a/posthog/kafka_client/topics.py
+++ b/posthog/kafka_client/topics.py
@@ -28,6 +28,7 @@ KAFKA_METRICS_TIME_TO_SEE_DATA = f"{KAFKA_PREFIX}clickhouse_metrics_time_to_see_
 KAFKA_PERSON_OVERRIDE = f"{KAFKA_PREFIX}clickhouse_person_override{SUFFIX}"
 KAFKA_LOG_ENTRIES = f"{KAFKA_PREFIX}log_entries{SUFFIX}"
 KAFKA_LOG_ENTRIES_V2_TEST = f"{KAFKA_PREFIX}log_entries_v2_test{SUFFIX}"
+KAFKA_COHORT_MEMBERSHIP_CHANGED = f"{KAFKA_PREFIX}cohort_membership_changed{SUFFIX}"
 
 KAFKA_CLICKHOUSE_HEATMAP_EVENTS = f"{KAFKA_PREFIX}clickhouse_heatmap_events{SUFFIX}"
 

--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -289,7 +289,7 @@ def process_condition_batch_activity(inputs: ProcessConditionBatchInputs) -> Coh
                         ),
                     ]
 
-                    if memberships % 100_000 == 0:
+                    if len(memberships) >= 100_000:
                         logger.info(f"Processed {len(memberships)} memberships. Flushing to Kafka...")
                         # TODO: Flush to Kafka
                         memberships = []


### PR DESCRIPTION
## Problem

We need to produce from Temporal because ClickHouse is too slow if we need to run thousands of inserts to Kafka.

## Changes

Populate a membership object that will later be flushed to Kafka.

## How did you test this code?

This is the test.
