### PR TITLE
fix: copy node title

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
@@ -296,6 +296,10 @@ export const notebookNodeLogic = kea<notebookNodeLogicType>([
                         return ''
                     }
 
+                    if (key === 'title') {
+                        return `title='${JSON.stringify(value)}'`
+                    }
+
                     return `${key}='${btoa(JSON.stringify(value))}'`
                 })
                 .filter((x) => !!x)


### PR DESCRIPTION
## Problem

Reported in https://posthoghelp.zendesk.com/agent/tickets/38568 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41968)

Recent changes in https://github.com/PostHog/posthog/pull/38733 were also encoding the title but not decoding it correctly

## Changes

We should skip encoding the title because it is only ever a string and not an "attribute" on the e.g. passes through a separate deserializer