### PR TITLE
fix emoji rendering in collapsed project menu, darkmode ensures contr…

### DIFF
--- a/frontend/src/lib/components/Account/ProjectMenu.tsx
+++ b/frontend/src/lib/components/Account/ProjectMenu.tsx
@@ -66,8 +66,8 @@ export function ProjectMenu({
                     className={cn('max-w-fit min-w-[40px]', iconOnly ? 'min-w-auto' : '', buttonProps.className)}
                 >
                     {iconOnly ? (
-                        <div className="Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] w-5 h-5 ">
-                            {currentTeam.name.slice(0, 1).toLocaleUpperCase()}
+                        <div className="Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] w-5 h-5 dark:text-tertiary">
+                            {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toUpperCase()}
                         </div>
                     ) : (
                         <span className="truncate">{currentTeam.name ?? 'Project'}</span>

--- a/frontend/src/lib/components/Account/ProjectMenu.tsx
+++ b/frontend/src/lib/components/Account/ProjectMenu.tsx
@@ -67,7 +67,7 @@ export function ProjectMenu({
                 >
                     {iconOnly ? (
                         <div className="Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] w-5 h-5 dark:text-tertiary">
-                            {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toUpperCase()}
+                            {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toLocaleUpperCase()}
                         </div>
                     ) : (
                         <span className="truncate">{currentTeam.name ?? 'Project'}</span>


### PR DESCRIPTION
## Problem
Emojis weren't rendering properly in the collapsed project dropdown
darkmode with letters in collapsed project dropdown had poor contrast
<img width="256" height="225" alt="image" src="https://github.com/user-attachments/assets/992fc92e-9006-4833-bd68-84ac0b4d9e8c" />


## Changes
use codepoint instead of slice (emojis are more than one byte)
<img width="173" height="221" alt="image" src="https://github.com/user-attachments/assets/2e174ac0-550b-43d6-8486-083db4daaefa" />

ensure contrast regardless of theme for darkmode
<img width="191" height="215" alt="image" src="https://github.com/user-attachments/assets/d2430734-965b-49c8-b162-c9bc3e7dcdee" />


## How did you test this code?
locally
