### PR TITLE
chore(data-warehouse): Toggle all tables on and off

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -25,9 +25,9 @@ import { SyncMethodForm } from './SyncMethodForm'
 
 export default function SchemaForm(): JSX.Element {
     const containerRef = useFloatingContainer()
-    const { toggleSchemaShouldSync, openSyncMethodModal, updateSyncTimeOfDay, setIsProjectTime } =
+    const { toggleSchemaShouldSync, openSyncMethodModal, updateSyncTimeOfDay, setIsProjectTime, toggleAllTables } =
         useActions(sourceWizardLogic)
-    const { databaseSchema, isProjectTime } = useValues(sourceWizardLogic)
+    const { databaseSchema, isProjectTime, tablesAllToggledOn } = useValues(sourceWizardLogic)
     const { currentTeam } = useValues(teamLogic)
 
     const onClickCheckbox = (schema: ExternalDataSourceSyncSchema, checked: boolean): void => {
@@ -52,6 +52,12 @@ export default function SchemaForm(): JSX.Element {
                         dataSource={databaseSchema}
                         columns={[
                             {
+                                title: (
+                                    <LemonCheckbox
+                                        checked={tablesAllToggledOn}
+                                        onChange={(checked) => toggleAllTables(checked)}
+                                    />
+                                ),
                                 width: 0,
                                 key: 'enabled',
                                 render: function RenderEnabled(_, schema) {

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -254,6 +254,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             syncTimeOfDay,
         }),
         setIsProjectTime: (isProjectTime: boolean) => ({ isProjectTime }),
+        toggleAllTables: (selectAll: boolean) => ({ selectAll }),
     }),
     connect(() => ({
         values: [
@@ -274,6 +275,12 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
         ],
     })),
     reducers({
+        tablesAllToggledOn: [
+            true as boolean,
+            {
+                toggleAllTables: (_, { selectAll }) => selectAll,
+            },
+        ],
         manualLinkingProvider: [
             null as ManualLinkSourceType | null,
             {
@@ -750,6 +757,14 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 product_type: ProductKey.DATA_WAREHOUSE,
                 intent_context: ProductIntentContext.SELECTED_CONNECTOR,
             })
+        },
+        toggleAllTables: ({ selectAll }) => {
+            actions.setDatabaseSchemas(
+                values.databaseSchema.map((schema) => ({
+                    ...schema,
+                    should_sync: selectAll,
+                }))
+            )
         },
     })),
     urlToAction(({ actions, values }) => {


### PR DESCRIPTION
## Problem
- When adding a new warehouse source, we now auto enable all tables - if you wanna only sync one or two tables when you have like 100 in your db, then you have to manually disable all the checkboxes 

## Changes
- Added a enable/disable all checkbox in the header of the schema form


https://github.com/user-attachments/assets/c7b2fa72-9e9e-45ab-8aa7-946ab37c5c13


