### PR TITLE
feat: Add migration to drop and recreate sessions v3

### DIFF
--- a/posthog/clickhouse/migrations/0157_sessions_v3_remake.py
+++ b/posthog/clickhouse/migrations/0157_sessions_v3_remake.py
@@ -1,0 +1,27 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sql_v3 import (
+    DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3,
+    DROP_RAW_SESSION_DISTRIBUTED_TABLE_SQL_V3,
+    DROP_RAW_SESSION_TABLE_SQL_V3,
+    DROP_RAW_SESSION_WRITABLE_TABLE_SQL_V3,
+    RAW_SESSIONS_CREATE_OR_REPLACE_VIEW_SQL_V3,
+    RAW_SESSIONS_TABLE_SQL_V3,
+    WRITABLE_RAW_SESSIONS_TABLE_SQL_V3,
+)
+
+operations = [
+    # drop the tables first in the reverse of the creation order
+    run_sql_with_exceptions(DROP_RAW_SESSION_TABLE_SQL_V3()),
+    run_sql_with_exceptions(
+        DROP_RAW_SESSION_DISTRIBUTED_TABLE_SQL_V3(), node_roles=[NodeRole.DATA, NodeRole.COORDINATOR]
+    ),
+    run_sql_with_exceptions(DROP_RAW_SESSION_WRITABLE_TABLE_SQL_V3()),
+    # then recreate them
+    run_sql_with_exceptions(WRITABLE_RAW_SESSIONS_TABLE_SQL_V3()),
+    run_sql_with_exceptions(DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3(), node_roles=[NodeRole.DATA, NodeRole.COORDINATOR]),
+    run_sql_with_exceptions(RAW_SESSIONS_TABLE_SQL_V3()),
+    run_sql_with_exceptions(RAW_SESSIONS_CREATE_OR_REPLACE_VIEW_SQL_V3()),
+    # normally there would be SQL to add the MV here too, but at the moment we only want this table to backfill,
+    # so let's not increase the load on the cluster just yet
+]


### PR DESCRIPTION
## Problem
The sessions v3 table design has changed. We don't have any data in this table on prod, so drop it and recreate it.

## Changes

Add a migration to drop and recreate the sessions v3 table.

## How did you test this code?

The tests all pass with the new design (that happened in a separate PR here https://github.com/PostHog/posthog/pull/39092 )

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
