### PR TITLE
fix: avoid mistaken 404s when loading snapshots for LTS recordings

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -970,9 +970,6 @@ class SessionRecordingViewSet(
         trace.get_current_span().set_attribute("team_id", self.team_id)
         trace.get_current_span().set_attribute("session_id", str(recording.session_id))
 
-        if not SessionReplayEvents().exists(session_id=str(recording.session_id), team=self.team):
-            raise exceptions.NotFound("Recording not found")
-
         is_personal_api_key = isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication)
         serializer = SessionRecordingSnapshotsRequestSerializer(
             data=request.GET.dict(),
@@ -986,6 +983,15 @@ class SessionRecordingViewSet(
 
         is_v2_enabled: bool = validated_data.get("blob_v2", False)
         is_v2_lts_enabled: bool = validated_data.get("blob_v2_lts", False)
+
+        is_v2_lts_recording: bool = (
+            (source == "blob_v2") and ("min_blob_key" not in validated_data) and ("blob_key" in validated_data)
+        )
+
+        if not is_v2_lts_recording and not SessionReplayEvents().exists(
+            session_id=str(recording.session_id), team=self.team
+        ):
+            raise exceptions.NotFound("Recording not found")
 
         SNAPSHOT_SOURCE_REQUESTED.labels(source=source_log_label).inc()
 

--- a/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v1.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v1.py
@@ -307,10 +307,9 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         assert mock_presigned_url.call_count == 0
         # we don't try to load the data if the blob key is invalid
         assert mock_stream_from.call_count == 0
-        # we do check the session before validating input
-        # TODO it would be maybe cheaper to validate the input first
+        # we don't check if the session exists before validating the input
         assert mock_get_session_recording.call_count == 1
-        assert mock_exists.call_count == 1
+        assert mock_exists.call_count == 0
 
     @parameterized.expand([("2024-04-30"), (None)])
     @patch(
@@ -358,7 +357,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         self, _mock_stream_from, _mock_presigned_url, mock_get_session_recording
     ) -> None:
         session_id = str(uuid7())
-        blob_key = f"1682608337071"
+        blob_key = "1682608337071"
         url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob&blob_key={blob_key}"
 
         # by default a session recording is deleted, and _that_ is what we check for to see if it exists
@@ -371,7 +370,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
     @patch("posthog.session_recordings.session_recording_api.object_storage.get_presigned_url")
     def test_can_not_get_session_recording_blob_that_does_not_exist(self, mock_presigned_url) -> None:
         session_id = str(uuid7())
-        blob_key = f"session_recordings/team_id/{self.team.pk}/session_id/{session_id}/data/1682608337071"
+        blob_key = "1682608337071"
         url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob&blob_key={blob_key}"
 
         mock_presigned_url.return_value = None


### PR DESCRIPTION
This PR fixes an issue where we always return 404 when loading snapshots for LTS recordings.