### PR TITLE
fix(max): memory onboarding in SLE

### DIFF
--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -373,7 +373,7 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
                 context_message,
             ],
             start_id=context_message.id,
-            root_window_start_id=context_message.id,
+            root_conversation_start_id=context_message.id,
         )
 
     @property

--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -22,6 +22,7 @@ from posthog.schema import (
     AssistantMessage,
     AssistantMessageMetadata,
     CachedEventTaxonomyQueryResponse,
+    ContextMessage,
     EventTaxonomyItem,
     EventTaxonomyQuery,
     HumanMessage,
@@ -39,6 +40,7 @@ from ee.hogai.graph.root.nodes import SLASH_COMMAND_INIT, SLASH_COMMAND_REMEMBER
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import filter_and_merge_messages, find_last_message_of_type
 from ee.hogai.utils.markdown import remove_markdown
+from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from ee.hogai.utils.types.base import AssistantNodeName
 from ee.hogai.utils.types.composed import MaxNodeName
@@ -52,6 +54,7 @@ from .prompts import (
     INITIALIZE_CORE_MEMORY_WITH_DOMAINS_USER_PROMPT,
     MEMORY_COLLECTOR_PROMPT,
     MEMORY_COLLECTOR_WITH_VISUALIZATION_PROMPT,
+    MEMORY_INITIALIZED_CONTEXT_PROMPT,
     MEMORY_ONBOARDING_ENQUIRY_PROMPT,
     ONBOARDING_COMPRESSION_PROMPT,
     SCRAPING_CONFIRMATION_MESSAGE,
@@ -302,7 +305,7 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
                 question = self._format_question(response)
                 core_memory.append_question_to_initial_text(question)
                 return PartialAssistantState(onboarding_question=question)
-        return PartialAssistantState(onboarding_question=None)
+        return PartialAssistantState(onboarding_question=None, answers_left=None)
 
     @property
     def _model(self):
@@ -332,7 +335,7 @@ class MemoryOnboardingEnquiryInterruptNode(AssistantNode):
     def node_name(self) -> MaxNodeName:
         return AssistantNodeName.MEMORY_ONBOARDING_ENQUIRY_INTERRUPT
 
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         last_assistant_message = find_last_message_of_type(state.messages, AssistantMessage)
         if not state.onboarding_question:
             raise ValueError("No onboarding question found.")
@@ -359,8 +362,18 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
         compressed_memory = cast(str, chain.invoke({"memory_content": core_memory.initial_text}, config=config))
         compressed_memory = compressed_memory.replace("\n", " ").strip()
         core_memory.set_core_memory(compressed_memory)
+
+        context_message = ContextMessage(
+            content=format_prompt_string(MEMORY_INITIALIZED_CONTEXT_PROMPT, core_memory=core_memory.initial_text),
+            id=str(uuid4()),
+        )
         return PartialAssistantState(
-            messages=[AssistantMessage(content=SCRAPING_MEMORY_SAVED_MESSAGE, id=str(uuid4()))]
+            messages=[
+                AssistantMessage(content=SCRAPING_MEMORY_SAVED_MESSAGE, id=str(uuid4())),
+                context_message,
+            ],
+            start_id=context_message.id,
+            root_window_start_id=context_message.id,
         )
 
     @property

--- a/ee/hogai/graph/memory/nodes.py
+++ b/ee/hogai/graph/memory/nodes.py
@@ -59,7 +59,6 @@ from .prompts import (
     ONBOARDING_COMPRESSION_PROMPT,
     SCRAPING_CONFIRMATION_MESSAGE,
     SCRAPING_INITIAL_MESSAGE,
-    SCRAPING_MEMORY_SAVED_MESSAGE,
     SCRAPING_REJECTION_MESSAGE,
     SCRAPING_SUCCESS_KEY_PHRASE,
     SCRAPING_TERMINATION_MESSAGE,
@@ -368,10 +367,7 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
             id=str(uuid4()),
         )
         return PartialAssistantState(
-            messages=[
-                AssistantMessage(content=SCRAPING_MEMORY_SAVED_MESSAGE, id=str(uuid4())),
-                context_message,
-            ],
+            messages=[context_message],
             start_id=context_message.id,
             root_conversation_start_id=context_message.id,
         )

--- a/ee/hogai/graph/memory/prompts.py
+++ b/ee/hogai/graph/memory/prompts.py
@@ -57,9 +57,6 @@ SCRAPING_CONFIRMATION_MESSAGE = "Yes, save this"
 
 SCRAPING_REJECTION_MESSAGE = "No, not quite right"
 
-SCRAPING_MEMORY_SAVED_MESSAGE = (
-    "Thanks! I've updated my initial memory. Remember that you can always ask me to remember information!"
-)
 
 ONBOARDING_COMPRESSION_PROMPT = """
 Segment the provided information into a series of brief, independent paragraphs, preserving the original meaning of the text.

--- a/ee/hogai/graph/memory/prompts.py
+++ b/ee/hogai/graph/memory/prompts.py
@@ -248,3 +248,9 @@ If you have no more questions to ask, or you consider your job done, just output
 </format_instructions>
 """.strip()
 )
+
+MEMORY_INITIALIZED_CONTEXT_PROMPT = """
+{{{core_memory}}}
+
+<system_reminder>You have just initialized the core memory for a user's product.</system_reminder>
+""".strip()

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -532,9 +532,9 @@ class TestMemoryEnquiryInterruptNode(ClickhouseTestMixin, BaseTest):
         self.core_memory = CoreMemory.objects.create(team=self.team)
         self.node = MemoryOnboardingEnquiryInterruptNode(team=self.team, user=self.user)
 
-    def test_run(self):
+    async def test_run(self):
         with self.assertRaises(NodeInterrupt) as e:
-            self.node.run(
+            await self.node.arun(
                 AssistantState(
                     messages=[AssistantMessage(content="What is your name?"), HumanMessage(content="Hello")],
                     onboarding_question="What is your target market?",
@@ -545,7 +545,7 @@ class TestMemoryEnquiryInterruptNode(ClickhouseTestMixin, BaseTest):
         self.assertIsInstance(e.exception.args[0][0].value, AssistantMessage)
         self.assertEqual(e.exception.args[0][0].value.content, "What is your target market?")
 
-        new_state = self.node.run(
+        new_state = await self.node.arun(
             AssistantState(
                 messages=[AssistantMessage(content="What is your target market?"), HumanMessage(content="Hello")],
                 onboarding_question="What is your target market?",
@@ -567,7 +567,7 @@ class TestMemoryOnboardingFinalizeNode(ClickhouseTestMixin, BaseTest):
             self.core_memory.initial_text = "Question: What does the company do?\nAnswer: Product description"
             self.core_memory.save()
             new_state = self.node.run(AssistantState(messages=[]), {})
-            self.assertEqual(len(new_state.messages), 1)
+            self.assertEqual(len(new_state.messages), 2)
             self.assertEqual(
                 cast(AssistantMessage, new_state.messages[0]).content, prompts.SCRAPING_MEMORY_SAVED_MESSAGE
             )
@@ -599,7 +599,7 @@ Additional context: Our system also handles nested configurations like {"feature
             # This should not raise a KeyError about missing template variables
             new_state = self.node.run(AssistantState(messages=[]), {})
 
-            self.assertEqual(len(new_state.messages), 1)
+            self.assertEqual(len(new_state.messages), 2)
             self.assertEqual(
                 cast(AssistantMessage, new_state.messages[0]).content, prompts.SCRAPING_MEMORY_SAVED_MESSAGE
             )

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -13,7 +13,7 @@ from langchain_core.messages import (
 from langchain_core.runnables import RunnableLambda
 from langgraph.errors import NodeInterrupt
 
-from posthog.schema import AssistantMessage, EventTaxonomyItem, HumanMessage
+from posthog.schema import AssistantMessage, ContextMessage, EventTaxonomyItem, HumanMessage
 
 from ee.hogai.graph.memory import prompts
 from ee.hogai.graph.memory.nodes import (
@@ -571,6 +571,9 @@ class TestMemoryOnboardingFinalizeNode(ClickhouseTestMixin, BaseTest):
             self.assertEqual(
                 cast(AssistantMessage, new_state.messages[0]).content, prompts.SCRAPING_MEMORY_SAVED_MESSAGE
             )
+            self.assertIsInstance(new_state.messages[1], ContextMessage)
+            self.assertEqual(new_state.messages[1].id, new_state.root_conversation_start_id)
+            self.assertEqual(new_state.messages[1].id, new_state.start_id)
             self.core_memory.refresh_from_db()
             self.assertEqual(self.core_memory.text, "Compressed memory about enterprise product")
 

--- a/ee/hogai/graph/memory/test/test_nodes.py
+++ b/ee/hogai/graph/memory/test/test_nodes.py
@@ -567,13 +567,10 @@ class TestMemoryOnboardingFinalizeNode(ClickhouseTestMixin, BaseTest):
             self.core_memory.initial_text = "Question: What does the company do?\nAnswer: Product description"
             self.core_memory.save()
             new_state = self.node.run(AssistantState(messages=[]), {})
-            self.assertEqual(len(new_state.messages), 2)
-            self.assertEqual(
-                cast(AssistantMessage, new_state.messages[0]).content, prompts.SCRAPING_MEMORY_SAVED_MESSAGE
-            )
-            self.assertIsInstance(new_state.messages[1], ContextMessage)
-            self.assertEqual(new_state.messages[1].id, new_state.root_conversation_start_id)
-            self.assertEqual(new_state.messages[1].id, new_state.start_id)
+            self.assertEqual(len(new_state.messages), 1)
+            self.assertIsInstance(new_state.messages[0], ContextMessage)
+            self.assertEqual(new_state.messages[0].id, new_state.root_conversation_start_id)
+            self.assertEqual(new_state.messages[0].id, new_state.start_id)
             self.core_memory.refresh_from_db()
             self.assertEqual(self.core_memory.text, "Compressed memory about enterprise product")
 
@@ -602,10 +599,8 @@ Additional context: Our system also handles nested configurations like {"feature
             # This should not raise a KeyError about missing template variables
             new_state = self.node.run(AssistantState(messages=[]), {})
 
-            self.assertEqual(len(new_state.messages), 2)
-            self.assertEqual(
-                cast(AssistantMessage, new_state.messages[0]).content, prompts.SCRAPING_MEMORY_SAVED_MESSAGE
-            )
+            self.assertEqual(len(new_state.messages), 1)
+            self.assertIsInstance(new_state.messages[0], ContextMessage)
             self.core_memory.refresh_from_db()
             self.assertEqual(self.core_memory.text, "Company uses structured JSON for event tracking")
 


### PR DESCRIPTION
## Problem

The memory onboarding was broken after the release of the single executor loop. Anthropic APIs expect that the last AssistantMessage in a turn contains a thinking block.

## Changes

- When the memory initialization is finished, the context message will be appended with the new memory content.

## How did you test this code?

Manual & unit tests
