### PR TITLE
fix: use 'is' for identity comparison in select query check

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -342,7 +342,7 @@ class _Printer(Visitor[str]):
             part_of_select_union
             and isinstance(self.stack[0], ast.SelectSetQuery)
             and len(self.stack[0].subsequent_select_queries) > 0
-            and self.stack[0].subsequent_select_queries[-1].select_query == node
+            and self.stack[0].subsequent_select_queries[-1].select_query is node
         )
 
         # We will add extra clauses onto this from the joined tables


### PR DESCRIPTION
## Problem
I'm having this error when running this query:
```
{
  "kind": "InsightVizNode",
  "embedded": true,
  "hidePersonsModal": true,
  "hideTooltipOnScroll": true,
  "source": {
    "kind": "TrendsQuery",
    "compareFilter": {
      "compare": true
    },
    "series": [
      {
        "kind": "DataWarehouseNode",
        "id": "0199e8e8-e21b-0000-1350-6bc184ed982e",
        "name": "google",
        "custom_name": "googleads.test.campaign_stats cost",
        "id_field": "id",
        "distinct_id_field": "id",
        "timestamp_field": "segments_date",
        "table_name": "googleads.test.campaign_stats",
        "math": "sum",
        "math_property": "metrics_cost_micros",
        "math_property_revenue_currency": {
          "static": "USD"
        },
        "math_multiplier": 0.000001
      },
      {
        "kind": "DataWarehouseNode",
        "id": "0199ddd5-3925-0000-1796-daeb8e4ce33d",
        "name": "google",
        "custom_name": "googleads.testvideo.campaign_stats cost",
        "id_field": "id",
        "distinct_id_field": "id",
        "timestamp_field": "segments_date",
        "table_name": "googleads.testvideo.campaign_stats",
        "math": "sum",
        "math_property": "metrics_cost_micros",
        "math_property_revenue_currency": {
          "static": "USD"
        },
        "math_multiplier": 0.000001
      }
    ],
    "interval": "day",
    "dateRange": {
      "date_from": "-7d",
      "date_to": null
    },
    "trendsFilter": {
      "display": "ActionsAreaGraph",
      "aggregationAxisFormat": "numeric",
      "aggregationAxisPrefix": "$"
    }
  }
}

```
<img width="743" height="300" alt="image" src="https://github.com/user-attachments/assets/53ca3a84-6fbb-4625-8429-99fe3b57fca9" />
When I run them separately they work but not together. This is the trace:

```
2025-10-15T19:16:49.959323Z [error    ] Internal Server Error: /api/environments/1/query/ [django.request] container_hostname=unknown host=localhost:8010 pid=64446 team_id=1 tid=15118462976 x_forwarded_for=192.168.97.1
  Traceback (most recent call last):
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
      response = get_response(request)
                 ^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
      response = wrapped_callback(request, *callback_args, **callback_kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
      return view_func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/rest_framework/viewsets.py", line 125, in view
      return self.dispatch(request, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
      response = self.handle_exception(exc)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
      self.raise_uncaught_exception(exc)
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
      raise exc
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
      response = handler(request, *args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/api/monitoring.py", line 44, in wrapper
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/api/query.py", line 144, in create
      result = process_query_model(
               ^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/api/services/query.py", line 194, in process_query_model
      result = query_runner.run(
               ^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql_queries/query_runner.py", line 1129, in run
      query_result = self.calculate()
                     ^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql_queries/query_runner.py", line 1396, in calculate
      response = self._calculate()
                 ^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql_queries/insights/trends/trends_query_runner.py", line 354, in _calculate
      response_hogql = to_printed_hogql(response_hogql_query, self.team, self.modifiers)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/printer.py", line 94, in to_printed_hogql
      return print_ast(
             ^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/printer.py", line 117, in print_ast
      return print_prepared_ast(
             ^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/printer.py", line 217, in print_prepared_ast
      ).visit(node)
        ^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/printer.py", line 298, in visit
      response = super().visit(node)
                 ^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/visitor.py", line 34, in visit
      return node.accept(self)
             ^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/base.py", line 37, in accept
      return visit(self)
             ^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/printer.py", line 313, in visit_select_set_query
      ret = self.visit(node.initial_select_query)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/printer.py", line 298, in visit
      response = super().visit(node)
                 ^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/visitor.py", line 34, in visit
      return node.accept(self)
             ^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/base.py", line 37, in accept
      return visit(self)
             ^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/posthog/hogql/printer.py", line 345, in visit_select_query
      and self.stack[0].subsequent_select_queries[-1].select_query == node
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "<string>", line 4, in __eq__
    File "<string>", line 4, in __eq__
    File "<string>", line 4, in __eq__
    [Previous line repeated 5 more times]
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/pydantic/main.py", line 1028, in __eq__
      if self.__dict__ == other.__dict__:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/pydantic/main.py", line 1028, in __eq__
      if self.__dict__ == other.__dict__:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/pydantic/main.py", line 1028, in __eq__
      if self.__dict__ == other.__dict__:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    [Previous line repeated 2186 more times]
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/pydantic/main.py", line 1008, in __eq__
      if isinstance(other, BaseModel):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/pydantic/_internal/_model_construction.py", line 331, in __instancecheck__
      return hasattr(instance, '__pydantic_validator__') and super().__instancecheck__(instance)
                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/javierbahamondes/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/abc.py", line 119, in __instancecheck__
      return _abc_instancecheck(cls, instance)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  RecursionError: maximum recursion depth exceeded in comparison
```


## Changes

Using `is` instead of `==` for object comparison. Probably the `__eq__` is calling itself somewhere 🤔  . Maybe this could be hiding something, so I'll wait for the hogql reviews 🙏 

## How did you test this code?
Run the query and worked