### PR TITLE
feat(max): single-loop executor UI

### DIFF
--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -18,6 +18,7 @@ from posthog.schema import (
     AssistantRetentionQuery,
     AssistantToolCallMessage,
     AssistantTrendsQuery,
+    AssistantUpdateEvent,
     ContextMessage,
     FailureMessage,
     FunnelsQuery,
@@ -57,6 +58,7 @@ AssistantMessageOrStatusUnion = Union[AssistantMessageUnion, AssistantGeneration
 AssistantOutput = (
     tuple[Literal[AssistantEventType.CONVERSATION], Conversation]
     | tuple[Literal[AssistantEventType.MESSAGE], AssistantMessageOrStatusUnion]
+    | tuple[Literal[AssistantEventType.UPDATE], AssistantUpdateEvent]
 )
 
 AnyAssistantGeneratedQuery = (

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -409,7 +409,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
 
                 <div>
                     <MaxTool
-                        identifier="create_and_query_insight"
+                        identifier="edit_current_insight"
                         context={{
                             current_query: querySource,
                         }}

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -847,7 +847,7 @@
             "type": "string"
         },
         "AssistantEventType": {
-            "enum": ["status", "message", "conversation", "notebook"],
+            "enum": ["status", "message", "conversation", "notebook", "update"],
             "type": "string"
         },
         "AssistantForm": {
@@ -1507,9 +1507,6 @@
                 "type": {
                     "const": "ai",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "content"],
@@ -1888,9 +1885,6 @@
                 "ui_payload": {
                     "description": "Payload passed through to the frontend - specifically for calls of contextual tool. Tool call messages without a ui_payload are not passed through to the frontend.",
                     "type": "object"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "content", "tool_call_id"],
@@ -2201,6 +2195,21 @@
             "required": ["kind", "series"],
             "type": "object"
         },
+        "AssistantUpdateEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "const": "update",
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "AssistantUpdateEventType": {
+            "const": "update",
+            "type": "string"
+        },
         "AttributionMode": {
             "enum": ["first_touch", "last_touch"],
             "type": "string"
@@ -2273,9 +2282,6 @@
                 },
                 "parent_tool_call_id": {
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -7350,9 +7356,6 @@
                 "type": {
                     "const": "context",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "content"],
@@ -13157,9 +13160,6 @@
                 "type": {
                     "const": "ai/failure",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type"],
@@ -15092,9 +15092,6 @@
                 },
                 "ui_context": {
                     "$ref": "#/definitions/MaxUIContext"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "content"],
@@ -17523,9 +17520,6 @@
                     "const": "ai/multi_viz",
                     "type": "string"
                 },
-                "visible": {
-                    "type": "boolean"
-                },
                 "visualizations": {
                     "items": {
                         "$ref": "#/definitions/VisualizationItem"
@@ -17698,9 +17692,6 @@
                 "type": {
                     "const": "ai/notebook",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "notebook_id", "content"],
@@ -18175,9 +18166,6 @@
                     "const": "ai/planning",
                     "deprecated": "The class should not be used",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "steps"],
@@ -22499,9 +22487,6 @@
                     "const": "ai/reasoning",
                     "deprecated": "The model should not be used",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "content"],
@@ -24045,9 +24030,6 @@
                 },
                 {
                     "$ref": "#/definitions/AssistantToolCallMessage"
-                },
-                {
-                    "$ref": "#/definitions/UpdateMessage"
                 }
             ]
         },
@@ -25836,9 +25818,6 @@
                     "const": "ai/task_execution",
                     "deprecated": "The class should not be used",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["type", "tasks"],
@@ -26762,7 +26741,7 @@
             "required": ["results"],
             "type": "object"
         },
