### PR TITLE
fix(max): improve compaction

### DIFF
--- a/ee/hogai/graph/conversation_summarizer/test/test_nodes.py
+++ b/ee/hogai/graph/conversation_summarizer/test/test_nodes.py
@@ -1,0 +1,177 @@
+from typing import Any, cast
+
+from posthog.test.base import BaseTest
+
+from langchain_core.messages import (
+    AIMessage as LangchainAIMessage,
+    HumanMessage as LangchainHumanMessage,
+)
+from parameterized import parameterized
+
+from ee.hogai.graph.conversation_summarizer.nodes import AnthropicConversationSummarizer
+
+
+class TestAnthropicConversationSummarizer(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.summarizer = AnthropicConversationSummarizer(team=self.team, user=self.user)
+
+    @parameterized.expand(
+        [
+            (
+                "single_message_with_cache_control",
+                [
+                    LangchainHumanMessage(
+                        content=[
+                            {"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral"}},
+                        ]
+                    )
+                ],
+                [[{"type": "text", "text": "Hello"}]],
+            ),
+            (
+                "multiple_items_with_cache_control",
+                [
+                    LangchainAIMessage(
+                        content=[
+                            {"type": "text", "text": "First", "cache_control": {"type": "ephemeral"}},
+                            {"type": "text", "text": "Second", "cache_control": {"type": "ephemeral"}},
+                        ]
+                    )
+                ],
+                [[{"type": "text", "text": "First"}, {"type": "text", "text": "Second"}]],
+            ),
+            (
+                "mixed_items_some_with_cache_control",
+                [
+                    LangchainHumanMessage(
+                        content=[
+                            {"type": "text", "text": "With cache", "cache_control": {"type": "ephemeral"}},
+                            {"type": "text", "text": "Without cache"},
+                        ]
+                    )
+                ],
+                [[{"type": "text", "text": "With cache"}, {"type": "text", "text": "Without cache"}]],
+            ),
+            (
+                "multiple_messages_with_cache_control",
+                [
+                    LangchainHumanMessage(
+                        content=[
+                            {"type": "text", "text": "Message 1", "cache_control": {"type": "ephemeral"}},
+                        ]
+                    ),
+                    LangchainAIMessage(
+                        content=[
+                            {"type": "text", "text": "Message 2", "cache_control": {"type": "ephemeral"}},
+                        ]
+                    ),
+                ],
+                [
+                    [{"type": "text", "text": "Message 1"}],
+                    [{"type": "text", "text": "Message 2"}],
+                ],
+            ),
+        ]
+    )
+    def test_removes_cache_control(self, name, input_messages, expected_contents):
+        result = self.summarizer._construct_messages(input_messages)
+
+        # Extract the actual messages from the prompt template
+        messages = result.messages[1:-1]  # Skip system prompt and user prompt
+
+        self.assertEqual(len(messages), len(expected_contents), f"Wrong number of messages in test case: {name}")
+
+        for i, (message, expected_content) in enumerate(zip(messages, expected_contents)):
+            self.assertEqual(
+                message.content,
+                expected_content,
+                f"Message {i} content mismatch in test case: {name}",
+            )
+
+    @parameterized.expand(
+        [
+            (
+                "string_content",
+                [LangchainHumanMessage(content="Simple string")],
+            ),
+            (
+                "empty_list_content",
+                [LangchainHumanMessage(content=[])],
+            ),
+            (
+                "non_dict_items_in_list",
+                [LangchainHumanMessage(content=["string_item", {"type": "text", "text": "dict_item"}])],
+            ),
+        ]
+    )
+    def test_handles_non_dict_content_without_errors(self, name, input_messages):
+        result = self.summarizer._construct_messages(input_messages)
+        self.assertIsNotNone(result)
+
+    def test_original_message_not_modified(self):
+        original_content: list[str | dict[Any, Any]] = [
+            {"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral"}},
+        ]
+        message = LangchainHumanMessage(content=original_content)
+
+        # Store the original cache_control to verify it's not modified
+        content_list = cast(list[dict[str, Any]], message.content)
+        self.assertIn("cache_control", content_list[0])
+
+        self.summarizer._construct_messages([message])
+
+        # Verify original message still has cache_control
+        content_list = cast(list[dict[str, Any]], message.content)
+        self.assertIn("cache_control", content_list[0])
+        self.assertEqual(content_list[0]["cache_control"], {"type": "ephemeral"})
+
+    def test_deep_copy_prevents_modification(self):
+        original_content: list[str | dict[Any, Any]] = [
+            {
+                "type": "text",
+                "text": "Test",
+                "cache_control": {"type": "ephemeral"},
+                "other_key": "value",
+            },
+        ]
+        message = LangchainHumanMessage(content=original_content)
+
+        content_list = cast(list[dict[str, Any]], message.content)
+        original_keys = set(content_list[0].keys())
+
+        self.summarizer._construct_messages([message])
+
+        # Verify original message structure unchanged
+        content_list = cast(list[dict[str, Any]], message.content)
+        self.assertEqual(set(content_list[0].keys()), original_keys)
+        self.assertIn("cache_control", content_list[0])
+
+    def test_preserves_other_content_properties(self):
+        input_messages = [
+            LangchainHumanMessage(
+                content=[
+                    {
+                        "type": "text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                        "custom_field": "custom_value",
+                        "another_field": 123,
+                    },
+                ]
+            )
+        ]
+
+        result = self.summarizer._construct_messages(input_messages)
+        messages = result.messages[1:-1]
+
+        # Verify other fields are preserved
+        content = messages[0].content[0]
+        self.assertEqual(content["custom_field"], "custom_value")
+        self.assertEqual(content["another_field"], 123)
+        self.assertNotIn("cache_control", content)
+
+    def test_empty_messages_list(self):
+        result = self.summarizer._construct_messages([])
+        # Should return prompt template with just system and user prompts
+        self.assertEqual(len(result.messages), 2)

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -35,7 +35,7 @@ from ee.hogai.graph.shared_prompts import CORE_MEMORY_PROMPT
 from ee.hogai.llm import MaxChatAnthropic
 from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL, ToolMessagesArtifact
 from ee.hogai.utils.anthropic import add_cache_control, convert_to_anthropic_messages, normalize_ai_anthropic_message
