### PR TITLE
feat(max): split the search tool

### DIFF
--- a/ee/hogai/assistant/main_assistant.py
+++ b/ee/hogai/assistant/main_assistant.py
@@ -85,6 +85,7 @@ class MainAssistant(BaseAssistant):
     def STREAMING_NODES(self) -> set[MaxNodeName]:
         return {
             AssistantNodeName.ROOT,
+            AssistantNodeName.ROOT_TOOLS,
             AssistantNodeName.INKEEP_DOCS,
             AssistantNodeName.MEMORY_ONBOARDING,
             AssistantNodeName.MEMORY_INITIALIZER,

--- a/ee/hogai/graph/graph.py
+++ b/ee/hogai/graph/graph.py
@@ -11,8 +11,6 @@ from ee.hogai.graph.title_generator.nodes import TitleGeneratorNode
 from ee.hogai.utils.types import AssistantNodeName, AssistantState
 
 from .dashboards.nodes import DashboardCreationNode
-from .inkeep_docs.nodes import InkeepDocsNode
-from .insights.nodes import InsightSearchNode
 from .memory.nodes import (
     MemoryCollectorNode,
     MemoryCollectorToolsNode,
@@ -46,7 +44,6 @@ class AssistantGraph(BaseAssistantGraph[AssistantState]):
         path_map = path_map or {
             "root": AssistantNodeName.ROOT,
             "end": AssistantNodeName.END,
-            "insights_search": AssistantNodeName.INSIGHTS_SEARCH,
             "session_summarization": AssistantNodeName.SESSION_SUMMARIZATION,
             "create_dashboard": AssistantNodeName.DASHBOARD_CREATION,
         }
@@ -137,36 +134,6 @@ class AssistantGraph(BaseAssistantGraph[AssistantState]):
         self._graph.add_edge(AssistantNodeName.MEMORY_COLLECTOR_TOOLS, AssistantNodeName.MEMORY_COLLECTOR)
         return self
 
-    def add_inkeep_docs(self, path_map: Optional[dict[Hashable, AssistantNodeName]] = None):
-        """Add the Inkeep docs search node to the graph."""
-        path_map = path_map or {
-            "end": AssistantNodeName.END,
-            "root": AssistantNodeName.ROOT,
-        }
-        inkeep_docs_node = InkeepDocsNode(self._team, self._user)
-        self.add_node(AssistantNodeName.INKEEP_DOCS, inkeep_docs_node)
-        self._graph.add_conditional_edges(
-            AssistantNodeName.INKEEP_DOCS,
-            inkeep_docs_node.router,
-            path_map=cast(dict[Hashable, str], path_map),
-        )
-        return self
-
-    def add_insights_search(self, end_node: AssistantNodeName = AssistantNodeName.END):
-        path_map = {
-            "end": end_node,
-            "root": AssistantNodeName.ROOT,
-        }
-
-        insights_search_node = InsightSearchNode(self._team, self._user)
-        self.add_node(AssistantNodeName.INSIGHTS_SEARCH, insights_search_node)
-        self._graph.add_conditional_edges(
-            AssistantNodeName.INSIGHTS_SEARCH,
-            insights_search_node.router,
-            path_map=cast(dict[Hashable, str], path_map),
-        )
-        return self
-
     def add_session_summarization(self, end_node: AssistantNodeName = AssistantNodeName.END):
         session_summarization_node = SessionSummarizationNode(self._team, self._user)
         self.add_node(AssistantNodeName.SESSION_SUMMARIZATION, session_summarization_node)
@@ -187,8 +154,6 @@ class AssistantGraph(BaseAssistantGraph[AssistantState]):
             .add_memory_collector()
             .add_memory_collector_tools()
             .add_root()
-            .add_inkeep_docs()
-            .add_insights_search()
             .add_session_summarization()
             .add_dashboard_creation()
             .compile(checkpointer=checkpointer)

--- a/ee/hogai/graph/graph.py
+++ b/ee/hogai/graph/graph.py
@@ -44,7 +44,6 @@ class AssistantGraph(BaseAssistantGraph[AssistantState]):
         path_map: Optional[dict[Hashable, AssistantNodeName]] = None,
     ):
         path_map = path_map or {
-            "search_documentation": AssistantNodeName.INKEEP_DOCS,
             "root": AssistantNodeName.ROOT,
             "end": AssistantNodeName.END,
             "insights_search": AssistantNodeName.INSIGHTS_SEARCH,

--- a/ee/hogai/graph/inkeep_docs/test/test_nodes.py
+++ b/ee/hogai/graph/inkeep_docs/test/test_nodes.py
@@ -67,8 +67,12 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
             assert next_state is not None
             messages = cast(list, next_state.messages)
             self.assertEqual(len(messages), 2)
-            second_message = cast(AssistantMessage, messages[1])
-            self.assertEqual(second_message.content, response_with_continuation)
+            # When should_continue is True, messages are reversed
+            first_message = cast(AssistantMessage, messages[0])
+            self.assertEqual(first_message.content, response_with_continuation)
+            # Tool call message should have the continuation prompt
+            second_message = cast(AssistantToolCallMessage, messages[1])
+            self.assertIn("Continue with the user's data request", second_message.content)
 
     def test_node_constructs_messages(self):
         node = InkeepDocsNode(self.team, self.user)

--- a/ee/hogai/graph/inkeep_docs/test/test_nodes.py
+++ b/ee/hogai/graph/inkeep_docs/test/test_nodes.py
@@ -91,26 +91,6 @@ class TestInkeepDocsNode(ClickhouseTestMixin, BaseTest):
         self.assertIsInstance(messages[2], LangchainAIMessage)
         self.assertIsInstance(messages[3], LangchainHumanMessage)
 
-    def test_router_with_data_continuation(self):
-        node = InkeepDocsNode(self.team, self.user)
-        state = AssistantState(
-            messages=[
-                HumanMessage(content="Explain PostHog trends, and show me an example trends insight"),
-                AssistantMessage(content=f"Here's the documentation: XYZ.\n{INKEEP_DATA_CONTINUATION_PHRASE}"),
-            ]
-        )
-        self.assertEqual(node.router(state), "root")  # Going back to root, so that the agent can continue with the task
-
-    def test_router_without_data_continuation(self):
-        node = InkeepDocsNode(self.team, self.user)
-        state = AssistantState(
-            messages=[
-                HumanMessage(content="How do I use feature flags?"),
-                AssistantMessage(content="Here's how to use feature flags..."),
-            ]
-        )
-        self.assertEqual(node.router(state), "end")  # Ending
-
     async def test_tool_call_id_handling(self):
         """Test that tool_call_id is properly handled in both input and output states."""
         test_tool_call_id = str(uuid4())

--- a/ee/hogai/graph/insights/nodes.py
+++ b/ee/hogai/graph/insights/nodes.py
@@ -4,7 +4,7 @@ import inspect
 import warnings
 from datetime import timedelta
 from functools import wraps
-from typing import Literal, Optional, TypedDict
+from typing import Optional, TypedDict
 from uuid import uuid4
 
 from django.db.models import Max
@@ -30,13 +30,11 @@ from ee.hogai.utils.types.base import AssistantNodeName
 from ee.hogai.utils.types.composed import MaxNodeName
 
 from .prompts import (
-    EMPTY_DATABASE_ERROR_MESSAGE,
     HYPERLINK_USAGE_INSTRUCTIONS,
     ITERATIVE_SEARCH_SYSTEM_PROMPT,
     ITERATIVE_SEARCH_USER_PROMPT,
     NO_INSIGHTS_FOUND_MESSAGE,
     PAGINATION_INSTRUCTIONS_TEMPLATE,
-    SEARCH_ERROR_INSTRUCTIONS,
     TOOL_BASED_EVALUATION_SYSTEM_PROMPT,
 )
 
@@ -105,6 +103,10 @@ class InsightDict(TypedDict):
     short_id: str
 
 
+class NoInsightsException(Exception):
+    """Exception indicating that the insight search cannot be done because the user does not have any insights."""
+
+
 class InsightSearchNode(AssistantNode):
     PAGE_SIZE = 500
     MAX_SEARCH_ITERATIONS = 6
@@ -134,6 +136,31 @@ class InsightSearchNode(AssistantNode):
         self._cutoff_date_for_insights_in_days = self.INSIGHTS_CUTOFF_DAYS
         self._query_cache = {}
         self._insight_id_cache = {}
+
+    @timing_logger("InsightSearchNode.arun")
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
+        search_query = state.search_insights_query
+        self._current_iteration = 0
+
+        total_count = await self._get_total_insights_count()
+        if total_count == 0:
+            raise NoInsightsException
+
+        selected_insights = await self._search_insights_iteratively(search_query or "")
+        logger.warning(
+            f"{TIMING_LOG_PREFIX} search_insights_iteratively returned {len(selected_insights)} insights: {selected_insights}"
+        )
+
+        if selected_insights:
+            await self._write_reasoning(content=f"Evaluating {len(selected_insights)} insights to find the best match")
+        else:
+            await self._write_reasoning(content="No existing insights found, creating a new one")
+
+        evaluation_result = await self._evaluate_insights_with_tools(
+            selected_insights, search_query or "", max_selections=1
+        )
+
+        return self._handle_evaluation_result(evaluation_result, state)
 
     def _create_page_reader_tool(self):
         """Create tool for reading insights pages during agentic RAG loop."""
@@ -183,37 +210,6 @@ class InsightSearchNode(AssistantNode):
 
         return [select_insight, reject_all_insights]
 
-    @timing_logger("InsightSearchNode.arun")
-    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
-        search_query = state.search_insights_query
-        try:
-            self._current_iteration = 0
-
-            total_count = await self._get_total_insights_count()
-            if total_count == 0:
-                return self._handle_empty_database(state)
-
-            selected_insights = await self._search_insights_iteratively(search_query or "")
-            logger.warning(
-                f"{TIMING_LOG_PREFIX} search_insights_iteratively returned {len(selected_insights)} insights: {selected_insights}"
-            )
-
-            if selected_insights:
-                await self._write_reasoning(
-                    content=f"Evaluating {len(selected_insights)} insights to find the best match"
-                )
-            else:
-                await self._write_reasoning(content="No existing insights found, creating a new one")
-
-            evaluation_result = await self._evaluate_insights_with_tools(
-                selected_insights, search_query or "", max_selections=1
-            )
-
-            return self._handle_evaluation_result(evaluation_result, state)
-
-        except Exception as e:
-            return self._handle_search_error(e, state)
-
     @timing_logger("InsightSearchNode._get_insights_queryset")
     def _get_insights_queryset(self):
         """Get Insight objects with latest view time annotated and cutoff date."""
@@ -234,10 +230,6 @@ class InsightSearchNode(AssistantNode):
             self._total_insights_count = await self._get_insights_queryset().acount()
         return self._total_insights_count
 
-    def _handle_empty_database(self, state: AssistantState) -> PartialAssistantState:
-        """Handle the case when no insights exist in the database. (Rare edge-case but still possible)"""
-        return self._create_error_response(EMPTY_DATABASE_ERROR_MESSAGE, state.root_tool_call_id)
-
     def _handle_evaluation_result(self, evaluation_result: dict, state: AssistantState) -> PartialAssistantState:
         """Process the evaluation result and return appropriate response."""
         if evaluation_result["should_use_existing"]:
@@ -255,6 +247,8 @@ class InsightSearchNode(AssistantNode):
         formatted_content = f"**Evaluation Result**: {evaluation_result['explanation']}"
         formatted_content += HYPERLINK_USAGE_INSTRUCTIONS
 
+        messages_to_return.extend(evaluation_result["visualization_messages"])
+
         messages_to_return.append(
             AssistantToolCallMessage(
                 content=formatted_content,
@@ -262,8 +256,6 @@ class InsightSearchNode(AssistantNode):
                 id=str(uuid4()),
             )
         )
-
-        messages_to_return.extend(evaluation_result["visualization_messages"])
 
         return PartialAssistantState(
             messages=messages_to_return,
@@ -285,16 +277,6 @@ class InsightSearchNode(AssistantNode):
             root_tool_insight_plan=search_query,
             search_insights_query=None,
             selected_insight_ids=None,
-        )
-
-    @timing_logger("InsightSearchNode._handle_search_error")
-    def _handle_search_error(self, e: Exception, state: AssistantState) -> PartialAssistantState:
-        """Handle exceptions during search process."""
-        capture_exception(e)
-        logger.error(f"{TIMING_LOG_PREFIX} Error in InsightSearchNode: {e}", exc_info=True)
-        return self._create_error_response(
-            SEARCH_ERROR_INSTRUCTIONS,
-            state.root_tool_call_id,
         )
 
     def _format_insight_for_display(self, insight: InsightDict) -> str:
@@ -898,9 +880,6 @@ class InsightSearchNode(AssistantNode):
             "explanation": self._rejection_reason or "No suitable insights found.",
             "visualization_messages": [],
         }
-
-    def router(self, state: AssistantState) -> Literal["root"]:
-        return "root"
 
     @property
     def _model(self):

--- a/ee/hogai/graph/insights/prompts.py
+++ b/ee/hogai/graph/insights/prompts.py
@@ -38,7 +38,3 @@ Instructions:
 NO_INSIGHTS_FOUND_MESSAGE = (
     "No existing insights found matching your query. Creating a new insight based on your request."
 )
-
-SEARCH_ERROR_INSTRUCTIONS = "INSTRUCTIONS: Tell the user that you encountered an issue while searching for insights and suggest they try again with a different search term."
-
-EMPTY_DATABASE_ERROR_MESSAGE = "No insights found in the database."

--- a/ee/hogai/graph/insights/test/test_nodes.py
+++ b/ee/hogai/graph/insights/test/test_nodes.py
@@ -115,11 +115,6 @@ class TestInsightSearchNode(BaseTest):
             short_id=insight.short_id,
         )
 
