### PR TITLE
feat(customers): Add usage metrics config to notebook node

### DIFF
--- a/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.test.ts
+++ b/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.test.ts
@@ -12,7 +12,7 @@ import { initKeaTests } from '~/test/init'
 import { topBarSettingsButtonLogic } from './topBarSettingsButtonLogic'
 
 const groupsScene = (): any => ({
-    scene: { component: () => null, logic: null, settingSectionId: 'environment-crm' },
+    scene: { component: () => null, logic: null, settingSectionId: 'environment-customer-analytics' },
 })
 const personsScene = (): any => ({
     scene: { component: () => null, logic: null, settingSectionId: 'environment-product-analytics' },
@@ -24,7 +24,7 @@ const scenes: Record<string, () => any> = {
 }
 
 describe('topBarSettingsButtonLogic', () => {
-    describe('loadedSceneSettingsSectionId selector for environment-crm', () => {
+    describe('loadedSceneSettingsSectionId selector for environment-customer-analytics', () => {
         let logic: ReturnType<typeof topBarSettingsButtonLogic.build>
         let sceneLogicInstance: ReturnType<typeof sceneLogic.build>
 
@@ -43,17 +43,17 @@ describe('topBarSettingsButtonLogic', () => {
             sceneLogicInstance?.unmount()
         })
 
-        it('returns environment-crm when CRM feature flag is enabled', async () => {
+        it('returns environment-customer-analytics when CRM feature flag is enabled', async () => {
             featureFlagLogic.actions.setFeatureFlags([], {
                 [FEATURE_FLAGS.CRM_ITERATION_ONE]: true,
             })
 
             await expectLogic(logic).toMatchValues({
-                loadedSceneSettingsSectionId: 'environment-crm',
+                loadedSceneSettingsSectionId: 'environment-customer-analytics',
             })
         })
 
-        it('returns undefined when CRM feature flag is disabled for environment-crm', async () => {
+        it('returns undefined when CRM feature flag is disabled for environment-customer-analytics', async () => {
             featureFlagLogic.actions.setFeatureFlags([], {
                 [FEATURE_FLAGS.CRM_ITERATION_ONE]: false,
             })

--- a/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.ts
+++ b/frontend/src/lib/components/TopBarSettingsButton/topBarSettingsButtonLogic.ts
@@ -32,7 +32,10 @@ export const topBarSettingsButtonLogic = kea<topBarSettingsButtonLogicType>([
                 const settingSectionId = activeLoadedScene?.settingSectionId
 
                 // Only show CRM settings button when the feature flag is enabled
-                if (settingSectionId === 'environment-crm' && !featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]) {
+                if (
+                    settingSectionId === 'environment-customer-analytics' &&
+                    !featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]
+                ) {
                     return undefined
                 }
 

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -169,5 +169,5 @@ export function GroupsScene(): JSX.Element {
 export const scene: SceneExport = {
     component: GroupsScene,
     logic: groupsSceneLogic,
-    settingSectionId: 'environment-crm',
+    settingSectionId: 'environment-customer-analytics',
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -1,6 +1,7 @@
-import { useValues } from 'kea'
+import { BindLogic, useValues } from 'kea'
 
 import { UsageMetricsConfig } from 'scenes/settings/environment/UsageMetricsConfig'
+import { usageMetricsConfigLogic } from 'scenes/settings/environment/usageMetricsConfigLogic'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind, UsageMetric, UsageMetricsQueryResponse } from '~/queries/schema/schema-general'
@@ -10,7 +11,7 @@ import {
     UsageMetricCardSkeleton,
 } from 'products/customer_analytics/frontend/components/UsageMetricCard'
 
-import { NotebookNodeProps, NotebookNodeType } from '../types'
+import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
 import { createPostHogWidgetNode } from './NodeWrapper'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
@@ -57,10 +58,12 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     )
 }
 
-const Settings = (): JSX.Element => {
+const Settings = ({ attributes }: NotebookNodeAttributeProperties<NotebookNodeUsageMetricsAttributes>): JSX.Element => {
     return (
         <div className="p-2">
-            <UsageMetricsConfig />
+            <BindLogic logic={usageMetricsConfigLogic} props={{ logicKey: attributes.nodeId }}>
+                <UsageMetricsConfig />
+            </BindLogic>
         </div>
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -1,5 +1,7 @@
 import { useValues } from 'kea'
 
+import { CRMUsageMetricsConfig } from 'scenes/settings/environment/CRMUsageMetricsConfig'
+
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind, UsageMetric, UsageMetricsQueryResponse } from '~/queries/schema/schema-general'
 
@@ -55,6 +57,14 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     )
 }
 
+const Settings = (): JSX.Element => {
+    return (
+        <div className="p-2">
+            <CRMUsageMetricsConfig />
+        </div>
+    )
+}
+
 type NotebookNodeUsageMetricsAttributes = {
     personId: string
 }
@@ -63,6 +73,8 @@ export const NotebookNodeUsageMetrics = createPostHogWidgetNode<NotebookNodeUsag
     nodeType: NotebookNodeType.UsageMetrics,
     titlePlaceholder: 'Usage',
     Component,
+    Settings,
+    settingsIcon: 'gear',
     resizeable: false,
     expandable: true,
     startExpanded: true,

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { CRMUsageMetricsConfig } from 'scenes/settings/environment/CRMUsageMetricsConfig'
+import { UsageMetricsConfig } from 'scenes/settings/environment/UsageMetricsConfig'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind, UsageMetric, UsageMetricsQueryResponse } from '~/queries/schema/schema-general'
@@ -60,7 +60,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
 const Settings = (): JSX.Element => {
     return (
         <div className="p-2">
-            <CRMUsageMetricsConfig />
+            <UsageMetricsConfig />
         </div>
     )
 }

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -33,7 +33,6 @@ import { AccessControlLevel, AccessControlResourceType, Realm } from '~/types'
 
 import { IntegrationsList } from '../../lib/integrations/IntegrationsList'
 import { AutocaptureSettings, WebVitalsAutocaptureSettings } from './environment/AutocaptureSettings'
-import { CRMUsageMetricsConfig } from './environment/CRMUsageMetricsConfig'
 import { CSPReportingSettings } from './environment/CSPReportingSettings'
 import { CorrelationConfig } from './environment/CorrelationConfig'
 import { DataAttributes } from './environment/DataAttributes'
@@ -73,6 +72,7 @@ import {
     WebSnippet,
 } from './environment/TeamSettings'
 import { ProjectAccountFiltersSetting } from './environment/TestAccountFiltersConfig'
+import { UsageMetricsConfig } from './environment/UsageMetricsConfig'
 import { WebAnalyticsEnablePreAggregatedTables } from './environment/WebAnalyticsAPISetting'
 import { WebhookIntegration } from './environment/WebhookIntegration'
 import { Invites } from './organization/Invites'
@@ -163,6 +163,25 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'dead-clicks-autocapture',
                 title: 'Dead clicks autocapture',
                 component: <DeadClicksAutocaptureSettings />,
+            },
+        ],
+    },
+    {
+        level: 'environment',
+        id: 'environment-customer-analytics',
+        title: 'Customer analytics',
+        flag: 'CRM_ITERATION_ONE',
+        settings: [
+            {
+                id: 'group-analytics',
+                title: 'Group analytics',
+                component: <GroupAnalyticsConfig />,
+            },
+            {
+                id: 'crm-usage-metrics',
+                title: 'Usage metrics',
+                component: <UsageMetricsConfig />,
+                flag: 'CRM_USAGE_METRICS',
             },
         ],
     },
@@ -354,25 +373,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 title: 'New query engine',
                 component: <WebAnalyticsEnablePreAggregatedTables />,
                 flag: 'WEB_ANALYTICS_API',
-            },
-        ],
-    },
-    {
-        level: 'environment',
-        id: 'environment-crm',
-        title: 'CRM',
-        flag: 'CRM_ITERATION_ONE',
-        settings: [
-            {
-                id: 'group-analytics',
-                title: 'Group analytics',
-                component: <GroupAnalyticsConfig />,
-            },
-            {
-                id: 'crm-usage-metrics',
-                title: 'Usage metrics',
-                component: <CRMUsageMetricsConfig />,
-                flag: 'CRM_USAGE_METRICS',
             },
         ],
     },

--- a/frontend/src/scenes/settings/environment/CRMUsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/CRMUsageMetricsConfig.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
-import { Form, capitalizeFirstLetter } from 'kea-forms'
+import { Form } from 'kea-forms'
 
-import { IconEllipsis, IconPlus } from '@posthog/icons'
+import { IconEllipsis, IconPlusSmall } from '@posthog/icons'
 import {
     LemonButton,
     LemonDialog,
@@ -17,11 +17,9 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { LemonField } from 'lib/lemon-ui/LemonField'
-import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
-import { groupsModel } from '~/models/groupsModel'
 import { AnyPropertyFilter, EntityTypes, FilterType } from '~/types'
 
 import { UsageMetric, crmUsageMetricsConfigLogic } from './crmUsageMetricsConfigLogic'
@@ -280,43 +278,28 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
 }
 
 export function CRMUsageMetricsConfig(): JSX.Element {
-    const { isEditing, currentGroupTypeIndex, availableGroupTypes } = useValues(crmUsageMetricsConfigLogic)
-    const { setIsEditing, resetUsageMetric, setCurrentGroupTypeIndex } = useActions(crmUsageMetricsConfigLogic)
-    const { aggregationLabel } = useValues(groupsModel)
+    const { isEditing } = useValues(crmUsageMetricsConfigLogic)
+    const { setIsEditing, resetUsageMetric } = useActions(crmUsageMetricsConfigLogic)
 
     const handleAddMetric = (): void => {
         resetUsageMetric()
         setIsEditing(true)
     }
 
-    const tabs = availableGroupTypes.map((groupType) => ({
-        key: groupType.group_type_index.toString(),
-        label: capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural),
-        content: (
-            <div className="flex flex-col gap-2">
+    return (
+        <>
+            <p>
+                Choose which events matter for each metric: API calls, feature adoption, session frequency, error rates
+                to identify expansion opportunities and churn risk based on real customer behavior.
+            </p>
+            <div className="flex flex-col gap-2 items-start">
                 {!isEditing && (
-                    <LemonButton onClick={handleAddMetric} icon={<IconPlus />}>
+                    <LemonButton onClick={handleAddMetric} icon={<IconPlusSmall />}>
                         Add metric
                     </LemonButton>
                 )}
                 {isEditing ? <CRMUsageMetricsForm /> : <CRMUsageMetricsTable />}
             </div>
-        ),
-    }))
-
-    if (availableGroupTypes.length === 0) {
-        return <div>No group types available</div>
-    }
-
-    return (
-        <>
-            Choose which events matter for each metric: API calls, feature adoption, session frequency, error rates to
-            identify expansion opportunities and churn risk based on real customer behavior.
-            <LemonTabs
-                activeKey={currentGroupTypeIndex.toString()}
-                onChange={(key) => setCurrentGroupTypeIndex(parseInt(key, 10))}
-                tabs={tabs}
-            />
         </>
     )
 }

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -22,7 +22,7 @@ import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFil
 
 import { AnyPropertyFilter, EntityTypes, FilterType } from '~/types'
 
-import { UsageMetric, crmUsageMetricsConfigLogic } from './crmUsageMetricsConfigLogic'
+import { UsageMetric, usageMetricsConfigLogic } from './usageMetricsConfigLogic'
 
 function sanitizeFilters(filters?: FilterType): FilterType {
     if (!filters) {
@@ -43,9 +43,9 @@ function sanitizeFilters(filters?: FilterType): FilterType {
     return sanitized
 }
 
-function CRMUsageMetricsTable(): JSX.Element {
-    const { usageMetrics, usageMetricsLoading } = useValues(crmUsageMetricsConfigLogic)
-    const { removeUsageMetric } = useActions(crmUsageMetricsConfigLogic)
+function UsageMetricsTable(): JSX.Element {
+    const { usageMetrics, usageMetricsLoading } = useValues(usageMetricsConfigLogic)
+    const { removeUsageMetric } = useActions(usageMetricsConfigLogic)
 
     const columns: LemonTableColumns<UsageMetric> = [
         {
@@ -83,7 +83,7 @@ function CRMUsageMetricsTable(): JSX.Element {
                                         title: 'Edit usage metric',
                                         description: (
                                             <div>
-                                                <CRMUsageMetricsForm metric={metric} />
+                                                <UsageMetricsForm metric={metric} />
                                             </div>
                                         ),
                                         primaryButton: {
@@ -130,12 +130,12 @@ function CRMUsageMetricsTable(): JSX.Element {
     return <LemonTable columns={columns} dataSource={usageMetrics} loading={usageMetricsLoading} />
 }
 
-interface CRMUsageMetricsFormProps {
+interface UsageMetricsFormProps {
     metric?: UsageMetric
 }
 
-function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element {
-    const { resetUsageMetric, setIsEditing, setUsageMetricValues } = useActions(crmUsageMetricsConfigLogic)
+function UsageMetricsForm({ metric }: UsageMetricsFormProps): JSX.Element {
+    const { resetUsageMetric, setIsEditing, setUsageMetricValues } = useActions(usageMetricsConfigLogic)
 
     if (metric) {
         setUsageMetricValues(metric)
@@ -153,7 +153,7 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
     ]
 
     return (
-        <Form id="usageMetric" logic={crmUsageMetricsConfigLogic} formKey="usageMetric" enableFormOnSubmit>
+        <Form id="usageMetric" logic={usageMetricsConfigLogic} formKey="usageMetric" enableFormOnSubmit>
             <div className="flex flex-col gap-2">
                 <div className="grid grid-cols-2 gap-2">
                     <LemonField name="name" label="Name" help="This will be the title of the column in group list">
@@ -236,7 +236,7 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
                                             }
                                             onChange(newValue)
                                         }}
-                                        pageKey="CRMUsageMetricsConfig"
+                                        pageKey="UsageMetricsConfig"
                                     />
                                     <TestAccountFilterSwitch
                                         checked={currentFilters?.filter_test_accounts ?? false}
@@ -277,9 +277,9 @@ function CRMUsageMetricsForm({ metric }: CRMUsageMetricsFormProps): JSX.Element 
     )
 }
 
-export function CRMUsageMetricsConfig(): JSX.Element {
-    const { isEditing } = useValues(crmUsageMetricsConfigLogic)
-    const { setIsEditing, resetUsageMetric } = useActions(crmUsageMetricsConfigLogic)
+export function UsageMetricsConfig(): JSX.Element {
+    const { isEditing } = useValues(usageMetricsConfigLogic)
+    const { setIsEditing, resetUsageMetric } = useActions(usageMetricsConfigLogic)
 
     const handleAddMetric = (): void => {
         resetUsageMetric()
@@ -298,7 +298,7 @@ export function CRMUsageMetricsConfig(): JSX.Element {
                         Add metric
                     </LemonButton>
                 )}
-                {isEditing ? <CRMUsageMetricsForm /> : <CRMUsageMetricsTable />}
+                {isEditing ? <UsageMetricsForm /> : <UsageMetricsTable />}
             </div>
         </>
     )

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -89,13 +89,13 @@ function UsageMetricsTable(): JSX.Element {
                                         primaryButton: {
                                             htmlType: 'submit',
                                             children: 'Save',
-                                            'data-attr': 'update-crm-usage-metric',
+                                            'data-attr': 'update-usage-metric',
                                             form: 'usageMetric',
                                         },
                                         secondaryButton: {
                                             htmlType: 'button',
                                             children: 'Cancel',
-                                            'data-attr': 'cancel-update-crm-usage-metric',
+                                            'data-attr': 'cancel-update-usage-metric',
                                         },
                                     })
                                 },
@@ -256,17 +256,13 @@ function UsageMetricsForm({ metric }: UsageMetricsFormProps): JSX.Element {
                         <div className="flex gap-2 mt-2">
                             <LemonButton
                                 type="primary"
-                                data-attr="save-crm-usage-metric"
+                                data-attr="save-usage-metric"
                                 htmlType="submit"
                                 form="usageMetric"
                             >
                                 Save
                             </LemonButton>
-                            <LemonButton
-                                type="secondary"
-                                data-attr="cancel-crm-usage-metric"
-                                onClick={handleCancelForm}
-                            >
+                            <LemonButton type="secondary" data-attr="cancel-usage-metric" onClick={handleCancelForm}>
                                 Cancel
                             </LemonButton>
                         </div>

--- a/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
+++ b/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
@@ -7,7 +7,7 @@ import { projectLogic } from 'scenes/projectLogic'
 
 import { groupsModel } from '~/models/groupsModel'
 
-import type { crmUsageMetricsConfigLogicType } from './crmUsageMetricsConfigLogicType'
+import type { usageMetricsConfigLogicType } from './usageMetricsConfigLogicType'
 
 export interface UsageMetric {
     id: string
@@ -34,8 +34,8 @@ const NEW_USAGE_METRIC = {
     filters: {},
 } as UsageMetricFormData
 
-export const crmUsageMetricsConfigLogic = kea<crmUsageMetricsConfigLogicType>([
-    path(['scenes', 'settings', 'environment', 'crmUsageMetricsConfigLogic']),
+export const usageMetricsConfigLogic = kea<usageMetricsConfigLogicType>([
+    path(['scenes', 'settings', 'environment', 'usageMetricsConfigLogic']),
     connect(() => ({
         values: [groupsModel, ['groupTypes', 'groupTypesLoading'], projectLogic, ['currentProjectId']],
     })),

--- a/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
+++ b/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { lazyLoaders } from 'kea-loaders'
 
@@ -34,11 +34,17 @@ const NEW_USAGE_METRIC = {
     filters: {},
 } as UsageMetricFormData
 
+interface UsageMetricsConfigLogicProps {
+    logicKey?: string
+}
+
 export const usageMetricsConfigLogic = kea<usageMetricsConfigLogicType>([
     path(['scenes', 'settings', 'environment', 'usageMetricsConfigLogic']),
     connect(() => ({
         values: [groupsModel, ['groupTypes', 'groupTypesLoading'], projectLogic, ['currentProjectId']],
     })),
+    props({} as UsageMetricsConfigLogicProps),
+    key(({ logicKey }) => logicKey || 'defaultKey'),
 
     actions(() => ({
         setIsEditing: (isEditing: boolean) => ({ isEditing }),

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -18,6 +18,7 @@ export type SettingLevelId = (typeof SettingLevelIds)[number]
 export type SettingSectionId =
     | 'environment-details'
     | 'environment-autocapture'
+    | 'environment-customer-analytics'
     | 'environment-product-analytics'
     | 'environment-revenue-analytics'
     | 'environment-marketing-analytics'
@@ -27,7 +28,6 @@ export type SettingSectionId =
     | 'environment-feature-flags'
     | 'environment-error-tracking'
     | 'environment-csp-reporting'
-    | 'environment-crm'
     | 'environment-max'
     | 'environment-integrations'
     | 'environment-activity-logs'


### PR DESCRIPTION
## Problem
Let's make it easier to manage usage metrics from the person canvas by adding a shortcut to the settings in the notebook node.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/39179
## Changes
- Add `Settings` component to usage metrics notebook node, using the same component from settings page
- Rename CRM references
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
### Metric list
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/c11dd90b-aa12-494a-b35f-1cbd693bb1a6" />

### Adding new metric
<img width="1560" height="918" alt="image" src="https://github.com/user-attachments/assets/7b198ab0-b372-410f-bb03-9bf556deaac4" />

### Editting metric
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/0f4cd981-56c9-42d3-9559-44f10696a5b6" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
