### PR TITLE
chore(kafka-deduplicator): Improve rocksdb defaults, flush wal

### DIFF
--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -8,8 +8,7 @@ use num_cpus;
 use once_cell::sync::Lazy;
 use rocksdb::{
     checkpoint::Checkpoint, BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor,
-    DBWithThreadMode, MultiThreaded, Options, SliceTransform, WriteBatch, WriteBufferManager,
-    WriteOptions,
+    DBWithThreadMode, MultiThreaded, Options, WriteBatch, WriteBufferManager, WriteOptions,
 };
 use std::time::Instant;
 
@@ -77,10 +76,6 @@ fn rocksdb_options() -> Options {
     opts.optimize_universal_style_compaction(512 * 1024 * 1024); // 512MB
 
     let mut block_opts = block_based_table_factory();
-    // Timestamp CF
-    let mut ts_cf = Options::default();
-    ts_cf.set_block_based_table_factory(&block_opts);
-    ts_cf.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
 
     // CRITICAL: Use shared block cache across all stores
     block_opts.set_block_cache(&SHARED_BLOCK_CACHE);
@@ -93,7 +88,7 @@ fn rocksdb_options() -> Options {
     // Reduced memory budget per store (with 50 partitions per pod)
     opts.set_write_buffer_size(8 * 1024 * 1024); // Reduced to 8MB per memtable
     opts.set_max_write_buffer_number(3); // Max 3 buffers = 24MB per partition
-    opts.set_target_file_size_base(32 * 1024 * 1024); // SST files ~128MB
+    opts.set_target_file_size_base(32 * 1024 * 1024); // SST files ~32MB
 
     // Parallelism
     opts.increase_parallelism(num_threads as i32);
@@ -101,11 +96,8 @@ fn rocksdb_options() -> Options {
 
     // IO & safety
     opts.set_paranoid_checks(true);
-    opts.set_bytes_per_sync(1 * 1024 * 1024);
-    opts.set_wal_bytes_per_sync(1 * 1024 * 1024);
-    opts.set_use_direct_reads(true);
-    opts.set_use_direct_io_for_flush_and_compaction(true);
-    opts.set_compaction_readahead_size(2 * 1024 * 1024);
+    opts.set_bytes_per_sync(1024 * 1024);
+    opts.set_wal_bytes_per_sync(1024 * 1024);
 
     // Reduce background IO impact
     opts.set_disable_auto_compactions(false);

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -8,7 +8,8 @@ use num_cpus;
 use once_cell::sync::Lazy;
 use rocksdb::{
     checkpoint::Checkpoint, BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor,
-    DBWithThreadMode, MultiThreaded, Options, WriteBatch, WriteBufferManager, WriteOptions,
+    DBWithThreadMode, MultiThreaded, Options, SliceTransform, WriteBatch, WriteBufferManager,
+    WriteOptions,
 };
 use std::time::Instant;
 
@@ -46,16 +47,7 @@ static SHARED_WRITE_BUFFER_MANAGER: Lazy<Arc<WriteBufferManager>> = Lazy::new(||
     ))
 });
 
