### PR TITLE
revert: join cohort people counts with cohorts, not people (#39922)

### DIFF
--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -817,9 +817,9 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_cohortpeople"
-  INNER JOIN "posthog_cohort" ON ("posthog_cohortpeople"."cohort_id" = "posthog_cohort"."id")
-  WHERE ("posthog_cohort"."team_id" = 99999
-         AND "posthog_cohortpeople"."cohort_id" = 99999)
+  INNER JOIN "posthog_person" ON ("posthog_cohortpeople"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_cohortpeople"."cohort_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.24
@@ -1185,9 +1185,9 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_cohortpeople"
-  INNER JOIN "posthog_cohort" ON ("posthog_cohortpeople"."cohort_id" = "posthog_cohort"."id")
-  WHERE ("posthog_cohort"."team_id" = 99999
-         AND "posthog_cohortpeople"."cohort_id" = 99999)
+  INNER JOIN "posthog_person" ON ("posthog_cohortpeople"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_cohortpeople"."cohort_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.7
@@ -1423,9 +1423,9 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_cohortpeople"
-  INNER JOIN "posthog_cohort" ON ("posthog_cohortpeople"."cohort_id" = "posthog_cohort"."id")
-  WHERE ("posthog_cohort"."team_id" = 99999
-         AND "posthog_cohortpeople"."cohort_id" = 99999)
+  INNER JOIN "posthog_person" ON ("posthog_cohortpeople"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_cohortpeople"."cohort_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.13
@@ -2535,9 +2535,9 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_cohortpeople"
-  INNER JOIN "posthog_cohort" ON ("posthog_cohortpeople"."cohort_id" = "posthog_cohort"."id")
-  WHERE ("posthog_cohort"."team_id" = 99999
-         AND "posthog_cohortpeople"."cohort_id" = 99999)
+  INNER JOIN "posthog_person" ON ("posthog_cohortpeople"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_cohortpeople"."cohort_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.3
@@ -3043,9 +3043,9 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_cohortpeople"
-  INNER JOIN "posthog_cohort" ON ("posthog_cohortpeople"."cohort_id" = "posthog_cohort"."id")
-  WHERE ("posthog_cohort"."team_id" = 99999
-         AND "posthog_cohortpeople"."cohort_id" = 99999)
+  INNER JOIN "posthog_person" ON ("posthog_cohortpeople"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_cohortpeople"."cohort_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.8
@@ -3205,9 +3205,9 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_cohortpeople"
-  INNER JOIN "posthog_cohort" ON ("posthog_cohortpeople"."cohort_id" = "posthog_cohort"."id")
-  WHERE ("posthog_cohort"."team_id" = 99999
-         AND "posthog_cohortpeople"."cohort_id" = 99999)
+  INNER JOIN "posthog_person" ON ("posthog_cohortpeople"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_cohortpeople"."cohort_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.11
@@ -4101,9 +4101,9 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_cohortpeople"
-  INNER JOIN "posthog_cohort" ON ("posthog_cohortpeople"."cohort_id" = "posthog_cohort"."id")
-  WHERE ("posthog_cohort"."team_id" = 99999
-         AND "posthog_cohortpeople"."cohort_id" = 99999)
+  INNER JOIN "posthog_person" ON ("posthog_cohortpeople"."person_id" = "posthog_person"."id")
+  WHERE ("posthog_cohortpeople"."cohort_id" = 99999
+         AND "posthog_person"."team_id" = 99999)
   '''
 # ---
 # name: TestFeatureFlag.test_creating_static_cohort.2

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -420,7 +420,7 @@ def remove_person_from_static_cohort(person_uuid: uuid.UUID, cohort_id: int, *, 
 
 
 def get_static_cohort_size(*, cohort_id: int, team_id: int) -> int:
-    count = CohortPeople.objects.filter(cohort_id=cohort_id, cohort__team_id=team_id).count()
+    count = CohortPeople.objects.filter(cohort_id=cohort_id, person__team_id=team_id).count()
 
     return count
 


### PR DESCRIPTION
This reverts commit d4d41c3cf157ad73ce72eb16b796a1a0838591ee.

## Problem

Reverts https://github.com/PostHog/posthog/pull/39922
