### PR TITLE
fix: truncate event so it can still be renamed 

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
@@ -51,7 +51,10 @@ export function RenameModal({ typeKey, view }: RenameModalProps): JSX.Element {
                 onPressEnter={() => renameFilter(name)}
                 onChange={(value) => setName(value)}
                 suffix={
-                    <span className="text-secondary whitespace-nowrap">
+                    <span
+                        className="text-secondary truncate max-w-[200px]"
+                        title={getDisplayNameFromEntityFilter(selectedFilter, false) ?? ''}
+                    >
                         {getDisplayNameFromEntityFilter(selectedFilter, false) ?? ''}
                     </span>
                 }


### PR DESCRIPTION
## Problem

<img width="275" height="158" alt="image" src="https://github.com/user-attachments/assets/de431c57-f67b-4c04-81b8-dcc2c8771e29" />

## Changes
Truncated it to 200px

<img width="273" height="160" alt="image" src="https://github.com/user-attachments/assets/262fd855-0fa7-42cd-bcd2-b529b0da8693" />



## How did you test this code?

tested locally

