### PR TITLE
feat(experiments): create experiment warnings and validations (II)

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -21,6 +21,7 @@ import type { Experiment } from '~/types'
 import { ExperimentTypePanel } from './ExperimentTypePanel'
 import { ExposureCriteriaPanel } from './ExposureCriteriaPanel'
 import { MetricsPanel } from './MetricsPanel/MetricsPanel'
+import { SidePanel } from './SidePanel'
 import { VariantsPanel } from './VariantsPanel'
 import { createExperimentLogic } from './createExperimentLogic'
 
@@ -257,9 +258,7 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
             </Form>
             {/* Sidebar Checklist */}
             <div className="h-full">
-                <div className="sticky top-16">
-                    <span>Sidebar Checklist Goes Here</span>
-                </div>
+                <SidePanel experiment={experiment} onSelectPanel={setSelectedPanel} />
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/create/SidePanel.tsx
+++ b/frontend/src/scenes/experiments/create/SidePanel.tsx
@@ -1,0 +1,200 @@
+import { IconCheckCircle } from '@posthog/icons'
+import { LemonButton, LemonDivider, LemonTag } from '@posthog/lemon-ui'
+
+import { IconErrorOutline } from 'lib/lemon-ui/icons'
+
+import { ExperimentEventExposureConfig } from '~/queries/schema/schema-general'
+import type { Experiment, MultivariateFlagVariant } from '~/types'
+
+const SIDE_PANEL_KEYS = {
+    EXPERIMENT_TYPE: 'experiment-type',
+    VARIANTS: 'experiment-variants',
+    EXPOSURE_CRITERIA: 'experiment-exposure',
+    METRICS: 'experiment-metrics',
+} as const
+
+type SidePanelKey = (typeof SIDE_PANEL_KEYS)[keyof typeof SIDE_PANEL_KEYS]
+
+export type SidePanelProps = {
+    experiment: Experiment
+    onSelectPanel: (panelKey: SidePanelKey) => void
+}
+
+export const SidePanel = ({ experiment, onSelectPanel }: SidePanelProps): JSX.Element => {
+    const isComplete = true
+    const validationError = false
+    return (
+        <div className="space-y-4">
+            <div className="bg-bg-light rounded p-4 border">
+                <div className="flex items-center justify-between mb-4">
+                    <h3 className="font-semibold">Experiment Summary</h3>
+                </div>
+
+                <LemonDivider className="mb-4" />
+
+                <div className="space-y-6">
+                    <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                            {isComplete ? (
+                                <IconCheckCircle className="text-success w-5 h-5" />
+                            ) : validationError ? (
+                                <IconErrorOutline className="text-error w-5 h-5" />
+                            ) : (
+                                <div className="w-5 h-5 rounded-full border-2 border-border" />
+                            )}
+                            <div className="flex-1 font-semibold">Feature flag & variants</div>
+                            <LemonButton
+                                type={isComplete ? 'tertiary' : 'secondary'}
+                                size="small"
+                                onClick={() => onSelectPanel(SIDE_PANEL_KEYS.VARIANTS)}
+                            >
+                                Configure
+                            </LemonButton>
+                        </div>
+
+                        <div className="flex gap-3 ml-7">
+                            <div className="flex-1">
+                                <div className="flex items-start justify-between gap-2">
+                                    <div className="flex-1">
+                                        {validationError && (
+                                            <div className="text-sm text-error mb-2">
+                                                you need a control and a test variant
+                                            </div>
+                                        )}
+                                        <div className="text-sm text-muted">
+                                            Set up your feature flag key and define test variants
+                                        </div>
+
+                                        <div className="text-sm space-y-1 mt-2">
+                                            <div className="flex items-center gap-2 mb-2">
+                                                <LemonTag type="primary" size="small">
+                                                    Using default setup
+                                                </LemonTag>
+                                            </div>
+
+                                            <div className="text-muted">
+                                                Flag key:{' '}
+                                                <span className="font-mono text-default">
+                                                    {experiment.feature_flag_key}
+                                                </span>
+                                            </div>
+                                            <div className="space-y-0.5">
+                                                {experiment.parameters?.feature_flag_variants?.map(
+                                                    (variant: MultivariateFlagVariant, index: number) => (
+                                                        <div key={index} className="text-muted">
+                                                            • {variant.key}: {variant.rollout_percentage}% of users
+                                                        </div>
+                                                    )
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                            {isComplete ? (
+                                <IconCheckCircle className="text-success w-5 h-5" />
+                            ) : validationError ? (
+                                <IconErrorOutline className="text-error w-5 h-5" />
+                            ) : (
+                                <div className="w-5 h-5 rounded-full border-2 border-border" />
+                            )}
+                            <div className="flex-1 font-semibold">
+                                <span>Exposure criteria</span>
+                                <LemonTag type="primary" size="small">
+                                    Using default setup
+                                </LemonTag>
+                            </div>
+                            <LemonButton
+                                type={isComplete ? 'tertiary' : 'secondary'}
+                                size="small"
+                                onClick={() => onSelectPanel(SIDE_PANEL_KEYS.EXPOSURE_CRITERIA)}
+                            >
+                                Configure
+                            </LemonButton>
+                        </div>
+
+                        <div className="flex gap-3 ml-7">
+                            <div className="flex-1">
+                                <div className="flex items-start justify-between gap-2">
+                                    <div className="flex-1">
+                                        {validationError && (
+                                            <div className="text-sm text-error mb-2">
+                                                you need a control and a test variant
+                                            </div>
+                                        )}
+                                        <div className="text-sm text-muted">
+                                            Set up your feature flag key and define test variants
+                                        </div>
+
+                                        <div className="text-sm space-y-1 mt-2">
+                                            <div className="text-muted">
+                                                {experiment.exposure_criteria?.filterTestAccounts !== false ? '✓' : '✗'}{' '}
+                                                Filter test accounts
+                                            </div>
+                                            <div className="text-muted">
+                                                • Exposure trigger:&nbsp;
+                                                {experiment.exposure_criteria?.exposure_config
+                                                    ? (
+                                                          experiment.exposure_criteria
+                                                              ?.exposure_config as ExperimentEventExposureConfig
+                                                      ).event || 'Custom event'
+                                                    : 'Feature flag exposure'}
+                                            </div>
+                                            <div className="text-muted">
+                                                • Multi-variant:{' '}
+                                                {experiment.exposure_criteria?.multiple_variant_handling ||
+                                                    'Latest variant'}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                            {isComplete ? (
+                                <IconCheckCircle className="text-success w-5 h-5" />
+                            ) : validationError ? (
+                                <IconErrorOutline className="text-error w-5 h-5" />
+                            ) : (
+                                <div className="w-5 h-5 rounded-full border-2 border-border" />
+                            )}
+                            <div className="flex-1 font-semibold">Metrics</div>
+                            <LemonButton
+                                type={isComplete ? 'tertiary' : 'secondary'}
+                                size="small"
+                                onClick={() => onSelectPanel(SIDE_PANEL_KEYS.METRICS)}
+                            >
+                                Configure
+                            </LemonButton>
+                        </div>
+
+                        <div className="flex gap-3 ml-7">
+                            <div className="flex-1">
+                                <div className="flex items-start justify-between gap-2">
+                                    <div className="flex-1">
+                                        {validationError && (
+                                            <div className="text-sm text-error mb-2">
+                                                you need a control and a test variant
+                                            </div>
+                                        )}
+                                        <div className="text-sm text-muted">
+                                            Set up your feature flag key and define test variants
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Problem

The _experiment_ entity in the system has a complicated taxonomy of relationships, with dependent elements like metrics and relations to other entities like _feature flags_. 
The _create experiment_ form tries to reduce the cognitive load of defining these relationships by grouping related items into _collapsible panels_. One challenge for this strategy is making validation errors and warnings visible ot the user.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

| Experiment summary side panel |
| - |
| <img width="1643" height="858" alt="image" src="https://github.com/user-attachments/assets/1b34a6c9-5dca-4e01-b446-2c2c78959bd1" /> |

We have three severities for alerts:

- ✅ (green checkmark): when a panel is complete and the experiment can be __saved as draft__ or __launched__.
- ❗ (red exclamation point): when the experiment can't be __saved as draft__.
- ⚠️ (brown warning sign): when the experiment can be __saved as draft__, but not __launched__.

### Side panel validation status and messages

For every panel, we have a matching section on the summary, with the same title and a button to _Configure_ that opens the correct panel.

#### Feature flags and variants

For feature flags and variants, we don't have warnings because any misconfiguration prevents the experiment from being saved as __draft__. Changing this would require changes in the database structure.

We show a ✅ if the feature flag key is valid, and we have at least two metrics, and the sum of all exposures is 100%. The same rules apply when linking to an existing feature flag. Otherwise, we show a ❗. 

As part of the summary, we include the key name and the variants with their distribution percentage.

#### Exposure Criteria

We always show a ✅ because it's either _default_ or _custom event_, so there's no way not to have an event configured as the exposure criteria. But we add information about the selected properties.

As part of the summary, we show which option was selected and how we handle variants and test users.

#### Metrics

For metrics, we have a ✅ if there's at least one primary metric, and a ⚠️ if there are none. Having no primary metrics only prevents the experiment from launching.

As part of the summary, we show the primary and secondary metric counts.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/6be0dfbc-7a32-4baa-8d85-9279cc49991c)

<!-- Could you describe the steps you took? -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
