### PR TITLE
fix(cohorts): Optimize query for person properties

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -51,38 +51,24 @@
          99999 as team_id,
          1 AS sign,
          3 AS version
-  FROM (((
-            (SELECT persons.id AS id
-             FROM
-               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), person.version) AS `properties___$some_prop`,
-                       person.id AS id
-                FROM person
-                WHERE and(equals(person.team_id, 99999), in(id,
-                                                              (SELECT where_optimization.id AS id
-                                                               FROM person AS where_optimization
-                                                               WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0)))))
-                GROUP BY person.id
-                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
-             WHERE ifNull(equals(persons.`properties___$some_prop`, 'something'), 0)
-             ORDER BY persons.id ASC
-             LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
-                                       join_algorithm='auto')) INTERSECT DISTINCT (
-                                                                                     (SELECT persons.id AS id
-                                                                                      FROM
-                                                                                        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$another_prop'), ''), 'null'), '^"|"$', ''), person.version) AS `properties___$another_prop`,
-                                                                                                person.id AS id
-                                                                                         FROM person
-                                                                                         WHERE and(equals(person.team_id, 99999), in(id,
-                                                                                                                                       (SELECT where_optimization.id AS id
-                                                                                                                                        FROM person AS where_optimization
-                                                                                                                                        WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$another_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0)))))
-                                                                                         GROUP BY person.id
-                                                                                         HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
-                                                                                      WHERE ifNull(equals(persons.`properties___$another_prop`, 'something'), 0)
-                                                                                      ORDER BY persons.id ASC
-                                                                                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
-                                                                                                                join_algorithm='auto')))) as person SETTINGS optimize_aggregation_in_order = 1,
-                                                                                                                                                             join_algorithm = 'auto'
+  FROM
+    (SELECT persons.id AS id
+     FROM
+       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), person.version) AS `properties___$some_prop`,
+               argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$another_prop'), ''), 'null'), '^"|"$', ''), person.version) AS `properties___$another_prop`,
+               person.id AS id
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(id,
+                                                      (SELECT where_optimization.id AS id
+                                                       FROM person AS where_optimization
+                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$another_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0)))))
+        GROUP BY person.id
+        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+     WHERE and(ifNull(equals(persons.`properties___$some_prop`, 'something'), 0), ifNull(equals(persons.`properties___$another_prop`, 'something'), 0))
+     ORDER BY persons.id ASC
+     LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                               join_algorithm='auto') as person SETTINGS optimize_aggregation_in_order = 1,
+                                                                         join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator
@@ -122,23 +108,23 @@
          99999 as team_id,
          1 AS sign,
          3 AS version
-  FROM (
-          (SELECT persons.id AS id
-           FROM
-             (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), person.version) AS `properties___$some_prop`,
-                     person.id AS id
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(id,
-                                                            (SELECT where_optimization.id AS id
-                                                             FROM person AS where_optimization
-                                                             WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), 'something1'), 0)))))
-              GROUP BY person.id
-              HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
-           WHERE ifNull(equals(persons.`properties___$some_prop`, 'something1'), 0)
-           ORDER BY persons.id ASC
-           LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
-                                     join_algorithm='auto')) as person SETTINGS optimize_aggregation_in_order = 1,
-                                                                                join_algorithm = 'auto'
+  FROM
+    (SELECT persons.id AS id
+     FROM
+       (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), person.version) AS `properties___$some_prop`,
+               person.id AS id
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(id,
+                                                      (SELECT where_optimization.id AS id
+                                                       FROM person AS where_optimization
+                                                       WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), 'something1'), 0)))))
+        GROUP BY person.id
+        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+     WHERE ifNull(equals(persons.`properties___$some_prop`, 'something1'), 0)
+     ORDER BY persons.id ASC
+     LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                               join_algorithm='auto') as person SETTINGS optimize_aggregation_in_order = 1,
+                                                                         join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator.2

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from numbers import Number
 from typing import Literal, Optional, Union, cast
 
