### PR TITLE
fix: avoid downloading/uploading the same file to S3 multiple times

### DIFF
--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -1,7 +1,6 @@
 import os
 import re
 import json
-from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from tempfile import mkstemp
@@ -28,8 +27,10 @@ from posthog.temporal.delete_recordings.metrics import (
 )
 from posthog.temporal.delete_recordings.types import (
     DeleteRecordingError,
+    GroupRecordingError,
     LoadRecordingError,
     Recording,
+    RecordingBlockGroup,
     RecordingsWithPersonInput,
     RecordingWithBlocks,
 )
@@ -94,20 +95,30 @@ async def load_recording_blocks(input: Recording) -> list[RecordingBlock]:
 
 
 @activity.defn(name="group-recording-blocks")
-async def group_recording_blocks(input: RecordingWithBlocks) -> list[list[RecordingBlock]]:
+async def group_recording_blocks(input: RecordingWithBlocks) -> list[RecordingBlockGroup]:
     block_count = len(input.blocks)
     bind_contextvars(session_id=input.recording.session_id, team_id=input.recording.team_id, block_count=block_count)
     logger = LOGGER.bind()
     logger.info("Grouping recording blocks")
 
-    block_map = defaultdict(list)
+    block_map: dict[str, RecordingBlockGroup] = {}
 
     for block in input.blocks:
-        scheme, netloc, path, _, _, _ = urlparse(block.url)
+        scheme, netloc, path, _, query, _ = urlparse(block.url)
         base_key = urlunparse((scheme, netloc, path, None, None, None))
-        block_map[base_key].append(block)
 
-    block_groups: list[list[RecordingBlock]] = list(block_map.values())
+        match = re.match(r"^range=bytes=(\d+)-(\d+)$", query)
+
+        if not match:
+            raise GroupRecordingError(f"Got malformed byte range in block URL: {query}")
+
+        start_byte, end_byte = int(match.group(1)), int(match.group(2))
+
+        block_group: RecordingBlockGroup = block_map.get(base_key, RecordingBlockGroup(input.recording, base_key, []))
+        block_group.ranges.append((start_byte, end_byte))
+        block_map[base_key] = block_group
+
+    block_groups: list[RecordingBlockGroup] = list(block_map.values())
 
     logger.info(f"Grouped {block_count} blocks into {len(block_groups)} groups")
     return block_groups
