### PR TITLE
fix(b2b2c): render_query endpoint cors restrictions

### DIFF
--- a/posthog/api/test/test_render_query.py
+++ b/posthog/api/test/test_render_query.py
@@ -14,6 +14,7 @@ class TestRenderQueryView(APIBaseTest):
 
         assert response.status_code == 200
         assert "X-Frame-Options" not in response.headers
+        assert "frame-ancestors https: http:" in response.headers.get("Content-Security-Policy-Report-Only", "")
 
         mock_render_template.assert_called_once()
         template_name, request = mock_render_template.call_args[0][:2]

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -722,7 +722,10 @@ class CSPMiddleware:
             connect_debug_url = "ws://localhost:8234" if settings.DEBUG or settings.TEST else ""
             frame_ancestors = "frame-ancestors https://posthog.com https://preview.posthog.com"
             if request.path.startswith("/render_query"):
-                frame_ancestors = "frame-ancestors https: http:"
+                if settings.DEBUG or settings.TEST:
+                    frame_ancestors = "frame-ancestors https: http:"
+                else:
+                    frame_ancestors = "frame-ancestors https:"
 
             csp_parts = [
                 "default-src 'self'",

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -720,6 +720,10 @@ class CSPMiddleware:
                 resource_url = "https://*.dev.posthog.dev"
 
             connect_debug_url = "ws://localhost:8234" if settings.DEBUG or settings.TEST else ""
+            frame_ancestors = "frame-ancestors https://posthog.com https://preview.posthog.com"
+            if request.path.startswith("/render_query"):
+                frame_ancestors = "frame-ancestors https: http:"
+
             csp_parts = [
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",
@@ -729,7 +733,7 @@ class CSPMiddleware:
                 "child-src 'none'",
                 "object-src 'none'",
                 f"img-src 'self' data: {resource_url} https://posthog.com https://www.gravatar.com https://res.cloudinary.com https://platform.slack-edge.com",
-                "frame-ancestors https://posthog.com https://preview.posthog.com",
+                frame_ancestors,
                 f"connect-src 'self' https://status.posthog.com {resource_url} {connect_debug_url} https://raw.githubusercontent.com https://api.github.com",
                 # allow all sites for displaying heatmaps
                 "frame-src https:",


### PR DESCRIPTION
## Problem

The new `/render_query` endpoint fails in production:

<img width="1379" height="624" alt="image" src="https://github.com/user-attachments/assets/6ae8eb49-1460-4658-ba72-6fd52afb657e" />

It appears we're sending CORS headers preventing embeddings:

<img width="554" height="334" alt="image" src="https://github.com/user-attachments/assets/42dbce04-7915-43f4-b5b4-ffb4317c59a9" />

## Changes

Enable all frame ancestors for this path.

## How did you test this code?

I could no longer see the headers locally, but it's hard to verify for production 🤔 