### PR TITLE
fix(create experiments): fixes and validations

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -50,7 +50,7 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
     const { experiment, experimentErrors, sharedMetrics } = useValues(
         createExperimentLogic({ experiment: draftExperiment })
     )
-    const { setExperimentValue, setExperiment, setSharedMetrics } = useActions(
+    const { setExperimentValue, setExperiment, setSharedMetrics, setExposureCriteria } = useActions(
         createExperimentLogic({ experiment: draftExperiment })
     )
 

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -18,7 +18,6 @@ import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import type { Experiment } from '~/types'
 
-import { ExperimentTypePanel } from './ExperimentTypePanel'
 import { ExposureCriteriaPanel } from './ExposureCriteriaPanel'
 import { ExposureCriteriaPanelHeader } from './ExposureCriteriaPanelHeader'
 import { MetricsPanel, MetricsPanelHeader } from './MetricsPanel'
@@ -37,12 +36,6 @@ const LemonFieldError = ({ error }: { error: string }): JSX.Element => {
 type CreateExperimentProps = Partial<{
     draftExperiment: Experiment
 }>
-
-/**
- * temporary setup. We may want to put this behind a feature flag for testing.
- */
-const SHOW_EXPERIMENT_TYPE_PANEL = false
-const SHOW_TARGETING_PANEL = false
 
 export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JSX.Element => {
     const { HogfettiComponent } = useHogfetti({ count: 100, duration: 3000 })
@@ -120,26 +113,9 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                 key: 'experiment-exposure',
                                 header: <ExposureCriteriaPanelHeader experiment={experiment} />,
                                 content: (
-                                    <ExposureCriteriaPanel
-                                        experiment={experiment}
-                                        onChange={(exposureCriteria) => exposureCriteria}
-                                    />
+                                    <ExposureCriteriaPanel experiment={experiment} onChange={setExposureCriteria} />
                                 ),
                             },
-                            ...(SHOW_EXPERIMENT_TYPE_PANEL
-                                ? [
-                                      {
-                                          key: 'experiment-type',
-                                          header: 'Experiment type',
-                                          content: (
-                                              <ExperimentTypePanel
-                                                  experiment={experiment}
-                                                  setExperimentType={(type) => setExperimentValue('type', type)}
-                                              />
-                                          ),
-                                      },
-                                  ]
-                                : []),
                             {
                                 key: 'experiment-variants',
                                 header: <VariantsPanelHeader experiment={experiment} />,
@@ -147,19 +123,6 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                     <VariantsPanel experiment={experiment} updateFeatureFlag={setFeatureFlagConfig} />
                                 ),
                             },
-                            ...(SHOW_TARGETING_PANEL
-                                ? [
-                                      {
-                                          key: 'experiment-targeting',
-                                          header: 'Targeting',
-                                          content: (
-                                              <div className="p-4">
-                                                  <span>Targeting Panel Goes Here</span>
-                                              </div>
-                                          ),
-                                      },
-                                  ]
-                                : []),
                             {
                                 key: 'experiment-metrics',
                                 header: <MetricsPanelHeader experiment={experiment} />,

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -50,9 +50,8 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
     const { experiment, experimentErrors, sharedMetrics } = useValues(
         createExperimentLogic({ experiment: draftExperiment })
     )
-    const { setExperimentValue, setExperiment, setSharedMetrics, setExposureCriteria } = useActions(
-        createExperimentLogic({ experiment: draftExperiment })
-    )
+    const { setExperimentValue, setExperiment, setSharedMetrics, setExposureCriteria, setFeatureFlagConfig } =
+        useActions(createExperimentLogic({ experiment: draftExperiment }))
 
     const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
 
@@ -145,20 +144,7 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                 key: 'experiment-variants',
                                 header: <VariantsPanelHeader experiment={experiment} />,
                                 content: (
-                                    <VariantsPanel
-                                        experiment={experiment}
-                                        updateFeatureFlag={(updates) => {
-                                            if (updates.feature_flag_key !== undefined) {
-                                                setExperimentValue('feature_flag_key', updates.feature_flag_key)
-                                            }
-                                            if (updates.parameters) {
-                                                setExperimentValue('parameters', {
-                                                    ...experiment.parameters,
-                                                    ...updates.parameters,
-                                                })
-                                            }
-                                        }}
-                                    />
+                                    <VariantsPanel experiment={experiment} updateFeatureFlag={setFeatureFlagConfig} />
                                 ),
                             },
                             ...(SHOW_TARGETING_PANEL

--- a/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
+++ b/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
@@ -1,5 +1,4 @@
 import { useValues } from 'kea'
-import { useState } from 'react'
 
 import { LemonSelect, LemonTag } from '@posthog/lemon-ui'
 
@@ -9,8 +8,8 @@ import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { ExperimentEventExposureConfig, NodeKind } from '~/queries/schema/schema-general'
-import { Experiment, FilterType } from '~/types'
+import { ExperimentEventExposureConfig, ExperimentExposureCriteria, NodeKind } from '~/queries/schema/schema-general'
+import type { Experiment, FilterType } from '~/types'
 
 import { commonActionFilterProps } from '../Metrics/Selectors'
 import { SelectableCard } from '../components/SelectableCard'
@@ -18,11 +17,12 @@ import { exposureConfigToFilter, filterToExposureConfig } from '../utils'
 
 type ExposureCriteriaPanelProps = {
     experiment: Experiment
-    onChange: (exposureCriteria: Experiment['exposure_criteria']) => void
+    onChange: (exposureCriteria: Partial<ExperimentExposureCriteria>) => void
 }
 
 export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteriaPanelProps): JSX.Element {
-    const [selectedExposureType, setSelectedExposureType] = useState<'default' | 'custom'>('default')
+    // Derive exposure type from experiment state
+    const selectedExposureType = experiment.exposure_criteria?.exposure_config ? 'custom' : 'default'
 
     const { currentTeam } = useValues(teamLogic)
     const hasFilters = (currentTeam?.test_account_filters || []).length > 0
@@ -45,7 +45,6 @@ export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteria
                     }
                     selected={selectedExposureType === 'default'}
                     onClick={() => {
-                        setSelectedExposureType('default')
                         onChange({
                             exposure_config: undefined,
                         })
@@ -61,7 +60,6 @@ export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteria
                     }
                     selected={selectedExposureType === 'custom'}
                     onClick={() => {
-                        setSelectedExposureType('custom')
                         onChange({
                             exposure_config: {
                                 kind: NodeKind.ExperimentEventExposureConfig,

--- a/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
+++ b/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
@@ -17,7 +17,7 @@ import { exposureConfigToFilter, filterToExposureConfig } from '../utils'
 
 type ExposureCriteriaPanelProps = {
     experiment: Experiment
-    onChange: (exposureCriteria: Partial<ExperimentExposureCriteria>) => void
+    onChange: (exposureCriteria: ExperimentExposureCriteria) => void
 }
 
 export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteriaPanelProps): JSX.Element {

--- a/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
+++ b/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
@@ -84,8 +84,8 @@ export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteria
                                     properties: [],
                                 } as ExperimentEventExposureConfig)
                         )}
-                        setFilters={({ events }: Partial<FilterType>): void => {
-                            const entity = events?.[0]
+                        setFilters={({ events, actions }: Partial<FilterType>): void => {
+                            const entity = events?.[0] || actions?.[0]
                             if (entity) {
                                 onChange({
                                     exposure_config: filterToExposureConfig(entity),
@@ -99,7 +99,7 @@ export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteria
                         entitiesLimit={1}
                         mathAvailability={MathAvailability.None}
                         showNumericalPropsOnly={false}
-                        actionsTaxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+                        actionsTaxonomicGroupTypes={[TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]}
                         propertiesTaxonomicGroupTypes={commonActionFilterProps.propertiesTaxonomicGroupTypes}
                     />
                 </div>

--- a/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
@@ -436,7 +436,7 @@ describe('VariantsPanel', () => {
             render(<VariantsPanel experiment={experimentWithEmptyKey} updateFeatureFlag={mockUpdateFeatureFlag} />)
 
             // Should show error message
-            expect(screen.getByText('All variant must have a key.')).toBeInTheDocument()
+            expect(screen.getByText('All variants must have a key.')).toBeInTheDocument()
         })
 
         it('shows error when variant keys are duplicated', async () => {

--- a/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
@@ -418,4 +418,201 @@ describe('VariantsPanel', () => {
             expect(screen.getByText('Create new feature flag')).toBeInTheDocument()
         })
     })
+
+    describe('variant validation', () => {
+        it('shows error when variant key is empty', async () => {
+            const experimentWithEmptyKey: Experiment = {
+                ...NEW_EXPERIMENT,
+                name: 'Test Experiment',
+                feature_flag_key: 'test-experiment',
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: '', rollout_percentage: 50 },
+                    ],
+                },
+            }
+
+            render(<VariantsPanel experiment={experimentWithEmptyKey} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Should show error message
+            expect(screen.getByText('All variant must have a key.')).toBeInTheDocument()
+        })
+
+        it('shows error when variant keys are duplicated', async () => {
+            const experimentWithDuplicateKeys: Experiment = {
+                ...NEW_EXPERIMENT,
+                name: 'Test Experiment',
+                feature_flag_key: 'test-experiment',
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: 'control', rollout_percentage: 50 },
+                    ],
+                },
+            }
+
+            render(<VariantsPanel experiment={experimentWithDuplicateKeys} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Should show error message
+            expect(screen.getByText('Variant keys must be unique.')).toBeInTheDocument()
+        })
+
+        it('shows error when variant has zero rollout and sum is not 100', async () => {
+            const experimentWithZeroRollout: Experiment = {
+                ...NEW_EXPERIMENT,
+                name: 'Test Experiment',
+                feature_flag_key: 'test-experiment',
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: 'test', rollout_percentage: 0 },
+                    ],
+                },
+            }
+
+            render(<VariantsPanel experiment={experimentWithZeroRollout} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Should show error message
+            expect(screen.getByText('All variants must have a rollout percentage greater than 0.')).toBeInTheDocument()
+        })
+
+        it('does not show zero rollout error when sum is 100', async () => {
+            const experimentWithValidZeroRollout: Experiment = {
+                ...NEW_EXPERIMENT,
+                name: 'Test Experiment',
+                feature_flag_key: 'test-experiment',
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 100 },
+                        { key: 'test', rollout_percentage: 0 },
+                    ],
+                },
+            }
+
+            render(
+                <VariantsPanel experiment={experimentWithValidZeroRollout} updateFeatureFlag={mockUpdateFeatureFlag} />
+            )
+
+            // Should not show zero rollout error
+            expect(
+                screen.queryByText('All variants must have a rollout percentage greater than 0.')
+            ).not.toBeInTheDocument()
+        })
+
+        it('highlights variant with error', async () => {
+            const experimentWithEmptyKey: Experiment = {
+                ...NEW_EXPERIMENT,
+                name: 'Test Experiment',
+                feature_flag_key: 'test-experiment',
+                parameters: {
+                    feature_flag_variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: '', rollout_percentage: 50 },
+                    ],
+                },
+            }
+
+            const { container } = render(
+                <VariantsPanel experiment={experimentWithEmptyKey} updateFeatureFlag={mockUpdateFeatureFlag} />
+            )
+
+            // Find variant rows
+            const variantRows = container.querySelectorAll('.grid.grid-cols-24')
+
+            // First variant (control) should not have error highlighting
+            expect(variantRows[1]).not.toHaveClass('bg-danger-highlight')
+
+            // Second variant (empty key) should have error highlighting
+            expect(variantRows[2]).toHaveClass('bg-danger-highlight')
+            expect(variantRows[2]).toHaveClass('border-danger')
+        })
+    })
+
+    describe('callback payloads', () => {
+        it('calls updateFeatureFlag with correct structure when selecting linked flag', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            // Switch to link mode and select a flag
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))
+            await userEvent.click(linkCard!)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+            })
+
+            const flagRows = screen.getAllByRole('row')
+            const firstFlagRow = flagRows.find((row) => row.textContent?.includes('eligible-flag-1'))
+            const selectFlagButton = within(firstFlagRow!).getByRole('button', { name: /select/i })
+            await userEvent.click(selectFlagButton)
+
+            // Verify callback was called with correct structure
+            await waitFor(() => {
+                expect(mockUpdateFeatureFlag).toHaveBeenCalledWith({
+                    feature_flag_key: 'eligible-flag-1',
+                    parameters: {
+                        feature_flag_variants: [
+                            { key: 'control', rollout_percentage: 50 },
+                            { key: 'variant-a', rollout_percentage: 50 },
+                        ],
+                    },
+                })
+            })
+        })
+    })
+
+    describe('state restoration', () => {
+        it('persists linked flag selection when switching link→create→link', async () => {
+            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+
+            const cards = screen.getAllByRole('button')
+            const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))!
+            const createCard = cards.find((card) => card.textContent?.includes('Create new'))!
+
+            // Step 1: Switch to link mode and select a flag
+            await userEvent.click(linkCard)
+
+            const selectButton = screen.getByRole('button', { name: /select feature flag/i })
+            await userEvent.click(selectButton)
+
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+            })
+
+            const flagRows = screen.getAllByRole('row')
+            const firstFlagRow = flagRows.find((row) => row.textContent?.includes('eligible-flag-1'))
+            const selectFlagButton = within(firstFlagRow!).getByRole('button', { name: /select/i })
+            await userEvent.click(selectFlagButton)
+
+            // Verify flag is selected and displayed
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+                expect(screen.getByText('control')).toBeInTheDocument()
+                expect(screen.getByText('variant-a')).toBeInTheDocument()
+            })
+
+            // Step 2: Switch to create mode
+            await userEvent.click(createCard)
+
+            // Should show create mode UI
+            expect(screen.getByText('Feature flag key')).toBeInTheDocument()
+
+            // Step 3: Switch back to link mode
+            await userEvent.click(linkCard)
+
+            // Should still show the previously selected flag
+            await waitFor(() => {
+                expect(screen.getByText('eligible-flag-1')).toBeInTheDocument()
+                expect(screen.getByText('control')).toBeInTheDocument()
+                expect(screen.getByText('variant-a')).toBeInTheDocument()
+            })
+
+            // Verify the flag is still displayed with its variants (not showing empty state)
+            expect(screen.queryByText('No feature flag selected')).not.toBeInTheDocument()
+        })
+    })
 })

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -65,6 +65,13 @@ export function VariantsPanel({ experiment, updateFeatureFlag }: VariantsPanelPr
                 onClose={() => closeSelectExistingFeatureFlagModal()}
                 onSelect={(flag: FeatureFlagType) => {
                     setLinkedFeatureFlag(flag)
+                    // Update experiment with linked flag's key and variants
+                    updateFeatureFlag({
+                        feature_flag_key: flag.key,
+                        parameters: {
+                            feature_flag_variants: flag.filters?.multivariate?.variants || [],
+                        },
+                    })
                     closeSelectExistingFeatureFlagModal()
                 }}
             />

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 import { match } from 'ts-pattern'
 
 import { SelectableCard } from '~/scenes/experiments/components/SelectableCard'
@@ -23,10 +22,8 @@ interface VariantsPanelProps {
 }
 
 export function VariantsPanel({ experiment, updateFeatureFlag }: VariantsPanelProps): JSX.Element {
-    const { mode } = useValues(variantsPanelLogic)
-    const { setMode } = useActions(variantsPanelLogic)
-
-    const [linkedFeatureFlag, setLinkedFeatureFlag] = useState<FeatureFlagType | null>(null)
+    const { mode, linkedFeatureFlag } = useValues(variantsPanelLogic)
+    const { setMode, setLinkedFeatureFlag } = useActions(variantsPanelLogic)
 
     const { openSelectExistingFeatureFlagModal, closeSelectExistingFeatureFlagModal } = useActions(
         selectExistingFeatureFlagModalLogic

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
@@ -428,16 +428,16 @@ describe('VariantsPanelCreateFeatureFlag', () => {
 
             expect(mockOnChange).toHaveBeenCalledWith({
                 parameters: expect.objectContaining({
-                    ensure_experience_continuity: false,
+                    ensure_experience_continuity: true,
                 }),
             })
         })
 
-        it('defaults to checked', () => {
+        it('defaults to unchecked', () => {
             renderComponent(defaultExperiment)
 
             const checkbox = screen.getByRole('checkbox') as HTMLInputElement
-            expect(checkbox.checked).toBe(true)
+            expect(checkbox.checked).toBe(false)
         })
     })
 

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -288,7 +288,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                         </p>
                     )}
                     {variants.length > 0 && !areVariantKeysValid && (
-                        <p className="text-danger">All variant must have a key.</p>
+                        <p className="text-danger">All variants must have a key.</p>
                     )}
                     {variants.length > 0 && hasDuplicateKeys && (
                         <p className="text-danger">Variant keys must be unique.</p>

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -73,6 +73,21 @@ export const VariantsPanelCreateFeatureFlag = ({
         variants.every(({ rollout_percentage }) => rollout_percentage >= 0 && rollout_percentage <= 100) &&
         variantRolloutSum === 100
 
+    const areVariantKeysValid = variants.every(({ key }) => key && key.trim().length > 0)
+    const variantKeys = variants.map(({ key }) => key)
+    const hasDuplicateKeys = variantKeys.length !== new Set(variantKeys).size
+    const hasZeroRolloutVariants =
+        variants.some(({ rollout_percentage }) => rollout_percentage === 0) && variantRolloutSum !== 100
+
+    // Check if specific variant has an error
+    const hasVariantError = (index: number): boolean => {
+        const variant = variants[index]
+        const isEmpty = !variant.key || variant.key.trim().length === 0
+        const isDuplicate = variantKeys.filter((k) => k === variant.key).length > 1
+        const hasZeroRollout = variant.rollout_percentage === 0 && variantRolloutSum !== 100
+        return isEmpty || isDuplicate || hasZeroRollout
+    }
+
     const updateVariant = (index: number, updates: Partial<MultivariateFlagVariant>): void => {
         const newVariants = [...variants]
         newVariants[index] = { ...newVariants[index], ...updates }
@@ -200,14 +215,24 @@ export const VariantsPanelCreateFeatureFlag = ({
                         </div>
                     </div>
                     {variants.map((variant, index) => (
-                        <div key={variant.key} className="grid grid-cols-24 gap-2 mb-2">
+                        <div
+                            key={index}
+                            className={`grid grid-cols-24 gap-2 mb-2 p-2 rounded ${
+                                hasVariantError(index)
+                                    ? 'bg-danger-highlight border border-danger'
+                                    : 'bg-transparent border border-transparent'
+                            }`}
+                        >
                             <div className="flex items-center justify-center">
                                 <Lettermark name={alphabet[index]} color={LettermarkColor.Gray} />
                             </div>
                             <div className="col-span-4">
                                 <LemonInput
                                     value={variant.key}
-                                    onChange={(value) => updateVariant(index, { key: value })}
+                                    disabledReason={
+                                        variant.key === 'control' ? 'Control variant cannot be changed' : null
+                                    }
+                                    onChange={(value) => updateVariant(index, { key: value.replace(/\s+/g, '-') })}
                                     data-attr="experiment-variant-key"
                                     data-key-index={index.toString()}
                                     className="ph-ignore-input"
@@ -261,6 +286,15 @@ export const VariantsPanelCreateFeatureFlag = ({
                         <p className="text-danger">
                             Percentage rollouts for variants must sum to 100 (currently {variantRolloutSum}).
                         </p>
+                    )}
+                    {variants.length > 0 && !areVariantKeysValid && (
+                        <p className="text-danger">All variant must have a key.</p>
+                    )}
+                    {variants.length > 0 && hasDuplicateKeys && (
+                        <p className="text-danger">Variant keys must be unique.</p>
+                    )}
+                    {variants.length > 0 && hasZeroRolloutVariants && (
+                        <p className="text-danger">All variants must have a rollout percentage greater than 0.</p>
                     )}
                     {variants.length < MAX_EXPERIMENT_VARIANTS && (
                         <LemonButton type="secondary" onClick={addVariant} icon={<IconPlus />} center>

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -66,7 +66,7 @@ export const VariantsPanelCreateFeatureFlag = ({
     ]
 
     const ensureExperienceContinuity =
-        (experiment.parameters as { ensure_experience_continuity?: boolean })?.ensure_experience_continuity ?? true
+        (experiment.parameters as { ensure_experience_continuity?: boolean })?.ensure_experience_continuity ?? false
 
     const variantRolloutSum = variants.reduce((sum, { rollout_percentage }) => sum + rollout_percentage, 0)
     const areVariantRolloutsValid =

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -53,7 +53,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     })),
     actions(() => ({
         setExperiment: (experiment: Experiment) => ({ experiment }),
-        setExposureCriteria: (criteria: Partial<ExperimentExposureCriteria>) => ({ criteria }),
+        setExposureCriteria: (criteria: ExperimentExposureCriteria) => ({ criteria }),
         createExperiment: () => ({}),
         createExperimentSuccess: true,
         setSharedMetrics: (sharedMetrics: { primary: ExperimentMetric[]; secondary: ExperimentMetric[] }) => ({

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -13,7 +13,7 @@ import { urls } from 'scenes/urls'
 
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { ExperimentExposureCriteria, ExperimentMetric } from '~/queries/schema/schema-general'
-import type { Experiment, FeatureFlagFilters } from '~/types'
+import type { Experiment, FeatureFlagFilters, MultivariateFlagVariant } from '~/types'
 import { ProductKey } from '~/types'
 
 import { NEW_EXPERIMENT } from '../constants'
@@ -54,6 +54,14 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     actions(() => ({
         setExperiment: (experiment: Experiment) => ({ experiment }),
         setExposureCriteria: (criteria: ExperimentExposureCriteria) => ({ criteria }),
+        setFeatureFlagConfig: (config: {
+            feature_flag_key?: string
+            feature_flag_variants?: MultivariateFlagVariant[]
+            parameters?: {
+                feature_flag_variants?: MultivariateFlagVariant[]
+                ensure_experience_continuity?: boolean
+            }
+        }) => ({ config }),
         createExperiment: () => ({}),
         createExperimentSuccess: true,
         setSharedMetrics: (sharedMetrics: { primary: ExperimentMetric[]; secondary: ExperimentMetric[] }) => ({
@@ -70,6 +78,20 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                     exposure_criteria: {
                         ...state.exposure_criteria,
                         ...criteria,
+                    },
+                }),
+                setFeatureFlagConfig: (state, { config }) => ({
+                    ...state,
+                    ...(config.feature_flag_key !== undefined && {
+                        feature_flag_key: config.feature_flag_key,
+                    }),
+                    parameters: {
+                        ...state.parameters,
+                        // Handle both flat structure (feature_flag_variants) and nested (parameters.*)
+                        ...(config.feature_flag_variants !== undefined && {
+                            feature_flag_variants: config.feature_flag_variants,
+                        }),
+                        ...(config.parameters && config.parameters),
                     },
                 }),
                 updateFeatureFlagKey: (state, { key }) => ({ ...state, feature_flag_key: key }),

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
@@ -21,7 +21,7 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
     },
     connect: {
         values: [featureFlagsLogic, ['featureFlags'], experimentsLogic, ['experiments']],
-        actions: [createExperimentLogic, ['setExperimentValue']],
+        actions: [createExperimentLogic, ['setExperimentValue', 'setFeatureFlagConfig']],
     },
     actions: {
         validateFeatureFlagKey: (key: string) => ({ key }),
@@ -32,6 +32,7 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
         generateFeatureFlagKey: (name: string) => ({ name }),
         setMode: (mode: 'create' | 'link') => ({ mode }),
         setFeatureFlagKeyDirty: true,
+        setLinkedFeatureFlag: (flag: FeatureFlagType | null) => ({ flag }),
     },
     reducers: {
         featureFlagKeyError: [
@@ -51,6 +52,13 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
             {
                 setFeatureFlagKeyDirty: () => true,
                 setMode: () => false, // Reset dirty flag when switching modes
+            },
+        ],
+        linkedFeatureFlag: [
+            null as FeatureFlagType | null,
+            {
+                setLinkedFeatureFlag: (_, { flag }) => flag,
+                setMode: () => null, // Reset linked flag when switching modes
             },
         ],
     },
@@ -185,7 +193,7 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
         },
         generateFeatureFlagKeySuccess: ({ generatedKey }) => {
             if (generatedKey) {
-                actions.setExperimentValue('feature_flag_key', generatedKey)
+                actions.setFeatureFlagConfig({ feature_flag_key: generatedKey })
                 actions.validateFeatureFlagKey(generatedKey)
             }
         },


### PR DESCRIPTION
## Problem

The new create experiment form has a few state management quirks that need to be fixed	and validations to be added.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Move the exposure criteria reducer from the `CreateExperiment` event handler to the kea logic.
- Derive the state from the experiment for the exposure criteria configuration.
- Add actions to the exposure criteria `ActionFilter` component.
- Move the variants panel reducer from the `CreateExperiment` event handlers to the kea logic.
- Preserve _linking feaure flag_ state.
- Trigger validations when switching from _linked_ flag to _create new_.
- Disable changes to the control variant.
- Automatically replace spaces with `-` on feature flag keys and variant names.
- Add a comprehensive set of variant validations (key, rollout percentages, edge cases)

| key variant validations | unique key variant validation
| - | - |
| <img width="932" height="362" alt="image" src="https://github.com/user-attachments/assets/a09e8f2e-2936-47e9-89b5-2684ca41a9ac" /> | <img width="925" height="413" alt="image" src="https://github.com/user-attachments/assets/1e526ab0-bd0a-486e-b393-722f6c570d0b" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.test.tsx
```

![cat-type-small](https://github.com/user-attachments/assets/ccd3afb9-243e-4cc9-9a62-35b8c6218a43)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
