### PR TITLE
fix: remove GroupTypeMappingInline temporarily from admin

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -2,7 +2,6 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
 
-from posthog.admin.inlines.group_type_mapping_inline import GroupTypeMappingInline
 from posthog.admin.inlines.team_marketing_analytics_config_inline import TeamMarketingAnalyticsConfigInline
 from posthog.models import Team
 
@@ -42,7 +41,7 @@ class TeamAdmin(admin.ModelAdmin):
         "internal_properties",
     ]
 
-    inlines = [GroupTypeMappingInline, TeamMarketingAnalyticsConfigInline]
+    inlines = [TeamMarketingAnalyticsConfigInline]
     fieldsets = [
         (
             None,


### PR DESCRIPTION
## Problem

Removing this from the team admin to unblock support while working on a more definitive fix.

More context: https://posthog.slack.com/archives/C0113360FFV/p1760726039076419?thread_ts=1760712897.365019&cid=C0113360FFV