### PR TITLE
feat: Allow overriding start to close timeout

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1468,7 +1468,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                     interval=inputs.interval,
                     # TODO: Temporarily bump start to close timeout until we speed up
                     # Redshift inserts.
-                    override_start_to_close_timeout_seconds=60 * 60 * 24,
+                    override_start_to_close_timeout_seconds=60 * 60 * 24,  # 24 hours
                     maximum_retry_interval_seconds=240,
                 )
         else:

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1468,7 +1468,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                     interval=inputs.interval,
                     # TODO: Temporarily bump start to close timeout until we speed up
                     # Redshift inserts.
-                    override_start_to_close_timeout_seconds=60 * 60 * 12,
+                    override_start_to_close_timeout_seconds=60 * 60 * 24,
                     maximum_retry_interval_seconds=240,
                 )
         else:

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1466,6 +1466,9 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                         table=table_parameters,
                     ),
                     interval=inputs.interval,
+                    # TODO: Temporarily bump start to close timeout until we speed up
+                    # Redshift inserts.
+                    override_start_to_close_timeout_seconds=60 * 60 * 12,
                     maximum_retry_interval_seconds=240,
                 )
         else:

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -58,6 +58,7 @@ async def execute_batch_export_using_internal_stage(
     maximum_attempts: int = 0,
     initial_retry_interval_seconds: int = 5,
     maximum_retry_interval_seconds: int = 120,
+    override_start_to_close_timeout_seconds: int | None = None,
 ) -> None:
     """
     This is the entrypoint for a new version of the batch export insert activity.
@@ -104,19 +105,22 @@ async def execute_batch_export_using_internal_stage(
     if isinstance(settings.BATCH_EXPORT_HEARTBEAT_TIMEOUT_SECONDS, int):
         heartbeat_timeout_seconds = settings.BATCH_EXPORT_HEARTBEAT_TIMEOUT_SECONDS
 
+    override_start_to_close_timeout_timedelta = dt.timedelta(seconds=override_start_to_close_timeout_seconds or 0)
     if interval == "hour":
         # TODO - we should reduce this to 1 hour once we are more confident about hitting 1 hour SLAs.
         # TODO: Review timeouts for internal stage activity.
-        main_activity_start_to_close_timeout = dt.timedelta(hours=2)
+        main_activity_start_to_close_timeout = max(dt.timedelta(hours=2), override_start_to_close_timeout_timedelta)
         stage_activity_start_to_close_timeout = dt.timedelta(hours=1)
     elif interval == "day":
-        main_activity_start_to_close_timeout = dt.timedelta(days=1)
+        main_activity_start_to_close_timeout = max(dt.timedelta(days=1), override_start_to_close_timeout_timedelta)
         stage_activity_start_to_close_timeout = main_activity_start_to_close_timeout
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}
         # TODO: Consider removing this 20 minute minimum once we are more confident about hitting 5 minute or lower SLAs.
-        main_activity_start_to_close_timeout = max(dt.timedelta(minutes=20), dt.timedelta(**kwargs))
+        main_activity_start_to_close_timeout = max(
+            dt.timedelta(minutes=20), dt.timedelta(**kwargs), override_start_to_close_timeout_timedelta
+        )
         stage_activity_start_to_close_timeout = main_activity_start_to_close_timeout
     else:
         raise ValueError(f"Unsupported interval: '{interval}'")

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -81,6 +81,9 @@ async def execute_batch_export_using_internal_stage(
             Assuming the error that triggered the retry is not in non_retryable_error_types.
         initial_retry_interval_seconds: When retrying, seconds until the first retry.
         maximum_retry_interval_seconds: Maximum interval in seconds between retries.
+        override_start_to_close_timeout_seconds: Optionally, override the start-to-close
+            timeout of the main activity. If this is lower than the calculated default
+            timeout for the main activity, then the default will be preferred.
     """
     get_export_started_metric().add(1)
 


### PR DESCRIPTION
## Problem

Redshift inserts can be really slow. We need to parallelize these somehow. In the meantime, I propose we override the timeout of the main activity so that we at least have a chance to finish.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Allow overriding timeouts of main activities.
Override Redshift timeout of insert activity to 24 hours.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
