### PR TITLE
fix(ux): add save on blur to some scene titles

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -101,7 +101,9 @@ type SceneMainTitleProps = {
     renameDebounceMs?: number
     /**
      * If true, saves only on blur (when leaving the field)
-     * If false, saves on every change (debounced) - original behavior
+     * If false, saves on every change (debounced) - original behavior.
+     *
+     * Note: It's probably a good idea to set renameDebounceMs to 0 if this is true
      * @default false
      */
     saveOnBlur?: boolean

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -444,7 +444,8 @@ export function PageHeaderCustom(): JSX.Element {
                     AccessControlLevel.Editor,
                     experiment.user_access_level
                 )}
-                renameDebounceMs={1000}
+                renameDebounceMs={0}
+                saveOnBlur
                 actions={
                     <>
                         {experiment && !isExperimentRunning && (

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -515,10 +515,9 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 canEdit={canEditInsight}
                 isLoading={insightLoading && !insight?.id}
                 forceEdit={insightMode === ItemMode.Edit}
-                // Renaming insights is too fast, so we need to debounce it
-                renameDebounceMs={1000}
+                renameDebounceMs={0}
                 // Use onBlur-only saves to prevent autosave while typing
-                saveOnBlur={true}
+                saveOnBlur
                 actions={
                     <>
                         {insightMode === ItemMode.Edit && hasDashboardItemId && (

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -248,6 +248,7 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                 )}
                             </>
                         }
+                        saveOnBlur
                     />
                     <SceneDivider />
                     <LemonTabs

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -149,9 +149,10 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                             AccessControlLevel.Editor,
                             survey.user_access_level
                         )}
+                        saveOnBlur
                         onNameChange={(name) => updateSurvey({ id, name })}
                         onDescriptionChange={(description) => updateSurvey({ id, description })}
-                        renameDebounceMs={1000}
+                        renameDebounceMs={0}
                         isLoading={surveyLoading}
                         actions={
                             <>
@@ -248,7 +249,6 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                 )}
                             </>
                         }
-                        saveOnBlur
                     />
                     <SceneDivider />
                     <LemonTabs


### PR DESCRIPTION
## Problem
When typing a new name for Surveys, insights and experiments, scene title section saves on debounced typing, but these scenes specifically do a sort of hard refresh (isLoading) catches and makes the naming experience a bit broken.

## Changes
* Add `saveOnBlur` prop to these scene title sections
* Add/change `renameDebounceMs` to 0 seconds so that when they blur it's instant update.

## How did you test this code?
Locally