### PR TITLE
fix(err): add a context around bulk_create_symbol_sets

### DIFF
--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1352,7 +1352,7 @@ def create_symbol_set(
 
         return symbol_set
 
-
+@posthoganalytics.scoped()
 def bulk_create_symbol_sets(
     new_symbol_sets: list[SymbolSetUpload],
     team: Team,

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1352,6 +1352,7 @@ def create_symbol_set(
 
         return symbol_set
 
+
 @posthoganalytics.scoped()
 def bulk_create_symbol_sets(
     new_symbol_sets: list[SymbolSetUpload],


### PR DESCRIPTION
ValidationErrors end up as 400's, which the django integration doesn't catch cause they're not "exceptional", as far as I can tell.