### PR TITLE
fix(cohorts): Use ConnectionRouter for writing CohortPeople

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -519,9 +519,10 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         current_batch_index = -1
         processing_error = None
         try:
-            from django.db import connections
+            from django.db import connections, router
 
-            persons_connection = connections[READ_DB_FOR_PERSONS]
+            write_db = router.db_for_write(CohortPeople) or "default"
+            persons_connection = connections[write_db]
             cursor = persons_connection.cursor()
             for batch_index, batch in batch_iterator:
                 current_batch_index = batch_index


### PR DESCRIPTION
## Problem

Foreign key constraint violations are being raised when creating records in `posthog_cohortpeople`. See the following exception:
https://us.posthog.com/project/2/error_tracking/0199e7f6-b0be-7eb0-b98b-e01205817b34

This FK only exists in the default database. If it was routed to the new `posthog_persons` db, we wouldn't see this occur.

Additionally, the cursor is later used to write to `posthog_cohortpeople`, so it shouldn't use a connection to a read-only database.

## How did you test this code?

This is (and has been) passing tests and working locally. Database configuration is different in production, so we won't know if this works for sure until it's been deployed.