### PR TITLE
fix(experiments): fix add metric button in pre-launch checklist

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/PreLaunchChecklist.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/PreLaunchChecklist.tsx
@@ -3,12 +3,15 @@ import { useActions, useValues } from 'kea'
 import { IconCheckCircle } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { METRIC_CONTEXTS } from '../Metrics/experimentMetricModalLogic'
+import { metricSourceModalLogic } from '../Metrics/metricSourceModalLogic'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 
 export function PreLaunchChecklist(): JSX.Element {
-    const { experiment } = useValues(experimentLogic)
+    const { experiment, usesNewQueryRunner } = useValues(experimentLogic)
     const { openDescriptionModal, openPrimaryMetricSourceModal } = useActions(modalsLogic)
+    const { openMetricSourceModal } = useActions(metricSourceModalLogic)
 
     return (
         <div>
@@ -98,7 +101,9 @@ export function PreLaunchChecklist(): JSX.Element {
                                         type="secondary"
                                         size="small"
                                         onClick={() => {
-                                            openPrimaryMetricSourceModal()
+                                            usesNewQueryRunner
+                                                ? openMetricSourceModal(METRIC_CONTEXTS.primary)
+                                                : openPrimaryMetricSourceModal()
                                         }}
                                     >
                                         Add metric


### PR DESCRIPTION
## Problem

Nothing happens when you click "Add metric".

The button always triggers the legacy modal state, but when using the new query runner, only the new modal is rendered (which listens to a completely different state/logic). Result: nothing happens.

## Changes
  The fix: PreLaunchChecklist needs to check usesNewQueryRunner and call the appropriate action:
  - If new runner: call openMetricSourceModal(METRIC_CONTEXTS.primary) from metricSourceModalLogic
  - If legacy: call openPrimaryMetricSourceModal() from modalsLogic

## How did you test this code?

- tested locally, modal opens fine now
