### PR TITLE
fix(err): symbol set upload api bug

### DIFF
--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -855,8 +855,8 @@ class SymbolSetUpload:
 
 class ErrorTrackingSymbolSetUploadSerializer(serializers.Serializer):
     chunk_id = serializers.CharField()
-    release_id = serializers.CharField()
-    content_hash = serializers.CharField()
+    release_id = serializers.CharField(default=None)
+    content_hash = serializers.CharField(default=None)
 
 
 class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -855,8 +855,8 @@ class SymbolSetUpload:
 
 class ErrorTrackingSymbolSetUploadSerializer(serializers.Serializer):
     chunk_id = serializers.CharField()
-    release_id = serializers.CharField()
-    content_hash = serializers.CharField()
+    release_id = serializers.CharField(allow_null=True, required=False)
+    content_hash = serializers.CharField(allow_null=True, required=False)
 
 
 class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -855,8 +855,8 @@ class SymbolSetUpload:
 
 class ErrorTrackingSymbolSetUploadSerializer(serializers.Serializer):
     chunk_id = serializers.CharField()
-    release_id = serializers.CharField(default=None)
-    content_hash = serializers.CharField(default=None)
+    release_id = serializers.CharField(allow_null=True, required=False)
+    content_hash = serializers.CharField(allow_null=True, required=False)
 
 
 class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -855,8 +855,8 @@ class SymbolSetUpload:
 
 class ErrorTrackingSymbolSetUploadSerializer(serializers.Serializer):
     chunk_id = serializers.CharField()
-    release_id = serializers.CharField(allow_null=True, required=False)
-    content_hash = serializers.CharField(allow_null=True, required=False)
+    release_id = serializers.CharField(allow_null=True, default=None)
+    content_hash = serializers.CharField(allow_null=True, default=None)
 
 
 class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -543,8 +543,6 @@ class TestErrorTracking(APIBaseTest):
             format="json",
         )
 
-        print(response.json())
-
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_bulk_start_upload_updates_release_for_pending_symbol_set(self) -> None:

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -518,16 +518,26 @@ class TestErrorTracking(APIBaseTest):
         assert not ErrorTrackingSymbolSet.objects.filter(ref=chunk_id).exists()
 
     def test_bulk_start_upload_allows_no_release(self) -> None:
-        chunk_id = str(uuid7())
-
         response = self.client.post(
             f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_start_upload",
             data={
                 "symbol_sets": [
                     {
-                        "chunk_id": chunk_id,
+                        "chunk_id": str(uuid7()),
+                        "release_id": None,
                         "content_hash": "hash",
-                    }
+                    },
+                    {
+                        "chunk_id": str(uuid7()),
+                        "content_hash": "hash",
+                    },
+                    {
+                        "chunk_id": str(uuid7()),
+                        "content_hash": None,
+                    },
+                    {
+                        "chunk_id": str(uuid7()),
+                    },
                 ]
             },
             format="json",

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -543,6 +543,8 @@ class TestErrorTracking(APIBaseTest):
             format="json",
         )
 
+        print(response.json())
+
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_bulk_start_upload_updates_release_for_pending_symbol_set(self) -> None:

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -517,6 +517,24 @@ class TestErrorTracking(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert not ErrorTrackingSymbolSet.objects.filter(ref=chunk_id).exists()
 
+    def test_bulk_start_upload_allows_no_release(self) -> None:
+        chunk_id = str(uuid7())
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_start_upload",
+            data={
+                "symbol_sets": [
+                    {
+                        "chunk_id": chunk_id,
+                        "content_hash": "hash",
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
     def test_bulk_start_upload_updates_release_for_pending_symbol_set(self) -> None:
         chunk_id = str(uuid7())
 


### PR DESCRIPTION
Release ID should be optional in each symbol set uploaded, but django's serialiser is rejecting that