### PR TITLE
fix: set default None on default_modifiers_for_team

### DIFF
--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -55,7 +55,7 @@ def create_default_modifiers_for_team(
 
     if isinstance(team.modifiers, dict):
         for key, value in team.modifiers.items():
-            if getattr(modifiers, key) is None:
+            if getattr(modifiers, key, None) is None:
                 if key == "customChannelTypeRules":
                     # don't break all queries if customChannelTypeRules are invalid
                     try:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
After merging #39630 and enabling the modifier on Team 3, we saw 5 minutes of errors where the HogQLModifiers model did not yet have the optimizeProjections field. 

This shouldn't break things!
