### PR TITLE
feat: Support default role in Redshift COPY

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -267,7 +267,10 @@ class RedshiftClient(PostgreSQLClient):
             )
 
         else:
-            credentials = sql.SQL("IAM_ROLE {iam_role}").format(iam_role=sql.Literal(authorization))
+            if authorization == "default":
+                credentials = sql.SQL("IAM_ROLE default")
+            else:
+                credentials = sql.SQL("IAM_ROLE {iam_role}").format(iam_role=sql.Literal(authorization))
 
         copy_query = sql.SQL(
             """

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -256,7 +256,7 @@ class RedshiftClient(PostgreSQLClient):
         s3_files = sql.Literal(f"s3://{s3_bucket}/{manifest_key}")
 
         if isinstance(authorization, AWSCredentials):
-            credentials = sql.SQL(
+            credentials: sql.SQL | sql.Composed = sql.SQL(
                 """
                 ACCESS_KEY_ID {access_key_id}
                 SECRET_ACCESS_KEY {secret_access_key}


### PR DESCRIPTION
## Problem

Redshift COPY authorization supports using the `default` keyword to indicate the default role associated with the Redshift cluster should be used. We, currently, don't support this.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

In authorization mode `IAMRole`, pass the `default` keyword if authorization is set to `"default"`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
