### PR TITLE
fix(mcp): avoid not found page flash

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -10,6 +10,7 @@ import { Error404 as Error404Component } from '~/layout/Error404'
 import { ErrorAccessDenied as ErrorAccessDeniedComponent } from '~/layout/ErrorAccessDenied'
 import { ErrorNetwork as ErrorNetworkComponent } from '~/layout/ErrorNetwork'
 import { ErrorProjectUnavailable as ErrorProjectUnavailableComponent } from '~/layout/ErrorProjectUnavailable'
+import { scene as oauthAuthorizeScene } from '~/scenes/oauth/OAuthAuthorize'
 import { productConfiguration, productRedirects, productRoutes } from '~/products'
 import { EventsQuery } from '~/queries/schema/schema-general'
 import { ActivityScope, ActivityTab, InsightShortId, PropertyFilterType, ReplayTabs } from '~/types'
@@ -32,6 +33,7 @@ export const preloadedScenes: Record<string, SceneExport> = {
     [Scene.ErrorProjectUnavailable]: {
         component: ErrorProjectUnavailableComponent,
     },
+    [Scene.OAuthAuthorize]: oauthAuthorizeScene,
 }
 
 export const sceneConfigurations: Record<Scene | string, SceneConfig> = {


### PR DESCRIPTION
This page flashes with a 404 because the scene is loaded dynamically, and only resolved in the sceneLogic.

This preloads it to avoid the 404 flashing.