### PR TITLE
chore: HogQL: let the printer optimize only if dialect is clickhouse

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -637,9 +637,10 @@ class _Printer(Visitor[str]):
         1. and(expr0, 1, expr2, ...) <=> and(expr0, expr2, ...)
         2. and(expr0, 0, expr2, ...) <=> 0
         """
+        if len(node.exprs) == 1:
+            return self.visit(node.exprs[0])
+        
         if self.dialect == "hogql":
-            if len(node.exprs) == 1:
-                return self.visit(node.exprs[0])
             return f"and({', '.join([self.visit(expr) for expr in node.exprs])})"
 
         exprs: list[str] = []

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -662,9 +662,10 @@ class _Printer(Visitor[str]):
         1. or(expr0, 1, expr2, ...) <=> 1
         2. or(expr0, 0, expr2, ...) <=> or(expr0, expr2, ...)
         """
+        if len(node.exprs) == 1:
+            return self.visit(node.exprs[0])
+        
         if self.dialect == "hogql":
-            if len(node.exprs) == 1:
-                return self.visit(node.exprs[0])
             return f"or({', '.join([self.visit(expr) for expr in node.exprs])})"
 
         exprs: list[str] = []

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -637,7 +637,12 @@ class _Printer(Visitor[str]):
         1. and(expr0, 1, expr2, ...) <=> and(expr0, expr2, ...)
         2. and(expr0, 0, expr2, ...) <=> 0
         """
-        exprs = []
+        if self.dialect == "hogql":
+            if len(node.exprs) == 1:
+                return self.visit(node.exprs[0])
+            return f"and({', '.join([self.visit(expr) for expr in node.exprs])})"
+
+        exprs: list[str] = []
         for expr in node.exprs:
             printed = self.visit(expr)
             if printed == "0":  # optimization 2
@@ -656,7 +661,12 @@ class _Printer(Visitor[str]):
         1. or(expr0, 1, expr2, ...) <=> 1
         2. or(expr0, 0, expr2, ...) <=> or(expr0, expr2, ...)
         """
-        exprs = []
+        if self.dialect == "hogql":
+            if len(node.exprs) == 1:
+                return self.visit(node.exprs[0])
+            return f"or({', '.join([self.visit(expr) for expr in node.exprs])})"
+
+        exprs: list[str] = []
         for expr in node.exprs:
             printed = self.visit(expr)
             if printed == "1":

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -639,7 +639,7 @@ class _Printer(Visitor[str]):
         """
         if len(node.exprs) == 1:
             return self.visit(node.exprs[0])
-        
+
         if self.dialect == "hogql":
             return f"and({', '.join([self.visit(expr) for expr in node.exprs])})"
 
@@ -664,7 +664,7 @@ class _Printer(Visitor[str]):
         """
         if len(node.exprs) == 1:
             return self.visit(node.exprs[0])
-        
+
         if self.dialect == "hogql":
             return f"or({', '.join([self.visit(expr) for expr in node.exprs])})"
 

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -228,7 +228,7 @@
   
   SELECT session_id, $entry_current_url 
   FROM sessions 
-  WHERE equals(sessions.$entry_current_url, 'https://example.com/1') 
+  WHERE and(equals(sessions.$entry_current_url, 'https://example.com/1'), 1) 
   LIMIT 100
   '''
 # ---
@@ -237,7 +237,7 @@
   
   SELECT session_id, $entry_current_url 
   FROM sessions 
-  WHERE equals(sessions.$entry_current_url, 'https://example.com/1') 
+  WHERE and(equals(sessions.$entry_current_url, 'https://example.com/1'), 1) 
   LIMIT 100
   '''
 # ---

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -19,7 +19,7 @@
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM raw_cohort_people 
   WHERE and(equals(cohort_id, XX), equals(version, 0))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
-  WHERE and(equals(event, 'RANDOM_TEST_ID::UUID'), equals(__in_cohort.matched, 1)) 
+  WHERE and(and(1, equals(event, 'RANDOM_TEST_ID::UUID')), equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''
 # ---
@@ -43,7 +43,7 @@
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
   WHERE in(cohort_id, [1, 2, 3, 4, 5 /* ... */])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
-  WHERE equals(__in_cohort.matched, 1) 
+  WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''
 # ---
@@ -67,7 +67,7 @@
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
   WHERE in(cohort_id, [1, 2, 3, 4, 5 /* ... */])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
-  WHERE equals(__in_cohort.matched, 1) 
+  WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''
 # ---


### PR DESCRIPTION
Skip redundant `AND` / `OR` optimizations if printing HogQL.

Follow up for discussion in: https://github.com/PostHog/posthog/pull/39590