### PR TITLE
feat(surveys): add bulk survey duplication endpoint

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import transaction
 from django.db.models import Min
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
@@ -43,7 +44,7 @@ from posthog.models import Action
 from posthog.models.activity_logging.activity_log import Change, Detail, changes_between, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.feature_flag import FeatureFlag
-from posthog.models.surveys.survey import MAX_ITERATION_COUNT, Survey
+from posthog.models.surveys.survey import MAX_ITERATION_COUNT, Survey, ensure_question_ids
 from posthog.models.surveys.util import (
     SurveyEventName,
     SurveyEventProperties,
@@ -1327,6 +1328,174 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         if timings_header:
             r.headers["Server-Timing"] = timings_header
         return r
+
+    @action(methods=["POST"], detail=True, required_scopes=["survey:write"])
+    def duplicate_to_projects(self, request: request.Request, **kwargs):
+        """Duplicate a survey to multiple projects in a single transaction.
+
+        Accepts a list of target team IDs and creates a copy of the survey in each project.
+        Uses an all-or-nothing approach - if any duplication fails, all changes are rolled back.
+        """
+        if not request.user.is_authenticated:
+            raise exceptions.NotAuthenticated()
+
+        user = cast(User, request.user)
+        survey_id = kwargs["pk"]
+
+        if not Survey.objects.filter(id=survey_id, team__project_id=self.project_id).exists():
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        source_survey = self.get_object()
+        target_team_ids = request.data.get("target_team_ids", [])
+
+        if not target_team_ids or not isinstance(target_team_ids, list):
+            raise exceptions.ValidationError("target_team_ids must be a non-empty list of team IDs")
+
+        user_organization = user.organization
+        if not user_organization:
+            raise exceptions.ValidationError("User must belong to an organization")
+
+        target_teams = Team.objects.filter(id__in=target_team_ids, organization_id=user_organization.id)
+
+        if len(target_teams) != len(target_team_ids):
+            raise exceptions.ValidationError("One or more target teams not found or you don't have access to them")
+
+        duplicate_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        created_surveys = []
+
+        try:
+            with transaction.atomic():
+                # Validate all survey data first
+                surveys_to_create = []
+                for team in target_teams:
+                    cleaned_conditions = None
+                    if source_survey.conditions:
+                        cleaned_conditions = dict(source_survey.conditions)
+                        # Remove project-specific fields: flags, actions, and events don't transfer across projects
+                        cleaned_conditions.pop("linkedFlagVariant", None)
+                        cleaned_conditions.pop("actions", None)
+                        cleaned_conditions.pop("events", None)
+
+                    survey_data = {
+                        "name": f"{source_survey.name} (duplicated at {duplicate_timestamp})",
+                        "description": source_survey.description,
+                        "type": source_survey.type,
+                        "questions": [
+                            {k: v for k, v in q.items() if k != "id"} for q in (source_survey.questions or [])
+                        ],
+                        "appearance": source_survey.appearance,
+                        "conditions": cleaned_conditions,
+                        "archived": False,
+                        "start_date": None,
+                        "end_date": None,
+                        "responses_limit": source_survey.responses_limit,
+                        "iteration_count": source_survey.iteration_count,
+                        "iteration_frequency_days": source_survey.iteration_frequency_days,
+                        "schedule": source_survey.schedule,
+                        "enable_partial_responses": source_survey.enable_partial_responses,
+                    }
+                    # NOTE: linked_flag_id, targeting_flag, and internal flags are intentionally omitted
+                    # as they are project-specific and don't exist in other projects
+
+                    serializer = SurveySerializerCreateUpdateOnly(
+                        data=survey_data,
+                        context={
+                            "request": request,
+                            "team_id": team.id,
+                            "project_id": team.project_id,
+                        },
+                    )
+
+                    serializer.is_valid(raise_exception=True)
+
+                    # Build Survey instance from validated data
+                    new_survey = Survey(
+                        team=team,
+                        created_by=user,
+                        **serializer.validated_data,
+                    )
+                    surveys_to_create.append(new_survey)
+
+                for survey in surveys_to_create:
+                    ensure_question_ids(survey)
+
+                # Bulk create all surveys
+                created_survey_objects = Survey.objects.bulk_create(surveys_to_create)
+
+                # Prepare response data and activity logs
+                for created_survey in created_survey_objects:
+                    created_surveys.append(
+                        {
+                            "team_id": created_survey.team_id,
+                            "survey_id": str(created_survey.id),
+                            "name": created_survey.name,
+                        }
+                    )
+
+                    log_activity(
+                        organization_id=user_organization.id,
+                        team_id=created_survey.team_id,
+                        user=user,
+                        was_impersonated=is_impersonated_session(request),
+                        item_id=created_survey.id,
+                        scope="Survey",
+                        activity="created",
+                        detail=Detail(
+                            name=created_survey.name,
+                            changes=[
+                                Change(
+                                    type="Survey",
+                                    action="created",
+                                    field="source_survey_id",
+                                    after=str(survey_id),
+                                )
+                            ],
+                        ),
+                    )
+
+        except exceptions.ValidationError as e:
+            structlog.get_logger(__name__).error(
+                "bulk_survey_duplication_validation_error",
+                error=str(e),
+                error_detail=e.detail if hasattr(e, "detail") else None,
+                survey_id=survey_id,
+                user_id=user.id,
+                target_team_ids=target_team_ids,
+            )
+            raise
+        except Exception as e:
+            structlog.get_logger(__name__).error(
+                "bulk_survey_duplication_error",
+                error=str(e),
+                error_type=type(e).__name__,
+                survey_id=survey_id,
+                user_id=user.id,
+                target_team_ids=target_team_ids,
+            )
+            capture_exception(e)
+            raise exceptions.ValidationError(
+                {
+                    "error": "Bulk duplication failed due to an unexpected error",
+                }
+            )
+
+        posthoganalytics.capture(
+            event="survey bulk duplicated",
+            distinct_id=str(user.distinct_id),
+            properties={
+                "source_survey_id": str(survey_id),
+                "target_count": len(created_surveys),
+                "target_team_ids": target_team_ids,
+            },
+        )
+
+        return Response(
+            {
+                "created_surveys": created_surveys,
+                "count": len(created_surveys),
+            },
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class SurveyConfigSerializer(serializers.ModelSerializer):

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -1,5 +1,6 @@
 import re
 import json
+import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -29,6 +30,7 @@ from posthog.api.test.test_personal_api_keys import PersonalAPIKeysBaseTest
 from posthog.constants import AvailableFeature
 from posthog.models import Action, FeatureFlag, Person, Team
 from posthog.models.cohort.cohort import Cohort
+from posthog.models.organization import Organization
 from posthog.models.surveys.survey import MAX_ITERATION_COUNT, Survey
 
 
@@ -3953,3 +3955,264 @@ class TestExternalSurveyValidation(APIBaseTest):
 )
 def test_nh3_clean_configuration(test_input, expected):
     assert nh3_clean_with_allow_list(test_input).replace(" ", "") == expected.replace(" ", "")
+
+
+class TestSurveyBulkDuplication(APIBaseTest):
+    """Test bulk survey duplication endpoint"""
+
+    def setUp(self):
+        super().setUp()
+        # Create additional teams in the same organization
+        self.team2 = Team.objects.create(organization=self.organization, name="Team 2")
+        self.team3 = Team.objects.create(organization=self.organization, name="Team 3")
+
+        # Create a survey to duplicate
+        self.source_survey = Survey.objects.create(
+            team=self.team,
+            name="Source Survey",
+            description="A survey to be duplicated",
+            type="popover",
+            questions=[
+                {"id": str(uuid.uuid4()), "type": "open", "question": "What do you think?"},
+                {"id": str(uuid.uuid4()), "type": "rating", "question": "Rate us", "scale": 5},
+            ],
+            created_by=self.user,
+        )
+
+    def test_bulk_duplicate_to_multiple_projects(self):
+        """Test successful bulk duplication to multiple projects"""
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id, self.team3.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+
+        # Check response structure
+        assert "created_surveys" in response_data
+        assert "count" in response_data
+        assert response_data["count"] == 2
+        assert len(response_data["created_surveys"]) == 2
+
+        # Verify surveys were created in target teams
+        team2_survey = Survey.objects.get(team=self.team2)
+        team3_survey = Survey.objects.get(team=self.team3)
+
+        # Check that surveys have the correct names (with timestamp)
+        assert "Source Survey (duplicated at" in team2_survey.name
+        assert "Source Survey (duplicated at" in team3_survey.name
+
+        # Verify survey content was copied correctly
+        assert team2_survey.questions is not None
+        assert len(team2_survey.questions) == 2
+        assert team2_survey.questions[0]["type"] == "open"
+        assert team2_survey.questions[1]["type"] == "rating"
+        assert team2_survey.description == "A survey to be duplicated"
+        assert team2_survey.type == "popover"
+
+        # Verify surveys are created as drafts
+        assert team2_survey.start_date is None
+        assert team3_survey.start_date is None
+        assert team2_survey.archived is False
+        assert team3_survey.archived is False
+
+    def test_bulk_duplicate_to_single_project(self):
+        """Test bulk duplication works with a single target project"""
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        assert response_data["count"] == 1
+        assert Survey.objects.filter(team=self.team2).count() == 1
+
+    def test_bulk_duplicate_with_empty_team_ids(self):
+        """Test that empty target_team_ids returns validation error"""
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": []},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "target_team_ids must be a non-empty list" in str(response.json())
+
+    def test_bulk_duplicate_with_missing_team_ids(self):
+        """Test that missing target_team_ids returns validation error"""
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_bulk_duplicate_with_nonexistent_team(self):
+        """Test that nonexistent team IDs return validation error"""
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id, 99999]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "not found" in str(response.json()).lower()
+
+    def test_bulk_duplicate_with_team_from_different_org(self):
+        """Test that teams from different organizations are rejected"""
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id, other_team.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "not found" in str(response.json()).lower()
+
+    def test_bulk_duplicate_multiple_times_to_same_team(self):
+        """Test that multiple duplications to the same team create surveys with different timestamps"""
+        # Create first duplicate
+        response1 = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+        assert response1.status_code == status.HTTP_201_CREATED
+
+        # Wait a second to ensure different timestamp
+        time.sleep(1)
+
+        # Try to create another duplicate (should succeed because timestamp is different)
+        response2 = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+        assert response2.status_code == status.HTTP_201_CREATED
+
+        # Verify two surveys exist with different names
+        team2_surveys = Survey.objects.filter(team=self.team2).order_by("created_at")
+        assert team2_surveys.count() == 2
+        assert team2_surveys[0].name != team2_surveys[1].name
+
+    def test_bulk_duplicate_does_not_copy_project_specific_fields(self):
+        """Test that project-specific fields like flags and actions are not copied"""
+        # Create a survey with linked flag, targeting, and conditions
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            name="Test Flag",
+            key="test-flag",
+            created_by=self.user,
+        )
+
+        action = Action.objects.create(
+            team=self.team,
+            name="Test Action",
+        )
+
+        survey_with_specifics = Survey.objects.create(
+            team=self.team,
+            name="Survey with Project Specifics",
+            type="popover",
+            questions=[{"type": "open", "question": "Test?"}],
+            linked_flag=flag,
+            conditions={
+                "url": "https://example.com",
+                "linkedFlagVariant": "test-variant",
+                "actions": {"values": [{"id": action.id}]},
+                "events": {"values": [{"name": "test_event"}]},
+            },
+            created_by=self.user,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{survey_with_specifics.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify the duplicated survey does NOT have project-specific fields
+        duplicated = Survey.objects.get(team=self.team2)
+
+        # Linked flag should NOT be copied
+        assert duplicated.linked_flag is None
+        assert duplicated.targeting_flag is None
+
+        # Project-specific condition fields should NOT be copied
+        assert duplicated.conditions is not None
+        assert "linkedFlagVariant" not in duplicated.conditions
+        assert "actions" not in duplicated.conditions
+        assert "events" not in duplicated.conditions
+
+        # Generic condition fields SHOULD be copied
+        assert duplicated.conditions.get("url") == "https://example.com"
+
+    def test_bulk_duplicate_transaction_rollback_on_error(self):
+        """Test that all duplications are rolled back if one fails"""
+        # Create a survey with the same name in team2 to cause a conflict
+        Survey.objects.create(
+            team=self.team2,
+            name=f"{self.source_survey.name} (duplicated at 2025-01-20 12:00:00)",
+            type="popover",
+            questions=[{"type": "open", "question": "Existing"}],
+            created_by=self.user,
+        )
+
+        # This might succeed or fail depending on timestamp collision
+        # The important thing is that if it fails, it should fail atomically
+        initial_team2_count = Survey.objects.filter(team=self.team2).count()
+        initial_team3_count = Survey.objects.filter(team=self.team3).count()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id, self.team3.id]},
+            format="json",
+        )
+
+        # Regardless of success or failure, counts should be consistent
+        if response.status_code != status.HTTP_201_CREATED:
+            # If it failed, no surveys should have been created
+            assert Survey.objects.filter(team=self.team2).count() == initial_team2_count
+            assert Survey.objects.filter(team=self.team3).count() == initial_team3_count
+
+    def test_bulk_duplicate_nonexistent_survey(self):
+        """Test that duplicating a nonexistent survey returns 404"""
+        fake_uuid = uuid.uuid4()
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{fake_uuid}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_bulk_duplicate_preserves_question_ids(self):
+        """Test that question IDs are reset (set to None) in duplicated surveys"""
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        duplicated = Survey.objects.get(team=self.team2)
+        # New questions should have new IDs, not the same as the source
+        assert self.source_survey.questions is not None
+        assert duplicated.questions is not None
+        source_question_ids = [q.get("id") for q in self.source_survey.questions]
+        duplicated_question_ids = [q.get("id") for q in duplicated.questions]
+
+        # IDs should exist but be different
+        assert all(qid is not None for qid in duplicated_question_ids)
+        assert duplicated_question_ids != source_question_ids


