### PR TITLE
fix: Fix SDK doctor mocks for Storybook

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
@@ -9,8 +9,6 @@ import { urls } from 'scenes/urls'
 
 import { mswDecorator, useStorybookMocks } from '~/mocks/browser'
 import organizationCurrent from '~/mocks/fixtures/api/organizations/@current/@current.json'
-import sdkVersions from '~/mocks/fixtures/api/sdk_versions.json'
-import teamSdkVersions from '~/mocks/fixtures/api/team_sdk_versions.json'
 import { SidePanelTab } from '~/types'
 
 import { sidePanelStateLogic } from './sidePanelStateLogic'
@@ -40,8 +38,6 @@ const meta: Meta = {
                 '/api/projects/:id/surveys/responses_count/': { results: [] },
                 '/api/environments/:team_id/exports/': { results: [] },
                 '/api/environments/:team_id/events': { results: [] },
-                '/api/sdk_versions/': sdkVersions,
-                '/api/team_sdk_versions/': teamSdkVersions,
             },
             post: {
                 '/api/environments/:team_id/query': {},

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -14,6 +14,8 @@ import {
 
 import { ResponseComposition, RestContext, RestRequest } from 'msw'
 
+import sdkVersions from '~/mocks/fixtures/api/sdk_versions.json'
+import teamSdkVersions from '~/mocks/fixtures/api/team_sdk_versions.json'
 import { SharingConfigurationType } from '~/types'
 
 import { getAvailableProductFeatures } from './features'
@@ -214,6 +216,8 @@ export const defaultMocks: Mocks = {
         'api/projects/@current/resource_access_controls': EMPTY_PAGINATED_RESPONSE,
         'api/projects/@current/access_controls': EMPTY_PAGINATED_RESPONSE,
         'api/projects/:team_id/notebooks/recording_comments': EMPTY_PAGINATED_RESPONSE,
+        '/api/sdk_versions/': sdkVersions,
+        '/api/team_sdk_versions/': teamSdkVersions,
     },
     post: {
         'https://us.i.posthog.com/e/': (req, res, ctx): MockSignature => posthogCORSResponse(req, res, ctx),


### PR DESCRIPTION
Let's set these globally to avoid errors/flakey snapshots because of a missing global handler for this request