### PR TITLE
feat: track ignored person profile updates

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -183,3 +183,9 @@ export function observeLatencyByVersion(person: InternalPerson | undefined, star
     const versionBucket = getVersionBucketLabel(person.version)
     personOperationLatencyByVersionSummary.labels(operation, versionBucket).observe(performance.now() - start)
 }
+
+export const personProfileUpdateOutcomeCounter = new Counter({
+    name: 'person_profile_update_outcome_total',
+    help: 'Outcome of person profile update operations',
+    labelNames: ['outcome'], // outcome: changed, ignored, no_change, unsupported
+})

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -189,3 +189,9 @@ export const personProfileUpdateOutcomeCounter = new Counter({
     help: 'Outcome of person profile update operations',
     labelNames: ['outcome'], // outcome: changed, ignored, no_change, unsupported
 })
+
+export const personProfileIgnoredPropertiesCounter = new Counter({
+    name: 'person_profile_ignored_properties_total',
+    help: 'Count of specific properties that were ignored during person profile updates',
+    labelNames: ['property'],
+})

--- a/plugin-server/src/worker/ingestion/persons/person-update.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.test.ts
@@ -1,0 +1,405 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { personProfileUpdateOutcomeCounter } from './metrics'
+import { eventToPersonProperties } from './person-property-utils'
+import { applyEventPropertyUpdates, computeEventPropertyUpdates } from './person-update'
+
+jest.mock('./metrics', () => ({
+    personProfileUpdateOutcomeCounter: {
+        labels: jest.fn().mockReturnValue({
+            inc: jest.fn(),
+        }),
+    },
+    personPropertyKeyUpdateCounter: {
+        labels: jest.fn().mockReturnValue({
+            inc: jest.fn(),
+        }),
+    },
+}))
+
+const mockPersonProfileUpdateOutcomeCounter = personProfileUpdateOutcomeCounter as jest.Mocked<
+    typeof personProfileUpdateOutcomeCounter
+>
+
+describe('person-update', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('computeEventPropertyUpdates', () => {
+        describe('outcome: changed', () => {
+            it('should track "changed" when custom properties are updated', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { custom_prop: 'new_value' },
+                    },
+                } as any
+
+                const personProperties = { custom_prop: 'old_value' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ custom_prop: 'new_value' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc).toHaveBeenCalled()
+            })
+
+            it('should track "changed" when properties are unset', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $unset: ['prop_to_remove'],
+                    },
+                } as any
+
+                const personProperties = { prop_to_remove: 'value', other_prop: 'keep' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toUnset).toEqual(['prop_to_remove'])
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            })
+
+            it('should track "changed" when setting a new property', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { new_prop: 'value' },
+                    },
+                } as any
+
+                const personProperties = {}
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ new_prop: 'value' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            })
+
+            it('should track "changed" when $set_once sets a property that does not exist', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set_once: { first_seen: '2024-01-01' },
+                    },
+                } as any
+
+                const personProperties = {}
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ first_seen: '2024-01-01' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            })
+
+            it('should track "changed" when a new eventToPersonProperty is set (not just updated)', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { $browser: 'Chrome' },
+                    },
+                } as any
+
+                const personProperties = {}
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ $browser: 'Chrome' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            })
+        })
+
+        describe('outcome: ignored', () => {
+            it.each(Array.from(eventToPersonProperties))(
+                'should track "ignored" when only "%s" is updated on non-person events',
+                (propertyName) => {
+                    const event: PluginEvent = {
+                        event: 'pageview',
+                        properties: {
+                            $set: { [propertyName]: 'new_value' },
+                        },
+                    } as any
+
+                    const personProperties = { [propertyName]: 'old_value' }
+
+                    const result = computeEventPropertyUpdates(event, personProperties)
+
+                    expect(result.hasChanges).toBe(false)
+                    expect(result.toSet).toEqual({ [propertyName]: 'new_value' })
+                    expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'ignored' })
+                    expect(mockPersonProfileUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc).toHaveBeenCalled()
+                }
+            )
+
+            it('should track "ignored" when only $geoip_* properties are updated', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { $geoip_city_name: 'San Francisco' },
+                    },
+                } as any
+
+                const personProperties = { $geoip_city_name: 'New York' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(result.toSet).toEqual({ $geoip_city_name: 'San Francisco' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'ignored' })
+            })
+
+            it('should track "ignored" when mixing eventToPersonProperties with unchanged custom properties', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { $browser: 'Chrome', custom_prop: 'same_value' },
+                    },
+                } as any
+
+                const personProperties = { $browser: 'Firefox', custom_prop: 'same_value' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(result.toSet).toEqual({ $browser: 'Chrome' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'ignored' })
+            })
+        })
+
+        describe('outcome: no_change', () => {
+            it('should track "no_change" when no properties are provided', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {},
+                } as any
+
+                const personProperties = { existing_prop: 'value' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(result.toSet).toEqual({})
+                expect(result.toUnset).toEqual([])
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'no_change' })
+            })
+
+            it('should track "no_change" when all properties have the same value', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { custom_prop: 'same_value' },
+                    },
+                } as any
+
+                const personProperties = { custom_prop: 'same_value' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(result.toSet).toEqual({})
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'no_change' })
+            })
+
+            it('should track "no_change" when $set_once property already exists', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set_once: { first_seen: '2024-01-01' },
+                    },
+                } as any
+
+                const personProperties = { first_seen: '2023-01-01' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(result.toSet).toEqual({})
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'no_change' })
+            })
+
+            it('should track "no_change" when trying to unset non-existent property', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $unset: ['non_existent_prop'],
+                    },
+                } as any
+
+                const personProperties = { other_prop: 'value' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(result.toUnset).toEqual([])
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'no_change' })
+            })
+        })
+
+        describe('person events behavior', () => {
+            it('should track "changed" for eventToPersonProperties on $identify events', () => {
+                const event: PluginEvent = {
+                    event: '$identify',
+                    properties: {
+                        $set: { $browser: 'Chrome' },
+                    },
+                } as any
+
+                const personProperties = { $browser: 'Firefox' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ $browser: 'Chrome' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            })
+
+            it('should track "changed" for eventToPersonProperties on $set events', () => {
+                const event: PluginEvent = {
+                    event: '$set',
+                    properties: {
+                        $set: { utm_source: 'google' },
+                    },
+                } as any
+
+                const personProperties = { utm_source: 'twitter' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            })
+        })
+
+        describe('NO_PERSON_UPDATE_EVENTS behavior', () => {
+            it('should track "unsupported" for $exception events regardless of properties', () => {
+                const event: PluginEvent = {
+                    event: '$exception',
+                    properties: {
+                        $set: { custom_prop: 'new_value' },
+                    },
+                } as any
+
+                const personProperties = { custom_prop: 'old_value' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(result.toSet).toEqual({})
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'unsupported' })
+            })
+
+            it('should track "unsupported" for $$heatmap events regardless of properties', () => {
+                const event: PluginEvent = {
+                    event: '$$heatmap',
+                    properties: {
+                        $set: { custom_prop: 'new_value' },
+                    },
+                } as any
+
+                const personProperties = {}
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(false)
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'unsupported' })
+            })
+        })
+
+        describe('mixed scenarios', () => {
+            it('should track "changed" when both custom and eventToPersonProperties change, but custom properties drive the change', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { custom_prop: 'new_value', $browser: 'Chrome' },
+                    },
+                } as any
+
+                const personProperties = { custom_prop: 'old_value', $browser: 'Firefox' }
+
+                const result = computeEventPropertyUpdates(event, personProperties)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ custom_prop: 'new_value', $browser: 'Chrome' })
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            })
+        })
+    })
+
+    describe('applyEventPropertyUpdates', () => {
+        it('should apply property updates and return updated person', () => {
+            const propertyUpdates = {
+                hasChanges: true,
+                toSet: { name: 'John', email: 'john@example.com' },
+                toUnset: ['old_prop'],
+            }
+
+            const person = {
+                id: '1',
+                team_id: 123,
+                uuid: 'test-uuid',
+                properties: { old_prop: 'value', name: 'Jane' },
+                created_at: new Date(),
+                version: 0,
+                is_identified: false,
+            }
+
+            const [updatedPerson, wasUpdated] = applyEventPropertyUpdates(propertyUpdates, person as any)
+
+            expect(wasUpdated).toBe(true)
+            expect(updatedPerson.properties).toEqual({ name: 'John', email: 'john@example.com' })
+            expect(updatedPerson.properties.old_prop).toBeUndefined()
+        })
+
+        it('should not modify original person object', () => {
+            const propertyUpdates = {
+                hasChanges: true,
+                toSet: { name: 'John' },
+                toUnset: [],
+            }
+
+            const person = {
+                id: '1',
+                team_id: 123,
+                uuid: 'test-uuid',
+                properties: { name: 'Jane' },
+                created_at: new Date(),
+                version: 0,
+                is_identified: false,
+            }
+
+            const [updatedPerson, _] = applyEventPropertyUpdates(propertyUpdates, person as any)
+
+            expect(person.properties.name).toBe('Jane')
+            expect(updatedPerson.properties.name).toBe('John')
+            expect(person).not.toBe(updatedPerson)
+        })
+
+        it('should return false for wasUpdated when no actual changes occur', () => {
+            const propertyUpdates = {
+                hasChanges: false,
+                toSet: { name: 'John' },
+                toUnset: [],
+            }
+
+            const person = {
+                id: '1',
+                team_id: 123,
+                uuid: 'test-uuid',
+                properties: { name: 'John' },
+                created_at: new Date(),
+                version: 0,
+                is_identified: false,
+            }
+
+            const [_, wasUpdated] = applyEventPropertyUpdates(propertyUpdates, person as any)
+
+            expect(wasUpdated).toBe(false)
+        })
+    })
+})

