### PR TITLE
fix: Stop generating incorrectly-named Rev Analytics views

### DIFF
--- a/posthog/warehouse/models/test/test_managed_viewset.py
+++ b/posthog/warehouse/models/test/test_managed_viewset.py
@@ -58,8 +58,6 @@ class TestDataWarehouseManagedViewSetModel(BaseTest):
             self.assertIsNotNone(view.columns)
             self.assertIn("HogQLQuery", view.query.get("kind", ""))  # type: ignore
 
-        # TODO: There's a bug here, these shouldn't include the weird `no_property` bit
-        # Will fix in a follow-up, not related to the changes that introduced this test
         expected_view_names = sorted(
             [
                 "revenue_analytics.all.revenue_analytics_charge",
@@ -70,13 +68,13 @@ class TestDataWarehouseManagedViewSetModel(BaseTest):
                 "revenue_analytics.events.purchase.charge_events_revenue_view",
                 "revenue_analytics.events.purchase.customer_events_revenue_view",
                 "revenue_analytics.events.purchase.revenue_item_events_revenue_view",
-                "revenue_analytics.events.purchase_no_property.product_events_revenue_view",
-                "revenue_analytics.events.purchase_no_property.subscription_events_revenue_view",
+                "revenue_analytics.events.purchase.product_events_revenue_view",
+                "revenue_analytics.events.purchase.subscription_events_revenue_view",
                 "revenue_analytics.events.subscription_charge.charge_events_revenue_view",
                 "revenue_analytics.events.subscription_charge.customer_events_revenue_view",
                 "revenue_analytics.events.subscription_charge.product_events_revenue_view",
                 "revenue_analytics.events.subscription_charge.revenue_item_events_revenue_view",
-                "revenue_analytics.events.subscription_charge_no_property.subscription_events_revenue_view",
+                "revenue_analytics.events.subscription_charge.subscription_events_revenue_view",
             ]
         )
 

--- a/products/revenue_analytics/backend/views/core.py
+++ b/products/revenue_analytics/backend/views/core.py
@@ -46,11 +46,3 @@ def view_prefix_for_source(source: ExternalDataSource) -> str:
         return source.source_type.lower()
     prefix = source.prefix.strip("_")
     return f"{source.source_type.lower()}.{prefix}"
-
-
-def view_name_for_event(event: str, suffix: str) -> str:
-    return f"{view_prefix_for_event(event)}.{suffix}"
-
-
-def view_name_for_source(source: ExternalDataSource, suffix: str) -> str:
-    return f"{view_prefix_for_source(source)}.{suffix}"

--- a/products/revenue_analytics/backend/views/core.py
+++ b/products/revenue_analytics/backend/views/core.py
@@ -27,6 +27,8 @@ class BuiltQuery:
     prefix: str
     # HogQL AST for the view
     query: ast.Expr
+    # Useful for debugging purposes, only asserted by in tests
+    test_comments: str | None = None
 
 
 # A builder is a function that takes a SourceHandle and returns a single BuiltQuery object

--- a/products/revenue_analytics/backend/views/orchestrator.py
+++ b/products/revenue_analytics/backend/views/orchestrator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Optional, cast
+from typing import Optional
 
 from django.db.models import Prefetch
 
@@ -18,12 +18,7 @@ from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.types import ExternalDataSourceType
 
 from products.revenue_analytics.backend.views import KIND_TO_CLASS, RevenueAnalyticsBaseView
-from products.revenue_analytics.backend.views.core import (
-    BuiltQuery,
-    SourceHandle,
-    view_name_for_event,
-    view_name_for_source,
-)
+from products.revenue_analytics.backend.views.core import BuiltQuery, SourceHandle
 from products.revenue_analytics.backend.views.schemas import SCHEMAS
 from products.revenue_analytics.backend.views.sources.registry import BUILDERS
 
