### PR TITLE
feat(data-warehouse): Added week partitioning

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/typings.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/typings.py
@@ -9,7 +9,7 @@ from posthog.warehouse.types import IncrementalFieldType
 
 SortMode = Literal["asc", "desc"]
 PartitionMode = Literal["md5", "numerical", "datetime"]
-PartitionFormat = Literal["month", "day"]
+PartitionFormat = Literal["month", "week", "day"]
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -439,7 +439,7 @@ def append_partition_key_to_table(
                 elif partition_format == "week":
                     date_format = "%G-w%V"
                 elif partition_format == "month":
-                    date_format = "%Y-%m-%d"
+                    date_format = "%Y-%m"
 
                 if isinstance(date, int):
                     date = datetime.datetime.fromtimestamp(date)

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -334,7 +334,7 @@ def setup_partitioning(
     )
 
     if partition_result is not None:
-        pa_table, partition_mode, updated_partition_keys = partition_result
+        pa_table, partition_mode, partition_format, updated_partition_keys = partition_result
 
         if not schema.partitioning_enabled:
             logger.debug(
@@ -355,7 +355,7 @@ def append_partition_key_to_table(
     partition_mode: PartitionMode | None,
     partition_format: PartitionFormat | None,
     logger: FilteringBoundLogger,
-) -> None | tuple[pa.Table, PartitionMode, list[str]]:
+) -> None | tuple[pa.Table, PartitionMode, PartitionFormat | None, list[str]]:
     """
     Partitions the pyarrow table via one of three methods:
     - md5: Hashes the primary keys into a fixed number of buckets, the least efficient method of partitioning
@@ -431,10 +431,15 @@ def append_partition_key_to_table(
                 key = normalized_partition_keys[0]
                 date = row[key]
 
+                if partition_format is None:
+                    partition_format = "month"
+
                 if partition_format == "day":
                     date_format = "%Y-%m-%d"
-                else:
-                    date_format = "%Y-%m"
+                elif partition_format == "week":
+                    date_format = "%G-w%V"
+                elif partition_format == "month":
+                    date_format = "%Y-%m-%d"
 
                 if isinstance(date, int):
                     date = datetime.datetime.fromtimestamp(date)
@@ -454,7 +459,7 @@ def append_partition_key_to_table(
     new_column = pa.array(partition_array, type=pa.string())
     logger.debug(f"append_partition_key_to_table: Partition key added with mode={mode}")
 
-    return table.append_column(PARTITION_KEY, new_column), mode, normalized_partition_keys
+    return table.append_column(PARTITION_KEY, new_column), mode, partition_format, normalized_partition_keys
 
 
 def _convert_uuid_to_string(row: dict) -> dict:

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1761,6 +1761,7 @@ async def test_partition_folders_with_uuid_id_and_created_at(team, postgres_conf
     assert schema.partitioning_enabled is True
     assert schema.partitioning_keys == ["created_at"]
     assert schema.partition_mode == "datetime"
+    assert schema.partition_format == "month"
     assert schema.partition_count is not None
 
 


### PR DESCRIPTION
## Problem
- We can only partition by day or month at the moment (the default being month). 
- The partition format also isn't stored in the DB when its the "default"

## Changes
- Added ISO `week` partitioning
- Ensure the partition format is stored in the DB

## How did you test this code?
- Updated unit tests

## Changelog: (features only) Is this feature complete?
Not worthy of a changelog addition - just an internal feature
