### PR TITLE
chore(flox): Suppress verbose upgrade check logging and cleanup old log files

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,9 @@
 # Docker Compose project name - forces all containers to use "posthog" namespace
 export COMPOSE_PROJECT_NAME=posthog
 
+# Suppress verbose Flox logging only (not PostHog Rust services)
+export RUST_LOG="flox=error,flox_rust_sdk=error,flox_watchdog=error"
+
 if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
     # Capture the directory user intended to work in before any Flox operations
     ORIGINAL_PWD="${PWD}"

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -54,6 +54,7 @@ ffmpeg.pkg-path = "ffmpeg"
 DEBUG = "1"
 POSTHOG_SKIP_MIGRATION_CHECKS = "1"
 DIRENV_LOG_FORMAT = "" # Disable direnv activation logging (in case direnv is present)
+RUST_LOG = "flox=error,flox_rust_sdk=error,flox_watchdog=error" # Suppress Flox logs only (also set in .envrc for early activation)
 OPENSSL_ROOT_DIR = "$FLOX_ENV"
 OPENSSL_LIB_DIR = "$FLOX_ENV/lib"
 DOTENV_FILE = ".env"

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -85,6 +85,9 @@ if [[ -t 0 ]] && ! command -v direnv >/dev/null 2>&1 && [ ! -f "$FLOX_ENV_CACHE/
   echo
 fi
 
+# Clean up old Flox log files (older than 7 days)
+find "$FLOX_ENV_PROJECT/.flox/log" -name "*.log" -type f -mtime +7 -delete 2>/dev/null || true
+
 # Ensure Python virtual environment - Python version is defined in pyproject.toml
 uv sync
 


### PR DESCRIPTION
## Problem

I keep running out of disk space and Flox is part of the problem 😢 

Flox generates DEBUG-level logs during package upgrade checks that clutter the `.flox/log/` directory. I've seen it get as large as 32GB before I noticed (when I ran out of disk space and everything broke).

## Changes

Set `RUST_LOG` in the flox manifest to suppress verbose logging from Flox modules only, while preserving normal logging for PostHog Rust services.

- Set `RUST_LOG` in `.envrc` for early activation (direnv users)
- Set `RUST_LOG` in `manifest.toml` for non-direnv users
- Filter only flox*, flox_rust_sdk*, and flox_watchdog* modules

This also deletes flox log files older than 7 days when flox is activated.

## How did you test this code?

Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
