### PR TITLE
refactor(customers): Move traces notebook node filters to node settings

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -1,24 +1,128 @@
-import { BindLogic, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 
-import { LLMAnalyticsTraces } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { groupsModel } from '~/models/groupsModel'
+import { Query } from '~/queries/Query/Query'
+import { DateRange } from '~/queries/nodes/DataNode/DateRange'
+import { Reload } from '~/queries/nodes/DataNode/Reload'
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { DataTableExport } from '~/queries/nodes/DataTable/DataTableExport'
+import { DataTableSavedFilters } from '~/queries/nodes/DataTable/DataTableSavedFilters'
+import { DataTableSavedFiltersButton } from '~/queries/nodes/DataTable/DataTableSavedFiltersButton'
+import { dataTableLogic } from '~/queries/nodes/DataTable/dataTableLogic'
+import { EventPropertyFilters } from '~/queries/nodes/EventsNode/EventPropertyFilters'
+import { TracesQuery } from '~/queries/schema/schema-general'
+import { isTracesQuery } from '~/queries/utils'
+
+import { useTracesQueryContext } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
 import { llmAnalyticsLogic } from 'products/llm_analytics/frontend/llmAnalyticsLogic'
 
-import { NotebookNodeProps, NotebookNodeType } from '../types'
+import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
 import { createPostHogWidgetNode } from './NodeWrapper'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttributes>): JSX.Element | null => {
     const { expanded } = useValues(notebookNodeLogic)
     const { personId } = attributes
+    const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(
+        llmAnalyticsLogic({ personId })
+    )
+    const { tracesQuery } = useValues(llmAnalyticsLogic({ personId }))
+    const context = useTracesQueryContext()
 
     if (!expanded) {
         return null
     }
 
     return (
-        <BindLogic logic={llmAnalyticsLogic} props={{ personId }}>
-            <LLMAnalyticsTraces />
+        <BindLogic logic={dataNodeLogic} props={{ key: personId }}>
+            <Query
+                query={{
+                    ...tracesQuery,
+                    embedded: true,
+                    showTestAccountFilters: false,
+                    showReload: false,
+                    showExport: false,
+                    showDateRange: false,
+                    showPropertyFilter: false,
+                }}
+                context={context}
+                setQuery={(query) => {
+                    if (!isTracesQuery(query.source)) {
+                        throw new Error('Invalid query')
+                    }
+                    setDates(query.source.dateRange?.date_from || null, query.source.dateRange?.date_to || null)
+                    setShouldFilterTestAccounts(query.source.filterTestAccounts || false)
+                    setPropertyFilters(query.source.properties || [])
+                    setTracesQuery(query)
+                }}
+            />
         </BindLogic>
+    )
+}
+
+const Settings = ({ attributes }: NotebookNodeAttributeProperties<NotebookNodeLLMTraceAttributes>): JSX.Element => {
+    const { personId, nodeId } = attributes
+    const { setDates, setPropertyFilters, setTracesQuery } = useActions(llmAnalyticsLogic({ personId }))
+    const { tracesQuery } = useValues(llmAnalyticsLogic({ personId }))
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
+
+    return (
+        <div className="p-2 space-y-2 mb-2">
+            <BindLogic
+                logic={dataTableLogic}
+                props={{ vizKey: nodeId, dataKey: personId, query: tracesQuery, dataNodeLogicKey: nodeId }}
+            >
+                <BindLogic logic={dataNodeLogic} props={{ key: nodeId, query: tracesQuery.source }}>
+                    <div className="flex gap-2 justify-between">
+                        <DateRange
+                            key="date-range"
+                            query={tracesQuery.source as TracesQuery}
+                            setQuery={(query) => {
+                                if (!isTracesQuery(query)) {
+                                    throw new Error('Invalid query')
+                                }
+                                setDates(query.dateRange?.date_from || null, query.dateRange?.date_to || null)
+                            }}
+                        />
+                        <EventPropertyFilters
+                            key="event-property"
+                            query={tracesQuery.source as TracesQuery}
+                            setQuery={(query) => {
+                                if (!isTracesQuery(query)) {
+                                    throw new Error('Invalid query')
+                                }
+                                setPropertyFilters(query.properties || [])
+                            }}
+                            taxonomicGroupTypes={[
+                                TaxonomicFilterGroupType.EventProperties,
+                                TaxonomicFilterGroupType.PersonProperties,
+                                ...groupsTaxonomicTypes,
+                                TaxonomicFilterGroupType.Cohorts,
+                                TaxonomicFilterGroupType.HogQLExpression,
+                            ]}
+                        />
+                        <DataTableSavedFiltersButton
+                            key="saved-filters-button"
+                            uniqueKey={nodeId}
+                            query={tracesQuery}
+                            setQuery={setTracesQuery}
+                        />
+                    </div>
+                    <DataTableSavedFilters uniqueKey={nodeId} query={tracesQuery} setQuery={setTracesQuery} />
+                    <div className="flex justify-between">
+                        <Reload key="reload" />
+                        <DataTableExport
+                            key="data-table-export"
+                            query={tracesQuery}
+                            setQuery={setTracesQuery}
+                            fileNameForExport={`${personId}-llm-traces-export`}
+                        />
+                    </div>
+                </BindLogic>
+            </BindLogic>
+        </div>
     )
 }
 
