### PR TITLE
chore(array): check git status is clean in snapshots

### DIFF
--- a/products/tasks/backend/lib/constants.py
+++ b/products/tasks/backend/lib/constants.py
@@ -1,7 +1,7 @@
 SETUP_REPOSITORY_PROMPT = """
 Your goal is to setup the repository in the current environment.
 
-You are operating in a sandbox environment. You must install all dependencies necessary and setup the environment such that it is ready for executing code tasks.
+You are operating in a sandbox environment that is completely isolated and safe. You can execute any commands without risk - feel free to run builds, tests, install dependencies, or any other operations needed. You must install all dependencies necessary and setup the environment such that it is ready for executing code tasks.
 
 CONTEXT:
 
@@ -20,4 +20,5 @@ DO NOT make any code changes to the repository. The final state of the disk of t
 Rules:
 - You should not ask the user for any input. This is run in a sandbox environment in a background process, so they will not be able to provide any input.
 - The disk will be snapshooted immediately after you complete the task, and it will be reused for future tasks, so make sure everything you want is setup there.
+- CRITICAL: You MUST NOT leave any uncommitted changes in the repository. The snapshot will be used to execute user tasks later, and we cannot modify their git history. Do not create any files that aren't already ignored by the repository's .gitignore, and do not add new entries to the .gitignore. If you accidentally create uncommitted files, you must delete them before completion. Check `git status` and ensure the working tree is clean at the end.
 """

--- a/products/tasks/backend/services/sandbox_agent.py
+++ b/products/tasks/backend/services/sandbox_agent.py
@@ -74,6 +74,18 @@ class SandboxAgent:
         logger.info(f"Running code agent setup for {repository} in sandbox {self.sandbox.id}")
         return await self.sandbox.execute(setup_command, timeout_seconds=15 * 60)
 
+    async def is_git_clean(self, repository: str) -> tuple[bool, str]:
+        if not self.sandbox.is_running:
+            raise RuntimeError(f"Sandbox not in running state. Current status: {self.sandbox.status}")
+
+        org, repo = repository.lower().split("/")
+        repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+
+        result = await self.sandbox.execute(f"cd {repo_path} && git status --porcelain")
+        is_clean = not result.stdout.strip()
+
+        return is_clean, result.stdout
+
     async def execute_task(self, task_id: str, repository: str, workflow_id: str) -> ExecutionResult:
         if not self.sandbox.is_running:
             raise RuntimeError(f"Sandbox not in running state. Current status: {self.sandbox.status}")

--- a/products/tasks/backend/temporal/process_task/activities/setup_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/setup_repository.py
@@ -44,4 +44,15 @@ async def setup_repository(input: SetupRepositoryInput) -> str:
                 {"repository": input.repository, "exit_code": result.exit_code, "stderr": result.stderr[:500]},
             )
 
+        is_clean, status_output = await agent.is_git_clean(input.repository)
+
+        if not is_clean:
+            raise RepositorySetupError(
+                "Repository setup left uncommitted changes. Cannot snapshot with modified git state.",
+                {
+                    "repository": input.repository,
+                    "uncommitted_changes": status_output[:500],
+                },
+            )
+
         return result.stdout

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_setup_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_setup_repository.py
@@ -116,3 +116,51 @@ class TestSetupRepositoryActivity:
 
         with pytest.raises(SandboxNotFoundError):
             await activity_environment.run(setup_repository, setup_input)
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db
+    async def test_setup_repository_fails_with_uncommitted_changes(self, activity_environment, github_integration):
+        config = SandboxEnvironmentConfig(
+            name="test-setup-uncommitted",
+            template=SandboxEnvironmentTemplate.DEFAULT_BASE,
+        )
+
+        sandbox = None
+        try:
+            sandbox = await SandboxEnvironment.create(config)
+
+            clone_input = CloneRepositoryInput(
+                sandbox_id=sandbox.id,
+                repository="posthog/posthog-js",
+                github_integration_id=github_integration.id,
+                task_id="test-task-uncommitted",
+                distinct_id="test-user-id",
+            )
+
+            with patch(
+                "products.tasks.backend.temporal.process_task.activities.clone_repository.get_github_token"
+            ) as mock_get_token:
+                mock_get_token.return_value = ""
+                await activity_environment.run(clone_repository, clone_input)
+
+            with patch(
+                "products.tasks.backend.temporal.process_task.activities.setup_repository.SandboxAgent._get_setup_command"
+            ) as mock_setup_cmd:
+                mock_setup_cmd.return_value = "pnpm install && echo 'test' > uncommitted_file.txt"
+
+                setup_input = SetupRepositoryInput(
+                    sandbox_id=sandbox.id,
+                    repository="posthog/posthog-js",
+                    task_id="test-task-uncommitted",
+                    distinct_id="test-user-id",
+                )
+
+                with pytest.raises(RepositorySetupError) as exc_info:
+                    await activity_environment.run(setup_repository, setup_input)
+
+                assert "uncommitted changes" in str(exc_info.value).lower()
+                assert "uncommitted_file.txt" in exc_info.value.context.get("uncommitted_changes", "")
+
+        finally:
+            if sandbox:
+                await sandbox.destroy()


### PR DESCRIPTION
## Problem

If the setup_repository command resulted in an unclean git state then running the task agent would always fail.

## Changes

Check that the git status is clean.