### PR TITLE
fix(cdp): make site_apps editable again

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -1159,7 +1159,6 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (type, template, hogFunction) => {
                 const codeLanguage = template?.code_language || hogFunction?.template?.code_language
 
-                // Allow editing for site_app regardless of code language
                 if (type === 'site_app') {
                     return true
                 }

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -1159,14 +1159,17 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (type, template, hogFunction) => {
                 const codeLanguage = template?.code_language || hogFunction?.template?.code_language
 
+                // Allow editing for site_app regardless of code language
+                if (type === 'site_app') {
+                    return true
+                }
+
                 // Only allow editing if code language is 'hog'
                 if (codeLanguage && codeLanguage !== 'hog') {
                     return false
                 }
 
-                return ['site_destination', 'site_app', 'source_webhook', 'transformation', 'destination'].includes(
-                    type
-                )
+                return ['site_destination', 'source_webhook', 'transformation', 'destination'].includes(type)
             },
         ],
 

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -1159,7 +1159,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (type, template, hogFunction) => {
                 const codeLanguage = template?.code_language || hogFunction?.template?.code_language
 
-                if (type === 'site_app') {
+                if (type === 'site_app' || type === 'site_destination') {
                     return true
                 }
 
@@ -1168,7 +1168,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     return false
                 }
 
-                return ['site_destination', 'source_webhook', 'transformation', 'destination'].includes(type)
+                return ['source_webhook', 'transformation', 'destination'].includes(type)
             },
         ],
 


### PR DESCRIPTION
## Problem

We restrict making hogfunctions editable that have javascript code but by doing that we also prevent site-apps from being editable anymore.

<img width="1197" height="617" alt="Screenshot 2025-10-22 at 11 52 43" src="https://github.com/user-attachments/assets/bdef5a96-f74c-4919-a682-03da9a3f6c43" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<img width="1199" height="815" alt="Screenshot 2025-10-22 at 11 52 20" src="https://github.com/user-attachments/assets/d67f6eb3-4be0-487a-ba09-47cc050ea04f" />

- site-apps can always be edited

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
