### PR TITLE
fix: Hide query timings from NotebookNodeLLMTrace

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -46,6 +46,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
                     showExport: false,
                     showDateRange: false,
                     showPropertyFilter: false,
+                    showTimings: false,
                 }}
                 context={context}
                 setQuery={(query) => {


### PR DESCRIPTION
## Problem
Didn't have the flag on locally, forgot to hide the timing.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
