### PR TITLE
fix: remove web worker from snappy decompression in replay

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts
@@ -1,7 +1,7 @@
 import snappyInit, { decompress_raw } from 'snappy-wasm'
 
 export class DecompressionWorkerManager {
-    private readonly readyPromise: Promise<void>
+    private readyPromise: Promise<void>
     private snappyInitialized = false
 
     constructor() {
@@ -12,8 +12,13 @@ export class DecompressionWorkerManager {
         if (this.snappyInitialized) {
             return
         }
-        await snappyInit()
-        this.snappyInitialized = true
+        // Prevent multiple concurrent initializations
+        if (!this.readyPromise) {
+            this.readyPromise = snappyInit().then(() => {
+                this.snappyInitialized = true
+            })
+        }
+        await this.readyPromise
     }
 
     async decompress(compressedData: Uint8Array): Promise<Uint8Array> {


### PR DESCRIPTION
the worker isn't where the code expects it to be

some mismatch between vite locally and esbuild in production or 🫠 

let's stop fighting that and prove that snappy will work at all

this removes the worker from the workflow so I can prove we can decompress in the front end _and_ that it's faster