### PR TITLE
fix(dashboard): Action to open all insights in new Posthog tabs 

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -341,6 +341,31 @@ export function DashboardHeader(): JSX.Element | null {
                             Open insights in new Posthog tabs
                         </ButtonPrimitive>
                     )}
+                    {dashboard && (
+                        <ButtonPrimitive
+                            onClick={() => {
+                                tiles.forEach((tile) => {
+                                    if (tile.insight?.short_id == null) {
+                                        return
+                                    }
+                                    const url = urls.insightView(
+                                        tile.insight.short_id,
+                                        dashboard.id,
+                                        effectiveDashboardVariableOverrides,
+                                        effectiveEditBarFilters,
+                                        tile?.filters_overrides
+                                    )
+
+                                    window.open(url, '_blank')
+                                })
+                            }}
+                            menuItem
+                            data-attr="open-insights-in-new-browser-tabs"
+                        >
+                            <IconGraph />
+                            Open insights in new browser tabs
+                        </ButtonPrimitive>
+                    )}
                 </ScenePanelActionsSection>
                 {dashboard && canEditDashboard && (
                     <>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -341,7 +341,7 @@ export function DashboardHeader(): JSX.Element | null {
                             data-attr="open-insights-in-new-posthog-tabs"
                             disabledReasons={{
                                 'Cannot open insights when editing dashboard': dashboardMode === DashboardMode.Edit,
-                                'Dashboard has no insights': dashboard.tiles.length === 0,
+                                'Dashboard has no insights': tiles.length === 0,
                             }}
                         >
                             <IconGraph />

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useMemo, useState } from 'react'
 
-import { IconGridMasonry, IconNotebook, IconPalette, IconScreen, IconTrash } from '@posthog/icons'
+import { IconGraph, IconGridMasonry, IconNotebook, IconPalette, IconScreen, IconTrash } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { TextCardModal } from 'lib/components/Cards/TextCard/TextCardModal'
@@ -29,6 +29,7 @@ import { DuplicateDashboardModal } from 'scenes/dashboard/DuplicateDashboardModa
 import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
 import { duplicateDashboardLogic } from 'scenes/dashboard/duplicateDashboardLogic'
 import { MaxTool } from 'scenes/max/MaxTool'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { urls } from 'scenes/urls'
@@ -73,12 +74,14 @@ export function DashboardHeader(): JSX.Element | null {
         textTileId,
     } = useValues(dashboardLogic)
     const { setDashboardMode, triggerDashboardUpdate, loadDashboard } = useActions(dashboardLogic)
-    const { asDashboardTemplate } = useValues(dashboardLogic)
+    const { asDashboardTemplate, effectiveEditBarFilters, effectiveDashboardVariableOverrides, tiles } =
+        useValues(dashboardLogic)
     const { updateDashboard, pinDashboard, unpinDashboard } = useActions(dashboardsModel)
     const { createNotebookFromDashboard } = useActions(notebooksModel)
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
     const { setDashboardTemplate, openDashboardTemplateEditor } = useActions(dashboardTemplateEditorLogic)
     const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
+    const { newTab } = useActions(sceneLogic)
 
     const { user } = useValues(userLogic)
 
@@ -314,6 +317,30 @@ export function DashboardHeader(): JSX.Element | null {
                     )}
 
                     {dashboard && <SceneMetalyticsSummaryButton dataAttrKey={RESOURCE_TYPE} />}
+                    {dashboard && (
+                        <ButtonPrimitive
+                            onClick={() => {
+                                tiles.forEach((tile) => {
+                                    if (tile.insight?.short_id == null) {
+                                        return
+                                    }
+                                    const url = urls.insightView(
+                                        tile.insight.short_id,
+                                        dashboard.id,
+                                        effectiveDashboardVariableOverrides,
+                                        effectiveEditBarFilters,
+                                        tile?.filters_overrides
+                                    )
+                                    newTab(url)
+                                })
+                            }}
+                            menuItem
+                            data-attr="open-insights-in-new-posthog-tabs"
+                        >
+                            <IconGraph className="text-none" />
+                            Open insights in new Posthog tabs
+                        </ButtonPrimitive>
+                    )}
                 </ScenePanelActionsSection>
                 {dashboard && canEditDashboard && (
                     <>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -340,7 +340,7 @@ export function DashboardHeader(): JSX.Element | null {
                             menuItem
                             data-attr="open-insights-in-new-posthog-tabs"
                         >
-                            <IconGraph className="text-none" />
+                            <IconGraph />
                             Open insights in new Posthog tabs
                         </ButtonPrimitive>
                     )}

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -341,31 +341,6 @@ export function DashboardHeader(): JSX.Element | null {
                             Open insights in new Posthog tabs
                         </ButtonPrimitive>
                     )}
-                    {dashboard && (
-                        <ButtonPrimitive
-                            onClick={() => {
-                                tiles.forEach((tile) => {
-                                    if (tile.insight?.short_id == null) {
-                                        return
-                                    }
-                                    const url = urls.insightView(
-                                        tile.insight.short_id,
-                                        dashboard.id,
-                                        effectiveDashboardVariableOverrides,
-                                        effectiveEditBarFilters,
-                                        tile?.filters_overrides
-                                    )
-
-                                    window.open(url, '_blank')
-                                })
-                            }}
-                            menuItem
-                            data-attr="open-insights-in-new-browser-tabs"
-                        >
-                            <IconGraph />
-                            Open insights in new browser tabs
-                        </ButtonPrimitive>
-                    )}
                 </ScenePanelActionsSection>
                 {dashboard && canEditDashboard && (
                     <>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -334,8 +334,8 @@ export function DashboardHeader(): JSX.Element | null {
                                         tile?.filters_overrides
                                     )
                                     newTab(url)
-                                    setScenePanelOpen(false)
                                 })
+                                setScenePanelOpen(false)
                             }}
                             menuItem
                             data-attr="open-insights-in-new-posthog-tabs"

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -339,6 +339,9 @@ export function DashboardHeader(): JSX.Element | null {
                             }}
                             menuItem
                             data-attr="open-insights-in-new-posthog-tabs"