@@ -60,9 +55,9 @@ def _query_to_view(
 
     if handle.source is not None:
         id = query.key  # Stable key (i.e. table.id)
-        name = view_name_for_source(cast(ExternalDataSource, handle.source), schema.source_suffix)
+        name = f"{query.prefix}.{schema.source_suffix}"
     else:
-        id = name = view_name_for_event(query.key, schema.events_suffix)
+        id = name = f"{query.prefix}.{schema.events_suffix}"
 
     return view_cls(
         id=id,

--- a/products/revenue_analytics/backend/views/sources/events/product.py
+++ b/products/revenue_analytics/backend/views/sources/events/product.py
@@ -16,9 +16,10 @@ def build(handle: SourceHandle) -> BuiltQuery:
 
     if not event.productProperty:
         return BuiltQuery(
-            key=f"{event.eventName}.no_property",
+            key=event.eventName,
             prefix=prefix,
             query=ast.SelectQuery.empty(columns=list(PRODUCT_SCHEMA.fields.keys())),
+            test_comments="no_property",
         )
 
     events_query = ast.SelectQuery(

--- a/products/revenue_analytics/backend/views/sources/events/subscription.py
+++ b/products/revenue_analytics/backend/views/sources/events/subscription.py
@@ -18,9 +18,10 @@ def build(handle: SourceHandle) -> BuiltQuery:
 
     if event.subscriptionProperty is None:
         return BuiltQuery(
-            key=f"{event.eventName}.no_property",
+            key=event.eventName,
             prefix=prefix,
             query=ast.SelectQuery.empty(columns=list(SUBSCRIPTION_SCHEMA.fields.keys())),
+            test_comments="no_property",
         )
 
     events_query = ast.SelectQuery(

--- a/products/revenue_analytics/backend/views/sources/stripe/charge.py
+++ b/products/revenue_analytics/backend/views/sources/stripe/charge.py
@@ -29,13 +29,19 @@ def build(handle: SourceHandle) -> BuiltQuery:
     charge_schema = next((schema for schema in schemas if schema.name == STRIPE_CHARGE_RESOURCE_NAME), None)
     if charge_schema is None:
         return BuiltQuery(
-            key=f"{prefix}.no_source", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_schema",
         )
 
     charge_schema = cast(ExternalDataSchema, charge_schema)
     if charge_schema.table is None:
         return BuiltQuery(
-            key=f"{prefix}.no_table", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_table",
         )
 
     table = cast(DataWarehouseTable, charge_schema.table)

--- a/products/revenue_analytics/backend/views/sources/stripe/customer.py
+++ b/products/revenue_analytics/backend/views/sources/stripe/customer.py
@@ -27,13 +27,19 @@ def build(handle: SourceHandle) -> BuiltQuery:
     customer_schema = next((schema for schema in schemas if schema.name == STRIPE_CUSTOMER_RESOURCE_NAME), None)
     if customer_schema is None:
         return BuiltQuery(
-            key=f"{prefix}.no_source", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_schema",
         )
 
     customer_schema = cast(ExternalDataSchema, customer_schema)
     if customer_schema.table is None:
         return BuiltQuery(
-            key=f"{prefix}.no_table", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_table",
         )
 
     invoice_schema = next((schema for schema in schemas if schema.name == STRIPE_INVOICE_RESOURCE_NAME), None)

--- a/products/revenue_analytics/backend/views/sources/stripe/product.py
+++ b/products/revenue_analytics/backend/views/sources/stripe/product.py
@@ -23,13 +23,19 @@ def build(handle: SourceHandle) -> BuiltQuery:
     product_schema = next((schema for schema in schemas if schema.name == STRIPE_PRODUCT_RESOURCE_NAME), None)
     if product_schema is None:
         return BuiltQuery(
-            key=f"{prefix}.no_source", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_schema",
         )
 
     product_schema = cast(ExternalDataSchema, product_schema)
     if product_schema.table is None:
         return BuiltQuery(
-            key=f"{prefix}.no_table", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_table",
         )
 
     table = cast(DataWarehouseTable, product_schema.table)

--- a/products/revenue_analytics/backend/views/sources/stripe/revenue_item.py
+++ b/products/revenue_analytics/backend/views/sources/stripe/revenue_item.py
@@ -113,7 +113,10 @@ def build(handle: SourceHandle) -> BuiltQuery:
 
     if invoice_schema is None and charge_schema is None:
         return BuiltQuery(
-            key=f"{prefix}.no_source", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_schema",
         )
 
     invoice_table: DataWarehouseTable | None = None
@@ -131,7 +134,10 @@ def build(handle: SourceHandle) -> BuiltQuery:
         team = charge_table.team
     else:
         return BuiltQuery(
-            key=f"{prefix}.no_table", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_table",
         )
 
     # Build the query for invoice items with revenue recognition splitting

--- a/products/revenue_analytics/backend/views/sources/stripe/subscription.py
+++ b/products/revenue_analytics/backend/views/sources/stripe/subscription.py
@@ -26,13 +26,19 @@ def build(handle: SourceHandle) -> BuiltQuery:
     subscription_schema = next((schema for schema in schemas if schema.name == STRIPE_SUBSCRIPTION_RESOURCE_NAME), None)
     if subscription_schema is None:
         return BuiltQuery(
-            key=f"{prefix}.no_source", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_schema",
         )
 
     subscription_schema = cast(ExternalDataSchema, subscription_schema)
     if subscription_schema.table is None:
         return BuiltQuery(
-            key=f"{prefix}.no_table", prefix=prefix, query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys()))
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=list(SCHEMA.fields.keys())),
+            test_comments="no_table",
         )
 
     table = cast(DataWarehouseTable, subscription_schema.table)

--- a/products/revenue_analytics/backend/views/sources/test/base.py
+++ b/products/revenue_analytics/backend/views/sources/test/base.py
@@ -29,7 +29,14 @@ class RevenueAnalyticsViewSourceBaseTest(ClickhouseTestMixin, QueryMatchingTest,
         super().setUp()
         # Common setup for revenue analytics tests can go here
 
-    def assertBuiltQueryStructure(self, built_query: BuiltQuery, expected_key: str, expected_prefix: str):
+    def assertBuiltQueryStructure(
+        self,
+        built_query: BuiltQuery,
+        expected_key: str,
+        expected_prefix: str,
+        *,
+        expected_test_comments: str | None = "<SENTINEL_VALUE>",
+    ):
         """
         Assert that a BuiltQuery has the expected structure.
 
@@ -40,6 +47,9 @@ class RevenueAnalyticsViewSourceBaseTest(ClickhouseTestMixin, QueryMatchingTest,
         """
         self.assertEqual(built_query.key, expected_key)
         self.assertEqual(built_query.prefix, expected_prefix)
+
+        if expected_test_comments != "<SENTINEL_VALUE>":
+            self.assertEqual(built_query.test_comments, expected_test_comments)
 
     def assertQueryContainsFields(self, query: ast.Expr, schema: Schema):
         """

--- a/products/revenue_analytics/backend/views/sources/test/events/test_events_product.py
+++ b/products/revenue_analytics/backend/views/sources/test/events/test_events_product.py
@@ -14,8 +14,12 @@ class TestProductEventsBuilder(EventsSourceBaseTest):
         # Test purchase event (no productProperty)
         handle = SourceHandle(type="events", team=self.team, event=self.events[0])
         query = build(handle)
-        key = f"{self.PURCHASE_EVENT_NAME}.no_property"
-        self.assertBuiltQueryStructure(query, key, "revenue_analytics.events.purchase")
+        self.assertBuiltQueryStructure(
+            query,
+            self.PURCHASE_EVENT_NAME,
+            "revenue_analytics.events.purchase",
+            expected_test_comments="no_property",
+        )
 
         query_sql = query.query.to_hogql()
         self.assertQueryMatchesSnapshot(query_sql, replace_all_numbers=True)
@@ -23,10 +27,9 @@ class TestProductEventsBuilder(EventsSourceBaseTest):
         # Test subscription_charge event (has productProperty)
         handle = SourceHandle(type="events", team=self.team, event=self.events[1])
         query = build(handle)
-        key = self.SUBSCRIPTION_CHARGE_EVENT_NAME
         self.assertBuiltQueryStructure(
             query,
-            key,
+            self.SUBSCRIPTION_CHARGE_EVENT_NAME,
             "revenue_analytics.events.subscription_charge",
         )
 

--- a/products/revenue_analytics/backend/views/sources/test/events/test_events_subscription.py
+++ b/products/revenue_analytics/backend/views/sources/test/events/test_events_subscription.py
@@ -17,19 +17,22 @@ class TestSubscriptionEventsBuilder(EventsSourceBaseTest):
         # Test purchase event (no subscriptionProperty)
         handle = SourceHandle(type="events", team=self.team, event=self.events[0])
         query = build(handle)
-        key = f"{self.PURCHASE_EVENT_NAME}.no_property"
-        self.assertBuiltQueryStructure(query, key, "revenue_analytics.events.purchase")
+        self.assertBuiltQueryStructure(
+            query,
+            self.PURCHASE_EVENT_NAME,
+            "revenue_analytics.events.purchase",
+            expected_test_comments="no_property",
+        )
 
         query_sql = query.query.to_hogql()
         self.assertQueryMatchesSnapshot(query_sql, replace_all_numbers=True)
 
         # Test subscription_charge event (has subscriptionProperty)
         handle = SourceHandle(type="events", team=self.team, event=self.events[1])
-        key = self.SUBSCRIPTION_CHARGE_EVENT_NAME
         query = build(handle)
         self.assertBuiltQueryStructure(
             cast(BuiltQuery, query),
-            key,
+            self.SUBSCRIPTION_CHARGE_EVENT_NAME,
             "revenue_analytics.events.subscription_charge",
         )
 

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_charge.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_charge.py
@@ -37,8 +37,9 @@ class TestChargeStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CHARGE_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_source",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
         )
 
         # Print and snapshot the generated HogQL query
@@ -62,8 +63,9 @@ class TestChargeStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CHARGE_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_table",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_table",
         )
 
         # Print and snapshot the generated HogQL query

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_charge.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_charge.py
@@ -37,7 +37,7 @@ class TestChargeStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CHARGE_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_schema",
         )
@@ -63,7 +63,7 @@ class TestChargeStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CHARGE_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_table",
         )

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_customer.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_customer.py
@@ -52,7 +52,7 @@ class TestCustomerStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_schema",
         )
@@ -77,7 +77,7 @@ class TestCustomerStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_table",
         )

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_customer.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_customer.py
@@ -52,8 +52,9 @@ class TestCustomerStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_source",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
         )
 
         # Print and snapshot the generated HogQL query
@@ -76,8 +77,9 @@ class TestCustomerStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_table",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_table",
         )
 
         # Print and snapshot the generated HogQL query

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_product.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_product.py
@@ -37,7 +37,7 @@ class TestProductStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, PRODUCT_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_schema",
         )
@@ -63,7 +63,7 @@ class TestProductStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, PRODUCT_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_table",
         )

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_product.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_product.py
@@ -37,8 +37,9 @@ class TestProductStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, PRODUCT_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_source",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
         )
 
         # Print and snapshot the generated HogQL query
@@ -62,8 +63,9 @@ class TestProductStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, PRODUCT_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_table",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_table",
         )
 
         # Print and snapshot the generated HogQL query

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_revenue_item.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_revenue_item.py
@@ -87,7 +87,7 @@ class TestRevenueItemStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, REVENUE_ITEM_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_schema",
         )

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_revenue_item.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_revenue_item.py
@@ -87,8 +87,9 @@ class TestRevenueItemStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, REVENUE_ITEM_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_source",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
         )
         # Print and snapshot the generated HogQL query
         self.assertQueryMatchesSnapshot(query.query.to_hogql(), replace_all_numbers=True)

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_subscription.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_subscription.py
@@ -35,8 +35,9 @@ class TestSubscriptionStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, SUBSCRIPTION_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_source",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
         )
 
         # Print and snapshot the generated HogQL query
@@ -59,8 +60,9 @@ class TestSubscriptionStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, SUBSCRIPTION_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            f"stripe.{self.external_data_source.prefix}.no_table",
+            str(self.stripe_handle.source.id),
             f"stripe.{self.external_data_source.prefix}",
+            expected_test_comments="no_table",
         )
 
         # Print and snapshot the generated HogQL query

--- a/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_subscription.py
+++ b/products/revenue_analytics/backend/views/sources/test/stripe/test_stripe_subscription.py
@@ -35,7 +35,7 @@ class TestSubscriptionStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, SUBSCRIPTION_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_schema",
         )
@@ -60,7 +60,7 @@ class TestSubscriptionStripeBuilder(StripeSourceBaseTest):
         self.assertQueryContainsFields(query.query, SUBSCRIPTION_SCHEMA)
         self.assertBuiltQueryStructure(
             query,
-            str(self.stripe_handle.source.id),
+            str(self.stripe_handle.source.id),  # type: ignore
             f"stripe.{self.external_data_source.prefix}",
             expected_test_comments="no_table",
         )

--- a/products/revenue_analytics/backend/views/test/test_core.py
+++ b/products/revenue_analytics/backend/views/test/test_core.py
@@ -2,36 +2,36 @@ import pytest
 
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 
-from products.revenue_analytics.backend.views.core import view_name_for_event, view_name_for_source
+from products.revenue_analytics.backend.views.core import view_prefix_for_event, view_prefix_for_source
 
 
 @pytest.mark.parametrize(
-    "source_type,prefix,view_name,expected",
+    "source_type,prefix,expected",
     [
-        ("stripe", None, "charges", "stripe.charges"),
-        ("stripe", "prod", "charges", "stripe.prod.charges"),
-        ("stripe", "prod_", "charges", "stripe.prod.charges"),
-        ("stripe", "_prod", "charges", "stripe.prod.charges"),
-        ("stripe", "_prod_", "charges", "stripe.prod.charges"),
+        ("stripe", None, "stripe"),
+        ("stripe", "prod", "stripe.prod"),
+        ("stripe", "prod_", "stripe.prod"),
+        ("stripe", "_prod", "stripe.prod"),
+        ("stripe", "_prod_", "stripe.prod"),
     ],
 )
-def test_get_view_name_for_source(source_type, prefix, view_name, expected):
+def test_get_view_name_for_source(source_type, prefix, expected):
     source = ExternalDataSource(source_type=source_type, prefix=prefix)
-    result = view_name_for_source(source, view_name)
+    result = view_prefix_for_source(source)
     assert result == expected
 
 
 @pytest.mark.parametrize(
-    "event,view_name,expected",
+    "event,expected",
     [
-        ("charge_succeeded", "charges", "revenue_analytics.events.charge_succeeded.charges"),
-        ("charge.succeeded", "charges", "revenue_analytics.events.charge_succeeded.charges"),
-        ("charge-succeeded", "charges", "revenue_analytics.events.charge_succeeded.charges"),
-        ("charge$succeeded", "charges", "revenue_analytics.events.charge_succeeded.charges"),
-        ("charge123succeeded", "charges", "revenue_analytics.events.charge123succeeded.charges"),
-        ("charge*!@#%^#$succeeded", "charges", "revenue_analytics.events.charge________succeeded.charges"),
+        ("charge_succeeded", "revenue_analytics.events.charge_succeeded"),
+        ("charge.succeeded", "revenue_analytics.events.charge_succeeded"),
+        ("charge-succeeded", "revenue_analytics.events.charge_succeeded"),
+        ("charge$succeeded", "revenue_analytics.events.charge_succeeded"),
+        ("charge123succeeded", "revenue_analytics.events.charge123succeeded"),
+        ("charge*!@#%^#$succeeded", "revenue_analytics.events.charge________succeeded"),
     ],
 )
-def test_get_view_name_for_event(event, view_name, expected):
-    result = view_name_for_event(event, view_name)
+def test_get_view_prefix_for_event(event, expected):
+    result = view_prefix_for_event(event)
     assert result == expected


### PR DESCRIPTION
I introduced these `no_something` for assertion purposes, but they ended up in the generated view names, let's fix that