--- a/plugin-server/src/worker/ingestion/persons/person-update.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.ts
@@ -4,7 +4,7 @@ import { cloneObject } from '~/utils/utils'
 
 import { InternalPerson } from '../../../types'
 import { logger } from '../../../utils/logger'
-import { personPropertyKeyUpdateCounter } from './metrics'
+import { personProfileUpdateOutcomeCounter, personPropertyKeyUpdateCounter } from './metrics'
 import { eventToPersonProperties, initialEventToPersonProperties } from './person-property-utils'
 
 export interface PropertyUpdates {
@@ -41,6 +41,7 @@ function getMetricKey(key: string): string {
  */
 export function computeEventPropertyUpdates(event: PluginEvent, personProperties: Properties): PropertyUpdates {
     if (NO_PERSON_UPDATE_EVENTS.has(event.event)) {
+        personProfileUpdateOutcomeCounter.labels({ outcome: 'unsupported' }).inc()
         return { hasChanges: false, toSet: {}, toUnset: [] }
     }
 
@@ -77,6 +78,16 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
             }
         }
     })
+
+    // Track person profile update outcomes
+    const hasPropertyChanges = Object.keys(toSet).length > 0 || toUnset.length > 0
+    if (hasChanges) {
+        personProfileUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc()
+    } else if (hasPropertyChanges) {
+        personProfileUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc()
+    } else {
+        personProfileUpdateOutcomeCounter.labels({ outcome: 'no_change' }).inc()
+    }
 
     return { hasChanges, toSet, toUnset }
 }

