### PR TITLE
feat(replay): add searchbar to 'pinned overview properties' popover

### DIFF
--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -129,6 +129,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
         setPinnedProperties: (properties: string[]) => ({ properties }),
         togglePropertyPin: (propertyKey: string) => ({ propertyKey }),
         setIsPropertyPopoverOpen: (isOpen: boolean) => ({ isOpen }),
+        setPropertySearchQuery: (query: string) => ({ query }),
     }),
     reducers(() => ({
         summaryHasHadFeedback: [
@@ -175,6 +176,12 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 setIsPropertyPopoverOpen: (_, { isOpen }) => isOpen,
             },
         ],
+        propertySearchQuery: [
+            '',
+            {
+                setPropertySearchQuery: (_, { query }) => query,
+            },
+        ],
     })),
     listeners(({ actions, values }) => ({
         togglePropertyPin: ({ propertyKey }) => {
@@ -183,6 +190,12 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 actions.setPinnedProperties(currentPinned.filter((k) => k !== propertyKey))
             } else {
                 actions.setPinnedProperties([...currentPinned, propertyKey])
+            }
+        },
+        setIsPropertyPopoverOpen: ({ isOpen }) => {
+            // Clear search query when popover is closed
+            if (!isOpen) {
+                actions.setPropertySearchQuery('')
             }
         },
     })),

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -385,6 +385,41 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 })
             },
         ],
