### PR TITLE
chore(prettier): align fixtures ignore with markdownlint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -25,3 +25,4 @@ cli/target/
 cli/tests/_cases/**/*
 frontend/src/products.tsx
 frontend/src/layout.html
+**/fixtures/**


### PR DESCRIPTION
## Summary

Adds `**/fixtures/**` to `.prettierignore` to match existing markdownlint ignore behavior.

## Context

In #38886, test fixture markdown files were added with `"ignores": ["**/fixtures/**"]` in `.config/.markdownlint-cli2.jsonc`. However, `.prettierignore` was not updated to match, causing inconsistent tooling behavior:

- markdownlint skips fixtures (by design)
- prettier reformats fixtures during pre-commit hooks

Test fixture files should preserve their original formatting as they represent authentic external data used for testing purposes.

cc @slshults (author of original fixtures ignore config)