### PR TITLE
chore(flags): Schedule update of feature flag last_called_at

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -2,7 +2,7 @@ import os
 import json
 from contextlib import suppress
 
-from posthog.settings.utils import get_list
+from posthog.settings.utils import get_from_env, get_list
 
 # The features here are released on the frontend, but the flags are just not yet removed from the code
 # WARNING: ONLY the frontend has feature flag overrides. Flags on the backend will NOT be affected by this setting
@@ -32,3 +32,14 @@ REMOTE_CONFIG_RATE_LIMITS: dict[int, str] = {}
 with suppress(Exception):
     as_json = json.loads(os.getenv("REMOTE_CONFIG_RATE_LIMITS", "{}"))
     REMOTE_CONFIG_RATE_LIMITS = {int(k): str(v) for k, v in as_json.items()}
+
+# Feature flag last_called_at sync settings
+FEATURE_FLAG_LAST_CALLED_AT_SYNC_BATCH_SIZE: int = get_from_env(
+    "FEATURE_FLAG_LAST_CALLED_AT_SYNC_BATCH_SIZE", 1000, type_cast=int
+)
+FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT: int = get_from_env(
+    "FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT", 100000, type_cast=int
+)
+FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS: int = get_from_env(
+    "FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS", 1, type_cast=int
+)

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -50,6 +50,7 @@ from posthog.tasks.tasks import (
     start_poll_query_performance,
     stop_surveys_reached_target,
     sync_all_organization_available_product_features,
+    sync_feature_flag_last_called,
     update_event_partitions,
     update_survey_adaptive_sampling,
     update_survey_iteration,
@@ -158,6 +159,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(minute="*/30"),
         calculate_decide_usage.s(),
         name="calculate decide usage",
+    )
+
+    # Sync feature flag last_called_at timestamps from ClickHouse every 30 minutes
+    sender.add_periodic_task(
+        crontab(minute="*/30"),
+        sync_feature_flag_last_called.s(),
+        name="sync feature flag last_called_at timestamps",
+        expires=1800,  # 30 minutes - prevents stale tasks from running
     )
 
     # Reset master project data every Monday at Thursday at 5 AM UTC. Mon and Thu because doing this every day

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -930,6 +930,182 @@ def background_delete_model_task(
         raise
 
 
+@shared_task(
+    ignore_result=True,
+    queue=CeleryQueue.DEFAULT.value,
+    autoretry_for=(Exception,),
+    retry_backoff=30,
+    retry_backoff_max=120,
+    max_retries=3,
+)
+def sync_feature_flag_last_called() -> None:
+    """
+    Sync last_called_at timestamps from ClickHouse $feature_flag_called events to PostgreSQL.
+
+    This task:
+    1. Uses Redis locking to prevent concurrent executions
+    2. Gets the last sync timestamp from Redis checkpoint
+    3. Queries ClickHouse for flag usage since last sync
+    4. Bulk updates PostgreSQL with latest timestamps
+    5. Updates the sync checkpoint in Redis
+
+    Concurrency Control:
+    - Uses Redis cache lock to prevent overlapping runs
+    - Lock timeout matches schedule interval (1800s = 30 minutes)
+    - Task expires after 1800 seconds if queued but not started (via scheduled.py)
+    - No time limits - task runs until complete
+
+    Configuration (via settings.feature_flags):
+    - FEATURE_FLAG_LAST_CALLED_AT_SYNC_BATCH_SIZE: Bulk update batch size (default: 1000)
+    - FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT: Max ClickHouse results (default: 100000)
+    - FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS: Fallback lookback period (default: 1)
+    """
+    from datetime import datetime, timedelta
+
+    from django.core.cache import cache
+
+    from posthog.clickhouse.client import sync_execute
+    from posthog.exceptions_capture import capture_exception
+    from posthog.models.feature_flag.feature_flag import FeatureFlag
+
+    FEATURE_FLAG_LAST_CALLED_SYNC_KEY = "posthog:feature_flag_last_called_sync:last_timestamp"
+    LOCK_KEY = "posthog:feature_flag_last_called_sync:lock"
+    LOCK_TIMEOUT = 1800  # 30 minutes = schedule interval (prevents concurrent execution)
+
+    # Attempt to acquire lock
+    if not cache.add(LOCK_KEY, "locked", timeout=LOCK_TIMEOUT):
+        logger.info("Feature flag sync already running, skipping")
+        return
+
+    start_time = timezone.now()
+
+    try:
+        redis_client = get_client()
+
+        # Get last sync timestamp from Redis or use lookback
+        try:
+            last_sync_str = redis_client.get(FEATURE_FLAG_LAST_CALLED_SYNC_KEY)
+            last_sync_timestamp = (
+                datetime.fromisoformat(last_sync_str.decode())
+                if last_sync_str
+                else timezone.now() - timedelta(days=settings.FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS)
+            )
+        except Exception as e:
+            logger.warning("Failed to get or parse last sync timestamp", error=str(e))
+            last_sync_timestamp = timezone.now() - timedelta(
+                days=settings.FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS
+            )
+
+        current_sync_timestamp = timezone.now()
+
+        logger.info(
+            "Starting feature flag sync",
+            last_sync_timestamp=last_sync_timestamp.isoformat(),
+            current_sync_timestamp=current_sync_timestamp.isoformat(),
+        )
+
+        # Query ClickHouse for flag usage since last sync
+        # Limit for insurance against large datasets and memory issues during a surge
+        result = sync_execute(
+            """
+            SELECT
+                team_id,
+                JSONExtractString(properties, '$feature_flag') as flag_key,
+                max(timestamp) as last_called_at,
+                count() as call_count
+            FROM events
+            PREWHERE event = '$feature_flag_called'
+            WHERE timestamp > %(last_sync_timestamp)s
+              AND timestamp <= %(current_sync_timestamp)s
+              AND JSONExtractString(properties, '$feature_flag') != ''
+            GROUP BY team_id, flag_key
+            ORDER BY last_called_at DESC
+            LIMIT %(limit)s
+            """,
+            {
+                "last_sync_timestamp": last_sync_timestamp,
+                "current_sync_timestamp": current_sync_timestamp,
+                "limit": settings.FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT,
+            },
+        )
+
+        if not result:
+            # Update checkpoint even if no results
+            redis_client.set(FEATURE_FLAG_LAST_CALLED_SYNC_KEY, current_sync_timestamp.isoformat())
+            logger.info(
+                "Feature flag sync completed with no events",
+                duration_seconds=(timezone.now() - start_time).total_seconds(),
+            )
+            return
+
+        # Collect flags for bulk update
+        flags_to_update = []
+
+        # Get latest timestamp for checkpoint, fallback to current if all None
+        checkpoint_timestamp = max((row[2] for row in result if row[2]), default=current_sync_timestamp)
+
+        # Build lookup map of (team_id, key) -> timestamp from ClickHouse results
+        flag_updates = {(row[0], row[1]): row[2] for row in result}
+
+        # Batch fetch all relevant flags in a single query
+        team_ids = list({row[0] for row in result})
+        flag_keys = list({row[1] for row in result})
+
+        flags = FeatureFlag.objects.filter(team_id__in=team_ids, key__in=flag_keys)
+
+        for flag in flags:
+            new_timestamp = flag_updates.get((flag.team_id, flag.key))
+            if new_timestamp and (flag.last_called_at is None or flag.last_called_at < new_timestamp):
+                flag.last_called_at = new_timestamp
+                flags_to_update.append(flag)
+
+        # Perform bulk update
+        updated_count = 0
+        if flags_to_update:
+            try:
+                FeatureFlag.objects.bulk_update(
+                    flags_to_update,
+                    ["last_called_at"],
+                    batch_size=settings.FEATURE_FLAG_LAST_CALLED_AT_SYNC_BATCH_SIZE,
+                )
+                updated_count = len(flags_to_update)
+            except Exception as e:
+                capture_exception(e, additional_properties={"flags_count": len(flags_to_update)})
+                raise
+
+        # Store checkpoint for next sync using the latest timestamp from results
+        redis_client.set(FEATURE_FLAG_LAST_CALLED_SYNC_KEY, checkpoint_timestamp.isoformat())
+
+        duration = (timezone.now() - start_time).total_seconds()
+
+        logger.info(
+            "Feature flag sync completed",
+            updated_count=updated_count,
+            processed_events=sum(row[3] for row in result),
+            clickhouse_results=len(result),
+            duration_seconds=duration,
+        )
+
+        # Alert if approaching schedule interval (25 min warning threshold)
+        if duration > 1500:
+            logger.warning(
+                "Feature flag sync taking longer than expected",
+                duration_seconds=duration,
+                updated_count=updated_count,
+                processed_events=sum(row[3] for row in result),
+                recommendation="Consider reducing FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT or optimizing query",
+            )
+
+    except Exception as e:
+        duration = (timezone.now() - start_time).total_seconds()
+        logger.exception("Feature flag sync failed", error=e, duration_seconds=duration)
+        capture_exception(e)
+        raise
+    finally:
+        # Always release the lock
+        cache.delete(LOCK_KEY)
+
+
 @shared_task(ignore_result=True, time_limit=7200)
 def refresh_activity_log_fields_cache(flush: bool = False, hours_back: int = 14) -> None:
     """

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1075,7 +1075,14 @@ def sync_feature_flag_last_called() -> None:
                 )
                 updated_count = len(flags_to_update)
             except Exception as e:
-                capture_exception(e, additional_properties={"flags_count": len(flags_to_update)})
+                capture_exception(
+                    e,
+                    additional_properties={
+                        "feature": "feature_flags",
+                        "task": "sync_feature_flag_last_called",
+                        "flags_count": len(flags_to_update),
+                    },
+                )
                 raise
 
         # Store checkpoint for next sync using the latest timestamp from results
@@ -1104,7 +1111,9 @@ def sync_feature_flag_last_called() -> None:
     except Exception as e:
         duration = (timezone.now() - start_time).total_seconds()
         logger.exception("Feature flag sync failed", error=e, duration_seconds=duration)
-        capture_exception(e)
+        capture_exception(
+            e, additional_properties={"feature": "feature_flags", "task": "sync_feature_flag_last_called"}
+        )
         raise
     finally:
         # Always release the lock

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1060,9 +1060,12 @@ def sync_feature_flag_last_called() -> None:
 
         for flag in flags:
             new_timestamp = flag_updates.get((flag.team_id, flag.key))
-            if new_timestamp and (flag.last_called_at is None or flag.last_called_at < new_timestamp):
-                flag.last_called_at = new_timestamp
-                flags_to_update.append(flag)
+            if new_timestamp:
+                # Ensure timestamp from ClickHouse is timezone-aware before comparison
+                new_timestamp = new_timestamp if new_timestamp.tzinfo else timezone.make_aware(new_timestamp)
+                if flag.last_called_at is None or flag.last_called_at < new_timestamp:
+                    flag.last_called_at = new_timestamp
+                    flags_to_update.append(flag)
 
         # Perform bulk update
         updated_count = 0

--- a/posthog/tasks/test/test_feature_flag_sync.py
+++ b/posthog/tasks/test/test_feature_flag_sync.py
@@ -1,0 +1,346 @@
+from datetime import datetime
+
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, Mock, patch
+
+from django.core.cache import cache
+from django.test import override_settings
+from django.utils import timezone as tz
+
+from posthog.models import FeatureFlag
+from posthog.tasks.tasks import sync_feature_flag_last_called
+
+
+def mock_redis_client() -> Mock:
+    """Mock Redis client with in-memory storage"""
+    mock = Mock()
+    mock.storage = {}
+    mock.get = lambda k: mock.storage.get(k)
+    mock.set = lambda k, v: mock.storage.update({k: v}) or None
+    return mock
+
+
+class TestSyncFeatureFlagLastCalled(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        # Clear Redis cache before each test
+        cache.clear()
+
+        # Create test flags
+        self.flag1 = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag-1",
+            created_by=self.user,
+            last_called_at=None,
+        )
+        self.flag2 = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag-2",
+            created_by=self.user,
+            last_called_at=tz.make_aware(datetime(2024, 1, 1, 0, 0, 0)),
+        )
+        self.flag3 = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag-3",
+            created_by=self.user,
+            last_called_at=tz.make_aware(datetime(2024, 6, 1, 0, 0, 0)),
+        )
+
+    def tearDown(self) -> None:
+        cache.clear()
+        super().tearDown()
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_no_events_updates_checkpoint(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """When there are no events, checkpoint should still be updated"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+        mock_sync_execute.return_value = []
+
+        sync_feature_flag_last_called()
+
+        # Verify checkpoint was updated in Redis
+        checkpoint_key = "posthog:feature_flag_last_called_sync:last_timestamp"
+        assert checkpoint_key in redis_mock.storage
+
+        # Verify no flags were updated
+        self.flag1.refresh_from_db()
+        assert self.flag1.last_called_at is None
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_existing_checkpoint_used(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Task should use existing checkpoint if available"""
+        redis_mock = mock_redis_client()
+        checkpoint_time = tz.make_aware(datetime(2024, 6, 14, 12, 0, 0))
+        checkpoint_key = "posthog:feature_flag_last_called_sync:last_timestamp"
+        redis_mock.storage[checkpoint_key] = checkpoint_time.isoformat().encode()
+
+        mock_get_client.return_value = redis_mock
+        mock_sync_execute.return_value = []
+
+        sync_feature_flag_last_called()
+
+        # Verify query used checkpoint time
+        call_args = mock_sync_execute.call_args
+        params = call_args[0][1]
+        assert params["last_sync_timestamp"] == checkpoint_time
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_updates_null_timestamps(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Flags with null last_called_at should be updated"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+
+        latest_timestamp = tz.make_aware(datetime(2024, 6, 15, 11, 0, 0))
+        mock_sync_execute.return_value = [
+            (self.team.pk, self.flag1.key, latest_timestamp, 100),
+        ]
+
+        sync_feature_flag_last_called()
+
+        self.flag1.refresh_from_db()
+        assert self.flag1.last_called_at == latest_timestamp
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_updates_only_more_recent_timestamps(
+        self, mock_get_client: MagicMock, mock_sync_execute: MagicMock
+    ) -> None:
+        """Only update timestamps that are more recent than existing ones"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+
+        # flag2 has last_called_at=2024-01-01, flag3 has last_called_at=2024-06-01
+        older_timestamp = tz.make_aware(datetime(2023, 12, 1, 0, 0, 0))  # Older than flag2's 2024-01-01
+        newer_timestamp = tz.make_aware(datetime(2024, 9, 1, 0, 0, 0))  # Newer than flag3's 2024-06-01
+
+        mock_sync_execute.return_value = [
+            (self.team.pk, self.flag2.key, older_timestamp, 50),  # Should NOT update (older)
+            (self.team.pk, self.flag3.key, newer_timestamp, 75),  # Should update (newer)
+        ]
+
+        sync_feature_flag_last_called()
+
+        self.flag2.refresh_from_db()
+        self.flag3.refresh_from_db()
+
+        # flag2 should remain unchanged
+        assert self.flag2.last_called_at == tz.make_aware(datetime(2024, 1, 1, 0, 0, 0))
+
+        # flag3 should be updated
+        assert self.flag3.last_called_at == newer_timestamp
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_handles_nonexistent_flags(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Should gracefully handle flags that don't exist in database"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+
+        mock_sync_execute.return_value = [
+            (self.team.pk, self.flag1.key, tz.make_aware(datetime(2024, 6, 15, 11, 0, 0)), 100),
+            (self.team.pk, "nonexistent-flag", tz.make_aware(datetime(2024, 6, 15, 11, 0, 0)), 50),
+        ]
+
+        # Should not raise an exception
+        sync_feature_flag_last_called()
+
+        # flag1 should still be updated
+        self.flag1.refresh_from_db()
+        assert self.flag1.last_called_at is not None
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    @override_settings(FEATURE_FLAG_LAST_CALLED_AT_SYNC_BATCH_SIZE=2)
+    def test_bulk_update_respects_batch_size(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Bulk updates should respect configured batch size"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+
+        # Create additional flags
+        flag4 = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag-4",
+            created_by=self.user,
+            last_called_at=None,
+        )
+        flag5 = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag-5",
+            created_by=self.user,
+            last_called_at=None,
+        )
+
+        timestamp = tz.make_aware(datetime(2024, 6, 15, 11, 0, 0))
+        mock_sync_execute.return_value = [
+            (self.team.pk, self.flag1.key, timestamp, 100),
+            (self.team.pk, self.flag2.key, timestamp, 100),
+            (self.team.pk, self.flag3.key, timestamp, 100),
+            (self.team.pk, flag4.key, timestamp, 100),
+            (self.team.pk, flag5.key, timestamp, 100),
+        ]
+
+        sync_feature_flag_last_called()
+
+        # Verify all flags were updated
+        self.flag1.refresh_from_db()
+        self.flag2.refresh_from_db()
+        self.flag3.refresh_from_db()
+        flag4.refresh_from_db()
+        flag5.refresh_from_db()
+
+        assert self.flag1.last_called_at == timestamp
+        assert self.flag2.last_called_at == timestamp
+        assert self.flag3.last_called_at == timestamp
+        assert flag4.last_called_at == timestamp
+        assert flag5.last_called_at == timestamp
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_redis_error_falls_back_to_lookback_days(
+        self, mock_get_client: MagicMock, mock_sync_execute: MagicMock
+    ) -> None:
+        """When checkpoint cannot be retrieved, fall back to lookback_days"""
+        redis_mock = mock_redis_client()
+        # Make redis.get() raise an exception
+        redis_mock.get = Mock(side_effect=Exception("Redis error"))
+        mock_get_client.return_value = redis_mock
+        mock_sync_execute.return_value = []
+
+        sync_feature_flag_last_called()
+
+        # Verify query used lookback_days
+        call_args = mock_sync_execute.call_args
+        params = call_args[0][1]
+        # Should query back 1 day (default FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS)
+        last_sync = params["last_sync_timestamp"]
+        assert last_sync.year == 2024
+        assert last_sync.month == 6
+        assert last_sync.day == 14
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_concurrent_execution_prevented(self, mock_get_client: MagicMock) -> None:
+        """Only one instance should execute at a time due to lock"""
+        lock_key = "posthog:feature_flag_last_called_sync:lock"
+
+        # Set lock to prevent execution
+        cache.set(lock_key, "locked", timeout=600)
+
+        with patch("posthog.clickhouse.client.sync_execute") as mock_sync_execute:
+            sync_feature_flag_last_called()
+
+            # Task should exit early without executing query
+            mock_sync_execute.assert_not_called()
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_lock_released_after_execution(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Lock should be released after successful execution"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+        mock_sync_execute.return_value = []
+        lock_key = "posthog:feature_flag_last_called_sync:lock"
+
+        sync_feature_flag_last_called()
+
+        # Lock should be deleted
+        assert cache.get(lock_key) is None
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_lock_released_after_exception(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Lock should be released even if task raises exception"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+        mock_sync_execute.side_effect = Exception("Database error")
+        lock_key = "posthog:feature_flag_last_called_sync:lock"
+
+        # Task should raise exception but still clean up lock
+        try:
+            sync_feature_flag_last_called()
+        except Exception:
+            pass
+
+        # Lock should be deleted
+        assert cache.get(lock_key) is None
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_handles_invalid_timestamps(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Should handle None or invalid timestamps from ClickHouse"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+
+        mock_sync_execute.return_value = [
+            (self.team.pk, self.flag1.key, None, 10),  # Invalid timestamp
+            (self.team.pk, self.flag2.key, tz.make_aware(datetime(2024, 6, 15, 11, 0, 0)), 20),  # Valid timestamp
+        ]
+
+        sync_feature_flag_last_called()
+
+        # flag1 should remain unchanged
+        self.flag1.refresh_from_db()
+        assert self.flag1.last_called_at is None
+
+        # flag2 should be updated
+        self.flag2.refresh_from_db()
+        assert self.flag2.last_called_at is not None
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    def test_checkpoint_updated_to_latest_timestamp(
+        self, mock_get_client: MagicMock, mock_sync_execute: MagicMock
+    ) -> None:
+        """Checkpoint should be updated to the latest timestamp from results"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+
+        earliest_timestamp = tz.make_aware(datetime(2024, 6, 15, 10, 0, 0))
+        latest_timestamp = tz.make_aware(datetime(2024, 6, 15, 11, 59, 59))
+
+        mock_sync_execute.return_value = [
+            (self.team.pk, self.flag1.key, earliest_timestamp, 10),
+            (self.team.pk, self.flag2.key, tz.make_aware(datetime(2024, 6, 15, 11, 30, 0)), 20),
+            (self.team.pk, self.flag3.key, latest_timestamp, 30),
+        ]
+
+        sync_feature_flag_last_called()
+
+        # Checkpoint should be set to latest timestamp
+        checkpoint_key = "posthog:feature_flag_last_called_sync:last_timestamp"
+        stored_timestamp = redis_mock.storage.get(checkpoint_key)
+        assert stored_timestamp is not None
+        assert latest_timestamp.isoformat() in stored_timestamp
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
+    @override_settings(FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT=2)
+    def test_respects_clickhouse_limit(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """Query should respect FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT setting"""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+        mock_sync_execute.return_value = []
+
+        sync_feature_flag_last_called()
+
+        # Verify query includes LIMIT clause with configured value
+        call_args = mock_sync_execute.call_args
+        params = call_args[0][1]
+        assert params["limit"] == 2


### PR DESCRIPTION
This is a follow-up to https://github.com/PostHog/posthog/pull/38962

This creates a Celery schedule to run a task to update the `last_called_at` column for every feature flag based on `$feature_flag_called` events in Clickhouse.

The task runs every 30 minutes.

## Problem

We want to start tracking the last time a flag was called.

## Changes

Adds a Celery task that runs every 30 minutes. It uses redis locking to ensure only one instance is running at a time. It runs a clickhouse query to get the last time a flag was called looking at `$feature_flag_called` events and updates the new `last_called_at` column with this information. This is not yet exposed to users.

## How did you test this code?

Manually.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
