### PR TITLE
refactor: Re-use aioboto3.Sesssion, not S3 client

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -47,6 +47,7 @@ from products.batch_exports.backend.temporal.sql import (
 from products.batch_exports.backend.temporal.utils import set_status_to_running_task
 
 LOGGER = get_write_only_logger()
+SESSION = aioboto3.Session()
 
 
 def _get_s3_endpoint_url() -> str:
@@ -63,8 +64,7 @@ def _get_s3_endpoint_url() -> str:
 @asynccontextmanager
 async def get_s3_client():
     """Async context manager for creating and managing an S3 client."""
-    session = aioboto3.Session()
-    async with session.client(
+    async with SESSION.client(
         "s3",
         aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
         aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,

--- a/products/batch_exports/backend/temporal/pipeline/producer.py
+++ b/products/batch_exports/backend/temporal/pipeline/producer.py
@@ -1,4 +1,3 @@
-import typing
 import asyncio
 
 from django.conf import settings
@@ -11,10 +10,6 @@ from posthog.temporal.common.logger import get_write_only_logger
 from products.batch_exports.backend.temporal.pipeline.internal_stage import get_s3_client, get_s3_staging_folder
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, slice_record_batch
 from products.batch_exports.backend.temporal.utils import make_retryable_with_exponential_backoff
-
-if typing.TYPE_CHECKING:
-    from types_aiobotocore_s3.client import S3Client
-
 
 LOGGER = get_write_only_logger(__name__)
 
@@ -81,33 +76,33 @@ class Producer:
             keys = [obj["Key"] for obj in contents if "Key" in obj]
             await self.logger.ainfo(f"Producer found {len(keys)} files in S3 stage")
 
-            # Read in batches
-            try:
-                await self._stream_record_batches_from_s3(
-                    s3_client, keys, queue, max_record_batch_size_bytes, min_records_per_batch
-                )
-            except Exception as e:
-                await self.logger.aexception("Unexpected error occurred while producing record batches", exc_info=e)
-                raise
+        # Read in batches
+        try:
+            await self._stream_record_batches_from_s3(keys, queue, max_record_batch_size_bytes, min_records_per_batch)
+        except Exception as e:
+            await self.logger.aexception("Unexpected error occurred while producing record batches", exc_info=e)
+            raise
 
     async def _stream_record_batches_from_s3(
         self,
-        s3_client: "S3Client",
         keys: list[str],
         queue: RecordBatchQueue,
         max_record_batch_size_bytes: int = 0,
         min_records_per_batch: int = 100,
     ):
         async def stream_from_s3_file(key):
-            s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
-            assert "Body" in s3_ob, "Body not found in S3 object"
-            stream: StreamingBody = s3_ob["Body"]
-            # read in 128KB chunks of data from S3
-            reader = asyncpa.AsyncRecordBatchReader(stream.iter_chunks(chunk_size=128 * 1024))
+            async with get_s3_client() as s3_client:
+                s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+                assert "Body" in s3_ob, "Body not found in S3 object"
+                stream: StreamingBody = s3_ob["Body"]
+                # read in 128KB chunks of data from S3
+                reader = asyncpa.AsyncRecordBatchReader(stream.iter_chunks(chunk_size=128 * 1024))
 
-            async for batch in reader:
-                for record_batch_slice in slice_record_batch(batch, max_record_batch_size_bytes, min_records_per_batch):
-                    await queue.put(record_batch_slice)
+                async for batch in reader:
+                    for record_batch_slice in slice_record_batch(
+                        batch, max_record_batch_size_bytes, min_records_per_batch
+                    ):
+                        await queue.put(record_batch_slice)
 
         async with asyncio.TaskGroup() as tg:
             stream_func = make_retryable_with_exponential_backoff(


### PR DESCRIPTION
## Problem

S3 clients (or their underlying credentials used in a request) can expire when reading from internal stage. We should instead have each task spawn its own client from the same session. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Do not pass `S3Client` when reading from internal stage bucket, instead spawn a client on each task.

This change could have some performance impact if the clients are heavy. Testing individual workflows does not reveal any significant performance impact though.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
