### PR TITLE
fix(temporal): fix django orm usage in temporal worker

### DIFF
--- a/posthog/temporal/messaging/actions_workflow.py
+++ b/posthog/temporal/messaging/actions_workflow.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 import temporalio.activity
 import temporalio.workflow
-from asgiref.sync import sync_to_async
+from posthog.sync import database_sync_to_async
 
 from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.client.execute import sync_execute

--- a/posthog/temporal/messaging/actions_workflow.py
+++ b/posthog/temporal/messaging/actions_workflow.py
@@ -66,7 +66,7 @@ async def process_actions_activity(inputs: ActionsWorkflowInputs) -> ProcessActi
         else queryset[inputs.offset :]
     )
 
-    # Convert queryset to list in async-safe way
+    actions = await database_sync_to_async(list)(queryset)
     actions: list[Action] = await sync_to_async(lambda: list(queryset))()
 
     actions_count = 0

--- a/posthog/temporal/messaging/actions_workflow.py
+++ b/posthog/temporal/messaging/actions_workflow.py
@@ -67,7 +67,7 @@ async def process_actions_activity(inputs: ActionsWorkflowInputs) -> ProcessActi
     )
 
     # Convert queryset to list in async-safe way
-    actions = await sync_to_async(list)(queryset)
+    actions: list[Action] = await sync_to_async(lambda: list(queryset))()
 
     actions_count = 0
 

--- a/posthog/temporal/messaging/actions_workflow.py
+++ b/posthog/temporal/messaging/actions_workflow.py
@@ -4,12 +4,12 @@ from typing import Any, Optional
 
 import temporalio.activity
 import temporalio.workflow
-from posthog.sync import database_sync_to_async
 
 from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.client.execute import sync_execute
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.action import Action
+from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
 from posthog.temporal.common.logger import get_logger
@@ -66,8 +66,7 @@ async def process_actions_activity(inputs: ActionsWorkflowInputs) -> ProcessActi
         else queryset[inputs.offset :]
     )
 
-    actions = await database_sync_to_async(list)(queryset)
-    actions: list[Action] = await sync_to_async(lambda: list(queryset))()
+    actions: list[Action] = await database_sync_to_async(lambda: list(queryset))()
 
     actions_count = 0
 

--- a/posthog/temporal/messaging/actions_workflow_coordinator.py
+++ b/posthog/temporal/messaging/actions_workflow_coordinator.py
@@ -47,7 +47,7 @@ async def get_actions_count_activity(inputs: ActionsCoordinatorWorkflowInputs) -
     # Only get actions that are not deleted and have bytecode
     queryset = Action.objects.filter(deleted=False, bytecode__isnull=False)
 
-    count = await sync_to_async(queryset.count)()
+    count = await database_sync_to_async(queryset.count)()
     return ActionsCountResult(count=count)
 
 

--- a/posthog/temporal/messaging/actions_workflow_coordinator.py
+++ b/posthog/temporal/messaging/actions_workflow_coordinator.py
@@ -6,10 +6,10 @@ from typing import Any
 import temporalio.common
 import temporalio.activity
 import temporalio.workflow
-from posthog.sync import database_sync_to_async
 
 from posthog.constants import MESSAGING_TASK_QUEUE
 from posthog.models.action import Action
+from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.logger import get_logger
 

--- a/posthog/temporal/messaging/actions_workflow_coordinator.py
+++ b/posthog/temporal/messaging/actions_workflow_coordinator.py
@@ -6,7 +6,7 @@ from typing import Any
 import temporalio.common
 import temporalio.activity
 import temporalio.workflow
-from asgiref.sync import sync_to_async
+from posthog.sync import database_sync_to_async
 
 from posthog.constants import MESSAGING_TASK_QUEUE
 from posthog.models.action import Action

--- a/posthog/temporal/messaging/actions_workflow_coordinator.py
+++ b/posthog/temporal/messaging/actions_workflow_coordinator.py
@@ -6,6 +6,7 @@ from typing import Any
 import temporalio.common
 import temporalio.activity
 import temporalio.workflow
+from asgiref.sync import sync_to_async
 
 from posthog.constants import MESSAGING_TASK_QUEUE
 from posthog.models.action import Action
@@ -46,7 +47,7 @@ async def get_actions_count_activity(inputs: ActionsCoordinatorWorkflowInputs) -
     # Only get actions that are not deleted and have bytecode
     queryset = Action.objects.filter(deleted=False, bytecode__isnull=False)
 
-    count = queryset.count()
+    count = await sync_to_async(queryset.count)()
     return ActionsCountResult(count=count)
 
 


### PR DESCRIPTION
## Problem

Temporal activities declared as async def were calling Django ORM methods synchronously, causing SynchronousOnlyOperation errors.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Wrapped all Django ORM operations in sync_to_async() to make them compatible with async contexts

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