--- a/plugin-server/src/worker/ingestion/persons/person-update.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.ts
@@ -4,7 +4,11 @@ import { cloneObject } from '~/utils/utils'
 
 import { InternalPerson } from '../../../types'
 import { logger } from '../../../utils/logger'
-import { personProfileUpdateOutcomeCounter, personPropertyKeyUpdateCounter } from './metrics'
+import {
+    personProfileIgnoredPropertiesCounter,
+    personProfileUpdateOutcomeCounter,
+    personPropertyKeyUpdateCounter,
+} from './metrics'
 import { eventToPersonProperties, initialEventToPersonProperties } from './person-property-utils'
 
 export interface PropertyUpdates {
@@ -85,6 +89,10 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
         personProfileUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc()
     } else if (hasPropertyChanges) {
         personProfileUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc()
+        // Track which specific properties were ignored
+        Object.keys(toSet).forEach((propertyName) => {
+            personProfileIgnoredPropertiesCounter.labels({ property: propertyName }).inc()
+        })
     } else {
         personProfileUpdateOutcomeCounter.labels({ outcome: 'no_change' }).inc()
     }


### PR DESCRIPTION
## Problem

We would like to know how many person profile updates are ignored.

## Changes

Adds two metrics for ignored updates:
- Total number of person profile updates - changed, ignored, no change, not supported (e.g. heatmaps)
- Number of person profile updates ignored per property type

## How did you test this code?

Added new tests
