### PR TITLE
fix: switching to revenue sort

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
@@ -162,7 +162,11 @@ export function IssuesList(): JSX.Element {
 
 const CurrencyColumn = ({ record }: { record: unknown }): JSX.Element => {
     const { baseCurrency } = useValues(teamLogic)
-    const revenue = (record as ErrorTrackingIssue).revenue!
+    const revenue = (record as ErrorTrackingIssue).revenue
+
+    if (!revenue) {
+        return <>-</>
+    }
 
     return <LemonTableLink to={urls.revenueAnalytics()} title={formatCurrency(revenue, baseCurrency)} />
 }


### PR DESCRIPTION
## Problem

When playing around with sorting by revenue in production I noticed a bug where we were assuming the revenue value would be instantly available
