### PR TITLE
fix(surveys): UI fixes

### DIFF
--- a/frontend/src/scenes/surveys/SurveyNoResponsesBanner.tsx
+++ b/frontend/src/scenes/surveys/SurveyNoResponsesBanner.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export function SurveyNoResponsesBanner({ type }: Props): JSX.Element {
     return (
-        <div className="border-2 border-dashed border-border w-full rounded flex flex-col items-center justify-center gap-4">
+        <div className="border-2 border-dashed border-border w-full rounded flex flex-col items-center justify-center gap-4 py-10">
             <SurprisedHog className="size-36" />
             <div className="text-center">
                 <h3 className="text-lg font-semibold m-0">No responses for this {type}</h3>

--- a/frontend/src/scenes/surveys/components/AnalyzeResponsesButton.tsx
+++ b/frontend/src/scenes/surveys/components/AnalyzeResponsesButton.tsx
@@ -2,6 +2,8 @@ import { useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useMemo } from 'react'
 
+import { IconAI } from '@posthog/icons'
+
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { ProductIntentContext, addProductIntent } from 'lib/utils/product-intents'
 import { useMaxTool } from 'scenes/max/useMaxTool'
@@ -67,7 +69,7 @@ export function AnalyzeResponsesButton(): JSX.Element | null {
     }
 
     return (
-        <LemonButton onClick={openMax} type="secondary">
+        <LemonButton onClick={openMax} type="secondary" icon={<IconAI />}>
             Analyze responses
         </LemonButton>
     )


### PR DESCRIPTION
## Changes
Two quick UI fixes :)

- Add a `IconAI` to the awesome "Summarize responses" button
- Add padding for an empty state

## How did you test this code?
|Before|After|
|----|----|
|<img width="163" height="49" alt="image" src="https://github.com/user-attachments/assets/f1dc2ae5-e6b4-4c4a-a34b-edd1ea2630d7" />|<img width="188" height="50" alt="image" src="https://github.com/user-attachments/assets/88436b1c-7750-4d40-99aa-4094c5512855" />|

|Before|After|
|----|----|
|<img width="1220" height="226" alt="image" src="https://github.com/user-attachments/assets/e95afa6f-e7d3-4b93-a2f5-25efe873b82b" />|<img width="1221" height="306" alt="image" src="https://github.com/user-attachments/assets/dd0a3010-71ac-4398-8bbe-0785dc57c2e4" />|