### PR TITLE
chore: deflake a performance test

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.test.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.test.ts
@@ -35,7 +35,7 @@ describe('process all snapshots', () => {
             expect(snapshots).toHaveLength(99)
 
             const durations: number[] = []
-            const runs = 5
+            const runs = 10
 
             for (let i = 0; i < runs; i++) {
                 const start = performance.now()
@@ -67,9 +67,13 @@ describe('process all snapshots', () => {
             }
 
             durations.sort((a, b) => a - b)
-            const median = durations[Math.floor(runs / 2)]
-            const mean = durations.reduce((sum, d) => sum + d, 0) / runs
-            const stdDev = Math.sqrt(durations.reduce((sum, d) => sum + (d - mean) ** 2, 0) / runs)
+            // Drop slowest 2 runs (typically first runs with cold JIT/cache)
+            const trimmedDurations = durations.slice(0, -2)
+            const median = trimmedDurations[Math.floor(trimmedDurations.length / 2)]
+            const mean = trimmedDurations.reduce((sum, d) => sum + d, 0) / trimmedDurations.length
+            const stdDev = Math.sqrt(
+                trimmedDurations.reduce((sum, d) => sum + (d - mean) ** 2, 0) / trimmedDurations.length
+            )
 
             expect(median).toBeLessThan(50)
             expect(stdDev).toBeLessThan(25)


### PR DESCRIPTION
this recently started to flake... annoying

let's run multiple times and check median and std dev, to try and reduce impact of some CPU contention in an actions runner