### PR TITLE
fix(groups): `New` button should be gated by crm feature flag for groups

### DIFF
--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -86,14 +86,16 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: GroupTypeIndex }): 
                     forceIcon: <IconPeople />,
                 }}
                 actions={
-                    <LemonButton
-                        type="primary"
-                        size="small"
-                        data-attr={`new-group-${groupTypeIndex}`}
-                        onClick={() => router.actions.push(urls.group(groupTypeIndex, 'new', false))}
-                    >
-                        New {aggregationLabel(groupTypeIndex).singular}
-                    </LemonButton>
+                    hasCrmIterationOneEnabled ? (
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            data-attr={`new-group-${groupTypeIndex}`}
+                            onClick={() => router.actions.push(urls.group(groupTypeIndex, 'new', false))}
+                        >
+                            New {aggregationLabel(groupTypeIndex).singular}
+                        </LemonButton>
+                    ) : undefined
                 }
             />
             <SceneDivider />


### PR DESCRIPTION
## Problem

The `New Group` button only works after afew clicks:

https://github.com/user-attachments/assets/a571db02-edd6-4045-a531-24bc19671602

After looking into it, i realised the button used to be gated by a feature flag when its first introduced: https://github.com/PostHog/posthog/pull/35365/files

## Changes
<img width="1025" height="820" alt="Screenshot 2025-10-15 at 2 55 29 PM" src="https://github.com/user-attachments/assets/ad65835e-4518-4422-a889-d82f2eae7d51" />



## How did you test this code?

1) Make sure you have a group.
2) Go to a group like: http://localhost:8010/project/2/groups/1

You should not see the `New Group` button.
