### PR TITLE
chore: add activity logging to Endpoints backend

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -36,6 +36,7 @@ ActivityScope = Literal[
     "EventDefinition",
     "PropertyDefinition",
     "Notebook",
+    "Endpoint",
     "Dashboard",
     "Replay",
     "Experiment",

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 
 from django_filters.rest_framework import DjangoFilterBackend
+from loginas.utils import is_impersonated_session
 from pydantic import BaseModel
 from rest_framework import status, viewsets
 from rest_framework.exceptions import Throttled, ValidationError
@@ -40,6 +41,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 from posthog.hogql_queries.query_runner import BLOCKING_EXECUTION_MODES
 from posthog.models import User
+from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.rate_limit import APIQueriesBurstThrottle, APIQueriesSustainedThrottle
 from posthog.schema_migrations.upgrade import upgrade
 from posthog.types import InsightQueryNode
@@ -137,6 +139,18 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 is_active=data.is_active if data.is_active is not None else True,
             )
 
+            # Activity log: created
+            log_activity(
+                organization_id=self.organization.id,
+                team_id=self.team.id,
+                user=cast(User, request.user),
+                was_impersonated=is_impersonated_session(request),
+                item_id=str(endpoint.id),
+                scope="Endpoint",
+                activity="created",
+                detail=Detail(name=endpoint.name),
+            )
+
             return Response(
                 {
                     "id": str(endpoint.id),
@@ -164,6 +178,11 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     def update(self, request: Request, name=None, *args, **kwargs) -> Response:
         """Update an existing endpoint."""
         endpoint = get_object_or_404(Endpoint, team=self.team, name=name)
+        # Capture a snapshot for diffing
+        try:
+            before_update = Endpoint.objects.get(pk=endpoint.id)
+        except Endpoint.DoesNotExist:
+            before_update = None
 
         upgraded_query = upgrade(request.data)
         data = self.get_model(upgraded_query, EndpointRequest)
@@ -180,6 +199,19 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 endpoint.is_active = data.is_active
 
             endpoint.save()
+
+            # Activity log: updated with field diffs
+            changes = changes_between("Endpoint", previous=before_update, current=endpoint)
+            log_activity(
+                organization_id=self.organization.id,
+                team_id=self.team.id,
+                user=cast(User, request.user),
+                was_impersonated=is_impersonated_session(request),
+                item_id=str(endpoint.id),
+                scope="Endpoint",
+                activity="updated",
+                detail=Detail(name=endpoint.name, changes=changes),
+            )
 
             return Response(
                 {


### PR DESCRIPTION
## Problem

Users need to track changes made to Endpoint objects (creation, updates, and diffs) to understand their history, a common pattern across PostHog products. This change enables activity logging for the Endpoints product.

## Changes

- Added `"Endpoint"` to the `ActivityScope` enum.
- Implemented activity logging for Endpoint creation, recording a `created` event with the endpoint's name.
- Implemented activity logging for Endpoint updates, capturing `updated` events with detailed diffs of changed fields.
- Added new backend tests to verify that `created` and `updated` activity logs are correctly generated and contain the expected details and changes.

## How did you test this code?

New backend tests were added to `products/endpoints/backend/tests/test_endpoint.py` to assert the presence and content of activity logs for both create and update operations.

## Changelog: (features only) Is this feature complete?

No, the backend logging is complete, but the frontend UI to display these activity logs for Endpoints is not yet implemented.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ef00b85-f6af-49b5-a691-3143374ff52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ef00b85-f6af-49b5-a691-3143374ff52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