-    def test_router_returns_root(self):
-        """Test that router returns 'root' as expected."""
-        result = self.node.router(AssistantState(messages=[]))
-        self.assertEqual(result, "root")
-
     async def test_load_insights_page(self):
         """Test loading paginated insights from database."""
         # Load first page
@@ -350,12 +345,6 @@ class TestInsightSearchNode(BaseTest):
         # Should return empty list when LLM fails to select anything
         self.assertEqual(len(result), 0)
 
-    def test_router_always_returns_root(self):
-        """Test that router always returns 'root'."""
-        state = AssistantState(messages=[], root_tool_insight_plan="some plan", search_insights_query=None)
-        result = self.node.router(state)
-        self.assertEqual(result, "root")
-
     async def test_evaluation_flow_returns_creation_when_no_suitable_insights(self):
         """Test that when evaluation returns NO, the system transitions to creation flow."""
         selected_insights = [self.insight1.id, self.insight2.id]
@@ -409,21 +398,6 @@ class TestInsightSearchNode(BaseTest):
                             result.root_tool_insight_plan,
                             search_query,
                             "root_tool_insight_plan should be set to search_query",
-                        )
-
-                        # Test router behavior with the returned state
-                        # Create a new state that simulates what happens after this node runs
-                        post_evaluation_state = AssistantState(
-                            messages=state.messages,
-                            root_tool_insight_plan=search_query,  # This gets set to search_query
-                            search_insights_query=None,  # This gets cleared
-                        )
-
-                        router_result = self.node.router(post_evaluation_state)
-                        self.assertEqual(
-                            router_result,
-                            "root",
-                            "Router should always return root",
                         )
 
                         # Verify that _evaluate_insights_with_tools was called with the search_query

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -80,7 +80,6 @@ RouteName = Literal[
     "root",
     "end",
     "memory_onboarding",
-    "insights_search",
     "session_summarization",
     "create_dashboard",
 ]
