### PR TITLE
fix(data-warehouse): Update frontend logic with defaults

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -154,7 +154,11 @@ export default function SchemaForm(): JSX.Element {
                                     'Incremental and append-only refresh methods key on a unique field to determine the most up-to-date data.',
                                 isHidden: !databaseSchema.some((schema) => schema.sync_type),
                                 render: function RenderSyncType(_, schema) {
-                                    if (schema.sync_type !== null && schema.incremental_field) {
+                                    if (
+                                        schema.sync_type !== 'full_refresh' &&
+                                        schema.sync_type !== null &&
+                                        schema.incremental_field
+                                    ) {
                                         const field =
                                             schema.incremental_fields.find(
                                                 (f) => f.field == schema.incremental_field

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -179,7 +179,7 @@ const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField |
     // check for timestamp field matching "updated_at" or "updatedAt" case insensitive
     const updatedAt = fields.find((field) => {
         const regex = /^updated/i
-        return regex.test(field.field) && isTimestampType(field)
+        return regex.test(field.label) && isTimestampType(field)
     })
     if (updatedAt) {
         return updatedAt
@@ -187,7 +187,7 @@ const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField |
     // fallback to timestamp field matching "created_at" or "createdAt" case insensitive
     const createdAt = fields.find((field) => {
         const regex = /^created/i
-        return regex.test(field.field) && isTimestampType(field)
+        return regex.test(field.label) && isTimestampType(field)
     })
     if (createdAt) {
         return createdAt
@@ -201,7 +201,7 @@ const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField |
     const id = fields.find((field) => {
         const idRegex = /^id/i
         const uuidRegex = /^uuid/i
-        return (idRegex.test(field.field) || uuidRegex.test(field.field)) && field.field_type === 'integer'
+        return (idRegex.test(field.label) || uuidRegex.test(field.label)) && field.type === 'integer'
     })
     if (id) {
         return id

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -728,10 +728,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                                 schema.incremental_field = resolvedField.field
                                 schema.incremental_field_type = resolvedField.field_type
                             } else {
-                                const field = schema.incremental_fields.find((n) => n.field == schema.incremental_field)
-                                if (field) {
-                                    schema.incremental_field_type = field.type || field.field_type
-                                }
+                                schema.sync_type = 'full_refresh'
                             }
                         } else {
                             schema.sync_type = 'full_refresh'

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -171,7 +171,7 @@ const manualLinkSourceMap: Record<ManualLinkSourceType, string> = {
 }
 
 const isTimestampType = (field: IncrementalField): boolean => {
-    const type = field.field_type || field.type
+    const type = field.type || field.field_type
     return type === 'timestamp' || type === 'datetime' || type === 'date'
 }
 
@@ -722,11 +722,16 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                         // Use incremental if available
                         if (schema.incremental_available || schema.append_available) {
                             const method = schema.incremental_available ? 'incremental' : 'append'
-                            const field = resolveIncrementalField(schema.incremental_fields)
+                            const resolvedField = resolveIncrementalField(schema.incremental_fields)
                             schema.sync_type = method
-                            if (field) {
-                                schema.incremental_field = field.field
-                                schema.incremental_field_type = field.field_type
+                            if (resolvedField) {
+                                schema.incremental_field = resolvedField.field
+                                schema.incremental_field_type = resolvedField.field_type
+                            } else {
+                                const field = schema.incremental_fields.find((n) => n.field == schema.incremental_field)
+                                if (field) {
+                                    schema.incremental_field_type = field.type || field.field_type
+                                }
                             }
                         } else {
                             schema.sync_type = 'full_refresh'


### PR DESCRIPTION
## Changes
- The default `incremental_field_type` wasn't getting set when we weren't resolving an applicable incremental field (correctly), but then we weren't falling back to `full_refresh` in this case