### PR TITLE
fix(msg): segment destinations make fields secret based on list

### DIFF
--- a/plugin-server/src/cdp/segment/__snapshots__/segment-templates.test.ts.snap
+++ b/plugin-server/src/cdp/segment/__snapshots__/segment-templates.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`segment templates template segment-actions-absmartly matches expected result 1`] = `
 {
@@ -25,7 +25,7 @@ exports[`segment templates template segment-actions-absmartly matches expected r
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -892,7 +892,7 @@ exports[`segment templates template segment-actions-algolia-insights matches exp
       "key": "apiKey",
       "label": "apiKey",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -1615,7 +1615,7 @@ exports[`segment templates template segment-actions-amplitude matches expected r
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -1624,7 +1624,7 @@ exports[`segment templates template segment-actions-amplitude matches expected r
       "key": "secretKey",
       "label": "Secret Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -7139,7 +7139,7 @@ exports[`segment templates template segment-actions-attentive matches expected r
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -7258,7 +7258,7 @@ exports[`segment templates template segment-actions-blend-ai matches expected re
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -7376,7 +7376,7 @@ exports[`segment templates template segment-actions-canny matches expected resul
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -8510,7 +8510,7 @@ exports[`segment templates template segment-actions-drip matches expected result
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -9952,7 +9952,7 @@ exports[`segment templates template segment-actions-hyperengage matches expected
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -10955,7 +10955,7 @@ exports[`segment templates template segment-actions-iterable matches expected re
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -13433,7 +13433,7 @@ exports[`segment templates template segment-actions-mixpanel matches expected re
       "key": "apiSecret",
       "label": "Secret Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -23783,7 +23783,7 @@ exports[`segment templates template segment-actions-ripe-cloud matches expected 
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -24779,7 +24779,7 @@ exports[`segment templates template segment-actions-schematic matches expected r
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -24990,7 +24990,7 @@ exports[`segment templates template segment-actions-sprig matches expected resul
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -26775,7 +26775,7 @@ exports[`segment templates template segment-actions-usermotion matches expected 
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -27034,7 +27034,7 @@ exports[`segment templates template segment-actions-userpilot-cloud matches expe
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -27264,7 +27264,7 @@ exports[`segment templates template segment-actions-voyage matches expected resu
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -27494,7 +27494,7 @@ exports[`segment templates template segment-actions-vwo-cloud matches expected r
       "key": "apikey",
       "label": "VWO SDK Key",
       "required": false,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -27910,7 +27910,7 @@ exports[`segment templates template segment-actions-xtremepush matches expected 
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -28642,7 +28642,7 @@ exports[`segment templates template segment-encharge-cloud-actions matches expec
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -29370,7 +29370,7 @@ exports[`segment templates template segment-inleads-ai matches expected result 1
       "key": "apiKey",
       "label": "API Key",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {
@@ -30535,7 +30535,7 @@ exports[`segment templates template segment-voucherify-actions matches expected 
       "key": "apiKey",
       "label": "Application ID",
       "required": true,
-      "secret": false,
+      "secret": true,
       "type": "string",
     },
     {

--- a/plugin-server/src/cdp/segment/segment-templates.ts
+++ b/plugin-server/src/cdp/segment/segment-templates.ts
@@ -362,6 +362,24 @@ const getFieldDescription = (description: string) => {
     return description.replaceAll(/\[([^\]]+)\]\(https?:\/\/[^\/]*segment\.com[^)]*\)(\s*\{:.*?\})?/g, '$1') // Remove segment.com links completely, keeping only the link text
 }
 
+export const RESERVED_FIELD_NAMES = [
+    'oauth',
+    'oauth2',
+    'accesstoken',
+    'access-token',
+    'acccess_token',
+    'refresh-token',
+    'refresh_token',
+    'token_type',
+    'apikey',
+    'apisecret',
+    'clientsecret',
+    'password',
+    'secretkey',
+    'secret',
+    'securitytoken',
+]
+
 const translateInputsSchema = (
     inputs_schema: Record<string, any> | undefined,
     mapping?: Record<string, any> | undefined
@@ -378,7 +396,7 @@ const translateInputsSchema = (
             description: getFieldDescription(field.description),
             default: getDefaultValue(key, field, mapping),
             required: field.required ?? false,
-            secret: field.type === 'password' ? true : false,
+            secret: field.type === 'password' || RESERVED_FIELD_NAMES.includes(key.toLowerCase()) ? true : false,
             ...(field.choices ? { choices: field.choices } : {}),
         })) as HogFunctionInputSchemaType[]
 }

--- a/plugin-server/src/cdp/segment/segment-templates.ts
+++ b/plugin-server/src/cdp/segment/segment-templates.ts
@@ -362,7 +362,7 @@ const getFieldDescription = (description: string) => {
     return description.replaceAll(/\[([^\]]+)\]\(https?:\/\/[^\/]*segment\.com[^)]*\)(\s*\{:.*?\})?/g, '$1') // Remove segment.com links completely, keeping only the link text
 }
 
-export const RESERVED_FIELD_NAMES = [
+const SECRET_FIELD_NAMES = [
     'oauth',
     'oauth2',
     'accesstoken',
@@ -396,7 +396,7 @@ const translateInputsSchema = (
             description: getFieldDescription(field.description),
             default: getDefaultValue(key, field, mapping),
             required: field.required ?? false,
-            secret: field.type === 'password' || RESERVED_FIELD_NAMES.includes(key.toLowerCase()) ? true : false,
+            secret: field.type === 'password' || SECRET_FIELD_NAMES.includes(key.toLowerCase()) ? true : false,
             ...(field.choices ? { choices: field.choices } : {}),
         })) as HogFunctionInputSchemaType[]
 }


### PR DESCRIPTION
## Problem

Some secret fields weren't marked as secret's

## Changes

- Mark them as secret fields based on a list of `RESERVED_FIELD_NAMES`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
