### PR TITLE
fix: Fix query runner cached response check

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -916,7 +916,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 {"cache_key": cache_manager.cache_key},
             )
 
-        if self.is_cached_response(cached_response_candidate):
+        if self.is_cached_response(cached_response):
             assert isinstance(cached_response, CachedResponse)
 
             if not self._is_stale(last_refresh=last_refresh_from_cached_result(cached_response)):

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -916,9 +916,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 {"cache_key": cache_manager.cache_key},
             )
 
-        if self.is_cached_response(cached_response):
-            assert isinstance(cached_response, CachedResponse)
-
+        if isinstance(cached_response, CachedResponse):
             if not self._is_stale(last_refresh=last_refresh_from_cached_result(cached_response)):
                 count_query_cache_hit(self.team.pk, hit="hit", trigger=cached_response.calculation_trigger or "")
                 # We have a valid result that's fresh enough, let's return it


### PR DESCRIPTION
## Problem
TL;DR: Changing a query's response schema is causing stale cached responses to return 500.

`UsageMetricsQueryResponse` schema was changed. Running the new query, the query runner got results with the old schema from cache.

At this point we correctly identified that the schema had changed ([raising this exception](https://us.posthog.com/error_tracking/0199e898-1262-7d41-b0f2-2b901c4cdabd)), setting `cached_response = CacheMissResponse`.

The problem was that in the check for cached response, this was somehow resolving to `True`, thus raising an unhandled [AssertionError](https://us.posthog.com/error_tracking/0199e898-1263-7cf0-8d89-bd3d602c7d92) that results in a 500 response.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Changed `self.is_cached_response(cached_response_candidate)` check to `self.is_cached_response(cached_response)` as, as far as I understood, `cached_response_candidate` will always have `is_cached = True` in this scenario.

I am not 100% sure this is correct, maybe there is something else wrong in `UsageMetricsQueryRunner` that I need to fix.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests + triggering the query in the UI.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
