### PR TITLE
feat: Add new `TableNode` to support overlapping database names

### DIFF
--- a/docker/clickhouse/config.d/dev-memory.xml
+++ b/docker/clickhouse/config.d/dev-memory.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <clickhouse>
     <!-- Development server-level memory optimizations -->
-    <mark_cache_size>268435456</mark_cache_size> <!-- 256MB -->
-    <uncompressed_cache_size>268435456</uncompressed_cache_size> <!-- 256MB -->
+    <mark_cache_size>1073741824</mark_cache_size> <!-- 1GB -->
+    <uncompressed_cache_size>1073741824</uncompressed_cache_size> <!-- 1GB -->
     <cache_size_to_ram_max_ratio>0.25</cache_size_to_ram_max_ratio>
 </clickhouse>

--- a/ee/hogai/graph/query_planner/nodes.py
+++ b/ee/hogai/graph/query_planner/nodes.py
@@ -206,7 +206,7 @@ class QueryPlannerNode(TaxonomyReasoningNodeMixin, AssistantNode):
                 + "\n".join(f"- {field.name} ({field.type})" for field in table.fields.values())
                 for table_name, table in serialized_database.items()
                 # Only the most important core tables, plus all warehouse tables
-                if table_name in ["events", "groups", "persons"] or table_name in database.get_warehouse_tables()
+                if table_name in ["events", "groups", "persons"] or table_name in database.get_warehouse_table_names()
             )
         )
         conversation = ChatPromptTemplate(

--- a/ee/hogai/graph/sql/test/test_sql_mixins.py
+++ b/ee/hogai/graph/sql/test/test_sql_mixins.py
@@ -120,7 +120,7 @@ class TestSQLMixins(NonAtomicBaseTest):
             await mixin._quality_check_output(invalid_output)
 
         self.assertEqual(context.exception.llm_output, "SELECT * FROM nowhere")
-        self.assertEqual(context.exception.validation_message, 'Unknown table "nowhere".')
+        self.assertEqual(context.exception.validation_message, "Unknown table `nowhere`.")
 
     async def test_quality_check_output_empty_query_raises_exception(self):
         """Test quality check failure with empty query."""
@@ -175,7 +175,7 @@ class TestSQLMixins(NonAtomicBaseTest):
             await mixin._quality_check_output(invalid_table_output)
 
         self.assertEqual(context.exception.llm_output, "SELECT count() FROM nonexistent_table")
-        self.assertEqual(context.exception.validation_message, 'Unknown table "nonexistent_table".')
+        self.assertEqual(context.exception.validation_message, "Unknown table `nonexistent_table`.")
 
     async def test_quality_check_output_complex_query_with_joins(self):
         """Test quality check success with complex query including joins."""

--- a/ee/hogai/utils/warehouse.py
+++ b/ee/hogai/utils/warehouse.py
@@ -11,7 +11,7 @@ def serialize_database_schema(database: Database, hogql_context: HogQLContext):
     # Simplify the schema description by only including the most important core tables, plus all warehouse tables and views
     serialized_database = serialize_database(
         hogql_context,
-        include_only={"events", "groups", "persons", *database.get_warehouse_tables(), *database.get_views()},
+        include_only={"events", "groups", "persons", *database.get_warehouse_table_names(), *database.get_view_names()},
     )
 
     schema_description = "\n\n".join(

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -605,7 +605,6 @@ posthog/hogql/resolver.py:0: error: Incompatible types in assignment (expression
 posthog/hogql/resolver.py:0: error: Incompatible types in assignment (expression has type "Expr", variable has type "SelectQuery | SelectSetQuery | Placeholder | HogQLXTag | Field | None")  [assignment]
 posthog/hogql/resolver.py:0: error: Incompatible types in assignment (expression has type "TableType", variable has type "LazyTableType")  [assignment]
 posthog/hogql/resolver.py:0: error: Incompatible types in assignment (expression has type "Type | None", target has type "Type")  [assignment]
-posthog/hogql/resolver.py:0: error: Item "None" of "Database | None" has no attribute "get_table_by_chain"  [union-attr]
 posthog/hogql/resolver.py:0: error: Item "None" of "Type | None" has no attribute "resolve_constant_type"  [union-attr]
 posthog/hogql/resolver.py:0: error: Item "None" of "Type | None" has no attribute "resolve_constant_type"  [union-attr]
 posthog/hogql/resolver.py:0: error: Item "None" of "Type | None" has no attribute "resolve_constant_type"  [union-attr]

--- a/posthog/hogql/autocomplete.py
+++ b/posthog/hogql/autocomplete.py
@@ -218,7 +218,7 @@ def get_table(context: HogQLContext, join_expr: ast.JoinExpr, ctes: Optional[dic
         # Handle a base table
         table_chain = [str(e) for e in join_expr.table.chain]
         if context.database.has_table(table_chain):
-            return context.database.get_table_by_chain(table_chain)
+            return context.database.get_table(table_chain)
     elif isinstance(join_expr.table, ast.SelectQuery):
         if join_expr.table.select_from is None:
             return None
@@ -652,8 +652,8 @@ def get_hogql_autocomplete(
             elif isinstance(node, ast.Field) and isinstance(parent_node, ast.JoinExpr):
                 # Handle table names
                 with timings.measure("table_name"):
-                    table_names = database.get_all_tables()
-                    posthog_table_names = database.get_posthog_tables()
+                    table_names = database.get_all_table_names()
+                    posthog_table_names = database.get_posthog_table_names()
 
                     if len(node.chain) == 1:
                         extend_responses(

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -207,15 +207,13 @@ class Database(BaseModel):
     _timezone: Optional[str]
     _week_start_day: Optional[WeekStartDay]
 
-    # TODO: Improve typing, allow different levels of errors
-    diagnostics: list[str] = []
-
     def __init__(self, timezone: Optional[str] = None, week_start_day: Optional[WeekStartDay] = None):
         super().__init__()
         try:
             self._timezone = str(ZoneInfo(timezone)) if timezone else None
         except ZoneInfoNotFoundError:
             raise ValueError(f"Unknown timezone: '{str(timezone)}'")
+
         self._week_start_day = week_start_day
 
     def get_timezone(self) -> str:

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -589,7 +589,7 @@ def create_hogql_database(
         # but still allowing the bare `stripe.prefix.table_name` string access
         for view in revenue_views:
             try:
-                create_nested_table_group(view.name.split("."), views, view)
+                create_nested_table_node(view.name.split("."), views, view)
             except Exception as e:
                 capture_exception(e)
                 continue
@@ -650,7 +650,7 @@ def create_hogql_database(
                     # For a chain of type a.b.c, we want to create a nested table group
                     # where a is the parent, b is the child of a, and c is the child of b
                     # where a.b.c will contain the s3_table
-                    create_nested_table_group(table_chain, warehouse_tables, s3_table)
+                    create_nested_table_node(table_chain, warehouse_tables, s3_table)
 
                     joined_table_chain = ".".join(table_chain)
                     s3_table.name = joined_table_chain
@@ -868,7 +868,7 @@ def create_hogql_database(
     return database
 
 
-def create_nested_table_group(table_chain: list[str], root_node: TableNode, table: Table) -> None:
+def create_nested_table_node(table_chain: list[str], root_node: TableNode, table: Table) -> None:
     # Create a deeply nested table node structure
     start: TableNode = TableNode(name=table_chain[0])
     current: TableNode = start

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -132,7 +132,6 @@ class Database(BaseModel):
 
     # Users can query from the tables below
     tables: TableNode = TableNode(
-        name="root",
         children={
             "events": TableNode(name="events", table=EventsTable()),
             "groups": TableNode(name="groups", table=GroupsTable()),
@@ -558,9 +557,9 @@ def create_hogql_database(
                 events_table.fields[mapping.group_type] = FieldTraverser(chain=[f"group_{mapping.group_type_index}"])
 
     warehouse_tables_dot_notation_mapping: dict[str, str] = {}
-    warehouse_tables: TableNode = TableNode(name="root", children={})
-    self_managed_warehouse_tables: TableNode = TableNode(name="root", children={})
-    views: TableNode = TableNode(name="root", children={})
+    warehouse_tables: TableNode = TableNode()
+    self_managed_warehouse_tables: TableNode = TableNode()
+    views: TableNode = TableNode()
 
     with timings.measure("data_warehouse_saved_query"):
         with timings.measure("select"):

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -267,7 +267,7 @@ class Database(BaseModel):
         ]
 
     def get_system_table_names(self) -> list[str]:
-        return [*cast(SystemTables, self.tables.children["system"]).resolve_all_table_names(), "query_log"]
+        return ["query_log", *cast(SystemTables, self.tables.children["system"]).resolve_all_table_names()]
 
     def get_warehouse_table_names(self) -> list[str]:
         return self._warehouse_table_names + self._warehouse_self_managed_table_names
@@ -669,10 +669,13 @@ def create_hogql_database(
 
         if "." in warehouse_modifier.table_name:
             table_chain = warehouse_modifier.table_name.split(".")
-            if not root_node.has_child(table_chain[0]):
+            if table_chain[0] not in root_node.children:
                 return root_node
 
-            table = root_node.get_child(table_chain).get()
+            _table = root_node.get_child(table_chain).get()
+            assert isinstance(_table, Table)
+
+            table = _table
 
         if table is None:
             return root_node

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -208,7 +208,7 @@ class TableNode(
 ):
     model_config = ConfigDict(extra="forbid")
 
-    name: Literal["root"] | str
+    name: Literal["root"] | str = "root"  # Default to root for ease of use
     table: FieldOrTable | None = None
     children: dict[str, "TableNode"] = {}
 

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -266,7 +266,6 @@ class TableNode(
 
         self.children[child.name] = child
 
-    # TODO: Add error and warning modes for `table_conflict_mode``, should append to the diagnostics context
     def merge_with(
         self,
         other: "TableNode",

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -306,6 +306,23 @@ class TableNode(
 
         return names
 
+    @staticmethod
+    def create_nested_for_chain(chain: list[str], table: Table) -> "TableNode":
+        assert len(chain) > 0
+
+        # Create a deeply nested table node structure
+        start: TableNode = TableNode(name=chain[0])
+        current: TableNode = start
+        for name in chain[1:]:
+            child = TableNode(name=name)
+            current.add_child(child)
+            current = child
+
+        # Add the table at the end
+        current.table = table
+
+        return start
+
 
 class LazyJoin(FieldOrTable):
     model_config = ConfigDict(extra="forbid")

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -240,7 +240,7 @@ class TableNode(
 
         first, *rest_of_path = path
         if first not in self.children:
-            raise ResolutionError(f"Unknown children `{first}` at `{self.name}`.")
+            raise ResolutionError(f"Unknown child `{first}` at `{self.name}`.")
 
         return self.children[first].get_child(rest_of_path)
 

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -273,16 +273,14 @@ class TableNode(
         table_conflict_mode: Literal["override", "ignore"] = "ignore",
         children_conflict_mode: Literal["override", "merge", "ignore"] = "merge",
     ):
-        if self.table is None and other.table is not None:
-            self.table = other.table
-            return
-
-        # This implies we have a conflict so check conflict mode to decide what to do here
-        if self.table is not None and other.table is not None:
-            if table_conflict_mode == "override":
+        if other.table is not None:
+            if self.table is None:  # Easy case, just set it
                 self.table = other.table
-            elif table_conflict_mode == "ignore":
-                pass
+            else:  # We have a conflict so check conflict mode to decide what to do here
+                if table_conflict_mode == "override":
+                    self.table = other.table
+                elif table_conflict_mode == "ignore":
+                    pass
 
         for child in other.children.values():
             self.add_child(

--- a/posthog/hogql/database/schema/groups_revenue_analytics.py
+++ b/posthog/hogql/database/schema/groups_revenue_analytics.py
@@ -58,7 +58,7 @@ def select_from_groups_revenue_analytics_table(context: HogQLContext) -> ast.Sel
     # Get all customer/revenue item pairs from the existing views making sure we ignore `all`
     # since the `group` join is in the child view
     all_views: dict[str, dict[type[RevenueAnalyticsBaseView], RevenueAnalyticsBaseView]] = defaultdict(defaultdict)
-    for view_name in context.database.get_views():
+    for view_name in context.database.get_view_names():
         view = context.database.get_table(view_name)
 
         if isinstance(view, RevenueAnalyticsBaseView) and not view.union_all:

--- a/posthog/hogql/database/schema/persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/persons_revenue_analytics.py
@@ -58,7 +58,7 @@ def select_from_persons_revenue_analytics_table(context: HogQLContext) -> ast.Se
     # Get all customer/revenue item pairs from the existing views making sure we ignore `all`
     # since the `persons` join is in the child view
     all_views: dict[str, dict[type[RevenueAnalyticsBaseView], RevenueAnalyticsBaseView]] = defaultdict(defaultdict)
-    for view_name in context.database.get_views():
+    for view_name in context.database.get_view_names():
         view = context.database.get_table(view_name)
 
         if isinstance(view, RevenueAnalyticsBaseView) and not view.union_all:

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -209,7 +209,7 @@ exports: PostgresTable = PostgresTable(
 
 class SystemTables(TableNode):
     name: str = "system"
-    tables: dict[str, TableNode] = {
+    children: dict[str, TableNode] = {
         "dashboards": TableNode(name="dashboards", table=dashboards),
         "cohorts": TableNode(name="cohorts", table=cohorts),
         "insights": TableNode(name="insights", table=insights),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -6,8 +6,7 @@ from posthog.hogql.database.models import (
     IntegerDatabaseField,
     StringDatabaseField,
     StringJSONDatabaseField,
-    Table,
-    TableGroup,
+    TableNode,
 )
 from posthog.hogql.database.postgres_table import PostgresTable
 
@@ -208,23 +207,19 @@ exports: PostgresTable = PostgresTable(
 )
 
 
-class SystemTables(TableGroup):
-    tables: dict[str, Table | TableGroup] = {
-        "dashboards": dashboards,
-        "cohorts": cohorts,
-        "insights": insights,
-        "experiments": experiments,
-        "exports": exports,
-        "data_warehouse_sources": data_warehouse_sources,
-        "feature_flags": feature_flags,
-        "groups": groups,
-        "group_type_mappings": group_type_mappings,
-        "insight_variables": insight_variables,
-        "surveys": surveys,
-        "teams": teams,
+class SystemTables(TableNode):
+    name: str = "system"
+    tables: dict[str, TableNode] = {
+        "dashboards": TableNode(name="dashboards", table=dashboards),
+        "cohorts": TableNode(name="cohorts", table=cohorts),
+        "insights": TableNode(name="insights", table=insights),
+        "experiments": TableNode(name="experiments", table=experiments),
+        "exports": TableNode(name="exports", table=exports),
+        "data_warehouse_sources": TableNode(name="data_warehouse_sources", table=data_warehouse_sources),
+        "feature_flags": TableNode(name="feature_flags", table=feature_flags),
+        "groups": TableNode(name="groups", table=groups),
+        "group_type_mappings": TableNode(name="group_type_mappings", table=group_type_mappings),
+        "insight_variables": TableNode(name="insight_variables", table=insight_variables),
+        "surveys": TableNode(name="surveys", table=surveys),
+        "teams": TableNode(name="teams", table=teams),
     }
-
-    def resolve_all_table_names(self) -> list[str]:
-        tables = super().resolve_all_table_names()
-
-        return [f"system.{table}" for table in tables]

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -106,8 +106,8 @@ class TestDatabase(BaseTest, QueryMatchingTest):
 
         serialized_database = serialize_database(HogQLContext(team_id=self.team.pk, database=database))
 
-        tables = database.get_posthog_tables()
-        for table_name in tables:
+        posthog_table_names = database.get_posthog_table_names()
+        for table_name in posthog_table_names:
             assert serialized_database.get(table_name) is not None
 
     def test_serialize_database_deleted_saved_query(self):
@@ -1106,8 +1106,8 @@ class TestDatabase(BaseTest, QueryMatchingTest):
     def test_team_id_on_all_tables(self):
         db = create_hogql_database(team=self.team)
 
-        tables = db.get_all_tables()
-        for table_name in tables:
+        table_names = db.get_all_table_names()
+        for table_name in table_names:
             table = db.get_table(table_name)
             assert table is not None
             assert isinstance(table, Table)

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -452,7 +452,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         )
         db = create_hogql_database(team=self.team)
 
-        assert db.events.fields["test"] == FieldTraverser(chain=["group_0"])
+        assert db.get_table("events").fields["test"] == FieldTraverser(chain=["group_0"])
 
     def test_database_group_type_mappings_overwrite(self):
         create_group_type_mapping_without_created_at(
@@ -460,12 +460,14 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         )
         db = create_hogql_database(team=self.team)
 
-        assert db.events.fields["event"] == StringDatabaseField(name="event", nullable=False)
+        assert db.get_table("events").fields["event"] == StringDatabaseField(name="event", nullable=False)
 
     def test_database_expression_fields(self):
         db = create_hogql_database(team=self.team)
-        db.numbers.fields["expression"] = ExpressionField(name="expression", expr=parse_expr("1 + 1"))
-        db.numbers.fields["double"] = ExpressionField(name="double", expr=parse_expr("number * 2"))
+
+        numbers_table = db.get_table("numbers")
+        numbers_table.fields["expression"] = ExpressionField(name="expression", expr=parse_expr("1 + 1"))
+        numbers_table.fields["double"] = ExpressionField(name="double", expr=parse_expr("number * 2"))
         context = HogQLContext(
             team_id=self.team.pk,
             enable_select_queries=True,
@@ -591,7 +593,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             database=db,
         )
 
-        pdi = cast(LazyJoin, db.events.fields["pdi"])
+        pdi = cast(LazyJoin, db.get_table("events").fields["pdi"])
         pdi_persons_join = cast(LazyJoin, pdi.resolve_table(context).fields["person"])
         pdi_table = pdi_persons_join.resolve_table(context)
 
@@ -617,7 +619,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             database=db,
         )
 
-        poe = cast(Table, db.events.fields["poe"])
+        poe = cast(Table, db.get_table("events").fields["poe"])
 
         assert poe.fields["some_field"] is not None
 
@@ -642,7 +644,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             database=db,
         )
 
-        poe = cast(Table, db.events.fields["poe"])
+        poe = cast(Table, db.get_table("events").fields["poe"])
 
         assert poe.fields["some_field"] is not None
 
@@ -671,7 +673,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             database=db,
         )
 
-        poe = cast(Table, db.events.fields["poe"])
+        poe = cast(Table, db.get_table("events").fields["poe"])
 
         assert poe.fields["some_field"] is not None
 
@@ -823,7 +825,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             database=db,
         )
 
-        person_on_event_table = cast(LazyJoin, db.events.fields["person"])
+        person_on_event_table = cast(LazyJoin, db.get_table("events").fields["person"])
         assert "some_field" in person_on_event_table.join_table.fields.keys()  # type: ignore
 
         prepare_and_print_ast(parse_select("select person.some_field.key from events"), context, dialect="clickhouse")

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -4,7 +4,7 @@ from posthog.test.base import BaseTest
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
-from posthog.hogql.database.models import IntegerDatabaseField, StringDatabaseField
+from posthog.hogql.database.models import IntegerDatabaseField, StringDatabaseField, TableNode
 from posthog.hogql.database.postgres_table import PostgresTable
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_and_print_ast
@@ -15,18 +15,19 @@ class TestPostgresTable(BaseTest):
     def _init_database(self):
         self.database = create_hogql_database(team=self.team)
 
-        setattr(  # noqa: B010
-            self.database,
-            "postgres_table",
-            PostgresTable(
+        self.database.tables.add_child(
+            TableNode(
                 name="postgres_table",
-                postgres_table_name="some_table_on_postgres",
-                fields={
-                    "id": IntegerDatabaseField(name="id"),
-                    "team_id": IntegerDatabaseField(name="team_id"),
-                    "name": StringDatabaseField(name="name"),
-                },
-            ),
+                table=PostgresTable(
+                    name="postgres_table",
+                    postgres_table_name="some_table_on_postgres",
+                    fields={
+                        "id": IntegerDatabaseField(name="id"),
+                        "team_id": IntegerDatabaseField(name="team_id"),
+                        "name": StringDatabaseField(name="name"),
+                    },
+                ),
+            )
         )
 
         self.context = HogQLContext(

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -6,6 +6,7 @@ from unittest import mock
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.models import TableNode
 from posthog.hogql.database.s3_table import build_function_call
 from posthog.hogql.database.test.tables import create_aapl_stock_s3_table
 from posthog.hogql.errors import ExposedHogQLError
@@ -19,9 +20,21 @@ from posthog.warehouse.models.table import DataWarehouseTable
 class TestS3Table(BaseTest):
     def _init_database(self):
         self.database = create_hogql_database(team=self.team)
-        self.database.add_warehouse_tables(
-            aapl_stock=create_aapl_stock_s3_table(), aapl_stock_2=create_aapl_stock_s3_table(name="aapl_stock_2")
+        self.database._add_warehouse_tables(
+            TableNode(
+                children={
+                    "aapl_stock": TableNode(
+                        name="aapl_stock",
+                        table=create_aapl_stock_s3_table(),
+                    ),
+                    "aapl_stock_2": TableNode(
+                        name="aapl_stock_2",
+                        table=create_aapl_stock_s3_table(name="aapl_stock_2"),
+                    ),
+                }
+            )
         )
+
         self.context = HogQLContext(
             team_id=self.team.pk,
             enable_select_queries=True,
@@ -174,9 +187,17 @@ class TestS3Table(BaseTest):
     def test_s3_table_select_alias_escaped(self):
         self._init_database()
 
-        escaped_table = create_aapl_stock_s3_table(name="random as (SELECT * FROM events), SELECT * FROM events --")
-        self.database.add_warehouse_tables(
-            **{"random as (SELECT * FROM events), SELECT * FROM events --": escaped_table}
+        self.database._add_warehouse_tables(
+            TableNode(
+                children={
+                    "random as (SELECT * FROM events), SELECT * FROM events --": TableNode(
+                        name="random as (SELECT * FROM events), SELECT * FROM events --",
+                        table=create_aapl_stock_s3_table(
+                            name="random as (SELECT * FROM events), SELECT * FROM events --"
+                        ),
+                    )
+                }
+            )
         )
 
         hogql = self._select(
@@ -202,8 +223,15 @@ class TestS3Table(BaseTest):
     def test_s3_table_select_table_name_bad_character(self):
         self._init_database()
 
-        escaped_table = create_aapl_stock_s3_table(name="some%(asd)sname")
-        self.database.add_warehouse_tables(**{"some%(asd)sname": escaped_table})
+        self.database._add_warehouse_tables(
+            TableNode(
+                children={
+                    "some%(asd)sname": TableNode(
+                        name="some%(asd)sname", table=create_aapl_stock_s3_table(name="some%(asd)sname")
+                    ),
+                }
+            )
+        )
 
         with self.assertRaises(ExposedHogQLError) as context:
             self._select(query='SELECT * FROM "some%(asd)sname" LIMIT 10', dialect="clickhouse")

--- a/posthog/hogql/database/test/test_view.py
+++ b/posthog/hogql/database/test/test_view.py
@@ -4,6 +4,7 @@ from posthog.test.base import BaseTest
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.models import TableNode
 from posthog.hogql.database.test.tables import (
     create_aapl_stock_s3_table,
     create_aapl_stock_table_self_referencing,
@@ -18,14 +19,39 @@ from posthog.hogql.query import create_default_modifiers_for_team
 class TestView(BaseTest):
     maxDiff = None
 
-    def _init_database(self):
+    def setUp(self):
+        super().setUp()
+
         self.database = create_hogql_database(team=self.team)
-        self.database.add_views(
-            aapl_stock_view=create_aapl_stock_table_view(), aapl_stock_nested_view=create_nested_aapl_stock_view()
+        self.database._add_views(
+            TableNode(
+                children={
+                    "aapl_stock_view": TableNode(
+                        name="aapl_stock_view",
+                        table=create_aapl_stock_table_view(),
+                    ),
+                    "aapl_stock_nested_view": TableNode(
+                        name="aapl_stock_nested_view",
+                        table=create_nested_aapl_stock_view(),
+                    ),
+                }
+            )
         )
-        self.database.add_warehouse_tables(
-            aapl_stock=create_aapl_stock_s3_table(), aapl_stock_self=create_aapl_stock_table_self_referencing()
+        self.database._add_warehouse_tables(
+            TableNode(
+                children={
+                    "aapl_stock": TableNode(
+                        name="aapl_stock",
+                        table=create_aapl_stock_s3_table(),
+                    ),
+                    "aapl_stock_self": TableNode(
+                        name="aapl_stock_self",
+                        table=create_aapl_stock_table_self_referencing(),
+                    ),
+                }
+            )
         )
+
         self.context = HogQLContext(
             team_id=self.team.pk,
             enable_select_queries=True,
@@ -37,8 +63,6 @@ class TestView(BaseTest):
         return prepare_and_print_ast(parse_select(query), self.context, dialect=dialect)[0]
 
     def test_view_table_select(self):
-        self._init_database()
-
         hogql = self._select(query="SELECT * FROM aapl_stock LIMIT 10", dialect="hogql")
         self.assertEqual(
             hogql,
@@ -58,8 +82,6 @@ class TestView(BaseTest):
         )
 
     def test_view_with_alias(self):
-        self._init_database()
-
         hogql = self._select(query="SELECT * FROM aapl_stock LIMIT 10", dialect="hogql")
         self.assertEqual(
             hogql,

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -330,7 +330,7 @@ class Resolver(CloningVisitor):
             if table_alias in scope.tables:
                 raise QueryError(f'Already have joined a table called "{table_alias}". Can\'t redefine.')
 
-            database_table = self.database.get_table(table_name_chain)
+            database_table = self.database.get_table(table_name_chain)  # type: ignore
 
             if isinstance(database_table, SavedQuery):
                 self.current_view_depth += 1

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -330,7 +330,7 @@ class Resolver(CloningVisitor):
             if table_alias in scope.tables:
                 raise QueryError(f'Already have joined a table called "{table_alias}". Can\'t redefine.')
 
-            database_table = self.database.get_table_by_chain(table_name_chain)
+            database_table = self.database.get_table(table_name_chain)
 
             if isinstance(database_table, SavedQuery):
                 self.current_view_depth += 1

--- a/posthog/hogql/test/test_autocomplete.py
+++ b/posthog/hogql/test/test_autocomplete.py
@@ -301,7 +301,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
 
     def test_autocomplete_events_hidden_field(self):
         database = create_hogql_database(team=self.team)
-        database.events.fields["event"] = StringDatabaseField(name="event", hidden=True)
+        database.get_table("events").fields["event"] = StringDatabaseField(name="event", hidden=True)
 
         query = "select  from events"
         results = self._select(query=query, start=7, end=7, database=database)
@@ -311,7 +311,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
 
     def test_autocomplete_special_characters(self):
         database = create_hogql_database(team=self.team)
-        database.events.fields["event-name"] = StringDatabaseField(name="event-name")
+        database.get_table("events").fields["event-name"] = StringDatabaseField(name="event-name")
 
         query = "select  from events"
         results = self._select(query=query, start=7, end=7, database=database)
@@ -341,7 +341,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
     def test_autocomplete_resolve_expression_type(self):
         database = create_hogql_database(team=self.team)
 
-        database.events.fields["expr_field"] = ast.ExpressionField(
+        database.get_table("events").fields["expr_field"] = ast.ExpressionField(
             name="expr_field",
             isolate_scope=True,
             expr=ast.Call(name="toDateTime", args=[ast.Constant(value="2025-01-01")]),

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1151,7 +1151,7 @@ class TestPrinter(BaseTest):
             self._select("select 1 from events"),
             f"SELECT 1 FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
-        self._assert_select_error("select 1 from other", 'Unknown table "other".')
+        self._assert_select_error("select 1 from other", "Unknown table `other`.")
 
     def test_select_from_placeholder(self):
         self.assertEqual(
@@ -1480,7 +1480,7 @@ class TestPrinter(BaseTest):
             enable_select_queries=True,
             database=Database(None, WeekStartDay.SUNDAY),
         )
-        context.database.events.fields["test_date"] = DateDatabaseField(name="test_date")  # type: ignore
+        context.database.get_table("events").fields["test_date"] = DateDatabaseField(name="test_date")  # type: ignore
 
         self.assertEqual(
             self._select(
@@ -1903,7 +1903,9 @@ class TestPrinter(BaseTest):
 
     def test_field_nullable_like(self):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+            name="nullable_field", nullable=True
+        )  # type: ignore
         generated_sql_statements1 = self._select(
             "SELECT "
             "nullable_field like 'a' as a, "
@@ -1917,7 +1919,9 @@ class TestPrinter(BaseTest):
         )
 
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+            name="nullable_field", nullable=True
+        )  # type: ignore
         generated_sql_statements2 = self._select(
             "SELECT "
             "like(nullable_field, 'a') as a, "
@@ -1949,7 +1953,9 @@ class TestPrinter(BaseTest):
 
     def test_field_nullable_not_like(self):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+            name="nullable_field", nullable=True
+        )  # type: ignore
         generated_sql_statements1 = self._select(
             "SELECT "
             "nullable_field not like 'a' as a, "
@@ -1963,7 +1969,9 @@ class TestPrinter(BaseTest):
         )
 
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+            name="nullable_field", nullable=True
+        )  # type: ignore
         generated_sql_statements2 = self._select(
             "SELECT "
             "notLike(nullable_field, 'a') as a, "
@@ -2366,7 +2374,7 @@ class TestPrinter(BaseTest):
             enable_select_queries=True,
             database=Database(None, WeekStartDay.SUNDAY),
         )
-        context.database.events.fields["test_date"] = DateDatabaseField(name="test_date")  # type: ignore
+        context.database.get_table("events").fields["test_date"] = DateDatabaseField(name="test_date")  # type: ignore
 
         self.assertEqual(
             self._select(

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1903,9 +1903,9 @@ class TestPrinter(BaseTest):
 
     def test_field_nullable_like(self):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(  # type: ignore
             name="nullable_field", nullable=True
-        )  # type: ignore
+        )
         generated_sql_statements1 = self._select(
             "SELECT "
             "nullable_field like 'a' as a, "
@@ -1919,9 +1919,9 @@ class TestPrinter(BaseTest):
         )
 
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(  # type: ignore
             name="nullable_field", nullable=True
-        )  # type: ignore
+        )
         generated_sql_statements2 = self._select(
             "SELECT "
             "like(nullable_field, 'a') as a, "
@@ -1953,9 +1953,9 @@ class TestPrinter(BaseTest):
 
     def test_field_nullable_not_like(self):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(  # type: ignore
             name="nullable_field", nullable=True
-        )  # type: ignore
+        )
         generated_sql_statements1 = self._select(
             "SELECT "
             "nullable_field not like 'a' as a, "
@@ -1969,9 +1969,9 @@ class TestPrinter(BaseTest):
         )
 
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=Database())
-        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(
+        context.database.get_table("events").fields["nullable_field"] = StringDatabaseField(  # type: ignore
             name="nullable_field", nullable=True
-        )  # type: ignore
+        )
         generated_sql_statements2 = self._select(
             "SELECT "
             "notLike(nullable_field, 'a') as a, "

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -409,11 +409,11 @@ class TestResolver(BaseTest):
         # Create a condition where we want to ".." out of "events.poe." to get to a higher level prop
         self.database.get_table("events").fields["person"] = FieldTraverser(chain=["poe"])
         assert isinstance(self.database.get_table("events").fields["poe"], Table)
-        self.database.get_table("events").fields["poe"].fields["id"] = FieldTraverser(chain=["..", "pdi", "person_id"])
-        self.database.get_table("events").fields["poe"].fields["created_at"] = FieldTraverser(
+        self.database.get_table("events").fields["poe"].fields["id"] = FieldTraverser(chain=["..", "pdi", "person_id"])  # type: ignore
+        self.database.get_table("events").fields["poe"].fields["created_at"] = FieldTraverser(  # type: ignore
             chain=["..", "pdi", "person", "created_at"]
         )
-        self.database.get_table("events").fields["poe"].fields["properties"] = StringJSONDatabaseField(
+        self.database.get_table("events").fields["poe"].fields["properties"] = StringJSONDatabaseField(  # type: ignore
             name="person_properties", nullable=False
         )
 

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -325,7 +325,7 @@ class TestResolver(BaseTest):
 
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_asterisk_expander_hidden_field(self):
-        self.database.events.fields["hidden_field"] = ExpressionField(
+        self.database.get_table("events").fields["hidden_field"] = ExpressionField(
             name="hidden_field", hidden=True, expr=ast.Field(chain=["event"])
         )
         node = self._select("select * from events")
@@ -334,10 +334,10 @@ class TestResolver(BaseTest):
 
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_expression_field_type_scope(self):
-        self.database.events.fields["some_expr"] = ExpressionField(
+        self.database.get_table("events").fields["some_expr"] = ExpressionField(
             name="some_expr", expr=ast.Field(chain=["properties"]), isolate_scope=True
         )
-        self.database.persons.fields["some_expr"] = ExpressionField(
+        self.database.get_table("persons").fields["some_expr"] = ExpressionField(
             name="some_expr", expr=ast.Field(chain=["properties"]), isolate_scope=True
         )
 
@@ -407,13 +407,13 @@ class TestResolver(BaseTest):
 
     def test_field_traverser_double_dot(self):
         # Create a condition where we want to ".." out of "events.poe." to get to a higher level prop
-        self.database.events.fields["person"] = FieldTraverser(chain=["poe"])
-        assert isinstance(self.database.events.fields["poe"], Table)
-        self.database.events.fields["poe"].fields["id"] = FieldTraverser(chain=["..", "pdi", "person_id"])
-        self.database.events.fields["poe"].fields["created_at"] = FieldTraverser(
+        self.database.get_table("events").fields["person"] = FieldTraverser(chain=["poe"])
+        assert isinstance(self.database.get_table("events").fields["poe"], Table)
+        self.database.get_table("events").fields["poe"].fields["id"] = FieldTraverser(chain=["..", "pdi", "person_id"])
+        self.database.get_table("events").fields["poe"].fields["created_at"] = FieldTraverser(
             chain=["..", "pdi", "person", "created_at"]
         )
-        self.database.events.fields["poe"].fields["properties"] = StringJSONDatabaseField(
+        self.database.get_table("events").fields["poe"].fields["properties"] = StringJSONDatabaseField(
             name="person_properties", nullable=False
         )
 
@@ -763,7 +763,6 @@ class TestResolver(BaseTest):
 
     def test_nested_table_name(self):
         table_group = TableNode(
-            name="root",
             children={
                 "nested": TableNode(
                     name="nested",
@@ -778,7 +777,6 @@ class TestResolver(BaseTest):
 
     def test_deeply_nested_table_name(self):
         table_group = TableNode(
-            name="root",
             children={
                 "very": TableNode(
                     name="very",
@@ -803,7 +801,6 @@ class TestResolver(BaseTest):
 
     def test_nested_table_on_existing_table(self):
         table_group = TableNode(
-            name="root",
             children={
                 "events": TableNode(
                     name="events",

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -1085,7 +1085,7 @@ async def build_dag_from_selectors(selector_paths: SelectorPaths, team_id: int) 
     ever does happen, some solution involving another level of indirection by storing
     indexes to a list of nodes could be implemented. Good luck!
     """
-    posthog_tables = await get_posthog_tables(team_id)
+    posthog_table_names = await get_posthog_table_names(team_id)
     dag = {}
 
     for selector, paths in selector_paths.items():
@@ -1119,7 +1119,7 @@ async def build_dag_from_selectors(selector_paths: SelectorPaths, team_id: int) 
 
                 if (
                     (index == label_index or end >= index >= start)
-                    and label not in posthog_tables
+                    and label not in posthog_table_names
                     and node.selected is False
                 ):
                     node = dag[label] = node.as_selected(True)
@@ -1135,11 +1135,11 @@ async def build_dag_from_selectors(selector_paths: SelectorPaths, team_id: int) 
     return dag
 
 
-async def get_posthog_tables(team_id: int) -> list[str]:
+async def get_posthog_table_names(team_id: int) -> list[str]:
     team = await database_sync_to_async(Team.objects.get)(id=team_id)
     hogql_db = await database_sync_to_async(create_hogql_database)(team=team)
-    posthog_tables = hogql_db.get_posthog_tables()
-    return posthog_tables
+    posthog_table_names = hogql_db.get_posthog_table_names()
+    return posthog_table_names
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -57,12 +57,12 @@ TEST_TIME = dt.datetime.now(dt.UTC)
 
 
 @pytest_asyncio.fixture
-async def posthog_tables(ateam):
+async def posthog_table_names(ateam):
     team = await database_sync_to_async(Team.objects.get)(id=ateam.pk)
     hogql_db = await database_sync_to_async(create_hogql_database)(team=team)
-    posthog_tables = hogql_db.get_posthog_tables()
+    posthog_table_names = hogql_db.get_posthog_table_names()
 
-    return posthog_tables
+    return posthog_table_names
 
 
 @pytest.mark.parametrize(
@@ -83,10 +83,10 @@ async def posthog_tables(ateam):
         },
     ],
 )
-async def test_run_dag_activity_activity_materialize_mocked(activity_environment, ateam, dag, posthog_tables):
+async def test_run_dag_activity_activity_materialize_mocked(activity_environment, ateam, dag, posthog_table_names):
     """Test all models are completed with a mocked materialize."""
     for model_label in dag.keys():
-        if model_label not in posthog_tables:
+        if model_label not in posthog_table_names:
             await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
                 team=ateam,
                 name=model_label,
@@ -104,7 +104,7 @@ async def test_run_dag_activity_activity_materialize_mocked(activity_environment
         async with asyncio.timeout(10):
             results = await activity_environment.run(run_dag_activity, run_dag_activity_inputs)
 
-        models_materialized = [model for model in dag.keys() if model not in posthog_tables]
+        models_materialized = [model for model in dag.keys() if model not in posthog_table_names]
 
     calls = magic_mock.mock_calls
 
@@ -146,7 +146,7 @@ async def test_run_dag_activity_activity_materialize_mocked(activity_environment
     ],
 )
 async def test_run_dag_activity_activity_skips_if_ancestor_failed_mocked(
-    activity_environment, ateam, dag, make_fail, posthog_tables
+    activity_environment, ateam, dag, make_fail, posthog_table_names
 ):
     """Test some models are completed while some fail with a mocked materialize.
 
@@ -157,7 +157,7 @@ async def test_run_dag_activity_activity_skips_if_ancestor_failed_mocked(
     """
     # Create the necessary saved queries for the test
     for model_label in dag.keys():
-        if model_label not in posthog_tables:
+        if model_label not in posthog_table_names:
             await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
                 team=ateam,
                 name=model_label,
@@ -168,7 +168,7 @@ async def test_run_dag_activity_activity_skips_if_ancestor_failed_mocked(
         team=ateam,
     )
     run_dag_activity_inputs = RunDagActivityInputs(team_id=ateam.pk, dag=dag, job_id=job.id)
-    assert all(model not in posthog_tables for model in make_fail), "PostHog tables cannot fail"
+    assert all(model not in posthog_table_names for model in make_fail), "PostHog tables cannot fail"
 
     def raise_if_should_make_fail(model_label, *args, **kwargs):
         if model_label in make_fail:
@@ -197,7 +197,9 @@ async def test_run_dag_activity_activity_skips_if_ancestor_failed_mocked(
         async with asyncio.timeout(10):
             results = await activity_environment.run(run_dag_activity, run_dag_activity_inputs)
 
-        models_materialized = [model for model in expected_failed | expected_completed if model not in posthog_tables]
+        models_materialized = [
+            model for model in expected_failed | expected_completed if model not in posthog_table_names
+        ]
 
     calls = magic_mock.mock_calls
 

--- a/posthog/warehouse/models/modeling.py
+++ b/posthog/warehouse/models/modeling.py
@@ -433,7 +433,7 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
         the transaction and clean them up.
         """
         parents = get_parents_from_model_query(query)
-        posthog_tables = self.get_hogql_database(team).get_posthog_tables()
+        posthog_table_names = self.get_hogql_database(team).get_posthog_table_names()
 
         base_params = {
             "team_id": team.pk,
@@ -446,7 +446,7 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
                 cursor.execute("SET CONSTRAINTS ALL DEFERRED")
 
                 for parent in parents:
-                    if parent in posthog_tables:
+                    if parent in posthog_table_names:
                         parent_id = parent
                     else:
                         try:

--- a/products/data_warehouse/backend/hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/hogql_fixer_ai.py
@@ -156,8 +156,8 @@ def _get_schema_description(ai_context: dict[Any, Any], hogql_context: HogQLCont
                 for table_name, table in serialized_database.items()
                 # Only the most important core tables, plus all warehouse tables
                 if table_name in ["events", "groups", "persons"]
-                or table_name in database.get_warehouse_tables()
-                or table_name in database.get_views()
+                or table_name in database.get_warehouse_table_names()
+                or table_name in database.get_view_names()
             )
         )
 
@@ -190,14 +190,14 @@ class HogQLQueryFixerTool(MaxTool):
         database = create_hogql_database(team=self._team)
         hogql_context = HogQLContext(team=self._team, enable_select_queries=True, database=database)
 
-        all_tables = database.get_all_tables()
+        all_table_names = database.get_all_table_names()
         schema_description = _get_schema_description(self.context, hogql_context, database)
 
         prompt = ChatPromptTemplate.from_messages(
             [
                 (
                     "system",
-                    _get_system_prompt(all_tables),
+                    _get_system_prompt(all_table_names),
                 ),
                 (
                     "user",

--- a/products/data_warehouse/backend/test/test_hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/test/test_hogql_fixer_ai.py
@@ -29,9 +29,9 @@ def test_get_system_prompt(snapshot):
     team = Team.objects.create(organization=org)
 
     database = create_hogql_database(team.id)
-    all_tables = database.get_all_tables()
+    all_table_names = database.get_all_table_names()
 
-    res = _get_system_prompt(all_tables)
+    res = _get_system_prompt(all_table_names)
 
     assert res == snapshot
 

--- a/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
@@ -88,7 +88,7 @@ class MarketingSourceFactory:
         # Cache warehouse data to avoid repeated queries
         database = create_hogql_database(team=self.context.team)
         self._warehouse_tables = DataWarehouseTable.objects.filter(
-            team_id=self.context.team.pk, deleted=False, name__in=database.get_warehouse_tables()
+            team_id=self.context.team.pk, deleted=False, name__in=database.get_warehouse_table_names()
         ).prefetch_related("externaldataschema_set")
         self._sources_map = self.context.team.marketing_analytics_config.sources_map_typed
 

--- a/products/revenue_analytics/backend/api.py
+++ b/products/revenue_analytics/backend/api.py
@@ -31,7 +31,7 @@ def find_values_for_revenue_analytics_property(key: str, team: Team) -> list[str
 
     # Try and find the union view for this class
     union_view: RevenueAnalyticsBaseView | None = None
-    for view_name in database.get_views():
+    for view_name in database.get_view_names():
         view = database.get_table(view_name)
         if isinstance(view, view_class) and view.union_all:
             union_view = view

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -307,7 +307,7 @@ class RevenueAnalyticsQueryRunner(QueryRunnerWithHogQLContext[AR]):
         ViewKind: Optional[type[RevenueAnalyticsBaseView]] = None,
         union: bool = False,
     ) -> Iterable[RevenueAnalyticsBaseView]:
-        for view_name in self.database.get_views():
+        for view_name in self.database.get_view_names():
             view = self.database.get_table(view_name)
             if isinstance(view, RevenueAnalyticsBaseView):
                 if ViewKind is None:

--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_data_warehouse_tables_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_data_warehouse_tables_query_runner.py
@@ -30,7 +30,7 @@ class RevenueExampleDataWarehouseTablesQueryRunner(QueryRunnerWithHogQLContext):
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         queries: list[ast.SelectQuery] = []
-        for view_name in self.database.get_views():
+        for view_name in self.database.get_view_names():
             view = self.database.get_table(view_name)
             if isinstance(view, RevenueAnalyticsRevenueItemView) and not view.is_event_view() and not view.union_all:
                 view = cast(RevenueAnalyticsRevenueItemView, view)

--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
@@ -31,7 +31,7 @@ class RevenueExampleEventsQueryRunner(QueryRunnerWithHogQLContext):
         )
 
     def to_query(self) -> ast.SelectQuery:
-        view_names = self.database.get_views()
+        view_names = self.database.get_view_names()
         all_views = [self.database.get_table(view_name) for view_name in view_names]
         views = [
             view

--- a/ty-baseline.txt
+++ b/ty-baseline.txt
@@ -298,7 +298,6 @@ posthog/hogql/autocomplete.py:0: warning: Attribute `query` on type `(EventsNode
 posthog/hogql/autocomplete.py:0: warning: Attribute `query` on type `(EventsNode & ~AlwaysFalsy) | (ActionsNode & ~AlwaysFalsy) | (PersonsNode & ~AlwaysFalsy) | ... omitted 40 union elements` may be missing  [possibly-missing-attribute]
 posthog/hogql/autocomplete.py:0: warning: Value is already of type `SelectQuery`  [redundant-cast]
 posthog/hogql/database/database.py:0: error: Argument `schema` does not match any known parameter  [unknown-argument]
-posthog/hogql/database/models.py:0: warning: Value is already of type `TableGroup`  [redundant-cast]
 posthog/hogql/database/schema/persons.py:0: warning: Value is already of type `And`  [redundant-cast]
 posthog/hogql/filters.py:0: error: Default value of type `None` is not assignable to annotated parameter type `Team`  [invalid-parameter-default]
 posthog/hogql/parser.py:0: error: Return type does not match returned value: expected `Call`, found `Unknown | Expr`  [invalid-return-type]


### PR DESCRIPTION
Previously, we'd store some of our tables in the `Database` inside a `TableGroup` to support nested (dot-accessed) tables. Let's now move all tables under that structure to allow us to have something like `events.nested.nested` too!

This will also let me change the revenue analytics stuff from `revenue_analytics.events.something` to `events.revenue_analytics.blahblahblah` instead, which should be more semantic - and more similar to the existing `stripe.prod.revenue_analytics.blahblah` construct.