### PR TITLE
chore: Tweak wording for flag enabled switch

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -502,8 +502,8 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
                                             />
                                             <div className="text-secondary text-sm pl-7">
                                                 When enabled, this flag evaluates according to your release conditions.
-                                                When disabled, all evaluations return <code>false</code> regardless of
-                                                conditions.
+                                                When disabled, this flag will not be evaluated and PostHog SDKs default
+                                                to returning <code>false</code>.
                                             </div>
                                         </div>
                                     )}


### PR DESCRIPTION
## Problem

The wording for the flag enabled switch [caused some confusion for a customer](https://posthoghelp.zendesk.com/agent/tickets/39946). The confusion originated from the option to supply a `defaultValue` to `isFeatureEnabled` in the [Android SDK](https://github.com/PostHog/posthog-android/blob/44dece00a72ba131912be841ba523b2ecbae86f8/posthog/src/main/java/com/posthog/PostHog.kt#L804).

The Android SDK seems to be the only one that allows a `defaultValue` (and as far as I can see we don't document it), so I've kept the change of wording fairly vague.