### PR TITLE
fix(experiments): Add optional shared metric fields to schema

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12059,7 +12059,7 @@
                     "type": "array"
                 },
                 "sharedMetricId": {
-                    "type": "string"
+                    "type": "number"
                 },
                 "uuid": {
                     "type": "string"
@@ -12286,7 +12286,7 @@
                     "type": "object"
                 },
                 "sharedMetricId": {
-                    "type": "string"
+                    "type": "number"
                 },
                 "source": {
                     "$ref": "#/definitions/ExperimentMetricSource"
@@ -12370,7 +12370,7 @@
                     "type": "object"
                 },
                 "sharedMetricId": {
-                    "type": "string"
+                    "type": "number"
                 },
                 "uuid": {
                     "type": "string"
@@ -12653,7 +12653,7 @@
                     "type": "object"
                 },
                 "sharedMetricId": {
-                    "type": "string"
+                    "type": "number"
                 },
                 "uuid": {
                     "type": "string"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12035,6 +12035,9 @@
                 "goal": {
                     "$ref": "#/definitions/ExperimentMetricGoal"
                 },
+                "isSharedMetric": {
+                    "type": "boolean"
+                },
                 "kind": {
                     "const": "ExperimentMetric",
                     "type": "string"
@@ -12054,6 +12057,9 @@
                         "$ref": "#/definitions/ExperimentFunnelMetricStep"
                     },
                     "type": "array"
+                },
+                "sharedMetricId": {
+                    "type": "string"
                 },
                 "uuid": {
                     "type": "string"
@@ -12259,6 +12265,9 @@
                 "ignore_zeros": {
                     "type": "boolean"
                 },
+                "isSharedMetric": {
+                    "type": "boolean"
+                },
                 "kind": {
                     "const": "ExperimentMetric",
                     "type": "string"
@@ -12275,6 +12284,9 @@
                 },
                 "response": {
                     "type": "object"
+                },
+                "sharedMetricId": {
+                    "type": "string"
                 },
                 "source": {
                     "$ref": "#/definitions/ExperimentMetricSource"
@@ -12344,6 +12356,9 @@
                 "goal": {
                     "$ref": "#/definitions/ExperimentMetricGoal"
                 },
+                "isSharedMetric": {
+                    "type": "boolean"
+                },
                 "kind": {
                     "const": "ExperimentMetric",
                     "type": "string"
@@ -12353,6 +12368,9 @@
                 },
                 "response": {
                     "type": "object"
+                },
+                "sharedMetricId": {
+                    "type": "string"
                 },
                 "uuid": {
                     "type": "string"
@@ -12614,6 +12632,9 @@
                 "goal": {
                     "$ref": "#/definitions/ExperimentMetricGoal"
                 },
+                "isSharedMetric": {
+                    "type": "boolean"
+                },
                 "kind": {
                     "const": "ExperimentMetric",
                     "type": "string"
@@ -12630,6 +12651,9 @@
                 },
                 "response": {
                     "type": "object"
+                },
+                "sharedMetricId": {
+                    "type": "string"
                 },
                 "uuid": {
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2662,6 +2662,8 @@ export interface ExperimentMetricBaseProperties extends Node {
     conversion_window?: integer
     conversion_window_unit?: FunnelConversionWindowTimeUnit
     goal?: ExperimentMetricGoal
+    isSharedMetric?: boolean
+    sharedMetricId?: string
 }
 
 export type ExperimentMetricOutlierHandling = {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2663,7 +2663,7 @@ export interface ExperimentMetricBaseProperties extends Node {
     conversion_window_unit?: FunnelConversionWindowTimeUnit
     goal?: ExperimentMetricGoal
     isSharedMetric?: boolean
-    sharedMetricId?: string
+    sharedMetricId?: number
 }
 
 export type ExperimentMetricOutlierHandling = {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3968,9 +3968,11 @@ class ExperimentMetricBaseProperties(BaseModel):
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
     fingerprint: Optional[str] = None
     goal: Optional[ExperimentMetricGoal] = None
+    isSharedMetric: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
+    sharedMetricId: Optional[str] = None
     uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -12354,11 +12356,13 @@ class ExperimentRatioMetric(BaseModel):
     denominator: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
     fingerprint: Optional[str] = None
     goal: Optional[ExperimentMetricGoal] = None
+    isSharedMetric: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["ratio"] = "ratio"
     name: Optional[str] = None
     numerator: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
     response: Optional[dict[str, Any]] = None
+    sharedMetricId: Optional[str] = None
     uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -13273,11 +13277,13 @@ class ExperimentFunnelMetric(BaseModel):
     fingerprint: Optional[str] = None
     funnel_order_type: Optional[StepOrderValue] = None
     goal: Optional[ExperimentMetricGoal] = None
+    isSharedMetric: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["funnel"] = "funnel"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
     series: list[Union[EventsNode, ActionsNode]]
+    sharedMetricId: Optional[str] = None
     uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -13291,11 +13297,13 @@ class ExperimentMeanMetric(BaseModel):
     fingerprint: Optional[str] = None
     goal: Optional[ExperimentMetricGoal] = None
     ignore_zeros: Optional[bool] = None
+    isSharedMetric: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     lower_bound_percentile: Optional[float] = None
     metric_type: Literal["mean"] = "mean"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
+    sharedMetricId: Optional[str] = None
     source: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
     upper_bound_percentile: Optional[float] = None
     uuid: Optional[str] = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3972,7 +3972,7 @@ class ExperimentMetricBaseProperties(BaseModel):
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
-    sharedMetricId: Optional[str] = None
+    sharedMetricId: Optional[float] = None
     uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -12362,7 +12362,7 @@ class ExperimentRatioMetric(BaseModel):
     name: Optional[str] = None
     numerator: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
     response: Optional[dict[str, Any]] = None
-    sharedMetricId: Optional[str] = None
+    sharedMetricId: Optional[float] = None
     uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -13283,7 +13283,7 @@ class ExperimentFunnelMetric(BaseModel):
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
     series: list[Union[EventsNode, ActionsNode]]
-    sharedMetricId: Optional[str] = None
+    sharedMetricId: Optional[float] = None
     uuid: Optional[str] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -13303,7 +13303,7 @@ class ExperimentMeanMetric(BaseModel):
     metric_type: Literal["mean"] = "mean"
     name: Optional[str] = None
     response: Optional[dict[str, Any]] = None
-    sharedMetricId: Optional[str] = None
+    sharedMetricId: Optional[float] = None
     source: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
     upper_bound_percentile: Optional[float] = None
     uuid: Optional[str] = None


### PR DESCRIPTION
## Problem
In the frontend, we're enriching the metrics with extra fields `isSharedMetric` and `sharedMetricId`.

When the metric object is passed to the backend to create timeseries recalculation request, the schema validation fails since pydantic doesn't expect these:

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ExperimentMeanMetric
isSharedMetric
  Extra inputs are not permitted [type=extra_forbidden, input_value=True, input_type=bool]
    For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
sharedMetricId
  Extra inputs are not permitted [type=extra_forbidden, input_value=54127, input_type=int]
    For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
```

## Changes
Add these fields to the `ExperimentMetricBaseProperties` and mark them as optional.
I've considered removing these fields before passing to backend, but that seems even more brittle.

## How did you test this code?
👀 