### PR TITLE
feat(experiments): adding metrics panel

### DIFF
--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -17,6 +17,9 @@ import {
     ErrorTrackingQuery,
     EventsNode,
     EventsQuery,
+    ExperimentFunnelsQuery,
+    ExperimentMetric,
+    ExperimentTrendsQuery,
     FunnelsQuery,
     GoalLine,
     GroupsQuery,
@@ -242,6 +245,12 @@ export function isRevenueExampleDataWarehouseTablesQuery(
 
 export function isErrorTrackingQuery(node?: Record<string, any> | null): node is ErrorTrackingQuery {
     return node?.kind === NodeKind.ErrorTrackingQuery
+}
+
+export function isExperimentMetric(
+    metric: ExperimentMetric | ExperimentFunnelsQuery | ExperimentTrendsQuery
+): metric is ExperimentMetric {
+    return metric.kind === NodeKind.ExperimentMetric
 }
 
 export function isErrorTrackingIssueCorrelationQuery(

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -236,6 +236,12 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                                     ...(experiment[context.orderingField] ?? []),
                                                     ...metrics.map((metric) => metric.uuid),
                                                 ],
+                                                saved_metrics: [
+                                                    ...(experiment.saved_metrics ?? []),
+                                                    ...metrics.map((metric) => ({
+                                                        saved_metric: metric.sharedMetricId,
+                                                    })),
+                                                ],
                                             })
                                             setSharedMetrics({
                                                 ...sharedMetrics,

--- a/frontend/src/scenes/experiments/create/MetricsPanel/EmptyMetricsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/EmptyMetricsPanel.tsx
@@ -1,0 +1,27 @@
+import clsx from 'clsx'
+
+import { IconAreaChart } from 'lib/lemon-ui/icons'
+import { AddMetricButton } from 'scenes/experiments/Metrics/AddMetricButton'
+
+import { MetricContext } from '~/scenes/experiments/Metrics/experimentMetricModalLogic'
+
+export type EmptyMetricsPanelProps = {
+    metricContext: MetricContext
+    className?: string
+}
+
+export const EmptyMetricsPanel = ({ metricContext, className }: EmptyMetricsPanelProps): JSX.Element => (
+    <div className={clsx('border rounded bg-surface-primary pt-6 pb-8 text-secondary', className)}>
+        <div className="flex flex-col items-center mx-auto deprecated-space-y-3">
+            <IconAreaChart fontSize="30" />
+            <div className="text-sm text-center text-balance max-w-sm">
+                <p>
+                    {metricContext.type === 'secondary'
+                        ? 'Secondary metrics provide additional context and help detect unintended side effects.'
+                        : 'Primary metrics represent the main goal of the experiment and directly measure if your hypothesis was successful.'}
+                </p>
+            </div>
+            <AddMetricButton metricContext={metricContext} />
+        </div>
+    </div>
+)

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricCard.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricCard.tsx
@@ -32,6 +32,10 @@ export const MetricCard = ({ metric, metricContext, onDelete, filterTestAccounts
     const metricName = metric.name || getDefaultMetricTitle(metric)
 
     const handleDelete = (): void => {
+        if (metric.isSharedMetric) {
+            return onDelete(metric, metricContext)
+        }
+
         LemonDialog.open({
             title: 'Delete metric?',
             description: 'Are you sure you want to delete this metric? This action cannot be undone.',
@@ -57,6 +61,11 @@ export const MetricCard = ({ metric, metricContext, onDelete, filterTestAccounts
                             <LemonTag type="muted" size="small">
                                 {metricTag}
                             </LemonTag>
+                            {metric.isSharedMetric && (
+                                <LemonTag type="option" size="small">
+                                    Shared metric
+                                </LemonTag>
+                            )}
                         </div>
                     </div>
                     <div className="flex gap-1 flex-shrink-0">

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricCard.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricCard.tsx
@@ -1,0 +1,96 @@
+import { useActions } from 'kea'
+
+import { IconPencil, IconTrash } from '@posthog/icons'
+import { LemonDialog } from '@posthog/lemon-ui'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import type { MetricContext } from '~/scenes/experiments/Metrics/experimentMetricModalLogic'
+import { experimentMetricModalLogic } from '~/scenes/experiments/Metrics/experimentMetricModalLogic'
+import { getDefaultMetricTitle, getMetricTag } from '~/scenes/experiments/MetricsView/shared/utils'
+
+import { MetricConversionWindow } from './MetricConversionWindow'
+import { MetricEventDetails } from './MetricEventDetails'
+import { MetricGoal } from './MetricGoal'
+import { MetricOutlierHandling } from './MetricOutlierHandling'
+import { MetricRecentActivity } from './MetricRecentActivity'
+import { MetricStepOrder } from './MetricStepOrder'
+
+export type MetricCardProps = {
+    metric: ExperimentMetric
+    metricContext: MetricContext
+    onDelete: (metric: ExperimentMetric, context: MetricContext) => void
+    filterTestAccounts: boolean
+}
+
+export const MetricCard = ({ metric, metricContext, onDelete, filterTestAccounts }: MetricCardProps): JSX.Element => {
+    const { openExperimentMetricModal } = useActions(experimentMetricModalLogic)
+
+    const metricTag = getMetricTag(metric)
+    const metricName = metric.name || getDefaultMetricTitle(metric)
+
+    const handleDelete = (): void => {
+        LemonDialog.open({
+            title: 'Delete metric?',
+            description: 'Are you sure you want to delete this metric? This action cannot be undone.',
+            primaryButton: {
+                children: 'Delete',
+                status: 'danger',
+                onClick: () => onDelete(metric, metricContext),
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
+    return (
+        <div className="border rounded bg-surface-primary p-4">
+            <div className="space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 min-w-0 gap-2">
+                        <div className="font-semibold text-sm mb-1 break-words">{metricName}</div>
+                        <MetricEventDetails metric={metric} />
+                        <div className="flex items-center mt-2">
+                            <LemonTag type="muted" size="small">
+                                {metricTag}
+                            </LemonTag>
+                        </div>
+                    </div>
+                    <div className="flex gap-1 flex-shrink-0">
+                        <LemonButton
+                            type="secondary"
+                            size="xsmall"
+                            icon={<IconPencil fontSize="12" />}
+                            tooltip="Edit metric"
+                            onClick={() => openExperimentMetricModal(metricContext, metric)}
+                        />
+                        <LemonButton
+                            type="secondary"
+                            size="xsmall"
+                            icon={<IconTrash fontSize="12" />}
+                            tooltip="Delete metric"
+                            onClick={handleDelete}
+                            status="danger"
+                        />
+                    </div>
+                </div>
+
+                <div className="border-t border-border" />
+
+                <div className="space-y-1">
+                    <MetricGoal metric={metric} />
+                    <MetricConversionWindow metric={metric} />
+                    <MetricStepOrder metric={metric} />
+                    <MetricOutlierHandling metric={metric} />
+                </div>
+
+                <div className="border-t border-border" />
+
+                <MetricRecentActivity metric={metric} filterTestAccounts={filterTestAccounts} />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricConversionWindow.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricConversionWindow.tsx
@@ -1,0 +1,28 @@
+import { formatUnitByQuantity } from 'scenes/experiments/utils'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import { FunnelConversionWindowTimeUnit } from '~/types'
+
+export type MetricConversionWindowProps = {
+    metric: ExperimentMetric
+}
+
+export const MetricConversionWindow = ({ metric }: MetricConversionWindowProps): JSX.Element => {
+    if (metric.conversion_window != null && metric.conversion_window_unit) {
+        const unit = metric.conversion_window_unit || FunnelConversionWindowTimeUnit.Day
+        return (
+            <div className="text-xs">
+                <span className="text-muted">Conversion window:</span>{' '}
+                <span className="font-semibold">
+                    {metric.conversion_window} {formatUnitByQuantity(metric.conversion_window, unit)}
+                </span>
+            </div>
+        )
+    }
+    return (
+        <div className="text-xs">
+            <span className="text-muted">Conversion window:</span>{' '}
+            <span className="font-semibold">Experiment duration</span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricEventDetails.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricEventDetails.tsx
@@ -1,0 +1,103 @@
+import { match } from 'ts-pattern'
+
+import { IconArrowRight } from '@posthog/icons'
+
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import type {
+    ExperimentFunnelMetric,
+    ExperimentMeanMetric,
+    ExperimentMetricSource,
+    ExperimentRatioMetric,
+} from '~/queries/schema/schema-general'
+import {
+    isExperimentFunnelMetric,
+    isExperimentMeanMetric,
+    isExperimentRatioMetric,
+} from '~/queries/schema/schema-general'
+import { isActionsNode, isDataWarehouseNode, isEventsNode } from '~/queries/utils'
+
+const getSourceName = (source: ExperimentMetricSource): string =>
+    match(source)
+        .when(isEventsNode, (node) => node.name || node.event || 'Unknown event')
+        .when(isActionsNode, (node) => node.name || `Action ${node.id}`)
+        .when(isDataWarehouseNode, (node) => node.name || node.table_name)
+        .otherwise(() => 'Unknown')
+
+const getMathLabel = (math: string | undefined): string => {
+    if (!math) {
+        return 'Total count'
+    }
+    return match(math)
+        .with('total', () => 'Total count')
+        .with('dau', () => 'Unique users')
+        .with('sum', () => 'Sum')
+        .with('avg', () => 'Average')
+        .with('min', () => 'Minimum')
+        .with('max', () => 'Maximum')
+        .with('unique_session', () => 'Unique sessions')
+        .with('unique_group', () => 'Unique groups')
+        .with('hogql', () => 'HogQL')
+        .otherwise(() => math)
+}
+
+export type MetricEventDetailsProps = {
+    metric: ExperimentMetric
+}
+
+export const MetricEventDetails = ({ metric }: MetricEventDetailsProps): JSX.Element =>
+    match(metric)
+        .when(isExperimentFunnelMetric, (funnelMetric: ExperimentFunnelMetric) => {
+            const steps = funnelMetric.series.slice(0, 3)
+            const hasMore = funnelMetric.series.length > 3
+
+            return (
+                <div className="flex items-center gap-1 flex-wrap text-xs text-muted">
+                    {steps.map((step, index) => (
+                        <div key={index} className="flex items-center gap-1">
+                            {index > 0 && <IconArrowRight className="text-muted flex-shrink-0" fontSize="14" />}
+                            <span className="truncate max-w-[150px]">{getSourceName(step)}</span>
+                        </div>
+                    ))}
+                    {hasMore && (
+                        <Tooltip title={funnelMetric.series.slice(3).map(getSourceName).join(', ')}>
+                            <span className="text-muted">... +{funnelMetric.series.length - 3} more</span>
+                        </Tooltip>
+                    )}
+                </div>
+            )
+        })
+        .when(isExperimentMeanMetric, (meanMetric: ExperimentMeanMetric) => {
+            const sourceName = getSourceName(meanMetric.source)
+            const mathLabel = getMathLabel(meanMetric.source.math)
+
+            return (
+                <div className="text-xs text-muted">
+                    <span className="truncate">{sourceName}</span>
+                    <span className="text-muted"> ({mathLabel})</span>
+                </div>
+            )
+        })
+        .when(isExperimentRatioMetric, (ratioMetric: ExperimentRatioMetric) => {
+            const numeratorName = getSourceName(ratioMetric.numerator)
+            const denominatorName = getSourceName(ratioMetric.denominator)
+            const numeratorMath = getMathLabel(ratioMetric.numerator.math)
+            const denominatorMath = getMathLabel(ratioMetric.denominator.math)
+
+            return (
+                <div className="text-xs text-muted">
+                    <div className="flex items-center gap-1">
+                        <span className="font-semibold text-default">Numerator:</span>
+                        <span className="truncate">{numeratorName}</span>
+                        <span className="text-muted">({numeratorMath})</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                        <span className="font-semibold text-default">Denominator:</span>
+                        <span className="truncate">{denominatorName}</span>
+                        <span className="text-muted">({denominatorMath})</span>
+                    </div>
+                </div>
+            )
+        })
+        .otherwise(() => <div>Unknown metric type</div>)

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricGoal.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricGoal.tsx
@@ -1,0 +1,22 @@
+import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import { ExperimentMetricGoal } from '~/types'
+
+export type MetricGoalProps = {
+    metric: ExperimentMetric
+}
+
+export const MetricGoal = ({ metric }: MetricGoalProps): JSX.Element => {
+    const goal = metric.goal || ExperimentMetricGoal.Increase
+    const isIncrease = goal === ExperimentMetricGoal.Increase
+    const Icon = isIncrease ? IconArrowUp : IconArrowDown
+
+    return (
+        <div className="flex items-center gap-1 text-xs">
+            <span className="text-muted">Goal:</span>
+            <Icon className="text-success flex-shrink-0" fontSize="16" />
+            <span className="font-semibold">{isIncrease ? 'Increase' : 'Decrease'}</span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricList.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricList.tsx
@@ -1,0 +1,48 @@
+import { clsx } from 'clsx'
+
+import { AddMetricButton } from 'scenes/experiments/Metrics/AddMetricButton'
+import type { MetricContext } from 'scenes/experiments/Metrics/experimentMetricModalLogic'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+
+import { MetricCard } from './MetricCard'
+
+export type MetricListProps = {
+    metrics: ExperimentMetric[]
+    metricContext: MetricContext
+    onDelete: (metric: ExperimentMetric, context: MetricContext) => void
+    filterTestAccounts: boolean
+    className?: string
+}
+
+export const MetricList = ({
+    metrics,
+    metricContext,
+    onDelete,
+    filterTestAccounts,
+    className,
+}: MetricListProps): JSX.Element | null => {
+    if (metrics.length === 0) {
+        return null
+    }
+
+    return (
+        <div className={clsx('space-y-3', className)}>
+            <div className="flex justify-between items-center">
+                <span className="font-medium text-default">
+                    {metricContext.type.charAt(0).toUpperCase() + metricContext.type.slice(1)} metrics
+                </span>
+                <AddMetricButton metricContext={metricContext} />
+            </div>
+            {metrics.map((metric) => (
+                <MetricCard
+                    key={metric.uuid}
+                    metric={metric}
+                    metricContext={metricContext}
+                    onDelete={onDelete}
+                    filterTestAccounts={filterTestAccounts}
+                />
+            ))}
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricOutlierHandling.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricOutlierHandling.tsx
@@ -1,0 +1,29 @@
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import { isExperimentMeanMetric } from '~/queries/schema/schema-general'
+
+/**
+ * Only for mean metrics
+ */
+export type MetricOutlierHandlingProps = {
+    metric: ExperimentMetric
+}
+
+export const MetricOutlierHandling = ({ metric }: MetricOutlierHandlingProps): JSX.Element | null => {
+    if (!isExperimentMeanMetric(metric)) {
+        return null
+    }
+
+    const hasLower = metric.lower_bound_percentile != null
+    const hasUpper = metric.upper_bound_percentile != null
+
+    return (
+        <div className="text-xs">
+            <span className="text-muted">Outlier handling:</span>{' '}
+            <span className="font-semibold">
+                {hasLower && `Lower ${metric.lower_bound_percentile}%`}
+                {hasLower && hasUpper && ', '}
+                {hasUpper && `Upper ${metric.upper_bound_percentile}%`}
+            </span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricRecentActivity.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricRecentActivity.tsx
@@ -14,7 +14,7 @@ export type MetricRecentActivityProps = {
 export const MetricRecentActivity = ({ metric, filterTestAccounts }: MetricRecentActivityProps): JSX.Element => {
     const { eventCount, eventCountLoading } = useValues(metricRecentActivityLogic({ metric, filterTestAccounts }))
 
-    if (!eventCount || eventCountLoading) {
+    if (eventCountLoading) {
         return (
             <div className="text-xs text-muted">
                 <Spinner className="mr-1" />
@@ -23,7 +23,7 @@ export const MetricRecentActivity = ({ metric, filterTestAccounts }: MetricRecen
         )
     }
 
-    const count = eventCount || 0
+    const count = eventCount ?? 0
 
     return (
         <div className="text-xs">

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricRecentActivity.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricRecentActivity.tsx
@@ -1,0 +1,37 @@
+import { useValues } from 'kea'
+
+import { Spinner } from '@posthog/lemon-ui'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+
+import { metricRecentActivityLogic } from './metricRecentActivityLogic'
+
+export type MetricRecentActivityProps = {
+    metric: ExperimentMetric
+    filterTestAccounts: boolean
+}
+
+export const MetricRecentActivity = ({ metric, filterTestAccounts }: MetricRecentActivityProps): JSX.Element => {
+    const { eventCount, eventCountLoading } = useValues(metricRecentActivityLogic({ metric, filterTestAccounts }))
+
+    if (!eventCount || eventCountLoading) {
+        return (
+            <div className="text-xs text-muted">
+                <Spinner className="mr-1" />
+                Loading...
+            </div>
+        )
+    }
+
+    const count = eventCount || 0
+
+    return (
+        <div className="text-xs">
+            <span className="text-muted">Recent activity:</span>{' '}
+            <span className="font-semibold">
+                {count.toLocaleString()} event{count !== 1 ? 's' : ''}
+            </span>{' '}
+            <span className="text-muted">(past 14 days)</span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricStepOrder.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricStepOrder.tsx
@@ -1,0 +1,29 @@
+import { match } from 'ts-pattern'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import { isExperimentFunnelMetric } from '~/queries/schema/schema-general'
+import { StepOrderValue } from '~/types'
+
+/**
+ * Only for funnel metrics
+ */
+export type MetricStepOrderProps = {
+    metric: ExperimentMetric
+}
+
+export const MetricStepOrder = ({ metric }: MetricStepOrderProps): JSX.Element | null => {
+    if (!isExperimentFunnelMetric(metric)) {
+        return null
+    }
+
+    const orderLabel = match(metric.funnel_order_type)
+        .with(StepOrderValue.ORDERED, () => 'Sequential')
+        .with(StepOrderValue.UNORDERED, () => 'Any order')
+        .otherwise(() => 'Sequential')
+
+    return (
+        <div className="text-xs">
+            <span className="text-muted">Step order:</span> <span className="font-semibold">{orderLabel}</span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
@@ -1,0 +1,94 @@
+import { useActions } from 'kea'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import { isExperimentMetric } from '~/queries/utils'
+import { ExperimentMetricModal } from '~/scenes/experiments/Metrics/ExperimentMetricModal'
+import { MetricSourceModal } from '~/scenes/experiments/Metrics/MetricSourceModal'
+import { SharedMetricModal } from '~/scenes/experiments/Metrics/SharedMetricModal'
+import {
+    METRIC_CONTEXTS,
+    MetricContext,
+    experimentMetricModalLogic,
+} from '~/scenes/experiments/Metrics/experimentMetricModalLogic'
+import { sharedMetricModalLogic } from '~/scenes/experiments/Metrics/sharedMetricModalLogic'
+import type { SharedMetric } from '~/scenes/experiments/SharedMetrics/sharedMetricLogic'
+import type { Experiment } from '~/types'
+
+import { EmptyMetricsPanel } from './EmptyMetricsPanel'
+import { MetricList } from './MetricList'
+
+export type MetricsPanelProps = {
+    experiment: Experiment
+    onSaveMetric: (metric: ExperimentMetric, context: MetricContext) => void
+    onDeleteMetric: (metric: ExperimentMetric, context: MetricContext) => void
+    onSaveSharedMetrics: (metrics: SharedMetric[], context: MetricContext) => void
+    onDeleteSharedMetric: (metric: SharedMetric, context: MetricContext) => void
+}
+
+export const MetricsPanel = ({
+    experiment,
+    onSaveMetric,
+    onDeleteMetric,
+    onSaveSharedMetrics,
+    onDeleteSharedMetric,
+}: MetricsPanelProps): JSX.Element => {
+    const { closeExperimentMetricModal } = useActions(experimentMetricModalLogic)
+    const { closeSharedMetricModal } = useActions(sharedMetricModalLogic)
+
+    // we need this value to calculate the recent activity on the metrics list
+    const filterTestAccounts = experiment.filters?.filter_test_accounts || false
+
+    const primaryMetrics = (experiment.metrics || []).filter(isExperimentMetric)
+    const secondaryMetrics = (experiment.metrics_secondary || []).filter(isExperimentMetric)
+
+    return (
+        <div>
+            {primaryMetrics.length > 0 ? (
+                <MetricList
+                    metrics={primaryMetrics}
+                    metricContext={METRIC_CONTEXTS.primary}
+                    onDelete={onDeleteMetric}
+                    filterTestAccounts={filterTestAccounts}
+                />
+            ) : (
+                <EmptyMetricsPanel metricContext={METRIC_CONTEXTS.primary} />
+            )}
+
+            {secondaryMetrics.length > 0 ? (
+                <MetricList
+                    metrics={secondaryMetrics}
+                    metricContext={METRIC_CONTEXTS.secondary}
+                    onDelete={onDeleteMetric}
+                    filterTestAccounts={filterTestAccounts}
+                    className="mt-6"
+                />
+            ) : (
+                <EmptyMetricsPanel className="mt-6" metricContext={METRIC_CONTEXTS.secondary} />
+            )}
+
+            <MetricSourceModal />
+            <ExperimentMetricModal
+                experiment={experiment}
+                onSave={(metric, context) => {
+                    onSaveMetric(metric, context)
+                    closeExperimentMetricModal()
+                }}
+                onDelete={(metric, context) => {
+                    onDeleteMetric(metric, context)
+                    closeExperimentMetricModal()
+                }}
+            />
+            <SharedMetricModal
+                experiment={experiment}
+                onSave={(metrics, context) => {
+                    onSaveSharedMetrics(metrics, context)
+                    closeSharedMetricModal()
+                }}
+                onDelete={(metric, context) => {
+                    onDeleteSharedMetric(metric, context)
+                    closeSharedMetricModal()
+                }}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/create/MetricsPanel/metricRecentActivityLogic.ts
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/metricRecentActivityLogic.ts
@@ -48,7 +48,10 @@ export const metricRecentActivityLogic = kea<metricRecentActivityLogicType>([
         }
     }),
     propsChanged(({ actions, props }, oldProps) => {
-        if (!equal(props, oldProps) || props.filterTestAccounts !== oldProps.filterTestAccounts) {
+        /**
+         * this brings back memories of componentWillReceiveProps...
+         */
+        if (!equal(props, oldProps)) {
             actions.loadEventCount()
         }
     }),

--- a/frontend/src/scenes/experiments/create/MetricsPanel/metricRecentActivityLogic.ts
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/metricRecentActivityLogic.ts
@@ -1,0 +1,55 @@
+import equal from 'fast-deep-equal'
+import { afterMount, kea, key, path, props, propsChanged } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { performQuery } from '~/queries/query'
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import { getEventCountQuery } from '~/scenes/experiments/utils'
+
+import type { metricRecentActivityLogicType } from './metricRecentActivityLogicType'
+
+export type MetricRecentActivityLogicProps = {
+    metric: ExperimentMetric
+    filterTestAccounts: boolean
+}
+
+export const metricRecentActivityLogic = kea<metricRecentActivityLogicType>([
+    props({} as MetricRecentActivityLogicProps),
+    key((props) => `${props.metric.uuid}`),
+    path((key) => ['scenes', 'experiments', 'create', 'metricRecentActivityLogic', key]),
+    loaders(({ props }) => ({
+        eventCount: [
+            null as number | null,
+            {
+                loadEventCount: async () => {
+                    const query = getEventCountQuery(props.metric, props.filterTestAccounts)
+
+                    if (!query) {
+                        return null
+                    }
+
+                    const response = await performQuery(query)
+
+                    if (response.results && response.results.length > 0) {
+                        const firstResult = response.results[0]
+                        if (firstResult && typeof firstResult.aggregated_value === 'number') {
+                            return firstResult.aggregated_value
+                        }
+                    }
+
+                    return null
+                },
+            },
+        ],
+    })),
+    afterMount(({ actions, props }) => {
+        if (props.metric.uuid) {
+            actions.loadEventCount()
+        }
+    }),
+    propsChanged(({ actions, props }, oldProps) => {
+        if (!equal(props, oldProps) || props.filterTestAccounts !== oldProps.filterTestAccounts) {
+            actions.loadEventCount()
+        }
+    }),
+])

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -12,6 +12,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
+import { ExperimentMetric } from '~/queries/schema/schema-general'
 import type { Experiment, FeatureFlagFilters } from '~/types'
 import { ProductKey } from '~/types'
 
@@ -54,6 +55,9 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
         setExperiment: (experiment: Experiment) => ({ experiment }),
         createExperiment: () => ({}),
         createExperimentSuccess: true,
+        setSharedMetrics: (sharedMetrics: { primary: ExperimentMetric[]; secondary: ExperimentMetric[] }) => ({
+            sharedMetrics,
+        }),
     })),
     reducers(({ props }) => ({
         experiment: [
@@ -62,6 +66,12 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 setExperiment: (_, { experiment }) => experiment,
                 updateFeatureFlagKey: (state, { key }) => ({ ...state, feature_flag_key: key }),
                 resetExperiment: () => props.experiment ?? { ...NEW_EXPERIMENT },
+            },
+        ],
+        sharedMetrics: [
+            { primary: [], secondary: [] } as { primary: ExperimentMetric[]; secondary: ExperimentMetric[] },
+            {
+                setSharedMetrics: (_, { sharedMetrics }) => sharedMetrics,
             },
         ],
     })),


### PR DESCRIPTION
## Problem

The new create experiment form does not support adding one-time or shared metrics before saving a draft.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding a new panel where the user can set primary and secondary metrics.

| Empty metrics panel | Primary and secondary metrics configured |
| - | - |
| <img width="963" height="590" alt="image" src="https://github.com/user-attachments/assets/b80682d7-6831-42b7-902e-748b472e6dd5" /> | <img width="958" height="949" alt="image" src="https://github.com/user-attachments/assets/f55dff47-499a-4dd5-a3b8-a0fa00845c52" /> |

We support managing on one-time and shared metrics. We include confirmation dialogs when appropriate.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/ba4fcfe1-8bd5-40e6-b998-729aa5111e23)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->