### PR TITLE
fix: don't show comments on list page

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic.ts
@@ -96,6 +96,7 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
             () => [],
             (): SidePanelSceneContext => ({
                 activity_scope: ActivityScope.ERROR_TRACKING_ISSUE,
+                discussions_disabled: true,
             }),
         ],
     }),


### PR DESCRIPTION
## Problem

Reported in https://posthoghelp.zendesk.com/agent/tickets/39973 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/42372)

## Changes

Don't show discussions for individual issues on the list page