### PR TITLE
chore(flags): add Prometheus metrics for last_called_at sync

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 import requests
 import posthoganalytics
 from celery import shared_task
-from prometheus_client import Gauge
+from prometheus_client import Counter, Gauge
 from redis import Redis
 from structlog import get_logger
 
@@ -26,6 +26,17 @@ from posthog.settings import CLICKHOUSE_CLUSTER
 from posthog.tasks.utils import CeleryQueue
 
 logger = get_logger(__name__)
+
+# Feature flag last_called_at sync metrics
+FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOCK_CONTENTION_COUNTER = Counter(
+    "posthog_feature_flag_last_called_at_sync_lock_contentions_total",
+    "Times feature flag last_called_at sync was skipped due to lock being held",
+)
+
+FEATURE_FLAG_LAST_CALLED_AT_SYNC_LIMIT_HIT_COUNTER = Counter(
+    "posthog_feature_flag_last_called_at_sync_limit_reached_total",
+    "Times the ClickHouse query result limit was reached during feature flag last_called_at sync",
+)
 
 
 @shared_task(ignore_result=True)
@@ -975,6 +986,7 @@ def sync_feature_flag_last_called() -> None:
     # Attempt to acquire lock
     if not cache.add(LOCK_KEY, "locked", timeout=LOCK_TIMEOUT):
         logger.info("Feature flag sync already running, skipping")
+        FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOCK_CONTENTION_COUNTER.inc()
         return
 
     start_time = timezone.now()
@@ -1037,6 +1049,31 @@ def sync_feature_flag_last_called() -> None:
         if not result:
             # Update checkpoint even if no results
             redis_client.set(FEATURE_FLAG_LAST_CALLED_SYNC_KEY, current_sync_timestamp.isoformat())
+
+            # Emit metrics for no-results case
+            checkpoint_lag_seconds = (timezone.now() - current_sync_timestamp).total_seconds()
+            with pushed_metrics_registry("feature_flag_last_called_at_sync_completion") as registry:
+                Gauge(
+                    "posthog_feature_flag_last_called_at_sync_updated_count",
+                    "Number of feature flags updated in last sync",
+                    registry=registry,
+                ).set(0)
+                Gauge(
+                    "posthog_feature_flag_last_called_at_sync_events_processed",
+                    "Number of events processed in last sync",
+                    registry=registry,
+                ).set(0)
+                Gauge(
+                    "posthog_feature_flag_last_called_at_sync_clickhouse_results",
+                    "Number of results returned from ClickHouse query",
+                    registry=registry,
+                ).set(0)
+                Gauge(
+                    "posthog_feature_flag_last_called_at_sync_checkpoint_lag_seconds",
+                    "Seconds between checkpoint timestamp and current time",
+                    registry=registry,
+                ).set(abs(checkpoint_lag_seconds))
+
             logger.info(
                 "Feature flag sync completed with no events",
                 duration_seconds=(timezone.now() - start_time).total_seconds(),
@@ -1092,12 +1129,42 @@ def sync_feature_flag_last_called() -> None:
         redis_client.set(FEATURE_FLAG_LAST_CALLED_SYNC_KEY, checkpoint_timestamp.isoformat())
 
         duration = (timezone.now() - start_time).total_seconds()
+        processed_events = sum(row[3] for row in result)
+        clickhouse_results = len(result)
+
+        # Emit metrics for successful completion
+        checkpoint_lag_seconds = (timezone.now() - checkpoint_timestamp).total_seconds()
+        with pushed_metrics_registry("feature_flag_last_called_at_sync_completion") as registry:
+            Gauge(
+                "posthog_feature_flag_last_called_at_sync_updated_count",
+                "Number of feature flags updated in last sync",
+                registry=registry,
+            ).set(updated_count)
+            Gauge(
+                "posthog_feature_flag_last_called_at_sync_events_processed",
+                "Number of events processed in last sync",
+                registry=registry,
+            ).set(processed_events)
+            Gauge(
+                "posthog_feature_flag_last_called_at_sync_clickhouse_results",
+                "Number of results returned from ClickHouse query",
+                registry=registry,
+            ).set(clickhouse_results)
+            Gauge(
+                "posthog_feature_flag_last_called_at_sync_checkpoint_lag_seconds",
+                "Seconds between checkpoint timestamp and current time",
+                registry=registry,
+            ).set(abs(checkpoint_lag_seconds))
+
+        # Track if we hit the ClickHouse result limit
+        if clickhouse_results >= settings.FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT:
+            FEATURE_FLAG_LAST_CALLED_AT_SYNC_LIMIT_HIT_COUNTER.inc()
 
         logger.info(
             "Feature flag sync completed",
             updated_count=updated_count,
-            processed_events=sum(row[3] for row in result),
-            clickhouse_results=len(result),
+            processed_events=processed_events,
+            clickhouse_results=clickhouse_results,
             duration_seconds=duration,
         )
 


### PR DESCRIPTION
## Problem

It's hard to get a sense of how well the feature flag `last_called_at` sync task is working. This was introduced in https://github.com/PostHog/posthog/pull/39808

## Changes

Add some operational metrics:

- Gauges for flags updated, events processed, checkpoint lag, and ClickHouse results per run
- Counters for lock contentions and limit hits

Metrics use the `pushed_metrics_registry` pattern for Celery tasks, with module-level Counters following the `posthog/celery.py` pattern.

## How did you test this code?

Manually

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
