### PR TITLE
fix: remove basic mode for saved insights

### DIFF
--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -107,7 +107,6 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
 
                 const params = {
                     ...values.paramsFromFilters,
-                    basic: true,
                 }
 
                 const legacyResponse: CountedPaginatedResponse<InsightModel> = await api.get(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Currently, saved insights are fetched in basic mode which is faster but contains a smaller payload. On the initial fetch, the insights won't contain the `results` key which is used when rendering the visualizations. Since the result is cached, when a user tries to swicth to Card layout on the product analytics tab, it uses the cached result which doesn't contain the results causing the empty state to be rendered. 

On refresh, this issue doesn't exist since there's no initial cache state, and the `dataNodeLogic` response loader forces a refresh of each insight individually

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #39703

## Changes
Removes basic mode for saved insights rendered on the Product analytics page

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
- Go to the product analytics page
- Switch to card layout
- The visualizations should be rendered correctly without having to refresh the page
