### PR TITLE
fix(max): fixed index error

### DIFF
--- a/products/product_analytics/backend/max_tools.py
+++ b/products/product_analytics/backend/max_tools.py
@@ -115,7 +115,8 @@ IMPORTANT: DO NOT REMOVE ANY FIELDS FROM THE CURRENT INSIGHT DEFINITION. DO NOT 
         state = AssistantState.model_validate(state_dict)
 
         result = state.messages[-1]
-        viz_message = [message for message in state.messages if isinstance(message, VisualizationMessage)][-1]
+        viz_messages = [message for message in state.messages if isinstance(message, VisualizationMessage)]
+        viz_message = viz_messages[-1] if viz_messages else None
         if not viz_message:
             raise ValueError("Visualization was not generated")
         if not isinstance(result, AssistantToolCallMessage):


### PR DESCRIPTION
## Problem

<img width="1259" height="216" alt="image" src="https://github.com/user-attachments/assets/bab4139a-ca19-47ca-a36e-dba0a9928559" />

[error](https://us.posthog.com/project/2/error_tracking/0199ee62-793c-7e51-9e3a-f327f6eebd9f?timestamp=2025-10-22%2001:44:25.027000-07:00&filterGroup=%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22key%22:%22tag%22,%22value%22:%5B%22max_ai%22%5D,%22operator%22:%22exact%22,%22type%22:%22event%22%7D%5D%7D%5D%7D&dateRange=%7B%22date_from%22:%22-14d%22,%22date_to%22:null%7D)

The single loop executor large revamp introduced a small index-based access error that we started experiencing in `production`, let's clean this out.

## Changes

* safer access

## How did you test this code?

- [x] unit tests
