### PR TITLE
refactor: Replace `create_hogql_database` with `Database.create_for`

### DIFF
--- a/ee/hogai/eval/ci/max_tools/eval_hogql_generator_tool.py
+++ b/ee/hogai/eval/ci/max_tools/eval_hogql_generator_tool.py
@@ -8,7 +8,7 @@ from braintrust import EvalCase, Score
 from pydantic import BaseModel
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.sync import database_sync_to_async
 
@@ -67,7 +67,7 @@ def call_generate_hogql_query(demo_org_team_user):
 @pytest.fixture
 async def database_schema(demo_org_team_user):
     team = demo_org_team_user[1]
-    database = await database_sync_to_async(create_hogql_database)(team=team)
+    database = await database_sync_to_async(Database.create_for)(team=team)
     context = HogQLContext(team=team, enable_select_queries=True, database=database)
     return await serialize_database_schema(database, context)
 

--- a/ee/hogai/eval/offline/eval_sql.py
+++ b/ee/hogai/eval/offline/eval_sql.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from posthog.schema import AssistantHogQLQuery, HumanMessage, VisualizationMessage
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
@@ -36,7 +36,7 @@ class EvalMetadata(TypedDict):
 
 
 async def serialize_database(team: Team):
-    database = await database_sync_to_async(create_hogql_database)(team=team)
+    database = await database_sync_to_async(Database.create_for)(team=team)
     context = HogQLContext(team=team, database=database, enable_select_queries=True)
     return await serialize_database_schema(database, context)
 