@@ -516,8 +515,6 @@ class RootNodeTools(AssistantNode):
                 tool_call_name = tool_call.name
                 if tool_call_name == "create_dashboard":
                     return "create_dashboard"
-            if state.search_insights_query:
-                return "insights_search"
             elif state.session_summarization_query:
                 return "session_summarization"
         return "end"

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -515,6 +515,6 @@ class RootNodeTools(AssistantNode):
                 tool_call_name = tool_call.name
                 if tool_call_name == "create_dashboard":
                     return "create_dashboard"
-            elif state.session_summarization_query:
+            if state.session_summarization_query:
                 return "session_summarization"
         return "end"

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -79,7 +79,6 @@ SLASH_COMMAND_REMEMBER = "/remember"
 RouteName = Literal[
     "root",
     "end",
-    "search_documentation",
     "memory_onboarding",
     "insights_search",
     "session_summarization",
@@ -476,21 +475,6 @@ class RootNodeTools(AssistantNode):
                 root_tool_calls_count=tool_call_count + 1,
             )
 
-        # Handle the basic toolkit
-        if result.name == "search" and isinstance(result.artifact, dict):
-            match result.artifact.get("kind"):
-                case "insights":
-                    return PartialAssistantState(
-                        root_tool_call_id=tool_call.id,
-                        search_insights_query=result.artifact.get("query"),
-                        root_tool_calls_count=tool_call_count + 1,
-                    )
-                case "docs":
-                    return PartialAssistantState(
-                        root_tool_call_id=tool_call.id,
-                        root_tool_calls_count=tool_call_count + 1,
-                    )
-
         # If this is a navigation tool call, pause the graph execution
         # so that the frontend can re-initialise Max with a new set of contextual tools.
         if tool_call.name == "navigate":
