### PR TITLE
fix(err): identify contexts in some API calls

### DIFF
--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1016,6 +1016,8 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
 
     @action(methods=["POST"], detail=False, parser_classes=[JSONParser])
     def bulk_start_upload(self, request, **kwargs):
+        if self.user.pk:
+            posthoganalytics.identify_context(self.user.pk)
         # Earlier ones send a list of chunk IDs, all associated with one release
         # Extract a list of chunk IDs from the request json
         chunk_ids: list[str] = request.data.get("chunk_ids") or []
@@ -1024,7 +1026,6 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
 
         posthoganalytics.capture(
             "error_tracking_symbol_set_upload_started",
-            distinct_id=request.user.pk,
             properties={"team_id": self.team.id, "endpoint": "bulk_start_upload"},
             groups=groups(self.team.organization, self.team),
         )
@@ -1049,6 +1050,8 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
 
     @action(methods=["POST"], detail=False, parser_classes=[JSONParser])
     def bulk_finish_upload(self, request, **kwargs):
+        if self.user.pk:
+            posthoganalytics.identify_context(self.user.pk)
         # Get the map of symbol_set_id:content_hashes
         content_hashes = request.data.get("content_hashes", {})
         if content_hashes is None:
@@ -1107,7 +1110,6 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
 
         posthoganalytics.capture(
             "error_tracking_symbol_set_uploaded",
-            distinct_id=request.user.pk,
             groups=groups(self.team.organization, self.team),
         )
 

--- a/products/error_tracking/backend/api/error_tracking.py
+++ b/products/error_tracking/backend/api/error_tracking.py
@@ -1016,8 +1016,8 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
 
     @action(methods=["POST"], detail=False, parser_classes=[JSONParser])
     def bulk_start_upload(self, request, **kwargs):
-        if self.user.pk:
-            posthoganalytics.identify_context(self.user.pk)
+        if request.user.pk:
+            posthoganalytics.identify_context(request.user.pk)
         # Earlier ones send a list of chunk IDs, all associated with one release
         # Extract a list of chunk IDs from the request json
         chunk_ids: list[str] = request.data.get("chunk_ids") or []
@@ -1050,8 +1050,8 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
 
     @action(methods=["POST"], detail=False, parser_classes=[JSONParser])
     def bulk_finish_upload(self, request, **kwargs):
-        if self.user.pk:
-            posthoganalytics.identify_context(self.user.pk)
+        if request.user.pk:
+            posthoganalytics.identify_context(request.user.pk)
         # Get the map of symbol_set_id:content_hashes
         content_hashes = request.data.get("content_hashes", {})
         if content_hashes is None:


### PR DESCRIPTION
Some of our API calls do not come with a distinct ID, so we need to identify them manually, rather than relying on the django extraction

Future work to have our auth middleware automatically do this any time it verifies a PK