### PR TITLE
fix(batch-exports): Postgres: retry transactions on `SerializationFailure`

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -172,7 +172,6 @@ async def run_in_retryable_transaction(
     Args:
         connection: The PostgreSQL connection to use
         fn: An async callable to execute within the transaction
-        max_retries: Maximum number of retry attempts
         max_attempts: Maximum number of retry attempts
     Returns:
         The return value of fn

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -173,7 +173,7 @@ async def run_in_retryable_transaction(
         connection: The PostgreSQL connection to use
         fn: An async callable to execute within the transaction
         max_retries: Maximum number of retry attempts
-
+        max_attempts: Maximum number of retry attempts
     Returns:
         The return value of fn
     """


### PR DESCRIPTION
## Problem

Sometimes Postgres transactions can fail but these are not currently being retried at all. These seem to occur reasonably frequently when interacting with Cockroach DB for example.

## Changes

Some errors are safe to retry, such as `SerializationFailure`s. Let's retry these if one is raised during a transaction.

## How did you test this code?

Added new tests.

Ran existing Postgres tests.