### PR TITLE
fix: prevent dirty writes when modifying tags in asyncio tasks

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -235,7 +235,10 @@ def tag_queries(**kwargs) -> None:
 
     :param kwargs: Key->value pairs of tags to be set.
     """
-    get_query_tags().update(**kwargs)
+    current_tags = get_query_tags()
+    updated_tags = current_tags.model_copy(deep=True)
+    updated_tags.update(**kwargs)
+    query_tags.set(updated_tags)
 
 
 def clear_tag(key):

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -224,8 +224,11 @@ def get_query_tag_value(key: str) -> Optional[Any]:
         return None
 
 
-def update_tags(query_tags: QueryTags):
-    get_query_tags().update(**query_tags.model_dump(exclude_none=True))
+def update_tags(new_query_tags: QueryTags):
+    current_tags = get_query_tags()
+    updated_tags = current_tags.model_copy(deep=True)
+    updated_tags.update(**new_query_tags.model_dump(exclude_none=True))
+    query_tags.set(updated_tags)
 
 
 def tag_queries(**kwargs) -> None:
@@ -243,8 +246,10 @@ def tag_queries(**kwargs) -> None:
 
 def clear_tag(key):
     with suppress(LookupError):
-        qt = query_tags.get()
-        setattr(qt, key, None)
+        current_tags = query_tags.get()
+        updated_tags = current_tags.model_copy(deep=True)
+        setattr(updated_tags, key, None)
+        query_tags.set(updated_tags)
 
 
 def reset_query_tags():

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -16,6 +16,7 @@ from posthog.clickhouse.query_tagging import (
     reset_query_tags,
     tag_queries,
     tags_context,
+    update_tags,
 )
 
 
@@ -119,12 +120,6 @@ def test_tags_context():
 
 @pytest.mark.asyncio
 async def test_async_tasks_have_isolated_tags():
-    """
-    Demonstrates that concurrent async tasks get isolated query tags.
-
-    When multiple async tasks run concurrently and call tag_queries(), each task
-    should see its own tags without contamination from other tasks.
-    """
     reset_query_tags()
 
     # Use Events to guarantee interleaved execution
@@ -167,3 +162,101 @@ async def test_async_tasks_have_isolated_tags():
 
     assert results["task_b"]["team_id"] == 200
     assert results["task_b"]["user_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_async_tasks_have_isolated_tags_with_update_tags():
+    reset_query_tags()
+
+    # Use Events to guarantee interleaved execution
+    task_a_set_tags = asyncio.Event()
+    task_b_set_tags = asyncio.Event()
+
+    results = {}
+
+    async def task_a():
+        # Task A updates its tags first
+        tags_to_update = QueryTags(team_id=100, user_id=1)
+        update_tags(tags_to_update)
+        task_a_set_tags.set()
+
+        # Wait for Task B to update its tags
+        await task_b_set_tags.wait()
+
+        tags = get_query_tags()
+        results["task_a"] = {"team_id": tags.team_id, "user_id": tags.user_id}
+
+    async def task_b():
+        # Wait for Task A to update its tags first
+        await task_a_set_tags.wait()
+
+        # Task B updates its own tags (after Task A)
+        tags_to_update = QueryTags(team_id=200, user_id=2)
+        update_tags(tags_to_update)
+        task_b_set_tags.set()
+
+        tags = get_query_tags()
+        results["task_b"] = {"team_id": tags.team_id, "user_id": tags.user_id}
+
+    task_a_handle = asyncio.create_task(task_a())
+    task_b_handle = asyncio.create_task(task_b())
+
+    await task_a_handle
+    await task_b_handle
+
+    # Each task should see its own values, not contaminated by the other
+    assert results["task_a"]["team_id"] == 100
+    assert results["task_a"]["user_id"] == 1
+
+    assert results["task_b"]["team_id"] == 200
+    assert results["task_b"]["user_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_async_tasks_have_isolated_tags_with_clear_tag():
+    reset_query_tags()
+
+    # Both tasks start with same initial tags
+    tag_queries(team_id=100, user_id=50)
+
+    # Use Events to guarantee interleaved execution
+    task_a_cleared = asyncio.Event()
+    task_b_cleared = asyncio.Event()
+
+    results = {}
+
+    async def task_a():
+        # Task A clears user_id
+        clear_tag("user_id")
+        task_a_cleared.set()
+
+        # Wait for Task B to clear team_id
+        await task_b_cleared.wait()
+
+        tags = get_query_tags()
+        results["task_a"] = {"team_id": tags.team_id, "user_id": tags.user_id}
+
+    async def task_b():
+        # Wait for Task A to clear user_id
+        await task_a_cleared.wait()
+
+        # Task B clears team_id (after Task A)
+        clear_tag("team_id")
+        task_b_cleared.set()
+
+        tags = get_query_tags()
+        results["task_b"] = {"team_id": tags.team_id, "user_id": tags.user_id}
+
+    task_a_handle = asyncio.create_task(task_a())
+    task_b_handle = asyncio.create_task(task_b())
+
+    await task_a_handle
+    await task_b_handle
+
+    # Task A cleared user_id, should still have team_id
+    assert results["task_a"]["team_id"] == 100
+    assert results["task_a"]["user_id"] is None
+
+    # Task B cleared team_id, should still have user_id
+    assert results["task_b"]["team_id"] is None
+    assert results["task_b"]["user_id"] == 50


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When modifying tags queries in asyncio tasks, interleaved tasks can overwrite each other's tags because they were mutating a shallow copy of the QueryTags object. This makes sense according to the docs: 

`asyncio.create_task()` [doc](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task):
> The current context copy is created when no context is provided.

`contextvars.Context.copy()` [doc](https://docs.python.org/3/library/contextvars.html#contextvars.Context.copy): 
> Return a shallow copy of the context object.

I noticed this when one of two exports running concurrently had the other's tags: https://github.com/PostHog/posthog/issues/39055#issuecomment-3412054318

## Changes

Modified `tag_queries()`, `clear_tag()`, and `update_tags()` to:
- Create a new QueryTags object via `model_copy(deep=True)`
- Call `ContextVar.set()` to update the task's context to point to the new copy

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Unit test 

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
