### PR TITLE
test(batch-exports): Fix test failures due to missing CH DB

### DIFF
--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -10,10 +10,12 @@ from django.conf import settings
 import psycopg
 import temporalio.worker
 from asgiref.sync import sync_to_async
+from infi.clickhouse_orm import Database
 from psycopg import sql
 from temporalio.testing import ActivityEnvironment
 
 from posthog import constants
+from posthog.conftest import create_clickhouse_tables
 from posthog.models import Organization, Team
 from posthog.models.utils import uuid7
 from posthog.temporal.common.clickhouse import ClickHouseClient
@@ -27,7 +29,23 @@ from posthog.temporal.tests.utils.persons import (
 
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 
-# TEST COMMENT
+
+@pytest.fixture(scope="package", autouse=True)
+def clickhouse_create_db_and_tables():
+    database = Database(
+        settings.CLICKHOUSE_DATABASE,
+        db_url=settings.CLICKHOUSE_HTTP_URL,
+        username=settings.CLICKHOUSE_USER,
+        password=settings.CLICKHOUSE_PASSWORD,
+        cluster=settings.CLICKHOUSE_CLUSTER,
+        verify_ssl_cert=settings.CLICKHOUSE_VERIFY,
+        randomize_replica_paths=True,
+    )
+
+    database.create_database()  # Create database if it doesn't exist
+    create_clickhouse_tables()  # Create all expected tables
+
+    yield
 
 
 @pytest.fixture

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -27,6 +27,8 @@ from posthog.temporal.tests.utils.persons import (
 
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 
+# TEST COMMENT
+
 
 @pytest.fixture
 def organization():


### PR DESCRIPTION
## Problem

The ClickHouse test database does not exist when running batch export tests.

## Changes

Ensure it is created if it does not exists, creating all the required tables too.
