### PR TITLE
fix(err): add event to track uploads starting

### DIFF
--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1053,12 +1053,6 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
         if content_hashes is None:
             return Response({"detail": "content_hashes are required"}, status=status.HTTP_400_BAD_REQUEST)
 
-        posthoganalytics.capture(
-            "error_tracking_symbol_set_upload_finished",
-            distinct_id=request.user.pk,
-            properties={"team_id": self.team.id, "endpoint": "bulk_finish_upload"},
-        )
-
         if len(content_hashes) == 0:
             # This can happen if someone re-runs an upload against a directory that's already been
             # uploaded - we'll return no new upload keys, they'll upload nothing, and then

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1022,6 +1022,12 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
         # Grab the release ID from the request json
         release_id: str | None = request.data.get("release_id", None)
 
+        posthoganalytics.capture(
+            "error_tracking_symbol_set_upload_started",
+            distinct_id=request.user.pk,
+            properties={"team_id": self.team.id, "endpoint": "bulk_start_upload"},
+        )
+
         # Validate symbol_sets using the serializer
         symbol_sets: list[SymbolSetUpload] = []
         if "symbol_sets" in request.data:

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1026,6 +1026,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
             "error_tracking_symbol_set_upload_started",
             distinct_id=request.user.pk,
             properties={"team_id": self.team.id, "endpoint": "bulk_start_upload"},
+            groups=groups(self.team.organization, self.team),
         )
 
         # Validate symbol_sets using the serializer

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1053,6 +1053,12 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
         if content_hashes is None:
             return Response({"detail": "content_hashes are required"}, status=status.HTTP_400_BAD_REQUEST)
 
+        posthoganalytics.capture(
+            "error_tracking_symbol_set_upload_finished",
+            distinct_id=request.user.pk,
+            properties={"team_id": self.team.id, "endpoint": "bulk_finish_upload"},
+        )
+
         if len(content_hashes) == 0:
             # This can happen if someone re-runs an upload against a directory that's already been
             # uploaded - we'll return no new upload keys, they'll upload nothing, and then


### PR DESCRIPTION
We already track command invocations, but that doesn't have user identities, and we want to contact churned CLI users.

Also tracks finishing, so we can track how often they fail