### PR TITLE
fix(data-warehouse): When copying to S3, delete files after the new have copied successfully

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -322,6 +322,7 @@ class PipelineNonDLT:
             # delete existing files if it's the first chunk, otherwise we'll just append to the existing files
             delete_existing=chunk_index == 0,
             use_timestamped_folders=False,
+            logger=self._logger,
         )
         self._logger.debug("Validating schema and updating table")
         validate_schema_and_update_table_sync(
@@ -348,7 +349,12 @@ class PipelineNonDLT:
         file_uris = delta_table.file_uris()
         self._logger.debug(f"Preparing S3 files - total parquet files: {len(file_uris)}")
         queryable_folder = prepare_s3_files_for_querying(
-            self._job.folder_path(), self._resource_name, file_uris, delete_existing=True, use_timestamped_folders=True
+            self._job.folder_path(),
+            self._resource_name,
+            file_uris,
+            delete_existing=True,
+            use_timestamped_folders=True,
+            logger=self._logger,
         )
 
         self._logger.debug("Updating last synced at timestamp on schema")

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -353,7 +353,7 @@ class PipelineNonDLT:
             self._resource_name,
             file_uris,
             delete_existing=True,
-            use_timestamped_folders=True,
+            existing_queryable_folder=self._schema.table.queryable_folder if self._schema.table else None,
             logger=self._logger,
         )
 

--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -1,10 +1,11 @@
 import re
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from django.conf import settings
 
 from dlt.common.normalizers.naming.snake_case import NamingConvention
+from structlog.types import FilteringBoundLogger
 
 from posthog.settings.utils import get_from_env
 from posthog.temporal.data_imports.deltalake_compaction_job import capture_exception
@@ -22,12 +23,24 @@ def prepare_s3_files_for_querying(
     preserve_table_name_casing: Optional[bool] = False,
     delete_existing: bool = True,
     use_timestamped_folders: bool = False,
+    logger: Optional[FilteringBoundLogger] = None,
 ) -> str:
     """Copies files from a given S3 folder to a new S3 folder that is used for querying.
     This is done to ensure that the files are in a consistent state before querying.
 
     Returns the folder that can be used for querying. Note: this isn't the whole S3 path, just the last directory, e.g. table__query
     """
+
+    def _log(msg: str, level: Optional[Literal["debug", "error"]] = "debug") -> None:
+        if logger:
+            if level == "debug":
+                logger.debug(msg)
+            elif level == "error":
+                logger.error(msg)
+
+    _log(
+        f"Preparing S3 files for querying for table {table_name} in folder {folder_path}. delete_existing={delete_existing}. use_timestamped_folders={use_timestamped_folders}."
+    )
 
     s3 = get_s3_client()
     s3.invalidate_cache()
@@ -51,12 +64,15 @@ def prepare_s3_files_for_querying(
         s3_folder_for_querying = f"{s3_folder_for_querying}_{timestamp}"
 
     if delete_existing:
+        files_to_delete: list[str] = []
         if use_timestamped_folders:
             query_folder_pattern = re.compile(r"^.+?\_\_query\_(\d+)\/?$")
 
             all_files = s3.ls(s3_folder_for_job, detail=True)
             all_file_values = all_files.values() if isinstance(all_files, dict) else all_files
             directories = [f["Key"] for f in all_file_values if f["type"] == "directory"]
+
+            _log(f"Found existing directories: {directories}")
 
             timestamped_query_folders: list[tuple[str, int]] = []
             for directory in directories:
@@ -72,25 +88,41 @@ def prepare_s3_files_for_querying(
             for index, directory in enumerate(timestamped_query_folders):
                 directory_path, directory_timestamp = directory
                 if index == total_dirs - 1:
+                    _log(f"Skipping deletion of most recent query folder: {directory_path}")
                     continue
 
                 try:
                     if (datetime.now().timestamp() - directory_timestamp) >= S3_DELETE_TIME_BUFFER:
-                        s3.delete(directory_path, recursive=True)
+                        files_to_delete.append(directory_path)
 
                     # Delete the old format query folder if it exists
                     old_query_folder = f"{s3_folder_for_job}/{normalized_table_name}__query"
                     if s3.exists(old_query_folder):
-                        s3.delete(old_query_folder, recursive=True)
+                        files_to_delete.append(old_query_folder)
                 except Exception as e:
+                    _log(f"Error while checking old query folders: {e}", level="error")
                     capture_exception(e)
         else:
             if s3.exists(s3_path_for_querying):
-                s3.delete(s3_path_for_querying, recursive=True)
+                files_to_delete.append(s3_path_for_querying)
 
     for file in file_uris:
         file_name = file.replace(f"{s3_folder_for_schema}/", "")
+        _log(f"Copying file {file} to {s3_path_for_querying}/{file_name}")
         s3.copy(file, f"{s3_path_for_querying}/{file_name}")
+
+    # Delete existing files after copying new ones. In the event of a pod OOM during file
+    # copying, the queryable_folder can get out of date and attempt to query deleted files.
+    if delete_existing and files_to_delete:
+        for file in files_to_delete:
+            _log(f"Deleting existing querying folder {file}")
+            try:
+                s3.delete(file, recursive=True)
+            except Exception as e:
+                _log(f"Error while deleting old query folder {file}: {e}", level="error")
+                capture_exception(e)
+
+    _log(f"Returning S3 folder for querying: {s3_folder_for_querying}")
 
     return s3_folder_for_querying
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -577,7 +577,7 @@ async def materialize_model(
         table_name=saved_query.normalized_name,
         file_uris=file_uris,
         preserve_table_name_casing=True,
-        use_timestamped_folders=True,
+        existing_queryable_folder=saved_query.table.queryable_folder if saved_query.table else None,
         logger=logger,
     )
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -578,6 +578,7 @@ async def materialize_model(
         file_uris=file_uris,
         preserve_table_name_casing=True,
         use_timestamped_folders=True,
+        logger=logger,
     )
 
     saved_query.is_materialized = True


### PR DESCRIPTION
## Problem
- We were deleting existing query files before copying the new over, most of the time this is fine, but if the pod OOMs during the copying of the new files then the `query_folder` column doesn't get updated even though the old files got deleted

## Changes
- Delete the old query folders after we've successfully copied over the new ones (the copying is often a much longer action)
- Pass the current existing folder into the s3 deletion function to make sure the current folder isn't deleted 

## How did you test this code?
- Existing tests cover this 