### PR TITLE
chore: improve usage_report retries

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -83,8 +83,9 @@ USAGE_REPORT_TASK_KWARGS = {
     "acks_late": True,
     "reject_on_worker_lost": True,
     "autoretry_for": (Exception,),
-    "retry_backoff": 300,
-    "retry_backoff_max": 1800,
+    "retry_backoff": 300,  # 5min
+    "retry_backoff_max": 1800,  # 30min
+    "expires": 14400,  # 4h
 }
 
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -80,8 +80,11 @@ QUERY_RETRY_BACKOFF = 2
 USAGE_REPORT_TASK_KWARGS = {
     "queue": CeleryQueue.USAGE_REPORTS.value,
     "ignore_result": True,
+    "acks_late": True,
+    "reject_on_worker_lost": True,
     "autoretry_for": (Exception,),
-    "retry_backoff": True,
+    "retry_backoff": 300,
+    "retry_backoff_max": 1800,
 }
 
 


### PR DESCRIPTION
## Problem

- Currently, usage reports run with 3 retries but with minimal backoff (effectively up to a few seconds)
- There are also no retries if the worker crashes

## Changes

- Set retry backoff to 5min -> 10min -> 20min
- Set `acks_late` to true so that task is removed from queue after task completes
- Set `reject_on_worker_lost` to true so that task is requeued if worker dies
- Set `expires` to 4h to prevent infinite retry loops (unlikely due to `max_retries` but there might be crashes where this gets lost)

## How did you test this code?

n/a