### PR TITLE
fix: fix WebAnalytics plural resource copy

### DIFF
--- a/frontend/src/lib/utils/accessControlUtils.ts
+++ b/frontend/src/lib/utils/accessControlUtils.ts
@@ -26,6 +26,8 @@ export const getMinimumAccessLevel = (resource: APIScopeObject): AccessControlLe
 export const pluralizeResource = (resource: APIScopeObject): string => {
     if (resource === AccessControlResourceType.RevenueAnalytics) {
         return 'revenue analytics'
+    } else if (resource === AccessControlResourceType.WebAnalytics) {
+        return 'web analytics'
     }
 
     return resource.replace(/_/g, ' ') + 's'
@@ -55,6 +57,8 @@ export const orderedAccessLevels = (resourceType: AccessControlResourceType): Ac
 export const resourceTypeToString = (resourceType: AccessControlResourceType): string => {
     if (resourceType === AccessControlResourceType.RevenueAnalytics) {
         return 'revenue analytics resource'
+    } else if (resourceType === AccessControlResourceType.WebAnalytics) {
+        return 'web analytics resource'
     }
 
     return resourceType.replace(/_/g, ' ')


### PR DESCRIPTION
Updated pluralizeResource and resourceTypeToString functions to handle the WebAnalytics resource type, ensuring correct string representations for this new resource.

<img width="466" height="208" alt="Screenshot 2025-10-14 at 12 53 21 PM" src="https://github.com/user-attachments/assets/a1ec269d-ea55-4c39-bc28-8211721a102c" />
