### PR TITLE
fix(workflows): Overflow queue naming

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-delay.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-delay.consumer.ts
@@ -16,9 +16,9 @@ export class CdpCyclotronDelayConsumer extends CdpConsumerBase {
 
     constructor(hub: Hub) {
         super(hub)
-        this.queue = !isCloud() ? 'delay_10m' : hub.CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND
+        this.queue = !isCloud() ? 'delay10m' : hub.CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND
 
-        if (!['delay_10m', 'delay_60m', 'delay_24h'].includes(this.queue)) {
+        if (!['delay10m', 'delay60m', 'delay24h'].includes(this.queue)) {
             throw new Error(`Invalid cyclotron job queue kind: ${this.queue}`)
         }
 

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -216,7 +216,7 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                 if (state === HogWatcherState.degraded) {
                     item.queuePriority = 2
                     if (this.hub.CDP_OVERFLOW_QUEUE_ENABLED) {
-                        item.queue = 'hog_overflow'
+                        item.queue = 'hogoverflow'
                     }
                 }
 

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -390,7 +390,7 @@ describe('SourceWebhooksConsumer', () => {
                 expect(mockExecuteSpy).not.toHaveBeenCalled()
                 expect(mockQueueInvocationsSpy).toHaveBeenCalledTimes(1)
                 const call = mockQueueInvocationsSpy.mock.calls[0][0][0]
-                expect(call.queue).toEqual('hog_overflow')
+                expect(call.queue).toEqual('hogoverflow')
             })
 
             it('should return a disabled response if the function is disabled', async () => {

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -307,7 +307,7 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
 
             if (hogFunctionState?.state === HogWatcherState.degraded) {
                 // Degraded functions are not executed immediately
-                invocation.queue = 'hog_overflow'
+                invocation.queue = 'hogoverflow'
                 await this.cyclotronJobQueue.queueInvocations([invocation])
 
                 result = createInvocationResult<CyclotronJobInvocationHogFunction>(

--- a/plugin-server/src/cdp/services/job-queue/job-queue-delay.test.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-delay.test.ts
@@ -35,7 +35,7 @@ describe('CyclotronJobQueueDelay', () => {
     beforeEach(() => {
         config = { ...defaultConfig }
         mockConsumeBatch = jest.fn().mockResolvedValue({ backgroundTask: Promise.resolve() })
-        delayQueue = new CyclotronJobQueueDelay(config, 'delay_10m', mockConsumeBatch)
+        delayQueue = new CyclotronJobQueueDelay(config, 'delay10m', mockConsumeBatch)
 
         jest.clearAllMocks()
 
@@ -90,11 +90,11 @@ describe('CyclotronJobQueueDelay', () => {
                 value: Buffer.from('test-value'),
                 offset: 123,
                 size: 100,
-                topic: 'cdp_cyclotron_delay_10m',
+                topic: 'cdp_cyclotron_delay10m',
                 partition: 0,
                 headers: [
                     {
-                        returnTopic: Buffer.from('delay_10m'),
+                        returnTopic: Buffer.from('delay10m'),
                         queueScheduledAt: Buffer.from(DateTime.now().plus({ minutes: 1 }).toISO()),
                     },
                 ],

--- a/plugin-server/src/cdp/services/job-queue/job-queue-delay.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-delay.ts
@@ -14,23 +14,23 @@ import { CyclotronJobInvocation, CyclotronJobQueueKind } from '../../types'
 
 export const getDelayQueue = (_queueScheduledAt: DateTime): CyclotronJobQueueKind => {
     // if (queueScheduledAt > DateTime.now().plus({ hours: 24 })) {
-    //     return 'delay_24h'
+    //     return 'delay24h'
     // }
 
     // if (queueScheduledAt > DateTime.now().plus({ minutes: 10 })) {
-    //     return 'delay_60m'
+    //     return 'delay60m'
     // }
 
-    return 'delay_10m' // Force everything to the 10m queue for now
+    return 'delay10m' // Force everything to the 10m queue for now
 }
 
 export const getDelayByQueue = (queue: CyclotronJobQueueKind): number => {
     switch (queue) {
-        case 'delay_24h':
+        case 'delay24h':
             return 24 * 60 * 60 * 1000 // 24 hours
-        case 'delay_60m':
+        case 'delay60m':
             return 60 * 60 * 1000 // 1 hour
-        case 'delay_10m':
+        case 'delay10m':
             return 10 * 60 * 1000 // 10 minutes
         default:
             throw new Error(`Invalid queue: ${queue}`)

--- a/plugin-server/src/cdp/services/job-queue/job-queue.test.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.test.ts
@@ -3,8 +3,7 @@ import { DateTime } from 'luxon'
 import { defaultConfig } from '~/config/config'
 import { PluginsServerConfig } from '~/types'
 
-import { HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../../_tests/examples'
-import { HOG_EXAMPLES } from '../../_tests/examples'
+import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../../_tests/examples'
 import { createHogExecutionGlobals, createHogFunction } from '../../_tests/fixtures'
 import { createInvocation } from '../../utils/invocation-utils'
 import { CyclotronJobQueue, JOB_SCHEDULED_AT_FUTURE_THRESHOLD_MS, getProducerMapping } from './job-queue'
@@ -200,7 +199,7 @@ describe('getProducerMapping', () => {
         ],
         [
             'wrong_queue:kafka',
-            'Invalid mapping: wrong_queue:kafka - queue wrong_queue must be one of *, hog, hog_overflow, hogflow',
+            'Invalid mapping: wrong_queue:kafka - queue wrong_queue must be one of *, hog, hogoverflow, hogflow',
         ],
         ['hog:kafka:1.1', 'Invalid mapping: hog:kafka:1.1 - percentage 1.1 must be 0 < x <= 1'],
         ['hog:kafka', 'No mapping for the default queue for example: *:postgres'],

--- a/plugin-server/src/cdp/services/job-queue/job-queue.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.ts
@@ -185,7 +185,7 @@ export class CyclotronJobQueue {
             this.producerForceScheduledToPostgres &&
             invocation.queueScheduledAt &&
             invocation.queueScheduledAt > DateTime.now().plus({ milliseconds: JOB_SCHEDULED_AT_FUTURE_THRESHOLD_MS }) &&
-            invocation.queue !== 'hog_overflow' // overflow is always sent to kafka
+            invocation.queue !== 'hogoverflow' // overflow is always sent to kafka
         ) {
             // Kafka doesn't support delays so if enabled we should force scheduled jobs to postgres
             return 'postgres'

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -225,13 +225,14 @@ export interface HogFunctionTiming {
     duration_ms: number
 }
 
+// IMPORTANT: All queue names should be lowercase and only [A-Z0-9] characters are allowed.
 export const CYCLOTRON_INVOCATION_JOB_QUEUES = [
     'hog',
-    'hog_overflow',
+    'hogoverflow',
     'hogflow',
-    'delay_10m',
-    'delay_60m',
-    'delay_24h',
+    'delay10m',
+    'delay60m',
+    'delay24h',
 ] as const
 export type CyclotronJobQueueKind = (typeof CYCLOTRON_INVOCATION_JOB_QUEUES)[number]
 


### PR DESCRIPTION
## Problem

We do a bunch of templating out of dashboards and alerts which will work better if the topic names are simpler

## Changes

* Changes them
* Will roll this out by freezing the existing overflow deployment and adding the new one

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
