### PR TITLE
fix(myke): fix forgotten activity

### DIFF
--- a/posthog/temporal/messaging/__init__.py
+++ b/posthog/temporal/messaging/__init__.py
@@ -5,6 +5,7 @@ from posthog.temporal.messaging.behavioral_cohorts_workflow import (
 )
 from posthog.temporal.messaging.behavioral_cohorts_workflow_coordinator import (
     BehavioralCohortsCoordinatorWorkflow,
+    check_running_workflows_activity,
     get_conditions_count_activity,
 )
 
@@ -16,4 +17,5 @@ ACTIVITIES = [
     get_unique_conditions_page_activity,
     process_condition_batch_activity,
     get_conditions_count_activity,
+    check_running_workflows_activity,
 ]


### PR DESCRIPTION
## Problem

fix for 

```
{
  "message": "Activity function check_running_workflows_activity for workflow behavioral-cohorts-coordinator-all-all-1760620543 is not registered on this worker, available activities: get_conditions_count_activity, get_unique_conditions_page_activity, process_condition_batch_activity",
  "stackTrace": "  File \"/python-runtime/lib/python3.12/site-packages/temporalio/worker/_activity.py\", line 301, in _handle_start_activity_task
    result = await self._execute_activity(start, running_activity, task_token)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File \"/python-runtime/lib/python3.12/site-packages/temporalio/worker/_activity.py\", line 426, in _execute_activity
    raise temporalio.exceptions.ApplicationError(
",
  "applicationFailureInfo": {
    "type": "NotFoundError"
  }
}
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- registered the forgotten activity .... 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
