### PR TITLE
fix: sql editor results panel broken

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -127,7 +127,7 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
                                     <BindLogic logic={multitabEditorLogic} props={{ tabId, monaco, editor }}>
                                         <div
                                             data-attr="editor-scene"
-                                            className="EditorScene w-full grow flex flex-row overflow-hidden"
+                                            className="EditorScene w-full h-[calc(var(--scene-layout-rect-height)-var(--scene-layout-header-height))] flex flex-row overflow-hidden"
                                             ref={ref}
                                         >
                                             <QueryWindow


### PR DESCRIPTION
## Problem
broken sql editor

revert height for sql editor from this change https://github.com/PostHog/posthog/pull/39920

works locally

<img width="1101" height="886" alt="image" src="https://github.com/user-attachments/assets/a6d04726-60d8-4c2a-88c9-2922505feef5" />
