### PR TITLE
fix(experiments): Fix unique key in funnel step bars

### DIFF
--- a/frontend/src/scenes/experiments/charts/funnel/StepBars.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBars.tsx
@@ -20,8 +20,8 @@ export function StepBars({ step, stepIndex }: StepBarsProps): JSX.Element {
                     />
                 ))}
             </div>
-            {step.nested_breakdown?.map((series) => (
-                <StepBar key={`bar-${stepIndex}-${series.order}`} step={series} stepIndex={stepIndex} />
+            {step.nested_breakdown?.map((series, i) => (
+                <StepBar key={`bar-${stepIndex}-${i}`} step={series} stepIndex={stepIndex} />
             )) || <StepBar step={step} stepIndex={stepIndex} />}
         </div>
     )


### PR DESCRIPTION
## Problem
React warns about duplicate keys in funnel charts. This is because we're not actually setting `series.order` in the experiments code path, which results in keys like `bar-1-undefined`:

```
react-dom.development.js:86 Warning: Encountered two children with the same key, `bar-1-undefined`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

## Changes
Replace `series.order` with array index `i` in the key generation to ensure unique keys.

## How did you test this code?
Checked that the warning no longer shows.