### PR TITLE
fix(cli): add back upload arguments, warn on them

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # posthog-cli
 
+# 0.5.1
+
+- Attempts to reduce impact of previous breaking changes - re-adds `--project` and `--version` arguments to sourcemap upload command, marking them
+  as no longer used
+
 # 0.5.0
 
 - Sourcemap injection, upload and process commands made retriable. Significant improvement to release creation.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 # 0.5.1
 
-- Attempts to reduce impact of previous breaking changes - re-adds `--project` and `--version` arguments to sourcemap upload command, marking them
-  as no longer used
+- Attempts to reduce impact of previous breaking changes - re-adds `--project` and `--version` arguments to sourcemap upload command, marking them as no longer used
 
 # 0.5.0
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1517,7 +1517,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.7.0",
  "hyper-util",
- "rustls 0.23.32",
+ "rustls 0.23.33",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1611,7 +1611,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.32",
+ "rustls 0.23.33",
  "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
@@ -1631,7 +1631,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.32",
+ "rustls 0.23.33",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -1858,7 +1858,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.32",
+ "rustls 0.23.33",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.32"
+version = "0.23.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
 dependencies = [
  "once_cell",
  "ring",
@@ -2476,7 +2476,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.32",
+ "rustls 0.23.33",
  "tokio",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/sourcemaps/mod.rs
+++ b/cli/src/sourcemaps/mod.rs
@@ -71,6 +71,8 @@ impl From<ProcessArgs> for (InjectArgs, UploadArgs) {
             delete_after: args.delete_after,
             skip_ssl_verification: args.skip_ssl_verification,
             batch_size: args.batch_size,
+            project: None,
+            version: None,
         };
 
         (inject_args, upload_args)

--- a/cli/src/sourcemaps/upload.rs
+++ b/cli/src/sourcemaps/upload.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Ok, Result};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::api::symbol_sets::{upload, SymbolSetUpload};
 use crate::invocation_context::context;
@@ -31,6 +31,14 @@ pub struct UploadArgs {
     /// The maximum number of chunks to upload in a single batch
     #[arg(long, default_value = "50")]
     pub batch_size: usize,
+
+    /// DEPRECATED: Does nothing. Set project during `inject` instead
+    #[arg(long)]
+    pub project: Option<String>,
+
+    /// DEPRECATED: Does nothing. Set version during `inject` instead
+    #[arg(long)]
+    pub version: Option<String>,
 }
 
 pub fn upload_cmd(args: UploadArgs) -> Result<()> {
@@ -40,7 +48,13 @@ pub fn upload_cmd(args: UploadArgs) -> Result<()> {
         delete_after,
         skip_ssl_verification: _,
         batch_size,
+        project: p,
+        version: v,
     } = args;
+
+    if p.is_some() || v.is_some() {
+        warn!("`--project` and `--version` are deprecated and do nothing. Set project and version during `inject` instead.");
+    }
 
     context().capture_command_invoked("sourcemap_upload");
 


### PR DESCRIPTION
We needed to move setting project and version to the inject phase. We've done this, but it was a bit of a hard breaking change, so let's roll back to at least not breaking peoples CI pipelines. Will release this once it's merged.