### PR TITLE
fix(batch-exports): Databricks: Add timeout for long running queries

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -74,6 +74,9 @@ NON_RETRYABLE_ERROR_TYPES: list[str] = [
     "DatabricksIntegrationNotFoundError",
     # Raised when the Databricks integration is not valid.
     "DatabricksIntegrationError",
+    # Raised when we hit our self-imposed long running operation timeout.
+    # We don't want to continually retry as it could consume a lot of compute resources in the user's account.
+    "DatabricksOperationTimeoutError",
 ]
 
 DatabricksField = tuple[str, str]
@@ -116,6 +119,17 @@ class DatabricksSchemaNotFoundError(Exception):
 
     def __init__(self, schema: str):
         super().__init__(f"Schema '{schema}' not found")
+
+
+class DatabricksOperationTimeoutError(Exception):
+    """Error raised when we hit our self-imposed long running operation timeout.
+
+    We impose this timeout to prevent operations from running for too long, which could cause SLA violations and consume
+    a lot of compute resources in the user's account.
+    """
+
+    def __init__(self, operation: str, timeout: float):
+        super().__init__(f"{operation} timed out after {timeout} seconds")
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -485,15 +499,22 @@ class DatabricksClient:
         )
 
     async def acopy_into_table_from_volume(
-        self, table_name: str, volume_path: str, fields: list[DatabricksField], with_schema_evolution: bool = True
-    ):
+        self,
+        table_name: str,
+        volume_path: str,
+        fields: list[DatabricksField],
+        with_schema_evolution: bool = True,
+        timeout: float = 60 * 60,
+    ) -> None:
         """Asynchronously copy data from a Databricks volume into a Databricks table."""
         self.logger.info("Copying data from volume into table '%s'", table_name)
         query = self._get_copy_into_table_from_volume_query(
             table_name=table_name, volume_path=volume_path, fields=fields, with_schema_evolution=with_schema_evolution
         )
         try:
-            await self.execute_async_query(query, fetch_results=False)
+            await self.execute_async_query(query, fetch_results=False, timeout=timeout)
+        except TimeoutError:
+            raise DatabricksOperationTimeoutError(operation="Copy into table from volume", timeout=timeout)
         except ServerOperationError as err:
             if _is_insufficient_permissions_error(err):
                 raise DatabricksInsufficientPermissionsError(
@@ -602,7 +623,8 @@ class DatabricksClient:
         update_key: collections.abc.Iterable[str],
         source_table_fields: collections.abc.Iterable[DatabricksField],
         with_schema_evolution: bool = True,
-    ):
+        timeout: float = 60 * 60,
+    ) -> None:
         """Merge data from source_table into target_table in Databricks.
 
         If `with_schema_evolution` is True, we will use `WITH SCHEMA EVOLUTION` to enable [automatic schema
@@ -643,7 +665,10 @@ class DatabricksClient:
                 target_table_field_names=target_table_field_names,
             )
 
-        await self.execute_async_query(merge_query, fetch_results=False)
+        try:
+            await self.execute_async_query(merge_query, fetch_results=False, timeout=timeout)
+        except TimeoutError:
+            raise DatabricksOperationTimeoutError(operation="Merge into target table", timeout=timeout)
 
     def _get_merge_query_with_schema_evolution(
         self,
@@ -887,6 +912,27 @@ def _is_insufficient_permissions_error(err: ServerOperationError) -> bool:
     return "INSUFFICIENT_PERMISSIONS" in err.message or "PERMISSION_DENIED" in err.message
 
 
+def _get_long_running_query_timeout(data_interval_start: dt.datetime | None, data_interval_end: dt.datetime) -> float:
+    """Get the timeout to use for long running queries.
+
+    Operations like COPY INTO TABLE can take a long time to complete, especially if there is a lot of data and
+    the warehouse being used is not very powerful. We don't want to allow these queries to run for too long, as they can
+    cause SLA violations and can consume a lot of compute resources in the user's account.
+
+    We can probably reduce this timeout a bit once the beta testing phase is complete.
+    """
+    min_timeout_seconds = 30 * 60  # 30 minutes
+    max_timeout_seconds = 6 * 60 * 60  # 6 hours
+    if data_interval_start is None:
+        return max_timeout_seconds
+    interval_seconds = (data_interval_end - data_interval_start).total_seconds()
+    # we don't want to timeout to be too short (eg in case of 5 min batch exports)
+    # we also multiply the interval by 2 for now while we are in beta testing
+    timeout_seconds = max(min_timeout_seconds, interval_seconds * 2)
+    # we don't want to timeout to be too long (eg in case of 1 day batch exports)
+    return min(timeout_seconds, max_timeout_seconds)
+
+
 class DatabricksConsumer(Consumer):
     """A consumer that uploads data to a Databricks managed volume."""
 
@@ -927,9 +973,9 @@ class DatabricksConsumer(Consumer):
             return  # Nothing to upload
 
         self.logger.info(
-            "Uploading file %d with %d bytes to Databricks volume '%s'",
+            "Uploading file %d with %.2f MB to Databricks volume '%s'",
             self.current_file_index,
-            buffer_size,
+            buffer_size / 1024 / 1024,
             self.volume_path,
         )
 
@@ -942,9 +988,9 @@ class DatabricksConsumer(Consumer):
         )
 
         self.external_logger.info(
-            "File %d with %d bytes uploaded to Databricks volume '%s'",
+            "File %d with %.2f MB bytes uploaded to Databricks volume '%s'",
             self.current_file_index,
-            buffer_size,
+            buffer_size / 1024 / 1024,
             self.volume_path,
         )
         self.current_buffer = io.BytesIO()
@@ -1047,6 +1093,11 @@ async def insert_into_databricks_activity_from_stage(inputs: DatabricksInsertInp
         volume_name = f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}_{attempt}"
         volume_path = f"/Volumes/{inputs.catalog}/{inputs.schema}/{volume_name}"
 
+        long_running_query_timeout = _get_long_running_query_timeout(
+            dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None,
+            dt.datetime.fromisoformat(inputs.data_interval_end),
+        )
+
         async with DatabricksClient.from_inputs_and_integration(
             inputs, databricks_integration
         ).connect() as databricks_client:
@@ -1088,6 +1139,7 @@ async def insert_into_databricks_activity_from_stage(inputs: DatabricksInsertInp
                     volume_path=volume_path,
                     fields=table_fields,
                     with_schema_evolution=inputs.use_automatic_schema_evolution,
+                    timeout=long_running_query_timeout,
                 )
 
                 if requires_merge and stage_table_name is not None:
@@ -1098,6 +1150,7 @@ async def insert_into_databricks_activity_from_stage(inputs: DatabricksInsertInp
                         merge_key=merge_key,
                         update_key=update_key,
                         with_schema_evolution=inputs.use_automatic_schema_evolution,
+                        timeout=long_running_query_timeout,
                     )
 
                 return result

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -129,7 +129,9 @@ class DatabricksOperationTimeoutError(Exception):
     """
 
     def __init__(self, operation: str, timeout: float):
