### PR TITLE
feat: run specific Temporal workers in vsc debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -169,8 +169,9 @@
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/manage.py",
-            "args": ["start_temporal_worker"],
+            "args": ["start_temporal_worker", "--task-queue", "${input:temporalTaskQueue}"],
             "django": true,
+            "justMyCode": false,
             "env": {
                 "PYTHONUNBUFFERED": "1",
                 "DJANGO_SETTINGS_MODULE": "posthog.settings",
@@ -297,6 +298,24 @@
             "id": "pickVersion",
             "type": "command",
             "command": "extension.node-version"
+        },
+        {
+            "id": "temporalTaskQueue",
+            "type": "pickString",
+            "description": "Task queue name",
+            "options": [
+                "general-purpose-task-queue",
+                "max-ai-task-queue",
+                "batch-exports-task-queue",
+                "data-warehouse-task-queue",
+                "data-warehouse-compaction-task-queue",
+                "data-modeling-task-queue",
+                "tasks-task-queue",
+                "billing-task-queue",
+                "video-export-task-queue",
+                "session-replay-task-queue"
+            ],
+            "default": "general-purpose-task-queue"
         }
     ],
     "compounds": [


### PR DESCRIPTION
## Problem

It's not possible to select a specific Temporal worker to run in the Cursor's debugger.

Tip: You can also inject environment variables into the Cursor by running the command below.

```bash
op run --env-file .env.local --no-masking -- cursor .
```

## Changes

- Allow to select a worker from Cursor.

## How did you test this code?

N/A
