### PR TITLE
fix(data-warehouse): Actually use temp table dataset given

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -28,7 +28,7 @@ from posthog.warehouse.types import ExternalDataSourceType
 
 
 def build_destination_table_prefix(schema_id: str | None) -> str:
-    return f"__posthog_import_{schema_id if schema_id else ''}"
+    return f"__posthog_import_{schema_id.replace('-', '_') if schema_id else ''}"
 
 
 @SourceRegistry.register
@@ -81,8 +81,8 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
         if not config.key_file.private_key:
             raise ValueError(f"Missing private key for BigQuery: '{inputs.job_id}'")
 
-        using_temporary_dataset = False
         dataset_project_id: str | None = None
+        destination_table_dataset_id = config.dataset_id
 
         if (
             config.dataset_project
@@ -90,23 +90,27 @@ class BigQuerySource(BaseSource[BigQuerySourceConfig]):
             and config.dataset_project.dataset_project_id is not None
             and config.dataset_project.dataset_project_id != ""
         ):
-            using_temporary_dataset = True
             dataset_project_id = config.dataset_project.dataset_project_id
+
+        if (
+            config.temporary_dataset
+            and config.temporary_dataset.enabled
+            and config.temporary_dataset.temporary_dataset_id is not None
+            and config.temporary_dataset.temporary_dataset_id != ""
+        ):
+            destination_table_dataset_id = config.temporary_dataset.temporary_dataset_id
 
         # Including the schema ID in table prefix ensures we only delete tables
         # from this schema, and that if we fail we will clean up any previous
         # execution's tables.
         # Table names in BigQuery can have up to 1024 bytes, so we can be pretty
         # relaxed with using a relatively long UUID as part of the prefix.
-        # Some special characters do need to be replaced, so we use the hex
-        # representation of the UUID.
         destination_table_prefix = build_destination_table_prefix(inputs.schema_id)
 
