### PR TITLE
fix: don't rate limit dashboard queries from temporal

### DIFF
--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -251,8 +251,17 @@ def get_app_org_rate_limiter():
 
 def get_app_dashboard_queries_rate_limiter():
     """
-    Limits the number of concurrent queries (running outside celery) per organization.
+    Limits the number of concurrent queries (running outside celery/temporal) per organization.
     """
+
+    def _is_in_temporal() -> bool:
+        try:
+            from temporalio import workflow
+
+            return workflow.in_workflow()
+        except ImportError:
+            return False
+
     global __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG
     if __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG is None:
         __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG = RateLimit(
@@ -264,6 +273,9 @@ def get_app_dashboard_queries_rate_limiter():
                 # if running in celery, we don't want rate limit to apply
                 # as celery tasks have their own limits on the queues + using @limit_concurrency
                 and not current_task
+                # if running in temporal workflow, don't apply rate limit
+                # as temporal activities have their own concurrency controls
+                and not _is_in_temporal()
             ),
             limit_name="app_dashboard_queries_per_org",
             get_task_name=lambda *args, **kwargs: f"app:dashboard_query:per-org:{kwargs.get('org_id')}",

--- a/posthog/clickhouse/client/test/test_limit.py
+++ b/posthog/clickhouse/client/test/test_limit.py
@@ -311,3 +311,63 @@ class TestOrgConcurrencyLimit(BaseTest):
 
             result = get_org_app_concurrency_limit(uuid.uuid4())  # Non-existent org
             self.assertIsNone(result)
+
+
+class TestDashboardQueriesRateLimiter(BaseTest):
+    @patch("posthog.clickhouse.client.limit.TEST", False)
+    def test_rate_limiter_skips_for_celery_tasks(self):
+        """Test that rate limiter is not applicable when running in Celery context"""
+        from celery import Task
+
+        from posthog.clickhouse.client.limit import get_app_dashboard_queries_rate_limiter
+
+        rate_limiter = get_app_dashboard_queries_rate_limiter()
+
+        mock_task = Mock(spec=Task)
+        with patch("posthog.clickhouse.client.limit.current_task", mock_task):
+            is_applicable = rate_limiter.applicable(
+                org_id=str(self.organization.id), dashboard_id=123, team_id=self.team.id
+            )
+            self.assertFalse(is_applicable)
+
+    @patch("posthog.clickhouse.client.limit.TEST", False)
+    def test_rate_limiter_skips_for_temporal_workflows(self):
+        """Test that rate limiter is not applicable when running in Temporal workflow context"""
+        from posthog.clickhouse.client.limit import get_app_dashboard_queries_rate_limiter
+
+        rate_limiter = get_app_dashboard_queries_rate_limiter()
+
+        with patch("posthog.clickhouse.client.limit.current_task", None):
+            with patch("temporalio.workflow.in_workflow", return_value=True):
+                is_applicable = rate_limiter.applicable(
+                    org_id=str(self.organization.id), dashboard_id=123, team_id=self.team.id
+                )
+                self.assertFalse(is_applicable)
+
+    @patch("posthog.clickhouse.client.limit.TEST", False)
+    def test_rate_limiter_applies_for_regular_requests(self):
+        """Test that rate limiter is applicable for regular web requests"""
+        from posthog.clickhouse.client.limit import get_app_dashboard_queries_rate_limiter
+
+        rate_limiter = get_app_dashboard_queries_rate_limiter()
+
+        with patch("posthog.clickhouse.client.limit.current_task", None):
+            with patch("temporalio.workflow.in_workflow", return_value=False):
+                is_applicable = rate_limiter.applicable(
+                    org_id=str(self.organization.id), dashboard_id=123, team_id=self.team.id
+                )
+                self.assertTrue(is_applicable)
+
+    @patch("posthog.clickhouse.client.limit.TEST", False)
+    def test_rate_limiter_skips_for_api_requests(self):
+        """Test that rate limiter skips for API requests"""
+        from posthog.clickhouse.client.limit import get_app_dashboard_queries_rate_limiter
+
+        rate_limiter = get_app_dashboard_queries_rate_limiter()
+
+        with patch("posthog.clickhouse.client.limit.current_task", None):
+            with patch("temporalio.workflow.in_workflow", return_value=False):
+                is_applicable = rate_limiter.applicable(
+                    org_id=str(self.organization.id), dashboard_id=123, team_id=self.team.id, is_api=True
+                )
+                self.assertFalse(is_applicable)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Subscriptions can partially fail because an asset wasn't exported due to the dashboard query rate limit: `Exceeded maximum concurrency limit: 6 for key: app:dashboard_query:per-org:`

Example case where one of the assets was rate limited, resulting in a partial Slack thread: https://github.com/PostHog/posthog/issues/39055#issuecomment-3408354125


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Like Celery, don't have a concurrency dashboard query rate limit for Temporal
- Also, don't emit a failure metric for Slack API errors where the customer did something wrong like not adding the PostHog app, archiving the channel, or not giving the app access to the channel. This metric should only be emitted when it is our fault 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Unit tests.

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
