### PR TITLE
fix(create experiment): metric recent event count fixes

### DIFF
--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricCard.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricCard.tsx
@@ -89,16 +89,16 @@ export const MetricCard = ({ metric, metricContext, onDelete, filterTestAccounts
 
                 <div className="border-t border-border" />
 
-                <div className="space-y-1">
-                    <MetricGoal metric={metric} />
-                    <MetricConversionWindow metric={metric} />
-                    <MetricStepOrder metric={metric} />
-                    <MetricOutlierHandling metric={metric} />
+                <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                        <MetricGoal metric={metric} />
+                        <MetricConversionWindow metric={metric} />
+                        <MetricStepOrder metric={metric} />
+                        <MetricOutlierHandling metric={metric} />
+                    </div>
+
+                    <MetricRecentActivity metric={metric} filterTestAccounts={filterTestAccounts} />
                 </div>
-
-                <div className="border-t border-border" />
-
-                <MetricRecentActivity metric={metric} filterTestAccounts={filterTestAccounts} />
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricRecentActivity.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricRecentActivity.tsx
@@ -26,12 +26,9 @@ export const MetricRecentActivity = ({ metric, filterTestAccounts }: MetricRecen
     const count = eventCount ?? 0
 
     return (
-        <div className="text-xs">
-            <span className="text-muted">Recent activity:</span>{' '}
-            <span className="font-semibold">
-                {count.toLocaleString()} event{count !== 1 ? 's' : ''}
-            </span>{' '}
-            <span className="text-muted">(past 14 days)</span>
+        <div className="flex flex-col gap-1">
+            <span className="text-muted">events in the past 14 days</span>
+            <span className="text-2xl font-semibold text-right">{count.toLocaleString()}</span>
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
@@ -48,7 +48,7 @@ export const MetricsPanel = ({
     const { closeSharedMetricModal } = useActions(sharedMetricModalLogic)
 
     // we need this value to calculate the recent activity on the metrics list
-    const filterTestAccounts = experiment.filters?.filter_test_accounts || false
+    const filterTestAccounts = experiment.exposure_criteria?.filterTestAccounts ?? false
 
     const primaryMetrics = sortMetrics(
         [...(experiment.metrics || []).filter(isExperimentMetric), ...sharedMetrics.primary],


### PR DESCRIPTION
## Problem

The recent event count on the metric panel is incorrect, and the display is visually unbalanced.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The event count was sending the wrong value for the `filterTestAccounts` property, which was causing a mismatch between the create metric modal and the metric panel. I'll blame cursor autocomplete for this.

For the UX part, we adjusted the layout and used the same fonts as the create metric modal.

| Before | After |
| - | - |
| <img width="932" height="546" alt="image" src="https://github.com/user-attachments/assets/c04daab4-bde1-40d2-add2-ae7f6ef7fe14" /> | <img width="931" height="508" alt="image" src="https://github.com/user-attachments/assets/10b6535d-32f9-444e-acba-89ed6f894109" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/383a46e6-b055-42bb-8568-12b95b836839)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->