### PR TITLE
fix(data-warehouse): Deltalake table engine now takes format

### DIFF
--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -96,6 +96,8 @@ def build_function_call(
 
             expr += f", {escaped_access_key}, {escaped_access_secret}"
 
+        expr += ", 'Parquet'"
+
         if structure:
             expr += f", {escaped_structure}"
 

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -277,7 +277,7 @@ class TestS3Table(BaseTest):
         res = build_function_call(
             "http://url.com", DataWarehouseTable.TableFormat.Delta, None, "key", "secret", "some structure", None
         )
-        assert res == "deltaLake('http://url.com', 'key', 'secret', 'some structure')"
+        assert res == "deltaLake('http://url.com', 'key', 'secret')"
 
     def test_s3_build_function_call_azure(self):
         res = build_function_call(

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -247,7 +247,7 @@ class TestS3Table(BaseTest):
         res = build_function_call(
             "http://url.com", DataWarehouseTable.TableFormat.Delta, None, "key", "secret", None, None
         )
-        assert res == "deltaLake('http://url.com', 'key', 'secret')"
+        assert res == "deltaLake('http://url.com', 'key', 'secret', 'Parquet')"
 
     def test_s3_build_function_call_without_context_and_deltaS3Wrapper_format(self):
         res = build_function_call(
@@ -277,7 +277,7 @@ class TestS3Table(BaseTest):
         res = build_function_call(
             "http://url.com", DataWarehouseTable.TableFormat.Delta, None, "key", "secret", "some structure", None
         )
-        assert res == "deltaLake('http://url.com', 'key', 'secret')"
+        assert res == "deltaLake('http://url.com', 'key', 'secret', 'Parquet', 'some structure')"
 
     def test_s3_build_function_call_azure(self):
         res = build_function_call(


### PR DESCRIPTION
## Changes
- Turns out the `deltaLake` table function now takes a `format` param 🤯  https://clickhouse.com/docs/sql-reference/table-functions/deltalake#syntax