### PR TITLE
fix(experiments): fix chance to win in result details when goals is decrease

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -30,7 +30,7 @@ import {
 
 import {
     ExperimentVariantResult,
-    formatChanceToWin,
+    formatChanceToWinForGoal,
     formatMetricValue,
     formatPValue,
     getIntervalLabel,
@@ -139,7 +139,7 @@ export function ResultDetails({
                 }
 
                 if (isBayesianResult(item)) {
-                    return <div className="font-semibold">{formatChanceToWin(item.chance_to_win)}</div>
+                    return <div className="font-semibold">{formatChanceToWinForGoal(item, metric.goal)}</div>
                 } else if (isFrequentistResult(item)) {
                     return <div className="font-semibold">{formatPValue(item.p_value)}</div>
                 }


### PR DESCRIPTION
## Problem

In the result details, we are not reversing the chance to win if the goal is to decrease.

## Changes

Use the helper function `formatChanceToWinForGoal` to correctly show the chance to win. 

## How did you test this code?

- tested locally