### PR TITLE
fix(experiments): Disable timeseries UI when not enrolled

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -108,7 +108,7 @@ export function MetricRowGroup({
     const scale = useAxisScale(axisRange, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
 
     const { featureFlags } = useValues(experimentLogic)
-    const timeseriesEnabled = featureFlags[FEATURE_FLAGS.EXPERIMENT_TIMESERIES]
+    const timeseriesEnabled = featureFlags[FEATURE_FLAGS.EXPERIMENT_TIMESERIES] && experiment.stats_config?.timeseries
 
     // Calculate total rows for loading/error states
     const totalRows = isLoading || error || !result ? 1 : 1 + (result.variant_results?.length || 0)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3890,6 +3890,7 @@ export interface Experiment {
     stats_config?: {
         version?: number
         method?: ExperimentStatsMethod
+        timeseries?: boolean
     }
     _create_in_folder?: string | null
     conclusion?: ExperimentConclusion | null


### PR DESCRIPTION
## Changes
If an experiment is not enrolled to timeseries by having `stats_config.timeseries: true`, do not enable the UI.

## How did you test this code?
👀 