### PR TITLE
fix(batch-import): Handle string boolean values in Amplitude migrations

### DIFF
--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -286,7 +286,12 @@ impl Job {
                         display_msg,
                     } => {
                         let mut model = self.model.lock().await;
-                        error!(job_id = %model.id, error = ?e, "Pausing job due to error: {}", error_msg);
+                        error!(
+                            job_id = %model.id,
+                            user_msg = %error_msg,
+                            "Pausing job due to error: {:#}",
+                            e
+                        );
                         model
                             .pause(self.context.clone(), error_msg, Some(display_msg))
                             .await?;

--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -24,7 +24,10 @@ pub struct ChangedGroup {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AmplitudeData {
     pub path: Option<String>,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::parse::serialization::deserialize_flexible_bool"
+    )]
     pub user_properties_updated: bool,
     #[serde(rename = "group_first_event", default)]
     pub group_first_event: HashMap<String, Value>,
@@ -75,6 +78,10 @@ pub struct AmplitudeEvent {
     pub groups: HashMap<String, Vec<String>>,
     pub idfa: Option<String>,
     pub ip_address: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "crate::parse::serialization::deserialize_flexible_option_bool"
+    )]
     pub is_attribution_event: Option<bool>,
     pub language: Option<String>,
     pub library: Option<String>,
@@ -83,6 +90,10 @@ pub struct AmplitudeEvent {
     pub os_name: Option<String>,
     pub os_version: Option<String>,
     pub partner_id: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "crate::parse::serialization::deserialize_flexible_option_bool"
+    )]
     pub paying: Option<bool>,
     #[serde(default)]
     pub plan: HashMap<String, Value>,
@@ -1813,6 +1824,106 @@ mod tests {
             data.properties.get("$import_job_id"),
             Some(&json!(test_job_id.to_string()))
         );
+    }
+
+    #[test]
+    fn test_user_properties_updated_string_bool() {
+        // Test that user_properties_updated accepts string "true"
+        let json = r#"{
+            "data": {
+                "user_properties_updated": "true"
+            }
+        }"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert!(event.data.user_properties_updated);
+
+        // Test that user_properties_updated accepts string "false"
+        let json = r#"{
+            "data": {
+                "user_properties_updated": "false"
+            }
+        }"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert!(!event.data.user_properties_updated);
+
+        // Test with actual boolean
+        let json = r#"{
+            "data": {
+                "user_properties_updated": true
+            }
+        }"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert!(event.data.user_properties_updated);
+
+        // Test with string "1"
+        let json = r#"{
+            "data": {
+                "user_properties_updated": "1"
+            }
+        }"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert!(event.data.user_properties_updated);
+    }
+
+    #[test]
+    fn test_is_attribution_event_string_bool() {
+        // Test with string "true"
+        let json = r#"{"is_attribution_event": "true"}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.is_attribution_event, Some(true));
+
+        // Test with string "false"
+        let json = r#"{"is_attribution_event": "false"}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.is_attribution_event, Some(false));
+
+        // Test with string "1"
+        let json = r#"{"is_attribution_event": "1"}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.is_attribution_event, Some(true));
+
+        // Test with actual boolean
+        let json = r#"{"is_attribution_event": true}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.is_attribution_event, Some(true));
+
+        // Test with null
+        let json = r#"{"is_attribution_event": null}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.is_attribution_event, None);
+
+        // Test with missing field
+        let json = r#"{}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.is_attribution_event, None);
+    }
+
+    #[test]
+    fn test_paying_string_bool() {
+        // Test with string "true"
+        let json = r#"{"paying": "true"}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.paying, Some(true));
+
+        // Test with string "0"
+        let json = r#"{"paying": "0"}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.paying, Some(false));
+
+        // Test with integer
+        let json = r#"{"paying": 1}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.paying, Some(true));
+
+        // Test with actual boolean
+        let json = r#"{"paying": false}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.paying, Some(false));
+
+        // Test with missing field
+        let json = r#"{}"#;
+        let event: AmplitudeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.paying, None);
     }
 
     #[test]

--- a/rust/batch-import-worker/src/parse/mod.rs
+++ b/rust/batch-import-worker/src/parse/mod.rs
@@ -1,5 +1,6 @@
 pub mod content;
 pub mod format;
+pub mod serialization;
 
 pub struct Parsed<T> {
     pub data: T,

--- a/rust/batch-import-worker/src/parse/serialization.rs
+++ b/rust/batch-import-worker/src/parse/serialization.rs
@@ -77,9 +77,7 @@ where
 
 /// Custom deserializer for optional boolean values that can also accept string booleans.
 /// Handles null and missing values as None, otherwise delegates to `deserialize_flexible_bool`.
-pub fn deserialize_flexible_option_bool<'de, D>(
-    deserializer: D,
-) -> Result<Option<bool>, D::Error>
+pub fn deserialize_flexible_option_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -195,10 +193,7 @@ mod tests {
 
     #[derive(Deserialize, Debug, PartialEq)]
     struct TestOptionalStruct {
-        #[serde(
-            default,
-            deserialize_with = "deserialize_flexible_option_bool"
-        )]
+        #[serde(default, deserialize_with = "deserialize_flexible_option_bool")]
         flag: Option<bool>,
     }
 

