### PR TITLE
fix: bad length calculation for uint array sometimes freezes processing

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
@@ -331,10 +331,11 @@ export const parseEncodedSnapshots = async (
                 }
 
                 const length =
-                    (uint8Data[offset] << 24) |
-                    (uint8Data[offset + 1] << 16) |
-                    (uint8Data[offset + 2] << 8) |
-                    uint8Data[offset + 3]
+                    ((uint8Data[offset] << 24) |
+                        (uint8Data[offset + 1] << 16) |
+                        (uint8Data[offset + 2] << 8) |
+                        uint8Data[offset + 3]) >>>
+                    0
                 offset += 4
 
                 // Read compressed block


### PR DESCRIPTION
ugh

bitwize operations
endianness

just like being back in CS lessons 🙈 

(for some content we would generate a negative length for the array representing compressed bytes and not be able to decompress it - so we need to make sure it's an unsigned length)

the robot tells me this is correct - and i can still play content locally