@@ -124,9 +135,9 @@ def overwrite_block(path: str, start_byte: int, block_length: int, buffer_size: 
 
 
 @activity.defn(name="delete-recording-blocks")
-async def delete_recording_blocks(input: RecordingWithBlocks) -> None:
+async def delete_recording_blocks(input: RecordingBlockGroup) -> None:
     bind_contextvars(
-        session_id=input.recording.session_id, team_id=input.recording.team_id, block_count=len(input.blocks)
+        session_id=input.recording.session_id, team_id=input.recording.team_id, block_count=len(input.ranges)
     )
     logger = LOGGER.bind()
     logger.info("Deleting recording blocks")
@@ -135,22 +146,14 @@ async def delete_recording_blocks(input: RecordingWithBlocks) -> None:
         block_deleted_counter = 0
         block_deleted_error_counter = 0
 
-        for block in input.blocks:
-            _, _, path, _, query, _ = urlparse(block.url)
-            match = re.match(r"^range=bytes=(\d+)-(\d+)$", query)
+        tmpfile = None
+        try:
+            _, tmpfile = mkstemp()
 
-            if not match:
-                raise DeleteRecordingError(f"Got malformed byte range in block URL: {query}")
+            await storage.download_file(input.block_url, tmpfile)
 
-            start_byte, end_byte = int(match.group(1)), int(match.group(2))
-            block_length = end_byte - start_byte + 1
-            key = path.lstrip("/")
-
-            tmpfile = None
-            try:
-                _, tmpfile = mkstemp()
-
-                await storage.download_file(key, tmpfile)
+            for start_byte, end_byte in input.ranges:
+                block_length = end_byte - start_byte + 1
 
                 size_before = Path(tmpfile).stat().st_size
 
@@ -160,19 +163,19 @@ async def delete_recording_blocks(input: RecordingWithBlocks) -> None:
 
                 assert size_before == size_after
 
-                await storage.upload_file(key, tmpfile)
+            await storage.upload_file(input.block_url, tmpfile)
 
-                logger.info(f"Deleted block at {block.url}")
-                block_deleted_counter += 1
-            except session_recording_v2_object_storage.FileDownloadError:
-                logger.warning(f"Failed to download block at {block.url}, skipping...")
-                block_deleted_error_counter += 1
-            except session_recording_v2_object_storage.FileUploadError:
-                logger.warning(f"Failed to upload block at {block.url}, skipping...")
-                block_deleted_error_counter += 1
-            finally:
-                if tmpfile is not None:
-                    os.remove(tmpfile)
+            logger.info(f"Deleted {len(input.ranges)} blocks in {input.block_url}")
+            block_deleted_counter += 1
+        except session_recording_v2_object_storage.FileDownloadError:
+            logger.warning(f"Failed to download file at {input.block_url}, skipping...")
+            block_deleted_error_counter += 1
+        except session_recording_v2_object_storage.FileUploadError:
+            logger.warning(f"Failed to upload file to {input.block_url}, skipping...")
+            block_deleted_error_counter += 1
+        finally:
+            if tmpfile is not None:
+                os.remove(tmpfile)
 
     get_block_deleted_counter().add(block_deleted_counter)
     get_block_deleted_error_counter().add(block_deleted_error_counter)

--- a/posthog/temporal/delete_recordings/types.py
+++ b/posthog/temporal/delete_recordings/types.py
@@ -25,7 +25,7 @@ class RecordingsWithPersonInput:
 @dataclass(frozen=True)
 class RecordingBlockGroup:
     recording: Recording
-    block_url: str
+    path: str
     ranges: list[tuple[int, int]]
 
 

--- a/posthog/temporal/delete_recordings/types.py
+++ b/posthog/temporal/delete_recordings/types.py
@@ -22,9 +22,20 @@ class RecordingsWithPersonInput:
     batch_size: int = 100
 
 
+@dataclass(frozen=True)
+class RecordingBlockGroup:
+    recording: Recording
+    block_url: str
+    ranges: list[tuple[int, int]]
+
+
 class DeleteRecordingError(Exception):
     pass
 
 
 class LoadRecordingError(Exception):
+    pass
+
+
+class GroupRecordingError(Exception):
     pass

--- a/posthog/temporal/delete_recordings/workflows.py
+++ b/posthog/temporal/delete_recordings/workflows.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from temporalio import common, workflow
 from temporalio.workflow import ParentClosePolicy
 
-from posthog.session_recordings.session_recording_v2_service import RecordingBlock
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.delete_recordings.activities import (
     delete_recording_blocks,
@@ -13,7 +12,12 @@ from posthog.temporal.delete_recordings.activities import (
     load_recording_blocks,
     load_recordings_with_person,
 )
-from posthog.temporal.delete_recordings.types import Recording, RecordingsWithPersonInput, RecordingWithBlocks
+from posthog.temporal.delete_recordings.types import (
+    Recording,
+    RecordingBlockGroup,
+    RecordingsWithPersonInput,
+    RecordingWithBlocks,
+)
 from posthog.temporal.delete_recordings.utils import batched
 
 
@@ -41,7 +45,7 @@ class DeleteRecordingWorkflow(PostHogWorkflow):
         )
 
         if len(recording_blocks) > 0:
-            block_groups: list[list[RecordingBlock]] = await workflow.execute_activity(
+            block_groups: list[RecordingBlockGroup] = await workflow.execute_activity(
                 group_recording_blocks,
                 RecordingWithBlocks(recording=recording_input, blocks=recording_blocks),
                 start_to_close_timeout=timedelta(minutes=1),
@@ -57,7 +61,7 @@ class DeleteRecordingWorkflow(PostHogWorkflow):
                     delete_blocks.create_task(
                         workflow.execute_activity(
                             delete_recording_blocks,
-                            RecordingWithBlocks(recording=recording_input, blocks=group),
+                            group,
                             start_to_close_timeout=timedelta(minutes=30),
                             schedule_to_close_timeout=timedelta(hours=3),
                             retry_policy=common.RetryPolicy(

--- a/posthog/temporal/tests/delete_recordings/test_grouping.py
+++ b/posthog/temporal/tests/delete_recordings/test_grouping.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta
+
+from posthog.session_recordings.session_recording_v2_service import RecordingBlock
+from posthog.temporal.delete_recordings.activities import group_recording_blocks
+from posthog.temporal.delete_recordings.types import Recording, RecordingBlockGroup, RecordingWithBlocks
+
+
+async def test_single_group_recording_blocks():
+    test_input = RecordingWithBlocks(
+        recording=Recording(
+            session_id="abc",
+            team_id=123,
+        ),
+        blocks=[
+            RecordingBlock(
+                start_time=datetime.now() - timedelta(minutes=5),
+                end_time=datetime.now() - timedelta(minutes=3),
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=12269307-12294780",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() - timedelta(minutes=15),
+                end_time=datetime.now() - timedelta(minutes=13),
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=81788204-81793010",
+            ),
+        ],
+    )
+
+    expected_output = [
+        RecordingBlockGroup(
+            recording=Recording(
+                session_id="abc",
+                team_id=123,
+            ),
+            block_url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994",
+            ranges=[
+                (12269307, 12294780),
+                (81788204, 81793010),
+            ],
+        )
+    ]
+
+    assert await group_recording_blocks(test_input) == expected_output
+
+
+async def test_multiple_group_recording_blocks():
+    test_input = RecordingWithBlocks(
+        recording=Recording(
+            session_id="abc",
+            team_id=123,
+        ),
+        blocks=[
+            RecordingBlock(
+                start_time=datetime.now() - timedelta(minutes=5),
+                end_time=datetime.now() - timedelta(minutes=3),
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=12269307-12294780",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() - timedelta(minutes=15),
+                end_time=datetime.now() - timedelta(minutes=13),
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=81788204-81793010",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() - timedelta(minutes=15),
+                end_time=datetime.now() - timedelta(minutes=13),
+                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=2790658-2800843",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() - timedelta(minutes=15),
+                end_time=datetime.now() - timedelta(minutes=13),
+                url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6?range=bytes=12269307-12294780",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() - timedelta(minutes=15),
+                end_time=datetime.now() - timedelta(minutes=13),
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=2790658-2800843",
+            ),
+        ],
+    )
+
+    expected_output = [
+        RecordingBlockGroup(
+            recording=Recording(
+                session_id="abc",
+                team_id=123,
+            ),
+            block_url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994",
+            ranges=[
+                (12269307, 12294780),
+                (81788204, 81793010),
+                (2790658, 2800843),
+            ],
+        ),
+        RecordingBlockGroup(
+            recording=Recording(
+                session_id="abc",
+                team_id=123,
+            ),
+            block_url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a",
+            ranges=[
+                (2790658, 2800843),
+            ],
+        ),
+        RecordingBlockGroup(
+            recording=Recording(
+                session_id="abc",
+                team_id=123,
+            ),
+            block_url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6",
+            ranges=[
+                (12269307, 12294780),
+            ],
+        ),
+    ]
+
+    assert await group_recording_blocks(test_input) == expected_output

--- a/posthog/temporal/tests/delete_recordings/test_grouping.py
+++ b/posthog/temporal/tests/delete_recordings/test_grouping.py
@@ -31,7 +31,7 @@ async def test_single_group_recording_blocks():
                 session_id="abc",
                 team_id=123,
             ),
-            block_url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994",
+            path="session_recordings/5y/1756117699905-b688321ffa0fa994",
             ranges=[
                 (12269307, 12294780),
                 (81788204, 81793010),
@@ -83,7 +83,7 @@ async def test_multiple_group_recording_blocks():
                 session_id="abc",
                 team_id=123,
             ),
-            block_url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994",
+            path="session_recordings/5y/1756117699905-b688321ffa0fa994",
             ranges=[
                 (12269307, 12294780),
                 (81788204, 81793010),
@@ -95,7 +95,7 @@ async def test_multiple_group_recording_blocks():
                 session_id="abc",
                 team_id=123,
             ),
-            block_url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a",
+            path="session_recordings/90d/1756117747546-97a0b1e81d492d3a",
             ranges=[
                 (2790658, 2800843),
             ],
@@ -105,7 +105,7 @@ async def test_multiple_group_recording_blocks():
                 session_id="abc",
                 team_id=123,
             ),
-            block_url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6",
+            path="session_recordings/1y/1756117652764-84b1bccb847e7ea6",
             ranges=[
                 (12269307, 12294780),
             ],

--- a/posthog/temporal/tests/delete_recordings/test_workflows.py
+++ b/posthog/temporal/tests/delete_recordings/test_workflows.py
@@ -11,7 +11,7 @@ from temporalio.worker import Worker
 
 from posthog.session_recordings.session_recording_v2_service import RecordingBlock
 from posthog.temporal.delete_recordings.activities import group_recording_blocks
-from posthog.temporal.delete_recordings.types import Recording, RecordingsWithPersonInput, RecordingWithBlocks
+from posthog.temporal.delete_recordings.types import Recording, RecordingBlockGroup, RecordingsWithPersonInput
 from posthog.temporal.delete_recordings.workflows import DeleteRecordingsWithPersonWorkflow, DeleteRecordingWorkflow
 
 
@@ -39,9 +39,9 @@ async def test_delete_recording_workflow():
         ],
     }
 
-    EXPECTED_GROUPS = [
-        [TEST_SESSIONS[TEST_SESSION_ID][0]],
-        [TEST_SESSIONS[TEST_SESSION_ID][1], TEST_SESSIONS[TEST_SESSION_ID][2]],
+    EXPECTED_GROUPED_RANGES = [
+        [(12269307, 12294780)],
+        [(81788204, 81793010), (2790658, 2800843)],
     ]
 
     @activity.defn(name="load-recording-blocks")
@@ -51,10 +51,10 @@ async def test_delete_recording_workflow():
         return TEST_SESSIONS[TEST_SESSION_ID]
 
     @activity.defn(name="delete-recording-blocks")
-    async def delete_recording_blocks_mocked(input: RecordingWithBlocks) -> None:
+    async def delete_recording_blocks_mocked(input: RecordingBlockGroup) -> None:
         assert input.recording.session_id == TEST_SESSION_ID
         assert input.recording.team_id == TEST_TEAM_ID
-        assert input.blocks in EXPECTED_GROUPS
+        assert input.ranges in EXPECTED_GROUPED_RANGES
         TEST_SESSIONS[input.recording.session_id] = []  # Delete recording blocks
 
     task_queue_name = str(uuid.uuid4())
@@ -125,23 +125,20 @@ async def test_delete_recording_with_person_workflow():
         ],
     }
 
-    EXPECTED_GROUPS = {
+    EXPECTED_GROUPED_RANGES = {
         "1c6c32da-0518-4a83-a513-eb2595c33b66": [
-            [TEST_SESSIONS["1c6c32da-0518-4a83-a513-eb2595c33b66"][0]],
-            [
-                TEST_SESSIONS["1c6c32da-0518-4a83-a513-eb2595c33b66"][1],
-                TEST_SESSIONS["1c6c32da-0518-4a83-a513-eb2595c33b66"][2],
-            ],
+            [(12269307, 12294780)],
+            [(81788204, 81793010), (2790658, 2800843)],
         ],
         "791244f2-2569-4ed9-a448-d5a6e35471cd": [
             [
-                TEST_SESSIONS["791244f2-2569-4ed9-a448-d5a6e35471cd"][0],
-                TEST_SESSIONS["791244f2-2569-4ed9-a448-d5a6e35471cd"][1],
+                (12269307, 12294780),
+                (81788204, 81793010),
             ],
         ],
         "3d2b505b-3a0e-48fd-89ab-6eb65a08e915": [
-            [TEST_SESSIONS["3d2b505b-3a0e-48fd-89ab-6eb65a08e915"][0]],
-            [TEST_SESSIONS["3d2b505b-3a0e-48fd-89ab-6eb65a08e915"][1]],
+            [(81788204, 81793010)],
+            [(2790658, 2800843)],
         ],
     }
 
@@ -158,10 +155,10 @@ async def test_delete_recording_with_person_workflow():
         return TEST_SESSIONS[input.session_id]
 
     @activity.defn(name="delete-recording-blocks")
-    async def delete_recording_blocks_mocked(input: RecordingWithBlocks) -> None:
+    async def delete_recording_blocks_mocked(input: RecordingBlockGroup) -> None:
         assert input.recording.session_id in TEST_SESSIONS
         assert input.recording.team_id == TEST_TEAM_ID
-        assert input.blocks in EXPECTED_GROUPS[input.recording.session_id]
+        assert input.ranges in EXPECTED_GROUPED_RANGES[input.recording.session_id]
         TEST_SESSIONS[input.recording.session_id] = []  # Delete recording blocks
 
     task_queue_name = str(uuid.uuid4())

--- a/posthog/temporal/tests/delete_recordings/test_workflows.py
+++ b/posthog/temporal/tests/delete_recordings/test_workflows.py
@@ -44,6 +44,11 @@ async def test_delete_recording_workflow():
         [(81788204, 81793010), (2790658, 2800843)],
     ]
 
+    EXPECTED_PATHS = [
+        "session_recordings/1y/1756117652764-84b1bccb847e7ea6",
+        "session_recordings/90d/1756117747546-97a0b1e81d492d3a",
+    ]
+
     @activity.defn(name="load-recording-blocks")
     async def load_recording_blocks_mocked(input: Recording) -> list[RecordingBlock]:
         assert input.session_id == TEST_SESSION_ID
@@ -55,6 +60,7 @@ async def test_delete_recording_workflow():
         assert input.recording.session_id == TEST_SESSION_ID
         assert input.recording.team_id == TEST_TEAM_ID
         assert input.ranges in EXPECTED_GROUPED_RANGES
+        assert input.path in EXPECTED_PATHS
         TEST_SESSIONS[input.recording.session_id] = []  # Delete recording blocks
 
     task_queue_name = str(uuid.uuid4())
@@ -142,6 +148,14 @@ async def test_delete_recording_with_person_workflow():
         ],
     }
 
