### PR TITLE
feat(flags): Add SDK library breakdown to feature flag billing

### DIFF
--- a/posthog/models/feature_flag/flag_analytics.py
+++ b/posthog/models/feature_flag/flag_analytics.py
@@ -171,7 +171,7 @@ def capture_team_decide_usage(ph_client: "Posthog", team_id: int, team_uuid: str
             # Extract SDK breakdown for decide requests
             decide_sdk_breakdown = _extract_sdk_breakdown_from_redis(client, team_id, FlagRequestType.DECIDE)
 
-            billing_token = getattr(settings, "DECIDE_BILLING_ANALYTICS_TOKEN", None)
+            billing_token = settings.DECIDE_BILLING_ANALYTICS_TOKEN
             if total_decide_request_count > 0 and billing_token:
                 properties: dict = {
                     "count": total_decide_request_count,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -886,7 +886,7 @@ def get_teams_with_feature_flag_requests_count_in_period(
 ) -> list[tuple[int, int]]:
     # depending on the region, events are stored in different teams
     team_to_query = 1 if get_instance_region() == "EU" else 2
-    validity_token = getattr(settings, "DECIDE_BILLING_ANALYTICS_TOKEN", None)
+    validity_token = settings.DECIDE_BILLING_ANALYTICS_TOKEN
 
     target_event = "decide usage" if request_type == FlagRequestType.DECIDE else "local evaluation usage"
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -914,6 +914,48 @@ def get_teams_with_feature_flag_requests_count_in_period(
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_feature_flag_requests_sdk_breakdown_in_period(
+    begin: datetime, end: datetime, request_type: FlagRequestType
+) -> list[tuple[int, str, int]]:
+    """
+    Get per-SDK breakdown of feature flag requests for each team.
+    Returns list of (team_id, sdk_name, count) tuples.
+    """
+    team_to_query = 1 if get_instance_region() == "EU" else 2
+    validity_token = settings.DECIDE_BILLING_ANALYTICS_TOKEN
+
+    target_event = "decide usage" if request_type == FlagRequestType.DECIDE else "local evaluation usage"
+
+    result = sync_execute(
+        """
+        SELECT
+            distinct_id as team,
+            arrayJoin(JSONExtractKeys(properties, 'sdk_breakdown')) as sdk,
+            sum(JSONExtractInt(JSONExtractRaw(properties, 'sdk_breakdown'), sdk)) as sum
+        FROM events
+        WHERE team_id = %(team_to_query)s
+          AND event = %(target_event)s
+          AND timestamp >= %(begin)s AND timestamp < %(end)s
+          AND has([%(validity_token)s], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
+          AND JSONHas(properties, 'sdk_breakdown')
+        GROUP BY team, sdk
+    """,
+        {
+            "begin": begin,
+            "end": end,
+            "team_to_query": team_to_query,
+            "validity_token": validity_token,
+            "target_event": target_event,
+        },
+        workload=Workload.OFFLINE,
+        settings=CH_BILLING_SETTINGS,
+    )
+
+    return result
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_survey_responses_count_in_period(
     begin: datetime,
     end: datetime,

--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -18,9 +18,12 @@ from posthog.api.feature_flag import _create_usage_dashboard
 from posthog.constants import FlagRequestType
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.feature_flag.flag_analytics import (
+    SDK_LIBRARIES,
+    _extract_sdk_breakdown_from_redis,
     capture_team_decide_usage,
     capture_usage_for_all_teams,
     find_flags_with_enriched_analytics,
+    get_team_request_library_key,
     increment_request_count,
 )
 from posthog.models.team.team import Team
@@ -555,6 +558,220 @@ class TestFeatureFlagAnalytics(BaseTest, QueryMatchingTest):
                 {b"165192620": b"8"},
             )
             self.assertEqual(client.hgetall(f"posthog:decide_requests:{other_team_id}"), {})
+
+
+class TestSdkBreakdown(BaseTest):
+    def setUp(self):
+        r = redis.get_client()
+        for key in r.scan_iter("*"):
+            r.delete(key)
+        return super().setUp()
+
+    def test_get_team_request_library_key_decide(self):
+        self.assertEqual(
+            get_team_request_library_key(123, FlagRequestType.DECIDE, "posthog-js"),
+            "posthog:decide_requests:sdk:123:posthog-js",
+        )
+        self.assertEqual(
+            get_team_request_library_key(456, FlagRequestType.DECIDE, "posthog-node"),
+            "posthog:decide_requests:sdk:456:posthog-node",
+        )
+
+    def test_get_team_request_library_key_local_evaluation(self):
+        self.assertEqual(
+            get_team_request_library_key(123, FlagRequestType.LOCAL_EVALUATION, "posthog-python"),
+            "posthog:local_evaluation_requests:sdk:123:posthog-python",
+        )
+
+    def test_sdk_libraries_matches_expected_values(self):
+        expected_libraries = [
+            "posthog-js",
+            "posthog-node",
+            "posthog-python",
+            "posthog-php",
+            "posthog-ruby",
+            "posthog-go",
+            "posthog-java",
+            "posthog-dotnet",
+            "posthog-elixir",
+            "posthog-android",
+            "posthog-ios",
+            "posthog-react-native",
+            "posthog-flutter",
+            "other",
+        ]
+        self.assertEqual(SDK_LIBRARIES, expected_libraries)
+
+    @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
+    def test_extract_sdk_breakdown_from_redis_empty(self):
+        client = redis.get_client()
+        team_id = 999
+
+        with freeze_time("2022-05-07 12:23:07"):
+            result = _extract_sdk_breakdown_from_redis(client, team_id, FlagRequestType.DECIDE)
+            self.assertEqual(result, {})
+
+    @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
+    def test_extract_sdk_breakdown_from_redis_with_data(self):
+        client = redis.get_client()
+        team_id = 888
+
+        with freeze_time("2022-05-07 12:23:07") as frozen_datetime:
+            # Set up SDK-specific data in Redis in first bucket
+            time_bucket_1 = "165192618"
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-js", time_bucket_1, 100)
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-node", time_bucket_1, 50)
+
+            # Move to second bucket - each SDK key needs 2+ buckets for extraction
+            frozen_datetime.tick(datetime.timedelta(seconds=10))
+            time_bucket_2 = "165192619"
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-js", time_bucket_2, 10)
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-node", time_bucket_2, 5)
+
+            # Move time forward so bucket 2 is no longer "current"
+            frozen_datetime.tick(datetime.timedelta(seconds=15))
+
+            result = _extract_sdk_breakdown_from_redis(client, team_id, FlagRequestType.DECIDE)
+            # Only bucket 1 should be extracted (bucket 2 is skipped as it's most recent)
+            self.assertEqual(result, {"posthog-js": 100, "posthog-node": 50})
+
+            # Bucket 1 should be consumed, bucket 2 should still exist
+            self.assertEqual(
+                client.hgetall(f"posthog:decide_requests:sdk:{team_id}:posthog-js"),
+                {b"165192619": b"10"},
+            )
+            self.assertEqual(
+                client.hgetall(f"posthog:decide_requests:sdk:{team_id}:posthog-node"),
+                {b"165192619": b"5"},
+            )
+
+    @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
+    def test_capture_team_decide_usage_includes_sdk_breakdown(self):
+        mock_capture = MagicMock()
+        team_id = 777
+        team_uuid = "team-uuid-777"
+
+        with (
+            freeze_time("2022-05-07 12:23:07") as frozen_datetime,
+            self.settings(DECIDE_BILLING_ANALYTICS_TOKEN="token"),
+        ):
+            client = redis.get_client()
+
+            # Set up aggregate counts in first bucket
+            time_bucket_1 = "165192618"
+            client.hincrby(f"posthog:decide_requests:{team_id}", time_bucket_1, 150)
+
+            # Set up SDK-specific counts (simulating what Rust would write)
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-js", time_bucket_1, 100)
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-node", time_bucket_1, 50)
+
+            # Move to second bucket - each key needs 2+ buckets for extraction
+            frozen_datetime.tick(datetime.timedelta(seconds=10))
+            time_bucket_2 = "165192619"
+            client.hincrby(f"posthog:decide_requests:{team_id}", time_bucket_2, 1)
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-js", time_bucket_2, 1)
+            client.hincrby(f"posthog:decide_requests:sdk:{team_id}:posthog-node", time_bucket_2, 1)
+
+            # Move time forward so bucket 2 is no longer "current"
+            frozen_datetime.tick(datetime.timedelta(seconds=15))
+
+            capture_team_decide_usage(mock_capture, team_id, team_uuid)
+
+            mock_capture.capture.assert_called_once_with(
+                distinct_id=team_id,
+                event="decide usage",
+                properties={
+                    "count": 150,
+                    "team_id": team_id,
+                    "team_uuid": team_uuid,
+                    "min_time": 1651926180,
+                    "max_time": 1651926180,
+                    "token": "token",
+                    "sdk_breakdown": {"posthog-js": 100, "posthog-node": 50},
+                },
+            )
+
+    @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
+    def test_capture_team_decide_usage_without_sdk_breakdown(self):
+        mock_capture = MagicMock()
+        team_id = 666
+        team_uuid = "team-uuid-666"
+
+        with (
+            freeze_time("2022-05-07 12:23:07") as frozen_datetime,
+            self.settings(DECIDE_BILLING_ANALYTICS_TOKEN="token"),
+        ):
+            client = redis.get_client()
+
+            # Set up only aggregate counts in first bucket (no SDK-specific data)
+            time_bucket_1 = "165192618"
+            client.hincrby(f"posthog:decide_requests:{team_id}", time_bucket_1, 100)
+
+            # Move to second bucket (extraction requires 2+ buckets)
+            frozen_datetime.tick(datetime.timedelta(seconds=10))
+            time_bucket_2 = "165192619"
+            client.hincrby(f"posthog:decide_requests:{team_id}", time_bucket_2, 1)
+
+            frozen_datetime.tick(datetime.timedelta(seconds=15))
+
+            capture_team_decide_usage(mock_capture, team_id, team_uuid)
+
+            # Should NOT include sdk_breakdown when there's no SDK data
+            mock_capture.capture.assert_called_once_with(
+                distinct_id=team_id,
+                event="decide usage",
+                properties={
+                    "count": 100,
+                    "team_id": team_id,
+                    "team_uuid": team_uuid,
+                    "min_time": 1651926180,
+                    "max_time": 1651926180,
+                    "token": "token",
+                },
+            )
+
+    @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
+    def test_capture_local_evaluation_usage_includes_sdk_breakdown(self):
+        mock_capture = MagicMock()
+        team_id = 555
+        team_uuid = "team-uuid-555"
+
+        with (
+            freeze_time("2022-05-07 12:23:07") as frozen_datetime,
+            self.settings(DECIDE_BILLING_ANALYTICS_TOKEN="token"),
+        ):
+            client = redis.get_client()
+
+            # Set up data in first bucket
+            time_bucket_1 = "165192618"
+            client.hincrby(f"posthog:local_evaluation_requests:{team_id}", time_bucket_1, 80)
+            client.hincrby(f"posthog:local_evaluation_requests:sdk:{team_id}:posthog-python", time_bucket_1, 50)
+            client.hincrby(f"posthog:local_evaluation_requests:sdk:{team_id}:posthog-node", time_bucket_1, 30)
+
+            # Move to second bucket - each key needs 2+ buckets for extraction
+            frozen_datetime.tick(datetime.timedelta(seconds=10))
+            time_bucket_2 = "165192619"
+            client.hincrby(f"posthog:local_evaluation_requests:{team_id}", time_bucket_2, 1)
+            client.hincrby(f"posthog:local_evaluation_requests:sdk:{team_id}:posthog-python", time_bucket_2, 1)
+            client.hincrby(f"posthog:local_evaluation_requests:sdk:{team_id}:posthog-node", time_bucket_2, 1)
+
+            frozen_datetime.tick(datetime.timedelta(seconds=15))
+
+            capture_team_decide_usage(mock_capture, team_id, team_uuid)
+
+            mock_capture.capture.assert_called_once_with(
+                distinct_id=team_id,
+                event="local evaluation usage",
+                properties={
+                    "count": 80,
+                    "team_id": team_id,
+                    "team_uuid": team_uuid,
+                    "min_time": 1651926180,
+                    "max_time": 1651926180,
+                    "token": "token",
+                    "sdk_breakdown": {"posthog-python": 50, "posthog-node": 30},
+                },
+            )
 
 
 class TestEnrichedAnalytics(BaseTest):

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -1,8 +1,8 @@
 use crate::{
     api::{auth, errors::FlagError},
-    metrics::consts::DB_TEAM_READS_COUNTER,
     flags::{flag_analytics::increment_request_count, flag_request::FlagRequestType},
     handler::types::Library,
+    metrics::consts::DB_TEAM_READS_COUNTER,
     router::State as AppState,
     team::team_models::Team,
 };
@@ -79,7 +79,7 @@ pub async fn flags_definitions(
     // Record usage for billing with library tracking
     let library = Library::from_headers(&headers);
     if let Err(e) = increment_request_count(
-        state.redis_writer.clone(),
+        state.redis_client.clone(),
         team.id,
         1,
         FlagRequestType::FlagDefinitions,

--- a/rust/feature-flags/src/flags/flag_analytics.rs
+++ b/rust/feature-flags/src/flags/flag_analytics.rs
@@ -1,4 +1,5 @@
 use crate::flags::flag_request::FlagRequestType;
+use crate::handler::types::Library;
 use anyhow::Result;
 use common_redis::{Client as RedisClient, CustomRedisError};
 use std::sync::Arc;
@@ -18,21 +19,46 @@ pub fn get_team_request_key(team_id: i32, request_type: FlagRequestType) -> Stri
     }
 }
 
+pub fn get_team_request_library_key(
+    team_id: i32,
+    request_type: FlagRequestType,
+    library: Library,
+) -> String {
+    match request_type {
+        FlagRequestType::Decide => {
+            format!("posthog:decide_requests:sdk:{team_id}:{library}")
+        }
+        FlagRequestType::FlagDefinitions => {
+            format!("posthog:local_evaluation_requests:sdk:{team_id}:{library}")
+        }
+    }
+}
+
 pub async fn increment_request_count(
     redis_client: Arc<dyn RedisClient + Send + Sync>,
     team_id: i32,
     count: i32,
     request_type: FlagRequestType,
+    library: Option<Library>,
 ) -> Result<(), CustomRedisError> {
     let time_bucket = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs()
         / CACHE_BUCKET_SIZE;
+
     let key_name = get_team_request_key(team_id, request_type);
     redis_client
-        .hincrby(key_name, time_bucket.to_string(), Some(count))
+        .hincrby(key_name.clone(), time_bucket.to_string(), Some(count))
         .await?;
+
+    if let Some(lib) = library {
+        let library_key = get_team_request_library_key(team_id, request_type, lib);
+        redis_client
+            .hincrby(library_key, time_bucket.to_string(), Some(count))
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -50,6 +76,22 @@ mod tests {
         assert_eq!(
             get_team_request_key(456, FlagRequestType::FlagDefinitions),
             "posthog:local_evaluation_requests:456"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_team_request_library_key() {
+        assert_eq!(
+            get_team_request_library_key(123, FlagRequestType::Decide, Library::PosthogNode),
+            "posthog:decide_requests:sdk:123:posthog-node"
+        );
+        assert_eq!(
+            get_team_request_library_key(456, FlagRequestType::FlagDefinitions, Library::PosthogJs),
+            "posthog:local_evaluation_requests:sdk:456:posthog-js"
+        );
+        assert_eq!(
+            get_team_request_library_key(789, FlagRequestType::Decide, Library::PosthogAndroid),
+            "posthog:decide_requests:sdk:789:posthog-android"
         );
     }
 
@@ -76,6 +118,7 @@ mod tests {
             team_id,
             count,
             FlagRequestType::Decide,
+            None,
         )
         .await
         .unwrap();
@@ -86,6 +129,7 @@ mod tests {
             team_id,
             count,
             FlagRequestType::FlagDefinitions,
+            None,
         )
         .await
         .unwrap();
@@ -117,5 +161,165 @@ mod tests {
         // Clean up Redis after the test
         redis_client.del(decide_key).await.unwrap();
         redis_client.del(flag_definitions_key).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_increment_request_count_with_sdk() {
+        let redis_client = setup_redis_client(None).await;
+
+        let team_id = 999;
+        let count = 10;
+
+        let decide_key = get_team_request_key(team_id, FlagRequestType::Decide);
+        let library_key =
+            get_team_request_library_key(team_id, FlagRequestType::Decide, Library::PosthogNode);
+
+        redis_client.del(decide_key.clone()).await.unwrap();
+        redis_client.del(library_key.clone()).await.unwrap();
+
+        increment_request_count(
+            redis_client.clone(),
+            team_id,
+            count,
+            FlagRequestType::Decide,
+            Some(Library::PosthogNode),
+        )
+        .await
+        .unwrap();
+
+        let time_bucket = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            / CACHE_BUCKET_SIZE;
+
+        let decide_count: i32 = redis_client
+            .hget(decide_key.clone(), time_bucket.to_string())
+            .await
+            .unwrap()
+            .parse()
+            .unwrap();
+        let library_count: i32 = redis_client
+            .hget(library_key.clone(), time_bucket.to_string())
+            .await
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        assert_eq!(decide_count, count);
+        assert_eq!(library_count, count);
+
+        redis_client.del(decide_key).await.unwrap();
+        redis_client.del(library_key).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_increment_request_count_without_library() {
+        let redis_client = setup_redis_client(None).await;
+
+        let team_id = 888;
+        let count = 7;
+
+        let decide_key = get_team_request_key(team_id, FlagRequestType::Decide);
+
+        redis_client.del(decide_key.clone()).await.unwrap();
+
+        increment_request_count(
+            redis_client.clone(),
+            team_id,
+            count,
+            FlagRequestType::Decide,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let time_bucket = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            / CACHE_BUCKET_SIZE;
+
+        let decide_count: i32 = redis_client
+            .hget(decide_key.clone(), time_bucket.to_string())
+            .await
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        assert_eq!(decide_count, count);
+
+        redis_client.del(decide_key).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_multiple_libraries_same_team() {
+        let redis_client = setup_redis_client(None).await;
+
+        let team_id = 777;
+        let count = 3;
+
+        let decide_key = get_team_request_key(team_id, FlagRequestType::Decide);
+        let js_key =
+            get_team_request_library_key(team_id, FlagRequestType::Decide, Library::PosthogJs);
+        let node_key =
+            get_team_request_library_key(team_id, FlagRequestType::Decide, Library::PosthogNode);
+
+        redis_client.del(decide_key.clone()).await.unwrap();
+        redis_client.del(js_key.clone()).await.unwrap();
+        redis_client.del(node_key.clone()).await.unwrap();
+
+        increment_request_count(
+            redis_client.clone(),
+            team_id,
+            count,
+            FlagRequestType::Decide,
+            Some(Library::PosthogJs),
+        )
+        .await
+        .unwrap();
+
+        increment_request_count(
+            redis_client.clone(),
+            team_id,
+            count,
+            FlagRequestType::Decide,
+            Some(Library::PosthogNode),
+        )
+        .await
+        .unwrap();
+
+        let time_bucket = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            / CACHE_BUCKET_SIZE;
+
+        let decide_count: i32 = redis_client
+            .hget(decide_key.clone(), time_bucket.to_string())
+            .await
+            .unwrap()
+            .parse()
+            .unwrap();
+        let js_count: i32 = redis_client
+            .hget(js_key.clone(), time_bucket.to_string())
+            .await
+            .unwrap()
+            .parse()
+            .unwrap();
+        let node_count: i32 = redis_client
+            .hget(node_key.clone(), time_bucket.to_string())
+            .await
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        assert_eq!(decide_count, count * 2);
+        assert_eq!(js_count, count);
+        assert_eq!(node_count, count);
+
+        redis_client.del(decide_key).await.unwrap();
+        redis_client.del(js_key).await.unwrap();
+        redis_client.del(node_key).await.unwrap();
     }
 }

--- a/rust/feature-flags/src/flags/flag_analytics.rs
+++ b/rust/feature-flags/src/flags/flag_analytics.rs
@@ -26,10 +26,10 @@ pub fn get_team_request_library_key(
 ) -> String {
     match request_type {
         FlagRequestType::Decide => {
-            format!("posthog:decide_requests:sdk:{team_id}:{}", library.to_string())
+            format!("posthog:decide_requests:sdk:{team_id}:{library}")
         }
         FlagRequestType::FlagDefinitions => {
-            format!("posthog:local_evaluation_requests:sdk:{team_id}:{}", library.to_string())
+            format!("posthog:local_evaluation_requests:sdk:{team_id}:{library}")
         }
     }
 }
@@ -49,7 +49,7 @@ pub async fn increment_request_count(
 
     let key_name = get_team_request_key(team_id, request_type);
     redis_client
-        .hincrby(key_name.clone(), time_bucket.to_string(), Some(count))
+        .hincrby(key_name, time_bucket.to_string(), Some(count))
         .await?;
 
     if let Some(lib) = library {

--- a/rust/feature-flags/src/flags/flag_analytics.rs
+++ b/rust/feature-flags/src/flags/flag_analytics.rs
@@ -26,10 +26,10 @@ pub fn get_team_request_library_key(
 ) -> String {
     match request_type {
         FlagRequestType::Decide => {
-            format!("posthog:decide_requests:sdk:{team_id}:{library}")
+            format!("posthog:decide_requests:sdk:{team_id}:{}", library.to_string())
         }
         FlagRequestType::FlagDefinitions => {
-            format!("posthog:local_evaluation_requests:sdk:{team_id}:{library}")
+            format!("posthog:local_evaluation_requests:sdk:{team_id}:{}", library.to_string())
         }
     }
 }

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -13,7 +13,7 @@ use common_metrics::inc;
 use limiters::redis::ServiceName;
 use std::collections::HashMap;
 
-use super::types::RequestContext;
+use super::types::{Library, RequestContext};
 
 pub async fn check_limits(
     context: &RequestContext,
@@ -48,11 +48,14 @@ pub async fn record_usage(
     let has_billable_flags = contains_billable_flags(filtered_flags);
 
     if has_billable_flags {
+        let library = Library::from_headers(&context.headers);
+
         if let Err(e) = increment_request_count(
             context.state.redis_client.clone(),
             team_id,
             1,
             FlagRequestType::Decide,
+            Some(library),
         )
         .await
         {

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -40,16 +40,18 @@ pub async fn check_limits(
 ///
 /// Only increments billing counters if there are billable flags present.
 /// Survey and product tour targeting flags are not billable.
+///
+/// The `library` parameter is passed in to avoid duplicate detection - it should
+/// be detected once at the start of request processing and reused.
 pub async fn record_usage(
     context: &RequestContext,
     filtered_flags: &FeatureFlagList,
     team_id: i32,
+    library: Library,
 ) {
     let has_billable_flags = contains_billable_flags(filtered_flags);
 
     if has_billable_flags {
-        let library = Library::from_headers(&context.headers);
-
         if let Err(e) = increment_request_count(
             context.state.redis_client.clone(),
             team_id,

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -52,6 +52,7 @@ pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, F
 struct MetricsData {
     team_id: Option<i32>,
     flags_disabled: Option<bool>,
+    library: Library,
 }
 
 fn record_metrics(
@@ -69,9 +70,12 @@ fn record_metrics(
         .map(|disabled| disabled.to_string())
         .unwrap_or_else(|| "not_available".to_string());
 
+    let library = data.library.to_string();
+
     let labels = [
         ("flags_disabled".to_string(), flags_disabled),
         ("team_id".to_string(), team_id.clone()),
+        ("library".to_string(), library),
     ];
 
     inc(FLAG_REQUESTS_COUNTER, &labels, 1);
@@ -91,9 +95,12 @@ fn record_metrics(
 async fn process_request_inner(
     context: RequestContext,
 ) -> (Result<FlagsResponse, FlagError>, MetricsData) {
+    let library = Library::from_headers(&context.headers);
+
     let mut metrics_data = MetricsData {
         team_id: None,
         flags_disabled: None,
+        library,
     };
 
     let result = async {
@@ -310,6 +317,7 @@ mod metrics_tests {
         let data = MetricsData {
             team_id: Some(123),
             flags_disabled: Some(false),
+            library: Library::PosthogNode,
         };
 
         // Call the real record_metrics function - it will use our test metrics functions
@@ -334,6 +342,9 @@ mod metrics_tests {
         assert!(counter
             .labels
             .contains(&("flags_disabled".to_string(), "false".to_string())));
+        assert!(counter
+            .labels
+            .contains(&("library".to_string(), "posthog-node".to_string())));
 
         // Check the histogram metric
         let histogram = &metrics[1];
@@ -355,6 +366,7 @@ mod metrics_tests {
         let data = MetricsData {
             team_id: None,
             flags_disabled: None,
+            library: Library::Other,
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(50));
@@ -381,6 +393,7 @@ mod metrics_tests {
         let data = MetricsData {
             team_id: Some(456),
             flags_disabled: Some(true),
+            library: Library::PosthogJs,
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(200));
@@ -413,6 +426,7 @@ mod metrics_tests {
         let data = MetricsData {
             team_id: None,
             flags_disabled: Some(false),
+            library: Library::PosthogPython,
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(150));
@@ -441,6 +455,7 @@ mod metrics_tests {
         let data = MetricsData {
             team_id: Some(789),
             flags_disabled: Some(false),
+            library: Library::PosthogAndroid,
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(75));

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -208,7 +208,8 @@ async fn process_request_inner(
 
             // Only record billing if flags are not disabled
             if !request.is_flags_disabled() {
-                billing::record_usage(&context, &filtered_flags, team.id).await;
+                billing::record_usage(&context, &filtered_flags, team.id, metrics_data.library)
+                    .await;
             }
 
             response

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::{
     api::types::FlagsQueryParams, cohorts::cohort_cache_manager::CohortCacheManager,
-    flags::flag_models::FeatureFlagList, router,
+    flags::flag_models::FeatureFlagList, router, utils::user_agent::UserAgentInfo,
 };
 
 pub struct RequestContext {
@@ -62,8 +62,11 @@ pub struct FeatureFlagEvaluationContext {
     pub optimize_experience_continuity_lookups: bool,
 }
 
-/// SDK type classification based on user-agent parsing
-/// Used for billing breakdown and usage analytics
+/// SDK type classification based on user-agent parsing.
+/// Used for billing breakdown and usage analytics.
+///
+/// This enum leverages [`UserAgentInfo`] for SDK detection to avoid code
+/// duplication, adding sec-fetch header detection for browser identification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Library {
@@ -81,6 +84,10 @@ pub enum Library {
     PosthogGo,
     /// posthog-java SDK
     PosthogJava,
+    /// posthog-dotnet SDK
+    PosthogDotnet,
+    /// posthog-elixir SDK
+    PosthogElixir,
     /// posthog-android SDK
     PosthogAndroid,
     /// posthog-ios SDK
@@ -103,6 +110,8 @@ impl fmt::Display for Library {
             Library::PosthogRuby => write!(f, "posthog-ruby"),
             Library::PosthogGo => write!(f, "posthog-go"),
             Library::PosthogJava => write!(f, "posthog-java"),
+            Library::PosthogDotnet => write!(f, "posthog-dotnet"),
+            Library::PosthogElixir => write!(f, "posthog-elixir"),
             Library::PosthogAndroid => write!(f, "posthog-android"),
             Library::PosthogIos => write!(f, "posthog-ios"),
             Library::PosthogReactNative => write!(f, "posthog-react-native"),
@@ -113,11 +122,11 @@ impl fmt::Display for Library {
 }
 
 impl Library {
-    /// Detect SDK type from HTTP headers, primarily the User-Agent
+    /// Detect SDK type from HTTP headers, primarily the User-Agent.
     ///
-    /// This function analyzes the User-Agent header to determine which PostHog SDK
-    /// or client type is making the request. It's used for billing breakdown and
-    /// usage analytics.
+    /// This function uses [`UserAgentInfo`] for SDK detection, with additional
+    /// browser detection via sec-fetch headers (which cannot be spoofed by
+    /// server-side code).
     ///
     /// # Examples
     ///
@@ -130,73 +139,55 @@ impl Library {
     /// assert_eq!(Library::from_headers(&headers), Library::PosthogNode);
     /// ```
     pub fn from_headers(headers: &HeaderMap) -> Self {
-        // Extract user-agent header
-        let user_agent = headers
-            .get("user-agent")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
+        let user_agent = headers.get("user-agent").and_then(|v| v.to_str().ok());
 
-        // Server SDKs - check these first as they have most specific patterns
-        if user_agent.starts_with("posthog-node/") {
-            return Library::PosthogNode;
-        }
-        if user_agent.starts_with("posthog-python/") {
-            return Library::PosthogPython;
-        }
-        if user_agent.starts_with("posthog-php/") {
-            return Library::PosthogPhp;
-        }
-        if user_agent.starts_with("posthog-ruby/") {
-            return Library::PosthogRuby;
-        }
-        if user_agent.starts_with("posthog-go/") {
-            return Library::PosthogGo;
-        }
-        if user_agent.starts_with("posthog-java/") {
-            return Library::PosthogJava;
+        // Use UserAgentInfo for SDK detection (avoids duplicating parsing logic)
+        let ua_info = UserAgentInfo::parse(user_agent);
+
+        // Map SDK name to Library enum variant
+        if let Some(sdk_name) = ua_info.sdk_name {
+            return Self::from_sdk_name(sdk_name);
         }
 
-        // Mobile SDKs
-        if user_agent.starts_with("posthog-android/") {
-            return Library::PosthogAndroid;
-        }
-        if user_agent.starts_with("posthog-ios/") {
-            return Library::PosthogIos;
-        }
-        if user_agent.starts_with("posthog-react-native/") {
-            return Library::PosthogReactNative;
-        }
-        if user_agent.starts_with("posthog-flutter/") {
-            return Library::PosthogFlutter;
-        }
-
-        // If it's an unrecognized posthog-* SDK, return Other
-        // This prevents custom SDKs like "posthog-custom/1.0 Chrome/..." from being
-        // misclassified as browsers
-        if user_agent.starts_with("posthog-") {
-            return Library::Other;
-        }
-
-        // Web browsers - check for browser signatures (posthog-js)
-        // Only apply if we haven't matched a PostHog SDK above
-        if user_agent.contains("Mozilla/")
-            || user_agent.contains("Chrome/")
-            || user_agent.contains("Safari/")
-            || user_agent.contains("Firefox/")
-            || user_agent.contains("Edge/")
-        {
+        // UserAgentInfo detected a browser via user-agent patterns
+        if ua_info.is_browser {
             return Library::PosthogJs;
         }
 
-        // Additional browser detection from headers
-        // Only use sec-fetch-* headers as they are browser-only and cannot be spoofed
-        // (origin/referer can be set by server SDKs, proxies, etc.)
+        // Check for unrecognized posthog-* SDKs (must come before sec-fetch check)
+        // This prevents custom SDKs like "posthog-custom/1.0" from being
+        // misclassified as browsers
+        if user_agent.is_some_and(|ua| ua.starts_with("posthog-")) {
+            return Library::Other;
+        }
+
+        // Additional browser detection via sec-fetch headers
+        // These headers are browser-only and cannot be spoofed by server-side code
         if headers.get("sec-fetch-mode").is_some() || headers.get("sec-fetch-site").is_some() {
             return Library::PosthogJs;
         }
 
-        // Default to Other for unrecognized SDKs
         Library::Other
+    }
+
+    /// Convert SDK name string to Library enum variant.
+    fn from_sdk_name(sdk_name: &str) -> Self {
+        match sdk_name {
+            "posthog-js" => Library::PosthogJs,
+            "posthog-node" => Library::PosthogNode,
+            "posthog-python" => Library::PosthogPython,
+            "posthog-php" => Library::PosthogPhp,
+            "posthog-ruby" => Library::PosthogRuby,
+            "posthog-go" => Library::PosthogGo,
+            "posthog-java" => Library::PosthogJava,
+            "posthog-dotnet" => Library::PosthogDotnet,
+            "posthog-elixir" => Library::PosthogElixir,
+            "posthog-android" => Library::PosthogAndroid,
+            "posthog-ios" => Library::PosthogIos,
+            "posthog-react-native" => Library::PosthogReactNative,
+            "posthog-flutter" => Library::PosthogFlutter,
+            _ => Library::Other,
+        }
     }
 }
 
@@ -204,6 +195,7 @@ impl Library {
 mod tests {
     use super::*;
     use axum::http::HeaderMap;
+    use rstest::rstest;
 
     fn make_headers_with_user_agent(ua: &str) -> HeaderMap {
         let mut headers = HeaderMap::new();
@@ -211,100 +203,42 @@ mod tests {
         headers
     }
 
-    #[test]
-    fn test_sdk_type_server_node() {
-        let headers = make_headers_with_user_agent("posthog-node/3.1.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogNode);
+    #[rstest]
+    // Server-side SDKs
+    #[case("posthog-node/3.1.0", Library::PosthogNode)]
+    #[case("posthog-python/2.5.0", Library::PosthogPython)]
+    #[case("posthog-php/3.0.0", Library::PosthogPhp)]
+    #[case("posthog-ruby/2.3.0", Library::PosthogRuby)]
+    #[case("posthog-go/1.0.0", Library::PosthogGo)]
+    #[case("posthog-java/1.2.0", Library::PosthogJava)]
+    #[case("posthog-dotnet/1.0.0", Library::PosthogDotnet)]
+    #[case("posthog-elixir/0.2.0", Library::PosthogElixir)]
+    // Client-side SDKs
+    #[case("posthog-js/1.88.0", Library::PosthogJs)]
+    #[case("posthog-android/3.0.0", Library::PosthogAndroid)]
+    #[case("posthog-ios/3.1.0", Library::PosthogIos)]
+    #[case("posthog-react-native/2.0.0", Library::PosthogReactNative)]
+    #[case("posthog-flutter/2.0.0", Library::PosthogFlutter)]
+    // Browser user-agents (detected as posthog-js)
+    #[case("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36", Library::PosthogJs)]
+    #[case(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
+        Library::PosthogJs
+    )]
+    #[case("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15", Library::PosthogJs)]
+    // Unrecognized posthog SDKs → Other (not misclassified as browsers)
+    #[case("posthog-custom/1.0 Chrome/91.0 Safari/537.36", Library::Other)]
+    // Unknown clients → Other
+    #[case("some-random-client/1.0", Library::Other)]
+    #[case("curl/7.68.0", Library::Other)]
+    #[case("python-requests/2.28.0", Library::Other)]
+    fn test_library_from_user_agent(#[case] user_agent: &str, #[case] expected: Library) {
+        let headers = make_headers_with_user_agent(user_agent);
+        assert_eq!(Library::from_headers(&headers), expected);
     }
 
     #[test]
-    fn test_sdk_type_server_python() {
-        let headers = make_headers_with_user_agent("posthog-python/2.5.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogPython);
-    }
-
-    #[test]
-    fn test_sdk_type_server_php() {
-        let headers = make_headers_with_user_agent("posthog-php/3.0.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogPhp);
-    }
-
-    #[test]
-    fn test_sdk_type_server_ruby() {
-        let headers = make_headers_with_user_agent("posthog-ruby/2.3.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogRuby);
-    }
-
-    #[test]
-    fn test_sdk_type_server_go() {
-        let headers = make_headers_with_user_agent("posthog-go/1.0.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogGo);
-    }
-
-    #[test]
-    fn test_sdk_type_server_java() {
-        let headers = make_headers_with_user_agent("posthog-java/1.2.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogJava);
-    }
-
-    #[test]
-    fn test_sdk_type_mobile_android() {
-        let headers = make_headers_with_user_agent("posthog-android/3.0.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogAndroid);
-    }
-
-    #[test]
-    fn test_sdk_type_mobile_ios() {
-        let headers = make_headers_with_user_agent("posthog-ios/3.1.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogIos);
-    }
-
-    #[test]
-    fn test_sdk_type_mobile_react_native() {
-        let headers = make_headers_with_user_agent("posthog-react-native/2.0.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogReactNative);
-    }
-
-    #[test]
-    fn test_sdk_type_mobile_flutter() {
-        let headers = make_headers_with_user_agent("posthog-flutter/2.0.0");
-        assert_eq!(Library::from_headers(&headers), Library::PosthogFlutter);
-    }
-
-    #[test]
-    fn test_sdk_type_web_chrome() {
-        let headers = make_headers_with_user_agent(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-        );
-        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
-    }
-
-    #[test]
-    fn test_sdk_type_web_firefox() {
-        let headers = make_headers_with_user_agent(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
-        );
-        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
-    }
-
-    #[test]
-    fn test_sdk_type_web_safari() {
-        let headers = make_headers_with_user_agent(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15"
-        );
-        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
-    }
-
-    #[test]
-    fn test_sdk_type_web_edge() {
-        let headers = make_headers_with_user_agent(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59"
-        );
-        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
-    }
-
-    #[test]
-    fn test_sdk_type_other_with_origin_header_only() {
+    fn test_library_other_with_origin_header_only() {
         // origin/referer headers alone don't indicate browser (can be set by servers)
         let mut headers = HeaderMap::new();
         headers.insert("user-agent", "some-custom-client".parse().unwrap());
@@ -313,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sdk_type_other_with_referer_header_only() {
+    fn test_library_other_with_referer_header_only() {
         // origin/referer headers alone don't indicate browser (can be set by servers)
         let mut headers = HeaderMap::new();
         headers.insert("user-agent", "some-custom-client".parse().unwrap());
@@ -322,7 +256,8 @@ mod tests {
     }
 
     #[test]
-    fn test_sdk_type_web_with_sec_fetch_headers() {
+    fn test_library_browser_with_sec_fetch_headers() {
+        // sec-fetch headers are browser-only and cannot be spoofed
         let mut headers = HeaderMap::new();
         headers.insert("user-agent", "some-custom-client".parse().unwrap());
         headers.insert("sec-fetch-mode", "navigate".parse().unwrap());
@@ -330,84 +265,43 @@ mod tests {
     }
 
     #[test]
-    fn test_sdk_type_other_missing_user_agent() {
+    fn test_library_other_missing_user_agent() {
         let headers = HeaderMap::new();
         assert_eq!(Library::from_headers(&headers), Library::Other);
     }
 
     #[test]
-    fn test_sdk_type_other_empty_user_agent() {
+    fn test_library_other_empty_user_agent() {
         let headers = make_headers_with_user_agent("");
         assert_eq!(Library::from_headers(&headers), Library::Other);
     }
 
-    #[test]
-    fn test_sdk_type_other_unrecognized() {
-        let headers = make_headers_with_user_agent("some-random-client/1.0");
-        assert_eq!(Library::from_headers(&headers), Library::Other);
+    #[rstest]
+    #[case(Library::PosthogJs, "posthog-js")]
+    #[case(Library::PosthogNode, "posthog-node")]
+    #[case(Library::PosthogPython, "posthog-python")]
+    #[case(Library::PosthogPhp, "posthog-php")]
+    #[case(Library::PosthogRuby, "posthog-ruby")]
+    #[case(Library::PosthogGo, "posthog-go")]
+    #[case(Library::PosthogJava, "posthog-java")]
+    #[case(Library::PosthogDotnet, "posthog-dotnet")]
+    #[case(Library::PosthogElixir, "posthog-elixir")]
+    #[case(Library::PosthogAndroid, "posthog-android")]
+    #[case(Library::PosthogIos, "posthog-ios")]
+    #[case(Library::PosthogReactNative, "posthog-react-native")]
+    #[case(Library::PosthogFlutter, "posthog-flutter")]
+    #[case(Library::Other, "other")]
+    fn test_library_display(#[case] library: Library, #[case] expected: &str) {
+        assert_eq!(library.to_string(), expected);
     }
 
-    #[test]
-    fn test_sdk_type_other_unrecognized_posthog_sdk_with_browser_strings() {
-        // Test that unknown posthog-* SDKs aren't misclassified as browsers
-        // even if they contain browser user-agent strings
-        let headers = make_headers_with_user_agent("posthog-custom/1.0 Chrome/91.0 Safari/537.36");
-        assert_eq!(Library::from_headers(&headers), Library::Other);
-    }
-
-    #[test]
-    fn test_sdk_type_display() {
-        assert_eq!(Library::PosthogJs.to_string(), "posthog-js");
-        assert_eq!(Library::PosthogNode.to_string(), "posthog-node");
-        assert_eq!(Library::PosthogPython.to_string(), "posthog-python");
-        assert_eq!(Library::PosthogAndroid.to_string(), "posthog-android");
-        assert_eq!(Library::Other.to_string(), "other");
-    }
-
-    #[test]
-    fn test_sdk_type_performance() {
-        // Test that parsing 1000 different user-agents is fast
-        use std::time::Instant;
-
-        let test_cases = vec![
-            "posthog-node/3.1.0",
-            "posthog-python/2.5.0",
-            "posthog-php/3.0.0",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-            "posthog-android/3.0.0",
-            "some-random-client/1.0",
-        ];
-
-        let start = Instant::now();
-        for _ in 0..1000 {
-            for ua in &test_cases {
-                let headers = make_headers_with_user_agent(ua);
-                let _ = Library::from_headers(&headers);
-            }
-        }
-        let duration = start.elapsed();
-
-        // Should process 6000 user-agents in less than 100ms
-        assert!(
-            duration.as_millis() < 100,
-            "SDK type detection took too long: {duration:?}"
-        );
-    }
-
-    #[test]
-    fn test_sdk_type_serialization() {
-        // Test that the enum serializes correctly to JSON
-        assert_eq!(
-            serde_json::to_string(&Library::PosthogNode).unwrap(),
-            "\"posthog-node\""
-        );
-        assert_eq!(
-            serde_json::to_string(&Library::PosthogJs).unwrap(),
-            "\"posthog-js\""
-        );
-        assert_eq!(
-            serde_json::to_string(&Library::PosthogAndroid).unwrap(),
-            "\"posthog-android\""
-        );
+    #[rstest]
+    #[case(Library::PosthogJs, "\"posthog-js\"")]
+    #[case(Library::PosthogNode, "\"posthog-node\"")]
+    #[case(Library::PosthogDotnet, "\"posthog-dotnet\"")]
+    #[case(Library::PosthogElixir, "\"posthog-elixir\"")]
+    #[case(Library::Other, "\"other\"")]
+    fn test_library_serialization(#[case] library: Library, #[case] expected_json: &str) {
+        assert_eq!(serde_json::to_string(&library).unwrap(), expected_json);
     }
 }

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -189,12 +189,9 @@ impl Library {
         }
 
         // Additional browser detection from headers
-        // Browser requests typically include these headers
-        if headers.contains_key("origin")
-            || headers.contains_key("referer")
-            || headers.get("sec-fetch-mode").is_some()
-            || headers.get("sec-fetch-site").is_some()
-        {
+        // Only use sec-fetch-* headers as they are browser-only and cannot be spoofed
+        // (origin/referer can be set by server SDKs, proxies, etc.)
+        if headers.get("sec-fetch-mode").is_some() || headers.get("sec-fetch-site").is_some() {
             return Library::PosthogJs;
         }
 
@@ -307,19 +304,21 @@ mod tests {
     }
 
     #[test]
-    fn test_sdk_type_web_with_origin_header() {
+    fn test_sdk_type_other_with_origin_header_only() {
+        // origin/referer headers alone don't indicate browser (can be set by servers)
         let mut headers = HeaderMap::new();
         headers.insert("user-agent", "some-custom-client".parse().unwrap());
         headers.insert("origin", "https://example.com".parse().unwrap());
-        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+        assert_eq!(Library::from_headers(&headers), Library::Other);
     }
 
     #[test]
-    fn test_sdk_type_web_with_referer_header() {
+    fn test_sdk_type_other_with_referer_header_only() {
+        // origin/referer headers alone don't indicate browser (can be set by servers)
         let mut headers = HeaderMap::new();
         headers.insert("user-agent", "some-custom-client".parse().unwrap());
         headers.insert("referer", "https://example.com/page".parse().unwrap());
-        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+        assert_eq!(Library::from_headers(&headers), Library::Other);
     }
 
     #[test]

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -127,7 +127,7 @@ impl Library {
     ///
     /// let mut headers = HeaderMap::new();
     /// headers.insert("user-agent", "posthog-node/3.1.0".parse().unwrap());
-    /// assert_eq!(Library::from_headers(&headers), Library::ServerNode);
+    /// assert_eq!(Library::from_headers(&headers), Library::PosthogNode);
     /// ```
     pub fn from_headers(headers: &HeaderMap) -> Self {
         // Extract user-agent header

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -1,7 +1,8 @@
 use axum::{extract::State, http::HeaderMap};
 use bytes::Bytes;
+use serde::Serialize;
 use serde_json::Value;
-use std::{collections::HashMap, net::IpAddr, sync::Arc};
+use std::{collections::HashMap, fmt, net::IpAddr, sync::Arc};
 use uuid::Uuid;
 
 use crate::{
@@ -59,4 +60,339 @@ pub struct FeatureFlagEvaluationContext {
     /// When true, skip hash key override lookups for flags that don't need them
     /// (e.g., 100% rollout with no multivariate variants).
     pub optimize_experience_continuity_lookups: bool,
+}
+
+/// SDK type classification based on user-agent parsing
+/// Used for billing breakdown and usage analytics
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Library {
+    /// posthog-js (web browsers)
+    PosthogJs,
+    /// posthog-node SDK (server-side Node.js)
+    PosthogNode,
+    /// posthog-python SDK
+    PosthogPython,
+    /// posthog-php SDK
+    PosthogPhp,
+    /// posthog-ruby SDK
+    PosthogRuby,
+    /// posthog-go SDK
+    PosthogGo,
+    /// posthog-java SDK
+    PosthogJava,
+    /// posthog-android SDK
+    PosthogAndroid,
+    /// posthog-ios SDK
+    PosthogIos,
+    /// posthog-react-native SDK
+    PosthogReactNative,
+    /// posthog-flutter SDK
+    PosthogFlutter,
+    /// Unknown or unrecognized SDK
+    Other,
+}
+
+impl fmt::Display for Library {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Library::PosthogJs => write!(f, "posthog-js"),
+            Library::PosthogNode => write!(f, "posthog-node"),
+            Library::PosthogPython => write!(f, "posthog-python"),
+            Library::PosthogPhp => write!(f, "posthog-php"),
+            Library::PosthogRuby => write!(f, "posthog-ruby"),
+            Library::PosthogGo => write!(f, "posthog-go"),
+            Library::PosthogJava => write!(f, "posthog-java"),
+            Library::PosthogAndroid => write!(f, "posthog-android"),
+            Library::PosthogIos => write!(f, "posthog-ios"),
+            Library::PosthogReactNative => write!(f, "posthog-react-native"),
+            Library::PosthogFlutter => write!(f, "posthog-flutter"),
+            Library::Other => write!(f, "other"),
+        }
+    }
+}
+
+impl Library {
+    /// Detect SDK type from HTTP headers, primarily the User-Agent
+    ///
+    /// This function analyzes the User-Agent header to determine which PostHog SDK
+    /// or client type is making the request. It's used for billing breakdown and
+    /// usage analytics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use axum::http::HeaderMap;
+    /// use feature_flags::handler::types::Library;
+    ///
+    /// let mut headers = HeaderMap::new();
+    /// headers.insert("user-agent", "posthog-node/3.1.0".parse().unwrap());
+    /// assert_eq!(Library::from_headers(&headers), Library::ServerNode);
+    /// ```
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        // Extract user-agent header
+        let user_agent = headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        // Server SDKs - check these first as they have most specific patterns
+        if user_agent.starts_with("posthog-node/") {
+            return Library::PosthogNode;
+        }
+        if user_agent.starts_with("posthog-python/") {
+            return Library::PosthogPython;
+        }
+        if user_agent.starts_with("posthog-php/") {
+            return Library::PosthogPhp;
+        }
+        if user_agent.starts_with("posthog-ruby/") {
+            return Library::PosthogRuby;
+        }
+        if user_agent.starts_with("posthog-go/") {
+            return Library::PosthogGo;
+        }
+        if user_agent.starts_with("posthog-java/") {
+            return Library::PosthogJava;
+        }
+
+        // Mobile SDKs
+        if user_agent.starts_with("posthog-android/") {
+            return Library::PosthogAndroid;
+        }
+        if user_agent.starts_with("posthog-ios/") {
+            return Library::PosthogIos;
+        }
+        if user_agent.starts_with("posthog-react-native/") {
+            return Library::PosthogReactNative;
+        }
+        if user_agent.starts_with("posthog-flutter/") {
+            return Library::PosthogFlutter;
+        }
+
+        // Web browsers - check for browser signatures (posthog-js)
+        if user_agent.contains("Mozilla/")
+            || user_agent.contains("Chrome/")
+            || user_agent.contains("Safari/")
+            || user_agent.contains("Firefox/")
+            || user_agent.contains("Edge/")
+        {
+            return Library::PosthogJs;
+        }
+
+        // Additional browser detection from headers
+        // Browser requests typically include these headers
+        if headers.contains_key("origin")
+            || headers.contains_key("referer")
+            || headers.get("sec-fetch-mode").is_some()
+            || headers.get("sec-fetch-site").is_some()
+        {
+            return Library::PosthogJs;
+        }
+
+        // Default to Other for unrecognized SDKs
+        Library::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    fn make_headers_with_user_agent(ua: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", ua.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn test_sdk_type_server_node() {
+        let headers = make_headers_with_user_agent("posthog-node/3.1.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogNode);
+    }
+
+    #[test]
+    fn test_sdk_type_server_python() {
+        let headers = make_headers_with_user_agent("posthog-python/2.5.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogPython);
+    }
+
+    #[test]
+    fn test_sdk_type_server_php() {
+        let headers = make_headers_with_user_agent("posthog-php/3.0.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogPhp);
+    }
+
+    #[test]
+    fn test_sdk_type_server_ruby() {
+        let headers = make_headers_with_user_agent("posthog-ruby/2.3.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogRuby);
+    }
+
+    #[test]
+    fn test_sdk_type_server_go() {
+        let headers = make_headers_with_user_agent("posthog-go/1.0.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogGo);
+    }
+
+    #[test]
+    fn test_sdk_type_server_java() {
+        let headers = make_headers_with_user_agent("posthog-java/1.2.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJava);
+    }
+
+    #[test]
+    fn test_sdk_type_mobile_android() {
+        let headers = make_headers_with_user_agent("posthog-android/3.0.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogAndroid);
+    }
+
+    #[test]
+    fn test_sdk_type_mobile_ios() {
+        let headers = make_headers_with_user_agent("posthog-ios/3.1.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogIos);
+    }
+
+    #[test]
+    fn test_sdk_type_mobile_react_native() {
+        let headers = make_headers_with_user_agent("posthog-react-native/2.0.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogReactNative);
+    }
+
+    #[test]
+    fn test_sdk_type_mobile_flutter() {
+        let headers = make_headers_with_user_agent("posthog-flutter/2.0.0");
+        assert_eq!(Library::from_headers(&headers), Library::PosthogFlutter);
+    }
+
+    #[test]
+    fn test_sdk_type_web_chrome() {
+        let headers = make_headers_with_user_agent(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        );
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+    }
+
+    #[test]
+    fn test_sdk_type_web_firefox() {
+        let headers = make_headers_with_user_agent(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
+        );
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+    }
+
+    #[test]
+    fn test_sdk_type_web_safari() {
+        let headers = make_headers_with_user_agent(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15"
+        );
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+    }
+
+    #[test]
+    fn test_sdk_type_web_edge() {
+        let headers = make_headers_with_user_agent(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59"
+        );
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+    }
+
+    #[test]
+    fn test_sdk_type_web_with_origin_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", "some-custom-client".parse().unwrap());
+        headers.insert("origin", "https://example.com".parse().unwrap());
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+    }
+
+    #[test]
+    fn test_sdk_type_web_with_referer_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", "some-custom-client".parse().unwrap());
+        headers.insert("referer", "https://example.com/page".parse().unwrap());
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+    }
+
+    #[test]
+    fn test_sdk_type_web_with_sec_fetch_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", "some-custom-client".parse().unwrap());
+        headers.insert("sec-fetch-mode", "navigate".parse().unwrap());
+        assert_eq!(Library::from_headers(&headers), Library::PosthogJs);
+    }
+
+    #[test]
+    fn test_sdk_type_other_missing_user_agent() {
+        let headers = HeaderMap::new();
+        assert_eq!(Library::from_headers(&headers), Library::Other);
+    }
+
+    #[test]
+    fn test_sdk_type_other_empty_user_agent() {
+        let headers = make_headers_with_user_agent("");
+        assert_eq!(Library::from_headers(&headers), Library::Other);
+    }
+
+    #[test]
+    fn test_sdk_type_other_unrecognized() {
+        let headers = make_headers_with_user_agent("some-random-client/1.0");
+        assert_eq!(Library::from_headers(&headers), Library::Other);
+    }
+
+    #[test]
+    fn test_sdk_type_display() {
+        assert_eq!(Library::PosthogJs.to_string(), "posthog-js");
+        assert_eq!(Library::PosthogNode.to_string(), "posthog-node");
+        assert_eq!(Library::PosthogPython.to_string(), "posthog-python");
+        assert_eq!(Library::PosthogAndroid.to_string(), "posthog-android");
+        assert_eq!(Library::Other.to_string(), "other");
+    }
+
+    #[test]
+    fn test_sdk_type_performance() {
+        // Test that parsing 1000 different user-agents is fast
+        use std::time::Instant;
+
+        let test_cases = vec![
+            "posthog-node/3.1.0",
+            "posthog-python/2.5.0",
+            "posthog-php/3.0.0",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "posthog-android/3.0.0",
+            "some-random-client/1.0",
+        ];
+
+        let start = Instant::now();
+        for _ in 0..1000 {
+            for ua in &test_cases {
+                let headers = make_headers_with_user_agent(ua);
+                let _ = Library::from_headers(&headers);
+            }
+        }
+        let duration = start.elapsed();
+
+        // Should process 6000 user-agents in less than 100ms
+        assert!(
+            duration.as_millis() < 100,
+            "SDK type detection took too long: {duration:?}"
+        );
+    }
+
+    #[test]
+    fn test_sdk_type_serialization() {
+        // Test that the enum serializes correctly to JSON
+        assert_eq!(
+            serde_json::to_string(&Library::PosthogNode).unwrap(),
+            "\"posthog-node\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Library::PosthogJs).unwrap(),
+            "\"posthog-js\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Library::PosthogAndroid).unwrap(),
+            "\"posthog-android\""
+        );
+    }
 }


### PR DESCRIPTION
Creating this PR for discussion. Is this worth doing?

## Problem

Customers are billed by the number of `/flags` requests, not the number of `$feature-flag-called` events. This can lead to confusion as it's difficult to understand where the source of the `/flags` requests come from. We often have support issues along those lines.

## Changes

Add SDK library type detection and tracking for feature flag requests to provide customers with visibility into their usage by SDK (web, server-node, mobile-android, etc.).

While this won't necessarily allow pinpointing where a `/flags` request comes from (for example, if they have multiple websites all using `posthog-js`, this won't tell them which site). However, it can narrow it down more than we can today since it's common to have Web and posthog-node in a single app.

This adds a new sdk_breakdown section to the usage report event:

__BEFORE:__

```python
  ph_client.capture(
      distinct_id=team_id,  # e.g., 2
      event="decide usage",
      properties={
          "count": 13,
          "team_id": 2,
          "team_uuid": "019adc76-dca9-0000-e6d5-3b1787d23ccb",
          "min_time": 1768933560,
          "max_time": 1768933560,
          "token": "<DECIDE_BILLING_ANALYTICS_TOKEN>"
      }
  )
```

__AFTER:__

```python
  # From capture_team_decide_usage()
  ph_client.capture(
      distinct_id=team_id,  # e.g., 2
      event="decide usage",
      properties={
          "count": 13,
          "team_id": 2,
          "team_uuid": "019adc76-dca9-0000-e6d5-3b1787d23ccb",
          "min_time": 1768933560,
          "max_time": 1768933560,
          "token": "<DECIDE_BILLING_ANALYTICS_TOKEN>",
          "sdk_breakdown": {
              "posthog-js": 2,
              "posthog-node": 9,
              "posthog-python": 2
          }
      }
  )
```

## How did you test this code?

Unit tests
Manual testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
