### PR TITLE
fix(data-warehouse): Transform earliest incremental value to the correct type for comparisons

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -395,11 +395,14 @@ def _get_incremental_field_value(
         return
 
     column = table[normalize_column_name(incremental_field_name)]
+    processed_column = pa.array(
+        [process_incremental_value(val, schema.incremental_field_type) for val in column.to_pylist()]
+    )
 
     if aggregate == "max":
-        last_value = pc.max(column)
+        last_value = pc.max(processed_column)
     elif aggregate == "min":
-        last_value = pc.min(column)
+        last_value = pc.min(processed_column)
     else:
         raise Exception(f"Unsupported aggregate function for _get_incremental_field_value: {aggregate}")
 

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any, Literal, Optional
 
 from django.conf import settings
@@ -276,9 +276,18 @@ def process_incremental_value(value: Any | None, field_type: IncrementalFieldTyp
         return value
 
     if field_type == IncrementalFieldType.DateTime or field_type == IncrementalFieldType.Timestamp:
+        if isinstance(value, datetime):
+            return value
+
         return parser.parse(value)
 
     if field_type == IncrementalFieldType.Date:
+        if isinstance(value, datetime):
+            return value.date()
+
+        if isinstance(value, date):
+            return value
+
         return parser.parse(value).date()
 
     if field_type == IncrementalFieldType.ObjectID:


### PR DESCRIPTION
## Problem
- Our vitally Messages syncs are failing cos we're trying to compare a `str` and `datetime` for the earliest incremental value - we're not parsing the value from the pyarrow table in the same format as the incremental field type, causing an error to be thrown

<img width="556" height="382" alt="image" src="https://github.com/user-attachments/assets/b4a7d788-2a36-4d64-ace5-74d12054a7c3" />


## Changes
- Parse the incremental value to ensure its in the correct type before comparing it 

## How did you test this code?
- Already covered be test cases