### PR TITLE
fix(embed): add metrics

### DIFF
--- a/rust/embedding-worker/src/ad_hoc.rs
+++ b/rust/embedding-worker/src/ad_hoc.rs
@@ -4,7 +4,10 @@ use anyhow::Result;
 use common_types::embedding::EmbeddingModel;
 use serde::{Deserialize, Serialize};
 
-use crate::{app_context::AppContext, generate_embedding, organization::apply_ai_opt_in};
+use crate::{
+    app_context::AppContext, generate_embedding, metrics_utils::RequestLabels,
+    organization::apply_ai_opt_in,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AdHocEmbeddingRequest {
@@ -38,8 +41,13 @@ pub async fn handle_ad_hoc_request(
         return Err(anyhow::anyhow!("Content too long"));
     }
 
-    let (embedding, token_count) =
-        generate_embedding(context.clone(), request.model, &request.content).await?;
+    let (embedding, token_count) = generate_embedding(
+        context.clone(),
+        request.model,
+        &request.content,
+        &RequestLabels::from(&request),
+    )
+    .await?;
 
     Ok(AdHocEmbeddingResponse {
         embedding,

--- a/rust/embedding-worker/src/app_context.rs
+++ b/rust/embedding-worker/src/app_context.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use crate::{
     config::Config,
-    metric_consts::{LIMITS_UPDATED, LIMIT_BALANCE},
+    metrics_utils::{LIMITS_UPDATED, LIMIT_BALANCE},
     organization::Organization,
 };
 

--- a/rust/embedding-worker/src/metric_consts.rs
+++ b/rust/embedding-worker/src/metric_consts.rs
@@ -1,5 +1,0 @@
-pub const MESSAGES_RECEIVED: &str = "embedding_worker_messages_received";
-pub const EMBEDDINGS_GENERATED: &str = "embedding_worker_embeddings_generated";
-pub const LIMITS_UPDATED: &str = "embedding_worker_limits_updated";
-pub const LIMIT_BALANCE: &str = "embedding_worker_limit_balance";
-pub const DROPPED_REQUESTS: &str = "embedding_worker_dropped_requests";

--- a/rust/embedding-worker/src/metrics_utils.rs
+++ b/rust/embedding-worker/src/metrics_utils.rs
@@ -1,0 +1,69 @@
+use common_types::embedding::{EmbeddingModel, EmbeddingRequest};
+
+use crate::ad_hoc::AdHocEmbeddingRequest;
+
+pub const MESSAGES_RECEIVED: &str = "embedding_worker_messages_received";
+pub const EMBEDDINGS_GENERATED: &str = "embedding_worker_embeddings_generated";
+pub const LIMITS_UPDATED: &str = "embedding_worker_limits_updated";
+pub const LIMIT_BALANCE: &str = "embedding_worker_limit_balance";
+pub const DROPPED_REQUESTS: &str = "embedding_worker_dropped_requests";
+pub const MESSAGE_TRUNCATED: &str = "embedding_worker_content_truncated";
+pub const EMBEDDING_FAILED: &str = "embedding_worker_embedding_failed";
+pub const EMBEDDING_TOTAL_TIME: &str = "embedding_worker_embedding_total_time";
+pub const EMBEDDING_REQUEST_TIME: &str = "embedding_worker_embedding_request_time";
+pub const EMBEDDING_TOTAL_TOKENS: &str = "embedding_worker_embedding_total_tokens";
+
+pub struct RequestLabels {
+    labels: Vec<(String, String)>,
+}
+
+impl RequestLabels {
+    pub fn and<E, K, V>(mut self, extra: E) -> Self
+    where
+        E: IntoIterator<Item = (K, V)>,
+        K: ToString,
+        V: ToString,
+    {
+        self.labels.extend(
+            extra
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string())),
+        );
+        self
+    }
+
+    pub fn and_model(self, model: EmbeddingModel) -> Self {
+        self.and([("model", model.name())])
+    }
+
+    pub fn render(&self) -> &[(String, String)] {
+        &self.labels
+    }
+}
+
+impl From<&EmbeddingRequest> for RequestLabels {
+    fn from(request: &EmbeddingRequest) -> Self {
+        Self {
+            labels: vec![
+                ("product".to_string(), request.product.as_str().to_string()),
+                (
+                    "document_type".to_string(),
+                    request.document_type.as_str().to_string(),
+                ),
+                (
+                    "rendering".to_string(),
+                    request.rendering.as_str().to_string(),
+                ),
+            ],
+        }
+    }
+}
+
+impl From<&AdHocEmbeddingRequest> for RequestLabels {
+    fn from(request: &AdHocEmbeddingRequest) -> Self {
+        Self {
+            labels: vec![("from".to_string(), "api".to_string())],
+        }
+        .and_model(request.model)
+    }
+}


### PR DESCRIPTION
Adds some more metrics, labels them by product, rendering, document type and model, so teams can add their own alerts etc as needed for the types of messages they care about

CC paul since he asked about it

Right now messages that cause some kind of error will halt the worker. We can change that to a DLQ as we work, but I'd rather be noisy for now.