### PR TITLE
chore(docker): optimize layer caching by moving source code copies to end

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -4,6 +4,7 @@ from posthog.celery import app as celery_app  # noqa: E402
 
 __all__ = ("celery_app",)
 
+
 # snowflake-connector-python tries to access a root folder which errors out in pods.
 # This sets the snowflake home directory to a relative folder
 import os  # noqa: E402


### PR DESCRIPTION
## Summary
- Moved source code copies to end of Dockerfile to maximize cache reuse
- Any Python/Django source change now preserves expensive layer caches

## Impact
Before: Source changes invalidated all layers after line 318, including:
- Node.js installation (~7s)
- Playwright installation with deps (~35-38s per architecture)
- Validation steps

After: Source changes only invalidate final COPY layers (fast operations)

Expected improvement: ~30-45 seconds saved per build on typical source changes (which happen on most commits)

## Test plan
- Monitor CI build times on this PR
- Compare against baseline: 5m 44s total (with cache), 13m 56s saved from cache
- Look for improved cache hit rates on subsequent pushes with source-only changes

## Context
Analysis of Depot build showed biggest bottleneck after node_modules was layer invalidation from source code copies happening too early. Same Dockerfile serves both self-hosted and PostHog Cloud, so this improves all builds.