### PR TITLE
fix(feature flag): Creation of new flag does not show the correct value for the checkbox

### DIFF
--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -355,6 +355,7 @@ const featureFlagActionsMapping: Record<
     version: () => null,
     last_modified_by: () => null,
     _create_in_folder: () => null,
+    _should_create_usage_dashboard: () => null,
 }
 
 const getActorName = (logItem: ActivityLogItem): JSX.Element => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -122,6 +122,7 @@ export const NEW_FLAG: FeatureFlagType = {
     last_modified_by: null,
     evaluation_runtime: FeatureFlagEvaluationRuntime.ALL,
     evaluation_tags: [],
+    _should_create_usage_dashboard: true,
 }
 const NEW_VARIANT = {
     key: '',
@@ -364,7 +365,6 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             defaults: {
                 ...NEW_FLAG,
                 ensure_experience_continuity: values.currentTeam?.flags_persistence_default || false,
-                _should_create_usage_dashboard: true,
             },
             errors: ({ key, filters, is_remote_configuration }) => {
                 return {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3452,6 +3452,7 @@ export interface FeatureFlagType extends Omit<FeatureFlagBasicType, 'id' | 'team
     status: 'ACTIVE' | 'INACTIVE' | 'STALE' | 'DELETED' | 'UNKNOWN'
     _create_in_folder?: string | null
     evaluation_runtime: FeatureFlagEvaluationRuntime
+    _should_create_usage_dashboard?: boolean
 }
 
 export interface OrganizationFeatureFlag {


### PR DESCRIPTION
## Problem

After the creation of a flag, clicking on the new flag button shows the wrong value for the `_should_create_usage_dashboard` checkbox:


https://github.com/user-attachments/assets/d43f8b68-d9ff-4131-b241-3491bf73e148

I suspect this is happening because during the second url change, `loadFeatureFlag` is triggered and it does not include the `_should_create_usage_dashboard` value:

https://github.com/PostHog/posthog/blob/f44373d15f90d179683f3793755b8b38bd338e48/frontend/src/scenes/feature-flags/featureFlagLogic.ts#L733-L736

## Changes

Included `_should_create_usage_dashboard` in `NEW_FLAG` so its more consistent.

## How did you test this code?

1) Create a feature flag
2) After the creation, navigate back to the feature flag page
3) Click on `create new flag`

You should see that the create usage dashboard checkbox is checked 
