### PR TITLE
fix: weekly digest toggle

### DIFF
--- a/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
+++ b/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
@@ -58,6 +58,8 @@ export function UpdateEmailPreferences(): JSX.Element {
                             label="Weekly digest"
                             description="The weekly digest keeps you up to date with everything that's happening in your PostHog organizations"
                             dataAttr="weekly_digest_enabled"
+                            // because the setting is disabled, but the control is expressed as enabled
+                            inverse={true}
                         />
 
                         {weeklyDigestEnabled && (
@@ -141,17 +143,25 @@ const SimpleSwitch = ({
     label,
     description,
     setting,
+    inverse = false,
 }: {
     dataAttr: string
     label: string
     description: string
     setting: keyof BooleanNotificationSettings
+    /**
+     * Some settings are expressed as "disabled" but the control is expressed as "enabled" (e.g. "All weekly digests" setting). 🫠
+     */
+    inverse?: boolean
 }): JSX.Element => {
     const { user, userLoading } = useValues(userLogic)
     const { updateUser } = useActions(userLogic)
 
     const value = user?.notification_settings?.[setting]
-    const checked = value ?? NOTIFICATION_DEFAULTS[setting]
+    let checked = value ?? NOTIFICATION_DEFAULTS[setting]
+    if (inverse) {
+        checked = !checked
+    }
 
     return (
         <div className="space-y-2">
@@ -162,7 +172,7 @@ const SimpleSwitch = ({
                         updateUser({
                             notification_settings: {
                                 ...user?.notification_settings,
-                                [setting]: newChecked,
+                                [setting]: inverse ? !newChecked : newChecked,
                             },
                         })
                 }}


### PR DESCRIPTION
the weekly digest toggle was very confusing
the setting is expressed as "is it disabled"
but the toggle is expressed as "is it enabled"
so we were showing disabled when enabled and vice versa

added an "inverse" mode to the toggle as the shortest path to getting this showing correctly in production
(arguably anyone that has toggled this since the bug was introduced has not done so and got the result they expect)

| before | after |
| - | - |
| ![2025-10-15 15 12 21](https://github.com/user-attachments/assets/033e59f7-555c-44e5-9598-687ca761b0cc)|![2025-10-15 15 11 58](https://github.com/user-attachments/assets/7d7024ae-1822-462b-8a45-9590ffc855ee)|
