### PR TITLE
fix: fix timestamp field checks in source wizard

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -170,11 +170,16 @@ const manualLinkSourceMap: Record<ManualLinkSourceType, string> = {
     azure: 'Azure',
 }
 
+const isTimestampType = (field: IncrementalField): boolean => {
+    const type = field.field_type || field.type
+    return type === 'timestamp' || type === 'datetime' || type === 'date'
+}
+
 const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField | undefined => {
     // check for timestamp field matching "updated_at" or "updatedAt" case insensitive
     const updatedAt = fields.find((field) => {
         const regex = /^updated/i
-        return regex.test(field.field) && (field.field_type === 'timestamp' || field.type === 'datetime')
+        return regex.test(field.field) && isTimestampType(field)
     })
     if (updatedAt) {
         return updatedAt
@@ -182,15 +187,13 @@ const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField |
     // fallback to timestamp field matching "created_at" or "createdAt" case insensitive
     const createdAt = fields.find((field) => {
         const regex = /^created/i
-        return regex.test(field.field) && (field.field_type === 'timestamp' || field.type === 'datetime')
+        return regex.test(field.field) && isTimestampType(field)
     })
     if (createdAt) {
         return createdAt
     }
     // fallback to any timestamp or datetime field
-    const timestamp = fields.find((field) => {
-        return field.field_type === 'timestamp' || field.type === 'datetime'
-    })
+    const timestamp = fields.find((field) => isTimestampType(field))
     if (timestamp) {
         return timestamp
     }


### PR DESCRIPTION
## Problem

<img width="2520" height="1236" alt="image" src="https://github.com/user-attachments/assets/5f26cbc0-d3e6-41ad-88a1-f2770ac1c427" />

<img width="780" height="152" alt="image" src="https://github.com/user-attachments/assets/d72297e3-7fc2-4375-8672-873224510dfb" />


## Changes

Added a missing date type into the check.

## How did you test this code?
Manually:
<img width="1313" height="659" alt="image" src="https://github.com/user-attachments/assets/ad71a76e-262d-41e3-bd03-a2f0e6390d98" />