### PR DESCRIPTION
## Problem

Survey creators often need to deploy the same survey across multiple projects (e.g., staging, production, different regions). Currently, they must duplicate surveys one at a time, which is tedious and error-prone for teams managing multiple projects.

## Changes

Add a new bulk duplication API endpoint that allows duplicating a survey to multiple projects in a single atomic operation.

**Backend changes:**
- New `duplicate_to_projects` endpoint in `SurveyViewSet`
- Accepts list of target team IDs for bulk duplication
- Uses `transaction.atomic()` for all-or-nothing behavior
- Validates all teams belong to user's organization
- Generates unique names with timestamps
- Excludes project-specific fields (linked_flag_id, targeting_flag, actions, events) as these don't exist across projects
- Comprehensive test coverage with 11 test cases

**Key technical decisions:**
- Project-specific fields intentionally omitted: flags and actions don't transfer across projects and would create broken references
- Same timestamp used for all duplicates for consistency
- Full rollback if any duplication fails (no partial success)

## How did you test this code?

Added comprehensive test suite (`TestSurveyBulkDuplication`) covering:
- ✅ Successful bulk duplication to multiple projects
- ✅ Single project duplication
- ✅ Validation errors (empty/missing/invalid team IDs)
- ✅ Security: cross-organization team rejection
- ✅ Multiple duplications to same team (timestamp uniqueness)
- ✅ Project-specific field exclusion
- ✅ Transaction rollback on error
- ✅ 404 for nonexistent surveys
- ✅ Question ID regeneration

Run tests: `pytest posthog/api/test/test_survey.py::TestSurveyBulkDuplication -v`

## Changelog: (features only) Is this feature complete?

No - this is part 1 of 2. The frontend UI will be added in the stacked PR.
