### PR TITLE
fix: can't update django admin team 

### DIFF
--- a/posthog/templates/admin/posthog/team/change_form.html
+++ b/posthog/templates/admin/posthog/team/change_form.html
@@ -1,0 +1,8 @@
+{% extends "admin/change_form.html" %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {# This template ensures Django admin works with CSP nonce requirements #}
+  {# Team admin includes inline formsets (GroupTypeMapping, TeamMarketingAnalyticsConfig) #}
+  {# which require this template override for CSP compliance #}
+{% endblock %}


### PR DESCRIPTION
## Problem

We're unable to update the Team models on the Django admin. It seems related to the new CSP resource blocking the resource, as there is an inline script there that is considered unsafe.

<img width="1351" height="1014" alt="image" src="https://github.com/user-attachments/assets/7027e649-c873-42df-b399-91b5f2a06a40" />


## Changes

Adding the template override here, as in other models (user/apikeys), updates the rules to include the inline script hash.

I can't verify completely that it will fix without deploying it due to the nature of CSP rules, but it should not **break** anything else (famous last words).

## How did you test this code?

Locally, and comparing the network request to other models.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
