### PR TITLE
fix(ci): add schema.json to path filter and regenerate schema.py

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -34,6 +34,8 @@ jobs:
                         - .github/workflows/ci-python.yml
                         - .github/workflows/ci-dagster.yml
                         - .github/workflows/ci-backend.yml
+                        # Schema changes need to trigger Python CI to validate schema.py is regenerated
+                        - 'frontend/src/queries/schema.json'
 
     code-quality:
         needs: changes

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2172,6 +2172,7 @@ class PlaywrightWorkspaceSetupResult(BaseModel):
 class PropertyFilterType(StrEnum):
     META = "meta"
     EVENT = "event"
+    INTERNAL_EVENT = "internal_event"
     EVENT_METADATA = "event_metadata"
     PERSON = "person"
     ELEMENT = "element"
@@ -2804,6 +2805,7 @@ class TaxonomicFilterGroupType(StrEnum):
     DATA_WAREHOUSE_PERSON_PROPERTIES = "data_warehouse_person_properties"
     ELEMENTS = "elements"
     EVENTS = "events"
+    INTERNAL_EVENTS = "internal_events"
     EVENT_PROPERTIES = "event_properties"
     EVENT_FEATURE_FLAGS = "event_feature_flags"
     EVENT_METADATA = "event_metadata"


### PR DESCRIPTION
## Summary

Fixes schema.py validation bypass caused by incomplete path filter in Python CI workflow. Regenerates schema.py with missing types and ensures future schema.json changes trigger validation.

## Root cause

PR #39306 optimized workflow skip logic by moving the `if: needs.changes.outputs.python == 'true'` condition from step-level to job-level in ci-python.yml. This is a good optimization that reduces runner waste by skipping entire jobs rather than running them just to skip individual steps.

However, this optimization exposed an incomplete path filter (lines 28-36). The filter didn't include `frontend/src/queries/schema.json`, so:

1. When PR #39689 updated schema.json with `internal_event` type, Python CI evaluated to `false` (no Python files changed)
2. The entire `code-quality` job was skipped due to the job-level `if` condition (line 40)
3. The schema.py validation check (lines 124-127: `npm run schema:build:python && git diff --exit-code`) never ran
4. schema.py got out of sync with schema.json on master

## Changes

- Add `frontend/src/queries/schema.json` to path filter in `.github/workflows/ci-python.yml`
- Regenerate `posthog/schema.py` to include missing `INTERNAL_EVENT` and `INTERNAL_EVENTS` types in PropertyFilterType and TaxonomicFilterGroupType enums

## References

- **PR #39306**: "fix(ci): optimize workflow skip logic to reduce runner waste" - the optimization that exposed this gap
- **PR #39689**: The PR that updated schema.json but had schema.py validation skipped
- **Check location**: ci-python.yml:124-127 runs the schema.py validation
- **Path filter**: ci-python.yml:28-36 defines which file changes trigger Python CI

## Test plan

- Python CI should now run when `frontend/src/queries/schema.json` changes
- The schema.py validation check will catch any future out-of-sync issues