@@ -536,6 +520,4 @@ class RootNodeTools(AssistantNode):
                 return "insights_search"
             elif state.session_summarization_query:
                 return "session_summarization"
-            else:
-                return "search_documentation"
         return "end"

--- a/ee/hogai/graph/root/tools/read_billing_tool/test/test_nodes.py
+++ b/ee/hogai/graph/root/tools/read_billing_tool/test/test_nodes.py
@@ -30,13 +30,17 @@ class TestBillingNode(ClickhouseTestMixin, NonAtomicBaseTest):
 
     def setUp(self):
         super().setUp()
-        self.tool = ReadBillingTool(self.team, self.user, AssistantContextManager(self.team, self.user, {}))
+        self.tool = ReadBillingTool(
+            self.team,
+            self.user,
+            AssistantState(messages=[], root_tool_call_id=self.tool_call_id),
+            AssistantContextManager(self.team, self.user, {}),
+        )
         self.tool_call_id = str(uuid4())
-        self.state = AssistantState(messages=[], root_tool_call_id=self.tool_call_id)
 
     async def test_run_with_no_billing_context(self):
         with patch.object(self.tool._context_manager, "get_billing_context", return_value=None):
-            result = await self.tool.execute(self.state)
+            result = await self.tool.execute()
             self.assertEqual(result, "No billing information available")
 
     async def test_run_with_billing_context(self):
