### PR TITLE
chore: Use maxWidth for SharedMetricModal

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -61,7 +61,7 @@ export function SharedMetricModal({
         <LemonModal
             isOpen={isModalOpen}
             onClose={closeSharedMetricModal}
-            width={500}
+            maxWidth={800}
             title={isCreateMode ? 'Select one or more shared metrics' : 'Shared metric'}
             footer={
                 <div className="flex justify-between w-full">


### PR DESCRIPTION
## Problem

The modal was a bit skinny, especially when shared metrics have long descriptions and tags - this lets it grow a bit

https://posthoghelp.zendesk.com/agent/tickets/40119 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41419)

| before | after |
|---|---|
|<img width="1257" height="432" alt="image" src="https://github.com/user-attachments/assets/10bf0d11-b00a-420e-9b73-fe9c17ad8748" />|<img width="2490" height="874" alt="CleanShot 2025-10-17 at 07 43 58@2x" src="https://github.com/user-attachments/assets/9b5686a6-2326-4ad8-9a97-bbaa309006c3" />|
|<img width="2504" height="986" alt="CleanShot 2025-10-17 at 07 45 45@2x" src="https://github.com/user-attachments/assets/b1847d30-3405-4cf6-a71d-78bfe6551393" />|<img width="2510" height="850" alt="CleanShot 2025-10-17 at 07 46 08@2x" src="https://github.com/user-attachments/assets/f1589473-8108-4353-8fe4-45053570e765" />|