### PR TITLE
fix: csp error on 500 error page

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -701,6 +701,8 @@ class CSPMiddleware:
                 "object-src 'none'",
                 "frame-ancestors 'none'",
                 "manifest-src 'none'",
+                # used by the error page
+                "frame-src https://posthog.com",
                 "base-uri 'self'",
                 "report-uri https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=2",
                 "report-to posthog",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -91,6 +91,7 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "posthog.middleware.CSPMiddleware",
     "django.middleware.common.CommonMiddleware",
     "posthog.middleware.CsrfOrKeyViewMiddleware",
     "posthog.middleware.QueryTimeCountingMiddleware",
@@ -109,7 +110,6 @@ MIDDLEWARE = [
     "posthog.middleware.CHQueries",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
     "posthog.middleware.PostHogTokenCookieMiddleware",
-    "posthog.middleware.CSPMiddleware",
     "posthoganalytics.integrations.django.PosthogContextMiddleware",
 ]
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -82,10 +82,10 @@ def handler500(request):
     500 error handler.
 
     Templates: :template:`500.html`
-    Context: None
+    Context: request
     """
     template = loader.get_template("500.html")
-    return HttpResponseServerError(template.render())
+    return HttpResponseServerError(template.render({"request": request}, request))
 
 
 @ensure_csrf_cookie


### PR DESCRIPTION
## Problem

The 500 page wasn't including the request context, which means `request.csp_nonce` was empty. This was resulting in a CSP error in Admin where we enforce a strict CSP. We also now load the CSP middleware sooner, just to be safe.