### PR TITLE
fix: don't override tzinfo if the given date has explicit tzinfo

### DIFF
--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -114,14 +114,9 @@ class ReplaceFilters(CloningVisitor):
             dateTo = self.filters.dateRange.date_to if self.filters.dateRange else None
             if dateTo is not None:
                 try:
-                    parsed_date = isoparse(dateTo).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateTo).tzinfo is not None:
-                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
-                        # create a temporary exception just to capture it and make debugging easier
-                        try:
-                            raise Exception("timezone would be overridden")
-                        except Exception as e:
-                            capture_exception(e)
+                    parsed_date = isoparse(dateTo)
+                    if parsed_date.tzinfo is None:
+                        parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
                 except ValueError:
                     parsed_date = relative_date_parse(dateTo, self.team.timezone_info)
                 exprs.append(
@@ -136,14 +131,9 @@ class ReplaceFilters(CloningVisitor):
             dateFrom = self.filters.dateRange.date_from if self.filters.dateRange else None
             if dateFrom is not None and dateFrom != "all":
                 try:
-                    parsed_date = isoparse(dateFrom).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateFrom).tzinfo is not None:
-                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
-                        # create a temporary exception just to capture it and make debugging easier
-                        try:
-                            raise Exception("timezone would be overridden")
-                        except Exception as e:
-                            capture_exception(e)
+                    parsed_date = isoparse(dateFrom)
+                    if parsed_date.tzinfo is None:
+                        parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
                 except ValueError:
                     parsed_date = relative_date_parse(dateFrom, self.team.timezone_info)
                 exprs.append(
@@ -175,14 +165,9 @@ class ReplaceFilters(CloningVisitor):
             dateFrom = self.filters.dateRange.date_from if self.filters.dateRange else None
             if dateFrom is not None and dateFrom != "all":
                 try:
-                    parsed_date = isoparse(dateFrom).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateFrom).tzinfo is not None:
-                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
-                        # create a temporary exception just to capture it and make debugging easier
-                        try:
-                            raise Exception("timezone would be overridden")
-                        except Exception as e:
-                            capture_exception(e)
+                    parsed_date = isoparse(dateFrom)
+                    if parsed_date.tzinfo is None:
+                        parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
                 except ValueError:
                     parsed_date = relative_date_parse(dateFrom, self.team.timezone_info)
 
@@ -202,14 +187,9 @@ class ReplaceFilters(CloningVisitor):
             dateTo = self.filters.dateRange.date_to if self.filters.dateRange else None
             if dateTo is not None:
                 try:
-                    parsed_date = isoparse(dateTo).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateTo).tzinfo is not None:
-                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
-                        # create a temporary exception just to capture it and make debugging easier
-                        try:
-                            raise Exception("timezone would be overridden")
-                        except Exception as e:
-                            capture_exception(e)
+                    parsed_date = isoparse(dateTo)
+                    if parsed_date.tzinfo is None:
+                        parsed_date = parsed_date.replace(tzinfo=self.team.timezone_info)
                 except ValueError:
                     parsed_date = relative_date_parse(dateTo, self.team.timezone_info)
                 return ast.Constant(value=parsed_date)

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -10,7 +10,6 @@ from posthog.hogql.errors import QueryError
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.visitor import CloningVisitor
 
-from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.utils import relative_date_parse
 


### PR DESCRIPTION
## Problem
we should only set the tzinfo here if we're given a naive date, if we explicitly pass e.g. a UTC date replacing the tzinfo breaks it

this was breaking the logs sparkline query as we sent UTC datetimes from the frontend

i just hope we don't rely on this bug anywhere 😬 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