+                            disabledReasons={{
+                                'Dashboard has no insights': dashboard.tiles.length === 0,
+                            }}
                         >
                             <IconGraph />
                             Open insights in new Posthog tabs

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -44,6 +44,7 @@ import {
 } from '~/layout/scenes/SceneLayout'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { notebooksModel } from '~/models/notebooksModel'
 import { tagsModel } from '~/models/tagsModel'
@@ -82,6 +83,7 @@ export function DashboardHeader(): JSX.Element | null {
     const { setDashboardTemplate, openDashboardTemplateEditor } = useActions(dashboardTemplateEditorLogic)
     const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
     const { newTab } = useActions(sceneLogic)
+    const { setScenePanelOpen } = useActions(sceneLayoutLogic)
 
     const { user } = useValues(userLogic)
 
@@ -332,6 +334,7 @@ export function DashboardHeader(): JSX.Element | null {
                                         tile?.filters_overrides
                                     )
                                     newTab(url)
+                                    setScenePanelOpen(false)
                                 })
                             }}
                             menuItem

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -345,7 +345,7 @@ export function DashboardHeader(): JSX.Element | null {
                             }}
                         >
                             <IconGraph />
-                            Open insights in new Posthog tabs
+                            Open insights in new PostHog tabs
                         </ButtonPrimitive>
                     )}
                 </ScenePanelActionsSection>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -340,6 +340,7 @@ export function DashboardHeader(): JSX.Element | null {
                             menuItem
                             data-attr="open-insights-in-new-posthog-tabs"
                             disabledReasons={{
+                                'Cannot open insights when editing dashboard': dashboardMode === DashboardMode.Edit,
                                 'Dashboard has no insights': dashboard.tiles.length === 0,
                             }}
                         >


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/39102

## Changes

Added a new action to open all insights in new posthog tabs; its under the info & actions because I feel a button in the dashboard might clutter the UI.



https://github.com/user-attachments/assets/47409fe6-b63e-4468-a56d-65ea6d83358d


### Reviewer's Note
I implemented it for browser tabs as well, but it only opened one tab:


https://github.com/user-attachments/assets/988a616d-1200-4117-ad9b-0241f8e1990a

Could be a google chrome only issue based on this : https://stackoverflow.com/questions/52007867/calling-window-open-multiple-times-fails-after-the-first-time

Let me know if you guys wanna include it; I can do it in this PR or a subsequent one.


## How did you test this code?
Locally:
1) Go to a dashboard with insights
2) Look for the 3 dots menu on the right top corner and click on it
3) Look for `Open insights in new Posthog tabs` and click on it

You should see the insights open as posthog tabs
