### PR TITLE
fix(experiments): show raw numbers also when exposures is less than 50

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
@@ -478,7 +478,6 @@ function DeltaChartContent({ chartSvgRef }: { chartSvgRef: React.RefObject<SVGSV
             <ChartEmptyState
                 height={chartHeight}
                 experimentStarted={!!experiment.start_date}
-                hasMinimumExposure={hasMinimumExposureForResults}
                 metric={metric}
                 error={error}
             />

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
@@ -7,6 +7,7 @@ import {
     getDelta,
     getIntervalBounds,
     getNiceTickValues,
+    getValidationFailureType,
     getVariantInterval,
     isBayesianResult,
 } from '../shared/utils'
@@ -53,6 +54,7 @@ export function ChartCell({
     const [lower, upper] = getIntervalBounds(variantResult)
     const delta = getDelta(variantResult)
     const hasEnoughData = !!interval
+    const validationFailureType = getValidationFailureType(variantResult)
 
     // Position calculations
     const viewBoxHeight = CHART_CELL_VIEW_BOX_HEIGHT
@@ -147,11 +149,17 @@ export function ChartCell({
                     )}
                 </svg>
 
-                {/* "Not enough data" message as HTML overlay */}
-                {!hasEnoughData && (
+                {/* Validation failure message as HTML overlay */}
+                {(!hasEnoughData || validationFailureType) && (
                     <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                        <div className="bg-border-light px-3 py-1 rounded text-xs text-muted whitespace-nowrap">
-                            Not enough data yet
+                        <div
+                            className={`px-3 py-1 rounded text-xs whitespace-nowrap ${
+                                validationFailureType === 'error'
+                                    ? 'bg-danger-highlight text-danger'
+                                    : 'bg-border-light text-muted'
+                            }`}
+                        >
+                            {validationFailureType === 'error' ? 'Error' : 'Not enough data yet'}
                         </div>
                     </div>
                 )}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -205,9 +205,9 @@ export function MetricRowGroup({
 
     // Handle loading, API errors, or missing result
     // Note: If result has validation_failures but no API error, we'll show the data with inline warnings
-    const hasValidationFailuresOnly = !error && result && hasValidationFailures(result)
+    const hasResultWithValidationFailures = result && hasValidationFailures(result)
 
-    if (isLoading || error || !result || (!hasMinimumExposureForResults && !hasValidationFailuresOnly)) {
+    if (isLoading || error || !result || (!hasMinimumExposureForResults && !hasResultWithValidationFailures)) {
         return (
             <tr
                 className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -30,6 +30,7 @@ import {
     getDelta,
     getMetricSubtitleValues,
     getNiceTickValues,
+    hasValidationFailures,
     isDeltaPositive,
     isSignificant,
     isWinning,
@@ -202,8 +203,11 @@ export function MetricRowGroup({
         })
     }
 
-    // Handle loading or error states
-    if (isLoading || error || !result || !hasMinimumExposureForResults) {
+    // Handle loading, API errors, or missing result
+    // Note: If result has validation_failures but no API error, we'll show the data with inline warnings
+    const hasValidationFailuresOnly = !error && result && hasValidationFailures(result)
+
+    if (isLoading || error || !result || (!hasMinimumExposureForResults && !hasValidationFailuresOnly)) {
         return (
             <tr
                 className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
@@ -243,7 +247,6 @@ export function MetricRowGroup({
                         <ChartEmptyState
                             height={CELL_HEIGHT}
                             experimentStarted={!!experiment.start_date}
-                            hasMinimumExposure={hasMinimumExposureForResults}
                             metric={metric}
                             error={error}
                         />

--- a/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
@@ -1,25 +1,16 @@
-import { IconActivity, IconClock } from '@posthog/icons'
+import { IconClock } from '@posthog/icons'
 import { LemonTag, Tooltip } from '@posthog/lemon-ui'
-
-import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS } from '~/scenes/experiments/constants'
 
 import { ErrorChecklist } from './ErrorChecklist'
 
 interface ChartEmptyStateProps {
     height: number
     experimentStarted: boolean
-    hasMinimumExposure: boolean
     metric: any
     error?: any
 }
 
-export function ChartEmptyState({
-    height,
-    experimentStarted,
-    hasMinimumExposure,
-    error,
-    metric,
-}: ChartEmptyStateProps): JSX.Element {
+export function ChartEmptyState({ height, experimentStarted, error, metric }: ChartEmptyStateProps): JSX.Element {
     return (
         // eslint-disable-next-line react/forbid-dom-props
         <div className="flex items-center justify-center w-full" style={{ height: `${height}px` }}>
@@ -29,13 +20,6 @@ export function ChartEmptyState({
                         <IconClock fontSize="1em" />
                     </LemonTag>
                     <span>Waiting for experiment to start&hellip;</span>
-                </div>
-            ) : !hasMinimumExposure ? (
-                <div className="flex items-center justify-center text-secondary cursor-default text-[12px] font-normal">
-                    <LemonTag size="small" className="mr-2">
-                        <IconActivity fontSize="1em" />
-                    </LemonTag>
-                    <span>Waiting for {EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS}+ exposures to show results</span>
                 </div>
             ) : (
                 <div className="flex items-center justify-center text-secondary cursor-default text-[12px] font-normal">

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -7,10 +7,12 @@ import type {
     ExperimentTrendsQuery,
     ExperimentVariantResultBayesian,
     ExperimentVariantResultFrequentist,
+    NewExperimentQueryResponse,
 } from '~/queries/schema/schema-general'
 import {
     ExperimentDataWarehouseNode,
     ExperimentMetricType,
+    ExperimentStatsValidationFailure,
     NodeKind,
     isExperimentMeanMetric,
     isExperimentRatioMetric,
@@ -341,4 +343,29 @@ export function getMetricColors(
         positive: colors.BAR_POSITIVE,
         negative: colors.BAR_NEGATIVE,
     }
+}
+
+export function hasValidationFailures(result: NewExperimentQueryResponse | null): boolean {
+    if (!result) {
+        return false
+    }
+    return !!(
+        result.baseline?.validation_failures?.length ||
+        result.variant_results?.some((v) => v.validation_failures?.length)
+    )
+}
+
+export function getValidationFailureType(variant: ExperimentStatsBaseValidated): 'not-enough-data' | 'error' | null {
+    if (!variant.validation_failures || variant.validation_failures.length === 0) {
+        return null
+    }
+
+    if (
+        variant.validation_failures.includes(ExperimentStatsValidationFailure.NotEnoughExposures) ||
+        variant.validation_failures.includes(ExperimentStatsValidationFailure.NotEnoughMetricData)
+    ) {
+        return 'not-enough-data'
+    }
+
+    return 'error'
 }


### PR DESCRIPTION
## Problem

We are not showing the raw numbers if exposures are less than 50. This is annoying for customers when they just want to see if their experiment is configured correctly and returning _some_ data.

This has been requested a few times in support.

## Changes

Instead of showing "Waiting for ..." that fills the whole row, show the raw numbers returned from the query and the "Not enough data" label when there is not enough data to compute statistical significance.

<img width="1332" height="212" alt="Screenshot 2025-10-14 at 13 26 51" src="https://github.com/user-attachments/assets/ce7f0683-bf2e-4061-920d-4717f9ebec62" />

## How did you test this code?

- tested locally