### PR TITLE
chore: migrate_clickhouse --strict to prevent duplicate migration ids

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -36,7 +36,7 @@ echo "0" > $CLICKHOUSE_STATUS
 # Run ClickHouse migrations in the background but track their status
 (
     # Run migrations and capture status
-    python manage.py migrate_clickhouse
+    python manage.py migrate_clickhouse --strict
     CH_MIGRATE_STATUS=$?
     if [ $CH_MIGRATE_STATUS -ne 0 ]; then
         echo "Error in migrate_clickhouse, setting error status."


### PR DESCRIPTION
let's make migration fail before it messes up migration table

follow up to: https://github.com/PostHog/posthog/pull/39829