-        "UpdateMessage": {
+        "UpdateEvent": {
             "additionalProperties": false,
             "properties": {
                 "content": {
@@ -26771,7 +26750,7 @@
                 "id": {
                     "type": "string"
                 },
-                "parent_tool_call_id": {
+                "tool_call_id": {
                     "type": "string"
                 },
                 "type": {
@@ -26779,7 +26758,7 @@
                     "type": "string"
                 }
             },
-            "required": ["type", "id", "parent_tool_call_id", "content"],
+            "required": ["type", "id", "tool_call_id", "content"],
             "type": "object"
         },
         "UsageMetric": {
@@ -27091,9 +27070,6 @@
                 "type": {
                     "const": "ai/viz",
                     "type": "string"
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": ["answer", "query", "type"],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -786,36 +786,6 @@
             },
             "type": "object"
         },
-        "AssistantContextualTool": {
-            "enum": [
-                "search_session_recordings",
-                "generate_hogql_query",
-                "fix_hogql_query",
-                "analyze_user_interviews",
-                "create_and_query_insight",
-                "create_hog_transformation_function",
-                "create_hog_function_filters",
-                "create_hog_function_inputs",
-                "create_message_template",
-                "navigate",
-                "filter_error_tracking_issues",
-                "find_error_tracking_impactful_issue_event_list",
-                "experiment_results_summary",
-                "create_survey",
-                "analyze_survey_responses",
-                "search_docs",
-                "search_insights",
-                "session_summarization",
-                "create_dashboard",
-                "edit_current_dashboard",
-                "read_taxonomy",
-                "search",
-                "read_data",
-                "todo_write",
-                "filter_revenue_analytics"
-            ],
-            "type": "string"
-        },
         "AssistantDateRange": {
             "additionalProperties": false,
             "description": "This filter only works with absolute dates.",
@@ -1525,6 +1495,9 @@
                 "meta": {
                     "$ref": "#/definitions/AssistantMessageMetadata"
                 },
+                "parent_tool_call_id": {
+                    "type": "string"
+                },
                 "tool_calls": {
                     "items": {
                         "$ref": "#/definitions/AssistantToolCall"
@@ -1570,7 +1543,8 @@
                 "ai/failure",
                 "ai/notebook",
                 "ai/planning",
-                "ai/task_execution"
+                "ai/task_execution",
+                "ai/update"
             ],
             "type": "string"
         },
@@ -1840,6 +1814,35 @@
             "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
             "type": "string"
         },
+        "AssistantTool": {
+            "enum": [
+                "search_session_recordings",
+                "generate_hogql_query",
+                "fix_hogql_query",
+                "analyze_user_interviews",
+                "create_and_query_insight",
+                "create_hog_transformation_function",
+                "create_hog_function_filters",
+                "create_hog_function_inputs",
+                "create_message_template",
+                "navigate",
+                "edit_current_insight",
+                "filter_error_tracking_issues",
+                "find_error_tracking_impactful_issue_event_list",
+                "experiment_results_summary",
+                "create_survey",
+                "analyze_survey_responses",
+                "session_summarization",
+                "create_dashboard",
+                "edit_current_dashboard",
+                "read_taxonomy",
+                "search",
+                "read_data",
+                "todo_write",
+                "filter_revenue_analytics"
+            ],
+            "type": "string"
+        },
         "AssistantToolCall": {
             "additionalProperties": false,
             "properties": {
@@ -1870,6 +1873,9 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "parent_tool_call_id": {
                     "type": "string"
                 },
                 "tool_call_id": {
@@ -2263,6 +2269,9 @@
             "additionalProperties": false,
             "properties": {
                 "id": {
+                    "type": "string"
+                },
+                "parent_tool_call_id": {
                     "type": "string"
                 },
                 "visible": {
@@ -7333,6 +7342,9 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "parent_tool_call_id": {
                     "type": "string"
                 },
                 "type": {
@@ -13139,6 +13151,9 @@
                 "id": {
                     "type": "string"
                 },
+                "parent_tool_call_id": {
+                    "type": "string"
+                },
                 "type": {
                     "const": "ai/failure",
                     "type": "string"
@@ -15066,6 +15081,9 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "parent_tool_call_id": {
                     "type": "string"
                 },
                 "type": {
@@ -17498,6 +17516,9 @@
                 "id": {
                     "type": "string"
                 },
+                "parent_tool_call_id": {
+                    "type": "string"
+                },
                 "type": {
                     "const": "ai/multi_viz",
                     "type": "string"
@@ -17664,6 +17685,9 @@
                 },
                 "notebook_type": {
                     "$ref": "#/definitions/Category"
+                },
+                "parent_tool_call_id": {
+                    "type": "string"
                 },
                 "tool_calls": {
                     "items": {
@@ -18138,6 +18162,9 @@
                 "id": {
                     "type": "string"
                 },
+                "parent_tool_call_id": {
+                    "type": "string"
+                },
                 "steps": {
                     "items": {
                         "$ref": "#/definitions/PlanningStep"
@@ -18146,6 +18173,7 @@
                 },
                 "type": {
                     "const": "ai/planning",
+                    "deprecated": "The class should not be used",
                     "type": "string"
                 },
                 "visible": {
@@ -18159,6 +18187,7 @@
             "additionalProperties": false,
             "properties": {
                 "description": {
+                    "deprecated": "The class should not be used",
                     "type": "string"
                 },
                 "status": {
@@ -22457,6 +22486,9 @@
                 "id": {
                     "type": "string"
                 },
+                "parent_tool_call_id": {
+                    "type": "string"
+                },
                 "substeps": {
                     "items": {
                         "type": "string"
@@ -22465,6 +22497,7 @@
                 },
                 "type": {
                     "const": "ai/reasoning",
+                    "deprecated": "The model should not be used",
                     "type": "string"
                 },
                 "visible": {
@@ -24011,31 +24044,10 @@
                     "$ref": "#/definitions/TaskExecutionMessage"
                 },
                 {
-                    "additionalProperties": false,
-                    "properties": {
-                        "content": {
-                            "type": "string"
-                        },
-                        "id": {
-                            "type": "string"
-                        },
-                        "tool_call_id": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "const": "tool",
-                            "type": "string"
-                        },
-                        "ui_payload": {
-                            "description": "Payload passed through to the frontend - specifically for calls of contextual tool. Tool call messages without a ui_payload are not passed through to the frontend.",
-                            "type": "object"
-                        },
-                        "visible": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": ["content", "tool_call_id", "type"],
-                    "type": "object"
+                    "$ref": "#/definitions/AssistantToolCallMessage"
+                },
+                {
+                    "$ref": "#/definitions/UpdateMessage"
                 }
             ]
         },
@@ -25786,6 +25798,7 @@
                     "type": "string"
                 },
                 "id": {
+                    "deprecated": "The class should not be used",
                     "type": "string"
                 },
                 "progress_text": {
@@ -25810,6 +25823,9 @@
                 "id": {
                     "type": "string"
                 },
+                "parent_tool_call_id": {
+                    "type": "string"
+                },
                 "tasks": {
                     "items": {
                         "$ref": "#/definitions/TaskExecutionItem"
@@ -25818,6 +25834,7 @@
                 },
                 "type": {
                     "const": "ai/task_execution",
+                    "deprecated": "The class should not be used",
                     "type": "string"
                 },
                 "visible": {
@@ -26745,6 +26762,26 @@
             "required": ["results"],
             "type": "object"
         },
+        "UpdateMessage": {
+            "additionalProperties": false,
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "parent_tool_call_id": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ai/update",
+                    "type": "string"
+                }
+            },
+            "required": ["type", "id", "parent_tool_call_id", "content"],
+            "type": "object"
+        },
         "UsageMetric": {
             "additionalProperties": false,
             "properties": {
@@ -27036,6 +27073,9 @@
                     "type": "string"
                 },
                 "initiator": {
+                    "type": "string"
+                },
+                "parent_tool_call_id": {
                     "type": "string"
                 },
                 "plan": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1540,8 +1540,7 @@
                 "ai/failure",
                 "ai/notebook",
                 "ai/planning",
-                "ai/task_execution",
-                "ai/update"
+                "ai/task_execution"
             ],
             "type": "string"
         },
@@ -2198,17 +2197,18 @@
         "AssistantUpdateEvent": {
             "additionalProperties": false,
             "properties": {
-                "type": {
-                    "const": "update",
+                "content": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "tool_call_id": {
                     "type": "string"
                 }
             },
-            "required": ["type"],
+            "required": ["id", "tool_call_id", "content"],
             "type": "object"
-        },
-        "AssistantUpdateEventType": {
-            "const": "update",
-            "type": "string"
         },
         "AttributionMode": {
             "enum": ["first_touch", "last_touch"],
@@ -26739,26 +26739,6 @@
                 }
             },
             "required": ["results"],
-            "type": "object"
-        },
-        "UpdateEvent": {
-            "additionalProperties": false,
-            "properties": {
-                "content": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "tool_call_id": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "ai/update",
-                    "type": "string"
-                }
-            },
-            "required": ["type", "id", "tool_call_id", "content"],
             "type": "object"
         },
         "UsageMetric": {

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -237,7 +237,7 @@ export enum AssistantEventType {
     Update = 'update',
 }
 
-export interface UpdateEvent {
+export interface AssistantUpdateEvent {
     id: string
     tool_call_id: string
     content: string

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -52,11 +52,12 @@ export enum AssistantMessageType {
     Notebook = 'ai/notebook',
     Planning = 'ai/planning',
     TaskExecution = 'ai/task_execution',
+    Update = 'ai/update',
 }
 
 export interface BaseAssistantMessage {
     id?: string
-    visible?: boolean
+    parent_tool_call_id?: string
 }
 
 export interface HumanMessage extends BaseAssistantMessage {
@@ -98,6 +99,9 @@ export interface AssistantMessage extends BaseAssistantMessage {
 }
 
 export interface ReasoningMessage extends BaseAssistantMessage {
+    /**
+     * @deprecated The model should not be used
+     */
     type: AssistantMessageType.Reasoning
     content: string
     substeps?: string[]
@@ -105,6 +109,13 @@ export interface ReasoningMessage extends BaseAssistantMessage {
 
 export interface ContextMessage extends BaseAssistantMessage {
     type: AssistantMessageType.Context
+    content: string
+}
+
+export interface UpdateMessage {
+    type: AssistantMessageType.Update
+    id: string
+    parent_tool_call_id: string
     content: string
 }
 
@@ -165,11 +176,17 @@ export enum PlanningStepStatus {
 }
 
 export interface PlanningStep {
+    /**
+     * @deprecated The class should not be used
+     */
     description: string
     status: PlanningStepStatus
 }
 
 export interface PlanningMessage extends BaseAssistantMessage {
+    /**
+     * @deprecated The class should not be used
+     */
     type: AssistantMessageType.Planning
     steps: PlanningStep[]
 }
@@ -182,6 +199,9 @@ export enum TaskExecutionStatus {
 }
 
 export interface TaskExecutionItem {
+    /**
+     * @deprecated The class should not be used
+     */
     id: string
     description: string
     prompt: string
@@ -192,6 +212,9 @@ export interface TaskExecutionItem {
 }
 
 export interface TaskExecutionMessage extends BaseAssistantMessage {
+    /**
+     * @deprecated The class should not be used
+     */
     type: AssistantMessageType.TaskExecution
     tasks: TaskExecutionItem[]
 }
@@ -212,7 +235,8 @@ export type RootAssistantMessage =
     | NotebookUpdateMessage
     | PlanningMessage
     | TaskExecutionMessage
-    | (AssistantToolCallMessage & Required<Pick<AssistantToolCallMessage, 'ui_payload'>>)
+    | AssistantToolCallMessage
+    | UpdateMessage
 
 export enum AssistantEventType {
     Status = 'status',
@@ -241,7 +265,7 @@ export interface AssistantToolCallMessage extends BaseAssistantMessage {
     tool_call_id: string
 }
 
-export type AssistantContextualTool =
+export type AssistantTool =
     | 'search_session_recordings'
     | 'generate_hogql_query'
     | 'fix_hogql_query'
@@ -252,13 +276,12 @@ export type AssistantContextualTool =
     | 'create_hog_function_inputs'
     | 'create_message_template'
     | 'navigate'
+    | 'edit_current_insight'
     | 'filter_error_tracking_issues'
     | 'find_error_tracking_impactful_issue_event_list'
     | 'experiment_results_summary'
     | 'create_survey'
     | 'analyze_survey_responses'
-    | 'search_docs'
-    | 'search_insights'
     | 'session_summarization'
     | 'create_dashboard'
     | 'edit_current_dashboard'

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -52,7 +52,6 @@ export enum AssistantMessageType {
     Notebook = 'ai/notebook',
     Planning = 'ai/planning',
     TaskExecution = 'ai/task_execution',
-    Update = 'ai/update',
 }
 
 export interface BaseAssistantMessage {
@@ -109,13 +108,6 @@ export interface ReasoningMessage extends BaseAssistantMessage {
 
 export interface ContextMessage extends BaseAssistantMessage {
     type: AssistantMessageType.Context
-    content: string
-}
-
-export interface UpdateMessage {
-    type: AssistantMessageType.Update
-    id: string
-    parent_tool_call_id: string
     content: string
 }
 
@@ -236,13 +228,19 @@ export type RootAssistantMessage =
     | PlanningMessage
     | TaskExecutionMessage
     | AssistantToolCallMessage
-    | UpdateMessage
 
 export enum AssistantEventType {
     Status = 'status',
     Message = 'message',
     Conversation = 'conversation',
     Notebook = 'notebook',
+    Update = 'update',
+}
+
+export interface UpdateEvent {
+    id: string
+    tool_call_id: string
+    content: string
 }
 
 export enum AssistantGenerationStatusType {

--- a/frontend/src/scenes/max/MaxTool.tsx
+++ b/frontend/src/scenes/max/MaxTool.tsx
@@ -25,7 +25,6 @@ interface MaxToolProps extends Omit<ToolRegistration, 'name' | 'description'> {
 
 export function MaxTool({
     identifier,
-    icon,
     context,
     introOverride,
     callback,
@@ -41,7 +40,6 @@ export function MaxTool({
 
     const { definition, isMaxOpen, openMax } = useMaxTool({
         identifier,
-        icon,
         context,
         introOverride,
         callback,
@@ -68,7 +66,7 @@ export function MaxTool({
                             <>
                                 Max can use this tool
                                 <br />
-                                {icon || <IconWrench />}
+                                {definition.icon || <IconWrench />}
                                 <i className="ml-1.5">{definition.name}</i>
                             </>
                         )

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -727,7 +727,7 @@ function AssistantActionComponent({
                 )}
             >
                 {icon && (
-                    <div className="relative flex-shrink-0 flex items-center justify-center size-7 h-full">
+                    <div className="relative flex-shrink-0 flex items-start justify-center size-7 h-full">
                         {/* Weird icon align issue, had to add a small pt to align it */}
                         <div className="pt-[1px] flex items-center justify-center">
                             {isInProgress && animate ? (

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -182,7 +182,7 @@ function Message({ message, isLastInGroup, isFinal }: MessageProps): JSX.Element
     return (
         <MessageGroupContainer groupType={groupType}>
             <div className={clsx('flex flex-col min-w-0 w-full', groupType === 'human' ? 'items-end' : 'items-start')}>
-                {() => {
+                {(() => {
                     if (isHumanMessage(message)) {
                         const maybeCommand = MAX_SLASH_COMMANDS.find(
                             (cmd) => cmd.name === message.content.split(' ', 1)[0]
@@ -316,7 +316,7 @@ function Message({ message, isLastInGroup, isFinal }: MessageProps): JSX.Element
                         return <NotebookUpdateAnswer key={key} message={message} />
                     }
                     return null // We currently skip other types of messages
-                }}
+                })()}
                 {isLastInGroup && message.status === 'error' && (
                     <MessageTemplate type="ai" boxClassName="border-warning">
                         <div className="flex items-center gap-1.5">
@@ -727,8 +727,9 @@ function AssistantActionComponent({
                 )}
             >
                 {icon && (
-                    <div className="relative flex-shrink-0 flex items-start justify-center size-7 h-full">
-                        <div className="p-1 flex items-center justify-center">
+                    <div className="relative flex-shrink-0 flex items-center justify-center size-7 h-full">
+                        {/* Weird icon align issue, had to add a small pt to align it */}
+                        <div className="pt-[1px] flex items-center justify-center">
                             {isInProgress && animate ? (
                                 <ShimmeringContent>{icon}</ShimmeringContent>
                             ) : (
@@ -856,15 +857,14 @@ function ToolCallsAnswer({ toolCalls }: ToolCallsAnswerProps): JSX.Element {
                         const commentary = toolCall.args.commentary as string
                         const updates = toolCall.updates ?? []
                         const definition = getToolDefinition(toolCall.name)
-                        let description =
-                            toolCall.status === 'completed'
-                                ? definition?.passiveDescription
-                                : definition?.activeDescription
-                        if (!description) {
-                            description = `Executing ${toolCall.name}`
-                        }
-                        if (commentary) {
-                            description = commentary
+                        let description = `Executing ${toolCall.name}`
+                        if (definition) {
+                            if (definition.displayFormatter) {
+                                description = definition.displayFormatter(toolCall)
+                            }
+                            if (commentary) {
+                                description = commentary
+                            }
                         }
                         return (
                             <AssistantActionComponent

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -712,9 +712,7 @@ function AssistantActionComponent({
     const [isExpanded, setIsExpanded] = useState(showChevron)
 
     useEffect(() => {
-        if (showChevron) {
-            setIsExpanded(!(isCompleted || isFailed))
-        }
+        setIsExpanded(showChevron ? !(isCompleted || isFailed) : false)
     }, [showChevron, isCompleted, isFailed])
 
     let markdownContent = <MarkdownMessage id={id} content={content} />

--- a/frontend/src/scenes/max/__mocks__/chatResponse.mocks.ts
+++ b/frontend/src/scenes/max/__mocks__/chatResponse.mocks.ts
@@ -4,7 +4,6 @@ import {
     AssistantMessage,
     AssistantMessageType,
     HumanMessage,
-    ReasoningMessage,
 } from '~/queries/schema/schema-assistant-messages'
 
 import { MaxContextType } from '../maxTypes'
@@ -21,16 +20,22 @@ export const humanMessage: HumanMessage = {
     id: 'human-1',
 }
 
-const reasoningMessage1: ReasoningMessage = {
-    type: AssistantMessageType.Reasoning,
-    content: 'Picking relevant events and properties',
+const reasoningMessage1: AssistantMessage = {
+    type: AssistantMessageType.Assistant,
+    content: '',
     id: 'reasoning-1',
+    meta: {
+        thinking: [{ thinking: 'Picking relevant events and properties' }],
+    },
 }
 
-const reasoningMessage2: ReasoningMessage = {
-    type: AssistantMessageType.Reasoning,
-    content: 'Generating trends',
+const reasoningMessage2: AssistantMessage = {
+    type: AssistantMessageType.Assistant,
+    content: '',
     id: 'reasoning-2',
+    meta: {
+        thinking: [{ thinking: 'Generating trends' }],
+    },
 }
 
 function generateChunk(events: string[]): string {

--- a/frontend/src/scenes/max/components/ToolsDisplay.tsx
+++ b/frontend/src/scenes/max/components/ToolsDisplay.tsx
@@ -61,16 +61,17 @@ export const ToolsDisplay: React.FC<ToolsDisplayProps> = ({ isFloating, tools, b
                 >
                     <TruncatedHorizontalCollection>
                         <span className="shrink-0">Tools:</span>
-                        {toolsInReverse.map((tool) => (
-                            // We're using --color-posthog-3000-300 instead of border-primary (--color-posthog-3000-200)
-                            // or border-secondary (--color-posthog-3000-400) because the former is almost invisible here, and the latter too distinct
-                            <em className="relative inline-flex items-center gap-1" key={tool.identifier}>
-                                <span className="flex text-sm">
-                                    {getToolDefinition(tool.identifier)?.icon || <IconWrench />}
-                                </span>
-                                {tool.name}
-                            </em>
-                        ))}
+                        {toolsInReverse.map((tool) => {
+                            const toolDef = getToolDefinition(tool.identifier)
+                            return (
+                                // We're using --color-posthog-3000-300 instead of border-primary (--color-posthog-3000-200)
+                                // or border-secondary (--color-posthog-3000-400) because the former is almost invisible here, and the latter too distinct
+                                <em className="relative inline-flex items-center gap-1" key={tool.identifier}>
+                                    <span className="flex text-sm">{toolDef?.icon || <IconWrench />}</span>
+                                    {toolDef?.name}
+                                </em>
+                            )
+                        })}
                     </TruncatedHorizontalCollection>
                     <IconInfo className="text-sm shrink-0 box-content z-10" />
                 </div>
@@ -179,8 +180,8 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                     [] as { name?: string; description?: string; icon?: JSX.Element }[]
                 )
                 .concat(MAX_GENERALLY_CAN)
-                .map((tool, index) => (
-                    <React.Fragment key={index}>
+                .map((tool) => (
+                    <React.Fragment key={tool.name}>
                         <span className="flex text-base text-success shrink-0 ml-1 mr-2 h-[1.25em]">
                             {tool.icon || <IconWrench />}
                         </span>
@@ -225,7 +226,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                     <span>
                         <em>In {sceneConfigurations[product]?.name || identifierToHuman(product)}: </em>
                         {tools.map((tool, index) => (
-                            <React.Fragment key={index}>
+                            <React.Fragment key={tool.name}>
                                 <strong className="italic">{tool.name}</strong>
                                 {tool.description?.replace(tool.name, '')}
                                 {index < tools.length - 1 && <>; </>}

--- a/frontend/src/scenes/max/components/ToolsDisplay.tsx
+++ b/frontend/src/scenes/max/components/ToolsDisplay.tsx
@@ -21,6 +21,7 @@ import {
     TOOL_DEFINITIONS,
     ToolDefinition,
     ToolRegistration,
+    getToolDefinition,
 } from '../max-constants'
 
 export interface ToolsDisplayProps {
@@ -64,7 +65,9 @@ export const ToolsDisplay: React.FC<ToolsDisplayProps> = ({ isFloating, tools, b
                             // We're using --color-posthog-3000-300 instead of border-primary (--color-posthog-3000-200)
                             // or border-secondary (--color-posthog-3000-400) because the former is almost invisible here, and the latter too distinct
                             <em className="relative inline-flex items-center gap-1" key={tool.identifier}>
-                                <span className="flex text-sm">{tool.icon || <IconWrench />}</span>
+                                <span className="flex text-sm">
+                                    {getToolDefinition(tool.name)?.icon || <IconWrench />}
+                                </span>
                                 {tool.name}
                             </em>
                         ))}
@@ -162,10 +165,22 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
     /** Dynamic list of things Max can do right now, i.e. general capabilities + tools registered. */
     const maxCanHere = useMemo(
         () =>
-            (toolsInReverse as { icon?: JSX.Element; name?: string; description?: string }[])
+            (toolsInReverse as { name?: string; description?: string; identifier?: keyof typeof TOOL_DEFINITIONS }[])
+                .reduce(
+                    (tools, tool) => {
+                        const toolDef = tool.identifier ? TOOL_DEFINITIONS[tool.identifier] : undefined
+                        if (toolDef?.kinds) {
+                            tools.push(...Object.values(toolDef.kinds))
+                        } else {
+                            tools.push(tool)
+                        }
+                        return tools
+                    },
+                    [] as { name?: string; description?: string; icon?: JSX.Element }[]
+                )
                 .concat(MAX_GENERALLY_CAN)
-                .map((tool) => (
-                    <>
+                .map((tool, index) => (
+                    <React.Fragment key={index}>
                         <span className="flex text-base text-success shrink-0 ml-1 mr-2 h-[1.25em]">
                             {tool.icon || <IconWrench />}
                         </span>
@@ -173,7 +188,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                             <strong className="italic">{tool.name}</strong>
                             {tool.description?.replace(tool.name || '', '')}
                         </span>
-                    </>
+                    </React.Fragment>
                 )),
         [toolsInReverse.map((t) => t.name).join(';')] // eslint-disable-line react-hooks/exhaustive-deps
     )

--- a/frontend/src/scenes/max/components/ToolsDisplay.tsx
+++ b/frontend/src/scenes/max/components/ToolsDisplay.tsx
@@ -66,7 +66,7 @@ export const ToolsDisplay: React.FC<ToolsDisplayProps> = ({ isFloating, tools, b
                             // or border-secondary (--color-posthog-3000-400) because the former is almost invisible here, and the latter too distinct
                             <em className="relative inline-flex items-center gap-1" key={tool.identifier}>
                                 <span className="flex text-sm">
-                                    {getToolDefinition(tool.name)?.icon || <IconWrench />}
+                                    {getToolDefinition(tool.identifier)?.icon || <IconWrench />}
                                 </span>
                                 {tool.name}
                             </em>
@@ -172,7 +172,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                         if (toolDef?.kinds) {
                             tools.push(...Object.values(toolDef.kinds))
                         } else {
-                            tools.push(tool)
+                            tools.push({ name: toolDef?.name, description: toolDef?.description, icon: toolDef?.icon })
                         }
                         return tools
                     },
@@ -204,7 +204,6 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                 .reduce(
                     (acc, [_, tool]) => {
                         if (!tool.product) {
-                            console.warn(`Unexpected: Global Max tool ${tool.name} appears not to be registered`)
                             return acc
                         }
                         if (!acc[tool.product]) {

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -124,9 +124,8 @@ export const TOOL_DEFINITIONS: Record<Exclude<AssistantTool, 'todo_write'>, Tool
         passiveDescription: 'Navigated to a different page',
     },
     create_and_query_insight: {
-        name: 'Edit the insight',
-        description: "Edit the insight you're viewing",
-        product: Scene.Insight,
+        name: 'Query data',
+        description: 'Query data by creating insights and SQL queries',
         icon: iconForType('product_analytics'),
         activeDescription: 'Creating an insight...', // This is not correct, we currently don't have a division between creating and editing an insight
         passiveDescription: 'Created an insight',
@@ -237,8 +236,10 @@ export const TOOL_DEFINITIONS: Record<Exclude<AssistantTool, 'todo_write'>, Tool
         passiveDescription: 'Fixed SQL',
     },
     edit_current_insight: {
-        name: 'Edit the insight you are viewing',
+        name: 'Edit the insight',
+        description: "Edit the insight you're viewing",
         icon: iconForType('product_analytics'),
+        product: Scene.Insight,
         activeDescription: 'Editing the insight you are viewing...',
         passiveDescription: 'Edited the insight you are viewing',
     },

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -1,9 +1,10 @@
-import { IconAtSign, IconMemory } from '@posthog/icons'
+import { IconAtSign, IconBook, IconCompass, IconCreditCard, IconMemory, IconSearch } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Scene } from 'scenes/sceneTypes'
 
-import { AssistantContextualTool } from '~/queries/schema/schema-assistant-messages'
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { AssistantTool } from '~/queries/schema/schema-assistant-messages'
 
 /** Static tool definition for display purposes. */
 export interface ToolDefinition<N extends string = string> {
@@ -13,13 +14,23 @@ export interface ToolDefinition<N extends string = string> {
      * The tool's description, which must be a sentence that's an extension of the name,
      * e.g. "Create surveys in seconds"
      */
-    description: `${N} ${string}`
+    description?: `${N} ${string}`
+    /** If the tool has multiple kinds, you can specify them here
+     * These will populate the tool summary list, instead of the tool itself
+     */
+    kinds?: Record<
+        string, // identifier, should match the "kind" key in the tool call
+        ToolDefinition
+    >
+    icon: JSX.Element
+    activeDescription?: string
+    passiveDescription?: string
     /**
-     * If the tool is global, set explicitly to null. If only available in a specific product, specify it here.
+     * If only available in a specific product, specify it here.
      * We're using Scene instead of ProductKey, because that's more flexible (specifically for SQL editor there
      * isn't ProductKey.SQL_EDITOR, only ProductKey.DATA_WAREHOUSE - much clearer for users to say Scene.SQLEditor here)
      */
-    product: Scene | null
+    product?: Scene
     /** If the tool is only available if a feature flag is enabled, you can specify it here. */
     flag?: (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 }
@@ -32,7 +43,6 @@ export interface ToolRegistration extends Pick<ToolDefinition, 'name' | 'descrip
      * Optional specific @posthog/icons icon
      * @default <IconWrench />
      */
-    icon?: JSX.Element
     /** Contextual data to be included for use by the LLM */
     context?: Record<string, any>
     /**
@@ -52,113 +62,201 @@ export interface ToolRegistration extends Pick<ToolDefinition, 'name' | 'descrip
     callback?: (toolOutput: any, conversationId: string) => void | Promise<void>
 }
 
-export const TOOL_DEFINITIONS: Omit<
-    Record<AssistantContextualTool, ToolDefinition>,
-    'fix_hogql_query' | 'search_insights' | 'read_data' | 'read_taxonomy' | 'todo_write'
-> = {
-    search: {
-        name: 'Search',
-        description: 'Search documentation and your data in PostHog',
-        product: null,
-    },
+export const TOOL_DEFINITIONS: Record<Exclude<AssistantTool, 'todo_write'>, ToolDefinition> = {
     session_summarization: {
         name: 'Summarize sessions',
         description: 'Summarize sessions to analyze real user behavior',
-        product: null,
         flag: 'max-session-summarization',
+        icon: iconForType('session_replay'),
+        activeDescription: 'Summarizing sessions...',
+        passiveDescription: 'Summarized sessions',
     },
     create_dashboard: {
         name: 'Create dashboards',
         description: 'Create dashboards with insights based on your requirements',
-        product: null,
+        icon: iconForType('dashboard'),
     },
-    search_docs: {
-        name: 'Search docs',
-        description: 'Search docs for answers regarding PostHog',
-        product: null,
+    search: {
+        name: 'Search',
+        icon: <IconSearch />,
+        kinds: {
+            docs: {
+                name: 'Search docs',
+                description: 'Search docs for answers regarding PostHog',
+                icon: <IconBook />,
+                activeDescription: 'Searching docs...',
+                passiveDescription: 'Searched docs',
+            },
+            insights: {
+                name: 'Search existing insights',
+                description: 'Search existing insights for answers',
+                icon: iconForType('product_analytics'),
+                activeDescription: 'Searching insights...',
+                passiveDescription: 'Searched insights',
+            },
+        },
+    },
+    read_taxonomy: {
+        name: 'Read taxonomy',
+        icon: iconForType('data_warehouse'),
+        activeDescription: 'Reading taxonomy...',
+        passiveDescription: 'Read taxonomy',
+    },
+    read_data: {
+        name: 'Read data',
+        description: 'Read data from PostHog',
+        icon: iconForType('data_warehouse'),
+        kinds: {
+            billing_info: {
+                name: 'Read billing data',
+                description: 'Check your billing data',
+                icon: <IconCreditCard />,
+                activeDescription: 'Reading billing data...',
+                passiveDescription: 'Read billing data',
+            },
+        },
     },
     navigate: {
         name: 'Navigate',
         description: 'Navigate to other places in PostHog',
-        product: null,
+        icon: <IconCompass />,
+        activeDescription: 'Navigating to a different page...',
+        passiveDescription: 'Navigated to a different page',
     },
     create_and_query_insight: {
         name: 'Edit the insight',
         description: "Edit the insight you're viewing",
         product: Scene.Insight,
+        icon: iconForType('product_analytics'),
+        activeDescription: 'Creating an insight...', // This is not correct, we currently don't have a division between creating and editing an insight
+        passiveDescription: 'Created an insight',
     },
     search_session_recordings: {
         name: 'Search recordings',
         description: 'Search recordings quickly',
         product: Scene.Replay,
+        icon: iconForType('session_replay'),
+        activeDescription: 'Searching recordings...',
+        passiveDescription: 'Searched recordings',
     },
     generate_hogql_query: {
         name: 'Write and tweak SQL',
         description: 'Write and tweak SQL right there',
         product: Scene.SQLEditor,
+        icon: iconForType('insight/hog'),
+        activeDescription: 'Writing and tweaking SQL...',
+        passiveDescription: 'Edited SQL',
     },
     analyze_user_interviews: {
         name: 'Analyze user interviews',
         description: 'Analyze user interviews, summarizing pages of feedback, and extracting learnings',
         product: Scene.UserInterviews,
         flag: FEATURE_FLAGS.USER_INTERVIEWS,
+        icon: iconForType('user_interview'),
+        activeDescription: 'Analyzing user interviews...',
+        passiveDescription: 'Analyzed user interviews',
     },
     create_hog_function_filters: {
         name: 'Set up function filters',
         description: 'Set up function filters for quick pipeline configuration',
         product: Scene.DataPipelines,
+        icon: iconForType('data_warehouse'),
+        activeDescription: 'Setting up function filters...',
+        passiveDescription: 'Set up function filters',
     },
     create_hog_transformation_function: {
         name: 'Write and tweak Hog code',
         description: 'Write and tweak Hog code of transformations',
         product: Scene.DataPipelines,
+        icon: iconForType('data_warehouse'),
+        activeDescription: 'Writing and tweaking Hog code...',
+        passiveDescription: 'Edited Hog code',
     },
     create_hog_function_inputs: {
         name: 'Manage function variables',
         description: 'Manage function variables in Hog functions',
         product: Scene.DataPipelines,
+        icon: iconForType('data_warehouse'),
+        activeDescription: 'Managing function variables...',
+        passiveDescription: 'Managed function variables',
     },
     filter_error_tracking_issues: {
         name: 'Filter issues',
         description: 'Filter issues to dig into errors',
         product: Scene.ErrorTracking,
+        icon: iconForType('error_tracking'),
+        activeDescription: 'Filtering issues...',
+        passiveDescription: 'Filtered issues',
     },
     find_error_tracking_impactful_issue_event_list: {
         name: 'Find impactful issues',
         description: 'Find impactful issues affecting your conversion, activation, or any other events',
         product: Scene.ErrorTracking,
         flag: FEATURE_FLAGS.ERROR_TRACKING_ISSUE_CORRELATION,
+        icon: iconForType('error_tracking'),
+        activeDescription: 'Finding impactful issues...',
+        passiveDescription: 'Found impactful issues',
     },
     experiment_results_summary: {
         name: 'Summarize experiment results',
         description: 'Summarize experiment results for a comprehensive rundown',
         product: Scene.Experiment,
         flag: 'experiments-ai-summary',
+        icon: iconForType('experiment'),
+        activeDescription: 'Summarizing experiment results...',
+        passiveDescription: 'Summarized experiment results',
     },
     create_survey: {
         name: 'Create surveys',
         description: 'Create surveys in seconds',
         product: Scene.Surveys,
+        icon: iconForType('survey'),
+        activeDescription: 'Creating surveys...',
+        passiveDescription: 'Created surveys',
     },
     analyze_survey_responses: {
         name: 'Analyze survey responses',
         description: 'Analyze survey responses to extract themes and actionable insights',
         product: Scene.Surveys,
+        icon: iconForType('survey'),
+        activeDescription: 'Analyzing survey responses...',
+        passiveDescription: 'Analyzed survey responses',
     },
     create_message_template: {
         name: 'Create email templates',
         description: 'Create email templates from scratch or using a URL for inspiration',
         product: Scene.Workflows,
+        icon: iconForType('workflows'),
+        activeDescription: 'Creating email templates...',
+        passiveDescription: 'Created email templates',
     },
-    edit_current_dashboard: {
-        name: 'Add insight to the dashboard',
-        description: "Add insight to the dashboard you're viewing",
-        product: Scene.Dashboard,
+    fix_hogql_query: {
+        name: 'Fix SQL',
+        icon: iconForType('data_warehouse'),
+        activeDescription: 'Fixing SQL...',
+        passiveDescription: 'Fixed SQL',
+    },
+    edit_current_insight: {
+        name: 'Edit the insight you are viewing',
+        icon: iconForType('product_analytics'),
+        activeDescription: 'Editing the insight you are viewing...',
+        passiveDescription: 'Edited the insight you are viewing',
     },
     filter_revenue_analytics: {
         name: 'Filter revenue analytics',
         description: 'Filter revenue analytics to find the most impactful revenue insights',
         product: Scene.RevenueAnalytics,
+        icon: iconForType('revenue_analytics'),
+        activeDescription: 'Filtering revenue analytics...',
+        passiveDescription: 'Filtered revenue analytics',
+    },
+    edit_current_dashboard: {
+        name: 'Add insight to the dashboard',
+        description: "Edit insight to the dashboard you're viewing",
+        product: Scene.Dashboard,
+        icon: iconForType('dashboard'),
+        activeDescription: 'Adding insight to the dashboard...',
+        passiveDescription: 'Added insight to the dashboard',
     },
 }
 
@@ -174,3 +272,17 @@ export const MAX_GENERALLY_CANNOT: string[] = [
     'Guarantee correctness',
     'Order tungsten cubes',
 ]
+
+export function getToolDefinition(identifier: string): ToolDefinition | null {
+    const flatTools = Object.entries(TOOL_DEFINITIONS).flatMap(([key, tool]) => {
+        if (tool.kinds) {
+            return [{ ...tool, key }, ...Object.entries(tool.kinds).map(([key, value]) => ({ ...value, key }))]
+        }
+        return [{ ...tool, key }]
+    })
+    let definition = flatTools.find((tool) => tool.key === identifier)
+    if (!definition) {
+        return null
+    }
+    return definition
+}

--- a/frontend/src/scenes/max/max.test.ts
+++ b/frontend/src/scenes/max/max.test.ts
@@ -81,9 +81,12 @@ describe('Max Logics Integration Tests', () => {
                 ],
                 [
                     partial({
-                        type: AssistantMessageType.Reasoning,
+                        type: AssistantMessageType.Assistant,
                         status: 'completed',
                         id: 'loader',
+                        meta: partial({
+                            thinking: expect.any(Array),
+                        }),
                     }),
                 ],
             ],

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -73,8 +73,8 @@ export const STATIC_TOOLS: ToolRegistration[] = [
     },
     {
         identifier: 'create_and_query_insight' as const,
-        name: 'Query data',
-        description: 'Query data by creating insights and SQL queries',
+        name: TOOL_DEFINITIONS['create_and_query_insight'].name,
+        description: TOOL_DEFINITIONS['create_and_query_insight'].description,
     },
 ]
 

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -2,8 +2,6 @@ import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
-import { IconBook, IconCompass, IconDashboard, IconGraph, IconRewindPlay } from '@posthog/icons'
-
 import api from 'lib/api'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
@@ -27,7 +25,6 @@ export const STATIC_TOOLS: ToolRegistration[] = [
         identifier: 'navigate' as const,
         name: TOOL_DEFINITIONS['navigate'].name,
         description: TOOL_DEFINITIONS['navigate'].description,
-        icon: <IconCompass />,
         context: { current_page: location.pathname, scene_descriptions: buildSceneDescriptionsContext() },
         callback: async (toolOutput, conversationId) => {
             const { page_key: pageKey } = toolOutput
@@ -63,25 +60,21 @@ export const STATIC_TOOLS: ToolRegistration[] = [
         identifier: 'create_dashboard' as const,
         name: TOOL_DEFINITIONS['create_dashboard'].name,
         description: TOOL_DEFINITIONS['create_dashboard'].description,
-        icon: <IconDashboard />,
     },
     {
-        identifier: 'search_docs' as const,
-        name: TOOL_DEFINITIONS['search_docs'].name,
-        description: TOOL_DEFINITIONS['search_docs'].description,
-        icon: <IconBook />,
+        identifier: 'search' as const,
+        name: TOOL_DEFINITIONS['search'].name,
+        description: TOOL_DEFINITIONS['search'].description,
     },
     {
         identifier: 'session_summarization' as const,
         name: TOOL_DEFINITIONS['session_summarization'].name,
         description: TOOL_DEFINITIONS['session_summarization'].description,
-        icon: <IconRewindPlay />,
     },
     {
         identifier: 'create_and_query_insight' as const,
         name: 'Query data',
         description: 'Query data by creating insights and SQL queries',
-        icon: <IconGraph />,
     },
 ]
 
@@ -217,10 +210,17 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         ],
         toolMap: [
             (s) => [s.registeredToolMap, s.availableStaticTools],
-            (registeredToolMap, availableStaticTools) => ({
-                ...Object.fromEntries(availableStaticTools.map((tool) => [tool.identifier, tool])),
-                ...registeredToolMap,
-            }),
+            (registeredToolMap, availableStaticTools) => {
+                if (registeredToolMap.edit_current_insight) {
+                    availableStaticTools = availableStaticTools.filter(
+                        (tool) => tool.identifier !== 'create_and_query_insight'
+                    )
+                }
+                return {
+                    ...Object.fromEntries(availableStaticTools.map((tool) => [tool.identifier, tool])),
+                    ...registeredToolMap,
+                }
+            },
         ],
         tools: [(s) => [s.toolMap], (toolMap): ToolRegistration[] => Object.values(toolMap)],
         editInsightToolRegistered: [

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -80,14 +80,12 @@ describe('maxThreadLogic', () => {
             ])
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Assistant,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'mock-assistant-msg-1',
-                    },
-                ],
+                {
+                    type: AssistantMessageType.Assistant,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'mock-assistant-msg-1',
+                },
             ],
         })
     })
@@ -113,25 +111,21 @@ describe('maxThreadLogic', () => {
             ])
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'human-1',
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'human-1',
+                },
+                {
+                    type: AssistantMessageType.Assistant,
+                    content: 'response',
+                    status: 'completed',
+                    id: 'assistant-1',
+                    meta: {
+                        thinking: [{ thinking: 'Processing request' }],
                     },
-                ],
-                [
-                    {
-                        type: AssistantMessageType.Assistant,
-                        content: 'response',
-                        status: 'completed',
-                        id: 'assistant-1',
-                        meta: {
-                            thinking: [{ thinking: 'Processing request' }],
-                        },
-                    },
-                ],
+                },
             ],
         })
     })
@@ -160,30 +154,24 @@ describe('maxThreadLogic', () => {
             ])
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'human-1',
-                    },
-                ],
-                [
-                    {
-                        type: AssistantMessageType.Assistant,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'assistant-1',
-                    },
-                ],
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'human-2',
-                    },
-                ],
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'human-1',
+                },
+                {
+                    type: AssistantMessageType.Assistant,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'assistant-1',
+                },
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'human-2',
+                },
             ],
         })
     })
@@ -205,21 +193,17 @@ describe('maxThreadLogic', () => {
             ])
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'human-1',
-                    },
-                ],
-                [
-                    {
-                        type: AssistantMessageType.Assistant,
-                        content: 'hello',
-                        status: 'completed',
-                    },
-                ],
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'human-1',
+                },
+                {
+                    type: AssistantMessageType.Assistant,
+                    content: 'hello',
+                    status: 'completed',
+                },
             ],
         })
     })
@@ -241,22 +225,18 @@ describe('maxThreadLogic', () => {
             ])
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'human-1',
-                    },
-                ],
-                [
-                    partial({
-                        type: AssistantMessageType.Assistant,
-                        meta: partial({ thinking: expect.any(Array) }),
-                        status: 'completed',
-                        id: 'loader',
-                    }),
-                ],
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'human-1',
+                },
+                partial({
+                    type: AssistantMessageType.Assistant,
+                    meta: partial({ thinking: expect.any(Array) }),
+                    status: 'completed',
+                    id: 'loader',
+                }),
             ],
         })
     })
@@ -265,7 +245,7 @@ describe('maxThreadLogic', () => {
         logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
         logic.mount()
 
-        // Human and assistant messages with IDs–should append to the last group
+        // Human and assistant messages with IDs–should append thinking message
         await expectLogic(logic, () => {
             logic.actions.setConversation(MOCK_IN_PROGRESS_CONVERSATION)
             logic.actions.setThread([
@@ -284,28 +264,24 @@ describe('maxThreadLogic', () => {
             ])
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'human-1',
-                    },
-                ],
-                [
-                    {
-                        type: AssistantMessageType.Assistant,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'assistant-1',
-                    },
-                    partial({
-                        type: AssistantMessageType.Assistant,
-                        meta: partial({ thinking: expect.any(Array) }),
-                        status: 'completed',
-                        id: 'loader',
-                    }),
-                ],
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'human-1',
+                },
+                {
+                    type: AssistantMessageType.Assistant,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'assistant-1',
+                },
+                partial({
+                    type: AssistantMessageType.Assistant,
+                    meta: partial({ thinking: expect.any(Array) }),
+                    status: 'completed',
+                    id: 'loader',
+                }),
             ],
         })
     })
@@ -331,21 +307,17 @@ describe('maxThreadLogic', () => {
             ])
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                        id: 'human-1',
-                    },
-                ],
-                [
-                    {
-                        type: AssistantMessageType.Assistant,
-                        content: 'hello',
-                        status: 'completed',
-                    },
-                ],
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                    id: 'human-1',
+                },
+                {
+                    type: AssistantMessageType.Assistant,
+                    content: 'hello',
+                    status: 'completed',
+                },
             ],
         })
     })
@@ -361,21 +333,17 @@ describe('maxThreadLogic', () => {
             logic.actions.askMax('hello')
         }).toMatchValues({
             threadGrouped: [
-                [
-                    {
-                        type: AssistantMessageType.Human,
-                        content: 'hello',
-                        status: 'completed',
-                    },
-                ],
-                [
-                    partial({
-                        type: AssistantMessageType.Assistant,
-                        meta: partial({ thinking: expect.any(Array) }),
-                        status: 'completed',
-                        id: 'loader',
-                    }),
-                ],
+                {
+                    type: AssistantMessageType.Human,
+                    content: 'hello',
+                    status: 'completed',
+                },
+                partial({
+                    type: AssistantMessageType.Assistant,
+                    meta: partial({ thinking: expect.any(Array) }),
+                    status: 'completed',
+                    id: 'loader',
+                }),
             ],
         })
         expect(streamSpy).toHaveBeenCalledTimes(1)
@@ -526,20 +494,18 @@ describe('maxThreadLogic', () => {
                 ])
             }).toMatchValues({
                 threadGrouped: [
-                    [
-                        {
-                            type: AssistantMessageType.Human,
-                            content: 'hello',
-                            status: 'completed',
-                            id: 'human-1',
-                        },
-                        {
-                            type: AssistantMessageType.Assistant,
-                            content: 'response',
-                            status: 'completed',
-                            id: 'assistant-1',
-                        },
-                    ],
+                    {
+                        type: AssistantMessageType.Human,
+                        content: 'hello',
+                        status: 'completed',
+                        id: 'human-1',
+                    },
+                    {
+                        type: AssistantMessageType.Assistant,
+                        content: 'response',
+                        status: 'completed',
+                        id: 'assistant-1',
+                    },
                 ],
             })
         })
@@ -565,22 +531,18 @@ describe('maxThreadLogic', () => {
                 })
             }).toMatchValues({
                 threadGrouped: [
-                    [
-                        {
-                            type: AssistantMessageType.Human,
-                            content: 'test question',
-                            status: 'completed',
-                            id: 'human-1',
-                        },
-                    ],
-                    [
-                        {
-                            type: AssistantMessageType.Failure,
-                            content: 'Something went wrong',
-                            status: 'completed',
-                            id: 'failure-1',
-                        },
-                    ],
+                    {
+                        type: AssistantMessageType.Human,
+                        content: 'test question',
+                        status: 'completed',
+                        id: 'human-1',
+                    },
+                    {
+                        type: AssistantMessageType.Failure,
+                        content: 'Something went wrong',
+                        status: 'completed',
+                        id: 'failure-1',
+                    },
                 ],
             })
         })
@@ -916,7 +878,7 @@ describe('maxThreadLogic', () => {
 
     describe('UpdateMessage handling', () => {
         beforeEach(() => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
             logic.mount()
         })
 
@@ -924,7 +886,7 @@ describe('maxThreadLogic', () => {
             const updateMessage = {
                 type: AssistantMessageType.Update,
                 id: 'update-1',
-                parent_tool_call_id: 'tool-call-123',
+                tool_call_id: 'tool-call-123',
                 content: 'Processing data...',
             }
 
@@ -942,19 +904,19 @@ describe('maxThreadLogic', () => {
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-1',
-                    parent_tool_call_id: toolCallId,
+                    tool_call_id: toolCallId,
                     content: 'Step 1 complete',
                 })
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-2',
-                    parent_tool_call_id: toolCallId,
+                    tool_call_id: toolCallId,
                     content: 'Step 2 complete',
                 })
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-3',
-                    parent_tool_call_id: toolCallId,
+                    tool_call_id: toolCallId,
                     content: 'Step 3 complete',
                 })
             })
@@ -974,13 +936,13 @@ describe('maxThreadLogic', () => {
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-1',
-                    parent_tool_call_id: toolCallId,
+                    tool_call_id: toolCallId,
                     content: sameContent,
                 })
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-2',
-                    parent_tool_call_id: toolCallId,
+                    tool_call_id: toolCallId,
                     content: sameContent,
                 })
             })
@@ -994,13 +956,13 @@ describe('maxThreadLogic', () => {
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-1',
-                    parent_tool_call_id: 'tool-1',
+                    tool_call_id: 'tool-1',
                     content: 'Tool 1 update',
                 })
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-2',
-                    parent_tool_call_id: 'tool-2',
+                    tool_call_id: 'tool-2',
                     content: 'Tool 2 update',
                 })
             })
@@ -1029,27 +991,23 @@ describe('maxThreadLogic', () => {
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-1',
-                    parent_tool_call_id: 'tool-call-123',
+                    tool_call_id: 'tool-call-123',
                     content: 'This should not appear',
                 })
             }).toMatchValues({
                 threadGrouped: [
-                    [
-                        {
-                            type: AssistantMessageType.Human,
-                            content: 'hello',
-                            status: 'completed',
-                            id: 'human-1',
-                        },
-                    ],
-                    [
-                        {
-                            type: AssistantMessageType.Assistant,
-                            content: 'response',
-                            status: 'completed',
-                            id: 'assistant-1',
-                        },
-                    ],
+                    {
+                        type: AssistantMessageType.Human,
+                        content: 'hello',
+                        status: 'completed',
+                        id: 'human-1',
+                    },
+                    {
+                        type: AssistantMessageType.Assistant,
+                        content: 'response',
+                        status: 'completed',
+                        id: 'assistant-1',
+                    },
                 ],
             })
         })
@@ -1057,7 +1015,7 @@ describe('maxThreadLogic', () => {
 
     describe('enhanceThreadToolCalls', () => {
         beforeEach(() => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
             logic.mount()
         })
 
@@ -1091,13 +1049,13 @@ describe('maxThreadLogic', () => {
                 ])
             })
 
-            const enhancedToolCalls = logic.values.threadGrouped[0][0].tool_calls
+            const enhancedToolCalls = logic.values.threadGrouped[0].tool_calls
             expect(enhancedToolCalls).toBeTruthy()
             expect(enhancedToolCalls?.[0].status).toBe('completed')
         })
 
         it('marks tool call as in_progress when no completion message and still loading', async () => {
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -1120,7 +1078,7 @@ describe('maxThreadLogic', () => {
                 ])
             })
 
-            const enhancedToolCalls = logic.values.threadGrouped[0][0].tool_calls
+            const enhancedToolCalls = logic.values.threadGrouped[0].tool_calls
             expect(enhancedToolCalls?.[0].status).toBe('in_progress')
         })
 
@@ -1144,7 +1102,7 @@ describe('maxThreadLogic', () => {
                 ])
             })
 
-            const enhancedToolCalls = logic.values.threadGrouped[0][0].tool_calls
+            const enhancedToolCalls = logic.values.threadGrouped[0].tool_calls
             expect(enhancedToolCalls?.[0].status).toBe('failed')
         })
 
@@ -1155,13 +1113,13 @@ describe('maxThreadLogic', () => {
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-1',
-                    parent_tool_call_id: toolCallId,
+                    tool_call_id: toolCallId,
                     content: 'Progress update 1',
                 })
                 logic.actions.setToolCallUpdate({
                     type: AssistantMessageType.Update,
                     id: 'update-2',
-                    parent_tool_call_id: toolCallId,
+                    tool_call_id: toolCallId,
                     content: 'Progress update 2',
                 })
                 logic.actions.setThread([
@@ -1182,7 +1140,7 @@ describe('maxThreadLogic', () => {
                 ])
             })
 
-            const enhancedToolCalls = logic.values.threadGrouped[0][0].tool_calls
+            const enhancedToolCalls = logic.values.threadGrouped[0].tool_calls
             expect(enhancedToolCalls?.[0].updates).toEqual(['Progress update 1', 'Progress update 2'])
         })
 
@@ -1220,8 +1178,8 @@ describe('maxThreadLogic', () => {
                 ])
             })
 
-            const firstToolCall = logic.values.threadGrouped[0][0].tool_calls?.[0]
-            const secondToolCall = logic.values.threadGrouped[0][1].tool_calls?.[0]
+            const firstToolCall = logic.values.threadGrouped[0].tool_calls?.[0]
+            const secondToolCall = logic.values.threadGrouped[1].tool_calls?.[0]
 
             expect(firstToolCall?.isLastPlanningMessage).toBeFalsy()
             expect(secondToolCall?.isLastPlanningMessage).toBeTruthy()
@@ -1261,7 +1219,7 @@ describe('maxThreadLogic', () => {
                 ])
             })
 
-            const enhancedToolCalls = logic.values.threadGrouped[0][0].tool_calls
+            const enhancedToolCalls = logic.values.threadGrouped[0].tool_calls
             expect(enhancedToolCalls?.[0].status).toBe('completed')
             expect(enhancedToolCalls?.[1].status).toBe('failed') // No completion message
         })
@@ -1288,7 +1246,7 @@ describe('maxThreadLogic', () => {
                 ])
             })
 
-            const enhancedToolCalls = logic.values.threadGrouped[0][0].tool_calls
+            const enhancedToolCalls = logic.values.threadGrouped[0].tool_calls
             expect(enhancedToolCalls?.[0].updates).toEqual([])
         })
     })

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -876,22 +876,21 @@ describe('maxThreadLogic', () => {
         })
     })
 
-    describe('UpdateMessage handling', () => {
+    describe('assistant update event handling', () => {
         beforeEach(() => {
             logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
             logic.mount()
         })
 
         it('setToolCallUpdate adds update to toolCallUpdateMap', async () => {
-            const updateMessage = {
-                type: AssistantMessageType.Update,
+            const updateEvent = {
                 id: 'update-1',
                 tool_call_id: 'tool-call-123',
                 content: 'Processing data...',
             }
 
             await expectLogic(logic, () => {
-                logic.actions.setToolCallUpdate(updateMessage)
+                logic.actions.setToolCallUpdate(updateEvent)
             })
 
             expect(logic.values.toolCallUpdateMap.get('tool-call-123')).toEqual(['Processing data...'])
@@ -902,19 +901,16 @@ describe('maxThreadLogic', () => {
 
             await expectLogic(logic, () => {
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-1',
                     tool_call_id: toolCallId,
                     content: 'Step 1 complete',
                 })
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-2',
                     tool_call_id: toolCallId,
                     content: 'Step 2 complete',
                 })
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-3',
                     tool_call_id: toolCallId,
                     content: 'Step 3 complete',
@@ -934,13 +930,11 @@ describe('maxThreadLogic', () => {
 
             await expectLogic(logic, () => {
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-1',
                     tool_call_id: toolCallId,
                     content: sameContent,
                 })
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-2',
                     tool_call_id: toolCallId,
                     content: sameContent,
@@ -954,13 +948,11 @@ describe('maxThreadLogic', () => {
         it('setToolCallUpdate handles updates for different tool calls', async () => {
             await expectLogic(logic, () => {
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-1',
                     tool_call_id: 'tool-1',
                     content: 'Tool 1 update',
                 })
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-2',
                     tool_call_id: 'tool-2',
                     content: 'Tool 2 update',
@@ -989,7 +981,6 @@ describe('maxThreadLogic', () => {
                 ])
                 // UpdateMessages should not appear in thread directly
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-1',
                     tool_call_id: 'tool-call-123',
                     content: 'This should not appear',
@@ -1111,13 +1102,11 @@ describe('maxThreadLogic', () => {
 
             await expectLogic(logic, () => {
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-1',
                     tool_call_id: toolCallId,
                     content: 'Progress update 1',
                 })
                 logic.actions.setToolCallUpdate({
-                    type: AssistantMessageType.Update,
                     id: 'update-2',
                     tool_call_id: toolCallId,
                     content: 'Progress update 2',

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -36,11 +36,11 @@ import {
     AssistantGenerationStatusType,
     AssistantMessage,
     AssistantMessageType,
+    AssistantUpdateEvent,
     FailureMessage,
     HumanMessage,
     RootAssistantMessage,
     TaskExecutionStatus,
-    UpdateEvent,
 } from '~/queries/schema/schema-assistant-messages'
 import { Conversation, ConversationDetail, ConversationStatus, ConversationType } from '~/types'
 
@@ -156,7 +156,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         setDeepResearchMode: (deepResearchMode: boolean) => ({ deepResearchMode }),
         processNotebookUpdate: (notebookId: string, notebookContent: JSONContent) => ({ notebookId, notebookContent }),
         setForAnotherAgenticIteration: (value: boolean) => ({ value }),
-        setToolCallUpdate: (update: UpdateEvent) => ({ update }),
+        setToolCallUpdate: (update: AssistantUpdateEvent) => ({ update }),
     }),
 
     reducers(({ props }) => ({
@@ -231,7 +231,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         toolCallUpdateMap: [
             new Map<string, string[]>(),
             {
-                setToolCallUpdate: (value, { update }: { update: UpdateEvent }) => {
+                setToolCallUpdate: (value, { update }: { update: AssistantUpdateEvent }) => {
                     const currentValue = value.get(update.tool_call_id) || []
                     if (currentValue.includes(update.content)) {
                         return value
@@ -768,7 +768,7 @@ async function onEventImplementation(
         actions.setConversation(conversationWithTitle)
         actions.updateGlobalConversationCache(conversationWithTitle)
     } else if (event === AssistantEventType.Update) {
-        const parsedResponse = parseResponse<UpdateEvent>(data)
+        const parsedResponse = parseResponse<AssistantUpdateEvent>(data)
         if (!parsedResponse) {
             return
         }

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -34,12 +34,13 @@ import {
     AssistantEventType,
     AssistantGenerationStatusEvent,
     AssistantGenerationStatusType,
+    AssistantMessage,
     AssistantMessageType,
     FailureMessage,
     HumanMessage,
-    ReasoningMessage,
     RootAssistantMessage,
     TaskExecutionStatus,
+    UpdateMessage,
 } from '~/queries/schema/schema-assistant-messages'
 import { Conversation, ConversationDetail, ConversationStatus, ConversationType } from '~/types'
 
@@ -53,8 +54,7 @@ import {
     isAssistantToolCallMessage,
     isHumanMessage,
     isNotebookUpdateMessage,
-    isReasoningMessage,
-    isTaskExecutionMessage,
+    isUpdateMessage,
 } from './utils'
 import { getRandomThinkingMessage } from './utils/thinkingMessages'
 
@@ -162,6 +162,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         setDeepResearchMode: (deepResearchMode: boolean) => ({ deepResearchMode }),
         processNotebookUpdate: (notebookId: string, notebookContent: JSONContent) => ({ notebookId, notebookContent }),
         setForAnotherAgenticIteration: (value: boolean) => ({ value }),
+        setToolCallUpdate: (update: UpdateMessage) => ({ update }),
     }),
 
     reducers(({ props }) => ({
@@ -230,6 +231,21 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 setForAnotherAgenticIteration: (_, { value }) => value,
                 askMax: () => false,
                 completeThreadGeneration: () => false,
+            },
+        ],
+
+        toolCallUpdateMap: [
+            new Map<string, string[]>(),
+            {
+                setToolCallUpdate: (value, { update }: { update: UpdateMessage }) => {
+                    const currentValue = value.get(update.parent_tool_call_id) || []
+                    if (currentValue.includes(update.content)) {
+                        return value
+                    }
+
+                    value.set(update.parent_tool_call_id, [...currentValue, update.content])
+                    return value
+                },
             },
         ],
     })),
@@ -499,75 +515,92 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ],
 
         threadGrouped: [
-            (s) => [s.threadRaw, s.threadLoading],
-            (thread, threadLoading): ThreadMessage[][] => {
+            (s) => [s.threadRaw, s.threadLoading, s.toolCallUpdateMap],
+            (thread, threadLoading, toolCallUpdateMap): ThreadMessage[][] => {
                 const isHumanMessageType = (message?: ThreadMessage): boolean =>
                     message?.type === AssistantMessageType.Human
-                const threadGrouped: ThreadMessage[][] = []
+
+                let threadGrouped: ThreadMessage[][] = []
 
                 for (let i = 0; i < thread.length; i++) {
                     const currentMessage: ThreadMessage = thread[i]
                     const previousMessage = thread[i - 1] as ThreadMessage | undefined
 
-                    if (currentMessage.type === AssistantMessageType.ToolCall && !currentMessage.visible) {
+                    // Skip AssistantToolCallMessage - they're now merged into AssistantMessage tool_calls
+                    if (currentMessage.type === AssistantMessageType.ToolCall) {
+                        continue
+                    }
+
+                    if (
+                        currentMessage.type === AssistantMessageType.Assistant &&
+                        currentMessage.content.length === 0 &&
+                        currentMessage.tool_calls &&
+                        currentMessage.tool_calls.length == 0 &&
+                        (!currentMessage.meta || currentMessage.meta.thinking?.length == 0)
+                    ) {
                         continue
                     }
 
                     // Do not use the human message type guard here, as it incorrectly infers the type
                     if (previousMessage && isHumanMessageType(currentMessage) === isHumanMessageType(previousMessage)) {
                         const lastThreadSoFar = threadGrouped[threadGrouped.length - 1]
-                        if (
-                            currentMessage.id &&
-                            previousMessage &&
-                            previousMessage.type === AssistantMessageType.Reasoning
-                        ) {
-                            // Only preserve the latest reasoning message, and remove once reasoning is done
-                            lastThreadSoFar[lastThreadSoFar.length - 1] = currentMessage
-                        } else if (lastThreadSoFar) {
-                            lastThreadSoFar.push(currentMessage)
-                        }
+                        lastThreadSoFar.push(currentMessage)
                     } else {
                         threadGrouped.push([currentMessage])
                     }
                 }
+                // Pass the original thread to enhanceThreadToolCalls so it can find ToolCall messages
+                threadGrouped = threadGrouped.map((group, index) =>
+                    enhanceThreadToolCalls(
+                        group,
+                        thread,
+                        threadLoading,
+                        toolCallUpdateMap,
+                        index === threadGrouped.length - 1
+                    )
+                )
 
                 if (threadLoading) {
                     const finalMessageSoFar = threadGrouped.at(-1)?.at(-1)
 
-                    // Check if there's an active TaskExecutionMessage
-                    const hasActiveTaskExecution =
-                        isTaskExecutionMessage(finalMessageSoFar) &&
-                        finalMessageSoFar.tasks.some(
-                            (task) =>
-                                task.status === TaskExecutionStatus.Pending ||
-                                task.status === TaskExecutionStatus.InProgress
-                        )
-
                     // Don't show thinking message if there's an active TaskExecutionMessage
-                    if (!hasActiveTaskExecution) {
-                        const thinkingMessage: ReasoningMessage & ThreadMessage = {
-                            type: AssistantMessageType.Reasoning,
-                            content: getRandomThinkingMessage(),
-                            status: 'completed',
-                            id: 'loader',
-                        }
+                    const thinkingMessage: AssistantMessage & ThreadMessage = {
+                        type: AssistantMessageType.Assistant,
+                        content: '',
+                        status: 'completed',
+                        id: 'loader',
+                        meta: {
+                            thinking: [
+                                {
+                                    thinking: getRandomThinkingMessage(),
+                                },
+                            ],
+                        },
+                    }
+                    const toolCallsInProgress = threadGrouped.flatMap((group) =>
+                        group
+                            .flatMap((message) => (isAssistantMessage(message) ? message.tool_calls : []))
+                            .filter((toolCall) => toolCall && (toolCall as any).status === 'in_progress')
+                    )
 
-                        if (finalMessageSoFar?.type === AssistantMessageType.Human || finalMessageSoFar?.id) {
-                            // If now waiting for the current node to start streaming, add "Thinking" message
-                            // so that there's _some_ indication of processing
-                            if (finalMessageSoFar.type === AssistantMessageType.Human) {
-                                // If the last message was human, we need to add a new "ephemeral" AI group
-                                threadGrouped.push([thinkingMessage])
-                            } else {
-                                // Otherwise, add to the last group
-                                threadGrouped[threadGrouped.length - 1].push(thinkingMessage)
-                            }
-                        }
-
-                        // Special case for the thread in progress
-                        if (threadGrouped.length === 0) {
+                    if (
+                        toolCallsInProgress.length === 0 &&
+                        (finalMessageSoFar?.type === AssistantMessageType.Human || finalMessageSoFar?.id)
+                    ) {
+                        // If now waiting for the current node to start streaming, add "Thinking" message
+                        // so that there's _some_ indication of processing
+                        if (finalMessageSoFar.type === AssistantMessageType.Human) {
+                            // If the last message was human, we need to add a new "ephemeral" AI group
                             threadGrouped.push([thinkingMessage])
+                        } else {
+                            // Otherwise, add to the last group
+                            threadGrouped[threadGrouped.length - 1].push(thinkingMessage)
                         }
+                    }
+
+                    // Special case for the thread in progress
+                    if (threadGrouped.length === 0) {
+                        threadGrouped.push([thinkingMessage])
                     }
                 }
 
@@ -575,10 +608,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             },
         ],
 
-        threadMessageCount: [
-            (s) => [s.threadRaw],
-            (threadRaw) => threadRaw.filter((message) => !isReasoningMessage(message)).length,
-        ],
+        threadMessageCount: [(s) => [s.threadRaw], (threadRaw) => threadRaw.length],
 
         formPending: [
             (s) => [s.threadRaw],
@@ -673,6 +703,72 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
     }),
 ])
 
+/**
+ * Enhances AssistantMessages with tool call completion status by matching
+ * AssistantToolCallMessage.tool_call_id with AssistantMessage.tool_calls[].id
+ * Also marks the last AssistantMessage with planning (todo_write tool calls)
+ */
+function enhanceThreadToolCalls(
+    group: ThreadMessage[],
+    fullThread: ThreadMessage[],
+    isLoading: boolean,
+    toolCallUpdateMap: Map<string, string[]>,
+    isFinalGroup: boolean
+): ThreadMessage[] {
+    // Create a map of tool_call_id -> AssistantToolCallMessage for quick lookup
+    // Search in the full thread to find ToolCall messages (which are filtered from groups)
+    const toolCallCompletions = new Map<string, ThreadMessage>()
+
+    for (const message of fullThread) {
+        // Use simple type check instead of isAssistantToolCallMessage, which requires ui_payload
+        // This allows us to match tool call completions in stories/tests without ui_payload
+        if (message.type === AssistantMessageType.ToolCall && 'tool_call_id' in message) {
+            toolCallCompletions.set((message as any).tool_call_id, message)
+        }
+    }
+
+    // Find the last AssistantMessage that has todo_write tool calls (planning)
+    let lastPlanningMessageId: string | undefined
+    for (let i = group.length - 1; i >= 0; i--) {
+        const message = group[i]
+        if (
+            isAssistantMessage(message) &&
+            message.tool_calls &&
+            message.tool_calls.some((tc) => tc.name === 'todo_write')
+        ) {
+            lastPlanningMessageId = message.id
+            break
+        }
+    }
+
+    // Enhance assistant messages with tool call status
+    return group.map((message) => {
+        if (isAssistantMessage(message) && message.tool_calls && message.tool_calls.length > 0) {
+            const isLastPlanningMessage = message.id === lastPlanningMessageId
+            const enhancedToolCalls = message.tool_calls.map((toolCall) => {
+                const isCompleted = !!toolCallCompletions.get(toolCall.id)
+                const isFailed = !isCompleted && (!isFinalGroup || !isLoading)
+                return {
+                    ...toolCall,
+                    status: isFailed
+                        ? TaskExecutionStatus.Failed
+                        : isCompleted
+                          ? TaskExecutionStatus.Completed
+                          : TaskExecutionStatus.InProgress,
+                    isLastPlanningMessage: toolCall.name === 'todo_write' && isLastPlanningMessage,
+                    updates: toolCallUpdateMap.get(toolCall.id) ?? [],
+                }
+            })
+
+            return {
+                ...message,
+                tool_calls: enhancedToolCalls,
+            }
+        }
+        return message
+    })
+}
+
 /** Assistant streaming event handler. */
 async function onEventImplementation(
     event: string,
@@ -733,6 +829,10 @@ async function onEventImplementation(
                     // we do not want to show partial notebook update messages
                     return
                 }
+            }
+            if (isUpdateMessage(parsedResponse)) {
+                actions.setToolCallUpdate(parsedResponse)
+                return
             }
             // Check if a message with the same ID already exists
             const existingMessageIndex = parsedResponse.id

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -243,8 +243,9 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                         return value
                     }
 
-                    value.set(update.parent_tool_call_id, [...currentValue, update.content])
-                    return value
+                    const newMap = new Map(value)
+                    newMap.set(update.parent_tool_call_id, [...currentValue, update.content])
+                    return newMap
                 },
             },
         ],

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -12,7 +12,6 @@ import {
     MultiVisualizationMessage,
     NotebookUpdateMessage,
     RootAssistantMessage,
-    UpdateMessage,
     VisualizationMessage,
 } from '~/queries/schema/schema-assistant-messages'
 import {
@@ -63,10 +62,6 @@ export function isNotebookUpdateMessage(
     message: RootAssistantMessage | undefined | null
 ): message is NotebookUpdateMessage {
     return message?.type === AssistantMessageType.Notebook
-}
-
-export function isUpdateMessage(message: RootAssistantMessage | undefined | null): message is UpdateMessage {
-    return message?.type === AssistantMessageType.Update
 }
 
 export function castAssistantQuery(

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -11,10 +11,8 @@ import {
     HumanMessage,
     MultiVisualizationMessage,
     NotebookUpdateMessage,
-    PlanningMessage,
-    ReasoningMessage,
     RootAssistantMessage,
-    TaskExecutionMessage,
+    UpdateMessage,
     VisualizationMessage,
 } from '~/queries/schema/schema-assistant-messages'
 import {
@@ -30,10 +28,6 @@ import { ActionType, DashboardType, EventDefinition, QueryBasedInsightModel } fr
 
 import { SuggestionGroup } from './maxLogic'
 import { MaxActionContext, MaxContextType, MaxDashboardContext, MaxEventContext, MaxInsightContext } from './maxTypes'
-
-export function isReasoningMessage(message: RootAssistantMessage | undefined | null): message is ReasoningMessage {
-    return message?.type === AssistantMessageType.Reasoning
-}
 
 export function isVisualizationMessage(
     message: RootAssistantMessage | undefined | null
@@ -71,14 +65,8 @@ export function isNotebookUpdateMessage(
     return message?.type === AssistantMessageType.Notebook
 }
 
-export function isPlanningMessage(message: RootAssistantMessage | undefined | null): message is PlanningMessage {
-    return message?.type === AssistantMessageType.Planning
-}
-
-export function isTaskExecutionMessage(
-    message: RootAssistantMessage | undefined | null
-): message is TaskExecutionMessage {
-    return message?.type === AssistantMessageType.TaskExecution
+export function isUpdateMessage(message: RootAssistantMessage | undefined | null): message is UpdateMessage {
+    return message?.type === AssistantMessageType.Update
 }
 
 export function castAssistantQuery(

--- a/frontend/src/scenes/max/utils/thinkingMessages.ts
+++ b/frontend/src/scenes/max/utils/thinkingMessages.ts
@@ -89,8 +89,8 @@ export const THINKING_MESSAGES = [
 
 export const getRandomThinkingMessage = (): string => {
     if (inStorybookTestRunner()) {
-        return 'Thinking'
+        return 'Thinking...'
     }
     const randomIndex = Math.floor(Math.random() * THINKING_MESSAGES.length)
-    return THINKING_MESSAGES[randomIndex]
+    return THINKING_MESSAGES[randomIndex] + '...'
 }

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1768,4 +1768,53 @@
         outline: 2px dashed currentColor;
         outline-offset: 2px;
     }
+
+    /* stylelint-disable-next-line order/order */
+    .animate-fade-in {
+        animation: fade-in 0.4s ease-out forwards;
+    }
+
+    /* stylelint-disable-next-line keyframes-name-pattern */
+    @keyframes shimmer {
+        0% {
+            background-position: 200% 0;
+        }
+
+        100% {
+            background-position: -200% 0;
+        }
+    }
+
+    /* stylelint-disable-next-line keyframes-name-pattern */
+    @keyframes shimmer-opacity {
+        0%,
+        100% {
+            opacity: 0.4;
+        }
+
+        25% {
+            opacity: 1;
+        }
+
+        50% {
+            opacity: 0.4;
+        }
+
+        75% {
+            opacity: 1;
+        }
+    }
+
+    /* stylelint-disable-next-line keyframes-name-pattern */
+    @keyframes fade-in {
+        0% {
+            opacity: 0;
+            transform: translateY(2px);
+        }
+
+        100% {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "overrides": {
             "playwright": "1.45.0",
             "typescript": "5.2.2",
-            "@posthog/icons": "0.33.0"
+            "@posthog/icons": "0.33.2"
         },
         "patchedDependencies": {
             "heatmap.js@2.0.5": "patches/heatmap.js@2.0.5.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   playwright: 1.45.0
   typescript: 5.2.2
-  '@posthog/icons': 0.33.0
+  '@posthog/icons': 0.33.2
 
 patchedDependencies:
   chartjs-plugin-crosshair@2.0.0:
@@ -445,8 +445,8 @@ importers:
         specifier: workspace:*
         version: link:../common/hogvm/typescript
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@posthog/plugin-scaffold':
         specifier: ^1.4.4
         version: 1.4.4
@@ -1561,8 +1561,8 @@ importers:
   products/actions:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)
@@ -1597,8 +1597,8 @@ importers:
   products/cohorts:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1624,8 +1624,8 @@ importers:
   products/customer_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1651,8 +1651,8 @@ importers:
   products/dashboards:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1678,8 +1678,8 @@ importers:
   products/early_access_features:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)
@@ -1708,8 +1708,8 @@ importers:
   products/endpoints:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1750,8 +1750,8 @@ importers:
         specifier: '*'
         version: 3.2.1(react@18.2.0)
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/addon-actions':
         specifier: '*'
         version: 7.6.4
@@ -1819,8 +1819,8 @@ importers:
   products/experiments:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1846,8 +1846,8 @@ importers:
   products/feature_flags:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1873,8 +1873,8 @@ importers:
   products/games:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1900,8 +1900,8 @@ importers:
   products/groups:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1927,8 +1927,8 @@ importers:
   products/links:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)
@@ -1960,8 +1960,8 @@ importers:
   products/llm_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)
@@ -2015,8 +2015,8 @@ importers:
   products/logs:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@posthog/products-error-tracking':
         specifier: workspace:*
         version: link:../error_tracking
@@ -2072,8 +2072,8 @@ importers:
   products/managed_migrations:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(kea-router@3.4.1(kea@3.1.7(react@18.2.0)))(kea@3.1.7(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2181,8 +2181,8 @@ importers:
   products/notebooks:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2208,8 +2208,8 @@ importers:
   products/persons:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2235,8 +2235,8 @@ importers:
   products/product_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2262,8 +2262,8 @@ importers:
   products/replay:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2289,8 +2289,8 @@ importers:
   products/revenue_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)
@@ -2319,8 +2319,8 @@ importers:
   products/surveys:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2358,8 +2358,8 @@ importers:
         specifier: '*'
         version: 3.2.1(react@18.2.0)
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)
@@ -2398,8 +2398,8 @@ importers:
   products/user_interviews:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2425,8 +2425,8 @@ importers:
   products/web_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2452,8 +2452,8 @@ importers:
   products/workflows:
     dependencies:
       '@posthog/icons':
-        specifier: 0.33.0
-        version: 0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 0.33.2
+        version: 0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -6400,8 +6400,8 @@ packages:
   '@posthog/core@1.3.0':
     resolution: {integrity: sha512-hxLL8kZNHH098geedcxCz8y6xojkNYbmJEW+1vFXsmPcExyCXIUUJ/34X6xa9GcprKxd0Wsx3vfJQLQX4iVPhw==}
 
-  '@posthog/icons@0.33.0':
-    resolution: {integrity: sha512-zH3yRdG7kvJ1UCReOz4o/l2A915Xbcq3+SS+OevJ6I9BdV2i2sRyLStnAm4LFqxfqT8hBMpP9G6I1Or9p2bdvw==}
+  '@posthog/icons@0.33.2':
+    resolution: {integrity: sha512-esTrM3cUChJwW/OsB4YEMMm0stHPyhaiaWxbKE8vaYdhfDw7ULSNsc16nM0TGFkhJ2VnPphxLT+YkAOloj92uw==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -16813,8 +16813,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  rc-overflow@1.4.1:
-    resolution: {integrity: sha512-3MoPQQPV1uKyOMVNd6SZfONi+f3st0r8PksexIdBTeIYbMX0Jr+k7pHEDvsXtR4BpCv90/Pv2MovVNhktKrwvw==}
+  rc-overflow@1.5.0:
+    resolution: {integrity: sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -18898,8 +18898,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.313.0:
-    resolution: {integrity: sha512-4r0Bp3LYcCqCqkq5xodO1d2Z+VSiXwWMj4w29xanwVryRY3OwTrCJXgID+7mGRlY1uPL+A7f2s7BLh6Pg+w9qw==}
+  unlayer-types@1.314.0:
+    resolution: {integrity: sha512-8O218ohQUMCdGqXSfwQgU7aWJ124Ucax3M1hNOtkbRa7RZbC80KnvwivlLyGYVvukHQrw6C8FKUGHAkD4AORAw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -25571,7 +25571,7 @@ snapshots:
 
   '@posthog/core@1.3.0': {}
 
-  '@posthog/icons@0.33.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@posthog/icons@0.33.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -28321,7 +28321,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -34936,7 +34936,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -35216,7 +35216,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -38693,7 +38693,7 @@ snapshots:
       '@rc-component/trigger': 2.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
       rc-motion: 2.9.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      rc-overflow: 1.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      rc-overflow: 1.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -38723,7 +38723,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  rc-overflow@1.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  rc-overflow@1.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
       classnames: 2.5.1
@@ -38745,7 +38745,7 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@rc-component/trigger': 2.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      rc-overflow: 1.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      rc-overflow: 1.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-resize-observer: 1.4.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
@@ -38796,7 +38796,7 @@ snapshots:
       '@rc-component/trigger': 2.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
       rc-motion: 2.9.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      rc-overflow: 1.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      rc-overflow: 1.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-virtual-list: 3.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
@@ -39012,7 +39012,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.2.0):
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.313.0
+      unlayer-types: 1.314.0
 
   react-error-overlay@6.0.9: {}
 
@@ -41221,7 +41221,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.313.0: {}
+  unlayer-types@1.314.0: {}
 
   unpipe@1.0.0: {}
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -113,7 +113,6 @@ class AssistantEventType(StrEnum):
     STATUS = "status"
     MESSAGE = "message"
     CONVERSATION = "conversation"
-    NOTEBOOK = "notebook"
     UPDATE = "update"
 
 
@@ -185,7 +184,6 @@ class AssistantMessageType(StrEnum):
     AI_NOTEBOOK = "ai/notebook"
     AI_PLANNING = "ai/planning"
     AI_TASK_EXECUTION = "ai/task_execution"
-    AI_UPDATE = "ai/update"
 
 
 class AssistantNavigateUrl(StrEnum):
@@ -421,11 +419,9 @@ class AssistantUpdateEvent(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    type: Literal["update"] = "update"
-
-
-class AssistantUpdateEventType(RootModel[Literal["update"]]):
-    root: Literal["update"] = "update"
+    content: str
+    id: str
+    tool_call_id: str
 
 
 class AttributionMode(StrEnum):
@@ -2911,16 +2907,6 @@ class TrendsFormulaNode(BaseModel):
     )
     custom_name: Optional[str] = Field(default=None, description="Optional user-defined name for the formula")
     formula: str
-
-
-class UpdateEvent(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    content: str
-    id: str
-    tool_call_id: str
-    type: Literal["ai/update"] = "ai/update"
 
 
 class UsageMetricDisplay(StrEnum):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -71,34 +71,6 @@ class AssistantBaseMultipleBreakdownFilter(BaseModel):
     property: str = Field(..., description="Property name from the plan to break down by.")
 
 
-class AssistantContextualTool(StrEnum):
-    SEARCH_SESSION_RECORDINGS = "search_session_recordings"
-    GENERATE_HOGQL_QUERY = "generate_hogql_query"
-    FIX_HOGQL_QUERY = "fix_hogql_query"
-    ANALYZE_USER_INTERVIEWS = "analyze_user_interviews"
-    CREATE_AND_QUERY_INSIGHT = "create_and_query_insight"
-    CREATE_HOG_TRANSFORMATION_FUNCTION = "create_hog_transformation_function"
-    CREATE_HOG_FUNCTION_FILTERS = "create_hog_function_filters"
-    CREATE_HOG_FUNCTION_INPUTS = "create_hog_function_inputs"
-    CREATE_MESSAGE_TEMPLATE = "create_message_template"
-    NAVIGATE = "navigate"
-    FILTER_ERROR_TRACKING_ISSUES = "filter_error_tracking_issues"
-    FIND_ERROR_TRACKING_IMPACTFUL_ISSUE_EVENT_LIST = "find_error_tracking_impactful_issue_event_list"
-    EXPERIMENT_RESULTS_SUMMARY = "experiment_results_summary"
-    CREATE_SURVEY = "create_survey"
-    ANALYZE_SURVEY_RESPONSES = "analyze_survey_responses"
-    SEARCH_DOCS = "search_docs"
-    SEARCH_INSIGHTS = "search_insights"
-    SESSION_SUMMARIZATION = "session_summarization"
-    CREATE_DASHBOARD = "create_dashboard"
-    EDIT_CURRENT_DASHBOARD = "edit_current_dashboard"
-    READ_TAXONOMY = "read_taxonomy"
-    SEARCH = "search"
-    READ_DATA = "read_data"
-    TODO_WRITE = "todo_write"
-    FILTER_REVENUE_ANALYTICS = "filter_revenue_analytics"
-
-
 class AssistantDateRange(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -212,6 +184,7 @@ class AssistantMessageType(StrEnum):
     AI_NOTEBOOK = "ai/notebook"
     AI_PLANNING = "ai/planning"
     AI_TASK_EXECUTION = "ai/task_execution"
+    AI_UPDATE = "ai/update"
 
 
 class AssistantNavigateUrl(StrEnum):
@@ -283,6 +256,33 @@ class AssistantStringOrBooleanValuePropertyFilterOperator(StrEnum):
     NOT_REGEX = "not_regex"
 
 
+class AssistantTool(StrEnum):
+    SEARCH_SESSION_RECORDINGS = "search_session_recordings"
+    GENERATE_HOGQL_QUERY = "generate_hogql_query"
+    FIX_HOGQL_QUERY = "fix_hogql_query"
+    ANALYZE_USER_INTERVIEWS = "analyze_user_interviews"
+    CREATE_AND_QUERY_INSIGHT = "create_and_query_insight"
+    CREATE_HOG_TRANSFORMATION_FUNCTION = "create_hog_transformation_function"
+    CREATE_HOG_FUNCTION_FILTERS = "create_hog_function_filters"
+    CREATE_HOG_FUNCTION_INPUTS = "create_hog_function_inputs"
+    CREATE_MESSAGE_TEMPLATE = "create_message_template"
+    NAVIGATE = "navigate"
+    EDIT_CURRENT_INSIGHT = "edit_current_insight"
+    FILTER_ERROR_TRACKING_ISSUES = "filter_error_tracking_issues"
+    FIND_ERROR_TRACKING_IMPACTFUL_ISSUE_EVENT_LIST = "find_error_tracking_impactful_issue_event_list"
+    EXPERIMENT_RESULTS_SUMMARY = "experiment_results_summary"
+    CREATE_SURVEY = "create_survey"
+    ANALYZE_SURVEY_RESPONSES = "analyze_survey_responses"
+    SESSION_SUMMARIZATION = "session_summarization"
+    CREATE_DASHBOARD = "create_dashboard"
+    EDIT_CURRENT_DASHBOARD = "edit_current_dashboard"
+    READ_TAXONOMY = "read_taxonomy"
+    SEARCH = "search"
+    READ_DATA = "read_data"
+    TODO_WRITE = "todo_write"
+    FILTER_REVENUE_ANALYTICS = "filter_revenue_analytics"
+
+
 class AssistantToolCall(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -301,6 +301,7 @@ class AssistantToolCallMessage(BaseModel):
     )
     content: str
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     tool_call_id: str
     type: Literal["tool"] = "tool"
     ui_payload: Optional[dict[str, Any]] = Field(
@@ -457,6 +458,7 @@ class BaseAssistantMessage(BaseModel):
         extra="forbid",
     )
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     visible: Optional[bool] = None
 
 
@@ -630,6 +632,7 @@ class ContextMessage(BaseModel):
     )
     content: str
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     type: Literal["context"] = "context"
     visible: Optional[bool] = None
 
@@ -1373,6 +1376,7 @@ class FailureMessage(BaseModel):
     )
     content: Optional[str] = None
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     type: Literal["ai/failure"] = "ai/failure"
     visible: Optional[bool] = None
 
@@ -2327,6 +2331,7 @@ class ReasoningMessage(BaseModel):
     )
     content: str
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     substeps: Optional[list[str]] = None
     type: Literal["ai/reasoning"] = "ai/reasoning"
     visible: Optional[bool] = None
@@ -2513,24 +2518,6 @@ class RevenueCurrencyPropertyConfig(BaseModel):
     )
     property: Optional[str] = None
     static: Optional[CurrencyCode] = None
-
-
-class RootAssistantMessage1(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    content: str
-    id: Optional[str] = None
-    tool_call_id: str
-    type: Literal["tool"] = "tool"
-    ui_payload: Optional[dict[str, Any]] = Field(
-        default=None,
-        description=(
-            "Payload passed through to the frontend - specifically for calls of contextual tool. Tool call messages"
-            " without a ui_payload are not passed through to the frontend."
-        ),
-    )
-    visible: Optional[bool] = None
 
 
 class SamplingRate(BaseModel):
@@ -2917,6 +2904,16 @@ class TrendsFormulaNode(BaseModel):
     )
     custom_name: Optional[str] = Field(default=None, description="Optional user-defined name for the formula")
     formula: str
+
+
+class UpdateMessage(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    content: str
+    id: str
+    parent_tool_call_id: str
+    type: Literal["ai/update"] = "ai/update"
 
 
 class UsageMetricDisplay(StrEnum):
@@ -4368,6 +4365,7 @@ class NotebookUpdateMessage(BaseModel):
     id: Optional[str] = None
     notebook_id: str
     notebook_type: Literal["deep_research"] = "deep_research"
+    parent_tool_call_id: Optional[str] = None
     tool_calls: Optional[list[AssistantToolCall]] = None
     type: Literal["ai/notebook"] = "ai/notebook"
     visible: Optional[bool] = None
@@ -5156,6 +5154,7 @@ class TaskExecutionMessage(BaseModel):
         extra="forbid",
     )
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     tasks: list[TaskExecutionItem]
     type: Literal["ai/task_execution"] = "ai/task_execution"
     visible: Optional[bool] = None
@@ -5895,6 +5894,7 @@ class AssistantMessage(BaseModel):
     content: str
     id: Optional[str] = None
     meta: Optional[AssistantMessageMetadata] = None
+    parent_tool_call_id: Optional[str] = None
     tool_calls: Optional[list[AssistantToolCall]] = None
     type: Literal["ai"] = "ai"
     visible: Optional[bool] = None
@@ -9625,6 +9625,7 @@ class PlanningMessage(BaseModel):
         extra="forbid",
     )
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     steps: list[PlanningStep]
     type: Literal["ai/planning"] = "ai/planning"
     visible: Optional[bool] = None
@@ -14473,6 +14474,7 @@ class VisualizationMessage(BaseModel):
     ]
     id: Optional[str] = None
     initiator: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     plan: Optional[str] = None
     query: Optional[str] = ""
     short_id: Optional[str] = None
@@ -14565,6 +14567,7 @@ class MultiVisualizationMessage(BaseModel):
     )
     commentary: Optional[str] = None
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     type: Literal["ai/multi_viz"] = "ai/multi_viz"
     visible: Optional[bool] = None
     visualizations: list[VisualizationItem]
@@ -15170,6 +15173,7 @@ class HumanMessage(BaseModel):
     )
     content: str
     id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
     type: Literal["human"] = "human"
     ui_context: Optional[MaxUIContext] = None
     visible: Optional[bool] = None
@@ -15658,7 +15662,8 @@ class RootAssistantMessage(
             NotebookUpdateMessage,
             PlanningMessage,
             TaskExecutionMessage,
-            RootAssistantMessage1,
+            AssistantToolCallMessage,
+            UpdateMessage,
         ]
     ]
 ):
@@ -15672,7 +15677,8 @@ class RootAssistantMessage(
         NotebookUpdateMessage,
         PlanningMessage,
         TaskExecutionMessage,
-        RootAssistantMessage1,
+        AssistantToolCallMessage,
+        UpdateMessage,
     ]
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -114,6 +114,7 @@ class AssistantEventType(StrEnum):
     MESSAGE = "message"
     CONVERSATION = "conversation"
     NOTEBOOK = "notebook"
+    UPDATE = "update"
 
 
 class AssistantFormOption(BaseModel):
@@ -311,7 +312,6 @@ class AssistantToolCallMessage(BaseModel):
             " without a ui_payload are not passed through to the frontend."
         ),
     )
-    visible: Optional[bool] = None
 
 
 class AssistantTrendsDisplayType(RootModel[Union[str, Any]]):
@@ -417,6 +417,17 @@ class AssistantTrendsFilter(BaseModel):
     )
 
 
+class AssistantUpdateEvent(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Literal["update"] = "update"
+
+
+class AssistantUpdateEventType(RootModel[Literal["update"]]):
+    root: Literal["update"] = "update"
+
+
 class AttributionMode(StrEnum):
     FIRST_TOUCH = "first_touch"
     LAST_TOUCH = "last_touch"
@@ -459,7 +470,6 @@ class BaseAssistantMessage(BaseModel):
     )
     id: Optional[str] = None
     parent_tool_call_id: Optional[str] = None
-    visible: Optional[bool] = None
 
 
 class BaseMathType(StrEnum):
@@ -634,7 +644,6 @@ class ContextMessage(BaseModel):
     id: Optional[str] = None
     parent_tool_call_id: Optional[str] = None
     type: Literal["context"] = "context"
-    visible: Optional[bool] = None
 
 
 class CountPerActorMathType(StrEnum):
@@ -1378,7 +1387,6 @@ class FailureMessage(BaseModel):
     id: Optional[str] = None
     parent_tool_call_id: Optional[str] = None
     type: Literal["ai/failure"] = "ai/failure"
-    visible: Optional[bool] = None
 
 
 class FileSystemCount(BaseModel):
@@ -2334,7 +2342,6 @@ class ReasoningMessage(BaseModel):
     parent_tool_call_id: Optional[str] = None
     substeps: Optional[list[str]] = None
     type: Literal["ai/reasoning"] = "ai/reasoning"
-    visible: Optional[bool] = None
 
 
 class RecordingDurationFilter(BaseModel):
@@ -2906,13 +2913,13 @@ class TrendsFormulaNode(BaseModel):
     formula: str
 
 
-class UpdateMessage(BaseModel):
+class UpdateEvent(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     content: str
     id: str
-    parent_tool_call_id: str
+    tool_call_id: str
     type: Literal["ai/update"] = "ai/update"
 
 
@@ -4368,7 +4375,6 @@ class NotebookUpdateMessage(BaseModel):
     parent_tool_call_id: Optional[str] = None
     tool_calls: Optional[list[AssistantToolCall]] = None
     type: Literal["ai/notebook"] = "ai/notebook"
-    visible: Optional[bool] = None
 
 
 class PathsFilter(BaseModel):
@@ -5157,7 +5163,6 @@ class TaskExecutionMessage(BaseModel):
     parent_tool_call_id: Optional[str] = None
     tasks: list[TaskExecutionItem]
     type: Literal["ai/task_execution"] = "ai/task_execution"
-    visible: Optional[bool] = None
 
 
 class TeamTaxonomyItem(BaseModel):
@@ -5897,7 +5902,6 @@ class AssistantMessage(BaseModel):
     parent_tool_call_id: Optional[str] = None
     tool_calls: Optional[list[AssistantToolCall]] = None
     type: Literal["ai"] = "ai"
-    visible: Optional[bool] = None
 
 
 class AssistantRetentionFilter(BaseModel):
@@ -9628,7 +9632,6 @@ class PlanningMessage(BaseModel):
     parent_tool_call_id: Optional[str] = None
     steps: list[PlanningStep]
     type: Literal["ai/planning"] = "ai/planning"
-    visible: Optional[bool] = None
 
 
 class PropertyGroupFilterValue(BaseModel):
@@ -14479,7 +14482,6 @@ class VisualizationMessage(BaseModel):
     query: Optional[str] = ""
     short_id: Optional[str] = None
     type: Literal["ai/viz"] = "ai/viz"
-    visible: Optional[bool] = None
 
 
 class DatabaseSchemaQueryResponse(BaseModel):
@@ -14569,7 +14571,6 @@ class MultiVisualizationMessage(BaseModel):
     id: Optional[str] = None
     parent_tool_call_id: Optional[str] = None
     type: Literal["ai/multi_viz"] = "ai/multi_viz"
-    visible: Optional[bool] = None
     visualizations: list[VisualizationItem]
 
 
@@ -15176,7 +15177,6 @@ class HumanMessage(BaseModel):
     parent_tool_call_id: Optional[str] = None
     type: Literal["human"] = "human"
     ui_context: Optional[MaxUIContext] = None
-    visible: Optional[bool] = None
 
 
 class MaxDashboardContext(BaseModel):
@@ -15663,7 +15663,6 @@ class RootAssistantMessage(
             PlanningMessage,
             TaskExecutionMessage,
             AssistantToolCallMessage,
-            UpdateMessage,
         ]
     ]
 ):
@@ -15678,7 +15677,6 @@ class RootAssistantMessage(
         PlanningMessage,
         TaskExecutionMessage,
         AssistantToolCallMessage,
-        UpdateMessage,
     ]
 
 


### PR DESCRIPTION
## Problem
We have shipped the new single-loop executor, but not the new UI. This PR includes all frontend-related changes.

NOTE: It is not a standalone PR! It's a stacked PR with base branch `loop-executor-ui-base`, and since the logic is split between different PRs, the tests will not pass.

To test the whole flow, use the branch `loop-executor-ui-full` which collects all stacked PRs. 

<img width="548" height="879" alt="image" src="https://github.com/user-attachments/assets/9fbcb460-515d-4d9d-96dc-71096b986483" />

## Changes
- No more `ReasoningMessage, `PlanningMessage`, `TaskExecutionMessage`, they're deprecated
- New UI components are directly derived from the conversation messages:
    - "Reasoning" component is derived from the assistant message's thinking tokens
    - "Planning" component is derived from the `todo_write` call
    - "ToolCallExecution" components are derived from the other tool calls
- New `UpdateMessage` to render transient updates for tool calls.
- `AssistantContextualTool` is now `AssistantTool` and contains all tools
- `TOOL_DEFINITIONS` now contains more information about each tool, including icon, present/past tense descriptions, and sub-tools (kinds), moved from the single MaxTools, as we want a central place for these definitions, since they apply to both core backend tools and frontend-based MaxTools
- The MaxTool to edit insights now uses `edit_current_insight` instead of replacing the `create_and_query_insight` key
- All messages have a `parent_tool_call_id`, more on that in the backend PRs

## How did you test this code?
- Added tests + stories
