### PR TITLE
fix(experiments): Adjust fingerprint computation

### DIFF
--- a/dags/experiment_regular_metrics_timeseries.py
+++ b/dags/experiment_regular_metrics_timeseries.py
@@ -20,6 +20,7 @@ from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, Experim
 
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
+from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models.experiment import Experiment, ExperimentMetricResult
 
 from dags.common import JobOwners
@@ -228,7 +229,7 @@ def _get_experiment_regular_metrics_timeseries(
             fingerprint = compute_metric_fingerprint(
                 metric,
                 experiment.start_date,
-                experiment.stats_config,
+                get_experiment_stats_method(experiment),
                 experiment.exposure_criteria,
             )
 

--- a/dags/experiment_saved_metrics_timeseries.py
+++ b/dags/experiment_saved_metrics_timeseries.py
@@ -18,6 +18,7 @@ from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, Experim
 
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
+from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models.experiment import Experiment, ExperimentMetricResult
 
 from dags.common import JobOwners
@@ -225,7 +226,7 @@ def _get_experiment_saved_metrics_timeseries(context: dagster.SensorEvaluationCo
             fingerprint = compute_metric_fingerprint(
                 saved_metric.query,
                 experiment.start_date,
-                experiment.stats_config,
+                get_experiment_stats_method(experiment),
                 experiment.exposure_criteria,
             )
 

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -22,6 +22,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
+from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models import Survey
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.cohort import Cohort
@@ -131,7 +132,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                 saved_metric["query"]["fingerprint"] = compute_metric_fingerprint(
                     saved_metric["query"],
                     instance.start_date,
-                    instance.stats_config,
+                    get_experiment_stats_method(instance),
                     instance.exposure_criteria,
                 )
 
@@ -300,8 +301,9 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
         for metric_field in ["metrics", "metrics_secondary"]:
             if metric_field in validated_data:
                 for metric in validated_data[metric_field]:
+                    stats_method = "bayesian" if stats_config is None else stats_config.get("method", "bayesian")
                     metric["fingerprint"] = compute_metric_fingerprint(
-                        metric, validated_data.get("start_date"), stats_config, validated_data.get("exposure_criteria")
+                        metric, validated_data.get("start_date"), stats_method, validated_data.get("exposure_criteria")
                     )
 
         experiment = Experiment.objects.create(
@@ -477,10 +479,11 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                 updated_metrics = []
                 for metric in metrics:
                     metric_copy = deepcopy(metric)
+                    stats_method = "bayesian" if stats_config is None else stats_config.get("method", "bayesian")
                     metric_copy["fingerprint"] = compute_metric_fingerprint(
                         metric_copy,
                         start_date,
-                        stats_config,
+                        stats_method,
                         exposure_criteria,
                     )
                     updated_metrics.append(metric_copy)

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -2695,9 +2695,9 @@ class TestExperimentCRUD(APILicensedTest):
         initial_metrics = response.json()["metrics"]
 
         expected_initial_fingerprints = {
-            "mean": "fd431b59b934ba0d2dc650f54a37da146f7532eb7a93bbcf78b9cfdbfcad0d26",
-            "funnel": "d25af73845180f7327572cd9a2cd8745432f1eed5bfa6b0d35d0a368c7175038",
-            "ratio": "fb2f447c7b49bc8973fd3dfd5fb5cd4f33523b4ed2281f6bd33def84fe95dc62",
+            "mean": "1a5694c7330b8fb9f920fa6f1e6d871cc07e55e9d87447cb01a3384ed732c605",
+            "funnel": "bf2d01d67d7a1f608177b6f3a9971a6c263870d23ad5935054b5069286575a94",
+            "ratio": "3332b31c0ec0c8be353d5ed1f5740758affc9136d9721dba60434cbe104adb95",
         }
 
         for metric in initial_metrics:
@@ -2756,9 +2756,9 @@ class TestExperimentCRUD(APILicensedTest):
         updated_metrics = response.json()["metrics"]
 
         expected_updated_fingerprints = {
-            "mean": "61e7a1f22f967262749b72ea086eae04fe2ced040eeb179d7d25a3be32a7ea31",
-            "funnel": "5c21352fe6e13282ca63b24f128ed7e0d8f0cc9d5988964b1bf89b11f4405b23",
-            "ratio": "9b81f680dbc8ff74978877e6eb3827bbafc881f7df80841648e5b97c85452977",
+            "mean": "d6a393e5456b71c16961c45e07eb17cb86e4f7972549033f9883c99430248c02",
+            "funnel": "9f7888cb2f7f9c3dac2b6482a964eef6911f97e376ed53305ed6653f7f70ce9b",
+            "ratio": "1b83a833a62ff9c2f01ba86be1f3e578b97749d3264e08ff9e76d863865e3ff3",
         }
 
         for metric in updated_metrics:

--- a/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
+++ b/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
@@ -22,7 +22,7 @@ METRIC_FIELDS_TO_IGNORE: set[str] = {
 
 
 def compute_metric_fingerprint(
-    metric: dict, start_date: Any, stats_config: dict | None, exposure_criteria: dict | None
+    metric: dict, start_date: Any, stats_method: str | None = None, exposure_criteria: dict | None = None
 ) -> str:
     """
     Compute fingerprint for a metric.
@@ -30,7 +30,7 @@ def compute_metric_fingerprint(
     Args:
         metric: The metric definition
         start_date: Experiment start date
-        stats_config
+        stats_method
         exposure_criteria
 
     Returns:
@@ -47,10 +47,13 @@ def compute_metric_fingerprint(
     else:
         start_date_str = start_date
 
+    if stats_method is None:
+        stats_method = "bayesian"
+
     fingerprint_data = {
         "metric": clean_metric,
         "start_date": start_date_str,
-        "stats_config": stats_config,
+        "stats_method": stats_method,
     }
 
     if exposure_criteria:


### PR DESCRIPTION
## Problem
I've made a mistake when setting up the `compute_metric_fingerprint method`. Right now, it includes the entire `stats_config` object in the computation, when all we really care about is the `stats.method`. Going forward this will be problematic - if we add any new fields to `stats_config`, this will invalidate existing fingerprints.

## Changes
Instead of `stats_config`, only include `stats_config.method` in the fingerprint.

This will invalidate timeseries data in ~20 production experiments. I will manually run recalculations for them.

## How did you test this code?
Updated tests