### PR TITLE
feat: sample teams onto the posthog replay script

### DIFF
--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -42,6 +42,11 @@ SESSION_REPLAY_RRWEB_SCRIPT = get_from_env("SESSION_REPLAY_RRWEB_SCRIPT", None, 
 # can be a comma separated list of team ids or '*' to allow all teams
 SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS = get_list(get_from_env("SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS", ""))
 
+# sample rate for teams to receive SESSION_REPLAY_RRWEB_SCRIPT (value between 0.0 and 1.0)
+# teams will receive the script if they are in the allowlist OR pass the sample rate check
+# uses stable hash-based sampling so the same team always gets the same result
+SESSION_REPLAY_RRWEB_SCRIPT_SAMPLE_RATE = get_from_env("SESSION_REPLAY_RRWEB_SCRIPT_SAMPLE_RATE", 0.01, type_cast=float)
+
 # an AI model to use for session recording filters
 SESSION_REPLAY_AI_REGEX_MODEL = get_from_env("SESSION_REPLAY_AI_REGEX_MODEL", "gpt-4.1-mini")
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -259,6 +259,9 @@ pub struct Config {
     #[envconfig(from = "SESSION_REPLAY_RRWEB_SCRIPT_ALLOWED_TEAMS", default = "none")]
     pub session_replay_rrweb_script_allowed_teams: TeamIdCollection,
 
+    #[envconfig(from = "SESSION_REPLAY_RRWEB_SCRIPT_SAMPLE_RATE", default = "0.01")]
+    pub session_replay_rrweb_script_sample_rate: f64,
+
     #[envconfig(from = "FLAGS_SESSION_REPLAY_QUOTA_CHECK", default = "false")]
     pub flags_session_replay_quota_check: bool,
 
@@ -318,6 +321,7 @@ impl Config {
             debug: FlexBool(false),
             session_replay_rrweb_script: "".to_string(),
             session_replay_rrweb_script_allowed_teams: TeamIdCollection::None,
+            session_replay_rrweb_script_sample_rate: 0.01,
             flags_session_replay_quota_check: false,
             otel_url: None,
             otel_sampling_rate: 1.0,


### PR DESCRIPTION
## Problem

totally draft!

we can roll the posthog-recorder out to one team at a time but that's now too slow

so we need to roll it out to a percentage of teams

## Changes

this means sampling by team to determine which script they should load

this has to be done in remote config, decide, and flags services

## How did you test this code?

i didn't yet

## Changelog: (features only) Is this feature complete?

don't put this in the changelog at all, no