### PR TITLE
fix: Create `behavioral_cohorts` DB locally on postgres init

### DIFF
--- a/docker/postgres-init-scripts/create-behavioral-cohorts-db.sh
+++ b/docker/postgres-init-scripts/create-behavioral-cohorts-db.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -u
+
+echo "Checking if database 'behavioral_cohorts' exists..."
+DB_EXISTS=$(psql -U "$POSTGRES_USER" -tAc "SELECT 1 FROM pg_database WHERE datname='behavioral_cohorts'")
+
+if [ -z "$DB_EXISTS" ]; then
+    echo "Creating database 'behavioral_cohorts'..."
+    psql -U "$POSTGRES_USER" -c "CREATE DATABASE behavioral_cohorts;"
+    psql -U "$POSTGRES_USER" -c "GRANT ALL PRIVILEGES ON DATABASE behavioral_cohorts TO $POSTGRES_USER;"
+    echo "Database 'behavioral_cohorts' created successfully"
+else
+    echo "Database 'behavioral_cohorts' already exists"
+fi


### PR DESCRIPTION
When resetting the DB we'd never create the `behavioral_cohorts` DB because we're missing this script - we have them for the persons DB table