### PR TITLE
refactor: Sync once every 12 hours

### DIFF
--- a/dags/sdk_doctor/team_sdk_versions.py
+++ b/dags/sdk_doctor/team_sdk_versions.py
@@ -228,8 +228,8 @@ def aggregate_results_op(context: dagster.OpExecutionContext, results: list[list
 
 @dagster.job(
     description="Queries ClickHouse for recent SDK versions and caches them in Redis",
-    # Do this slowly, 20 batches at a time at most
-    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 20}),
+    # Do this slowly, 10 batches at a time at most, more than this will cause the pod to OOM
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 10}),
     tags={"owner": JobOwners.TEAM_GROWTH.value},
 )
 def cache_all_team_sdk_versions_job():
@@ -240,7 +240,7 @@ def cache_all_team_sdk_versions_job():
 
 cache_all_team_sdk_versions_schedule = dagster.ScheduleDefinition(
     job=cache_all_team_sdk_versions_job,
-    cron_schedule="0 */6 * * *",  # Every 6 hours
+    cron_schedule="0 */12 * * *",  # Every 12 hours
     execution_timezone="UTC",
     name="cache_all_team_sdk_versions_schedule",
 )

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
@@ -129,7 +129,7 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
         title: (
             <span>
                 LAST EVENT AT{' '}
-                <Tooltip title="This gets refreshed every 6 hours, click 'Scan Events' to refresh manually">
+                <Tooltip title="This gets refreshed every 12 hours, click 'Scan Events' to refresh manually">
                     <IconInfo />
                 </Tooltip>
             </span>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -79,8 +79,8 @@ export type SdkHealthStatus = 'danger' | 'warning' | 'success'
  * Provides smart version outdatedness detection.
  *
  * Architecture:
- * - Backend detection: Team SDK detections cached server-side (72h Redis, re-fetched every 6 hours)
- * - Version checking: Per-SDK GitHub API queries cached server-side (72h Redis, re-fetched every 6 hours)
+ * - Backend detection: Team SDK detections cached server-side (72h Redis, refreshed every 12 hours)
+ * - Version checking: Per-SDK GitHub API queries cached server-side (72h Redis, refreshed every 6 hours)
  * - Smart semver: Contextual thresholds
  */
 


### PR DESCRIPTION
Ok, running 20 of these in parallel kills our pods, sadge

Let's go back to 10 but give it more time (run every 12 hours rather than every 6 hours).

If this proves to be useful we can improve this by querying data for several teams at the same time from Clickhouse rather than querying team by team, this should speed this up