-fn rocksdb_options() -> Options {
-    let num_threads = std::cmp::max(2, num_cpus::get()); // Avoid setting to 0 or 1
-
-    let mut opts = Options::default();
-    opts.create_if_missing(true);
-    opts.create_missing_column_families(true);
-
-    // Level style compaction with universal style for TTL-like use case
-    opts.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
-
+pub fn block_based_table_factory() -> BlockBasedOptions {
     // Optimize for point lookups (dedup check)
     let mut block_opts = BlockBasedOptions::default();
     // Set bloom filter to 10 bits per key, not approximate
@@ -65,6 +57,30 @@ fn rocksdb_options() -> Options {
     block_opts.set_bloom_filter(10.0, false);
     block_opts.set_cache_index_and_filter_blocks(true);
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+    block_opts.set_whole_key_filtering(true);
+    block_opts.set_partition_filters(true);
+    block_opts.set_pin_top_level_index_and_filter(true);
+    block_opts
+}
+
+fn rocksdb_options() -> Options {
+    let num_threads = std::cmp::max(2, num_cpus::get()); // Avoid setting to 0 or 1
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    // Enable atomic flush to ensure consistency between column families
+    opts.set_atomic_flush(true);
+    opts.create_missing_column_families(true);
+
+    // Level style compaction with universal style for TTL-like use case
+    opts.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+    opts.optimize_universal_style_compaction(512 * 1024 * 1024); // 512MB
+
+    let mut block_opts = block_based_table_factory();
+    // Timestamp CF
+    let mut ts_cf = Options::default();
+    ts_cf.set_block_based_table_factory(&block_opts);
+    ts_cf.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
 
     // CRITICAL: Use shared block cache across all stores
     block_opts.set_block_cache(&SHARED_BLOCK_CACHE);
@@ -76,16 +92,24 @@ fn rocksdb_options() -> Options {
 
     // Reduced memory budget per store (with 50 partitions per pod)
     opts.set_write_buffer_size(8 * 1024 * 1024); // Reduced to 8MB per memtable
-    opts.set_max_write_buffer_number(2); // Max 2 buffers = 16MB per partition
-    opts.set_target_file_size_base(64 * 1024 * 1024); // SST files ~64MB
+    opts.set_max_write_buffer_number(3); // Max 3 buffers = 24MB per partition
+    opts.set_target_file_size_base(32 * 1024 * 1024); // SST files ~128MB
 
     // Parallelism
     opts.increase_parallelism(num_threads as i32);
-    opts.optimize_level_style_compaction(512 * 1024 * 1024); // 512MB
+    opts.set_max_background_jobs(num_threads as i32);
+
+    // IO & safety
+    opts.set_paranoid_checks(true);
+    opts.set_bytes_per_sync(1 * 1024 * 1024);
+    opts.set_wal_bytes_per_sync(1 * 1024 * 1024);
+    opts.set_use_direct_reads(true);
+    opts.set_use_direct_io_for_flush_and_compaction(true);
+    opts.set_compaction_readahead_size(2 * 1024 * 1024);
 
     // Reduce background IO impact
     opts.set_disable_auto_compactions(false);
-    opts.set_max_open_files(100); // Reduced from 500 for 50 partitions per pod
+    opts.set_max_open_files(1024); // Reduced from 500 for 50 partitions per pod
 
     // CRITICAL: Disable mmap with many partitions to avoid virtual memory explosion
     opts.set_allow_mmap_reads(false);
@@ -312,6 +336,24 @@ impl RocksDbStore {
         result
     }
 
+    pub fn flush_all_cf(&self) -> Result<()> {
+        let mut flush_opts = rocksdb::FlushOptions::default();
+        flush_opts.set_wait(true);
+        let start_time = Instant::now();
+        let result = self.db.flush_opt(&flush_opts);
+        let duration = start_time.elapsed();
+        self.metrics
+            .histogram(ROCKSDB_FLUSH_DURATION_HISTOGRAM)
+            .record(duration.as_secs_f64());
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                self.metrics.counter(ROCKSDB_ERRORS_COUNTER).increment(1);
+                Err(anyhow::anyhow!("Failed to flush: {}", e))
+            }
+        }
+    }
+
     fn flush_cf_internal(&self, cf_name: &str) -> Result<()> {
         let mut flush_opts = rocksdb::FlushOptions::default();
         flush_opts.set_wait(true);
@@ -321,24 +363,18 @@ impl RocksDbStore {
             .context("Failed to flush")
     }
 
-    pub fn compact_cf(&self, cf_name: &str) -> Result<()> {
-        let start_time = Instant::now();
-
-        let result = self.compact_cf_internal(cf_name);
-
-        let duration = start_time.elapsed();
-        self.metrics
-            .histogram(ROCKSDB_COMPACTION_DURATION_HISTOGRAM)
-            .with_label("column_family", cf_name)
-            .record(duration.as_secs_f64());
-
-        result
+    /// Flush the WAL (Write-Ahead Log) to ensure durability
+    /// Setting sync=true ensures WAL is synced to disk before returning
+    pub fn flush_wal(&self, sync: bool) -> Result<()> {
+        self.db
+            .flush_wal(sync)
+            .map_err(|e| anyhow::anyhow!("Failed to flush WAL (sync={}): {}", sync, e))
     }
 
-    fn compact_cf_internal(&self, cf_name: &str) -> Result<()> {
-        let cf = self.get_cf_handle(cf_name)?;
-        self.db.compact_range_cf(&cf, None::<&[u8]>, None::<&[u8]>);
-        Ok(())
+    /// Get the latest sequence number from the database
+    /// This represents the current state of the database and can be used to verify checkpoint consistency
+    pub fn latest_sequence_number(&self) -> u64 {
+        self.db.latest_sequence_number()
     }
 
     /// Create an incremental checkpoint at the specified path

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -4,11 +4,11 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use common_types::RawEvent;
-use rocksdb::{ColumnFamilyDescriptor, Options};
+use rocksdb::{ColumnFamilyDescriptor, Options, SliceTransform};
 use tracing::info;
 
 use crate::rocksdb::dedup_metadata::EventSimilarity;
-use crate::rocksdb::store::RocksDbStore;
+use crate::rocksdb::store::{block_based_table_factory, RocksDbStore};
 
 use super::keys::{TimestampKey, UuidIndexKey, UuidKey};
 use super::metadata::{TimestampMetadata, UuidMetadata};
@@ -118,22 +118,47 @@ impl DeduplicationStore {
         let metrics = crate::metrics::MetricsHelper::with_partition(&topic, partition)
             .with_label("service", "kafka-deduplicator");
 
+        let cf_descriptors = Self::get_cf_descriptors();
         // Create all three column families
-        let store = RocksDbStore::new(
-            &config.path,
-            vec![
-                ColumnFamilyDescriptor::new(Self::TIMESTAMP_CF, Options::default()),
-                ColumnFamilyDescriptor::new(Self::UUID_CF, Options::default()),
-                ColumnFamilyDescriptor::new(Self::UUID_TIMESTAMP_INDEX_CF, Options::default()),
-            ],
-            metrics,
-        )?;
+        let store = RocksDbStore::new(&config.path, cf_descriptors, metrics)?;
 
         Ok(Self {
             store: Arc::new(store),
             topic,
             partition,
         })
+    }
+
+    fn get_cf_descriptors() -> Vec<ColumnFamilyDescriptor> {
+        let block_opts = block_based_table_factory();
+
+        // ----- CF: TimestampKey (prefix = 8-byte BE timestamp)
+        let mut ts_cf_opts = Options::default();
+        ts_cf_opts.set_block_based_table_factory(&block_opts);
+        ts_cf_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8)); // <- per-CF
+        ts_cf_opts.set_write_buffer_size(8 * 1024 * 1024);
+        ts_cf_opts.set_max_write_buffer_number(3);
+
+        // ----- CF: UuidIndexKey ([ts][uuid_key] => same 8-byte prefix)
+        let mut uuid_timestamp_index_cf_opts = Options::default();
+        uuid_timestamp_index_cf_opts.set_block_based_table_factory(&block_opts);
+        uuid_timestamp_index_cf_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
+        uuid_timestamp_index_cf_opts.set_write_buffer_size(8 * 1024 * 1024);
+        uuid_timestamp_index_cf_opts.set_max_write_buffer_number(3);
+
+        // ----- CF: UuidKey (point-gets; no prefix extractor)
+        let mut uuid_cf_opts = Options::default();
+        uuid_cf_opts.set_block_based_table_factory(&block_opts);
+
+        let cf_descriptors = vec![
+            ColumnFamilyDescriptor::new(Self::TIMESTAMP_CF, ts_cf_opts),
+            ColumnFamilyDescriptor::new(Self::UUID_CF, uuid_cf_opts),
+            ColumnFamilyDescriptor::new(
+                Self::UUID_TIMESTAMP_INDEX_CF,
+                uuid_timestamp_index_cf_opts,
+            ),
+        ];
+        cf_descriptors
     }
 
     // Storage operations for each column family
@@ -432,9 +457,7 @@ impl DeduplicationStore {
 
     /// Flush the store to disk
     pub fn flush(&self) -> Result<()> {
-        self.store.flush_cf(Self::TIMESTAMP_CF)?;
-        self.store.flush_cf(Self::UUID_CF)?;
-        Ok(())
+        self.store.flush_all_cf()
     }
 
     /// Update metrics for this store (including database size)
@@ -446,22 +469,45 @@ impl DeduplicationStore {
         Ok(())
     }
 
-    /// Create a checkpoint and return the SST files at the time of checkpoint
+    /// Create a checkpoint and return metadata about the checkpoint
+    /// This ensures consistency by:
+    /// 1. Flushing WAL to disk
+    /// 2. Flushing all column families
+    /// 3. Capturing sequence number for consistency verification
+    /// 4. Creating the checkpoint with hard links
     pub fn create_checkpoint_with_metadata<P: AsRef<std::path::Path>>(
         &self,
         checkpoint_path: P,
-    ) -> Result<Vec<String>> {
-        // Flush before checkpoint to ensure all data is in SST files
+    ) -> Result<CheckpointMetadata> {
+        // Step 1: Flush WAL to ensure durability
+        self.store.flush_wal(true)?;
+
+        // Step 2: Flush all column families to ensure data is in SST files
         self.flush()?;
 
-        // Get SST files before checkpoint
+        // Step 3: Get sequence number for consistency tracking
+        let sequence = self.store.latest_sequence_number();
+
+        // Step 4: Get SST files after flush
         let sst_files = self.get_sst_file_names()?;
 
-        // Create the checkpoint
+        // Step 5: Create the checkpoint (RocksDB internally handles file deletion safety)
         self.store.create_checkpoint(checkpoint_path)?;
 
-        Ok(sst_files)
+        Ok(CheckpointMetadata {
+            sst_files,
+            sequence,
+        })
     }
+}
+
+/// Metadata about a checkpoint
+#[derive(Debug, Clone)]
+pub struct CheckpointMetadata {
+    /// SST files included in the checkpoint
+    pub sst_files: Vec<String>,
+    /// RocksDB sequence number at checkpoint time
+    pub sequence: u64,
 }
 
 #[cfg(test)]

--- a/rust/kafka-deduplicator/src/store/keys.rs
+++ b/rust/kafka-deduplicator/src/store/keys.rs
@@ -213,12 +213,13 @@ impl UuidIndexKey {
     }
 
     /// Create a range end key for deletion (exclusive)
-    /// We add 0xFF bytes to ensure this key comes after all keys with the cleanup timestamp
+    /// Increments timestamp by 1, or uses u64::MAX if overflow would occur
     pub fn range_end(cleanup_timestamp: u64) -> Vec<u8> {
         cleanup_timestamp
             .checked_add(1)
-            .map(|v| v.to_be_bytes().to_vec())
-            .unwrap()
+            .unwrap_or(u64::MAX)
+            .to_be_bytes()
+            .to_vec()
     }
 }
 

--- a/rust/kafka-deduplicator/src/store/keys.rs
+++ b/rust/kafka-deduplicator/src/store/keys.rs
@@ -215,10 +215,10 @@ impl UuidIndexKey {
     /// Create a range end key for deletion (exclusive)
     /// We add 0xFF bytes to ensure this key comes after all keys with the cleanup timestamp
     pub fn range_end(cleanup_timestamp: u64) -> Vec<u8> {
-        let mut bytes = cleanup_timestamp.to_be_bytes().to_vec();
-        // Add a suffix to ensure this key is greater than any key with this timestamp
-        bytes.push(0xFF);
-        bytes
+        cleanup_timestamp
+            .checked_add(1)
+            .map(|v| v.to_be_bytes().to_vec())
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
## Problem

The rocksDB configuration for the kafka-deduplicator had some issues:
- Checkpoints were being created without flushing the WAL (Write-Ahead Log), this could cause inconsistencies
- Column families had default options
- Missing settings for IO and checkpointing optimizations
- Flush was iterating over CF which could cause inconsistencies

## Changes

- RocksDB configuration tuning
- Enabled atomic flush for cross-CF consistency
- Add Prefix extractors for timestamp based CFs to optimize range scans

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