--- a/ee/hogai/graph/query_planner/nodes.py
+++ b/ee/hogai/graph/query_planner/nodes.py
@@ -21,7 +21,7 @@ from posthog.schema import (
 
 from posthog.hogql.ai import SCHEMA_MESSAGE
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, serialize_database
+from posthog.hogql.database.database import Database
 
 from posthog.models.group_type_mapping import GroupTypeMapping
 
@@ -197,7 +197,7 @@ class QueryPlannerNode(TaxonomyReasoningNodeMixin, AssistantNode):
         """
         # Initial conversation setup
         database = Database.create_for(team=self._team)
-        serialized_database = serialize_database(
+        serialized_database = database.serialize(
             HogQLContext(team=self._team, enable_select_queries=True, database=database)
         )
         hogql_schema_description = "\n\n".join(

--- a/ee/hogai/graph/query_planner/nodes.py
+++ b/ee/hogai/graph/query_planner/nodes.py
@@ -21,7 +21,7 @@ from posthog.schema import (
 
 from posthog.hogql.ai import SCHEMA_MESSAGE
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database, serialize_database
+from posthog.hogql.database.database import Database, serialize_database
 
 from posthog.models.group_type_mapping import GroupTypeMapping
 
@@ -196,7 +196,7 @@ class QueryPlannerNode(TaxonomyReasoningNodeMixin, AssistantNode):
         and continuation with intermediate steps.
         """
         # Initial conversation setup
-        database = create_hogql_database(team=self._team)
+        database = Database.create_for(team=self._team)
         serialized_database = serialize_database(
             HogQLContext(team=self._team, enable_select_queries=True, database=database)
         )

--- a/ee/hogai/graph/sql/mixins.py
+++ b/ee/hogai/graph/sql/mixins.py
@@ -7,7 +7,7 @@ from posthog.schema import AssistantHogQLQuery
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import (
     ExposedHogQLError,
     NotImplementedError as HogQLNotImplementedError,
@@ -42,7 +42,7 @@ class HogQLDatabaseMixin:
     def _get_database(self):
         if self._database_instance:
             return self._database_instance
-        self._database_instance = create_hogql_database(team=self._team)
+        self._database_instance = Database.create_for(team=self._team)
         return self._database_instance
 
     @database_sync_to_async

--- a/ee/hogai/utils/warehouse.py
+++ b/ee/hogai/utils/warehouse.py
@@ -1,5 +1,5 @@
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, serialize_database
+from posthog.hogql.database.database import Database
 
 from posthog.sync import database_sync_to_async
 
@@ -9,7 +9,7 @@ def serialize_database_schema(database: Database, hogql_context: HogQLContext):
     """Unified serialization of the database schema for the LLM."""
 
     # Simplify the schema description by only including the most important core tables, plus all warehouse tables and views
-    serialized_database = serialize_database(
+    serialized_database = database.serialize(
         hogql_context,
         include_only={"events", "groups", "persons", *database.get_warehouse_table_names(), *database.get_view_names()},
     )

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -22,7 +22,7 @@ from posthog.hogql.autocomplete import get_hogql_autocomplete
 from posthog.hogql.compiler.bytecode import execute_hog
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database, serialize_database
+from posthog.hogql.database.database import Database, serialize_database
 from posthog.hogql.metadata import get_hogql_metadata
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 
@@ -164,7 +164,7 @@ def process_query_model(
             result = metadata_response
         elif isinstance(query, DatabaseSchemaQuery):
             joins = DataWarehouseJoin.objects.filter(team_id=team.pk).exclude(deleted=True)
-            database = create_hogql_database(team=team, modifiers=create_default_modifiers_for_team(team))
+            database = Database.create_for(team=team, modifiers=create_default_modifiers_for_team(team))
             context = HogQLContext(team_id=team.pk, team=team, database=database)
             result = DatabaseSchemaQueryResponse(
                 tables=serialize_database(context),

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -22,7 +22,7 @@ from posthog.hogql.autocomplete import get_hogql_autocomplete
 from posthog.hogql.compiler.bytecode import execute_hog
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, serialize_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.metadata import get_hogql_metadata
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 
@@ -167,7 +167,7 @@ def process_query_model(
             database = Database.create_for(team=team, modifiers=create_default_modifiers_for_team(team))
             context = HogQLContext(team_id=team.pk, team=team, database=database)
             result = DatabaseSchemaQueryResponse(
-                tables=serialize_database(context),
+                tables=database.serialize(context),
                 joins=[
                     DataWarehouseViewLink.model_validate(
                         {

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -20,7 +20,7 @@ from temporalio.client import (
     ScheduleState,
 )
 
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import HogQLContext
 
 from posthog.batch_exports.models import BatchExport, BatchExportBackfill, BatchExportDestination, BatchExportRun
@@ -742,7 +742,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
         enable_select_queries=True,
         limit_top_select=False,
     )
-    context.database = create_hogql_database(team=batch_export.team, modifiers=context.modifiers)
+    context.database = Database.create_for(team=batch_export.team, modifiers=context.modifiers)
 
     temporal = sync_connect()
     schedule = Schedule(

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -15,7 +15,7 @@ from posthog.hogql.printer import prepare_and_print_ast
 from posthog.event_usage import report_user_action
 from posthog.utils import get_instance_region
 
-from .database.database import create_hogql_database, serialize_database
+from .database.database import Database, serialize_database
 from .query import create_default_modifiers_for_team
 
 if TYPE_CHECKING:
@@ -115,7 +115,7 @@ class PromptUnclear(Exception):
 
 
 def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, team: "Team", user: "User") -> str:
-    database = create_hogql_database(team=team)
+    database = Database.create_for(team=team)
     context = HogQLContext(
         team_id=team.pk,
         enable_select_queries=True,

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -15,7 +15,7 @@ from posthog.hogql.printer import prepare_and_print_ast
 from posthog.event_usage import report_user_action
 from posthog.utils import get_instance_region
 
-from .database.database import Database, serialize_database
+from .database.database import Database
 from .query import create_default_modifiers_for_team
 
 if TYPE_CHECKING:
@@ -122,7 +122,7 @@ def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, t
         database=database,
         modifiers=create_default_modifiers_for_team(team),
     )
-    serialized_database = serialize_database(context)
+    serialized_database = database.serialize(context)
     schema_description = "\n\n".join(
         (
             f"Table {table_name} with fields:\n"

--- a/posthog/hogql/autocomplete.py
+++ b/posthog/hogql/autocomplete.py
@@ -17,7 +17,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.base import AST, CTE, ConstantType
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import HOGQL_CHARACTERS_TO_BE_WRAPPED, Database, create_hogql_database
+from posthog.hogql.database.database import HOGQL_CHARACTERS_TO_BE_WRAPPED, Database
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
     DatabaseField,
@@ -393,7 +393,7 @@ def get_hogql_autocomplete(
     if database_arg is not None:
         database = database_arg
     else:
-        database = create_hogql_database(team=team, timings=timings)
+        database = Database.create_for(team=team, timings=timings)
 
     context = HogQLContext(team_id=team.pk, team=team, database=database, timings=timings)
     if query.sourceQuery:

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1097,7 +1097,7 @@ def _use_virtual_fields(database: Database, modifiers: HogQLQueryModifiers, timi
                 poe.fields[field_name] = ast.FieldTraverser(chain=chain)
 
 
-def constant_type_to_serialized_field_type(constant_type: ast.ConstantType) -> DatabaseSerializedFieldType | None:
+def _constant_type_to_serialized_field_type(constant_type: ast.ConstantType) -> DatabaseSerializedFieldType | None:
     if isinstance(constant_type, ast.StringType):
         return DatabaseSerializedFieldType.STRING
     if isinstance(constant_type, ast.BooleanType):
@@ -1255,7 +1255,7 @@ def serialize_fields(
                 assert field_expr.type is not None
                 constant_type = field_expr.type.resolve_constant_type(context)
 
-                field_type = constant_type_to_serialized_field_type(constant_type)
+                field_type = _constant_type_to_serialized_field_type(constant_type)
                 if field_type is None:
                     field_type = DatabaseSerializedFieldType.EXPRESSION
 

--- a/posthog/hogql/database/schema/test/test_event_sessions.py
+++ b/posthog/hogql/database/schema/test/test_event_sessions.py
@@ -4,7 +4,7 @@ from posthog.test.base import BaseTest
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.schema.event_sessions import CleanTableNameFromChain, WhereClauseExtractor
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.resolver import resolve_types
@@ -13,7 +13,7 @@ from posthog.hogql.visitor import clone_expr
 
 class TestWhereClauseExtractor(BaseTest):
     def setUp(self):
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(database=self.database, team_id=self.team.pk)
 
     def _select(self, query: str) -> ast.SelectQuery:
@@ -137,7 +137,7 @@ class TestWhereClauseExtractor(BaseTest):
 
 class TestCleanTableNameFromChain(BaseTest):
     def setUp(self):
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(database=self.database, team_id=self.team.pk)
 
     def _select(self, query: str) -> ast.SelectQuery:

--- a/posthog/hogql/database/schema/test/test_table_query_log.py
+++ b/posthog/hogql/database/schema/test/test_table_query_log.py
@@ -2,7 +2,7 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import MagicMock, patch
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client import sync_execute
@@ -15,7 +15,7 @@ class TestQueryLogTable(ClickhouseTestMixin, APIBaseTest):
 
     def setUp(self):
         super().setUp()
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(database=self.database, team_id=self.team.pk, enable_select_queries=True)
 
     @patch("posthog.hogql.query.sync_execute", wraps=sync_execute)

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -3,7 +3,7 @@ from typing import Literal
 from posthog.test.base import BaseTest
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import IntegerDatabaseField, StringDatabaseField, TableNode
 from posthog.hogql.database.postgres_table import PostgresTable
 from posthog.hogql.parser import parse_select
@@ -13,7 +13,7 @@ from posthog.hogql.query import create_default_modifiers_for_team
 
 class TestPostgresTable(BaseTest):
     def _init_database(self):
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
 
         self.database.tables.add_child(
             TableNode(

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import TableNode
 from posthog.hogql.database.s3_table import build_function_call
 from posthog.hogql.database.test.tables import create_aapl_stock_s3_table
@@ -19,7 +19,7 @@ from posthog.warehouse.models.table import DataWarehouseTable
 
 class TestS3Table(BaseTest):
     def _init_database(self):
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.database._add_warehouse_tables(
             TableNode(
                 children={

--- a/posthog/hogql/database/test/test_view.py
+++ b/posthog/hogql/database/test/test_view.py
@@ -3,7 +3,7 @@ from typing import Literal
 from posthog.test.base import BaseTest
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import TableNode
 from posthog.hogql.database.test.tables import (
     create_aapl_stock_s3_table,
@@ -22,7 +22,7 @@ class TestView(BaseTest):
     def setUp(self):
         super().setUp()
 
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.database._add_views(
             TableNode(
                 children={

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional, cast
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import NotImplementedError, QueryError, SyntaxError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
@@ -33,7 +33,7 @@ def translate_hogql(
         if context.database is None:
             if context.team_id is None:
                 raise ValueError("Cannot translate HogQL for a filter with no team specified")
-            context.database = create_hogql_database(
+            context.database = Database.create_for(
                 team_id=context.team_id,
                 modifiers=context.modifiers,
                 timings=context.timings,

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -21,7 +21,7 @@ from posthog.hogql.ast import Constant, StringType
 from posthog.hogql.base import _T_AST, AST
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext, get_max_limit_for_context
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import DANGEROUS_NoTeamIdCheckTable, FunctionCallTable, SavedQuery, Table
 from posthog.hogql.database.s3_table import DataWarehouseTable, S3Table
 from posthog.hogql.errors import ImpossibleASTError, InternalHogQLError, QueryError, ResolutionError
@@ -134,9 +134,9 @@ def prepare_ast_for_printing(
     settings: HogQLGlobalSettings | None = None,
 ) -> _T_AST | None:
     if context.database is None:
-        with context.timings.measure("create_hogql_database"):
+        with context.timings.measure("create_hogql_database"):  # Legacy name to keep backwards compatibility
             # Passing both `team_id` and `team` because `team` is not always available in the context
-            context.database = create_hogql_database(
+            context.database = Database.create_for(
                 context.team_id,
                 modifiers=context.modifiers,
                 team=context.team,

--- a/posthog/hogql/test/test_autocomplete.py
+++ b/posthog/hogql/test/test_autocomplete.py
@@ -12,7 +12,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.autocomplete import get_hogql_autocomplete
-from posthog.hogql.database.database import Database, create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import StringDatabaseField
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.persons import PERSONS_FIELDS
@@ -300,7 +300,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         assert len(results.suggestions) == 0
 
     def test_autocomplete_events_hidden_field(self):
-        database = create_hogql_database(team=self.team)
+        database = Database.create_for(team=self.team)
         database.get_table("events").fields["event"] = StringDatabaseField(name="event", hidden=True)
 
         query = "select  from events"
@@ -310,7 +310,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
             assert suggestion.label != "event"
 
     def test_autocomplete_special_characters(self):
-        database = create_hogql_database(team=self.team)
+        database = Database.create_for(team=self.team)
         database.get_table("events").fields["event-name"] = StringDatabaseField(name="event-name")
 
         query = "select  from events"
@@ -325,7 +325,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         assert suggestion.insertText == "`event-name`"
 
     def test_autocomplete_expressions(self):
-        database = create_hogql_database(team=self.team)
+        database = Database.create_for(team=self.team)
 
         query = "person."
         results = self._expr(query=query, start=7, end=7, database=database)
@@ -339,7 +339,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         assert suggestion.insertText == "created_at"
 
     def test_autocomplete_resolve_expression_type(self):
-        database = create_hogql_database(team=self.team)
+        database = Database.create_for(team=self.team)
 
         database.get_table("events").fields["expr_field"] = ast.ExpressionField(
             name="expr_field",
@@ -360,7 +360,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         assert suggestion.detail == "DateTime"
 
     def test_autocomplete_template_strings(self):
-        database = create_hogql_database(team=self.team)
+        database = Database.create_for(team=self.team)
 
         query = "this isn't a string {concat(eve)} <- this is"
         results = self._template(query=query, start=28, end=31, database=database)
@@ -380,7 +380,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         assert len(results.suggestions) == 0
 
     def test_autocomplete_template_json(self):
-        database = create_hogql_database(team=self.team)
+        database = Database.create_for(team=self.team)
 
         query = '{ "key": "val_{event.distinct_id}_ue" }'
         results = self._json(query=query, start=15, end=20, database=database)
@@ -400,7 +400,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         assert len(results.suggestions) == 0
 
     def test_autocomplete_hog(self):
-        database = create_hogql_database(team=self.team)
+        database = Database.create_for(team=self.team)
 
         # 1
         query = "let var1 := 3; let otherVar := 5; print(v)"

--- a/posthog/hogql/test/test_group_filtering.py
+++ b/posthog/hogql/test/test_group_filtering.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from posthog.test.base import APIBaseTest
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_and_print_ast
 
@@ -19,7 +19,7 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def setUp(self):
         super().setUp()
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
     def test_group_field_with_mapping_and_created_at(self):
@@ -31,7 +31,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT $group_0 FROM events"
@@ -46,7 +46,7 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def test_group_field_without_mapping(self):
         """Test that $group_0 falls back when no GroupTypeMapping exists"""
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT $group_0 FROM events"
@@ -74,7 +74,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=1,
             created_at=datetime(2023, 2, 1, 10, 0, 0, tzinfo=UTC),
         )
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         # Parse a query that references multiple group fields
@@ -98,7 +98,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT event FROM events WHERE $group_0 = 'acme'"
@@ -119,7 +119,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=1,
             created_at=datetime(2023, 2, 1, 10, 0, 0, tzinfo=UTC),
         )
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT group_1.properties FROM events"
@@ -141,7 +141,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
         # No mapping for group_1
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT group_0.properties, group_1.properties FROM events"
@@ -162,7 +162,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT $group_0 FROM events"
@@ -181,7 +181,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT company.properties.name FROM events"
@@ -203,7 +203,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
         query = "SELECT event FROM events WHERE company.properties.name = 'acme'"

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1642,9 +1642,9 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         # In the ideal future, most queries will not need to create the DB.
         # In the present (your past), this test was added because we were creating it twice per query.
         query = "SELECT 1"
-        with patch("posthog.hogql.printer.create_hogql_database") as printer_create_hogql_database_mock:
+        with patch("posthog.hogql.database.database.Database.create_for") as create_for_mock:
             execute_hogql_query(query, team=self.team)
-            printer_create_hogql_database_mock.assert_called_once()
+            create_for_mock.assert_called_once()
 
     def test_sortable_semver(self):
         query = "SELECT arrayJoin(['0.0.0.0.1000', '0.9', '0.2354.2', '1.0.0', '1.1.0', '1.2.0', '1.9.233434.10', '1.10.0', '1.1000.0', '2.0.0', '2.2.0.betabac', '2.2.1']) AS semver ORDER BY sortableSemVer(semver) DESC"

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -11,7 +11,7 @@ from django.test import override_settings
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import (
     DateTimeDatabaseField,
     ExpressionField,
@@ -49,7 +49,7 @@ class TestResolver(BaseTest):
         )[0]
 
     def setUp(self):
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(database=self.database, team_id=self.team.pk, enable_select_queries=True)
 
     @pytest.mark.usefixtures("unittest_snapshot")

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -65,7 +65,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.modifiers import create_default_modifiers_for_user
 from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.query import create_default_modifiers_for_team
@@ -1452,7 +1452,7 @@ class QueryRunnerWithHogQLContext(AnalyticsQueryRunner[AR]):
         # We create a new context here because we need to access the database
         # below in the to_query method and creating a database is pretty heavy
         # so we'll reuse this database for the query once it eventually runs
-        self.database = create_hogql_database(team=self.team)
+        self.database = Database.create_for(team=self.team)
         self.hogql_context = HogQLContext(team_id=self.team.pk, database=self.database)
 
 

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Union
 
 from posthog.schema import PersonsOnEventsMode
 
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.clickhouse.materialized_columns import ColumnName
 from posthog.models import Cohort, Filter, Property
@@ -95,7 +95,7 @@ class EventQuery(metaclass=ABCMeta):
         self._filter.hogql_context.modifiers.personsOnEventsMode = self._person_on_events_mode
 
         # Recreate the database with the legacy-alised PoE mode
-        self._filter.hogql_context.database = create_hogql_database(
+        self._filter.hogql_context.database = Database.create_for(
             team=self._team, modifiers=self._filter.hogql_context.modifiers
         )
 

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import PersonsOnEventsMode
 
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.clickhouse.materialized_columns import ColumnName
 from posthog.constants import (
@@ -75,7 +75,7 @@ class ClickhouseFunnelBase(ABC):
         self._filter.hogql_context.modifiers.personsOnEventsMode = alias_poe_mode_for_legacy(team.person_on_events_mode)
 
         # Recreate the database with the legacy-alised PoE mode
-        self._filter.hogql_context.database = create_hogql_database(
+        self._filter.hogql_context.database = Database.create_for(
             team=self._team, modifiers=self._filter.hogql_context.modifiers
         )
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -27,7 +27,7 @@ from structlog.types import FilteringBoundLogger
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 
@@ -675,7 +675,7 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
         limit_top_select=False,
     )
     context.output_format = "TabSeparated"
-    context.database = await database_sync_to_async(create_hogql_database)(team=team, modifiers=context.modifiers)
+    context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
         query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
@@ -718,7 +718,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
         enable_select_queries=True,
         limit_top_select=False,
     )
-    context.database = await database_sync_to_async(create_hogql_database)(team=team, modifiers=context.modifiers)
+    context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
     prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
         query_node, context=context, dialect="clickhouse", settings=settings, stack=[]
@@ -1137,7 +1137,7 @@ async def build_dag_from_selectors(selector_paths: SelectorPaths, team_id: int) 
 
 async def get_posthog_table_names(team_id: int) -> list[str]:
     team = await database_sync_to_async(Team.objects.get)(id=team_id)
-    hogql_db = await database_sync_to_async(create_hogql_database)(team=team)
+    hogql_db = await database_sync_to_async(Database.create_for)(team=team)
     posthog_table_names = hogql_db.get_posthog_table_names()
     return posthog_table_names
 

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -20,7 +20,7 @@ import temporalio.common
 import temporalio.worker
 from asgiref.sync import sync_to_async
 
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.query import execute_hogql_query
 
 from posthog import constants
@@ -59,7 +59,7 @@ TEST_TIME = dt.datetime.now(dt.UTC)
 @pytest_asyncio.fixture
 async def posthog_table_names(ateam):
     team = await database_sync_to_async(Team.objects.get)(id=ateam.pk)
-    hogql_db = await database_sync_to_async(create_hogql_database)(team=team)
+    hogql_db = await database_sync_to_async(Database.create_for)(team=team)
     posthog_table_names = hogql_db.get_posthog_table_names()
 
     return posthog_table_names

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -11,7 +11,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
@@ -104,7 +104,7 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
 
         hogql_context = self.context.get("database", None)
         if not hogql_context:
-            hogql_context = create_hogql_database(team_id=self.context["team_id"])
+            hogql_context = Database.create_for(team_id=self.context["team_id"])
 
         if schema.table and schema.table.deleted:
             return None
@@ -228,7 +228,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        context["database"] = create_hogql_database(team_id=self.team_id)
+        context["database"] = Database.create_for(team_id=self.team_id)
         return context
 
     def safely_get_queryset(self, queryset):

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
@@ -317,7 +317,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        context["database"] = create_hogql_database(team_id=self.team_id)
+        context["database"] = Database.create_for(team_id=self.team_id)
 
         return context
 

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 from temporalio.client import ScheduleActionExecutionStartWorkflow
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import SerializedField, create_hogql_database, serialize_fields
+from posthog.hogql.database.database import Database, SerializedField, serialize_fields
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.placeholders import FindPlaceholders
@@ -118,7 +118,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
         team_id = self.context["team_id"]
         database = self.context.get("database", None)
         if not database:
-            database = create_hogql_database(team_id=team_id)
+            database = Database.create_for(team_id=team_id)
 
         context = HogQLContext(team_id=team_id, database=database)
 
@@ -399,7 +399,7 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
 
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
-        context["database"] = create_hogql_database(team_id=self.team_id)
+        context["database"] = Database.create_for(team_id=self.team_id)
         return context
 
     def safely_get_queryset(self, queryset):

--- a/posthog/warehouse/api/view_link.py
+++ b/posthog/warehouse/api/view_link.py
@@ -168,7 +168,7 @@ class ViewLinkViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["database"] = create_hogql_database(team_id=self.team_id)
+        context["database"] = Database.create_for(team_id=self.team_id)
         return context
 
     def safely_get_queryset(self, queryset):

--- a/posthog/warehouse/api/view_link.py
+++ b/posthog/warehouse/api/view_link.py
@@ -6,7 +6,7 @@ from rest_framework import filters, response, serializers, status, viewsets
 from posthog.hogql import ast
 from posthog.hogql.ast import Call, Field
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import LazyJoin
 from posthog.hogql.database.utils import get_join_field_chain
 from posthog.hogql.errors import QueryError, SyntaxError
@@ -25,7 +25,7 @@ class ViewLinkValidationMixin:
     def _database(self, team_id: int) -> Database:
         database = self.context.get("database", None)  # type: ignore[attr-defined]
         if not database:
-            database = create_hogql_database(team_id=team_id)
+            database = Database.create_for(team_id=team_id)
         return database
 
     def get_table_name(self, table_name: str) -> str:

--- a/posthog/warehouse/models/datawarehouse_managed_viewset.py
+++ b/posthog/warehouse/models/datawarehouse_managed_viewset.py
@@ -188,7 +188,7 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
 
     def _get_expected_views_for_revenue_analytics(self) -> list[ExpectedView]:
         """
-        Reuses build_all_revenue_analytics_views() from create_hogql_database logic.
+        Reuses build_all_revenue_analytics_views() from Database.create_for logic.
         For each source (events + external data sources):
           - Creates 5 views: customer, charge, subscription, revenue_item, product
         """

--- a/posthog/warehouse/models/datawarehouse_saved_query.py
+++ b/posthog/warehouse/models/datawarehouse_saved_query.py
@@ -170,7 +170,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
     @property
     def s3_tables(self):
         from posthog.hogql.context import HogQLContext
-        from posthog.hogql.database.database import create_hogql_database
+        from posthog.hogql.database.database import Database
         from posthog.hogql.parser import parse_select
         from posthog.hogql.query import create_default_modifiers_for_team
         from posthog.hogql.resolver import resolve_types
@@ -183,7 +183,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
             modifiers=create_default_modifiers_for_team(self.team),
         )
         node = parse_select(self.query["query"])
-        context.database = create_hogql_database(context.team_id)
+        context.database = Database.create_for(context.team_id)
 
         node = resolve_types(node, context, dialect="clickhouse")
         table_collector = S3TableVisitor()

--- a/posthog/warehouse/models/modeling.py
+++ b/posthog/warehouse/models/modeling.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection, models, transaction
 
 from posthog.hogql import ast
-from posthog.hogql.database.database import Database, create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWarehouseTable
 from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_select
@@ -326,7 +326,7 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
 
     def get_hogql_database(self, team: Team) -> Database:
         """Get the HogQL database for given team."""
-        return create_hogql_database(team=team)
+        return Database.create_for(team=team)
 
     def get_or_create_root_path_for_data_warehouse_table(
         self, data_warehouse_table: DataWarehouseTable

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -4,7 +4,7 @@ import typing
 import datetime as dt
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import ast
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 
@@ -45,7 +45,7 @@ class RecordBatchModel(abc.ABC):
                 "log_comment": self.get_log_comment(),
             },
         )
-        context.database = await database_sync_to_async(create_hogql_database)(team=team, modifiers=context.modifiers)
+        context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
 
         return context
 

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -15,7 +15,7 @@ import temporalio.common
 from posthog.schema import EventPropertyFilter, HogQLQueryModifiers, MaterializationMode
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import ast
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
@@ -980,7 +980,7 @@ def compose_filters_clause(
         values=values or {},
         modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.DISABLED),
     )
-    context.database = create_hogql_database(team=team, modifiers=context.modifiers)
+    context.database = Database.create_for(team=team, modifiers=context.modifiers)
 
     exprs = [property_to_expr(EventPropertyFilter(**filter), team=team) for filter in filters]
     and_expr = ast.And(exprs=exprs)

--- a/products/data_warehouse/backend/hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/hogql_fixer_ai.py
@@ -5,14 +5,12 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database, serialize_database
+from posthog.hogql.database.database import Database, serialize_database
 from posthog.hogql.errors import ExposedHogQLError, ResolutionError
 from posthog.hogql.functions.mapping import HOGQL_AGGREGATIONS, HOGQL_CLICKHOUSE_FUNCTIONS, HOGQL_POSTHOG_FUNCTIONS
 from posthog.hogql.metadata import get_table_names
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_and_print_ast
-
-from posthog.warehouse.models import Database
 
 from ee.hogai.graph.schema_generator.parsers import PydanticOutputParserException, parse_pydantic_structured_output
 from ee.hogai.graph.schema_generator.utils import SchemaGeneratorOutput
@@ -187,7 +185,7 @@ class HogQLQueryFixerTool(MaxTool):
     context_prompt_template: str = SQL_ASSISTANT_ROOT_SYSTEM_PROMPT
 
     def _run_impl(self) -> tuple[str, str | None]:
-        database = create_hogql_database(team=self._team)
+        database = Database.create_for(team=self._team)
         hogql_context = HogQLContext(team=self._team, enable_select_queries=True, database=database)
 
         all_table_names = database.get_all_table_names()

--- a/products/data_warehouse/backend/hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/hogql_fixer_ai.py
@@ -5,7 +5,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, serialize_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import ExposedHogQLError, ResolutionError
 from posthog.hogql.functions.mapping import HOGQL_AGGREGATIONS, HOGQL_CLICKHOUSE_FUNCTIONS, HOGQL_POSTHOG_FUNCTIONS
 from posthog.hogql.metadata import get_table_names
@@ -121,7 +121,7 @@ Below is the current HogQL query and the error message
 
 
 def _get_schema_description(ai_context: dict[Any, Any], hogql_context: HogQLContext, database: Database) -> str:
-    serialized_database = serialize_database(hogql_context)
+    serialized_database = database.serialize(hogql_context)
     schema_description = ""
 
     try:

--- a/products/data_warehouse/backend/test/test_hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/test/test_hogql_fixer_ai.py
@@ -1,7 +1,7 @@
 import pytest
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
@@ -15,7 +15,7 @@ def test_get_schema_description(snapshot):
     team = Team.objects.create(organization=org)
 
     query = "select * from events"
-    database = create_hogql_database(team.id)
+    database = Database.create_for(team.id)
     hogql_context = HogQLContext(team_id=team.id, enable_select_queries=True, database=database)
 
     res = _get_schema_description({"hogql_query": query}, hogql_context, database)
@@ -28,7 +28,7 @@ def test_get_system_prompt(snapshot):
     org = Organization.objects.create(name="org")
     team = Team.objects.create(organization=org)
 
-    database = create_hogql_database(team.id)
+    database = Database.create_for(team.id)
     all_table_names = database.get_all_table_names()
 
     res = _get_system_prompt(all_table_names)
@@ -42,7 +42,7 @@ def test_get_user_prompt(snapshot):
     team = Team.objects.create(organization=org)
 
     query = "select * from events"
-    database = create_hogql_database(team.id)
+    database = Database.create_for(team.id)
     hogql_context = HogQLContext(team_id=team.id, enable_select_queries=True, database=database)
 
     schema_description = _get_schema_description({"hogql_query": query}, hogql_context, database)

--- a/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
@@ -6,7 +6,7 @@ import structlog
 
 from posthog.schema import SourceMap
 
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 
 from posthog.warehouse.models import DataWarehouseTable, ExternalDataSource
 
@@ -86,7 +86,7 @@ class MarketingSourceFactory:
         self.logger = logger.bind(team_id=self.context.team.pk if self.context.team else None)
 
         # Cache warehouse data to avoid repeated queries
-        database = create_hogql_database(team=self.context.team)
+        database = Database.create_for(team=self.context.team)
         self._warehouse_tables = DataWarehouseTable.objects.filter(
             team_id=self.context.team.pk, deleted=False, name__in=database.get_warehouse_table_names()
         ).prefetch_related("externaldataschema_set")

--- a/products/revenue_analytics/backend/api.py
+++ b/products/revenue_analytics/backend/api.py
@@ -8,7 +8,7 @@ from rest_framework.viewsets import GenericViewSet
 from posthog.schema import DatabaseSchemaManagedViewTableKind
 
 from posthog.hogql import ast
-from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.database.database import Database
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -26,7 +26,7 @@ def find_values_for_revenue_analytics_property(key: str, team: Team) -> list[str
         chain = [scope]
         scope = "revenue_analytics_revenue_item"
 
-    database = create_hogql_database(team=team)
+    database = Database.create_for(team=team)
     view_class = KIND_TO_CLASS[DatabaseSchemaManagedViewTableKind(scope)]
 
     # Try and find the union view for this class


### PR DESCRIPTION
`create_hogql_database` is a staple of ~our community~ Posthog but I believe moving it to a static method brings better clarity and consistency