### PR TITLE
feat: make generations in list expandable

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -798,28 +798,30 @@ export function DataTable({
                                 )
                             }
                             expandable={
-                                expandable && columnsInResponse?.includes('*')
-                                    ? {
-                                          expandedRowRender: function renderExpand({ result }) {
-                                              if (
-                                                  (isEventsQuery(query.source) ||
-                                                      isRevenueExampleEventsQuery(query.source)) &&
-                                                  Array.isArray(result)
-                                              ) {
-                                                  return (
-                                                      <EventDetails
-                                                          event={result[columnsInResponse.indexOf('*')] ?? {}}
-                                                      />
-                                                  )
-                                              }
-                                              if (result && !Array.isArray(result)) {
-                                                  return <EventDetails event={result as EventType} />
-                                              }
-                                          },
-                                          rowExpandable: ({ result }) => !!result,
-                                          noIndent: true,
-                                      }
-                                    : undefined
+                                context?.expandable
+                                    ? context.expandable
+                                    : expandable && columnsInResponse?.includes('*')
+                                      ? {
+                                            expandedRowRender: function renderExpand({ result }) {
+                                                if (
+                                                    (isEventsQuery(query.source) ||
+                                                        isRevenueExampleEventsQuery(query.source)) &&
+                                                    Array.isArray(result)
+                                                ) {
+                                                    return (
+                                                        <EventDetails
+                                                            event={result[columnsInResponse.indexOf('*')] ?? {}}
+                                                        />
+                                                    )
+                                                }
+                                                if (result && !Array.isArray(result)) {
+                                                    return <EventDetails event={result as EventType} />
+                                                }
+                                            },
+                                            rowExpandable: ({ result }) => !!result,
+                                            noIndent: true,
+                                        }
+                                      : undefined
                             }
                             rowClassName={({ result, label }) =>
                                 clsx('DataTable__row', {

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -45,6 +45,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     dataNodeLogicKey?: string
     /** Override the maximum pagination limit for Data Tables. */
     dataTableMaxPaginationLimit?: number
+    /** Custom expandable config for DataTable rows */
+    expandable?: any // Will be typed as ExpandableConfig<DataTableRow> when used
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -1,5 +1,7 @@
 import { ComponentType, HTMLProps } from 'react'
 
+import { ExpandableConfig } from 'lib/lemon-ui/LemonTable'
+
 import { QueryFeature } from '~/queries/nodes/DataTable/queryFeatures'
 import {
     DataTableNode,
@@ -11,6 +13,7 @@ import {
 import { InsightLogicProps, TrendResult } from '~/types'
 
 import { ColumnFeature } from './nodes/DataTable/DataTable'
+import { DataTableRow } from './nodes/DataTable/dataTableLogic'
 
 /** Pass custom metadata to queries. Used for e.g. custom columns in the DataTable. */
 export interface QueryContext<Q extends QuerySchema = QuerySchema> {
@@ -46,7 +49,7 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     /** Override the maximum pagination limit for Data Tables. */
     dataTableMaxPaginationLimit?: number
     /** Custom expandable config for DataTable rows */
-    expandable?: any // Will be typed as ExpandableConfig<DataTableRow> when used
+    expandable?: ExpandableConfig<DataTableRow>
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -39,6 +39,7 @@ import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
+import { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isEventsQuery } from '~/queries/utils'
 import { EventType } from '~/types'
@@ -170,7 +171,7 @@ function LLMAnalyticsGenerations(): JSX.Element {
                 emptyStateHeading: 'There were no generations in this period',
                 emptyStateDetail: 'Try changing the date range or filters.',
                 expandable: {
-                    expandedRowRender: function renderExpandedGeneration({ result }: { result: any }) {
+                    expandedRowRender: function renderExpandedGeneration({ result }: DataTableRow) {
                         if (!Array.isArray(result)) {
                             return null
                         }
@@ -208,16 +209,16 @@ function LLMAnalyticsGenerations(): JSX.Element {
                             </div>
                         )
                     },
-                    rowExpandable: ({ result }: { result: any }) =>
+                    rowExpandable: ({ result }: DataTableRow) =>
                         !!result && Array.isArray(result) && !!result[0] && !!result[1],
-                    isRowExpanded: ({ result }: { result: any }) =>
+                    isRowExpanded: ({ result }: DataTableRow) =>
                         Array.isArray(result) && !!result[0] && expandedGenerationIds.has(result[0] as string),
-                    onRowExpand: ({ result }: { result: any }) => {
+                    onRowExpand: ({ result }: DataTableRow) => {
                         if (Array.isArray(result) && result[0] && result[1]) {
                             toggleGenerationExpanded(result[0] as string, result[1] as string)
                         }
                     },
-                    onRowCollapse: ({ result }: { result: any }) => {
+                    onRowCollapse: ({ result }: DataTableRow) => {
                         if (Array.isArray(result) && result[0] && result[1]) {
                             toggleGenerationExpanded(result[0] as string, result[1] as string)
                         }

--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -13,6 +13,7 @@ import {
     LemonTabs,
     LemonTag,
     Link,
+    Spinner,
 } from '@posthog/lemon-ui'
 
 import { QueryCard } from 'lib/components/Cards/InsightCard/QueryCard'
@@ -27,6 +28,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { humanFriendlyDuration } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { EventDetails } from 'scenes/activity/explore/EventDetails'
 import { SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -39,6 +41,7 @@ import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollec
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isEventsQuery } from '~/queries/utils'
+import { EventType } from '~/types'
 
 import { LLMMessageDisplay } from './ConversationDisplay/ConversationMessagesDisplay'
 import { LLMAnalyticsPlaygroundScene } from './LLMAnalyticsPlaygroundScene'
@@ -133,9 +136,15 @@ function LLMAnalyticsDashboard(): JSX.Element {
 }
 
 function LLMAnalyticsGenerations(): JSX.Element {
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setGenerationsQuery, setGenerationsColumns } =
-        useActions(llmAnalyticsLogic)
-    const { generationsQuery } = useValues(llmAnalyticsLogic)
+    const {
+        setDates,
+        setShouldFilterTestAccounts,
+        setPropertyFilters,
+        setGenerationsQuery,
+        setGenerationsColumns,
+        toggleGenerationExpanded,
+    } = useActions(llmAnalyticsLogic)
+    const { generationsQuery, expandedGenerationIds, loadedTraces } = useValues(llmAnalyticsLogic)
 
     return (
         <DataTable
@@ -160,22 +169,76 @@ function LLMAnalyticsGenerations(): JSX.Element {
             context={{
                 emptyStateHeading: 'There were no generations in this period',
                 emptyStateDetail: 'Try changing the date range or filters.',
+                expandable: {
+                    expandedRowRender: function renderExpandedGeneration({ result }: { result: any }) {
+                        if (!Array.isArray(result)) {
+                            return null
+                        }
+
+                        const uuid = result[0] as string
+                        const traceId = result[1] as string
+                        const trace = loadedTraces[traceId]
+                        const event = trace?.events.find((e) => e.id === uuid)
+
+                        if (!trace) {
+                            return (
+                                <div className="p-4">
+                                    <Spinner />
+                                </div>
+                            )
+                        }
+
+                        if (!event) {
+                            return <div className="p-4">Event not found in trace</div>
+                        }
+
+                        // Convert LLMTraceEvent to EventType format for EventDetails
+                        const eventForDetails: EventType = {
+                            id: event.id,
+                            distinct_id: '',
+                            properties: event.properties,
+                            event: event.event,
+                            timestamp: event.createdAt,
+                            elements: [],
+                        }
+
+                        return (
+                            <div className="pt-2 px-4 pb-4">
+                                <EventDetails event={eventForDetails} />
+                            </div>
+                        )
+                    },
+                    rowExpandable: ({ result }: { result: any }) =>
+                        !!result && Array.isArray(result) && !!result[0] && !!result[1],
+                    isRowExpanded: ({ result }: { result: any }) =>
+                        Array.isArray(result) && !!result[0] && expandedGenerationIds.has(result[0] as string),
+                    onRowExpand: ({ result }: { result: any }) => {
+                        if (Array.isArray(result) && result[0] && result[1]) {
+                            toggleGenerationExpanded(result[0] as string, result[1] as string)
+                        }
+                    },
+                    onRowCollapse: ({ result }: { result: any }) => {
+                        if (Array.isArray(result) && result[0] && result[1]) {
+                            toggleGenerationExpanded(result[0] as string, result[1] as string)
+                        }
+                    },
+                    noIndent: true,
+                },
                 columns: {
                     uuid: {
                         title: 'ID',
                         render: ({ record, value }) => {
                             const traceId = (record as unknown[])[1]
+
                             if (!value) {
-                                return <></>
+                                return null
                             }
 
                             const visualValue = truncateValue(value)
 
-                            if (!traceId) {
-                                return <strong>{visualValue}</strong>
-                            }
-
-                            return (
+                            return !traceId ? (
+                                <strong>{visualValue}</strong>
+                            ) : (
                                 <strong>
                                     <Tooltip title={value as string}>
                                         <Link to={`/llm-analytics/traces/${traceId}?event=${value as string}`}>
@@ -235,7 +298,7 @@ function LLMAnalyticsGenerations(): JSX.Element {
                         title: 'Trace ID',
                         render: ({ value }) => {
                             if (!value) {
-                                return <></>
+                                return null
                             }
 
                             const visualValue = truncateValue(value)

--- a/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
@@ -17,7 +17,7 @@ import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
 import { isAnyPropertyFilters } from '~/queries/schema-guards'
-import { DataTableNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { DataTableNode, LLMTrace, NodeKind, TraceQuery, TrendsQuery } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import {
     AnyPropertyFilter,
@@ -84,6 +84,9 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
         setTracesQuery: (query: DataTableNode) => ({ query }),
         refreshAllDashboardItems: true,
         setRefreshStatus: (tileId: string, loading?: boolean) => ({ tileId, loading }),
+        toggleGenerationExpanded: (uuid: string, traceId: string) => ({ uuid, traceId }),
+        setLoadedTrace: (traceId: string, trace: LLMTrace) => ({ traceId, trace }),
+        clearExpandedGenerations: true,
     }),
 
     reducers({
@@ -159,6 +162,39 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
                 setRefreshStatus: (state, { loading }) => (!loading ? new Date() : state),
             },
         ],
+
+        expandedGenerationIds: [
+            new Set<string>() as Set<string>,
+            {
+                toggleGenerationExpanded: (state, { uuid }) => {
+                    const newSet = new Set(state)
+                    if (newSet.has(uuid)) {
+                        newSet.delete(uuid)
+                    } else {
+                        newSet.add(uuid)
+                    }
+                    return newSet
+                },
+                clearExpandedGenerations: () => new Set<string>(),
+                setDates: () => new Set<string>(),
+                setPropertyFilters: () => new Set<string>(),
+                setShouldFilterTestAccounts: () => new Set<string>(),
+            },
+        ],
+
+        loadedTraces: [
+            {} as Record<string, LLMTrace>,
+            {
+                setLoadedTrace: (state, { traceId, trace }) => ({
+                    ...state,
+                    [traceId]: trace,
+                }),
+                clearExpandedGenerations: () => ({}),
+                setDates: () => ({}),
+                setPropertyFilters: () => ({}),
+                setShouldFilterTestAccounts: () => ({}),
+            },
+        ],
     }),
 
     loaders({
@@ -180,6 +216,35 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
             },
         },
     }),
+
+    listeners(({ actions, values }) => ({
+        toggleGenerationExpanded: async ({ uuid, traceId }) => {
+            // Only load if expanding and not already loaded
+            if (values.expandedGenerationIds.has(uuid) && !values.loadedTraces[traceId]) {
+                // Build TraceQuery with date range from current filters
+                const dateFrom = values.dateFilter.dateFrom || '-7d'
+                const dateTo = values.dateFilter.dateTo || undefined
+
+                const traceQuery: TraceQuery = {
+                    kind: NodeKind.TraceQuery,
+                    traceId,
+                    dateRange: {
+                        date_from: dateFrom,
+                        date_to: dateTo,
+                    },
+                }
+
+                try {
+                    const response = await api.query(traceQuery)
+                    if (response.results && response.results.length > 0) {
+                        actions.setLoadedTrace(traceId, response.results[0])
+                    }
+                } catch (error) {
+                    console.error('Failed to load trace:', error)
+                }
+            }
+        },
+    })),
 
     selectors({
         activeTab: [


### PR DESCRIPTION
Implements expandable generations in the generation list. We used to support this but we removed it, some customers asked for it back. It will also be a must once we store inputs and outputs in S3, to avoid having to load N+1 on loading the list.

<img width="1232" height="695" alt="Screenshot 2025-10-16 at 14 26 18" src="https://github.com/user-attachments/assets/203dd782-1fba-445b-8170-dc630c702dd4" />
