### PR TITLE
fix: persist early access features form changes

### DIFF
--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -87,8 +87,8 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
         updateStage,
         deleteEarlyAccessFeature,
         toggleImplementOptInInstructionsModal,
-        setEarlyAccessFeatureValue,
         showGAPromotionConfirmation,
+        saveEarlyAccessFeature,
     } = useActions(earlyAccessFeatureLogic)
 
     const isNewEarlyAccessFeature = id === 'new' || id === undefined
@@ -135,11 +135,12 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
                         type: 'early_access_feature',
                     }}
                     canEdit
-                    onNameChange={(value) => {
-                        setEarlyAccessFeatureValue('name', value)
+                    renameDebounceMs={1000}
+                    onNameChange={(name) => {
+                        saveEarlyAccessFeature({ id, name })
                     }}
-                    onDescriptionChange={(value) => {
-                        setEarlyAccessFeatureValue('description', value)
+                    onDescriptionChange={(description) => {
+                        saveEarlyAccessFeature({ id, description })
                     }}
                     forceEdit={isEditingFeature || isNewEarlyAccessFeature}
                     actions={
@@ -255,7 +256,22 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
                     <ScenePanelInfoSection>
                         <SceneSelect
                             onSave={(value) => {
-                                setEarlyAccessFeatureValue('stage', value)
+                                // Check if user is promoting to General Availability
+                                const isPromotingToGA = value === EarlyAccessFeatureStage.GeneralAvailability
+
+                                if (isPromotingToGA) {
+                                    showGAPromotionConfirmation(() =>
+                                        saveEarlyAccessFeature({
+                                            id,
+                                            stage: value as EarlyAccessFeatureStage,
+                                        })
+                                    )
+                                } else {
+                                    saveEarlyAccessFeature({
+                                        id,
+                                        stage: value as EarlyAccessFeatureStage,
+                                    })
+                                }
                             }}
                             value={earlyAccessFeature.stage}
                             name="stage"

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -137,10 +137,10 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
                     canEdit
                     renameDebounceMs={1000}
                     onNameChange={(name) => {
-                        saveEarlyAccessFeature({ id, name })
+                        saveEarlyAccessFeature({ ...earlyAccessFeature, name })
                     }}
                     onDescriptionChange={(description) => {
-                        saveEarlyAccessFeature({ id, description })
+                        saveEarlyAccessFeature({ ...earlyAccessFeature, description })
                     }}
                     forceEdit={isEditingFeature || isNewEarlyAccessFeature}
                     actions={
@@ -262,13 +262,13 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
                                 if (isPromotingToGA) {
                                     showGAPromotionConfirmation(() =>
                                         saveEarlyAccessFeature({
-                                            id,
+                                            ...earlyAccessFeature,
                                             stage: value as EarlyAccessFeatureStage,
                                         })
                                     )
                                 } else {
                                     saveEarlyAccessFeature({
-                                        id,
+                                        ...earlyAccessFeature,
                                         stage: value as EarlyAccessFeatureStage,
                                     })
                                 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Changing an early access feature's name/description via the scene title section and changing the stage via the action sidepanel does not persist and any changes made are lost on refresh 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #39814

## Changes

Makes the form changes persist
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

