### PR TITLE
fix(flags): Constrain rollout % to 0-100

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -428,10 +428,13 @@ export function FeatureFlagReleaseConditions({
                                 {group.sort_key && affectedUsers[group.sort_key] !== undefined ? (
                                     <b>
                                         {`${
-                                            computeBlastRadiusPercentage(
-                                                group.rollout_percentage,
-                                                group.sort_key
-                                            ).toPrecision(2) * 1
+                                            Math.max(
+                                                computeBlastRadiusPercentage(
+                                                    group.rollout_percentage,
+                                                    group.sort_key
+                                                ).toPrecision(2) * 1,
+                                                0
+                                            )
                                             // Multiplying by 1 removes trailing zeros after the decimal
                                             // point added by toPrecision
                                         }% `}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -447,7 +447,10 @@ export function FeatureFlagReleaseConditions({
                                         totalUsers !== null
                                     ) {
                                         return `(${humanFriendlyNumber(
-                                            Math.floor((affectedUserCount * (group.rollout_percentage ?? 100)) / 100)
+                                            Math.floor(
+                                                (affectedUserCount * Math.min(group.rollout_percentage ?? 100, 100)) /
+                                                    100
+                                            )
                                         )} / ${humanFriendlyNumber(totalUsers)})`
                                     }
                                     return ''

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -24,7 +24,7 @@ import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { IconArrowDown, IconArrowUp, IconErrorOutline, IconOpenInNew, IconSubArrowRight } from 'lib/lemon-ui/icons'
-import { capitalizeFirstLetter, dateFilterToText, dateStringToComponents, humanFriendlyNumber } from 'lib/utils'
+import { capitalizeFirstLetter, clamp, dateFilterToText, dateStringToComponents, humanFriendlyNumber } from 'lib/utils'
 import { FeatureFlagConditionWarning } from 'scenes/feature-flags/FeatureFlagConditionWarning'
 import { urls } from 'scenes/urls'
 
@@ -448,7 +448,7 @@ export function FeatureFlagReleaseConditions({
                                     ) {
                                         return `(${humanFriendlyNumber(
                                             Math.floor(
-                                                (affectedUserCount * Math.min(group.rollout_percentage ?? 100, 100)) /
+                                                (affectedUserCount * clamp(group.rollout_percentage ?? 100, 0, 100)) /
                                                     100
                                             )
                                         )} / ${humanFriendlyNumber(totalUsers)})`

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -430,7 +430,9 @@ export function FeatureFlagReleaseConditions({
                                         {`${
                                             Math.max(
                                                 computeBlastRadiusPercentage(
-                                                    group.rollout_percentage,
+                                                    Number.isNaN(group.rollout_percentage)
+                                                        ? 0
+                                                        : group.rollout_percentage,
                                                     group.sort_key
                                                 ).toPrecision(2) * 1,
                                                 0
@@ -449,11 +451,11 @@ export function FeatureFlagReleaseConditions({
                                         affectedUserCount >= 0 &&
                                         totalUsers !== null
                                     ) {
+                                        const rolloutPct = Number.isNaN(group.rollout_percentage)
+                                            ? 0
+                                            : (group.rollout_percentage ?? 100)
                                         return `(${humanFriendlyNumber(
-                                            Math.floor(
-                                                (affectedUserCount * clamp(group.rollout_percentage ?? 100, 0, 100)) /
-                                                    100
-                                            )
+                                            Math.floor((affectedUserCount * clamp(rolloutPct, 0, 100)) / 100)
                                         )} / ${humanFriendlyNumber(totalUsers)})`
                                     }
                                     return ''

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -535,6 +535,61 @@ describe('the feature flag release conditions logic', () => {
         })
     })
 
+    describe('rollout percentage validation', () => {
+        it('validates rollout percentage is defined', () => {
+            const filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: undefined, variant: null, sort_key: 'A' },
+            ])
+            logic.actions.setFilters(filters)
+
+            expect(logic.values.propertySelectErrors[0].rollout_percentage).toBe('You need to set a rollout % value')
+        })
+
+        it('validates rollout percentage is a valid number', () => {
+            const filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: NaN, variant: null, sort_key: 'A' },
+            ])
+            logic.actions.setFilters(filters)
+
+            expect(logic.values.propertySelectErrors[0].rollout_percentage).toBe(
+                'Rollout percentage must be a valid number'
+            )
+        })
+
+        it('validates rollout percentage is within 0-100 range', () => {
+            let filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: -10, variant: null, sort_key: 'A' },
+            ])
+            logic.actions.setFilters(filters)
+
+            expect(logic.values.propertySelectErrors[0].rollout_percentage).toBe(
+                'Rollout percentage must be between 0 and 100'
+            )
+
+            filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: 150, variant: null, sort_key: 'A' },
+            ])
+            logic.actions.setFilters(filters)
+
+            expect(logic.values.propertySelectErrors[0].rollout_percentage).toBe(
+                'Rollout percentage must be between 0 and 100'
+            )
+        })
+
+        it('accepts valid rollout percentages', () => {
+            const filters = generateFeatureFlagFilters([
+                { properties: [], rollout_percentage: 0, variant: null, sort_key: 'A' },
+                { properties: [], rollout_percentage: 50, variant: null, sort_key: 'B' },
+                { properties: [], rollout_percentage: 100, variant: null, sort_key: 'C' },
+            ])
+            logic.actions.setFilters(filters)
+
+            expect(logic.values.propertySelectErrors[0].rollout_percentage).toBeUndefined()
+            expect(logic.values.propertySelectErrors[1].rollout_percentage).toBeUndefined()
+            expect(logic.values.propertySelectErrors[2].rollout_percentage).toBeUndefined()
+        })
+    })
+
     describe('condition set descriptions', () => {
         it('updates description for a condition set', () => {
             const filters = generateFeatureFlagFilters([

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -486,7 +486,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                         value: isEmptyProperty(property) ? "Property filters can't be empty" : undefined,
                     })),
                     rollout_percentage:
-                        rollout_percentage === undefined
+                        rollout_percentage === undefined || rollout_percentage === null
                             ? 'You need to set a rollout % value'
                             : isNaN(Number(rollout_percentage))
                               ? 'Rollout percentage must be a valid number'

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -486,7 +486,13 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                         value: isEmptyProperty(property) ? "Property filters can't be empty" : undefined,
                     })),
                     rollout_percentage:
-                        rollout_percentage === undefined ? 'You need to set a rollout % value' : undefined,
+                        rollout_percentage === undefined
+                            ? 'You need to set a rollout % value'
+                            : isNaN(Number(rollout_percentage))
+                              ? 'Rollout percentage must be a valid number'
+                              : rollout_percentage < 0 || rollout_percentage > 100
+                                ? 'Rollout percentage must be between 0 and 100'
+                                : undefined,
                     variant: null,
                 }))
             },


### PR DESCRIPTION

## Problem

No client-side validation was in place for roll out percentages outside of the 0-100% range.

Closes #39528

## Changes

Client-side validation now occurs for numbers outside of 0-100. Affect users count cannot exceed total users.

https://github.com/user-attachments/assets/9fc5db1a-a3ab-45af-909b-5ae85536bb89


## How did you test this code?

Added additional unit tests