+import posthoganalytics
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
@@ -92,7 +93,10 @@ def convert(prop: PropertyGroup) -> PropertyGroupFilterValue:
 
 class HogQLCohortQuery:
     def __init__(
-        self, cohort_query: Optional[CohortQuery] = None, cohort: Optional[Cohort] = None, team: Optional[Team] = None
+        self,
+        cohort_query: Optional[CohortQuery] = None,
+        cohort: Optional[Cohort] = None,
+        team: Optional[Team] = None,
     ):
         if cohort is not None:
             self.hogql_context = HogQLContext(team_id=cohort.team.pk, enable_select_queries=True)
@@ -438,6 +442,56 @@ class HogQLCohortQuery:
     def _get_conditions(self) -> ast.SelectQuery | ast.SelectSetQuery:
         Condition = namedtuple("Condition", ["query", "negation"])
 
+        def unwrap_property(prop: Union[PropertyGroup, Property]) -> Optional[Property]:
+            """Unwrap a PropertyGroup to get the underlying Property if it contains exactly one."""
+            if isinstance(prop, Property):
+                return prop
+            if isinstance(prop, PropertyGroup) and len(prop.values) == 1:
+                return unwrap_property(prop.values[0])
+            return None
+
+        def can_combine_person_properties(properties: Union[list[PropertyGroup], list[Property]]) -> bool:
+            """Check if all properties are person properties that can be combined into a single query."""
+            unwrapped = [unwrap_property(prop) for prop in properties]
+            return all(p is not None and p.type == "person" and not p.negation for p in unwrapped)
+
+        def combine_person_properties(properties: Union[list[Property], list[PropertyGroup]]) -> ast.SelectQuery:
+            """Combine multiple person property filters into a single ActorsQuery."""
+            person_filters = []
+            for prop_or_group in properties:
+                # Unwrap PropertyGroup to get the underlying Property
+                prop = unwrap_property(prop_or_group)
+                if prop is None:
+                    continue
+                person_filters.append(convert_property(prop))
+
+            actors_query = ActorsQuery(
+                properties=person_filters,
+                select=["id"],
+            )
+            query_runner = ActorsQueryRunner(team=self.team, query=actors_query)
+            return query_runner.to_query()
+
+        def should_combine_person_properties() -> bool:
+            return posthoganalytics.feature_enabled(
+                "hogql-cohort-combine-person-properties",
+                str(self.team.uuid),
+                groups={
+                    "organization": str(self.team.organization_id),
+                    "project": str(self.team.id),
+                },
+                group_properties={
+                    "organization": {
+                        "id": str(self.team.organization_id),
+                    },
+                    "project": {
+                        "id": str(self.team.id),
+                    },
+                },
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+
         def build_conditions(
             prop: Optional[Union[PropertyGroup, Property]],
         ) -> Condition:
@@ -446,6 +500,10 @@ class HogQLCohortQuery:
 
             if isinstance(prop, Property):
                 return Condition(self._get_condition_for_property(prop), prop.negation or False)
+
+            if should_combine_person_properties():
+                if prop.type == PropertyOperatorType.AND and can_combine_person_properties(prop.values):
+                    return Condition(combine_person_properties(prop.values), False)
 
             children = [build_conditions(property) for property in prop.values]
 

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -61,3 +61,134 @@ class TestHogQLCohortQuery(ClickhouseTestMixin, APIBaseTest):
             "and(isNotNull(persons.properties___email), ifNull(ilike(toString(persons.properties___email), %(hogql_val_8)s), 0), ifNull(notILike(toString(persons.properties___email), %(hogql_val_9)s), 1))",
             query_str,
         )
