### PR TITLE
fix: remove unused openapi spec imports from test_capture_internal

### DIFF
--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -1,12 +1,9 @@
-import pathlib
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any
 from uuid import uuid4
 
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
-
-from prance import ResolvingParser
 
 from posthog.api.capture import CaptureInternalError, capture_batch_internal, capture_internal
 from posthog.settings.ingestion import (
@@ -15,12 +12,6 @@ from posthog.settings.ingestion import (
     NEW_ANALYTICS_CAPTURE_ENDPOINT,
     REPLAY_CAPTURE_ENDPOINT,
 )
-
-parser = ResolvingParser(
-    url=str(pathlib.Path(__file__).parent / "../../../openapi/capture.yaml"),
-    strict=True,
-)
-openapi_spec = cast(dict[str, Any], parser.specification)
 
 
 class InstallCapturePostSpy:


### PR DESCRIPTION
## Summary

Fixes test collection errors caused by deleted OpenAPI spec files.

The capture.yaml and customer-data-pipeline.yaml specs were deleted in PR #39991 but the test file still tried to load capture.yaml at module import time. The openapi_spec variable was never used in the tests, so removing the unused imports and parser initialization.

## Test plan

Run: `pytest posthog/api/test/test_capture_internal.py`

Should now collect and run tests without FileNotFoundError.