-        super().__init__(f"{operation} timed out after {timeout} seconds")
+        super().__init__(
+            f"{operation} timed out after {timeout} seconds. If this happens regularly, you may want to increase the size of your Databricks SQL warehouse."
+        )
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -990,7 +990,7 @@ class DatabricksConsumer(Consumer):
         )
 
         self.external_logger.info(
-            "File %d with %.2f MB bytes uploaded to Databricks volume '%s'",
+            "File %d with %.2f MB uploaded to Databricks volume '%s'",
             self.current_file_index,
             buffer_size / 1024 / 1024,
             self.volume_path,

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_utils.py
@@ -15,7 +15,7 @@ from products.batch_exports.backend.temporal.destinations.databricks_batch_expor
         # when the interval is 1 hour we expect the timeout to be 2 hours (as we multiply the interval by 2 for now while we are in beta testing)
         (dt.datetime(2025, 1, 1, 12, 0, 0), dt.datetime(2025, 1, 1, 13, 0, 0), 2 * 60 * 60),
         # when interval is 5 minutes, we expect the timeout to be the minimum timeout of 30 minutes
-        (dt.datetime(2025, 1, 1, 12, 0, 0), dt.datetime(2025, 1, 1, 12, 0, 5), 30 * 60),
+        (dt.datetime(2025, 1, 1, 12, 0, 0), dt.datetime(2025, 1, 1, 12, 5, 0), 30 * 60),
     ],
 )
 def test_get_long_running_query_timeout(data_interval_start, data_interval_end, expected_timeout):

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_utils.py
@@ -1,0 +1,22 @@
+import datetime as dt
+
+import pytest
+
+from products.batch_exports.backend.temporal.destinations.databricks_batch_export import _get_long_running_query_timeout
+
+
+@pytest.mark.parametrize(
+    "data_interval_start, data_interval_end, expected_timeout",
+    [
+        # when no data interval start is provided, we use the max timeout of 6 hours
+        (None, dt.datetime(2025, 1, 1, 12, 0, 0), 6 * 60 * 60),
+        # when the interval is 1 day we use the max timeout of 6 hours
+        (dt.datetime(2025, 1, 1, 0, 0, 0), dt.datetime(2025, 1, 2, 0, 0, 0), 6 * 60 * 60),
+        # when the interval is 1 hour we expect the timeout to be 2 hours (as we multiply the interval by 2 for now while we are in beta testing)
+        (dt.datetime(2025, 1, 1, 12, 0, 0), dt.datetime(2025, 1, 1, 13, 0, 0), 2 * 60 * 60),
+        # when interval is 5 minutes, we expect the timeout to be the minimum timeout of 30 minutes
+        (dt.datetime(2025, 1, 1, 12, 0, 0), dt.datetime(2025, 1, 1, 12, 0, 5), 30 * 60),
+    ],
+)
+def test_get_long_running_query_timeout(data_interval_start, data_interval_end, expected_timeout):
+    assert _get_long_running_query_timeout(data_interval_start, data_interval_end) == expected_timeout


### PR DESCRIPTION
## Problem

If long running queries such as `COPY INTO table` take too long we time out to prevent batch exports taking an unexpectedly long time. However, the activity will retry continuously in these cases, consuming a lot of compute resources in the user's account.

## Changes

Set the timeout based on the data interval.

Raise a non-retryable error in case of a timeout (with wording to suggest increasing warehouse size if this happens reguarly).

## How did you test this code?

Added tests.

Ran existing tests.
