### PR TITLE
chore(oauth): standardize tokens

### DIFF
--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -280,6 +280,14 @@ def generate_random_token_secret() -> str:
     return "phs_" + generate_random_token(35)  # "s" standing for "secret"
 
 
+def generate_random_oauth_access_token(_request) -> str:
+    return "pha_" + generate_random_token()  # "a" standing for "access"
+
+
+def generate_random_oauth_refresh_token(_request) -> str:
+    return "phr_" + generate_random_token()  # "r" standing for "refresh"
+
+
 def mask_key_value(value: str) -> str:
     """Turn 'phx_123456abcd' into 'phx_...abcd'."""
     if len(value) < 16:

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -518,6 +518,8 @@ OAUTH2_PROVIDER = {
     "AUTHORIZATION_CODE_EXPIRE_SECONDS": 60
     * 5,  # client has 5 minutes to complete the OAuth flow before the authorization code expires
     "DEFAULT_SCOPES": ["openid"],
+    "ACCESS_TOKEN_GENERATOR": "posthog.models.utils.generate_random_oauth_access_token",
+    "REFRESH_TOKEN_GENERATOR": "posthog.models.utils.generate_random_oauth_refresh_token",
     "OAUTH2_VALIDATOR_CLASS": "posthog.api.oauth.OAuthValidator",
     "ACCESS_TOKEN_EXPIRE_SECONDS": 60 * 60,  # 1 hour
     "ROTATE_REFRESH_TOKEN": True,  # Rotate the refresh token whenever a new access token is issued


### PR DESCRIPTION
Standardize access and refresh tokens to be:

pha_: access token
phr_: refresh token

Make both 32 bytes of entropy to match API keys