### PR TITLE
feat: Add endpoint to allow summarizing sessions individually/without patterns (for CRM)

### DIFF
--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -1,4 +1,5 @@
 import os
+import asyncio
 from datetime import datetime
 from typing import cast
 
@@ -20,9 +21,11 @@ from posthog.clickhouse.query_tagging import Product, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.models import Team, User
 from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
+from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session
 from posthog.temporal.ai.session_summary.summarize_session_group import execute_summarize_session_group
 from posthog.temporal.ai.session_summary.types.group import SessionSummaryStep, SessionSummaryStreamUpdate
 
+from ee.hogai.session_summaries.session.output_data import SessionSummarySerializer
 from ee.hogai.session_summaries.session.summarize_session import ExtraSummaryContext
 from ee.hogai.session_summaries.session_group.patterns import EnrichedSessionGroupSummaryPatternsList
 from ee.hogai.session_summaries.session_group.summarize_session_group import find_sessions_timestamps
@@ -52,6 +55,33 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
     permission_classes = [IsAuthenticated]
     throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]
     serializer_class = SessionSummariesSerializer
+
+    def _validate_user(self, request: Request) -> User:
+        if not request.user.is_authenticated:
+            raise exceptions.NotAuthenticated()
+        tag_queries(product=Product.SESSION_SUMMARY)
+        user = cast(User, request.user)
+        # Validate environment requirements
+        environment_is_allowed = settings.DEBUG or is_cloud()
+        has_openai_api_key = bool(os.environ.get("OPENAI_API_KEY"))
+        if not environment_is_allowed or not has_openai_api_key:
+            raise exceptions.ValidationError("Session summaries are only supported in PostHog Cloud")
+        if not posthoganalytics.feature_enabled("ai-session-summary", str(user.distinct_id)):
+            raise exceptions.ValidationError("Session summaries are not enabled for this user")
+        return user
+
+    def _validate_input(self, request: Request) -> tuple[list[str], datetime, datetime, ExtraSummaryContext | None]:
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        session_ids = serializer.validated_data["session_ids"]
+        focus_area = serializer.validated_data.get("focus_area")
+        # Check that sessions exist and get min/max timestamps for follow-up queries
+        min_timestamp, max_timestamp = find_sessions_timestamps(session_ids=session_ids, team=self.team)
+        # Prepare extra context, if provided
+        extra_summary_context = None
+        if focus_area:
+            extra_summary_context = ExtraSummaryContext(focus_area=focus_area)
+        return session_ids, min_timestamp, max_timestamp, extra_summary_context
 
     @staticmethod
     async def _get_summary_from_progress_stream(
@@ -90,39 +120,18 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
 
     @extend_schema(
         operation_id="create_session_summaries",
-        description="Generate AI summaries per-session and a general summary for a group of session recordings",
+        description="Generate AI summary for a group of session recordings to find patterns and generate a notebook.",
         request=SessionSummariesSerializer,
     )
     @action(methods=["POST"], detail=False)
     def create_session_summaries(self, request: Request, **kwargs) -> Response:
-        # Validate the user/team
-        if not request.user.is_authenticated:
-            raise exceptions.NotAuthenticated()
-        tag_queries(product=Product.SESSION_SUMMARY)
-        user = cast(User, request.user)
-        # Validate environment requirements
-        environment_is_allowed = settings.DEBUG or is_cloud()
-        has_openai_api_key = bool(os.environ.get("OPENAI_API_KEY"))
-        if not environment_is_allowed or not has_openai_api_key:
-            raise exceptions.ValidationError("Session summaries are only supported in PostHog Cloud")
-        if not posthoganalytics.feature_enabled("ai-session-summary", str(user.distinct_id)):
-            raise exceptions.ValidationError("Session summaries are not enabled for this user")
-        # Validate input
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        session_ids = serializer.validated_data["session_ids"]
-        focus_area = serializer.validated_data.get("focus_area")
-        # Check that sessions exist and get min/max timestamps for follow-up queries
-        min_timestamp, max_timestamp = find_sessions_timestamps(session_ids=session_ids, team=self.team)
-        # Prepare extra context, if provided
-        extra_summary_context = None
-        if focus_area:
-            extra_summary_context = ExtraSummaryContext(focus_area=focus_area)
+        user = self._validate_user(request)
+        session_ids, min_timestamp, max_timestamp, extra_summary_context = self._validate_input(request)
         # Summarize provided sessions
         try:
             summary = async_to_sync(self._get_summary_from_progress_stream)(
                 session_ids=session_ids,
-                user_id=user.pk,
+                user_id=user.id,
                 team=self.team,
                 min_timestamp=min_timestamp,
                 max_timestamp=max_timestamp,
@@ -149,4 +158,80 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             )
             raise exceptions.APIException(
                 f"Failed to generate session summaries for sessions {logging_session_ids(session_ids)}. Please try again later."
+            )
+
+    @staticmethod
+    async def _summarize_session(
+        session_id: str,
+        user_id: int,
+        team: Team,
+        extra_summary_context: ExtraSummaryContext | None = None,
+    ) -> SessionSummarySerializer | Exception:
+        try:
+            summary_raw = await execute_summarize_session(
+                session_id=session_id, user_id=user_id, team=team, extra_summary_context=extra_summary_context
+            )
+            summary = SessionSummarySerializer(data=summary_raw)
+            summary.is_valid(raise_exception=True)
+            return summary
+        except Exception as err:
+            # Let caller handle the error
+            return err
+
+    async def _get_individual_summaries(
+        self,
+        session_ids: list[str],
+        user_id: int,
+        team: Team,
+        extra_summary_context: ExtraSummaryContext | None = None,
+    ) -> list[SessionSummarySerializer]:
+        tasks = {}
+        async with asyncio.TaskGroup() as tg:
+            for session_id in session_ids:
+                tasks[session_id] = tg.create_task(
+                    self._summarize_session(
+                        session_id=session_id, user_id=user_id, team=team, extra_summary_context=extra_summary_context
+                    )
+                )
+        summaries: list[SessionSummarySerializer] = []
+        for session_id, task in tasks.items():
+            res = task.result()
+            if isinstance(res, Exception):
+                logger.exception(
+                    f"Failed to generate individual session summary for session {session_id} from team {team.pk} by user {user_id}: {res}",
+                    team_id=team.pk,
+                    user_id=user_id,
+                )
+            else:
+                # Return only successful summaries
+                summaries.append(res)
+        return summaries
+
+    @extend_schema(
+        operation_id="create_session_summaries_individually",
+        description="Generate AI individual summary for each session, without grouping.",
+        request=SessionSummariesSerializer,
+    )
+    @action(methods=["POST"], detail=False)
+    def create_session_summaries_individually(self, request: Request, **kwargs) -> Response:
+        user = self._validate_user(request)
+        session_ids, _, _, extra_summary_context = self._validate_input(request)
+        # Summarize provided sessions individually
+        try:
+            summaries = async_to_sync(self._get_individual_summaries)(
+                session_ids=session_ids,
+                user_id=user.id,
+                team=self.team,
+                extra_summary_context=extra_summary_context,
+            )
+            return Response(summaries, status=status.HTTP_200_OK)
+        except Exception as err:
+            logger.exception(
+                f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)} from team {self.team.pk} by user {user.pk}: {err}",
+                team_id=self.team.pk,
+                user_id=user.id,
+                error=str(err),
+            )
+            raise exceptions.APIException(
+                f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)}. Please try again later."
             )

