### PR TITLE
chore(flags): use a wicked high default for `acquire_timeout_seconds`, it seems to be working w.r.t. production timeouts

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -144,7 +144,7 @@ pub struct Config {
     // How long to wait for a connection from the pool before timing out
     // - Increase if seeing "pool timed out" errors under load (e.g., 5-10s)
     // - Decrease for faster failure detection (minimum 1s)
-    #[envconfig(default = "3")]
+    #[envconfig(default = "20")]
     pub acquire_timeout_secs: u64,
 
     // Close connections that have been idle for this many seconds


### PR DESCRIPTION
## Problem

context: https://posthog.slack.com/archives/C07Q2U4BH4L/p1760461241776299