### PR TITLE
chore(logs): add config and scripts to setup logs local dev

### DIFF
--- a/bin/clickhouse-logs-init
+++ b/bin/clickhouse-logs-init
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# temporary script to init logs clickhouse schema before we've got migrations setup properly
+bin/check_kafka_clickhouse_up
+
+cat bin/clickhouse-logs.sql | docker-compose exec -T clickhouse clickhouse-client

--- a/bin/clickhouse-logs.sql
+++ b/bin/clickhouse-logs.sql
@@ -1,0 +1,159 @@
+-- temporary sql to initialise log tables for local development
+-- will be removed once we have migrations set up
+CREATE TABLE if not exists logs16
+(
+    `uuid` String,
+    `team_id` Int32,
+    `trace_id` String,
+    `span_id` String,
+    `trace_flags` Int32,
+    `timestamp` DateTime64(6),
+    `observed_timestamp` DateTime64(6),
+    `created_at` DateTime64(6),
+    `body` String,
+    `severity_text` String,
+    `severity_number` Int32,
+    `service_name` String,
+    `resource_attributes` Map(String, String),
+    `resource_id` String,
+    `instrumentation_scope` String,
+    `event_name` String,
+    `attributes` Map(String, String),
+    `attributes_map_str` Map(String, String),
+    `attributes_map_float` Map(String, Float64),
+    `attributes_map_datetime` Map(String, DateTime64(6)),
+    `attribute_keys` Array(String),
+    `attribute_values` Array(String),
+    `level` String ALIAS severity_text,
+    INDEX idx_severity_text_set severity_text TYPE set(10) GRANULARITY 1,
+    INDEX idx_attributes_str_keys mapKeys(attributes_map_str) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attributes_str_values mapValues(attributes_map_str) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_body_ngram body TYPE ngrambf_v1(3, 20000, 4, 0) GRANULARITY 1
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/logs16', '{replica}')
+PARTITION BY toDate(timestamp)
+ORDER BY (team_id, toStartOfMinute(timestamp) DESC, service_name, severity_text, toUnixTimestamp(timestamp) DESC, trace_id, span_id)
+SETTINGS
+allow_remote_fs_zero_copy_replication = 1,
+allow_experimental_reverse_key = 1;
+
+create or replace TABLE logs AS logs16 ENGINE = Distributed('posthog', 'default', 'logs16');
+
+create table if not exists log_attributes
+
+(
+    `team_id` Int32,
+    `time_bucket` DateTime64(0),
+    `service_name` LowCardinality(String),
+    `attribute_key` LowCardinality(String),
+    `attribute_value` String,
+    `attribute_count` SimpleAggregateFunction(sum, UInt64),
+    INDEX idx_attribute_key attribute_key TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attribute_value attribute_value TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_attribute_key_n3 attribute_key TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1,
+    INDEX idx_attribute_value_n3 attribute_value TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1
+)
+ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/log_attributes', '{replica}')
+PARTITION BY toDate(time_bucket)
+ORDER BY (team_id, service_name, time_bucket, attribute_key, attribute_value);
+
+set enable_dynamic_type=1;
+CREATE MATERIALIZED VIEW if not exists log_to_log_attributes TO log_attributes
+(
+    `team_id` Int32,
+    `time_bucket` DateTime64(0),
+    `service_name` LowCardinality(String),
+    `attribute_key` LowCardinality(String),
+    `attribute_value` String,
+    `attribute_count` SimpleAggregateFunction(sum, UInt64)
+)
+AS SELECT
+    team_id,
+    time_bucket,
+    service_name,
+    attribute_key,
+    attribute_value,
+    attribute_count
+FROM (select
+    team_id AS team_id,
+    toStartOfInterval(timestamp, toIntervalMinute(10)) AS time_bucket,
+    service_name AS service_name,
+    arrayJoin(arrayMap((k, v) -> (k, if(length(v) > 256, '', v)), arrayFilter((k, v) -> (length(k) < 256), CAST(attributes, 'Array(Tuple(String, String))')))) AS attribute,
+    attribute.1 AS attribute_key,
+    CAST(JSONExtract(attribute.2, 'Dynamic'), 'String') AS attribute_value,
+    sumSimpleState(1) AS attribute_count
+FROM logs16
+GROUP BY
+    team_id,
+    time_bucket,
+    service_name,
+    attribute
+);
+
+CREATE OR REPLACE TABLE kafka_logs_avro
+(
+    `uuid` String,
+    `team_id` Int32,
+    `trace_id` String,
+    `span_id` String,
+    `trace_flags` Int32,
+    `timestamp` DateTime64(6),
+    `observed_timestamp` DateTime64(6),
+    `created_at` DateTime64(6),
+    `body` String,
+    `severity_text` String,
+    `severity_number` Int32,
+    `service_name` String,
+    `resource_attributes` Map(String, String),
+    `resource_id` String,
+    `instrumentation_scope` String,
+    `event_name` String,
+    `attributes` Map(String, Nullable(String)),
+    `attributes_map_str` Map(String, Nullable(String)),
+    `attributes_map_float` Map(String, Nullable(Float64)),
+    `attributes_map_datetime` Map(String, Nullable(DateTime64(6))),
+    `attribute_keys` Array(Nullable(String)),
+    `attribute_values` Array(Nullable(String))
+)
+ENGINE = Kafka('kafka:9092', 'logs_avro', 'clickhouse-logs-avro', 'Avro')
+SETTINGS
+    kafka_skip_broken_messages = 100,
+    kafka_security_protocol = 'PLAINTEXT',
+    kafka_thread_per_consumer = 1,
+    kafka_num_consumers = 1,
+    kafka_poll_timeout_ms=15000,
+    kafka_poll_max_batch_size=100,
+    kafka_max_block_size=1000;
+
+drop table if exists kafka_logs_avro_mv;
+
+CREATE MATERIALIZED VIEW kafka_logs_avro_mv TO logs16
+(
+    `uuid` String,
+    `team_id` Int32,
+    `trace_id` String,
+    `span_id` String,
+    `trace_flags` Int32,
+    `timestamp` DateTime64(6),
+    `observed_timestamp` DateTime64(6),
+    `created_at` DateTime64(6),
+    `body` String,
+    `severity_text` String,
+    `severity_number` Int32,
+    `service_name` String,
+    `resource_attributes` Map(String, String),
+    `resource_id` String,
+    `instrumentation_scope` String,
+    `event_name` String,
+    `attributes` Map(String, Nullable(String)),
+    `attributes_map_str` Map(String, Nullable(String)),
+    `attributes_map_float` Map(String, Nullable(Float64)),
+    `attributes_map_datetime` Map(String, Nullable(DateTime64(6))),
+    `attribute_keys` Array(Nullable(String)),
+    `attribute_values` Array(Nullable(String))
+)
+AS SELECT
+*
+FROM kafka_logs_avro settings materialize_skip_indexes_on_insert = 1, distributed_background_insert_sleep_time_ms=5000, distributed_background_insert_batch=true;
+
+select 'clickhouse logs tables initialised successfully!';

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -431,9 +431,10 @@ services:
         image: otel/opentelemetry-collector-contrib:latest
         container_name: otel-collector-local
         command: [--config=/etc/otel-collector-config.yaml]
-        user: '0:0'
+        user: '0:0'  # have to run as root to read the docker logs
         volumes:
             - ./otel-collector-config.dev.yaml:/etc/otel-collector-config.yaml
+            # mount docker containers dir so we can ship the docker logs to local posthog
             - /var/lib/docker/containers:/var/lib/docker/containers:ro
         ports:
             - '4317:4317' # OTLP gRPC receiver (mapped to host)

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -246,6 +246,25 @@ services:
             REDIS_URL: 'redis://redis:6379/'
             CAPTURE_MODE: recordings
 
+    log-capture:
+        image: ghcr.io/posthog/posthog/log-capture:master
+        build:
+            context: rust/
+            args:
+                BIN: log-capture
+        restart: on-failure
+        environment:
+            BIND_HOST: '0.0.0.0'
+            BIND_PORT: '3308'
+            RUST_LOG: info,rdkafka=warn
+            RUST_BACKTRACE: '1'
+            KAFKA_HOSTS: kafka:9092
+            JWT_SECRET: '<randomly generated secret key>'
+            KAFKA_TOPIC: logs_avro
+        networks:
+            - otel_network
+            - default
+
     property-defs-rs:
         image: ghcr.io/posthog/posthog/property-defs-rs:master
         build:
@@ -412,8 +431,10 @@ services:
         image: otel/opentelemetry-collector-contrib:latest
         container_name: otel-collector-local
         command: [--config=/etc/otel-collector-config.yaml]
+        user: '0:0'
         volumes:
             - ./otel-collector-config.dev.yaml:/etc/otel-collector-config.yaml
+            - /var/lib/docker/containers:/var/lib/docker/containers:ro
         ports:
             - '4317:4317' # OTLP gRPC receiver (mapped to host)
             - '4318:4318' # OTLP HTTP receiver (mapped to host)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -246,6 +246,14 @@ services:
             service: otel-collector
         depends_on:
             - jaeger
+            - log-capture
+
+    log-capture:
+        extends:
+            file: docker-compose.base.yml
+            service: log-capture
+        depends_on:
+            - kafka
 
     jaeger:
         extends:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -265,6 +265,13 @@ services:
             file: docker-compose.base.yml
             service: replay-capture
 
+    log-capture:
+        build:
+            context: ./posthog/rust
+        extends:
+            file: docker-compose.base.yml
+            service: log-capture
+
     property-defs-rs:
         build:
             context: ./posthog/rust

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -265,13 +265,6 @@ services:
             file: docker-compose.base.yml
             service: replay-capture
 
-    log-capture:
-        build:
-            context: ./posthog/rust
-        extends:
-            file: docker-compose.base.yml
-            service: log-capture
-
     property-defs-rs:
         build:
             context: ./posthog/rust

--- a/otel-collector-config.dev.yaml
+++ b/otel-collector-config.dev.yaml
@@ -1,4 +1,20 @@
 receivers:
+    filelog:
+        include:
+            - /var/lib/docker/containers/*/*.log
+        include_file_name: true
+        include_file_path: true
+        operators:
+            - id: container-parser
+              max_log_size: 102400
+              type: container
+              format: docker
+              on_error: send_quiet
+              add_metadata_from_filepath: false
+            - type: json_parser
+              parse_from: body
+              on_error: send_quiet
+              if: "hasPrefix(body, '{')"
     otlp:
         protocols:
             grpc:
@@ -11,6 +27,13 @@ exporters:
         endpoint: 'jaeger-local:4317' # Sending OTLP gRPC to Jaeger
         tls:
             insecure: true # For local communication to Jaeger
+    otlp/logs:
+        endpoint: 'log-capture:3308'
+        compression: none
+        tls:
+            insecure: true
+        headers:
+            authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZWFtX2lkIjoiMiIsImV4cCI6OTIyMzM3MjAzNjg1NDc3Nn0._HnjzroZ52kR9_7rKauMgnuCKU_ouwdvF_Jv--i9PTc
 
 extensions: # Declaring the extensions
     health_check: # Default configuration is usually fine
@@ -25,4 +48,12 @@ service:
             receivers: [otlp]
             processors: [batch]
             exporters: [otlp]
+        logs:
+            exporters:
+                - otlp/logs
+            processors:
+                - batch
+            receivers:
+                - otlp
+                - filelog
     extensions: [health_check, zpages] # Enabling the declared extensions

--- a/otel-collector-config.dev.yaml
+++ b/otel-collector-config.dev.yaml
@@ -33,6 +33,8 @@ exporters:
         tls:
             insecure: true
         headers:
+            # hardcoded JWT signed by the dev secret key ('<randomly generated secret key>') to ship logs to team 1
+            # (TODO: use normal capture tokens instead of these jwts)
             authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZWFtX2lkIjoiMSIsImV4cCI6OTIyMzM3MjAzNjg1NDc3Nn0.M2CClSDIm9T6aDUjffL1BjI2lHEsXYLkt_pShIgItrU
 
 extensions: # Declaring the extensions

--- a/otel-collector-config.dev.yaml
+++ b/otel-collector-config.dev.yaml
@@ -33,7 +33,7 @@ exporters:
         tls:
             insecure: true
         headers:
-            authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZWFtX2lkIjoiMiIsImV4cCI6OTIyMzM3MjAzNjg1NDc3Nn0._HnjzroZ52kR9_7rKauMgnuCKU_ouwdvF_Jv--i9PTc
+            authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZWFtX2lkIjoiMSIsImV4cCI6OTIyMzM3MjAzNjg1NDc3Nn0.M2CClSDIm9T6aDUjffL1BjI2lHEsXYLkt_pShIgItrU
 
 extensions: # Declaring the extensions
     health_check: # Default configuration is usually fine


### PR DESCRIPTION
## Problem

we can't develop locally, Ben is very sad about this

## Changes

add log-capture to the docker-compose file (can't be in the bin/start script as it needs to be in the docker-compose network with the otel collector)

update otel collector to collect docker logs and ship them to log-capture

for now `bin/clickhouse-logs-init` needs to be run manually after `bin/start` to create the clickhouse tables

*Note that it captures to team 1*

## How did you test this code?

ran locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
