### PR TITLE
fix(ux): upload logo click

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -62,7 +62,7 @@ export const LemonFileInput = ({
     }, [value]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     const handleCallToActionClick = (): void => {
-        if (disabledReason === undefined && fileInputRef.current) {
+        if (!disabledReason && fileInputRef.current) {
             fileInputRef.current.click()
         }
     }


### PR DESCRIPTION
## Problem

You couldn't click on the logo to upload a new organization logo, despite the text

<img width="467" height="194" alt="image" src="https://github.com/user-attachments/assets/b60c363a-588d-4a49-9e73-8191f5b53d3a" />

## Changes

Now you can. `disabledReason` was `null`, not `undefined` 🤷 

## How did you test this code?

Clicked locally on the logo.