### PR TITLE
fix(replay): save recording on refresh token

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -392,6 +392,11 @@ class SharingConfigurationViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin,
         context = self.get_serializer_context()
         instance = self._get_sharing_configuration(context)
 
+        if context.get("recording"):
+            recording = cast(SessionRecording, context.get("recording"))
+            # Special case where we need to save the instance for recordings so that the actual record gets created
+            recording.save()
+
         check_can_edit_sharing_configuration(self, request, instance)
 
         # Create new sharing configuration and expire the old one


### PR DESCRIPTION
## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/39709 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41991)

The refresh method was trying to create a new SharingConfiguration that referenced an unsaved SessionRecording object, causing a foreign key constraint violation.

## Changes

Added the same pattern that was already used in the `patch` method - ensuring the SessionRecording is saved to the database before calling `rotate_access_token()`.

