### PR TITLE
chore(workflows): make exit condition copy more clear

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -470,15 +470,15 @@ function ExitConditionSection(): JSX.Element {
                         },
                         {
                             value: 'exit_on_trigger_not_matched',
-                            label: 'Exit on trigger not matched',
+                            label: 'Exit when trigger filter(s) no longer match',
                         },
                         {
                             value: 'exit_on_conversion',
-                            label: 'Exit on conversion',
+                            label: 'Exit when conversion condition is met',
                         },
                         {
                             value: 'exit_on_trigger_not_matched_or_conversion',
-                            label: 'Exit on trigger not matched or conversion',
+                            label: 'Exit when trigger filter(s) no longer match or when conversion condition is met',
                         },
                     ]}
                 />

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -466,19 +466,19 @@ function ExitConditionSection(): JSX.Element {
                     options={[
                         {
                             value: 'exit_only_at_end',
-                            label: 'Exit at end of workflow',
+                            label: 'Exit only once workflow reaches the end',
                         },
                         {
                             value: 'exit_on_trigger_not_matched',
-                            label: 'Exit when trigger filter(s) no longer match',
+                            label: 'Exit when trigger filters no longer match',
                         },
                         {
                             value: 'exit_on_conversion',
-                            label: 'Exit when conversion condition is met',
+                            label: 'Exit when conversion goal is met',
                         },
                         {
                             value: 'exit_on_trigger_not_matched_or_conversion',
-                            label: 'Exit when trigger filter(s) no longer match or when conversion condition is met',
+                            label: 'Exit when trigger filters no longer match, or when conversion goal is met',
                         },
                     ]}
                 />


### PR DESCRIPTION
## Problem

Early feedback suggests these exit conditions are not super intuitive, tweaking to explain very clearly.

## Changes

<img width="623" height="245" alt="image" src="https://github.com/user-attachments/assets/7aabdb7e-f598-4495-a67b-255e7c4d3f46" />


## How did you test this code?
See above
