### PR TITLE
fix(persons): fix person search for non-string properties

### DIFF
--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -113,12 +113,12 @@ class PersonStrategy(ActorStrategy):
                     exprs=[
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.ILike,
-                            left=ast.Field(chain=["properties", "email"]),
+                            left=ast.Call(name="toString", args=[ast.Field(chain=["properties", "email"])]),
                             right=ast.Constant(value=f"%{self.query.search}%"),
                         ),
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.ILike,
-                            left=ast.Field(chain=["properties", "name"]),
+                            left=ast.Call(name="toString", args=[ast.Field(chain=["properties", "name"])]),
                             right=ast.Constant(value=f"%{self.query.search}%"),
                         ),
                         ast.CompareOperation(

--- a/posthog/hogql_queries/test/__snapshots__/test_actors_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_actors_query_runner.ambr
@@ -4,7 +4,7 @@
   
   SELECT id, id, 1 
   FROM persons 
-  WHERE or(ilike(properties.email, '%SEARCHSTRING%'), ilike(properties.name, '%SEARCHSTRING%'), ilike(toString(id), '%SEARCHSTRING%'), in(id, (
+  WHERE or(ilike(toString(properties.email), '%SEARCHSTRING%'), ilike(toString(properties.name), '%SEARCHSTRING%'), ilike(toString(id), '%SEARCHSTRING%'), in(id, (
   SELECT person_id 
   FROM person_distinct_ids 
   WHERE ilike(distinct_id, '%SEARCHSTRING%')))) ORDER BY id ASC 


### PR DESCRIPTION
## Problem

Non-string person properties for name or email cause the search query to error out. See also https://posthog.slack.com/archives/C0113360FFV/p1761069340038479.

Repro:
1. Change the name or email person property to boolean in property definitions
2. Go to the persons page http://localhost:8010/project/1/persons and search for any text
3. Observe the query erroring out

## Changes

Casts the properties to string, so that the search doesn't error.

## How did you test this code?

Tried locally