### PR TITLE
fix: allow refreshing query execution details

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -461,7 +461,9 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
 
                     try {
                         const result = await api.queryLog.get(queryId)
-                        actions.setQueryLogQueryId(queryId)
+                        if (result?.results && result.results.length > 0) {
+                            actions.setQueryLogQueryId(queryId)
+                        }
                         return result
                     } catch (e: any) {
                         console.warn('Failed to get query execution details', e)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

If a user hovers over the component when the query hasn't completed, they would not be able to see the exec details when it does complete. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- make sure we got results in the response before setting the queryLogQueryId