--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -224,7 +224,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 team=self.team,
                 extra_summary_context=extra_summary_context,
             )
-            return Response(summaries, status=status.HTTP_200_OK)
+            return Response([summary.data for summary in summaries], status=status.HTTP_200_OK)
         except Exception as err:
             logger.exception(
                 f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)} from team {self.team.pk} by user {user.pk}: {err}",

--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -151,9 +151,9 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             return Response(summary.model_dump(exclude_none=True, mode="json"), status=status.HTTP_200_OK)
         except Exception as err:
             logger.exception(
-                f"Failed to generate session group summary for sessions {logging_session_ids(session_ids)} from team {self.team.pk} by user {user.pk}: {err}",
-                team_id=self.team.pk,
-                user_id=user.pk,
+                f"Failed to generate session group summary for sessions {logging_session_ids(session_ids)} from team {self.team.id} by user {user.id}: {err}",
+                team_id=self.team.id,
+                user_id=user.id,
                 error=str(err),
             )
             raise exceptions.APIException(
@@ -227,8 +227,8 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             return Response(summaries, status=status.HTTP_200_OK)
         except Exception as err:
             logger.exception(
-                f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)} from team {self.team.pk} by user {user.pk}: {err}",
-                team_id=self.team.pk,
+                f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)} from team {self.team.id} by user {user.id}: {err}",
+                team_id=self.team.id,
                 user_id=user.id,
                 error=str(err),
             )


### PR DESCRIPTION
## Problem

- When summarizing for entities that don't have lots of sessions (for example, a person), there's no need to search for patterns (not enough data), but there's still value in analyzing individual sessions to find issues

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add a new endpoint (to the same session summary viewset CRM team already uses) to allow summarizing sessions individually (no streaming)

<img width="1363" height="911" alt="CleanShot 2025-10-16 at 13 41 09" src="https://github.com/user-attachments/assets/2726e386-6a85-4267-982d-a0785bb42711" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
