### PR TITLE
refactor(experiments): shared metric modal refactor for create

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -16,6 +16,7 @@ import { ExperimentImplementationDetails } from '../ExperimentImplementationDeta
 import { ExperimentMetricModal } from '../Metrics/ExperimentMetricModal'
 import { LegacyMetricModal } from '../Metrics/LegacyMetricModal'
 import { LegacyMetricSourceModal } from '../Metrics/LegacyMetricSourceModal'
+import { LegacySharedMetricModal } from '../Metrics/LegacySharedMetricModal'
 import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { SharedMetricModal } from '../Metrics/SharedMetricModal'
 import { experimentMetricModalLogic } from '../Metrics/experimentMetricModalLogic'
@@ -266,7 +267,7 @@ export function ExperimentView(): JSX.Element {
                         <>
                             <MetricSourceModal />
                             <ExperimentMetricModal
-                                experimentId={experimentId}
+                                experiment={experiment}
                                 onSave={(metric, context) => {
                                     const metrics = experiment[context.field]
                                     const isNew = !metrics.some(({ uuid }) => uuid === metric.uuid)
@@ -307,6 +308,7 @@ export function ExperimentView(): JSX.Element {
                                     closeExperimentMetricModal()
                                 }}
                             />
+                            <SharedMetricModal experiment={experiment} onSave={(metrics) => {}} />
                             <ExposureCriteriaModal />
                             <RunningTimeCalculatorModal />
                         </>
@@ -314,13 +316,12 @@ export function ExperimentView(): JSX.Element {
                         <>
                             <LegacyMetricSourceModal experimentId={experimentId} isSecondary={true} />
                             <LegacyMetricSourceModal experimentId={experimentId} isSecondary={false} />
+                            <LegacySharedMetricModal experimentId={experimentId} isSecondary={true} />
+                            <LegacySharedMetricModal experimentId={experimentId} isSecondary={false} />
                             <LegacyMetricModal experimentId={experimentId} isSecondary={true} />
                             <LegacyMetricModal experimentId={experimentId} isSecondary={false} />
                         </>
                     )}
-
-                    <SharedMetricModal experimentId={experimentId} isSecondary={true} />
-                    <SharedMetricModal experimentId={experimentId} isSecondary={false} />
 
                     <DistributionModal experimentId={experimentId} />
                     <ReleaseConditionsModal experimentId={experimentId} />

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -338,9 +338,7 @@ export function ExperimentView(): JSX.Element {
                                     )
 
                                     setExperiment({
-                                        [context.type === 'secondary'
-                                            ? 'secondary_metrics_ordered_uuids'
-                                            : 'primary_metrics_ordered_uuids']: newOrderingArray,
+                                        [context.orderingField]: newOrderingArray,
                                     })
 
                                     removeSharedMetricFromExperiment(metric.id)

--- a/frontend/src/scenes/experiments/Metrics/ExperimentMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/ExperimentMetricModal.tsx
@@ -6,20 +6,17 @@ import type { ExperimentMetric } from '~/queries/schema/schema-general'
 import type { Experiment } from '~/types'
 
 import { ExperimentMetricForm } from '../ExperimentMetricForm'
-import { experimentLogic } from '../experimentLogic'
 import { type MetricContext, experimentMetricModalLogic } from './experimentMetricModalLogic'
 
 export function ExperimentMetricModal({
-    experimentId,
+    experiment,
     onSave,
     onDelete,
 }: {
-    experimentId: Experiment['id']
+    experiment: Experiment
     onSave: (metric: ExperimentMetric, context: MetricContext) => void
     onDelete: (metric: ExperimentMetric, context: MetricContext) => void
 }): JSX.Element | null {
-    const { experiment, experimentLoading } = useValues(experimentLogic({ experimentId }))
-
     const { isModalOpen, metric, context, isCreateMode, isEditMode } = useValues(experimentMetricModalLogic)
     const { closeExperimentMetricModal, setMetric: setModalMetric } = useActions(experimentMetricModalLogic)
 
@@ -71,7 +68,6 @@ export function ExperimentMetricModal({
                             form="edit-experiment-metric-form"
                             onClick={() => onSave(metric, context)}
                             type="primary"
-                            loading={experimentLoading}
                             data-attr="save-experiment-metric"
                         >
                             {isCreateMode ? 'Create' : 'Save'}

--- a/frontend/src/scenes/experiments/Metrics/LegacySharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/LegacySharedMetricModal.tsx
@@ -1,0 +1,315 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonBanner, LemonButton, LemonLabel, LemonModal, Link } from '@posthog/lemon-ui'
+
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { AvailableFeature, Experiment } from '~/types'
+
+import { MetricDisplayFunnels, MetricDisplayTrends } from '../ExperimentView/components'
+import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
+import { experimentLogic } from '../experimentLogic'
+import { modalsLogic } from '../modalsLogic'
+import { appendMetricToOrderingArray, removeMetricFromOrderingArray } from '../utils'
+
+/**
+ * @deprecated
+ * This component is deprecated and only supports the legacy query runner.
+ * Use the SharedMetricModal component instead.
+ */
+export function LegacySharedMetricModal({
+    experimentId,
+    isSecondary,
+}: {
+    experimentId: Experiment['id']
+    isSecondary?: boolean
+}): JSX.Element {
+    const { experiment, compatibleSharedMetrics, editingSharedMetricId } = useValues(experimentLogic({ experimentId }))
+    const {
+        addSharedMetricsToExperiment,
+        removeSharedMetricFromExperiment,
+        restoreUnmodifiedExperiment,
+        setExperiment,
+    } = useActions(experimentLogic({ experimentId }))
+    const { closePrimarySharedMetricModal, closeSecondarySharedMetricModal } = useActions(modalsLogic)
+    const { isPrimarySharedMetricModalOpen, isSecondarySharedMetricModalOpen } = useValues(modalsLogic)
+    const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
+    const mode = editingSharedMetricId ? 'edit' : 'create'
+
+    const { hasAvailableFeature } = useValues(userLogic)
+
+    if (!compatibleSharedMetrics) {
+        return <></>
+    }
+
+    const isOpen = isSecondary ? isSecondarySharedMetricModalOpen : isPrimarySharedMetricModalOpen
+    const onClose = (): void => {
+        restoreUnmodifiedExperiment()
+        isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+    }
+
+    const addSharedMetricDisabledReason = (): string | undefined => {
+        if (selectedMetricIds.length === 0) {
+            return 'Please select at least one metric'
+        }
+    }
+
+    const availableSharedMetrics = compatibleSharedMetrics.filter(
+        (metric: SharedMetric) =>
+            !experiment.saved_metrics.some((savedMetric) => savedMetric.saved_metric === metric.id)
+    )
+
+    const availableTags = Array.from(
+        new Set(
+            availableSharedMetrics
+                .filter((metric: SharedMetric) => metric.tags)
+                .flatMap((metric: SharedMetric) => metric.tags)
+                .filter(Boolean)
+        )
+    ).sort()
+
+    return (
+        <LemonModal
+            isOpen={isOpen}
+            onClose={onClose}
+            width={500}
+            title={mode === 'create' ? 'Select one or more shared metrics' : 'Shared metric'}
+            footer={
+                <div className="flex justify-between w-full">
+                    <div>
+                        {editingSharedMetricId && (
+                            <LemonButton
+                                status="danger"
+                                onClick={() => {
+                                    const metric = compatibleSharedMetrics.find((m) => m.id === editingSharedMetricId)
+                                    if (metric) {
+                                        const newOrderingArray = removeMetricFromOrderingArray(
+                                            experiment,
+                                            metric.query.uuid,
+                                            !!isSecondary
+                                        )
+                                        setExperiment({
+                                            [isSecondary
+                                                ? 'secondary_metrics_ordered_uuids'
+                                                : 'primary_metrics_ordered_uuids']: newOrderingArray,
+                                        })
+                                    }
+                                    removeSharedMetricFromExperiment(editingSharedMetricId)
+                                    isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+                                }}
+                                type="secondary"
+                            >
+                                Remove from experiment
+                            </LemonButton>
+                        )}
+                    </div>
+                    <div className="flex gap-2">
+                        <LemonButton onClick={onClose} type="secondary">
+                            Cancel
+                        </LemonButton>
+                        {/* Changing the existing metric is a pain because saved metrics are stored separately */}
+                        {/* Only allow deletion for now */}
+                        {mode === 'create' && (
+                            <LemonButton
+                                onClick={() => {
+                                    let newOrderingArray = isSecondary
+                                        ? (experiment.secondary_metrics_ordered_uuids ?? [])
+                                        : (experiment.primary_metrics_ordered_uuids ?? [])
+
+                                    selectedMetricIds.forEach((metricId) => {
+                                        const metric = compatibleSharedMetrics.find((m) => m.id === metricId)
+                                        if (metric) {
+                                            newOrderingArray = appendMetricToOrderingArray(
+                                                {
+                                                    ...experiment,
+                                                    [isSecondary
+                                                        ? 'secondary_metrics_ordered_uuids'
+                                                        : 'primary_metrics_ordered_uuids']: newOrderingArray,
+                                                },
+                                                metric.query.uuid,
+                                                !!isSecondary
+                                            )
+                                        }
+                                    })
+
+                                    setExperiment({
+                                        [isSecondary
+                                            ? 'secondary_metrics_ordered_uuids'
+                                            : 'primary_metrics_ordered_uuids']: newOrderingArray,
+                                    })
+
+                                    addSharedMetricsToExperiment(selectedMetricIds, {
+                                        type: isSecondary ? 'secondary' : 'primary',
+                                    })
+                                    isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+                                }}
+                                type="primary"
+                                disabledReason={addSharedMetricDisabledReason()}
+                            >
+                                {selectedMetricIds.length < 2 ? 'Add metric' : 'Add metrics'}
+                            </LemonButton>
+                        )}
+                    </div>
+                </div>
+            }
+        >
+            {mode === 'create' && (
+                <div className="deprecated-space-y-2">
+                    {availableSharedMetrics.length > 0 ? (
+                        <>
+                            {experiment.saved_metrics.length > 0 && (
+                                <LemonBanner type="info">
+                                    {`Hiding ${experiment.saved_metrics.length} shared ${
+                                        experiment.saved_metrics.length > 1 ? 'metrics' : 'metric'
+                                    } already in use with this experiment.`}
+                                </LemonBanner>
+                            )}
+                            {hasAvailableFeature(AvailableFeature.TAGGING) && availableTags.length > 0 && (
+                                <div className="flex flex-wrap gap-2">
+                                    <LemonLabel>Quick select:</LemonLabel>
+                                    {availableTags.map((tag: string, index: number) => (
+                                        <LemonButton
+                                            key={index}
+                                            size="xsmall"
+                                            type="secondary"
+                                            onClick={() => {
+                                                setSelectedMetricIds(
+                                                    availableSharedMetrics
+                                                        .filter((metric: SharedMetric) => metric.tags?.includes(tag))
+                                                        .map((metric: SharedMetric) => metric.id)
+                                                )
+                                            }}
+                                        >
+                                            {tag}
+                                        </LemonButton>
+                                    ))}
+                                </div>
+                            )}
+                            <LemonTable
+                                dataSource={availableSharedMetrics}
+                                columns={[
+                                    {
+                                        title: '',
+                                        key: 'checkbox',
+                                        render: (_, metric: SharedMetric) => (
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedMetricIds.includes(metric.id)}
+                                                onChange={(e) => {
+                                                    if (e.target.checked) {
+                                                        setSelectedMetricIds([...selectedMetricIds, metric.id])
+                                                    } else {
+                                                        setSelectedMetricIds(
+                                                            selectedMetricIds.filter((id) => id !== metric.id)
+                                                        )
+                                                    }
+                                                }}
+                                            />
+                                        ),
+                                    },
+                                    {
+                                        title: 'Name',
+                                        dataIndex: 'name',
+                                        key: 'name',
+                                    },
+                                    {
+                                        title: 'Description',
+                                        dataIndex: 'description',
+                                        key: 'description',
+                                    },
+                                    ...(hasAvailableFeature(AvailableFeature.TAGGING)
+                                        ? [
+                                              {
+                                                  title: 'Tags',
+                                                  dataIndex: 'tags' as keyof SharedMetric,
+                                                  key: 'tags',
+                                                  render: (_: any, metric: SharedMetric) => (
+                                                      <ObjectTags tags={metric.tags || []} staticOnly />
+                                                  ),
+                                              },
+                                          ]
+                                        : []),
+                                    {
+                                        title: 'Type',
+                                        key: 'type',
+                                        render: (_, metric: SharedMetric) => {
+                                            if (metric.query.kind === NodeKind.ExperimentMetric) {
+                                                return metric.query.metric_type
+                                            }
+                                            return metric.query.kind === NodeKind.ExperimentTrendsQuery
+                                                ? 'Trend'
+                                                : 'Funnel'
+                                        },
+                                    },
+                                ]}
+                                footer={
+                                    <div className="flex items-center justify-center m-2">
+                                        <LemonButton
+                                            to={`${urls.experiments()}?tab=shared-metrics`}
+                                            size="xsmall"
+                                            type="tertiary"
+                                        >
+                                            See all shared metrics
+                                        </LemonButton>
+                                    </div>
+                                }
+                            />
+                        </>
+                    ) : (
+                        <LemonBanner
+                            className="w-full"
+                            type="info"
+                            action={{
+                                children: 'New shared metric',
+                                to: urls.experimentsSharedMetric('new'),
+                            }}
+                        >
+                            {compatibleSharedMetrics.length > 0
+                                ? 'All of your shared metrics are already in this experiment.'
+                                : "You don't have any shared metrics that match the experiment type. Shared metrics let you create reusable metrics that you can quickly add to any experiment."}
+                        </LemonBanner>
+                    )}
+                </div>
+            )}
+
+            {editingSharedMetricId && (
+                <div>
+                    {(() => {
+                        const metric = compatibleSharedMetrics.find((m: SharedMetric) => m.id === editingSharedMetricId)
+                        if (!metric) {
+                            return <></>
+                        }
+
+                        return (
+                            <div className="deprecated-space-y-2">
+                                <div className="flex items-center gap-2">
+                                    <h3 className="font-semibold m-0 flex items-center">{metric.name}</h3>
+                                    <Link
+                                        target="_blank"
+                                        className="font-semibold flex items-center"
+                                        to={urls.experimentsSharedMetric(metric.id)}
+                                    >
+                                        <IconOpenInNew fontSize="18" />
+                                    </Link>
+                                </div>
+                                {metric.description && <p className="mt-2">{metric.description}</p>}
+                                {metric.query.kind === 'ExperimentTrendsQuery' && (
+                                    <MetricDisplayTrends query={metric.query.count_query} />
+                                )}
+                                {metric.query.kind === 'ExperimentFunnelsQuery' && (
+                                    <MetricDisplayFunnels query={metric.query.funnels_query} />
+                                )}
+                            </div>
+                        )
+                    })()}
+                </div>
+            )}
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
@@ -2,16 +2,16 @@ import { useActions, useValues } from 'kea'
 
 import { LemonModal } from '@posthog/lemon-ui'
 
-import { modalsLogic } from '../modalsLogic'
 import { experimentMetricModalLogic } from './experimentMetricModalLogic'
 import { metricSourceModalLogic } from './metricSourceModalLogic'
+import { sharedMetricModalLogic } from './sharedMetricModalLogic'
 
-export const MetricSourceModal = (): JSX.Element => {
+export const MetricSourceModal = (): JSX.Element | null => {
     const { isModalOpen, context } = useValues(metricSourceModalLogic)
     const { closeMetricSourceModal } = useActions(metricSourceModalLogic)
 
     const { openExperimentMetricModal } = useActions(experimentMetricModalLogic)
-    const { openPrimarySharedMetricModal, openSecondarySharedMetricModal } = useActions(modalsLogic)
+    const { openSharedMetricModal } = useActions(sharedMetricModalLogic)
 
     return (
         <LemonModal isOpen={isModalOpen} onClose={closeMetricSourceModal} width={1000} title="Choose metric source">
@@ -34,9 +34,7 @@ export const MetricSourceModal = (): JSX.Element => {
                     className="flex-1 cursor-pointer p-4 rounded border hover:border-accent"
                     onClick={() => {
                         closeMetricSourceModal()
-                        context.type === 'primary'
-                            ? openPrimarySharedMetricModal(null)
-                            : openSecondarySharedMetricModal(null)
+                        openSharedMetricModal(context)
                     }}
                 >
                     <div className="font-semibold">

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -14,39 +14,26 @@ import { AvailableFeature, Experiment } from '~/types'
 
 import { MetricDisplayFunnels, MetricDisplayTrends } from '../ExperimentView/components'
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
-import { experimentLogic } from '../experimentLogic'
-import { modalsLogic } from '../modalsLogic'
-import { appendMetricToOrderingArray, removeMetricFromOrderingArray } from '../utils'
+import { SharedMetricContext, sharedMetricModalLogic } from './sharedMetricModalLogic'
 
 export function SharedMetricModal({
-    experimentId,
-    isSecondary,
+    experiment,
+    onSave,
+    onDelete,
 }: {
-    experimentId: Experiment['id']
-    isSecondary?: boolean
-}): JSX.Element {
-    const { experiment, compatibleSharedMetrics, editingSharedMetricId } = useValues(experimentLogic({ experimentId }))
-    const {
-        addSharedMetricsToExperiment,
-        removeSharedMetricFromExperiment,
-        restoreUnmodifiedExperiment,
-        setExperiment,
-    } = useActions(experimentLogic({ experimentId }))
-    const { closePrimarySharedMetricModal, closeSecondarySharedMetricModal } = useActions(modalsLogic)
-    const { isPrimarySharedMetricModalOpen, isSecondarySharedMetricModalOpen } = useValues(modalsLogic)
-    const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
-    const mode = editingSharedMetricId ? 'edit' : 'create'
-
+    experiment: Experiment
+    onSave: (metrics: SharedMetric[], context: SharedMetricContext) => void
+    onDelete: (metric: SharedMetric, context: SharedMetricContext) => void
+}): JSX.Element | null {
     const { hasAvailableFeature } = useValues(userLogic)
+    const { isModalOpen, context, compatibleSharedMetrics, sharedMetricId, isCreateMode, isEditMode } =
+        useValues(sharedMetricModalLogic)
+    const { closeSharedMetricModal } = useActions(sharedMetricModalLogic)
+
+    const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
 
     if (!compatibleSharedMetrics) {
-        return <></>
-    }
-
-    const isOpen = isSecondary ? isSecondarySharedMetricModalOpen : isPrimarySharedMetricModalOpen
-    const onClose = (): void => {
-        restoreUnmodifiedExperiment()
-        isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+        return null
     }
 
     const addSharedMetricDisabledReason = (): string | undefined => {
@@ -71,32 +58,23 @@ export function SharedMetricModal({
 
     return (
         <LemonModal
-            isOpen={isOpen}
-            onClose={onClose}
+            isOpen={isModalOpen}
+            onClose={closeSharedMetricModal}
             width={500}
-            title={mode === 'create' ? 'Select one or more shared metrics' : 'Shared metric'}
+            title={isCreateMode ? 'Select one or more shared metrics' : 'Shared metric'}
             footer={
                 <div className="flex justify-between w-full">
                     <div>
-                        {editingSharedMetricId && (
+                        {isEditMode && (
                             <LemonButton
                                 status="danger"
                                 onClick={() => {
-                                    const metric = compatibleSharedMetrics.find((m) => m.id === editingSharedMetricId)
-                                    if (metric) {
-                                        const newOrderingArray = removeMetricFromOrderingArray(
-                                            experiment,
-                                            metric.query.uuid,
-                                            !!isSecondary
-                                        )
-                                        setExperiment({
-                                            [isSecondary
-                                                ? 'secondary_metrics_ordered_uuids'
-                                                : 'primary_metrics_ordered_uuids']: newOrderingArray,
-                                        })
+                                    const metric = compatibleSharedMetrics.find((m) => m.id === sharedMetricId)
+                                    if (!metric) {
+                                        return
                                     }
-                                    removeSharedMetricFromExperiment(editingSharedMetricId)
-                                    isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+
+                                    onDelete(metric, context)
                                 }}
                                 type="secondary"
                             >
@@ -105,44 +83,19 @@ export function SharedMetricModal({
                         )}
                     </div>
                     <div className="flex gap-2">
-                        <LemonButton onClick={onClose} type="secondary">
+                        <LemonButton onClick={closeSharedMetricModal} type="secondary">
                             Cancel
                         </LemonButton>
                         {/* Changing the existing metric is a pain because saved metrics are stored separately */}
                         {/* Only allow deletion for now */}
-                        {mode === 'create' && (
+                        {isCreateMode && (
                             <LemonButton
                                 onClick={() => {
-                                    let newOrderingArray = isSecondary
-                                        ? (experiment.secondary_metrics_ordered_uuids ?? [])
-                                        : (experiment.primary_metrics_ordered_uuids ?? [])
+                                    const metrics = selectedMetricIds
+                                        .map((metricId) => compatibleSharedMetrics.find((m) => m.id === metricId))
+                                        .filter((metric): metric is SharedMetric => metric !== undefined)
 
-                                    selectedMetricIds.forEach((metricId) => {
-                                        const metric = compatibleSharedMetrics.find((m) => m.id === metricId)
-                                        if (metric) {
-                                            newOrderingArray = appendMetricToOrderingArray(
-                                                {
-                                                    ...experiment,
-                                                    [isSecondary
-                                                        ? 'secondary_metrics_ordered_uuids'
-                                                        : 'primary_metrics_ordered_uuids']: newOrderingArray,
-                                                },
-                                                metric.query.uuid,
-                                                !!isSecondary
-                                            )
-                                        }
-                                    })
-
-                                    setExperiment({
-                                        [isSecondary
-                                            ? 'secondary_metrics_ordered_uuids'
-                                            : 'primary_metrics_ordered_uuids']: newOrderingArray,
-                                    })
-
-                                    addSharedMetricsToExperiment(selectedMetricIds, {
-                                        type: isSecondary ? 'secondary' : 'primary',
-                                    })
-                                    isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+                                    onSave(metrics, context)
                                 }}
                                 type="primary"
                                 disabledReason={addSharedMetricDisabledReason()}
@@ -154,7 +107,7 @@ export function SharedMetricModal({
                 </div>
             }
         >
-            {mode === 'create' && (
+            {isCreateMode && (
                 <div className="deprecated-space-y-2">
                     {availableSharedMetrics.length > 0 ? (
                         <>
@@ -273,12 +226,12 @@ export function SharedMetricModal({
                 </div>
             )}
 
-            {editingSharedMetricId && (
+            {isEditMode && (
                 <div>
                     {(() => {
-                        const metric = compatibleSharedMetrics.find((m: SharedMetric) => m.id === editingSharedMetricId)
+                        const metric = compatibleSharedMetrics.find((m: SharedMetric) => m.id === sharedMetricId)
                         if (!metric) {
-                            return <></>
+                            return null
                         }
 
                         return (

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -14,7 +14,8 @@ import { AvailableFeature, Experiment } from '~/types'
 
 import { MetricDisplayFunnels, MetricDisplayTrends } from '../ExperimentView/components'
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
-import { SharedMetricContext, sharedMetricModalLogic } from './sharedMetricModalLogic'
+import { MetricContext } from './experimentMetricModalLogic'
+import { sharedMetricModalLogic } from './sharedMetricModalLogic'
 
 export function SharedMetricModal({
     experiment,
@@ -22,8 +23,8 @@ export function SharedMetricModal({
     onDelete,
 }: {
     experiment: Experiment
-    onSave: (metrics: SharedMetric[], context: SharedMetricContext) => void
-    onDelete: (metric: SharedMetric, context: SharedMetricContext) => void
+    onSave: (metrics: SharedMetric[], context: MetricContext) => void
+    onDelete: (metric: SharedMetric, context: MetricContext) => void
 }): JSX.Element | null {
     const { hasAvailableFeature } = useValues(userLogic)
     const { isModalOpen, context, compatibleSharedMetrics, sharedMetricId, isCreateMode, isEditMode } =

--- a/frontend/src/scenes/experiments/Metrics/experimentMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/experimentMetricModalLogic.ts
@@ -5,6 +5,8 @@ import type { ExperimentMetric } from '~/queries/schema/schema-general'
 import { getDefaultFunnelMetric } from '../utils'
 import type { experimentMetricModalLogicType } from './experimentMetricModalLogicType'
 
+// import type { SharedMetricContext } from './sharedMetricModalLogic'
+
 export const METRIC_CONTEXTS = {
     primary: {
         type: 'primary' as const,

--- a/frontend/src/scenes/experiments/Metrics/experimentMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/experimentMetricModalLogic.ts
@@ -5,8 +5,6 @@ import type { ExperimentMetric } from '~/queries/schema/schema-general'
 import { getDefaultFunnelMetric } from '../utils'
 import type { experimentMetricModalLogicType } from './experimentMetricModalLogicType'
 
-// import type { SharedMetricContext } from './sharedMetricModalLogic'
-
 export const METRIC_CONTEXTS = {
     primary: {
         type: 'primary' as const,

--- a/frontend/src/scenes/experiments/Metrics/metricSourceModalLogic.tsx
+++ b/frontend/src/scenes/experiments/Metrics/metricSourceModalLogic.tsx
@@ -1,11 +1,11 @@
 import { kea } from 'kea'
 import { actions, path, reducers } from 'kea'
 
-import { METRIC_CONTEXTS, MetricContext } from './experimentMetricModalLogic'
+import { METRIC_CONTEXTS, type MetricContext } from './experimentMetricModalLogic'
 import type { metricSourceModalLogicType } from './metricSourceModalLogicType'
 
 export const metricSourceModalLogic = kea<metricSourceModalLogicType>([
-    path(['scenes', 'experiments', 'create', 'metricSourceModalLogic']),
+    path(['scenes', 'experiments', 'metrics', 'metricSourceModalLogic']),
 
     actions({
         openMetricSourceModal: (context: MetricContext) => ({ context }),

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -1,0 +1,93 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+
+import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
+import { sharedMetricsLogic } from '../SharedMetrics/sharedMetricsLogic'
+import type { MetricContext } from './experimentMetricModalLogic'
+import type { sharedMetricModalLogicType } from './sharedMetricModalLogicType'
+
+export const SHARED_METRIC_CONTEXTS = {
+    primary: {
+        type: 'primary' as const,
+        field: 'shared_metrics' as const,
+        orderingField: 'primary_metrics_ordered_uuids' as const,
+    },
+    secondary: {
+        type: 'secondary' as const,
+        field: 'shared_metrics_secondary' as const,
+        orderingField: 'secondary_metrics_ordered_uuids' as const,
+    },
+} as const
+
+export type SharedMetricContext = (typeof SHARED_METRIC_CONTEXTS)[keyof typeof SHARED_METRIC_CONTEXTS]
+
+export const isSharedMetricContext = (context: MetricContext | SharedMetricContext): context is SharedMetricContext =>
+    context.field === 'shared_metrics' || context.field === 'shared_metrics_secondary'
+
+export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
+    path(['scenes', 'experiments', 'Metrics', 'sharedMetricModalLogic']),
+
+    connect(() => ({
+        actions: [sharedMetricsLogic, ['loadSharedMetrics'], eventUsageLogic, ['reportExperimentSharedMetricAssigned']],
+        values: [sharedMetricsLogic, ['sharedMetrics', 'sharedMetricsLoading']],
+    })),
+
+    actions({
+        openSharedMetricModal: (context: SharedMetricContext, sharedMetricId?: SharedMetric['id'] | null) => ({
+            context,
+            sharedMetricId,
+        }),
+        closeSharedMetricModal: true,
+        setSharedMetric: (sharedMetric: SharedMetric) => ({ sharedMetric }),
+    }),
+
+    listeners(({ actions }) => ({
+        openSharedMetricModal: () => {
+            actions.loadSharedMetrics()
+        },
+    })),
+
+    reducers({
+        isModalOpen: [
+            false,
+            {
+                openSharedMetricModal: () => true,
+                closeSharedMetricModal: () => false,
+            },
+        ],
+        sharedMetricId: [
+            null as SharedMetric['id'] | null,
+            {
+                openSharedMetricModal: (_, { sharedMetricId }) => sharedMetricId ?? null,
+                closeSharedMetricModal: () => null,
+            },
+        ],
+        context: [
+            SHARED_METRIC_CONTEXTS.primary as SharedMetricContext,
+            {
+                openSharedMetricModal: (_, { context }) => context,
+                closeSharedMetricModal: () => SHARED_METRIC_CONTEXTS.primary,
+            },
+        ],
+        isEditMode: [
+            false,
+            {
+                openSharedMetricModal: (_, { sharedMetricId }) => !!sharedMetricId,
+                closeSharedMetricModal: () => false,
+            },
+        ],
+    }),
+
+    selectors({
+        isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
+        compatibleSharedMetrics: [
+            (s) => [s.sharedMetrics],
+            (sharedMetrics: SharedMetric[]): SharedMetric[] => {
+                return sharedMetrics.filter((metric) => metric.query.kind === NodeKind.ExperimentMetric)
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -6,26 +6,8 @@ import { NodeKind } from '~/queries/schema/schema-general'
 
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
 import { sharedMetricsLogic } from '../SharedMetrics/sharedMetricsLogic'
-import type { MetricContext } from './experimentMetricModalLogic'
+import { METRIC_CONTEXTS, type MetricContext } from './experimentMetricModalLogic'
 import type { sharedMetricModalLogicType } from './sharedMetricModalLogicType'
-
-export const SHARED_METRIC_CONTEXTS = {
-    primary: {
-        type: 'primary' as const,
-        field: 'shared_metrics' as const,
-        orderingField: 'primary_metrics_ordered_uuids' as const,
-    },
-    secondary: {
-        type: 'secondary' as const,
-        field: 'shared_metrics_secondary' as const,
-        orderingField: 'secondary_metrics_ordered_uuids' as const,
-    },
-} as const
-
-export type SharedMetricContext = (typeof SHARED_METRIC_CONTEXTS)[keyof typeof SHARED_METRIC_CONTEXTS]
-
-export const isSharedMetricContext = (context: MetricContext | SharedMetricContext): context is SharedMetricContext =>
-    context.field === 'shared_metrics' || context.field === 'shared_metrics_secondary'
 
 export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
     path(['scenes', 'experiments', 'Metrics', 'sharedMetricModalLogic']),
@@ -36,7 +18,7 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
     })),
 
     actions({
-        openSharedMetricModal: (context: SharedMetricContext, sharedMetricId?: SharedMetric['id'] | null) => ({
+        openSharedMetricModal: (context: MetricContext, sharedMetricId?: SharedMetric['id'] | null) => ({
             context,
             sharedMetricId,
         }),
@@ -66,10 +48,10 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
             },
         ],
         context: [
-            SHARED_METRIC_CONTEXTS.primary as SharedMetricContext,
+            METRIC_CONTEXTS.primary as MetricContext,
             {
                 openSharedMetricModal: (_, { context }) => context,
-                closeSharedMetricModal: () => SHARED_METRIC_CONTEXTS.primary,
+                closeSharedMetricModal: () => METRIC_CONTEXTS.primary,
             },
         ],
         isEditMode: [

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -8,6 +8,7 @@ import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { METRIC_CONTEXTS, experimentMetricModalLogic } from 'scenes/experiments/Metrics/experimentMetricModalLogic'
+import { sharedMetricModalLogic } from 'scenes/experiments/Metrics/sharedMetricModalLogic'
 import { modalsLogic } from 'scenes/experiments/modalsLogic'
 import { isEventExposureConfig } from 'scenes/experiments/utils'
 import { urls } from 'scenes/urls'
@@ -122,6 +123,7 @@ export const MetricHeader = ({
     } = useActions(modalsLogic)
 
     const { openExperimentMetricModal } = useActions(experimentMetricModalLogic)
+    const { openSharedMetricModal } = useActions(sharedMetricModalLogic)
 
     return (
         <div className="text-xs font-semibold flex flex-col justify-between h-full">
@@ -143,10 +145,18 @@ export const MetricHeader = ({
                                 tooltip="Edit"
                                 onClick={() => {
                                     if (metric.isSharedMetric) {
+                                        /**
+                                         * this is for legacy experiments support
+                                         */
                                         const openSharedModal = isPrimaryMetric
                                             ? openPrimarySharedMetricModal
                                             : openSecondarySharedMetricModal
                                         openSharedModal(metric.sharedMetricId)
+
+                                        openSharedMetricModal(
+                                            METRIC_CONTEXTS[isPrimaryMetric ? 'primary' : 'secondary'],
+                                            metric.sharedMetricId
+                                        )
                                     } else {
                                         /**
                                          * this is for legacy experiments support


### PR DESCRIPTION
## Problem

The `SharedMetricModal` has dependencies on the experiment kea logic that make it hard to reuse on the new create experiment metrics panel.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We removed the dependency on experiments, transferring the handling of save, update, and delete operations to the `ExperimentView` component, using the same pattern as the `ExperimentMetricModal` component. We had to update the `MetricSourceModal` to provide the necessary context for using primary or secondary metrics. We duplicated the original code on a new `LegacySharedMetricModal` to preserve the _legacy_ experiment experience.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/b72d5645-fa25-4a63-89c8-53f76e069594)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