@@ -30,6 +134,7 @@ export const NotebookNodeLLMTrace = createPostHogWidgetNode<NotebookNodeLLMTrace
     nodeType: NotebookNodeType.LLMTrace,
     titlePlaceholder: 'Traces',
     Component,
+    Settings,
     resizeable: false,
     expandable: true,
     startExpanded: true,

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -8,8 +8,8 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
-import { LLMTrace } from '~/queries/schema/schema-general'
-import { QueryContextColumnComponent } from '~/queries/types'
+import { DataTableNode, LLMTrace } from '~/queries/schema/schema-general'
+import { QueryContext, QueryContextColumnComponent } from '~/queries/types'
 import { isTracesQuery } from '~/queries/utils'
 
 import { LLMMessageDisplay } from './ConversationDisplay/ConversationMessagesDisplay'
@@ -35,50 +35,54 @@ export function LLMAnalyticsTraces(): JSX.Element {
                 setPropertyFilters(query.source.properties || [])
                 setTracesQuery(query)
             }}
-            context={{
-                emptyStateHeading: 'There were no traces in this period',
-                emptyStateDetail: 'Try changing the date range or filters.',
-                columns: {
-                    id: {
-                        title: 'ID',
-                        render: IDColumn,
-                    },
-                    inputState: {
-                        title: 'Input message',
-                        render: InputMessageColumn,
-                    },
-                    outputState: {
-                        title: 'Output message',
-                        render: OutputMessageColumn,
-                    },
-                    timestamp: {
-                        title: 'Time',
-                        render: TimestampColumn,
-                    },
-                    traceName: {
-                        title: 'Trace Name',
-                        render: TraceNameColumn,
-                    },
-                    person: {
-                        title: 'Person',
-                    },
-                    totalLatency: {
-                        title: 'Latency',
-                        render: LatencyColumn,
-                    },
-                    usage: {
-                        title: 'Token Usage',
-                        render: UsageColumn,
-                    },
-                    totalCost: {
-                        title: 'Total Cost',
-                        render: CostColumn,
-                    },
-                },
-            }}
+            context={useTracesQueryContext()}
             uniqueKey="llm-analytics-traces"
         />
     )
+}
+
+export const useTracesQueryContext = (): QueryContext<DataTableNode> => {
+    return {
+        emptyStateHeading: 'There were no traces in this period',
+        emptyStateDetail: 'Try changing the date range or filters.',
+        columns: {
+            id: {
+                title: 'ID',
+                render: IDColumn,
+            },
+            inputState: {
+                title: 'Input message',
+                render: InputMessageColumn,
+            },
+            outputState: {
+                title: 'Output message',
+                render: OutputMessageColumn,
+            },
+            timestamp: {
+                title: 'Time',
+                render: TimestampColumn,
+            },
+            traceName: {
+                title: 'Trace Name',
+                render: TraceNameColumn,
+            },
+            person: {
+                title: 'Person',
+            },
+            totalLatency: {
+                title: 'Latency',
+                render: LatencyColumn,
+            },
+            usage: {
+                title: 'Token Usage',
+                render: UsageColumn,
+            },
+            totalCost: {
+                title: 'Total Cost',
+                render: CostColumn,
+            },
+        },
+    }
 }
 
 const IDColumn: QueryContextColumnComponent = ({ record }) => {


### PR DESCRIPTION
## Problem
Traces notebook node was looking a bit unpolished. Let's make it look like `Issues` notebook node, with the filters/options into node's settings and embed the table.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Move filters and table controls over to `Settings` component
- Render traces query using `<Query />` component directly to have more flexibility

### Before
<img width="895" height="410" alt="image" src="https://github.com/user-attachments/assets/103b1c00-e06e-428c-9847-232a2ad9aed3" />

### After
<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/5bae1500-4ca8-4e11-9783-41f9bd5230b8" />

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/efc8b6e7-ce07-4983-9fdd-5cfe7276ac72" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