-        destination_table_dataset_id = dataset_project_id if using_temporary_dataset else config.dataset_id
-        destination_table = f"{config.key_file.project_id}.{destination_table_dataset_id}.{destination_table_prefix}{inputs.job_id}_{str(datetime.now().timestamp()).replace('.', '')}"
+        destination_table = f"{config.key_file.project_id}.{destination_table_dataset_id}.{destination_table_prefix}_{inputs.job_id.replace('-', '_')}_{str(datetime.now().timestamp()).replace('.', '')}"
 
         delete_all_temp_destination_tables(
-            dataset_id=config.dataset_id,
+            dataset_id=destination_table_dataset_id,
             table_prefix=destination_table_prefix,
             project_id=config.key_file.project_id,
             dataset_project_id=dataset_project_id,

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1,6 +1,16 @@
+from freezegun import freeze_time
 from unittest import mock
 
+from dateutil import parser
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.bigquery.source import BigQuerySource
+from posthog.temporal.data_imports.sources.generated_configs import (
+    BigQueryDatasetProjectConfig,
+    BigQueryKeyFileConfig,
+    BigQuerySourceConfig,
+    BigQueryTemporaryDatasetConfig,
+)
 
 
 def test_bigquery_get_schemas():
@@ -22,3 +32,343 @@ def test_bigquery_get_schemas_with_existing_destination_tables():
         schemas = source_cls.get_schemas(mock.ANY, 1)
         assert len(schemas) == 1
         assert schemas[0].name == "table"
+
+
+def test_bigquery_destination_table_default():
+    source_cls = BigQuerySource()
+    config = BigQuerySourceConfig(
+        key_file=BigQueryKeyFileConfig(
+            project_id="project-id",
+            private_key="private-key",
+            private_key_id="private-key-id",
+            client_email="client-email",
+            token_uri="token-uri",
+        ),
+        dataset_id="dataset-id",
+        dataset_project=None,
+        temporary_dataset=None,
+    )
+
+    with (
+        freeze_time("2025-01-01T12:00:00.000Z"),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_all_temp_destination_tables",
+        ) as mock_delete_all_temp_destination_tables,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.bigquery_source",
+        ) as mock_bigquery_source,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_table",
+        ) as mock_delete_table,
+    ):
+        source_cls.source_for_pipeline(
+            config,
+            SourceInputs(
+                schema_name="schema",
+                schema_id="schema-id",
+                team_id=1,
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=None,
+                db_incremental_field_earliest_value=None,
+                incremental_field=None,
+                incremental_field_type=None,
+                job_id="job-id",
+                logger=mock.MagicMock(),
+            ),
+        )
+
+    mock_delete_all_temp_destination_tables.assert_called_once_with(
+        dataset_id="dataset-id",
+        table_prefix="__posthog_import_schema_id",
+        project_id=config.key_file.project_id,
+        dataset_project_id=None,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        logger=mock.ANY,
+    )
+
+    mock_bigquery_source.assert_called_once_with(
+        dataset_id=config.dataset_id,
+        project_id=config.key_file.project_id,
+        dataset_project_id=None,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        table_name="schema",
+        should_use_incremental_field=False,
+        logger=mock.ANY,
+        bq_destination_table_id=f"project-id.dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        incremental_field=None,
+        incremental_field_type=None,
+        db_incremental_field_last_value=None,
+    )
+
+    mock_delete_table.assert_called_once_with(
+        table_id=f"project-id.dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        project_id=config.key_file.project_id,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+    )
+
+
+def test_bigquery_destination_table_with_dataset_project_set():
+    source_cls = BigQuerySource()
+    config = BigQuerySourceConfig(
+        key_file=BigQueryKeyFileConfig(
+            project_id="project-id",
+            private_key="private-key",
+            private_key_id="private-key-id",
+            client_email="client-email",
+            token_uri="token-uri",
+        ),
+        dataset_id="dataset-id",
+        dataset_project=BigQueryDatasetProjectConfig(
+            dataset_project_id="other-project-id",
+            enabled=True,
+        ),
+        temporary_dataset=None,
+    )
+
+    with (
+        freeze_time("2025-01-01T12:00:00.000Z"),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_all_temp_destination_tables",
+        ) as mock_delete_all_temp_destination_tables,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.bigquery_source",
+        ) as mock_bigquery_source,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_table",
+        ) as mock_delete_table,
+    ):
+        source_cls.source_for_pipeline(
+            config,
+            SourceInputs(
+                schema_name="schema",
+                schema_id="schema-id",
+                team_id=1,
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=None,
+                db_incremental_field_earliest_value=None,
+                incremental_field=None,
+                incremental_field_type=None,
+                job_id="job-id",
+                logger=mock.MagicMock(),
+            ),
+        )
+
+    mock_delete_all_temp_destination_tables.assert_called_once_with(
+        dataset_id="dataset-id",
+        table_prefix="__posthog_import_schema_id",
+        project_id=config.key_file.project_id,
+        dataset_project_id="other-project-id",
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        logger=mock.ANY,
+    )
+
+    mock_bigquery_source.assert_called_once_with(
+        dataset_id=config.dataset_id,
+        project_id=config.key_file.project_id,
+        dataset_project_id="other-project-id",
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        table_name="schema",
+        should_use_incremental_field=False,
+        logger=mock.ANY,
+        bq_destination_table_id=f"project-id.dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        incremental_field=None,
+        incremental_field_type=None,
+        db_incremental_field_last_value=None,
+    )
+
+    mock_delete_table.assert_called_once_with(
+        table_id=f"project-id.dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        project_id=config.key_file.project_id,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+    )
+
+
+def test_bigquery_destination_table_with_temporary_dataset_set():
+    source_cls = BigQuerySource()
+    config = BigQuerySourceConfig(
+        key_file=BigQueryKeyFileConfig(
+            project_id="project-id",
+            private_key="private-key",
+            private_key_id="private-key-id",
+            client_email="client-email",
+            token_uri="token-uri",
+        ),
+        dataset_id="dataset-id",
+        dataset_project=None,
+        temporary_dataset=BigQueryTemporaryDatasetConfig(
+            temporary_dataset_id="some-other-dataset-id",
+            enabled=True,
+        ),
+    )
+
+    with (
+        freeze_time("2025-01-01T12:00:00.000Z"),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_all_temp_destination_tables",
+        ) as mock_delete_all_temp_destination_tables,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.bigquery_source",
+        ) as mock_bigquery_source,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_table",
+        ) as mock_delete_table,
+    ):
+        source_cls.source_for_pipeline(
+            config,
+            SourceInputs(
+                schema_name="schema",
+                schema_id="schema-id",
+                team_id=1,
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=None,
+                db_incremental_field_earliest_value=None,
+                incremental_field=None,
+                incremental_field_type=None,
+                job_id="job-id",
+                logger=mock.MagicMock(),
+            ),
+        )
+
+    mock_delete_all_temp_destination_tables.assert_called_once_with(
+        dataset_id="some-other-dataset-id",
+        table_prefix="__posthog_import_schema_id",
+        project_id=config.key_file.project_id,
+        dataset_project_id=None,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        logger=mock.ANY,
+    )
+
+    mock_bigquery_source.assert_called_once_with(
+        dataset_id=config.dataset_id,
+        project_id=config.key_file.project_id,
+        dataset_project_id=None,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        table_name="schema",
+        should_use_incremental_field=False,
+        logger=mock.ANY,
+        bq_destination_table_id=f"project-id.some-other-dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        incremental_field=None,
+        incremental_field_type=None,
+        db_incremental_field_last_value=None,
+    )
+
+    mock_delete_table.assert_called_once_with(
+        table_id=f"project-id.some-other-dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        project_id=config.key_file.project_id,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+    )
+
+
+def test_bigquery_destination_table_with_both_temporary_dataset_and_dataset_project_set():
+    source_cls = BigQuerySource()
+    config = BigQuerySourceConfig(
+        key_file=BigQueryKeyFileConfig(
+            project_id="project-id",
+            private_key="private-key",
+            private_key_id="private-key-id",
+            client_email="client-email",
+            token_uri="token-uri",
+        ),
+        dataset_id="dataset-id",
+        dataset_project=BigQueryDatasetProjectConfig(
+            dataset_project_id="other-project-id",
+            enabled=True,
+        ),
+        temporary_dataset=BigQueryTemporaryDatasetConfig(
+            temporary_dataset_id="some-other-dataset-id",
+            enabled=True,
+        ),
+    )
+
+    with (
+        freeze_time("2025-01-01T12:00:00.000Z"),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_all_temp_destination_tables",
+        ) as mock_delete_all_temp_destination_tables,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.bigquery_source",
+        ) as mock_bigquery_source,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.source.delete_table",
+        ) as mock_delete_table,
+    ):
+        source_cls.source_for_pipeline(
+            config,
+            SourceInputs(
+                schema_name="schema",
+                schema_id="schema-id",
+                team_id=1,
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=None,
+                db_incremental_field_earliest_value=None,
+                incremental_field=None,
+                incremental_field_type=None,
+                job_id="job-id",
+                logger=mock.MagicMock(),
+            ),
+        )
+
+    mock_delete_all_temp_destination_tables.assert_called_once_with(
+        dataset_id="some-other-dataset-id",
+        table_prefix="__posthog_import_schema_id",
+        project_id=config.key_file.project_id,
+        dataset_project_id="other-project-id",
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        logger=mock.ANY,
+    )
+
+    mock_bigquery_source.assert_called_once_with(
+        dataset_id=config.dataset_id,
+        project_id=config.key_file.project_id,
+        dataset_project_id="other-project-id",
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+        table_name="schema",
+        should_use_incremental_field=False,
+        logger=mock.ANY,
+        bq_destination_table_id=f"project-id.some-other-dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        incremental_field=None,
+        incremental_field_type=None,
+        db_incremental_field_last_value=None,
+    )
+
+    mock_delete_table.assert_called_once_with(
+        table_id=f"project-id.some-other-dataset-id.__posthog_import_schema_id_job_id_{str(parser.parse("2025-01-01T12:00:00.000Z").timestamp()).replace('.', '')}",
+        project_id=config.key_file.project_id,
+        private_key=config.key_file.private_key,
+        private_key_id=config.key_file.private_key_id,
+        client_email=config.key_file.client_email,
+        token_uri=config.key_file.token_uri,
+    )


### PR DESCRIPTION
## Problem
- In the bigquery source, when a user provides an alternative dataset to use for writing/reading the destination tables, we currently ignore it and still use the dataset id of the table we're replicating

## Changes
- Actually use the alternative dataset id for the destination table
- Added tests to cover this

## How did you test this code?
- Tests