+    EXPECTED_PATHS = [
+        "session_recordings/1y/1756117652764-84b1bccb847e7ea6",
+        "session_recordings/90d/1756117747546-97a0b1e81d492d3a",
+        "session_recordings/5y/1756117699905-b688321ffa0fa994",
+        "session_recordings/30d/1756117708699-28b991ee5019274d",
+        "session_recordings/30d/1756117711878-61ed9e32ebf3e27a",
+    ]
+
     @activity.defn(name="load-recordings-with-person")
     async def load_recordings_with_person_mocked(input: RecordingsWithPersonInput) -> list[str]:
         assert input.distinct_ids == TEST_DISTINCT_IDS
@@ -159,6 +173,7 @@ async def test_delete_recording_with_person_workflow():
         assert input.recording.session_id in TEST_SESSIONS
         assert input.recording.team_id == TEST_TEAM_ID
         assert input.ranges in EXPECTED_GROUPED_RANGES[input.recording.session_id]
+        assert input.path in EXPECTED_PATHS
         TEST_SESSIONS[input.recording.session_id] = []  # Delete recording blocks
 
     task_queue_name = str(uuid.uuid4())


### PR DESCRIPTION
By grouping delete-recording-blocks activity to blocks with the same base S3 URI we can just download the file once and overwrite multiple ranges as needed before uploading the file one time at the end.

This saves multiple needless trips back and forth from S3.