### PR TITLE
fix: use correct status and rename table

### DIFF
--- a/posthog/temporal/messaging/behavioral_cohorts_workflow.py
+++ b/posthog/temporal/messaging/behavioral_cohorts_workflow.py
@@ -213,17 +213,17 @@ def process_condition_batch_activity(inputs: ProcessConditionBatchInputs) -> Coh
                     CASE
                         WHEN
                             cmc.person_id IS NULL -- Does not exist in cohort_membership_changed
-                            THEN 'member' -- so, new member
+                            THEN 'entered' -- so, new member
                         WHEN
                             cmc.person_id IS NOT NULL -- Exists in cohort_membership_changed
-                            AND cmc.status = 'not_member' -- it left the cohort at some point
+                            AND cmc.status = 'left' -- it left the cohort at some point
                             AND bcm.person_id IS NOT NULL -- but now there is a match in behavioral_cohorts_matches
-                            THEN 'member' -- so, it re-entered the cohort
+                            THEN 'entered' -- so, it re-entered the cohort
                         WHEN
                             cmc.person_id IS NOT NULL -- Exists in cohort_membership_changed
-                            AND cmc.status = 'member' -- it is a member at some point
+                            AND cmc.status = 'entered' -- it is a member at some point
                             AND bcm.person_id IS NULL -- but there is no match in behavioral_cohorts_matches
-                            THEN 'not_member' -- so, it left the cohort
+                            THEN 'left' -- so, it left the cohort
                         ELSE
                             'unchanged' -- for all other cases, the membership did not change
                     END as status
@@ -242,7 +242,7 @@ def process_condition_batch_activity(inputs: ProcessConditionBatchInputs) -> Coh
                 FULL OUTER JOIN
                 (
                     SELECT team_id, cohort_id, person_id, argMax(status, last_updated) as status
-                    FROM cohort_membership_changed
+                    FROM cohort_membership
                     WHERE
                         team_id = %(team_id)s
                         AND cohort_id = %(cohort_id)s


### PR DESCRIPTION
Use left and entered statuses, which are the ones we agreed.

Also, change the table (it's already recreated in ClickHouse)