### PR TITLE
fix: drop messages if retention period lookup fails for team

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.test.ts
@@ -41,6 +41,7 @@ describe('TeamFilter', () => {
         jest.clearAllMocks()
         mockTeamService = {
             getTeamByToken: jest.fn(),
+            getRetentionPeriodByTeamId: jest.fn(),
         } as unknown as jest.Mocked<TeamService>
         teamFilter = new TeamFilter(mockTeamService)
     })
@@ -49,12 +50,14 @@ describe('TeamFilter', () => {
         it('processes messages with valid team token', async () => {
             const message = createMessage('valid-token')
             mockTeamService.getTeamByToken.mockResolvedValueOnce(validTeam)
+            mockTeamService.getRetentionPeriodByTeamId.mockResolvedValueOnce('90d')
 
             const result = await teamFilter.filterBatch([message])
 
             expect(result).toEqual([{ team: validTeam, message: message }])
             expect(mockTeamService.getTeamByToken).toHaveBeenCalledWith('valid-token')
             expect(mockTeamService.getTeamByToken).toHaveBeenCalledTimes(1)
+            expect(mockTeamService.getRetentionPeriodByTeamId).toHaveBeenCalledTimes(1)
         })
 
         it('drops messages with no token in header', async () => {
@@ -75,6 +78,19 @@ describe('TeamFilter', () => {
             expect(mockTeamService.getTeamByToken).toHaveBeenCalledWith('invalid-token')
             expect(mockTeamService.getTeamByToken).toHaveBeenCalledTimes(1)
         })
+
+        it('drops messages with team missing retention period', async () => {
+            const message = createMessage('valid-token')
+            mockTeamService.getTeamByToken.mockResolvedValueOnce(validTeam)
+            mockTeamService.getRetentionPeriodByTeamId.mockResolvedValueOnce(null)
+
+            const result = await teamFilter.filterBatch([message])
+
+            expect(result).toEqual([])
+            expect(mockTeamService.getTeamByToken).toHaveBeenCalledWith('valid-token')
+            expect(mockTeamService.getTeamByToken).toHaveBeenCalledTimes(1)
+            expect(mockTeamService.getRetentionPeriodByTeamId).toHaveBeenCalledTimes(1)
+        })
     })
 
     describe('batch processing', () => {
@@ -86,6 +102,7 @@ describe('TeamFilter', () => {
             ]
 
             mockTeamService.getTeamByToken.mockResolvedValue(validTeam)
+            mockTeamService.getRetentionPeriodByTeamId.mockResolvedValue('90d')
 
             const result = await teamFilter.filterBatch(messages)
 
@@ -107,6 +124,7 @@ describe('TeamFilter', () => {
 
             const team2 = { ...validTeam, teamId: 2 }
             mockTeamService.getTeamByToken.mockResolvedValueOnce(validTeam).mockResolvedValueOnce(team2)
+            mockTeamService.getRetentionPeriodByTeamId.mockResolvedValue('90d')
 
             const result = await teamFilter.filterBatch(messages)
 
@@ -127,6 +145,7 @@ describe('TeamFilter', () => {
             ]
 
             mockTeamService.getTeamByToken.mockResolvedValue(validTeam)
+            mockTeamService.getRetentionPeriodByTeamId.mockResolvedValue('90d')
 
             const result = await teamFilter.filterBatch(messages)
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.ts
@@ -57,6 +57,12 @@ export class TeamFilter {
             return null
         }
 
+        const retention_period = await this.teamService.getRetentionPeriodByTeamId(team.teamId)
+        if (!retention_period) {
+            dropMessage('team_missing_retention_period')
+            return null
+        }
+
         return team
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.ts
@@ -57,8 +57,8 @@ export class TeamFilter {
             return null
         }
 
-        const retention_period = await this.teamService.getRetentionPeriodByTeamId(team.teamId)
-        if (!retention_period) {
+        const retentionPeriod = await this.teamService.getRetentionPeriodByTeamId(team.teamId)
+        if (!retentionPeriod) {
             dropMessage('team_missing_retention_period')
             return null
         }


### PR DESCRIPTION
This PR adds a check to drop messages from teams for which the retention setting lookup fails.

This avoids errors during later processing which would cause the service to shut down.