### PR TITLE
fix(batch-exports): Increase Databricks timeout

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -267,7 +267,7 @@ class DatabricksClient:
                 # user agent can be used for usage tracking
                 user_agent_entry="PostHog batch exports",
                 enable_telemetry=False,
-                _socket_timeout=5,
+                _socket_timeout=300,  # Databricks seems to use this for all timeouts
                 _retry_stop_after_attempts_count=2,
                 _retry_delay_max=1,
             )

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -108,6 +108,19 @@ class RecordBatchQueue(asyncio.Queue):
         """
         return self._bytes_size
 
+    def __repr__(self):
+        return f"<{type(self).__name__} at {id(self):#x} {self._format()}>"
+
+    def __str__(self):
+        return f"<{type(self).__name__} {self._format()}>"
+
+    def _format(self) -> str:
+        result = f"record_batches={len(self._queue)}"
+        result += f" bytes={str(self._bytes_size)}"
+        if self.record_batch_schema is not None:
+            result += f" schema='{self.record_batch_schema}'"
+        return result
+
 
 class TaskNotDoneError(Exception):
     """Raised when a task that should be done, isn't."""

--- a/products/batch_exports/backend/tests/temporal/test_spmc.py
+++ b/products/batch_exports/backend/tests/temporal/test_spmc.py
@@ -73,6 +73,19 @@ async def test_record_batch_queue_sets_schema():
     assert schema == record_batch.schema
 
 
+async def test_record_batch_queue_str_and_repr():
+    """Test `RecordBatchQueue` returns sensible output for str and repr"""
+    records = [{"test": 1}, {"test": 2}, {"test": 3}]
+    record_batch = pa.RecordBatch.from_pylist(records)
+
+    queue = RecordBatchQueue()
+
+    await queue.put(record_batch)
+
+    assert str(queue) == "<RecordBatchQueue record_batches=1 bytes=24 schema='test: int64'>"
+    assert "record_batches=1 bytes=24 schema='test: int64'" in repr(queue)
+
+
 async def get_record_batch_from_queue(queue, produce_task):
     while not queue.empty() or not produce_task.done():
         try:


### PR DESCRIPTION
## Problem

File uploads to Databricks can result in a `TimeoutError` if the file is large.

When debugging this error, I found that we're outputting the entire contents of the `RecordBatchQueue` queue whenever an exception is raised in the consumer, which causes our logs to be truncated.

## Changes

Bump the `_socket_timeout` from 5 seconds to 5 mins (the default is 15 mins which seems quite high). This seems to be the same timeout used everywhere and is therefore not just a socket timeout but a full read/write timeout too. Not sure if this will fix the issue but worth a try.

Fix string representations of `RecordBatchQueue`

## How did you test this code?

I didn't really - just ensured existing tests pass and tests don't increase in duration (the invalid host test we have completes in the same amount of time as before).
