### PR TITLE
feat(flags): Add MAX_LIFETIME_JITTER_SECS for DB connections

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -208,6 +208,12 @@ pub struct Config {
     #[envconfig(default = "1800")]
     pub max_lifetime_secs: u64,
 
+    // Additional maximum jitter to max_lifetime to avoid thundering herd.
+    // - Adds random amount of seconds [0, max_lifetime_jitter_secs) to max_lifetime_secs
+    // - Set to 0 to disable (uses fixed max_lifetime).
+    #[envconfig(default = "1800")]
+    pub max_lifetime_jitter_secs: u64,
+
     // Test connection health before returning from pool
     // - Set to true for production to catch stale connections
     // - Set to false in tests or very stable environments for slight performance gain
@@ -344,6 +350,7 @@ impl Config {
             acquire_timeout_secs: 3,
             idle_timeout_secs: 300,
             max_lifetime_secs: 1800,
+            max_lifetime_jitter_secs: 1800,
             test_before_acquire: FlexBool(true),
             db_monitor_interval_secs: 30,
             db_pool_warn_utilization: 0.8,

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -5,6 +5,7 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::info;
+use rand::Rng;
 
 /// Direct database pool access for different operation types
 #[derive(Clone)]
@@ -34,7 +35,7 @@ impl DatabasePools {
             },
             max_lifetime: if config.max_lifetime_secs > 0 {
                 let jitter = if config.max_lifetime_jitter_secs > 0 {
-                    rand::random::<u64>() % config.max_lifetime_jitter_secs
+                    rand::thread_rng().gen_range(0..config.max_lifetime_jitter_secs)
                 } else {
                     0
                 };

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -33,7 +33,12 @@ impl DatabasePools {
                 None
             },
             max_lifetime: if config.max_lifetime_secs > 0 {
-                Some(Duration::from_secs(config.max_lifetime_secs))
+                let jitter = if config.max_lifetime_jitter_secs > 0 {
+                    rand::random::<u64>() % config.max_lifetime_jitter_secs
+                } else {
+                    0
+                };
+                Some(Duration::from_secs(config.max_lifetime_secs + jitter))
             } else {
                 None
             },


### PR DESCRIPTION
## Problem

New feature flag pods come online within a relatively short period of time following a deployment. `MAX_LIFETIME_SECS` defines the amount of time before an active connection is closed and re-opened. If this happens to trigger across all connections and pods in a relatively short period of time, this could cause a thundering herd.

## Changes

This value adds **additional** maximum lifetime to db connections between 0-MAX_LIFETIME_JITTER_SECS. This allows instances to more uniformly distribute db reconnections over a period of time.

This also restores the max connection lifetime to 30 minutes. This means that the maximum lifetime for a db connection in a single instance will be somewhere between 30 minutes and an hour.

## How did you test this code?

Compiled, ran locally
