### PR TITLE
chore: remove confusing failure metric

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -190,8 +190,7 @@ async def deliver_subscription_report_async(
             )
 
             if not integration:
-                logger.error("deliver_subscription_report_async.no_slack_integration", subscription_id=subscription_id)
-                get_subscription_failure_metric("slack", "temporal").add(1)
+                logger.warn("deliver_subscription_report_async.no_slack_integration", subscription_id=subscription_id)
                 return
 
             logger.info("deliver_subscription_report_async.sending_slack_message", subscription_id=subscription_id)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The subscription failure metric is getting emitted even when if the customer has not set up their slack integration (i.e. customer's fault not ours). 

## Changes

Remove the failure metric from this code path. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
