### PR TITLE
fix(cohorts): use cohort's team_id for inserting users into PG

### DIFF
--- a/posthog/management/commands/fix_cohort_people_unsynced_ch.py
+++ b/posthog/management/commands/fix_cohort_people_unsynced_ch.py
@@ -177,12 +177,13 @@ class Command(BaseCommand):
                                 cohort_to_uuids[cohort_id].append(uuid)
 
                         batch_inserted = 0
-                        team_id = clickhouse_batch[0][2]  # Get team_id from first record
 
                         for cohort_id, person_uuids in cohort_to_uuids.items():
                             try:
                                 cohort = Cohort.objects.get(id=cohort_id)
-                                cohort.insert_users_list_by_uuid_into_pg_only(items=person_uuids, team_id=team_id)
+                                cohort.insert_users_list_by_uuid_into_pg_only(
+                                    items=person_uuids, team_id=cohort.team_id
+                                )
                                 batch_inserted += len(person_uuids)
                             except Exception as e:
                                 self.stdout.write(self.style.ERROR(f"Error inserting into cohort {cohort_id}: {e}"))


### PR DESCRIPTION
## Problem

The command to sync cohorts people from CH to PG is using the first team from the ClickHouse query, instead of the team from the cohort, causing it to fail when running for multiple teams.

## Changes

Uses the cohort's team_id when inserting new people into PG.

The command was already ran in prod-US, I'm updating it in case we need to run the command in other environment.
