### PR TITLE
feat(experiments): Hide participant type if existing flag used

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -199,7 +199,7 @@ const ExperimentFormFields = (): JSX.Element => {
                     <SceneDivider />
                 </>
             )}
-            {groupsAccessStatus === GroupsAccessStatus.AlreadyUsing && (
+            {groupsAccessStatus === GroupsAccessStatus.AlreadyUsing && !validExistingFeatureFlag && (
                 <>
                     <SceneSection
                         title="Participant type"


### PR DESCRIPTION
## Problem
When a user links an existing flag to an experiment, we still show the `Participant type` field. This is wrong as this field is configured on the flag itself, and letting the user configure it on the experiment form could result in overwriting existing flag participant type.

## Changes
Hide `Participant type` field if existing flag is linked.

## How did you test this code?
|Before|After|
|----|----|
|<img width="651" height="408" alt="image" src="https://github.com/user-attachments/assets/097d3d83-1c02-4c42-b376-8031fe004dcd" />|<img width="651" height="314" alt="image" src="https://github.com/user-attachments/assets/9fff92e4-0fa5-4e6a-9995-74ac17ed3074" />|