### PR TITLE
feat: add report-only csp

### DIFF
--- a/ee/admin/oauth_views.py
+++ b/ee/admin/oauth_views.py
@@ -9,7 +9,7 @@ def admin_auth_check(request: HttpRequest) -> JsonResponse:
 
 
 def admin_oauth_success(request: HttpRequest) -> HttpResponse:
-    nonce = getattr(request, "admin_csp_nonce", "")
+    nonce = getattr(request, "csp_nonce", "")
     html = f"""
     <!DOCTYPE html>
     <html>

--- a/frontend/src/exporter/index.html
+++ b/frontend/src/exporter/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta name="robots" content="noindex" />
         {{ exported_data|json_script:"posthog-exported-data" }}
-        <script>
+        <script nonce="{{ request.csp_nonce }}">
             // need to parse twice to get JSON
             // we JSON serialize on the server since there may be objects like Queries
             // that need special handling in python in order to be serialized into the template
@@ -31,7 +31,7 @@
         {% endif %}
     </head>
     <body class="ExporterBody">
-        <script>
+        <script nonce="{{ request.csp_nonce }}">
             if (typeof Object.entries === 'undefined') {
                 var div = document.createElement('div')
                 div.style.color = '#fef6f6'

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,7 +5,7 @@
     </head>
     <body>
         {% include "overlays.html" %}
-        <script>
+        <script nonce="{{ request.csp_nonce }}">
             const tags = [
                 '{% if debug %}DEBUG mode{% elif region %}Region: {{ region }}{% else %}Hobby deployment{% endif %}',
                 '{% if debug %}Branch: {{ git_branch|default:"unknown" }}{% else %}Commit: {{ git_rev|default:"unknown" }}{% endif %}',

--- a/frontend/src/layout.ejs
+++ b/frontend/src/layout.ejs
@@ -6,7 +6,7 @@
         <title>PostHog</title>
         {% include "head.html" %}
 
-        <script>
+        <script nonce="{{ request.csp_nonce }}">
             const posthogJSApiKey = "{{ js_posthog_api_key|escapejs }}";
             let posthogHost = "{{ js_posthog_host|escapejs }}";
             if (posthogHost.trim().length === 0) {

--- a/frontend/src/layout.html
+++ b/frontend/src/layout.html
@@ -6,7 +6,7 @@
     <title>PostHog</title>
     {% include "head.html" %}
 
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         const posthogJSApiKey = "{{ js_posthog_api_key|escapejs }}";
         let posthogHost = "{{ js_posthog_host|escapejs }}";
         if (posthogHost.trim().length === 0) {

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1059,6 +1059,7 @@ posthog/udf_versioner.py:0: error: Item "None" of "Element[str] | None" has no a
 posthog/user_permissions.py:0: error: Incompatible return value type (got "int", expected "Level | None")  [return-value]
 posthog/user_permissions.py:0: error: Incompatible return value type (got "int", expected "RestrictionLevel")  [return-value]
 posthog/utils.py:0: error: Argument 1 to "asdict" has incompatible type "DataclassInstance | type[DataclassInstance]"; expected "DataclassInstance"  [arg-type]
+posthog/utils.py:0: error: "HttpRequest" has no attribute "csp_nonce"  [attr-defined]
 posthog/warehouse/api/external_data_schema.py:0: error: Argument "should_sync" to "sync_external_data_job_workflow" has incompatible type "Any | None"; expected "bool"  [arg-type]
 posthog/warehouse/api/external_data_schema.py:0: error: Incompatible return value type (got "str | None", expected "SyncType | None")  [return-value]
 posthog/warehouse/api/external_data_source.py:0: error: Incompatible return value type (got "Any | None", expected "str")  [return-value]

--- a/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v1.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v1.py
@@ -211,6 +211,11 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         headers = response.headers.__dict__["_store"]
         server_timing_headers = headers.pop("server-timing")[1]
         assert re.match(r"get_recording;dur=\d+\.\d+, stream_blob_to_client;dur=\d+\.\d+", server_timing_headers)
+
+        # ignore csp headers that are likely to change and irrelevant to this test
+        del headers["content-security-policy-report-only"]
+        del headers["reporting-endpoints"]
+
         assert headers == {
             "content-type": ("Content-Type", "application/json"),
             "cache-control": ("Cache-Control", "max-age=3600"),

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -106,7 +106,7 @@ MIDDLEWARE = [
     "posthog.middleware.CHQueries",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
     "posthog.middleware.PostHogTokenCookieMiddleware",
-    "posthog.middleware.AdminCSPMiddleware",
+    "posthog.middleware.CSPMiddleware",
     "posthoganalytics.integrations.django.PosthogContextMiddleware",
 ]
 

--- a/posthog/templates/admin/posthog/personal_api_key/change_form.html
+++ b/posthog/templates/admin/posthog/personal_api_key/change_form.html
@@ -4,7 +4,7 @@
 {% block extrahead %}
   {{ block.super }}
 
-  <script nonce="{{ request.admin_csp_nonce }}">
+  <script nonce="{{ request.csp_nonce }}">
     window.addEventListener("DOMContentLoaded", () => {
         document.getElementById("roll_key_button")?.addEventListener("click", (event) => {
             const url = window.prompt("Enter the URL where the key was exposed (optional). This will be included in the email sent to the user.");

--- a/posthog/templates/admin/posthog/user/change_form.html
+++ b/posthog/templates/admin/posthog/user/change_form.html
@@ -3,7 +3,7 @@
 {% block extrahead %}
   {{ block.super }}
 
-  <script nonce="{{ request.admin_csp_nonce }}">
+  <script nonce="{{ request.csp_nonce }}">
     window.addEventListener("DOMContentLoaded", () => {
         document.getElementById("send_verification_email_button")?.addEventListener("click", (event) => {
             // prevent anchor tag from navigating

--- a/posthog/templates/demo.html
+++ b/posthog/templates/demo.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         posthog.init('{{api_token}}', {
             api_host: window.location.origin,
             loaded: (posthog) => {
@@ -200,7 +200,7 @@
         {% endif %}
     </main>
 
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
 
         if (document.getElementById('submit-review')) {
             document.getElementById('submit-review').addEventListener('click', () => {

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -18,7 +18,7 @@
 <meta name="application-name" content="PostHog">
 
 {% if not opt_out_capture and js_posthog_api_key %}
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         window.JS_POSTHOG_API_KEY = "{{ js_posthog_api_key|escapejs }}";
         window.JS_POSTHOG_HOST = "{{ js_posthog_host|escapejs }}";
         if (window.JS_POSTHOG_HOST.trim().length === 0) {
@@ -32,11 +32,11 @@
     </script>
 {% endif %}
 {% if stripe_public_key %}
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         window.STRIPE_PUBLIC_KEY = '{{ stripe_public_key | escapejs }}';
     </script>
 {% endif %}
-<script id='posthog-app-user-preload'>
+<script nonce="{{ request.csp_nonce }}" id='posthog-app-user-preload'>
     window.POSTHOG_APP_CONTEXT = JSON.parse("{{ posthog_app_context | escapejs }}");
     // Inject the expected location of JS bundle,
     // use to allow the location of the bundle to be set at runtime,

--- a/posthog/templates/live_server_inject.html
+++ b/posthog/templates/live_server_inject.html
@@ -1,6 +1,6 @@
 {% if debug and js_url %}
 <!-- Code injected by live-server -->
-<script type="text/javascript">
+<script nonce="{{ request.csp_nonce }}" type="text/javascript">
     if ('EventSource' in window) {
         ;(function () {
             var jsUrl = '{{ js_url }}'.replace(/\/$/, '')

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -65,7 +65,7 @@
             </div>
         </div>
 
-        <script>
+        <script nonce="{{ request.csp_nonce }}">
             document.addEventListener('DOMContentLoaded', function () {
                 const form = document.getElementById('preferences-form')
                 const toggles = document.querySelectorAll('.toggle-checkbox')

--- a/posthog/templates/overlays.html
+++ b/posthog/templates/overlays.html
@@ -23,7 +23,7 @@
         <code style="background: 0; color: white">×</code>
     </button>
 </div>
-<script>
+<script nonce="{{ request.csp_nonce }}">
     document.getElementById('bottom-notice').addEventListener('click', function (e) {
         if (e.target.tagName !== 'SPAN') {
             document.getElementById('bottom-notice').remove()
@@ -31,7 +31,7 @@
     })
 </script>
 {% elif not e2e_testing %}
-<script>
+<script nonce="{{ request.csp_nonce }}">
     if (location.protocol !== 'https:') {
         const element = document.createElement('div')
         element.id = 'bottom-notice'

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -625,7 +625,7 @@
     </div>
 
     <!-- PostHog JavaScript -->
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         // Project config from Django and helper functions
         const survey = {{ survey_data | safe }};
         const projectConfig = {{ project_config_json | safe }};
@@ -922,7 +922,7 @@
             applySurveyAppearance(survey.appearance);
         }
     </script>
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         // Load PostHog from CDN
         !function (t, e) { var o, n, p, r; e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) { function g(t, e) { var o = e.split("."); 2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))) } } (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.full.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r); var u = e; for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) { var e = "posthog"; return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e }, u.people.toString = function () { return u.toString(1) + ".people (stub)" }, o = "init Ie Ts Ms Ee Es Rs capture Ge calculateEventProperties Os register register_once register_for_session unregister unregister_for_session js getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ds Fs createPersonProfile Ls Ps opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Cs debug I As getPageViewId captureTraceFeedback captureTraceMetric".split(" "), n = 0; n < o.length; n++)g(u, o[n]); e._i.push([i, s, a]) }, e.__SV = 1) }(document, window.posthog || []);
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -346,11 +346,11 @@ def get_context_for_template(
         context["debug"] = True
         context["git_branch"] = get_git_branch()
         # Add vite dev scripts for development
-        context["vite_dev_scripts"] = """
-        <script type="module">
+        context["vite_dev_scripts"] = f"""
+        <script nonce="{request.csp_nonce}" type="module">
             import RefreshRuntime from 'http://localhost:8234/@react-refresh'
             RefreshRuntime.injectIntoGlobalHook(window)
-            window.$RefreshReg$ = () => {}
+            window.$RefreshReg$ = () => {{}}
             window.$RefreshSig$ = () => (type) => type
             window.__vite_plugin_react_preamble_installed__ = true
         </script>


### PR DESCRIPTION
This PR adds a report-only Content Security Policy (CSP) header to django web. This will allow us to begin collecting CSP reports with the eventual goal of disallowing unsafe inline JS. A strict CSP is a great defense against XSS.