--- a/rust/batch-import-worker/src/parse/serialization.rs
+++ b/rust/batch-import-worker/src/parse/serialization.rs
@@ -1,0 +1,271 @@
+use serde::{de, Deserializer};
+use std::fmt;
+
+/// Custom deserializer for boolean values that can also accept string booleans.
+/// This is useful when dealing with external data sources that may serialize
+/// booleans as strings.
+///
+/// Accepts:
+/// - Actual booleans: true, false
+/// - String representations: "true", "false", "1", "0", "yes", "no", "" (empty string = false)
+/// - Integer representations: 1 (true), 0 (false) only
+pub fn deserialize_flexible_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct FlexibleBoolVisitor;
+
+    impl<'de> de::Visitor<'de> for FlexibleBoolVisitor {
+        type Value = bool;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a boolean, 0, 1, or a string representing a boolean")
+        }
+
+        fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(value)
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match value.to_lowercase().as_str() {
+                "true" | "1" | "yes" => Ok(true),
+                "false" | "0" | "no" | "" => Ok(false),
+                _ => Err(de::Error::invalid_value(
+                    de::Unexpected::Str(value),
+                    &"'true', 'false', '1', '0', 'yes', 'no', or empty string",
+                )),
+            }
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match value {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Err(de::Error::invalid_value(
+                    de::Unexpected::Signed(value),
+                    &"0 or 1",
+                )),
+            }
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match value {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Err(de::Error::invalid_value(
+                    de::Unexpected::Unsigned(value),
+                    &"0 or 1",
+                )),
+            }
+        }
+    }
+
+    deserializer.deserialize_any(FlexibleBoolVisitor)
+}
+
+/// Custom deserializer for optional boolean values that can also accept string booleans.
+/// Handles null and missing values as None, otherwise delegates to `deserialize_flexible_bool`.
+pub fn deserialize_flexible_option_bool<'de, D>(
+    deserializer: D,
+) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct Wrapper(#[serde(deserialize_with = "deserialize_flexible_bool")] bool);
+
+    Option::<Wrapper>::deserialize(deserializer).map(|opt| opt.map(|w| w.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct TestStruct {
+        #[serde(deserialize_with = "deserialize_flexible_bool")]
+        flag: bool,
+    }
+
+    #[test]
+    fn test_deserialize_actual_bool() {
+        let json = r#"{"flag": true}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(result.flag);
+
+        let json = r#"{"flag": false}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(!result.flag);
+    }
+
+    #[test]
+    fn test_deserialize_string_bool() {
+        let json = r#"{"flag": "true"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(result.flag);
+
+        let json = r#"{"flag": "false"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(!result.flag);
+    }
+
+    #[test]
+    fn test_deserialize_string_bool_case_insensitive() {
+        let json = r#"{"flag": "TRUE"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(result.flag);
+
+        let json = r#"{"flag": "False"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(!result.flag);
+    }
+
+    #[test]
+    fn test_deserialize_numeric_string() {
+        let json = r#"{"flag": "1"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(result.flag);
+
+        let json = r#"{"flag": "0"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(!result.flag);
+    }
+
+    #[test]
+    fn test_deserialize_yes_no() {
+        let json = r#"{"flag": "yes"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(result.flag);
+
+        let json = r#"{"flag": "no"}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(!result.flag);
+    }
+
+    #[test]
+    fn test_deserialize_empty_string() {
+        let json = r#"{"flag": ""}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(!result.flag);
+    }
+
+    #[test]
+    fn test_deserialize_integer_0_and_1() {
+        let json = r#"{"flag": 1}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(result.flag);
+
+        let json = r#"{"flag": 0}"#;
+        let result: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(!result.flag);
+    }
+
+    #[test]
+    fn test_deserialize_invalid_integer() {
+        let json = r#"{"flag": 42}"#;
+        let result: Result<TestStruct, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+
+        let json = r#"{"flag": -1}"#;
+        let result: Result<TestStruct, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_invalid_string() {
+        let json = r#"{"flag": "invalid"}"#;
+        let result: Result<TestStruct, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct TestOptionalStruct {
+        #[serde(
+            default,
+            deserialize_with = "deserialize_flexible_option_bool"
+        )]
+        flag: Option<bool>,
+    }
+
+    #[test]
+    fn test_deserialize_option_bool_some_true() {
+        let json = r#"{"flag": true}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(true));
+
+        let json = r#"{"flag": "true"}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(true));
+
+        let json = r#"{"flag": "1"}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(true));
+
+        let json = r#"{"flag": 1}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(true));
+    }
+
+    #[test]
+    fn test_deserialize_option_bool_some_false() {
+        let json = r#"{"flag": false}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(false));
+
+        let json = r#"{"flag": "false"}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(false));
+
+        let json = r#"{"flag": "0"}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(false));
+
+        let json = r#"{"flag": 0}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(false));
+    }
+
+    #[test]
+    fn test_deserialize_option_bool_none() {
+        let json = r#"{"flag": null}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, None);
+
+        let json = r#"{}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, None);
+    }
+
+    #[test]
+    fn test_deserialize_option_bool_empty_string() {
+        let json = r#"{"flag": ""}"#;
+        let result: TestOptionalStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(result.flag, Some(false));
+    }
+
+    #[test]
+    fn test_deserialize_option_bool_invalid() {
+        let json = r#"{"flag": "invalid"}"#;
+        let result: Result<TestOptionalStruct, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+
+        let json = r#"{"flag": 42}"#;
+        let result: Result<TestOptionalStruct, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Problem

We are failing some migrations from amplitude due to boolean values being formatted as strings, this PR adds support for this. 

## Changes

- Accepts booleans in the following format
   - Actual booleans: true, false
   - String representations: "true", "false", "1", "0", "yes", "no", "" (empty string = false)
   - Integer representations: 1 (true), 0 (false) only
- Fix server side logging for batch import when errors occur

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
