### PR TITLE
chore(myke): add more kafka-config-settings

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -311,6 +311,8 @@ KAFKA_PRODUCER_SETTINGS = {
         "max_in_flight_requests_per_connection": get_from_env(
             "KAFKA_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION", optional=True, type_cast=int
         ),
+        "buffer_memory": get_from_env("KAFKA_PRODUCER_BUFFER_MEMORY", optional=True, type_cast=int),
+        "max_block_ms": get_from_env("KAFKA_PRODUCER_MAX_BLOCK_MS", optional=True, type_cast=int),
     }.items()
     if value is not None
 }


### PR DESCRIPTION
## Problem

Our Temporal messaging workers occasionally hit 
```
KafkaTimeoutError: Failed to allocate memory within the configured max blocking time
```
potentially caused by the producer running out of buffer space while waiting for Kafka to acknowledge writes.

By configuring:

buffer_memory → increases available space for unsent messages

max_block_ms → gives the producer more time before failing when buffers are full

we can potentially reduce the risk of timeouts during high message volume.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

adds support for additional Kafka producer configuration options:

- KAFKA_PRODUCER_BUFFER_MEMORY

- KAFKA_PRODUCER_MAX_BLOCK_MS

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
