### PR TITLE
fix(batch-exports): Return appropriate error when using a CTE or subquery

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -602,6 +602,9 @@ class BatchExportSerializer(serializers.ModelSerializer):
         if parsed.select_from is None:
             raise serializers.ValidationError("Query must SELECT FROM events")
 
+        if isinstance(parsed.select_from.table, ast.SelectQuery):
+            raise serializers.ValidationError("Subqueries or CTEs are not supported")
+
         # Not sure how to make mypy understand this works, hence the ignore comment.
         # And if it doesn't, it's still okay as it could mean an unsupported query.
         # We would come back with the example to properly type this.


### PR DESCRIPTION
## Problem

CTEs or subqueries are not currently permitted when creating a batch export with a custom HogQL query. If one is used, we return a 500 error rather than a standard 400 error with a clear error message.

## Changes

Return a validation error.

Update tests.

## How did you test this code?

Added new tests.