-from ee.hogai.utils.helpers import convert_tool_messages_to_dict, insert_messages_before_start
+from ee.hogai.utils.helpers import convert_tool_messages_to_dict
 from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.types import (
     AssistantMessageUnion,
@@ -130,6 +130,7 @@ class RootNode(AssistantNode):
             messages_to_replace or state.messages, state.root_conversation_start_id, state.root_tool_calls_count
         )
         window_id = state.root_conversation_start_id
+        start_id = state.start_id
 
         # Summarize the conversation if it's too long.
         if await self._window_manager.should_compact_conversation(
@@ -144,12 +145,14 @@ class RootNode(AssistantNode):
             )
 
             # Insert the summary message before the last human message
-            messages_to_replace = insert_messages_before_start(
-                messages_to_replace or state.messages, [summary_message], start_id=state.start_id
+            insertion_result = self._window_manager.update_window(
+                messages_to_replace or state.messages, summary_message, start_id=start_id
             )
+            window_id = insertion_result.updated_window_start_id
+            start_id = insertion_result.updated_start_id
+            messages_to_replace = insertion_result.messages
 
-            # Update window
-            window_id = self._window_manager.find_window_boundary(messages_to_replace)
+            # Update the window
             langchain_messages = self._construct_messages(messages_to_replace, window_id, state.root_tool_calls_count)
 
         system_prompts = ChatPromptTemplate.from_messages(
@@ -174,7 +177,11 @@ class RootNode(AssistantNode):
         if messages_to_replace:
             new_messages = ReplaceMessages([*messages_to_replace, assistant_message])
 
-        return PartialAssistantState(root_conversation_start_id=window_id, messages=new_messages)
+        return PartialAssistantState(
+            messages=new_messages,
+            root_conversation_start_id=window_id,
+            start_id=start_id,
+        )
 
     async def get_reasoning_message(
         self, input: BaseState, default_message: Optional[str] = None

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -100,7 +100,8 @@ def dereference_schema(schema: dict) -> dict:
 
 
 def find_start_message_idx(messages: Sequence[AssistantMessageUnion], start_id: str | None = None) -> int:
-    for idx, msg in enumerate(messages):
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
         if isinstance(msg, HumanMessage) and msg.id == start_id:
             return idx
     return 0

--- a/ee/hogai/utils/test/test_assistant_helpers.py
+++ b/ee/hogai/utils/test/test_assistant_helpers.py
@@ -1,8 +1,16 @@
 from posthog.test.base import BaseTest
 
-from posthog.schema import AssistantMessage, AssistantToolCallMessage
+from parameterized import parameterized
 
-from ee.hogai.utils.helpers import should_output_assistant_message
+from posthog.schema import (
+    AssistantMessage,
+    AssistantToolCallMessage,
+    AssistantTrendsQuery,
+    HumanMessage,
+    VisualizationMessage,
+)
+
+from ee.hogai.utils.helpers import find_start_message, find_start_message_idx, should_output_assistant_message
 
 
 class TestAssistantHelpers(BaseTest):
@@ -33,3 +41,108 @@ class TestAssistantHelpers(BaseTest):
             content="Tool result", tool_call_id="456", type="tool", ui_payload=None
         )
         self.assertFalse(should_output_assistant_message(tool_message_without_payload))
+
+    @parameterized.expand(
+        [
+            ("no_start_id", [], None, 0),
+            ("empty_messages", [], "some-id", 0),
+            ("start_id_not_found", [HumanMessage(content="test", id="other-id")], "target-id", 0),
+            (
+                "single_matching_message",
+                [HumanMessage(content="test", id="target-id")],
+                "target-id",
+                0,
+            ),
+            (
+                "matching_message_at_end",
+                [
+                    AssistantMessage(content="response", type="ai"),
+                    HumanMessage(content="question", id="target-id"),
+                ],
+                "target-id",
+                1,
+            ),
+            (
+                "matching_message_in_middle",
+                [
+                    HumanMessage(content="first", id="first-id"),
+                    HumanMessage(content="second", id="target-id"),
+                    AssistantMessage(content="response", type="ai"),
+                ],
+                "target-id",
+                1,
+            ),
+            (
+                "multiple_human_messages_match_first_from_end",
+                [
+                    HumanMessage(content="first", id="other-id"),
+                    HumanMessage(content="second", id="target-id"),
+                    AssistantMessage(content="response", type="ai"),
+                    HumanMessage(content="third", id="another-id"),
+                ],
+                "target-id",
+                1,
+            ),
+            (
+                "non_human_message_with_matching_id_ignored",
+                [
+                    AssistantMessage(content="response", type="ai", id="target-id"),
+                    HumanMessage(content="question", id="other-id"),
+                ],
+                "target-id",
+                0,
+            ),
+            (
+                "mixed_messages_finds_correct_human_message",
+                [
+                    HumanMessage(content="first", id="first-id"),
+                    AssistantMessage(content="response 1", type="ai"),
+                    VisualizationMessage(answer=AssistantTrendsQuery(series=[])),
+                    HumanMessage(content="second", id="target-id"),
+                    AssistantMessage(content="response 2", type="ai"),
+                ],
+                "target-id",
+                3,
+            ),
+        ]
+    )
+    def test_find_start_message_idx(self, _name, messages, start_id, expected_idx):
+        result = find_start_message_idx(messages, start_id)
+        self.assertEqual(result, expected_idx)
+
+    @parameterized.expand(
+        [
+            ("empty_messages", [], None, None),
+            (
+                "returns_first_message_when_no_start_id",
+                [
+                    HumanMessage(content="first", id="first-id"),
+                    AssistantMessage(content="response", type="ai"),
+                ],
+                None,
+                HumanMessage(content="first", id="first-id"),
+            ),
+            (
+                "returns_matching_message",
+                [
+                    HumanMessage(content="first", id="first-id"),
+                    HumanMessage(content="second", id="target-id"),
+                    AssistantMessage(content="response", type="ai"),
+                ],
+                "target-id",
+                HumanMessage(content="second", id="target-id"),
+            ),
+            (
+                "returns_first_when_id_not_found",
+                [
+                    HumanMessage(content="first", id="first-id"),
+                    AssistantMessage(content="response", type="ai"),
+                ],
+                "nonexistent-id",
+                HumanMessage(content="first", id="first-id"),
+            ),
+        ]
+    )
+    def test_find_start_message(self, _name, messages, start_id, expected_message):
+        result = find_start_message(messages, start_id)
+        self.assertEqual(result, expected_message)


### PR DESCRIPTION
## Problem

The window compaction manager now only handles the single case: Inserting the summary message before the initiator human message. However, there are three cases in fact:
- The messages preserving the agent's trajectory are below 2000 tokens and 16 messages in total having the start message–perfect case. We should insert the summary message before the initiator message.
- The messages preserving the agent's trajectory are below 2000 tokens and 16 messages in total **NOT** having the start message–insert the context message and copy the initiator message to the end of sequence.
- The messages preserving the agent's trajectory cannot be used because it doesn't have an assistant or human messages or the sequence has too many tokens–insert the context message and copy the initiator message to the end of sequence.

[Related trace](https://us.posthog.com/project/2/llm-analytics/traces/d73054f4-ea84-4d8b-aa21-0b043a93f8db?event=ee0eaec0-ac9c-4a7f-98b2-5fd4f14ecedf&timestamp=2025-10-18T08:39:25Z)

## Changes

- Implement new logic.
- More tests.

## How did you test this code?

Unit tests & manual testing