### PR TITLE
chore(data-warehouse): Update the list of allowed job inputs keys to be returned to the brow…

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -143,7 +143,7 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
         representation = super().to_representation(instance)
 
         # non-sensitive fields
-        whitelisted_keys = {
+        job_inputs_allowed_keys = {
             # stripe
             "stripe_account_id",
             # sql
@@ -199,7 +199,7 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
 
             # Remove sensitive fields
             for key in list(job_inputs.keys()):  # Use list() to avoid modifying dict during iteration
-                if key not in whitelisted_keys:
+                if key not in job_inputs_allowed_keys:
                     job_inputs.pop(key, None)
 
         return representation

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -155,27 +155,40 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
             "ssh_tunnel",
             "using_ssl",
             # vitally
-            "payload",
-            "prefix",
-            "regionsubdomain",
-            "source_type",
+            "region"
             # chargebee
             "site_name",
             # zendesk
             "subdomain",
             "email_address",
             # hubspot
-            "redirect_uri",
+            "hubspot_integration_id",
             # snowflake
             "account_id",
             "warehouse",
             "role",
             # bigquery
             "dataset_id",
-            "project_id",
-            "client_email",
-            "token_uri",
-            "temporary-dataset",
+            "temporary_dataset",
+            "dataset_project"
+            # google ads
+            "customer_id",
+            "google_ads_integration_id",
+            "is_mcc_account",
+            # google sheets
+            "spreadsheet_url",
+            # linkedin ads
+            "linkedin_ads_integration_id",
+            # meta ads
+            "meta_ads_integration_id",
+            # reddit ads
+            "reddit_integration_id",
+            # salesforce
+            "salesforce_integration_id",
+            # shopify
+            "shopify_store_id",
+            # temporal
+            "namespace",
         }
         job_inputs = representation.get("job_inputs", {})
         if isinstance(job_inputs, dict):


### PR DESCRIPTION
## Changes
- Update the list of keys from the encrypted source `job_inputs` dict that we explicitly allow to be returned to the users browser when editing a source
  - These were a bit out of date 
- TODO: in the future, move this definition to be on the actual source config itself
