### PR TITLE
fix(err): add command line flag to disable non-zero exit codes

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.4
+
+- Added no fail flag to disable non-zero exit codes on errors.
+
 # 0.5.3
 
 - Add support for ignoring public path prefixes appended by bundlers to sourceMappingURLs when searching for sourcemaps

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1520,7 +1520,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.3"
+version = "0.5.4"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -14,6 +14,10 @@ pub struct Cli {
     #[arg(long)]
     host: Option<String>,
 
+    /// Disable non-zero exit codes on errors. Use with caution.
+    #[arg(long, default_value = "false")]
+    no_fail: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -60,23 +64,31 @@ pub enum ExpCommand {
 impl Cli {
     pub fn run() -> Result<(), CapturedError> {
         let command = Cli::parse();
+        let no_fail = command.no_fail;
+        let res = command.run_impl();
+        if no_fail {
+            return Ok(());
+        }
+        res
+    }
 
-        match command.command {
+    fn run_impl(self) -> Result<(), CapturedError> {
+        match self.command {
             Commands::Login => {
                 // Notably login doesn't have a context set up going it - it sets one up
                 crate::login::login()?;
             }
             Commands::Sourcemap { cmd } => match cmd {
                 SourcemapCommand::Inject(input_args) => {
-                    init_context(command.host.clone(), false)?;
+                    init_context(self.host.clone(), false)?;
                     crate::sourcemaps::inject::inject(&input_args)?;
                 }
                 SourcemapCommand::Upload(upload_args) => {
-                    init_context(command.host.clone(), upload_args.skip_ssl_verification)?;
+                    init_context(self.host.clone(), upload_args.skip_ssl_verification)?;
                     crate::sourcemaps::upload::upload_cmd(upload_args.clone())?;
                 }
                 SourcemapCommand::Process(args) => {
-                    init_context(command.host.clone(), args.skip_ssl_verification)?;
+                    init_context(self.host.clone(), args.skip_ssl_verification)?;
                     let (inject, upload) = args.into();
                     crate::sourcemaps::inject::inject(&inject)?;
                     crate::sourcemaps::upload::upload_cmd(upload)?;
@@ -87,11 +99,11 @@ impl Cli {
                     cmd,
                     skip_ssl_verification,
                 } => {
-                    init_context(command.host.clone(), skip_ssl_verification)?;
+                    init_context(self.host.clone(), skip_ssl_verification)?;
                     cmd.run()?;
                 }
                 ExpCommand::Query { cmd } => {
-                    init_context(command.host.clone(), false)?;
+                    init_context(self.host.clone(), false)?;
                     crate::experimental::query::command::query_command(&cmd)?
                 }
             },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,6 @@
 use posthog_cli::cmd;
 use rayon::ThreadPoolBuilder;
-use tracing::{error, info};
+use tracing::info;
 
 fn main() {
     let subscriber = tracing_subscriber::fmt()
@@ -21,12 +21,7 @@ fn main() {
 
     match cmd::Cli::run() {
         Ok(_) => info!("All done, happy hogging!"),
-        Err(e) => {
-            let msg = match e.exception_id {
-                Some(id) => format!("Oops! {} (ID: {})", e.inner, id),
-                None => format!("Oops! {:?}", e.inner),
-            };
-            error!(msg);
+        Err(_) => {
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
We want to be able to integrate our CLI safely into our own CI pipeline (should have done it a long time ago), and now that we're doing that, this seems like an obvious thing to want.