+
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_optimization_disabled_when_feature_flag_off(self, mock_feature_enabled: MagicMock) -> None:
+        """
+        Test that the optimization is disabled when the feature flag is off.
+
+        When the feature flag is disabled, multiple person properties should be processed
+        separately and combined with INTERSECT DISTINCT instead of a single query.
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "negation": False,
+                            "value": "is_set",
+                            "operator": "is_set",
+                        },
+                        {
+                            "key": "name",
+                            "type": "person",
+                            "value": "John",
+                            "negation": False,
+                            "operator": "icontains",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Feature Flag Off Cohort", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # With the feature flag off, should use INTERSECT DISTINCT
+        self.assertIn("INTERSECT DISTINCT", query_str)
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_optimization_skipped_for_mixed_property_types(self, mock_feature_enabled: MagicMock) -> None:
+        """
+        Test that the optimization is skipped when mixing person and behavioral properties.
+
+        The optimization only applies to pure person property filters. When behavioral
+        properties are mixed in, each property should be processed separately.
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "negation": False,
+                            "value": "is_set",
+                            "operator": "is_set",
+                        },
+                        {
+                            "key": "$pageview",
+                            "type": "behavioral",
+                            "value": "performed_event",
+                            "negation": False,
+                            "event_type": "events",
+                            "time_value": 30,
+                            "time_interval": "day",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Mixed Properties Cohort", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # Should use INTERSECT DISTINCT because properties are mixed
+        self.assertIn("INTERSECT DISTINCT", query_str)
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_optimization_skipped_for_properties_with_negation(self, mock_feature_enabled: MagicMock) -> None:
+        """
+        Test that the optimization is skipped when any property has negation.
+
+        The optimization only applies when all person properties are positive (not negated).
+        If any property is negated, each property should be processed separately.
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "negation": False,
+                            "value": "is_set",
+                            "operator": "is_set",
+                        },
+                        {
+                            "key": "name",
+                            "type": "person",
+                            "value": "Spam",
+                            "negation": True,
+                            "operator": "icontains",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Negation Cohort", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # Should use EXCEPT because one property is negated
+        self.assertIn("EXCEPT", query_str)

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -1,0 +1,63 @@
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import MagicMock, patch
+
+from posthog.hogql_queries.hogql_cohort_query import HogQLCohortQuery
+from posthog.models import Cohort
+
+
+class TestHogQLCohortQuery(ClickhouseTestMixin, APIBaseTest):
+    """Tests for HogQLCohortQuery, particularly the optimization for multiple person property filters."""
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_multiple_person_properties_optimization(self, mock_feature_enabled: MagicMock) -> None:
+        """
+        Test that multiple person property filters in an AND group are combined into a single query.
+
+        This optimization prevents generating N separate queries with N-1 INTERSECT DISTINCT operations,
+        which is extremely inefficient for cohorts with many person property filters.
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "negation": False,
+                            "value": "is_set",
+                            "operator": "is_set",
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@hotmail",
+                            "negation": False,
+                            "operator": "icontains",
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@yahoo",
+                            "negation": False,
+                            "operator": "not_icontains",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Multiple Filters Cohort", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # If the optimization worked, there should be no INTERSECT in the query
+        self.assertNotIn("INTERSECT DISTINCT", query_str)
+        self.assertIn(
+            "and(isNotNull(persons.properties___email), ifNull(ilike(toString(persons.properties___email), %(hogql_val_8)s), 0), ifNull(notILike(toString(persons.properties___email), %(hogql_val_9)s), 1))",
+            query_str,
+        )


### PR DESCRIPTION
## Problem

In production it's not unlikely to have cohorts with tens of person property conditions scanning over millions of people.

## Changes

This change combines multiple person property conditions together into a single query instead of multiple queries for each property.

<details>
	<summary>View the before query (time 0.96s, memory 123.0 MB)</summary>

	INSERT INTO cohortpeople
	SELECT id, %(cohort_id)s as cohort_id, %(team_id)s as team_id, 1 AS sign, %(new_version)s AS version
	FROM (
	    (((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_0)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_1)s), person.version), plus(now64(6, %(hogql_val_2)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_3)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_4)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_5)s), person.version), plus(now64(6, %(hogql_val_6)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_7)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_8)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_9)s), person.version), plus(now64(6, %(hogql_val_10)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_11)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_12)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_13)s), person.version), plus(now64(6, %(hogql_val_14)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_15)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_16)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_17)s), person.version), plus(now64(6, %(hogql_val_18)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_19)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_20)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_21)s), person.version), plus(now64(6, %(hogql_val_22)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_23)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_24)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_25)s), person.version), plus(now64(6, %(hogql_val_26)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_27)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_28)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_29)s), person.version), plus(now64(6, %(hogql_val_30)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_31)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	                    person AS where_optimization
	                WHERE
	                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_32)s), 1)))))
	    GROUP BY
	        person.id
	    HAVING
	        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_33)s), person.version), plus(now64(6, %(hogql_val_34)s), toIntervalDay(1))), 0))) AS persons
	WHERE
	    ifNull(notILike(toString(persons.properties___email), %(hogql_val_35)s), 1)
	ORDER BY
	    persons.id ASC
	LIMIT 1000000000
	SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto'))
	UNION DISTINCT
	((SELECT
	    persons.id AS id
	FROM
	    (SELECT
	        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
	        person.id AS id
	    FROM
	        person
	    WHERE
	        and(equals(person.team_id, 1), in(id, (SELECT
	                    where_optimization.id AS id
	                FROM
	           …

	
	    truncated sorry :(
</details>


<details>
<summary>View the after query (time 0.05s, memory 8.0 MB)</summary>

		INSERT INTO cohortpeople
		SELECT id, %(cohort_id)s as cohort_id, %(team_id)s as team_id, 1 AS sign, %(new_version)s AS version
		FROM (
		    SELECT
		    persons.id AS id
		FROM
		    (SELECT
		        argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
		        person.id AS id
		    FROM
		        person
		    WHERE
		        and(equals(person.team_id, 1), in(id, (SELECT
		                    where_optimization.id AS id
		                FROM
		                    person AS where_optimization
		                WHERE
		                    and(equals(where_optimization.team_id, 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_0)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_1)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_2)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_3)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_4)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_5)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_6)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_7)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_8)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_9)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_10)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_11)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_12)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_13)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_14)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_15)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_16)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_17)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_18)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_19)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_20)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_21)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_22)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_23)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_24)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_25)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_26)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_27)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_28)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_29)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_30)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_31)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_32)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_33)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_34)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_35)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_36)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_37)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_38)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_39)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_40)s), 1), ifNull(notILike(toString(nullIf(nullIf(where_optimization.pmat_email, ''), 'null')), %(hogql_val_41)s), 1)))))
		    GROUP BY
		        person.id
		    HAVING
		        and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, %(hogql_val_42)s), person.version), plus(now64(6, %(hogql_val_43)s), toIntervalDay(1))), 0))) AS persons
		WHERE
		    and(ifNull(notILike(toString(persons.properties___email), %(hogql_val_44)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_45)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_46)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_47)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_48)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_49)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_50)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_51)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_52)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_53)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_54)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_55)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_56)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_57)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_58)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_59)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_60)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_61)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_62)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_63)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_64)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_65)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_66)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_67)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_68)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_69)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_70)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_71)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_72)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_73)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_74)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_75)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_76)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_77)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_78)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_79)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_80)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_81)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_82)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_83)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_84)s), 1), ifNull(notILike(toString(persons.properties___email), %(hogql_val_85)s), 1))
		ORDER BY
		    persons.id ASC
		LIMIT 1000000000
		SETTINGS optimize_aggregation_in_order=1, join_algorithm='auto' 
		) as person
		SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto'
</details>


## How did you test this code?

Local testing, unit tests, feature flags.

