### PR TITLE
fix(cohort): Unable to create cohort after creating one unless the page is reloaded

### DIFF
--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -1,7 +1,7 @@
 import { actions, afterMount, beforeUnmount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
-import { actionToUrl, router } from 'kea-router'
+import { router } from 'kea-router'
 import posthog from 'posthog-js'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -92,6 +92,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         addPersonToCreateStaticCohort: (personId: string) => ({ personId }),
         removePersonFromCreateStaticCohort: (personId: string) => ({ personId }),
         removePersonFromCohort: (personId: string) => ({ personId }),
+        resetPersonsToCreateStaticCohort: true,
     }),
 
     reducers(({ props }) => ({
@@ -253,6 +254,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     delete newState[personId]
                     return newState
                 },
+                resetPersonsToCreateStaticCohort: () => ({}),
             },
         ],
     })),
@@ -394,6 +396,13 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         })
                         mountedDataNodeLogic?.actions.loadData('force_blocking')
                     }
+                    if (existingCohort.id === 'new') {
+                        router.actions.push(urls.cohort(cohort.id))
+                        if (existingCohort.is_static) {
+                            actions.resetPersonsToCreateStaticCohort()
+                        }
+                        return { ...NEW_COHORT }
+                    }
                     return processCohort(cohort)
                 },
                 onCriteriaChange: ({ newGroup, id }) => {
@@ -522,10 +531,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                 }
             }
         },
-    })),
-
-    actionToUrl(({ values }) => ({
-        saveCohortSuccess: () => urls.cohort(values.cohort.id),
     })),
 
     afterMount(({ actions, props }) => {


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/39601

Apologies, bug introduced in https://github.com/PostHog/posthog/pull/38762.

The issue is that because now the `cohortEdit` logic for `new` is permanently attached to the tab, after we create the cohort we need to reset the state.

## Changes

1) In `saveCohort`, after the cohort is created, instead of returning `processCohort(cohort)`, we route the user to the newly created cohort + return `NEW_COHORT`. 
2) Instead of relying on `actionToUrl` to route the user, we will just route them ourselves. (existing cohorts do not need to be routed)
3) We also reset the static cohort person state if the cohort created is static

https://github.com/user-attachments/assets/2ed94f0d-cd58-4008-8683-d01602d57c89



## How did you test this code?

Locally: 
1) Create a static cohort
2) Save the static cohort
3) Navigate back to cohorts
4) Try to create a static cohort again, you should be able to do it. 