+        filteredPropertiesWithInfo: [
+            (s) => [s.sessionPlayerMetaData, s.recordingPropertiesById, s.propertySearchQuery],
+            (sessionPlayerMetaData, recordingPropertiesById, propertySearchQuery) => {
+                const recordingProperties = sessionPlayerMetaData?.id
+                    ? recordingPropertiesById[sessionPlayerMetaData?.id] || {}
+                    : {}
+
+                const personProperties = getAllPersonProperties(sessionPlayerMetaData)
+                const personPropertyKeys = personProperties ? Object.keys(personProperties).sort() : []
+
+                // Get recording property keys from allOverviewItems
+                const recordingPropertyKeys = sessionPlayerMetaData?.id
+                    ? Object.keys(recordingPropertiesById[sessionPlayerMetaData?.id] || {})
+                    : []
+
+                const allPropertyKeys = Array.from(new Set([...recordingPropertyKeys, ...personPropertyKeys])).sort()
+
+                return allPropertyKeys
+                    .map((propertyKey) => {
+                        const propertyInfo = getPropertyDisplayInfo(propertyKey, recordingProperties)
+                        return { propertyKey, propertyInfo }
+                    })
+                    .filter(({ propertyInfo }) => {
+                        if (!propertySearchQuery.trim()) {
+                            return true
+                        }
+
+                        const searchLower = propertySearchQuery.toLowerCase()
+                        return (
+                            propertyInfo.label.toLowerCase().includes(searchLower) ||
+                            propertyInfo.originalKey.toLowerCase().includes(searchLower)
+                        )
+                    })
+            },
+        ],
     })),
     listeners(({ actions, values, props }) => ({
         loadRecordingMetaSuccess: () => {

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarEditPinnedPropertiesPopover.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarEditPinnedPropertiesPopover.tsx
@@ -8,7 +8,7 @@ import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableSh
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { personsLogic } from 'scenes/persons/personsLogic'
 
-import { getPropertyDisplayInfo, playerMetaLogic } from '../player-meta/playerMetaLogic'
+import { playerMetaLogic } from '../player-meta/playerMetaLogic'
 import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 
 export type PlayerSidebarEditPinnedPropertiesPopoverProps = {
@@ -23,8 +23,7 @@ export function PlayerSidebarEditPinnedPropertiesPopover(
     const { loadPerson, loadPersonUUID } = useActions(personsLogic({ syncWithUrl: false }))
     const { person, personLoading } = useValues(personsLogic({ syncWithUrl: false }))
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
-    const { allOverviewItems, pinnedProperties, sessionPlayerMetaData, recordingPropertiesById, propertySearchQuery } =
-        useValues(playerMetaLogic(logicProps))
+    const { pinnedProperties, propertySearchQuery, filteredPropertiesWithInfo } = useValues(playerMetaLogic(logicProps))
     const { togglePropertyPin, setPropertySearchQuery } = useActions(playerMetaLogic(logicProps))
 
     useEffect(() => {
@@ -57,35 +56,6 @@ export function PlayerSidebarEditPinnedPropertiesPopover(
             </div>
         )
     }
-
-    const personPropertyKeys = person.properties ? Object.keys(person.properties).sort() : []
-    const recordingPropertyKeys = allOverviewItems.map((item) =>
-        item.type === 'property' ? item.property : item.label
-    )
-
-    // Deduplicate and create a combined list
-    const allPropertyKeys = Array.from(new Set([...recordingPropertyKeys, ...personPropertyKeys])).sort()
-
-    const recordingProperties = sessionPlayerMetaData?.id
-        ? recordingPropertiesById[sessionPlayerMetaData?.id] || {}
-        : {}
-
-    const filteredPropertiesWithInfo = allPropertyKeys
-        .map((propertyKey) => {
-            const propertyInfo = getPropertyDisplayInfo(propertyKey, recordingProperties)
-            return { propertyKey, propertyInfo }
-        })
-        .filter(({ propertyInfo }) => {
-            if (!propertySearchQuery.trim()) {
-                return true
-            }
-
-            const searchLower = propertySearchQuery.toLowerCase()
-            return (
-                propertyInfo.label.toLowerCase().includes(searchLower) ||
-                propertyInfo.originalKey.toLowerCase().includes(searchLower)
-            )
-        })
 
     return (
         <div className="flex flex-col overflow-hidden max-h-96 w-[400px]">

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarEditPinnedPropertiesPopover.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarEditPinnedPropertiesPopover.tsx
@@ -1,8 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconPin, IconPinFilled } from '@posthog/icons'
-import { LemonButton, Link } from '@posthog/lemon-ui'
+import { IconPin, IconPinFilled, IconSearch } from '@posthog/icons'
+import { LemonButton, LemonInput, Link } from '@posthog/lemon-ui'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -23,10 +23,9 @@ export function PlayerSidebarEditPinnedPropertiesPopover(
     const { loadPerson, loadPersonUUID } = useActions(personsLogic({ syncWithUrl: false }))
     const { person, personLoading } = useValues(personsLogic({ syncWithUrl: false }))
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
-    const { allOverviewItems, pinnedProperties, sessionPlayerMetaData, recordingPropertiesById } = useValues(
-        playerMetaLogic(logicProps)
-    )
-    const { togglePropertyPin } = useActions(playerMetaLogic(logicProps))
+    const { allOverviewItems, pinnedProperties, sessionPlayerMetaData, recordingPropertiesById, propertySearchQuery } =
+        useValues(playerMetaLogic(logicProps))
+    const { togglePropertyPin, setPropertySearchQuery } = useActions(playerMetaLogic(logicProps))
 
     useEffect(() => {
         if (props.distinctId) {
@@ -67,47 +66,81 @@ export function PlayerSidebarEditPinnedPropertiesPopover(
     // Deduplicate and create a combined list
     const allPropertyKeys = Array.from(new Set([...recordingPropertyKeys, ...personPropertyKeys])).sort()
 
+    const recordingProperties = sessionPlayerMetaData?.id
+        ? recordingPropertiesById[sessionPlayerMetaData?.id] || {}
+        : {}
+
+    const filteredPropertiesWithInfo = allPropertyKeys
+        .map((propertyKey) => {
+            const propertyInfo = getPropertyDisplayInfo(propertyKey, recordingProperties)
+            return { propertyKey, propertyInfo }
+        })
+        .filter(({ propertyInfo }) => {
+            if (!propertySearchQuery.trim()) {
+                return true
+            }
+
+            const searchLower = propertySearchQuery.toLowerCase()
+            return (
+                propertyInfo.label.toLowerCase().includes(searchLower) ||
+                propertyInfo.originalKey.toLowerCase().includes(searchLower)
+            )
+        })
+
     return (
-        <div className="flex flex-col overflow-hidden max-h-96 max-w-160">
+        <div className="flex flex-col overflow-hidden max-h-96 w-[400px]">
             <div className="flex items-center gap-2 px-4 py-3 border-b">
                 <IconPinFilled className="text-muted" />
                 <h4 className="font-semibold m-0">Pinned properties</h4>
             </div>
 
+            <div className="px-4 py-2 border-b">
+                <LemonInput
+                    placeholder="Search properties..."
+                    value={propertySearchQuery}
+                    onChange={setPropertySearchQuery}
+                    prefix={<IconSearch />}
+                    size="small"
+                    fullWidth
+                />
+            </div>
+
             <ScrollableShadows direction="vertical" className="flex-1">
                 <div className="flex flex-col">
-                    {allPropertyKeys.map((propertyKey) => {
-                        const isPinned = pinnedProperties.includes(propertyKey)
-                        const recordingProperties = sessionPlayerMetaData?.id
-                            ? recordingPropertiesById[sessionPlayerMetaData?.id] || {}
-                            : {}
-                        const propertyInfo = getPropertyDisplayInfo(propertyKey, recordingProperties)
+                    {filteredPropertiesWithInfo.length === 0 ? (
+                        <div className="px-4 py-8 text-center text-muted">
+                            {propertySearchQuery.trim() ? 'No properties match your search' : 'No properties available'}
+                        </div>
+                    ) : (
+                        filteredPropertiesWithInfo.map(({ propertyKey, propertyInfo }) => {
+                            const isPinned = pinnedProperties.includes(propertyKey)
 
-                        const handleToggle = (): void => {
-                            togglePropertyPin(propertyKey)
-                        }
+                            const handleToggle = (): void => {
+                                togglePropertyPin(propertyKey)
+                            }
 
-                        return (
-                            <LemonButton
-                                key={propertyKey}
-                                data-attr={
-                                    isPinned ? 'session-overview-unpin-property' : 'session-overview-pin-property'
-                                }
-                                size="small"
-                                fullWidth
-                                className="justify-between"
-                                onClick={handleToggle}
-                                sideIcon={isPinned ? <IconPinFilled /> : <IconPin />}
-                                tooltip={
-                                    propertyInfo.label !== propertyInfo.originalKey
-                                        ? `Sent as: ${propertyInfo.originalKey}`
-                                        : undefined
-                                }
-                            >
-                                <span>{propertyInfo.label}</span>
-                            </LemonButton>
-                        )
-                    })}
+                            return (
+                                <LemonButton
+                                    key={propertyKey}
+                                    data-attr={
+                                        isPinned ? 'session-overview-unpin-property' : 'session-overview-pin-property'
+                                    }
+                                    size="small"
+                                    fullWidth
+                                    className="justify-between"
+                                    onClick={handleToggle}
+                                    sideIcon={isPinned ? <IconPinFilled /> : <IconPin />}
+                                    tooltip={
+                                        propertyInfo.label !== propertyInfo.originalKey
+                                            ? `Sent as: ${propertyInfo.originalKey}`
+                                            : undefined
+                                    }
+                                >
+                                    <span>{propertyInfo.label}</span>
+                                </LemonButton>
+                            )
+                        })
+                    )}
                 </div>
             </ScrollableShadows>
         </div>


### PR DESCRIPTION
## Problem

We introduced a popover to let people pin properties for replay overview, this allows people to search for properties via label OR key in that popover

## Changes

add a search bar in the pinned properties popover

## How did you test this code?

![Screenshot 2025-10-21 at 9.15.14 AM.png](https://app.graphite.dev/user-attachments/assets/ae30845b-ac04-490e-aeb8-55e484ed2a5b.png)

![Screenshot 2025-10-21 at 9.05.43 AM.png](https://app.graphite.dev/user-attachments/assets/02f8b299-eb29-40dd-9a78-341e9e3e7bf4.png)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
