### PR TITLE
fix(replay): events in one line

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -493,7 +493,7 @@ function EventTriggerOptions(): JSX.Element | null {
             </div>
             <p>Start recording when a PostHog event is queued.</p>
 
-            <div className="flex gap-2">
+            <div className="flex gap-2 flex-wrap">
                 {eventTriggerConfig?.map((trigger) => (
                     <AccessControlAction
                         key={trigger}


### PR DESCRIPTION
## Problem

Context: https://posthog.slack.com/archives/C03PB072FMJ/p1760390264000749

## Changes

### before
<img width="1334" height="241" alt="Screenshot 2025-10-14 at 10 32 38" src="https://github.com/user-attachments/assets/1f91c62d-a4b9-4df2-bd2e-7182cdf83dde" />


### after
<img width="1301" height="253" alt="Screenshot 2025-10-14 at 10 33 36" src="https://github.com/user-attachments/assets/569c75bb-4460-4648-ac22-6b8282742582" />
