### PR TITLE
chore(data-warehouse): Different postgres providers return slightly different messages here …

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -848,7 +848,7 @@ def postgres_source(
                             offset += len(rows)
             except psycopg.errors.SerializationFailure as e:
                 # If we hit a SerializationFailure and we're reading from a read replica, we fallback to offset chunking
-                if using_read_replica and "terminating connection due to conflict with recovery" in "".join(e.args):
+                if using_read_replica and "conflict with recovery" in "".join(e.args):
                     logger.debug(f"Falling back to offset chunking for table due to SerializationFailure error: {e}.")
                     yield from offset_chunking(offset, chunk_size)
                     return


### PR DESCRIPTION
## Problem
- Looks like RDS returns `canceling statement due to conflict with recovery` instead of `terminating connection due to conflict with recovery` like supabase for when we hit WAL replication issues

## Changes
- Loosen the rules around matching for this error

