### PR TITLE
fix(data-warehouse): Moved logic out of component and into kea

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -11,7 +11,6 @@ import {
     LemonTable,
     LemonTag,
     Tooltip,
-    lemonToast,
 } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -19,14 +18,14 @@ import { useFloatingContainer } from 'lib/hooks/useFloatingContainerContext'
 import { SyncTypeLabelMap, syncAnchorIntervalToHumanReadable } from 'scenes/data-warehouse/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { ExternalDataSourceSyncSchema, IncrementalField } from '~/types'
+import { ExternalDataSourceSyncSchema } from '~/types'
 
 import { sourceWizardLogic } from '../../new/sourceWizardLogic'
 import { SyncMethodForm } from './SyncMethodForm'
 
 export default function SchemaForm(): JSX.Element {
     const containerRef = useFloatingContainer()
-    const { toggleSchemaShouldSync, openSyncMethodModal, updateSyncTimeOfDay, setIsProjectTime, updateSchemaSyncType } =
+    const { toggleSchemaShouldSync, openSyncMethodModal, updateSyncTimeOfDay, setIsProjectTime } =
         useActions(sourceWizardLogic)
     const { databaseSchema, isProjectTime } = useValues(sourceWizardLogic)
     const { currentTeam } = useValues(teamLogic)
@@ -38,69 +37,6 @@ export default function SchemaForm(): JSX.Element {
         }
         toggleSchemaShouldSync(schema, checked)
     }
-
-    const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField | undefined => {
-        // check for timestamp field matching "updated_at" or "updatedAt" case insensitive
-        const updatedAt = fields.find((field) => {
-            const regex = /^updated/i
-            return regex.test(field.field) && (field.field_type === 'timestamp' || field.type === 'datetime')
-        })
-        if (updatedAt) {
-            return updatedAt
-        }
-        // fallback to timestamp field matching "created_at" or "createdAt" case insensitive
-        const createdAt = fields.find((field) => {
-            const regex = /^created/i
-            return regex.test(field.field) && (field.field_type === 'timestamp' || field.type === 'datetime')
-        })
-        if (createdAt) {
-            return createdAt
-        }
-        // fallback to any timestamp or datetime field
-        const timestamp = fields.find((field) => {
-            return field.field_type === 'timestamp' || field.type === 'datetime'
-        })
-        if (timestamp) {
-            return timestamp
-        }
-        // fallback to numeric fields matching "id" or "uuid" case insensitive
-        const id = fields.find((field) => {
-            const idRegex = /^id/i
-            const uuidRegex = /^uuid/i
-            return (idRegex.test(field.field) || uuidRegex.test(field.field)) && field.field_type === 'integer'
-        })
-        if (id) {
-            return id
-        }
-        // leave unset and require user configuration
-        return undefined
-    }
-
-    const smartConfigureTables = (databaseSchema: ExternalDataSourceSyncSchema[]): void => {
-        databaseSchema.forEach((schema) => {
-            if (schema.sync_type === null) {
-                // Use incremental if available
-                if (schema.incremental_available || schema.append_available) {
-                    const method = schema.incremental_available ? 'incremental' : 'append'
-                    const field = resolveIncrementalField(schema.incremental_fields)
-                    if (field) {
-                        updateSchemaSyncType(schema, method, field.field, field.field_type)
-                        toggleSchemaShouldSync(schema, true)
-                    }
-                } else {
-                    updateSchemaSyncType(schema, 'full_refresh', null, null)
-                    toggleSchemaShouldSync(schema, true)
-                }
-            }
-        })
-        lemonToast.info(
-            "We've setup some defaults for you! Please take a look to make sure you're happy with the results."
-        )
-    }
-
-    useEffect(() => {
-        smartConfigureTables(databaseSchema)
-    }, [smartConfigureTables, databaseSchema])
 
     // scroll to top of container
     useEffect(() => {

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -24,6 +24,7 @@ import {
     Breadcrumb,
     ExternalDataSourceCreatePayload,
     ExternalDataSourceSyncSchema,
+    IncrementalField,
     ManualLinkSourceType,
     ProductKey,
     manualLinkSources,
@@ -167,6 +168,43 @@ const manualLinkSourceMap: Record<ManualLinkSourceType, string> = {
     'google-cloud': 'Google Cloud Storage',
     'cloudflare-r2': 'Cloudflare R2',
     azure: 'Azure',
+}
+
+const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField | undefined => {
+    // check for timestamp field matching "updated_at" or "updatedAt" case insensitive
+    const updatedAt = fields.find((field) => {
+        const regex = /^updated/i
+        return regex.test(field.field) && (field.field_type === 'timestamp' || field.type === 'datetime')
+    })
+    if (updatedAt) {
+        return updatedAt
+    }
+    // fallback to timestamp field matching "created_at" or "createdAt" case insensitive
+    const createdAt = fields.find((field) => {
+        const regex = /^created/i
+        return regex.test(field.field) && (field.field_type === 'timestamp' || field.type === 'datetime')
+    })
+    if (createdAt) {
+        return createdAt
+    }
+    // fallback to any timestamp or datetime field
+    const timestamp = fields.find((field) => {
+        return field.field_type === 'timestamp' || field.type === 'datetime'
+    })
+    if (timestamp) {
+        return timestamp
+    }
+    // fallback to numeric fields matching "id" or "uuid" case insensitive
+    const id = fields.find((field) => {
+        const idRegex = /^id/i
+        const uuidRegex = /^uuid/i
+        return (idRegex.test(field.field) || uuidRegex.test(field.field)) && field.field_type === 'integer'
+    })
+    if (id) {
+        return id
+    }
+    // leave unset and require user configuration
+    return undefined
 }
 
 export interface SourceWizardLogicProps {
@@ -666,6 +704,30 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     values.selectedConnector.name,
                     values.source.payload ?? {}
                 )
+
+                for (const schema of schemas) {
+                    if (schema.sync_type === null) {
+                        schema.should_sync = true
+
+                        // Use incremental if available
+                        if (schema.incremental_available || schema.append_available) {
+                            const method = schema.incremental_available ? 'incremental' : 'append'
+                            const field = resolveIncrementalField(schema.incremental_fields)
+                            schema.sync_type = method
+                            if (field) {
+                                schema.incremental_field = field.field
+                                schema.incremental_field_type = field.field_type
+                            }
+                        } else {
+                            schema.sync_type = 'full_refresh'
+                        }
+                    }
+                }
+
+                lemonToast.info(
+                    "We've setup some defaults for you! Please take a look to make sure you're happy with the results."
+                )
+
                 actions.setDatabaseSchemas(schemas)
                 actions.onNext()
             } catch (e: any) {


### PR DESCRIPTION
## Problem
- A `useEffect` on the schema select form of the warehouse source wizard is being retriggered constantly and spamming the user with `lemonToast`'s

## Changes
- Moved the logic into kea and out of a `useEffect`
- We probably should do this logic on the backend and have it as the default for the database schema endpoint, but thats for another time

## How did you test this code?
- Tested this locally with a postgres source 