### PR TITLE
fix(rbac): speed up project switch by eliminating a n+1 query problem

### DIFF
--- a/ee/api/test/test_project.py
+++ b/ee/api/test/test_project.py
@@ -118,7 +118,7 @@ class TestProjectEnterpriseAPI(team_enterprise_api_test_factory()):
         projects_response = self.client.get(f"/api/environments/")
 
         # 9 (above):
-        with self.assertNumQueries(FuzzyInt(17, 18)):
+        with self.assertNumQueries(FuzzyInt(16, 17)):
             current_org_response = self.client.get(f"/api/organizations/{self.organization.id}/")
 
         self.assertEqual(projects_response.status_code, 200)

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -729,15 +729,15 @@
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.26
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.27
@@ -1947,15 +1947,15 @@
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.7
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.8
@@ -4232,15 +4232,15 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.110
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.111
@@ -5551,15 +5551,15 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.139
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.14
@@ -6970,15 +6970,15 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.168
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.169
@@ -8637,15 +8637,15 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.26
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.27
@@ -9541,15 +9541,15 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.45
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.46
@@ -10889,15 +10889,15 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.7
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.70
@@ -11382,15 +11382,15 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.81
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.82
@@ -13355,15 +13355,15 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard.9
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list
@@ -14209,15 +14209,15 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.26
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.27
@@ -15113,15 +15113,15 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.45
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.46
@@ -15340,15 +15340,15 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.7
   '''
-  SELECT 1 AS "a"
+  SELECT "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."access_level"
   FROM "ee_accesscontrol"
-  WHERE ("ee_accesscontrol"."access_level" = 'none'
-         AND "ee_accesscontrol"."organization_member_id" IS NULL
-         AND "ee_accesscontrol"."resource" = 'project'
-         AND "ee_accesscontrol"."resource_id" = '99999'
-         AND "ee_accesscontrol"."role_id" IS NULL
-         AND "ee_accesscontrol"."team_id" = 99999)
-  LIMIT 1
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  WHERE ("ee_accesscontrol"."resource" = 'project'
+         AND "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid))
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.8

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -172,7 +172,7 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         self.organization_membership.save()
 
         # Check effective membership level
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             assert self.permissions().current_team.effective_membership_level is None
 
     def test_team_effective_membership_level_new_access_control_private_team_with_member_access(self):
@@ -206,7 +206,7 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         )
 
         # Check effective membership level
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.MEMBER
 
     def test_team_effective_membership_level_new_access_control_private_team_with_role_access(self):
@@ -251,7 +251,7 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         )
 
         # Check effective membership level
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.MEMBER
 
 

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -104,6 +104,49 @@ class UserPermissions:
         except ImportError:
             return {}
 
+    @cached_property
+    def _prefetched_access_controls(self) -> dict[int, list[dict[str, Any]]]:
+        """
+        Prefetch all AccessControl entries for teams in user's organizations.
+        Returns a dict mapping team_id to list of access control entries.
+        """
+        from ee.models.rbac.access_control import AccessControl
+
+        organization_ids = list(self.organizations.keys())
+        # Get all access controls for teams in these organizations
+        access_controls = AccessControl.objects.filter(
+            team__organization_id__in=organization_ids, resource="project"
+        ).values("team_id", "resource_id", "organization_member_id", "role_id", "access_level")
+
+        # Group by team_id
+        result: dict[int, list[dict[str, Any]]] = {}
+        for ac in access_controls:
+            team_id = ac["team_id"]
+            if team_id not in result:
+                result[team_id] = []
+            result[team_id].append(ac)
+        return result
+
+    @cached_property
+    def _prefetched_role_memberships(self) -> dict[UUID, list[UUID]]:
+        """
+        Prefetch all role memberships for the user.
+        Returns a dict mapping organization_member_id to list of role_ids.
+        """
+        from ee.models.rbac.role import RoleMembership
+
+        memberships = RoleMembership.objects.filter(user=self.user).values(
+            "organization_member_id", "role_id"
+        )
+
+        result: dict[UUID, list[UUID]] = {}
+        for membership in memberships:
+            org_member_id = membership["organization_member_id"]
+            if org_member_id not in result:
+                result[org_member_id] = []
+            result[org_member_id].append(membership["role_id"])
+        return result
+
     def set_preloaded_dashboard_tiles(self, tiles: list[DashboardTile]):
         """
         Allows for speeding up insight-related permissions code
@@ -152,17 +195,17 @@ class UserTeamPermissions:
         if not organization.is_feature_available(AvailableFeature.ADVANCED_PERMISSIONS):
             return organization_membership.level
 
-        from ee.models.rbac.access_control import AccessControl
+        # Use prefetched data to check team privacy and access
+        access_controls = self.p._prefetched_access_controls.get(self.team.id, [])
 
         # Check if the team is private
-        team_is_private = AccessControl.objects.filter(
-            team_id=self.team.id,
-            resource="project",
-            resource_id=str(self.team.id),
-            organization_member=None,
-            role=None,
-            access_level="none",
-        ).exists()
+        team_is_private = any(
+            ac["resource_id"] == str(self.team.id)
+            and ac["organization_member_id"] is None
+            and ac["role_id"] is None
+            and ac["access_level"] == "none"
+            for ac in access_controls
+        )
 
         # If team is not private, all organization members have access
         if not team_is_private:
@@ -175,34 +218,29 @@ class UserTeamPermissions:
             return cast("OrganizationMembership.Level", organization_membership.level)
 
         # Check for direct member access through AccessControl entries
-        user_has_access = AccessControl.objects.filter(
-            team_id=self.team.id,
-            resource="project",
-            resource_id=str(self.team.id),
-            organization_member=organization_membership.id,
-            access_level__in=["member", "admin"],
-        ).exists()
+        user_has_access = any(
+            ac["resource_id"] == str(self.team.id)
+            and ac["organization_member_id"] == organization_membership.id
+            and ac["access_level"] in ["member", "admin"]
+            for ac in access_controls
+        )
 
         if user_has_access:
             return cast("OrganizationMembership.Level", organization_membership.level)
 
         # Check for role-based access
-        from ee.models.rbac.role import RoleMembership
+        user_roles = self.p._prefetched_role_memberships.get(organization_membership.id, [])
 
-        user_roles = RoleMembership.objects.filter(organization_member=organization_membership.id).values_list(
-            "role", flat=True
-        )
+        if user_roles:
+            role_has_access = any(
+                ac["resource_id"] == str(self.team.id)
+                and ac["role_id"] in user_roles
+                and ac["access_level"] in ["member", "admin"]
+                for ac in access_controls
+            )
 
-        role_has_access = AccessControl.objects.filter(
-            team_id=self.team.id,
-            resource="project",
-            resource_id=str(self.team.id),
-            role__in=user_roles,
-            access_level__in=["member", "admin"],
-        ).exists()
-
-        if role_has_access:
-            return cast("OrganizationMembership.Level", organization_membership.level)
+            if role_has_access:
+                return cast("OrganizationMembership.Level", organization_membership.level)
 
         # No access found
         return None

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -135,9 +135,7 @@ class UserPermissions:
         """
         from ee.models.rbac.role import RoleMembership
 
-        memberships = RoleMembership.objects.filter(user=self.user).values(
-            "organization_member_id", "role_id"
-        )
+        memberships = RoleMembership.objects.filter(user=self.user).values("organization_member_id", "role_id")
 
         result: dict[UUID, list[UUID]] = {}
         for membership in memberships:

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -124,7 +124,7 @@ class UserPermissions:
             team_id = ac["team_id"]
             if team_id not in result:
                 result[team_id] = []
-            result[team_id].append(ac)
+            result[team_id].append(dict(ac))
         return result
 
     @cached_property


### PR DESCRIPTION
## Problem

  Switching projects in the main menu takes 30+ seconds when an organization has 600+ projects due to an N+1 query problem in the permissions system.

  **Root cause:** When fetching the organization endpoint (`/api/organizations/{id}/`), the serializer calls `get_projects()` and `get_teams()`, which both rely on `UserPermissions.teams_visible_for_user`. This property checks each team's `effective_membership_level` to determine visibility.

  For organizations with RBAC enabled, `effective_membership_level` makes **4 database queries per team**:
  1. Check if team is private (AccessControl query)
  2. Check user's direct access (AccessControl query)
  3. Get user's roles (RoleMembership query)
  4. Check role-based access (AccessControl query)

  **Impact:** 600 teams × 4 queries = **2,400 database queries** → 30 second load time

  ## Changes

  Optimized `UserPermissions` class to eliminate the N+1 query problem by prefetching all permission data upfront:

  1. **Added `_prefetched_access_controls`** - Fetches all AccessControl entries for teams in user's organizations in a single query, grouped by team_id
  2. **Added `_prefetched_role_memberships`** - Fetches all RoleMembership entries for the user in a single query, grouped by organization_member_id
  3. **Refactored `effective_membership_level_for_parent_membership`** - Changed from making per-team database queries to using in-memory lookups from prefetched data

  The optimization maintains identical logic and behavior while reducing query count from O(n) to O(1) where n is the number of teams.

  **Expected impact:** 600 teams: 2,400 queries → **2 queries** (prefetch only) → <1 second load time

  The prefetched data is cached per request using `@cached_property`, ensuring the optimization works across all permission checks within a single request without persisting stale data across requests.

## How did you test this code?

- existing tests for user permission passes
- tested locally