@@ -52,7 +56,7 @@ class TestBillingNode(ClickhouseTestMixin, NonAtomicBaseTest):
             patch.object(self.tool._context_manager, "get_billing_context", return_value=billing_context),
             patch.object(self.tool, "_format_billing_context", return_value="Formatted Context"),
         ):
-            result = await self.tool.execute(self.state)
+            result = await self.tool.execute()
             self.assertEqual(result, "Formatted Context")
 
     async def test_format_billing_context(self):

--- a/ee/hogai/graph/root/tools/read_billing_tool/test/test_nodes.py
+++ b/ee/hogai/graph/root/tools/read_billing_tool/test/test_nodes.py
@@ -33,10 +33,9 @@ class TestBillingNode(ClickhouseTestMixin, NonAtomicBaseTest):
         self.tool = ReadBillingTool(
             self.team,
             self.user,
-            AssistantState(messages=[], root_tool_call_id=self.tool_call_id),
+            AssistantState(messages=[], root_tool_call_id=str(uuid4())),
             AssistantContextManager(self.team, self.user, {}),
         )
-        self.tool_call_id = str(uuid4())
 
     async def test_run_with_no_billing_context(self):
         with patch.object(self.tool._context_manager, "get_billing_context", return_value=None):

--- a/ee/hogai/graph/root/tools/read_billing_tool/tool.py
+++ b/ee/hogai/graph/root/tools/read_billing_tool/tool.py
@@ -33,11 +33,11 @@ USAGE_TYPES = [
 
 
 class ReadBillingTool(MaxSubtool):
-    def __init__(self, team: Team, user: User, context_manager: AssistantContextManager):
-        super().__init__(team, user, context_manager)
+    def __init__(self, team: Team, user: User, state: AssistantState, context_manager: AssistantContextManager):
+        super().__init__(team, user, state, context_manager)
         self._teams_map: dict[int, str] = {}
 
-    async def execute(self, state: AssistantState) -> str:
+    async def execute(self) -> str:
         billing_context = self._context_manager.get_billing_context()
         if not billing_context:
             return "No billing information available"

--- a/ee/hogai/graph/root/tools/read_data.py
+++ b/ee/hogai/graph/root/tools/read_data.py
@@ -90,8 +90,8 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 if not has_access:
                     return BILLING_INSUFFICIENT_ACCESS_PROMPT, None
                 # used for routing
-                billing_tool = ReadBillingTool(self._team, self._user, self._context_manager)
-                result = await billing_tool.execute(self._state)
+                billing_tool = ReadBillingTool(self._team, self._user, self._state, self._context_manager)
+                result = await billing_tool.execute()
                 return result, None
             case "datawarehouse_schema":
                 return await self._serialize_database_schema(), None

--- a/ee/hogai/graph/root/tools/search.py
+++ b/ee/hogai/graph/root/tools/search.py
@@ -1,12 +1,15 @@
-from typing import Any, Literal
+from typing import Annotated, Literal
 
 from django.conf import settings
 
+from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import InjectedToolCallId
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
-from ee.hogai.graph.inkeep_docs.nodes import InkeepDocsGraph
-from ee.hogai.tool import MaxTool, ToolMessagesArtifact
-from ee.hogai.utils.types.base import AssistantState
+from ee.hogai.graph.insights.nodes import InsightSearchNode, NoInsightsException
+from ee.hogai.tool import MaxSubtool, MaxTool, ToolMessagesArtifact
+from ee.hogai.utils.types.base import AssistantState, PartialAssistantState
 
 SEARCH_TOOL_PROMPT = """
 Use this tool to search docs or insights by using natural language.
@@ -56,6 +59,7 @@ SearchKind = Literal["insights"] | Literal["docs"]
 
 
 class SearchToolArgs(BaseModel):
+    tool_call_id: Annotated[str, InjectedToolCallId, SkipJsonSchema]
     kind: SearchKind = Field(description="Select the entity you want to find")
     query: str = Field(
         description="Describe what you want to find. Include as much details from the context as possible."
@@ -71,19 +75,49 @@ class SearchTool(MaxTool):
     show_tool_call_message: bool = False
 
     async def _arun_impl(
-        self, kind: SearchKind, query: str
-    ) -> tuple[str, dict[str, Any] | ToolMessagesArtifact | None]:
-        if kind == "docs":
-            if not settings.INKEEP_API_KEY:
-                return "This tool is not available in this environment.", None
-            # Init the graph
-            docs_graph = InkeepDocsGraph(self._team, self._user).compile_full_graph()
-            copied_state = self._state.model_copy(deep=True)
-            dict_state = await docs_graph.ainvoke(copied_state)
-            updated_state = AssistantState.model_validate(dict_state)
-            # Copy new messages
-            new_messages = updated_state.messages[len(self._state.messages) :]
-            return "", ToolMessagesArtifact(messages=new_messages)
+        self, kind: SearchKind, query: str, tool_call_id: str
+    ) -> tuple[str, ToolMessagesArtifact | None]:
+        match kind:
+            case "docs":
+                if not settings.INKEEP_API_KEY:
+                    return "This tool is not available in this environment.", None
+                docs_tool = InkeepDocsSearchTool(self._team, self._user, self._state, self._context_manager)
+                return await docs_tool.execute(query, tool_call_id)
+            case "insights":
+                insights_tool = InsightSearchTool(self._team, self._user, self._state, self._context_manager)
+                return await insights_tool.execute(query, tool_call_id)
+            case _:
+                raise ValueError(f"Unknown kind argument of the {self.get_name()} tool")
 
-        # Used for routing
-        return "Search tool executed", SearchToolArgs(kind=kind, query=query).model_dump()
+
+class InkeepDocsSearchTool(MaxSubtool):
+    async def execute(self, query: str, tool_call_id: str) -> tuple[str, ToolMessagesArtifact | None]:
+        # Avoid circular import
+        from ee.hogai.graph.inkeep_docs.nodes import InkeepDocsNode
+
+        # Init the graph
+        node = InkeepDocsNode(self._team, self._user)
+        chain: RunnableLambda[AssistantState, PartialAssistantState | None] = RunnableLambda(node)
+        copied_state = self._state.model_copy(deep=True, update={"root_tool_call_id": tool_call_id})
+        result = await chain.ainvoke(copied_state)
+        assert result is not None
+        return "", ToolMessagesArtifact(messages=result.messages)
+
+
+EMPTY_DATABASE_ERROR_MESSAGE = """
+The user doesn't have any insights created yet.
+""".strip()
+
+
+class InsightSearchTool(MaxSubtool):
+    async def execute(self, query: str, tool_call_id: str) -> tuple[str, ToolMessagesArtifact | None]:
+        try:
+            node = InsightSearchNode(self._team, self._user)
+            copied_state = self._state.model_copy(
+                deep=True, update={"search_insights_query": query, "root_tool_call_id": tool_call_id}
+            )
+            chain: RunnableLambda[AssistantState, PartialAssistantState | None] = RunnableLambda(node)
+            result = await chain.ainvoke(copied_state)
+            return "", ToolMessagesArtifact(messages=result.messages) if result else None
+        except NoInsightsException:
+            return EMPTY_DATABASE_ERROR_MESSAGE, None

--- a/ee/hogai/graph/root/tools/test/test_search.py
+++ b/ee/hogai/graph/root/tools/test/test_search.py
@@ -1,0 +1,196 @@
+from typing import cast
+from uuid import uuid4
+
+from posthog.test.base import ClickhouseTestMixin, NonAtomicBaseTest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from posthog.schema import AssistantMessage
+
+from ee.hogai.context.context import AssistantContextManager
+from ee.hogai.graph.root.tools.search import (
+    EMPTY_DATABASE_ERROR_MESSAGE,
+    InkeepDocsSearchTool,
+    InsightSearchTool,
+    SearchTool,
+)
+from ee.hogai.utils.types import AssistantState, PartialAssistantState
+
+
+class TestSearchTool(ClickhouseTestMixin, NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
+        self.context_manager = AssistantContextManager(self.team, self.user, {})
+        self.tool = SearchTool(
+            team=self.team,
+            user=self.user,
+            state=self.state,
+            context_manager=self.context_manager,
+        )
+
+    async def test_run_docs_search_without_api_key(self):
+        with patch("ee.hogai.graph.root.tools.search.settings") as mock_settings:
+            mock_settings.INKEEP_API_KEY = None
+            result, artifact = await self.tool._arun_impl(
+                kind="docs", query="How to use feature flags?", tool_call_id="test-id"
+            )
+            self.assertEqual(result, "This tool is not available in this environment.")
+            self.assertIsNone(artifact)
+
+    async def test_run_docs_search_with_api_key(self):
+        mock_docs_tool = MagicMock()
+        mock_docs_tool.execute = AsyncMock(return_value=("", MagicMock()))
+
+        with (
+            patch("ee.hogai.graph.root.tools.search.settings") as mock_settings,
+            patch("ee.hogai.graph.root.tools.search.InkeepDocsSearchTool", return_value=mock_docs_tool),
+        ):
+            mock_settings.INKEEP_API_KEY = "test-key"
+            result, artifact = await self.tool._arun_impl(
+                kind="docs", query="How to use feature flags?", tool_call_id="test-id"
+            )
+
+            mock_docs_tool.execute.assert_called_once_with("How to use feature flags?", "test-id")
+            self.assertEqual(result, "")
+            self.assertIsNotNone(artifact)
+
+    async def test_run_insights_search(self):
+        mock_insights_tool = MagicMock()
+        mock_insights_tool.execute = AsyncMock(return_value=("", MagicMock()))
+
+        with patch("ee.hogai.graph.root.tools.search.InsightSearchTool", return_value=mock_insights_tool):
+            result, artifact = await self.tool._arun_impl(kind="insights", query="user signups", tool_call_id="test-id")
+
+            mock_insights_tool.execute.assert_called_once_with("user signups", "test-id")
+            self.assertEqual(result, "")
+            self.assertIsNotNone(artifact)
+
+    async def test_run_unknown_kind(self):
+        with self.assertRaises(ValueError) as context:
+            await self.tool._arun_impl(kind="unknown", query="test", tool_call_id="test-id")  # type: ignore
+
+        self.assertIn("Unknown kind argument", str(context.exception))
+
+
+class TestInkeepDocsSearchTool(ClickhouseTestMixin, NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.tool_call_id = str(uuid4())
+        self.state = AssistantState(messages=[], root_tool_call_id=self.tool_call_id)
+        self.context_manager = AssistantContextManager(self.team, self.user, {})
+        self.tool = InkeepDocsSearchTool(
+            team=self.team,
+            user=self.user,
+            state=self.state,
+            context_manager=self.context_manager,
+        )
+
+    async def test_execute_calls_inkeep_docs_node(self):
+        mock_node_instance = MagicMock()
+        mock_result = PartialAssistantState(messages=[AssistantMessage(content="Here is the answer from docs")])
+
+        with patch("ee.hogai.graph.inkeep_docs.nodes.InkeepDocsNode", return_value=mock_node_instance):
+            with patch("ee.hogai.graph.root.tools.search.RunnableLambda") as mock_runnable:
+                mock_chain = MagicMock()
+                mock_chain.ainvoke = AsyncMock(return_value=mock_result)
+                mock_runnable.return_value = mock_chain
+
+                result, artifact = await self.tool.execute("How to track events?", "test-tool-call-id")
+
+                self.assertEqual(result, "")
+                self.assertIsNotNone(artifact)
+                assert artifact is not None
+                self.assertEqual(len(artifact.messages), 1)
+                message = cast(AssistantMessage, artifact.messages[0])
+                self.assertEqual(message.content, "Here is the answer from docs")
+
+    async def test_execute_updates_state_with_tool_call_id(self):
+        mock_result = PartialAssistantState(messages=[AssistantMessage(content="Test response")])
+
+        async def mock_ainvoke(state):
+            self.assertEqual(state.root_tool_call_id, "custom-tool-call-id")
+            return mock_result
+
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = mock_ainvoke
+
+        with patch("ee.hogai.graph.inkeep_docs.nodes.InkeepDocsNode"):
+            with patch("ee.hogai.graph.root.tools.search.RunnableLambda", return_value=mock_chain):
+                await self.tool.execute("test query", "custom-tool-call-id")
+
+
+class TestInsightSearchTool(ClickhouseTestMixin, NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.tool_call_id = str(uuid4())
+        self.state = AssistantState(messages=[], root_tool_call_id=self.tool_call_id)
+        self.context_manager = AssistantContextManager(self.team, self.user, {})
+        self.tool = InsightSearchTool(
+            team=self.team,
+            user=self.user,
+            state=self.state,
+            context_manager=self.context_manager,
+        )
+
+    async def test_execute_calls_insight_search_node(self):
+        mock_node_instance = MagicMock()
+        mock_result = PartialAssistantState(messages=[AssistantMessage(content="Found 3 insights matching your query")])
+
+        with patch("ee.hogai.graph.insights.nodes.InsightSearchNode", return_value=mock_node_instance):
+            with patch("ee.hogai.graph.root.tools.search.RunnableLambda") as mock_runnable:
+                mock_chain = MagicMock()
+                mock_chain.ainvoke = AsyncMock(return_value=mock_result)
+                mock_runnable.return_value = mock_chain
+
+                result, artifact = await self.tool.execute("user signups by week", "test-tool-call-id")
+
+                self.assertEqual(result, "")
+                self.assertIsNotNone(artifact)
+                assert artifact is not None
+                self.assertEqual(len(artifact.messages), 1)
+                message = cast(AssistantMessage, artifact.messages[0])
+                self.assertEqual(message.content, "Found 3 insights matching your query")
+
+    async def test_execute_updates_state_with_search_query(self):
+        mock_result = PartialAssistantState(messages=[AssistantMessage(content="Test response")])
+
+        async def mock_ainvoke(state):
+            self.assertEqual(state.search_insights_query, "custom search query")
+            self.assertEqual(state.root_tool_call_id, "custom-tool-call-id")
+            return mock_result
+
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = mock_ainvoke
+
+        with patch("ee.hogai.graph.insights.nodes.InsightSearchNode"):
+            with patch("ee.hogai.graph.root.tools.search.RunnableLambda", return_value=mock_chain):
+                await self.tool.execute("custom search query", "custom-tool-call-id")
+
+    async def test_execute_handles_no_insights_exception(self):
+        from ee.hogai.graph.insights.nodes import NoInsightsException
+
+        with patch("ee.hogai.graph.insights.nodes.InsightSearchNode", side_effect=NoInsightsException()):
+            result, artifact = await self.tool.execute("user signups", "test-tool-call-id")
+
+            self.assertEqual(result, EMPTY_DATABASE_ERROR_MESSAGE)
+            self.assertIsNone(artifact)
+
+    async def test_execute_returns_none_artifact_when_result_is_none(self):
+        async def mock_ainvoke(state):
+            return None
+
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = mock_ainvoke
+
+        with patch("ee.hogai.graph.insights.nodes.InsightSearchNode"):
+            with patch("ee.hogai.graph.root.tools.search.RunnableLambda", return_value=mock_chain):
+                result, artifact = await self.tool.execute("test query", "test-tool-call-id")
+
+                self.assertEqual(result, "")
+                self.assertIsNone(artifact)

--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -1318,12 +1318,10 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
             .add_root(
                 {
-                    "search_documentation": AssistantNodeName.INKEEP_DOCS,
                     "root": AssistantNodeName.ROOT,
                     "end": AssistantNodeName.END,
                 }
             )
-            .add_inkeep_docs()
             .compile()
         )
 

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -165,11 +165,12 @@ class MaxTool(AssistantContextMixin, BaseTool):
 
 
 class MaxSubtool(ABC):
-    def __init__(self, team: Team, user: User, context_manager: AssistantContextManager):
+    def __init__(self, team: Team, user: User, state: AssistantState, context_manager: AssistantContextManager):
         self._team = team
         self._user = user
+        self._state = state
         self._context_manager = context_manager
 
     @abstractmethod
-    async def execute(self, state: AssistantState) -> Any:
+    async def execute(self, *args, **kwargs) -> Any:
         pass


### PR DESCRIPTION
## Problem

Since we want to parallelize tool calls, we would like to split the monolithic graph into subgraphs or MaxTools, allowing the tools to be easily parallelized. This PR focuses on the search tool.

## Changes

- Encapsulated Inkeep under a MaxTool.
- Encapsulated the insights search under a MaxTool.
- Added tests.

## How did you test this code?

Manual & unit tests.