### PR TITLE
feat(flags): Add per-team rate limiting to flag definitions endpoint

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "dateparser",
  "envconfig",
  "futures",
+ "governor",
  "health",
  "hex",
  "json5",

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -16,6 +16,7 @@ common-database = { path = "../common/database" }
 common-redis = { path = "../common/redis" }
 common-types = { path = "../common/types" }
 envconfig = { workspace = true }
+governor = { workspace = true }
 limiters = { path = "../common/limiters" }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod auth;
 pub mod endpoint;
 pub mod errors;
-pub mod local_evaluation;
+pub mod flag_definitions;
+pub mod rate_limiter;
+pub mod rate_parser;
 pub mod types;

--- a/rust/feature-flags/src/api/rate_limiter.rs
+++ b/rust/feature-flags/src/api/rate_limiter.rs
@@ -1,0 +1,364 @@
+use crate::api::{errors::FlagError, rate_parser::parse_rate_string};
+use common_metrics::inc;
+use common_types::TeamId;
+use governor::{clock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::num::NonZeroU32;
+use std::sync::{Arc, RwLock};
+use tracing::{info, warn};
+
+/// Type alias for a keyed rate limiter
+type KeyedRateLimiterInner<K> = Arc<RateLimiter<K, DefaultKeyedStateStore<K>, clock::DefaultClock>>;
+
+/// Type alias for the custom limiters map
+type CustomLimitersMap<K> = Arc<RwLock<HashMap<K, KeyedRateLimiterInner<K>>>>;
+
+/// Generic keyed rate limiter with default and per-key custom rate overrides
+///
+/// This limiter supports:
+/// - A configurable default rate limit for all keys
+/// - Custom per-key rate limits
+/// - Thread-safe concurrent access via Arc and RwLock
+/// - Configurable Prometheus metrics
+///
+/// # Type Parameters
+/// * `K` - The key type (e.g., TeamId, UserId, etc.)
+///
+/// # Algorithm
+/// Uses the GCRA (Generic Cell Rate Algorithm) via the `governor` crate,
+/// which is functionally equivalent to a leaky bucket but more efficient.
+#[derive(Clone)]
+pub struct KeyedRateLimiter<K>
+where
+    K: Hash + Eq + Clone + Display + Send + Sync + 'static,
+{
+    /// Default rate limiter for keys without custom rates
+    default_limiter: KeyedRateLimiterInner<K>,
+
+    /// Custom rate limiters for specific keys
+    /// Maps key → rate limiter
+    /// Wrapped in RwLock for thread-safe access
+    custom_limiters: CustomLimitersMap<K>,
+
+    /// Prometheus metric name for total requests
+    request_counter: &'static str,
+
+    /// Prometheus metric name for rate limited requests
+    limited_counter: &'static str,
+}
+
+/// Type alias for flag definitions rate limiting (per-team)
+pub type FlagDefinitionsRateLimiter = KeyedRateLimiter<TeamId>;
+
+impl<K> KeyedRateLimiter<K>
+where
+    K: Hash + Eq + Clone + Display + Send + Sync + 'static,
+{
+    /// Create a new KeyedRateLimiter with configurable default and custom rates
+    ///
+    /// # Arguments
+    /// * `default_rate_per_minute` - Default rate limit for keys without custom rates (requests per minute)
+    /// * `custom_rates` - HashMap of key → rate string (e.g., "1200/minute")
+    /// * `request_counter` - Prometheus metric name for total requests
+    /// * `limited_counter` - Prometheus metric name for rate limited requests
+    ///
+    /// # Returns
+    /// A new limiter instance, or an error if any custom rate string is invalid
+    pub fn new(
+        default_rate_per_minute: u32,
+        custom_rates: HashMap<K, String>,
+        request_counter: &'static str,
+        limited_counter: &'static str,
+    ) -> Result<Self, String> {
+        // Create default limiter using configured rate
+        let default_quota = Quota::per_minute(
+            NonZeroU32::new(default_rate_per_minute)
+                .ok_or_else(|| "default_rate_per_minute must be non-zero".to_string())?,
+        );
+        let default_limiter = Arc::new(RateLimiter::dashmap(default_quota));
+
+        // Parse and create custom rate limiters
+        let mut custom_limiters_map = HashMap::new();
+
+        for (key, rate_string) in custom_rates {
+            match parse_rate_string(&rate_string) {
+                Ok(quota) => {
+                    let limiter = Arc::new(RateLimiter::dashmap(quota));
+                    custom_limiters_map.insert(key.clone(), limiter);
+                    info!(
+                        key = %key,
+                        rate = %rate_string,
+                        "Configured custom rate limit for key"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        key = %key,
+                        rate = %rate_string,
+                        error = %e,
+                        "Invalid rate string for key, ignoring custom rate"
+                    );
+                    // Continue with default rate for this key instead of failing
+                }
+            }
+        }
+
+        let custom_limiters = Arc::new(RwLock::new(custom_limiters_map));
+
+        Ok(KeyedRateLimiter {
+            default_limiter,
+            custom_limiters,
+            request_counter,
+            limited_counter,
+        })
+    }
+
+    /// Check if a request from the given key should be rate limited
+    ///
+    /// # Arguments
+    /// * `key` - The key (e.g., team ID, user ID) making the request
+    ///
+    /// # Returns
+    /// Ok(()) if request is allowed, Err(FlagError::ClientFacing(ClientFacingError::RateLimited)) if rate limited
+    pub fn check_rate_limit(&self, key: K) -> Result<(), FlagError> {
+        // Check if key has a custom rate limiter
+        let custom_limiters = self.custom_limiters.read().unwrap();
+        let is_rate_limited = if let Some(custom_limiter) = custom_limiters.get(&key) {
+            // Use custom rate limiter
+            custom_limiter.check_key(&key).is_err()
+        } else {
+            // Use default rate limiter
+            self.default_limiter.check_key(&key).is_err()
+        };
+
+        // Track all requests
+        inc(
+            self.request_counter,
+            &[("key".to_string(), key.to_string())],
+            1,
+        );
+
+        if is_rate_limited {
+            // Track rate-limited requests
+            inc(
+                self.limited_counter,
+                &[("key".to_string(), key.to_string())],
+                1,
+            );
+
+            // Log rate limit event with key context
+            warn!(key = %key, "Request rate limited");
+
+            return Err(FlagError::ClientFacing(
+                crate::api::errors::ClientFacingError::RateLimited,
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Get the number of keys with custom rate limits configured
+    pub fn custom_rate_count(&self) -> usize {
+        self.custom_limiters.read().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::consts::{
+        FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_REQUESTS_COUNTER,
+    };
+    use std::collections::HashMap;
+    use tokio::time::{sleep, Duration};
+
+    #[test]
+    fn test_new_limiter_with_no_custom_rates() {
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            HashMap::new(),
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+        assert_eq!(limiter.custom_rate_count(), 0);
+    }
+
+    #[test]
+    fn test_new_limiter_with_valid_custom_rates() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert(123, "1200/minute".to_string());
+        custom_rates.insert(456, "2400/hour".to_string());
+
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            custom_rates,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+        assert_eq!(limiter.custom_rate_count(), 2);
+    }
+
+    #[test]
+    fn test_new_limiter_with_invalid_rate_string() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert(123, "invalid".to_string());
+        custom_rates.insert(456, "1200/minute".to_string());
+
+        // Should succeed but only configure the valid rate
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            custom_rates,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+        assert_eq!(limiter.custom_rate_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_default_rate_limit_allows_requests() {
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            HashMap::new(),
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+
+        // First request should succeed
+        assert!(limiter.check_rate_limit(999).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_custom_rate_limit_applies() {
+        let mut custom_rates = HashMap::new();
+        // Very low limit for testing: 1 per second
+        custom_rates.insert(123, "1/second".to_string());
+
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            custom_rates,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+
+        // First request should succeed
+        assert!(limiter.check_rate_limit(123).is_ok());
+
+        // Second request should be rate limited
+        assert!(limiter.check_rate_limit(123).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_different_teams_independent_limits() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert(123, "1/second".to_string());
+
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            custom_rates,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+
+        // Team 123 first request succeeds
+        assert!(limiter.check_rate_limit(123).is_ok());
+
+        // Team 123 second request fails (rate limited)
+        assert!(limiter.check_rate_limit(123).is_err());
+
+        // Team 999 (using default rate) still succeeds
+        assert!(limiter.check_rate_limit(999).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_resets_after_window() {
+        let mut custom_rates = HashMap::new();
+        // 1 per second - should reset after 1 second
+        custom_rates.insert(123, "1/second".to_string());
+
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            custom_rates,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+
+        // First request succeeds
+        assert!(limiter.check_rate_limit(123).is_ok());
+
+        // Second request immediately fails
+        assert!(limiter.check_rate_limit(123).is_err());
+
+        // Wait for rate limit window to reset
+        sleep(Duration::from_millis(1100)).await;
+
+        // Should succeed again after reset
+        assert!(limiter.check_rate_limit(123).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_access() {
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            HashMap::new(),
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+        let limiter_clone = limiter.clone();
+
+        // Spawn multiple tasks checking rate limits concurrently
+        let handle1 = tokio::spawn(async move {
+            for _ in 0..10 {
+                drop(limiter_clone.check_rate_limit(123));
+            }
+        });
+
+        let limiter_clone2 = limiter.clone();
+        let handle2 = tokio::spawn(async move {
+            for _ in 0..10 {
+                drop(limiter_clone2.check_rate_limit(456));
+            }
+        });
+
+        // Should complete without panicking
+        handle1.await.unwrap();
+        handle2.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_check_rate_limit_returns_correct_error() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert(123, "1/second".to_string());
+
+        let limiter = FlagDefinitionsRateLimiter::new(
+            600,
+            custom_rates,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        )
+        .unwrap();
+
+        // Use up the rate limit
+        drop(limiter.check_rate_limit(123));
+
+        // Next request should return RateLimited error
+        let result = limiter.check_rate_limit(123);
+        assert!(result.is_err());
+
+        match result {
+            Err(FlagError::ClientFacing(crate::api::errors::ClientFacingError::RateLimited)) => {
+                // Expected error type
+            }
+            _ => panic!("Expected RateLimited error"),
+        }
+    }
+}

--- a/rust/feature-flags/src/api/rate_parser.rs
+++ b/rust/feature-flags/src/api/rate_parser.rs
@@ -1,0 +1,186 @@
+use governor::Quota;
+use std::num::NonZeroU32;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum RateParseError {
+    #[error("Invalid rate format: {0}. Expected format: 'N/period' (e.g., '600/minute')")]
+    InvalidFormat(String),
+    #[error("Invalid rate number: {0}")]
+    InvalidNumber(String),
+    #[error("Invalid time period: {0}. Valid periods: second, minute, hour, day")]
+    InvalidPeriod(String),
+    #[error("Rate must be greater than zero")]
+    ZeroRate,
+}
+
+/// Parse a Django SimpleRateThrottle-style rate string into a governor Quota
+///
+/// Supported formats:
+/// - "N/second" - N requests per second
+/// - "N/minute" - N requests per minute
+/// - "N/hour" - N requests per hour
+/// - "N/day" - N requests per day
+///
+/// Only the first character of the period is significant ('s', 'm', 'h', 'd').
+///
+/// Examples:
+/// ```
+/// use feature_flags::api::rate_parser::parse_rate_string;
+/// use std::num::NonZeroU32;
+///
+/// let quota = parse_rate_string("600/minute").unwrap();
+/// let quota = parse_rate_string("1200/hour").unwrap();
+/// let quota = parse_rate_string("100/second").unwrap();
+/// ```
+pub fn parse_rate_string(rate_str: &str) -> Result<Quota, RateParseError> {
+    let rate_str = rate_str.trim();
+
+    // Split on '/' to get number and period
+    let parts: Vec<&str> = rate_str.split('/').collect();
+    if parts.len() != 2 {
+        return Err(RateParseError::InvalidFormat(rate_str.to_string()));
+    }
+
+    // Parse the number part
+    let num_str = parts[0].trim();
+    let num = num_str
+        .parse::<u32>()
+        .map_err(|_| RateParseError::InvalidNumber(num_str.to_string()))?;
+
+    if num == 0 {
+        return Err(RateParseError::ZeroRate);
+    }
+
+    let num = NonZeroU32::new(num).unwrap(); // Safe because we checked for zero above
+
+    // Parse the period part (only first character matters)
+    let period_str = parts[1].trim().to_lowercase();
+    let period_char = period_str
+        .chars()
+        .next()
+        .ok_or_else(|| RateParseError::InvalidPeriod(parts[1].to_string()))?;
+
+    // Create quota based on period
+    let quota = match period_char {
+        's' => Quota::per_second(num),
+        'm' => Quota::per_minute(num),
+        'h' => Quota::per_hour(num),
+        'd' => Quota::with_period(std::time::Duration::from_secs(86400))
+            .ok_or_else(|| RateParseError::InvalidPeriod("day".to_string()))?
+            .allow_burst(num),
+        _ => return Err(RateParseError::InvalidPeriod(parts[1].to_string())),
+    };
+
+    Ok(quota)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_rate_strings() {
+        // Test all valid formats
+        assert!(parse_rate_string("600/minute").is_ok());
+        assert!(parse_rate_string("1200/hour").is_ok());
+        assert!(parse_rate_string("100/second").is_ok());
+        assert!(parse_rate_string("2400/day").is_ok());
+    }
+
+    #[test]
+    fn test_parse_with_whitespace() {
+        // Should handle whitespace
+        assert!(parse_rate_string(" 600 / minute ").is_ok());
+        assert!(parse_rate_string("600/minute ").is_ok());
+        assert!(parse_rate_string(" 600/minute").is_ok());
+    }
+
+    #[test]
+    fn test_parse_first_char_only() {
+        // Only first character of period matters (Django behavior)
+        assert!(parse_rate_string("600/m").is_ok());
+        assert!(parse_rate_string("600/min").is_ok());
+        assert!(parse_rate_string("600/minutes").is_ok());
+        assert!(parse_rate_string("100/s").is_ok());
+        assert!(parse_rate_string("100/sec").is_ok());
+        assert!(parse_rate_string("100/seconds").is_ok());
+        assert!(parse_rate_string("1200/h").is_ok());
+        assert!(parse_rate_string("1200/hr").is_ok());
+        assert!(parse_rate_string("1200/hours").is_ok());
+        assert!(parse_rate_string("2400/d").is_ok());
+        assert!(parse_rate_string("2400/day").is_ok());
+        assert!(parse_rate_string("2400/days").is_ok());
+    }
+
+    #[test]
+    fn test_parse_case_insensitive() {
+        // Period should be case-insensitive
+        assert!(parse_rate_string("600/MINUTE").is_ok());
+        assert!(parse_rate_string("600/Minute").is_ok());
+        assert!(parse_rate_string("100/SECOND").is_ok());
+    }
+
+    #[test]
+    fn test_invalid_format_no_slash() {
+        let result = parse_rate_string("600");
+        assert!(matches!(result, Err(RateParseError::InvalidFormat(_))));
+    }
+
+    #[test]
+    fn test_invalid_format_multiple_slashes() {
+        let result = parse_rate_string("600/minute/extra");
+        assert!(matches!(result, Err(RateParseError::InvalidFormat(_))));
+    }
+
+    #[test]
+    fn test_invalid_format_empty_period() {
+        let result = parse_rate_string("600/");
+        assert!(matches!(result, Err(RateParseError::InvalidPeriod(_))));
+    }
+
+    #[test]
+    fn test_invalid_number() {
+        let result = parse_rate_string("abc/minute");
+        assert!(matches!(result, Err(RateParseError::InvalidNumber(_))));
+    }
+
+    #[test]
+    fn test_invalid_number_negative() {
+        let result = parse_rate_string("-600/minute");
+        assert!(matches!(result, Err(RateParseError::InvalidNumber(_))));
+    }
+
+    #[test]
+    fn test_invalid_number_float() {
+        let result = parse_rate_string("600.5/minute");
+        assert!(matches!(result, Err(RateParseError::InvalidNumber(_))));
+    }
+
+    #[test]
+    fn test_zero_rate() {
+        let result = parse_rate_string("0/minute");
+        assert_eq!(result, Err(RateParseError::ZeroRate));
+    }
+
+    #[test]
+    fn test_invalid_period() {
+        let result = parse_rate_string("600/invalid");
+        assert!(matches!(result, Err(RateParseError::InvalidPeriod(_))));
+    }
+
+    #[test]
+    fn test_invalid_period_year() {
+        // 'y' for year is not supported
+        let result = parse_rate_string("600/year");
+        assert!(matches!(result, Err(RateParseError::InvalidPeriod(_))));
+    }
+
+    #[test]
+    fn test_quota_values() {
+        // Verify the quota is created with correct values
+        let quota = parse_rate_string("600/minute").unwrap();
+        // We can't directly inspect quota internals, but we can verify it was created
+        assert!(format!("{quota:?}").contains("600"));
+    }
+}

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -1,6 +1,8 @@
 use common_cookieless::CookielessConfig;
+use common_types::TeamId;
 use envconfig::Envconfig;
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::num::ParseIntError;
 use std::ops::Deref;
@@ -102,6 +104,41 @@ impl FromStr for TeamIdCollection {
             }
             Ok(TeamIdCollection::TeamIds(team_ids))
         }
+    }
+}
+
+/// Flag definitions rate limits configuration
+/// Parses JSON from FLAG_DEFINITIONS_RATE_LIMITS environment variable
+/// Format: {"team_id": "rate_string", ...}
+/// Example: {"123": "1200/minute", "456": "2400/hour"}
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FlagDefinitionsRateLimits(pub HashMap<TeamId, String>);
+
+impl FromStr for FlagDefinitionsRateLimits {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+
+        // Empty string means no custom rate limits
+        if s.is_empty() {
+            return Ok(FlagDefinitionsRateLimits::default());
+        }
+
+        // Parse JSON into HashMap<String, String>
+        let parsed: HashMap<String, String> = serde_json::from_str(s)
+            .map_err(|e| format!("Failed to parse FLAG_DEFINITIONS_RATE_LIMITS as JSON: {e}"))?;
+
+        // Convert string keys to TeamId
+        let mut rate_limits = HashMap::new();
+        for (team_id_str, rate_string) in parsed {
+            let team_id = team_id_str
+                .parse::<TeamId>()
+                .map_err(|e| format!("Invalid team ID '{team_id_str}': {e}"))?;
+            rate_limits.insert(team_id, rate_string);
+        }
+
+        Ok(FlagDefinitionsRateLimits(rate_limits))
     }
 }
 
@@ -304,6 +341,18 @@ pub struct Config {
     #[envconfig(from = "FLAGS_SESSION_REPLAY_QUOTA_CHECK", default = "false")]
     pub flags_session_replay_quota_check: bool,
 
+    // Flag definitions rate limiting
+    // Default rate limit for all teams (requests per minute)
+    // Can be overridden per-team using FLAG_DEFINITIONS_RATE_LIMITS
+    #[envconfig(from = "FLAG_DEFINITIONS_DEFAULT_RATE_PER_MINUTE", default = "600")]
+    pub flag_definitions_default_rate_per_minute: u32,
+
+    // Per-team rate limit overrides for flag definitions endpoint
+    // JSON format: {"team_id": "rate_string", ...}
+    // Example: {"123": "1200/minute", "456": "2400/hour"}
+    #[envconfig(from = "FLAG_DEFINITIONS_RATE_LIMITS", default = "")]
+    pub flag_definitions_rate_limits: FlagDefinitionsRateLimits,
+
     // OpenTelemetry configuration
     #[envconfig(from = "OTEL_EXPORTER_OTLP_ENDPOINT")]
     pub otel_url: Option<String>,
@@ -402,6 +451,8 @@ impl Config {
             session_replay_rrweb_script: "".to_string(),
             session_replay_rrweb_script_allowed_teams: TeamIdCollection::None,
             flags_session_replay_quota_check: false,
+            flag_definitions_default_rate_per_minute: 600,
+            flag_definitions_rate_limits: FlagDefinitionsRateLimits::default(),
             otel_url: None,
             otel_sampling_rate: 1.0,
             otel_service_name: "posthog-feature-flags".to_string(),
@@ -649,5 +700,63 @@ mod tests {
     fn test_invalid_number() {
         let result: Result<TeamIdCollection, _> = "abc".parse();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_flag_definitions_rate_limits_empty() {
+        let limits: FlagDefinitionsRateLimits = "".parse().unwrap();
+        assert_eq!(limits.0.len(), 0);
+    }
+
+    #[test]
+    fn test_flag_definitions_rate_limits_valid_json() {
+        let json = r#"{"123": "1200/minute", "456": "2400/hour"}"#;
+        let limits: FlagDefinitionsRateLimits = json.parse().unwrap();
+        assert_eq!(limits.0.len(), 2);
+        assert_eq!(limits.0.get(&123), Some(&"1200/minute".to_string()));
+        assert_eq!(limits.0.get(&456), Some(&"2400/hour".to_string()));
+    }
+
+    #[test]
+    fn test_flag_definitions_rate_limits_single_team() {
+        let json = r#"{"789": "100/second"}"#;
+        let limits: FlagDefinitionsRateLimits = json.parse().unwrap();
+        assert_eq!(limits.0.len(), 1);
+        assert_eq!(limits.0.get(&789), Some(&"100/second".to_string()));
+    }
+
+    #[test]
+    fn test_flag_definitions_rate_limits_invalid_json() {
+        let result: Result<FlagDefinitionsRateLimits, _> = "not json".parse();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Failed to parse FLAG_DEFINITIONS_RATE_LIMITS"));
+    }
+
+    #[test]
+    fn test_flag_definitions_rate_limits_invalid_team_id() {
+        let json = r#"{"abc": "600/minute"}"#;
+        let result: Result<FlagDefinitionsRateLimits, _> = json.parse();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid team ID"));
+    }
+
+    #[test]
+    fn test_flag_definitions_rate_limits_negative_team_id() {
+        let json = r#"{"-123": "600/minute"}"#;
+        let result: Result<FlagDefinitionsRateLimits, _> = json.parse();
+        // Negative numbers are technically valid i32, so this should succeed
+        assert!(result.is_ok());
+        let limits = result.unwrap();
+        assert_eq!(limits.0.get(&-123), Some(&"600/minute".to_string()));
+    }
+
+    #[test]
+    fn test_flag_definitions_rate_limits_whitespace() {
+        let json = r#"  {"123": "600/minute"}  "#;
+        let limits: FlagDefinitionsRateLimits = json.parse().unwrap();
+        assert_eq!(limits.0.len(), 1);
+        assert_eq!(limits.0.get(&123), Some(&"600/minute".to_string()));
     }
 }

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -28,7 +28,7 @@ where
 #[derive(Debug, Clone, Copy)]
 pub enum FlagRequestType {
     Decide,
-    LocalEvaluation,
+    FlagDefinitions,
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -56,3 +56,7 @@ pub const FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER: &str =
     "flags_reader_timeout_with_writer_state_total";
 pub const FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER: &str =
     "flags_experience_continuity_requests_total";
+
+// Flag definitions rate limiting
+pub const FLAG_DEFINITIONS_RATE_LIMITED_COUNTER: &str = "flags_flag_definitions_rate_limited_total";
+pub const FLAG_DEFINITIONS_REQUESTS_COUNTER: &str = "flags_flag_definitions_requests_total";

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -19,10 +19,13 @@ use tower_http::{
 };
 
 use crate::{
-    api::{endpoint, local_evaluation},
+    api::{endpoint, flag_definitions, rate_limiter::FlagDefinitionsRateLimiter},
     cohorts::cohort_cache_manager::CohortCacheManager,
     config::{Config, TeamIdCollection},
-    metrics::utils::team_id_label_filter,
+    metrics::{
+        consts::{FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_REQUESTS_COUNTER},
+        utils::team_id_label_filter,
+    },
 };
 
 #[derive(Clone)]
@@ -36,6 +39,7 @@ pub struct State {
     pub feature_flags_billing_limiter: FeatureFlagsLimiter,
     pub session_replay_billing_limiter: SessionReplayLimiter,
     pub cookieless_manager: Arc<CookielessManager>,
+    pub flag_definitions_limiter: FlagDefinitionsRateLimiter,
     pub config: Config,
 }
 
@@ -56,6 +60,15 @@ where
     RR: RedisClient + Send + Sync + 'static,
     RW: RedisClient + Send + Sync + 'static,
 {
+    // Initialize flag definitions rate limiter with default and custom team rates
+    let flag_definitions_limiter = FlagDefinitionsRateLimiter::new(
+        config.flag_definitions_default_rate_per_minute,
+        config.flag_definitions_rate_limits.0.clone(),
+        FLAG_DEFINITIONS_REQUESTS_COUNTER,
+        FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+    )
+    .expect("Failed to initialize flag definitions rate limiter");
+
     let state = State {
         redis_reader,
         redis_writer,
@@ -66,6 +79,7 @@ where
         feature_flags_billing_limiter,
         session_replay_billing_limiter,
         cookieless_manager,
+        flag_definitions_limiter,
         config: config.clone(),
     };
 
@@ -89,11 +103,11 @@ where
         .route("/flags/", any(endpoint::flags))
         .route(
             "/flags/definitions",
-            any(local_evaluation::flags_definitions),
+            any(flag_definitions::flags_definitions),
         )
         .route(
             "/flags/definitions/",
-            any(local_evaluation::flags_definitions),
+            any(flag_definitions::flags_definitions),
         )
         .route("/decide", any(endpoint::flags))
         .route("/decide/", any(endpoint::flags))

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1270,9 +1270,9 @@ impl TestContext {
         Ok((team, secret_token, backup_secret_token))
     }
 
-    /// Populates the HyperCache with flag definitions for local_evaluation endpoint
+    /// Populates the HyperCache with flag definitions for flag_definitions endpoint
     /// Uses the same cache key format that Django's cache warming uses
-    pub async fn populate_local_evaluation_cache(
+    pub async fn populate_flag_definitions_cache(
         &self,
         redis: Arc<dyn RedisClientTrait + Send + Sync>,
         team_id: i32,
@@ -1313,7 +1313,7 @@ impl TestContext {
     /// Handles Redis client setup internally
     pub async fn populate_cache_for_team(&self, team_id: i32) -> Result<(), Error> {
         let redis_client = setup_redis_client(Some(self.config.redis_url.clone())).await;
-        self.populate_local_evaluation_cache(redis_client, team_id)
+        self.populate_flag_definitions_cache(redis_client, team_id)
             .await
     }
 


### PR DESCRIPTION
## Problem

The new Rust `/flags/definitions` endpoint needs rate limiting the same way `/local_evaluation` does.

## Changes

Implements configurable rate limiting for the `/flags/definitions` endpoint to protect against excessive requests and allow per-team customization.

Key features:
- Configurable default rate limit via `FLAG_DEFINITIONS_DEFAULT_RATE_PER_MINUTE` (default: 600/minute)
- Per-team overrides via `FLAG_DEFINITIONS_RATE_LIMITS` environment variable Format: `{"team_id": "rate_string"}` (e.g., `{"123": "1200/minute", "456": "2400/hour"}`)
- Supports Django `SimpleRateThrottle` rate format (N/second|minute|hour|day)
- Rate limiting occurs after authentication to prevent enumeration attacks
- Thread-safe implementation using governor with `Arc<RwLock>`
- Prometheus metrics for monitoring:
  - `flags_flag_definitions_requests_total`
  - `flags_flag_definitions_rate_limited_total`

Implementation:
- Generic `KeyedRateLimiter<K>` struct for reusable rate limiting with any key type
- Configurable Prometheus metrics via constructor parameters
- Uses GCRA (Generic Cell Rate Algorithm) via `governor` crate for efficiency
- `rate_parser` module for parsing Django-style rate strings
- Renamed `local_evaluation` module to `flag_definitions` for clarity
- Integrated into `flags_definitions` handler in `flag_definitions` module
- Comprehensive test coverage (9 unit tests, 24 integration tests)

Module refactoring:
- local_evaluation.rs → flag_definitions.rs
- test_local_evaluation.rs → test_flag_definitions.rs
- LocalEvaluationResponse → FlagDefinitionsResponse
- LocalEvaluationQueryParams → FlagDefinitionsQueryParams
- authenticate_local_evaluation → authenticate_flag_definitions
- FlagRequestType::LocalEvaluation → FlagRequestType::FlagDefinitions

Environment variables:
- `FLAG_DEFINITIONS_DEFAULT_RATE_PER_MINUTE`: Default rate for all teams (default: 600)
- `FLAG_DEFINITIONS_RATE_LIMITS`: JSON map of team_id to rate string for overrides

## How did you test this code?

Manually
Unit Tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
