### PR TITLE
fix(node): Don't keep the messages array in the closure

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -1,4 +1,4 @@
-import { LogLevel, PluginLogLevel, PluginsServerConfig, ValueMatcher, stringToPluginServerMode } from '../types'
+import { PluginLogLevel, PluginsServerConfig, ValueMatcher, stringToPluginServerMode } from '../types'
 import { isDevEnv, isProdEnv, isTestEnv, stringToBoolean } from '../utils/env-utils'
 import { KAFKAJS_LOG_LEVEL_MAPPING } from './constants'
 import {
@@ -75,6 +75,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
         CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: false,
         CONSUMER_AUTO_CREATE_TOPICS: true,
+        CONSUMER_LOG_STATS_LEVEL: 'debug',
         KAFKA_HOSTS: 'kafka:9092', // KEEP IN SYNC WITH posthog/settings/data_stores.py
         KAFKA_CLIENT_CERT_B64: undefined,
         KAFKA_CLIENT_CERT_KEY_B64: undefined,
@@ -103,7 +104,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID: '',
         INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: false,
         PLUGINS_DEFAULT_LOG_LEVEL: isTestEnv() ? PluginLogLevel.Full : PluginLogLevel.Log,
-        LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,
+        LOG_LEVEL: isTestEnv() ? 'warn' : 'info',
         HTTP_SERVER_PORT: DEFAULT_HTTP_SERVER_PORT,
         SCHEDULE_LOCK_TTL: 60,
         REDIS_POOL_MIN_SIZE: 1,

--- a/plugin-server/src/config/constants.ts
+++ b/plugin-server/src/config/constants.ts
@@ -4,8 +4,8 @@ export const ONE_MINUTE = 60 * 1000
 export const ONE_HOUR = 60 * 60 * 1000
 export const KAFKAJS_LOG_LEVEL_MAPPING = {
     NOTHING: logLevel.NOTHING,
-    DEBUG: 'info',
-    INFO: 'info',
+    DEBUG: logLevel.INFO,
+    INFO: logLevel.INFO,
     WARN: logLevel.WARN,
     ERROR: logLevel.ERROR,
 }

--- a/plugin-server/src/config/constants.ts
+++ b/plugin-server/src/config/constants.ts
@@ -4,8 +4,8 @@ export const ONE_MINUTE = 60 * 1000
 export const ONE_HOUR = 60 * 60 * 1000
 export const KAFKAJS_LOG_LEVEL_MAPPING = {
     NOTHING: logLevel.NOTHING,
-    DEBUG: logLevel.INFO,
-    INFO: logLevel.INFO,
+    DEBUG: 'info',
+    INFO: 'info',
     WARN: logLevel.WARN,
     ERROR: logLevel.ERROR,
 }

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -527,12 +527,8 @@ export class KafkaConsumer {
                     topics: Object.keys(parsedStats.topics || {}),
                     broker_count: brokerStats.size,
                     brokers: Array.from(brokerStats.entries()).map(([name, stats]) => ({
+                        ...stats,
                         name,
-                        state: stats.state,
-                        rtt_avg: stats.rtt?.avg,
-                        connects: stats.connects,
-                        disconnects: stats.disconnects,
-                        buffer_bytes: stats.zbuf_grow,
                     })),
                 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -50,12 +50,7 @@ export { Element } from '@posthog/plugin-scaffold' // Re-export Element from sca
 
 type Brand<K, T> = K & { __brand: T }
 
-export enum LogLevel {
-    Debug = 'debug',
-    Info = 'info',
-    Warn = 'warn',
-    Error = 'error',
-}
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
 export enum KafkaSecurityProtocol {
     Plaintext = 'PLAINTEXT',
@@ -312,6 +307,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     CONSUMER_BATCH_SIZE: number // Primarily for kafka consumers the batch size to use
     CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: number // Primarily for kafka consumers the max heartbeat interval to use after which it will be considered unhealthy
     CONSUMER_LOOP_STALL_THRESHOLD_MS: number // Threshold in ms after which the consumer loop is considered stalled
+    CONSUMER_LOG_STATS_LEVEL: LogLevel // Log level for consumer statistics
     CONSUMER_LOOP_BASED_HEALTH_CHECK: boolean // Use consumer loop monitoring for health checks instead of heartbeats
     CONSUMER_MAX_BACKGROUND_TASKS: number
     CONSUMER_WAIT_FOR_BACKGROUND_TASKS_ON_REBALANCE: boolean

--- a/plugin-server/src/utils/logger.ts
+++ b/plugin-server/src/utils/logger.ts
@@ -79,19 +79,19 @@ export class Logger {
     }
 
     debug(...args: any[]) {
-        this._log(LogLevel.Debug, ...args)
+        this._log('debug', ...args)
     }
 
     info(...args: any[]) {
-        this._log(LogLevel.Info, ...args)
+        this._log('info', ...args)
     }
 
     warn(...args: any[]) {
-        this._log(LogLevel.Warn, ...args)
+        this._log('warn', ...args)
     }
 
     error(...args: any[]) {
-        this._log(LogLevel.Error, ...args)
+        this._log('error', ...args)
     }
 
     async shutdown(): Promise<void> {

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -21,7 +21,7 @@ import { PersonsStoreForBatch } from '~/worker/ingestion/persons/persons-store-f
 
 import { createEmitEventStep } from '../../src/ingestion/event-processing/emit-event-step'
 import { isOkResult } from '../../src/ingestion/pipelines/results'
-import { ClickHouseEvent, Hub, LogLevel, Person, PluginsServerConfig, Team } from '../../src/types'
+import { ClickHouseEvent, Hub, Person, PluginsServerConfig, Team } from '../../src/types'
 import { closeHub, createHub } from '../../src/utils/db/hub'
 import { PostgresUse } from '../../src/utils/db/postgres'
 import { UUIDT } from '../../src/utils/utils'
@@ -73,7 +73,7 @@ async function flushPersonStoreToKafka(hub: Hub, personStore: PersonsStoreForBat
 }
 
 const TEST_CONFIG: Partial<PluginsServerConfig> = {
-    LOG_LEVEL: LogLevel.Info,
+    LOG_LEVEL: 'info',
 }
 
 describe('processEvent', () => {

--- a/plugin-server/tests/server.test.ts
+++ b/plugin-server/tests/server.test.ts
@@ -1,5 +1,5 @@
 import { PluginServer } from '../src/server'
-import { LogLevel, PluginServerMode } from '../src/types'
+import { PluginServerMode } from '../src/types'
 import { resetTestDatabase } from './helpers/sql'
 
 jest.setTimeout(20000) // 20 sec timeout - longer indicates an issue
@@ -29,7 +29,7 @@ describe('server', () => {
     // Running all capabilities together takes too long in tests, so they are split up
     it('should not error on startup - ingestion', async () => {
         pluginsServer = new PluginServer({
-            LOG_LEVEL: LogLevel.Debug,
+            LOG_LEVEL: 'debug',
             PLUGIN_SERVER_MODE: PluginServerMode.ingestion_v2,
         })
         await pluginsServer.start()
@@ -37,7 +37,7 @@ describe('server', () => {
 
     it('should not error on startup - cdp', async () => {
         pluginsServer = new PluginServer({
-            LOG_LEVEL: LogLevel.Debug,
+            LOG_LEVEL: 'debug',
             PLUGIN_SERVER_MODE: PluginServerMode.cdp_processed_events,
         })
         await pluginsServer.start()
@@ -45,7 +45,7 @@ describe('server', () => {
 
     it('should not error on startup - replay', async () => {
         pluginsServer = new PluginServer({
-            LOG_LEVEL: LogLevel.Debug,
+            LOG_LEVEL: 'debug',
             PLUGIN_SERVER_MODE: PluginServerMode.recordings_blob_ingestion_v2,
         })
         await pluginsServer.start()

--- a/plugin-server/tests/worker/capabilities.test.ts
+++ b/plugin-server/tests/worker/capabilities.test.ts
@@ -1,4 +1,4 @@
-import { Hub, LogLevel, PluginCapabilities } from '../../src/types'
+import { Hub, PluginCapabilities } from '../../src/types'
 import { closeHub, createHub } from '../../src/utils/db/hub'
 import { getVMPluginCapabilities, shouldSetupPluginInServer } from '../../src/worker/vm/capabilities'
 import { createPluginConfigVM } from '../../src/worker/vm/vm'
@@ -14,7 +14,7 @@ describe('capabilities', () => {
     beforeAll(async () => {
         console.info = jest.fn() as any
         console.warn = jest.fn() as any
-        hub = await createHub({ LOG_LEVEL: LogLevel.Warn })
+        hub = await createHub({ LOG_LEVEL: 'warn' })
     })
 
     afterAll(async () => {

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -3,7 +3,6 @@ import { DateTime } from 'luxon'
 import { PluginServer } from '../../../src/server'
 import {
     Hub,
-    LogLevel,
     PluginServerMode,
     PluginsServerConfig,
     PropertyUpdateOperation,
@@ -26,7 +25,7 @@ jest.mock('../../../src/utils/logger')
 jest.setTimeout(30000)
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
-    LOG_LEVEL: LogLevel.Info,
+    LOG_LEVEL: 'info',
 }
 
 describe('postgres parity', () => {

--- a/plugin-server/tests/worker/ingestion/utils.test.ts
+++ b/plugin-server/tests/worker/ingestion/utils.test.ts
@@ -1,4 +1,4 @@
-import { Hub, LogLevel } from '../../../src/types'
+import { Hub } from '../../../src/types'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { captureIngestionWarning } from '../../../src/worker/ingestion/utils'
 import { Clickhouse } from '../../helpers/clickhouse'
@@ -10,7 +10,7 @@ describe('captureIngestionWarning()', () => {
     let clickhouse: Clickhouse
 
     beforeEach(async () => {
-        hub = await createHub({ LOG_LEVEL: LogLevel.Info })
+        hub = await createHub({ LOG_LEVEL: 'info' })
         clickhouse = Clickhouse.create()
         await clickhouse.resetTestDatabase()
     })

--- a/plugin-server/tests/worker/plugins.test.ts
+++ b/plugin-server/tests/worker/plugins.test.ts
@@ -1,4 +1,4 @@
-import { Hub, LogLevel } from '../../src/types'
+import { Hub } from '../../src/types'
 import { processError } from '../../src/utils/db/error'
 import { closeHub, createHub } from '../../src/utils/db/hub'
 import { loadPlugin } from '../../src/worker/plugins/loadPlugin'
@@ -29,7 +29,7 @@ describe('plugins', () => {
     let hub: Hub
 
     beforeEach(async () => {
-        hub = await createHub({ LOG_LEVEL: LogLevel.Info })
+        hub = await createHub({ LOG_LEVEL: 'info' })
         console.warn = jest.fn() as any
         await resetTestDatabase()
     })

--- a/plugin-server/tests/worker/plugins/inline.test.ts
+++ b/plugin-server/tests/worker/plugins/inline.test.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { Hub, LogLevel, Plugin, PluginConfig } from '../../../src/types'
+import { Hub, Plugin, PluginConfig } from '../../../src/types'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { PostgresUse } from '../../../src/utils/db/postgres'
 import {
@@ -19,7 +19,7 @@ describe('Inline plugin', () => {
     beforeAll(async () => {
         console.info = jest.fn() as any
         console.warn = jest.fn() as any
-        hub = await createHub({ LOG_LEVEL: LogLevel.Info })
+        hub = await createHub({ LOG_LEVEL: 'info' })
         await resetTestDatabase()
     })
 

--- a/plugin-server/tests/worker/plugins/inline_plugins/user-agent.test.ts
+++ b/plugin-server/tests/worker/plugins/inline_plugins/user-agent.test.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { LogLevel, PluginConfig } from '../../../../src/types'
+import { PluginConfig } from '../../../../src/types'
 import { closeHub, createHub } from '../../../../src/utils/db/hub'
 import { constructInlinePluginInstance } from '../../../../src/worker/vm/inline/inline'
 import { resetTestDatabase } from '../../../helpers/sql'
@@ -11,7 +11,7 @@ describe('user-agent tests', () => {
     beforeAll(async () => {
         console.info = jest.fn() as any
         console.warn = jest.fn() as any
-        hub = await createHub({ LOG_LEVEL: LogLevel.Info })
+        hub = await createHub({ LOG_LEVEL: 'info' })
         await resetTestDatabase()
     })
 


### PR DESCRIPTION
## Problem

Not certain this fixes the issue but there's something potentially off. 

## Changes

* Calculate the offsets to commit _before_ calling the background task promise.
* This should only affect the in-flight background task memory so would be weird if this actually solves the issue of the longer term memory releasing
* My hunch is that the issue is coming from the bindings from node->c where we keep a reference to the messages whilst we call the next `.consume` which is likely not standard. There is a bunch of mention in node-rdkafka about memory management issue between the two so it could be the listener they have to free up memory is losing sync here

Big diff as I wanted to have the log level be more easily configurable and `enums` are the devil

## How did you test this code?

* Not sure how to but tried to add some more logging to stats

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
