### PR TITLE
fix(array): update permission mode in runAgent script

### DIFF
--- a/products/tasks/scripts/runAgent.mjs
+++ b/products/tasks/scripts/runAgent.mjs
@@ -28,7 +28,7 @@ export async function runAgent(taskId, workflowId, repositoryPath, posthogApiUrl
 
     await agent.runWorkflow(taskId, workflowId, {
         repositoryPath,
-        permissionMode: PermissionMode.ACCEPT_EDITS,
+        permissionMode: PermissionMode.BYPASS,
         autoProgress: true,
     })
 }


### PR DESCRIPTION
Change the permission mode in the runAgent.mjs script from 
ACCEPT_EDITS to BYPASS since we’re in a sandbox environment.