### PR TITLE
fix(experiments): use generic step names in chart when funnel is unordered

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -236,6 +236,7 @@ export function ResultDetails({
                     inCardView={true}
                     experimentResult={result}
                     experiment={experiment}
+                    metric={metric}
                 />
             )}
         </div>

--- a/frontend/src/scenes/experiments/charts/funnel/FunnelChart.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelChart.tsx
@@ -2,7 +2,7 @@ import '../../../funnels/Funnel.scss'
 
 import { createContext, useContext, useMemo } from 'react'
 
-import { NewExperimentQueryResponse } from '~/queries/schema/schema-general'
+import { ExperimentMetric, NewExperimentQueryResponse } from '~/queries/schema/schema-general'
 import {
     ChartParams,
     Experiment,
@@ -26,6 +26,8 @@ export interface FunnelChartProps extends ChartParams {
     /** Experiment result data */
     experimentResult: NewExperimentQueryResponse
     experiment?: Experiment
+    /** Experiment metric configuration */
+    metric?: ExperimentMetric
 }
 
 export interface FunnelChartDataContext {
@@ -34,6 +36,7 @@ export interface FunnelChartDataContext {
     hasFunnelResults: boolean
     experimentResult: NewExperimentQueryResponse
     experiment?: Experiment
+    metric?: ExperimentMetric
 }
 
 const FunnelChartDataContext = createContext<FunnelChartDataContext | null>(null)
@@ -59,6 +62,7 @@ export function FunnelChart({
     inCardView = false,
     experimentResult,
     experiment,
+    metric,
     ...chartParams
 }: FunnelChartProps): JSX.Element {
     const processedData = useMemo(() => {
@@ -77,8 +81,9 @@ export function FunnelChart({
             hasFunnelResults: processedData.hasFunnelResults,
             experimentResult,
             experiment,
+            metric,
         }),
-        [processedData, experimentResult, experiment]
+        [processedData, experimentResult, experiment, metric]
     )
 
     return (

--- a/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
@@ -6,7 +6,10 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconTrendingFlat, IconTrendingFlatDown } from 'lib/lemon-ui/icons'
 import { capitalizeFirstLetter, humanFriendlyDuration, percentage, pluralize } from 'lib/utils'
 
-import { FunnelStepWithConversionMetrics } from '~/types'
+import { isExperimentFunnelMetric } from '~/queries/schema/schema-general'
+import { FunnelStepWithConversionMetrics, StepOrderValue } from '~/types'
+
+import { useFunnelChartData } from './FunnelChart'
 
 interface StepLegendProps {
     step: FunnelStepWithConversionMetrics
@@ -15,7 +18,13 @@ interface StepLegendProps {
 }
 
 export function StepLegend({ step, stepIndex, showTime }: StepLegendProps): JSX.Element {
+    const { metric } = useFunnelChartData()
     const aggregationTargetLabel = { singular: 'user', plural: 'users' }
+
+    const isUnorderedFunnel = isExperimentFunnelMetric(metric) && metric.funnel_order_type === StepOrderValue.UNORDERED
+    const stepLabel = isUnorderedFunnel
+        ? `Completed ${stepIndex + 1} ${stepIndex === 0 ? 'step' : 'steps'}`
+        : step.custom_name || step.name
 
     const convertedCountPresentation = pluralize(
         step.count ?? 0,
@@ -44,7 +53,7 @@ export function StepLegend({ step, stepIndex, showTime }: StepLegendProps): JSX.
     return (
         <div className="StepLegend">
             <LemonRow icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />}>
-                <span title={step.custom_name || step.name}>{step.custom_name || step.name}</span>
+                <span title={stepLabel}>{stepLabel}</span>
             </LemonRow>
             <LemonRow icon={<IconTrendingFlat />} status="success" style={{ color: 'unset' }}>
                 <Tooltip

--- a/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
@@ -21,7 +21,8 @@ export function StepLegend({ step, stepIndex, showTime }: StepLegendProps): JSX.
     const { metric } = useFunnelChartData()
     const aggregationTargetLabel = { singular: 'user', plural: 'users' }
 
-    const isUnorderedFunnel = isExperimentFunnelMetric(metric) && metric.funnel_order_type === StepOrderValue.UNORDERED
+    const isUnorderedFunnel =
+        !!metric && isExperimentFunnelMetric(metric) && metric.funnel_order_type === StepOrderValue.UNORDERED
     const stepLabel = isUnorderedFunnel
         ? `Completed ${stepIndex + 1} ${stepIndex === 0 ? 'step' : 'steps'}`
         : step.custom_name || step.name


### PR DESCRIPTION
## Problem

  When experiment funnel metrics are configured as "unordered", the chart displays actual step names instead of generic names like "Completed 1 step", "Completed 2 steps", etc. This is inconsistent with the behavior of the original funnel chart.

  ## Changes

  - Added `metric` prop to `FunnelChart` component and passed it through the data context
  - Updated `StepLegend` to check if the funnel is unordered and display generic step names accordingly
  - Follows the same pattern used in `FunnelBarHorizontal` for consistency

  | Before | After |
  |--------|-------|
  | <img width="1294" height="546" alt="Screenshot 2025-10-17 at 09 58 30" src="https://github.com/user-attachments/assets/9451a18e-9660-4b5f-a7f3-1be16eae6527" /> | <img width="1288" height="543" alt="Screenshot 2025-10-17 at 09 58 49" src="https://github.com/user-attachments/assets/3d507591-72cf-41b4-9fc3-3b57ba0f26c5" /> |

## How did you test this code?

- tested locally