### PR TITLE
feat(kafka-deduplicator): implement DR download and import modules

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -36,7 +36,8 @@ pub struct CheckpointConfig {
     pub checkpoint_worker_shutdown_timeout: Duration,
 
     /// Number of hours prior to "now" that the checkpoint import mechanism
-    /// will search for valid checkpoint attempts in a DR recovery scenario
+    /// will search for valid checkpoint attempts in a DR recovery or HPA
+    /// autoscaling scenario where net-new Persistent Volumes are created
     pub checkpoint_import_window_hours: u32,
 
     /// Timeout for S3 operations (including all retry attempts)

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -35,8 +35,15 @@ pub struct CheckpointConfig {
     /// Timeout for checkpoint worker graceful shutdown (applied in CheckpointManager::stop)
     pub checkpoint_worker_shutdown_timeout: Duration,
 
-    /// Timeout for S3 operations
-    pub s3_timeout: Duration,
+    /// Number of hours prior to "now" that the checkpoint import mechanism
+    /// will search for valid checkpoint attempts in a DR recovery scenario
+    pub checkpoint_import_window_hours: u32,
+
+    /// Timeout for S3 operations (including all retry attempts)
+    pub s3_operation_timeout: Duration,
+
+    /// Timeout for a single S3 operation attempt
+    pub s3_attempt_timeout: Duration,
 }
 
 impl Default for CheckpointConfig {
@@ -53,7 +60,9 @@ impl Default for CheckpointConfig {
             max_concurrent_checkpoints: 3,
             checkpoint_gate_interval: Duration::from_millis(200),
             checkpoint_worker_shutdown_timeout: Duration::from_secs(10),
-            s3_timeout: Duration::from_secs(300),
+            checkpoint_import_window_hours: 24,
+            s3_operation_timeout: Duration::from_secs(120),
+            s3_attempt_timeout: Duration::from_secs(20),
         }
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/downloader.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::path::Path;
+
+/// Trait for downloading checkpoint data files from remote storage
+#[async_trait]
+pub trait CheckpointDownloader: Send + Sync + std::fmt::Debug {
+    /// List the paths to the most recent checkpoint attempt metadata.json
+    /// tracking files uploaded in remote storage, sorted newest to oldest
+    async fn list_recent_checkpoints(
+        &self,
+        topic: &str,
+        partition_number: i32,
+    ) -> Result<Vec<String>>;
+
+    /// Download a single file from remote storage and return the byte contents
+    async fn download_file(&self, remote_key: &str) -> Result<Vec<u8>>;
+
+    /// Given a list of fully-qualified remote file keys, download all
+    /// files in parallel from remote storage and into the given local
+    /// directory path, creating that base directory if it doesn't exist
+    async fn download_files(&self, remote_keys: &[String], local_base_path: &Path) -> Result<()>;
+
+    /// Check if the downloader is available and configured for use
+    async fn is_available(&self) -> bool;
+}

--- a/rust/kafka-deduplicator/src/checkpoint/downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/downloader.rs
@@ -16,6 +16,10 @@ pub trait CheckpointDownloader: Send + Sync + std::fmt::Debug {
     /// Download a single file from remote storage and return the byte contents
     async fn download_file(&self, remote_key: &str) -> Result<Vec<u8>>;
 
+    // Download a single file from remote storage and store it in the given local file path.
+    // The method assumes the local path parent directories were pre-created
+    async fn download_and_store_file(&self, remote_key: &str, local_filepath: &Path) -> Result<()>;
+
     /// Given a list of fully-qualified remote file keys, download all
     /// files in parallel from remote storage and into the given local
     /// directory path, creating that base directory if it doesn't exist

--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -1,0 +1,154 @@
+use std::path::{Path, PathBuf};
+
+use super::{CheckpointDownloader, CheckpointMetadata};
+
+use anyhow::{Context, Result};
+use tracing::{error, info};
+
+#[derive(Debug)]
+pub struct CheckpointImporter {
+    downloader: Box<dyn CheckpointDownloader>,
+}
+
+impl CheckpointImporter {
+    pub fn new(downloader: Box<dyn CheckpointDownloader>) -> Self {
+        Self { downloader }
+    }
+
+    /// This is the one-stop entry point for DR checkpoint import.
+    /// Given the following inputs:
+    /// - local_base_path: a base path for temporary downloads (not scoped to topic/partition)
+    /// - topic: the topic to import checkpoints for
+    /// - partition: the partition number to import checkpoints for
+    /// - import_limit: the maximum number of recent checkpoints to attempt to import as fallbacks
+    ///
+    /// This method will:
+    /// 1. Fetch checkpoint metadata.json files from the most recent N checkpoints for the topic+partition
+    /// 2. For each metadata file (newest to oldest), attempt to download all tracked files to local directory
+    ///    of the form <local_base_path>/<topic>/<partition>/<checkpoint_id>/ (assumed to be a temp dir)
+    /// 3. If a checkpoint import fails, fall back to the next most recent (up to import_limit) before giving up
+    /// 4. If successful, return the final local path to the most recent successful checkpoint was imported to
+    pub async fn import_checkpoint_for_topic_partition(
+        &self,
+        local_base_path: &Path,
+        topic: &str,
+        partition_number: i32,
+        import_limit: usize,
+    ) -> Result<PathBuf> {
+        let mut checkpoint_metadata = self
+            .fetch_checkpoint_metadata(topic, partition_number)
+            .await?;
+
+        info!(
+            "Found {} checkpoint attempts for topic:{} partition:{}",
+            checkpoint_metadata.len(),
+            topic,
+            partition_number
+        );
+
+        // Slice to at most the most-recent N checkpoints
+        // we'll attempt to import according to import_limit
+        checkpoint_metadata.truncate(import_limit);
+        info!("Attempting recovery from the most recent {} checkpoints for topic:{topic} partition:{partition_number}",
+            checkpoint_metadata.len());
+
+        // checkpoints iterated in order of recency; we keep the first good one we fetch
+        for attempt in checkpoint_metadata {
+            match self.fetch_checkpoint_files(&attempt, local_base_path).await {
+                Ok(local_attempt_path) => {
+                    // TODO: stat this too
+                    info!("Successfully imported checkpoint to: {local_attempt_path:?}");
+                    return Ok(local_attempt_path);
+                }
+                Err(e) => {
+                    // TODO: stat this too
+                    error!("Failed to import checkpoint files for metadata: {attempt:?} got: {e}");
+                    continue;
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "No usable checkpoints identified in search window for topic:{} partition:{}",
+            topic,
+            partition_number
+        ))
+    }
+
+    pub async fn fetch_checkpoint_metadata(
+        &self,
+        topic: &str,
+        partition_number: i32,
+    ) -> Result<Vec<CheckpointMetadata>> {
+        let remote_metadata_files = self
+            .downloader
+            .list_recent_checkpoints(topic, partition_number)
+            .await
+            .context("In fetch_checkpoint_metadata")?;
+
+        let mut fetched_metadata_files = Vec::new();
+        for remote_key in remote_metadata_files {
+            match self.downloader.download_file(&remote_key).await {
+                Ok(content) => match CheckpointMetadata::from_json_bytes(&content) {
+                    Ok(metadata) => {
+                        fetched_metadata_files.push(metadata);
+                    }
+                    Err(e) => {
+                        error!("Failed to parse metadata from file bytes: {remote_key}: {e}");
+                    }
+                },
+                Err(e) => {
+                    error!("Failed to download metadata file: {remote_key}: {e}");
+                }
+            }
+        }
+
+        if fetched_metadata_files.is_empty() {
+            return Err(anyhow::anyhow!("No checkpoint metadata files downloaded successfully for topic:{topic} partition:{partition_number}"));
+        }
+
+        Ok(fetched_metadata_files)
+    }
+
+    pub async fn fetch_checkpoint_files(
+        &self,
+        checkpoint_metadata: &CheckpointMetadata,
+        local_base_path: &Path,
+    ) -> Result<PathBuf> {
+        let target_files = checkpoint_metadata
+            .files
+            .iter()
+            .map(|f| f.remote_filepath.clone())
+            .collect::<Vec<_>>();
+
+        info!(
+            metadata = checkpoint_metadata.get_metadata_filepath(),
+            file_count = checkpoint_metadata.files.len(),
+            "Fetching checkpoint files from metadata tracking list",
+        );
+
+        // append <topic>/<partition>/<checkpoint_id>/ to the local base path
+        let local_attempt_path = local_base_path.join(checkpoint_metadata.get_attempt_path());
+        match self
+            .downloader
+            .download_files(&target_files, &local_attempt_path)
+            .await
+        {
+            Ok(_) => {
+                info!(
+                    "Successfully downloaded {} checkpoint files to: {local_attempt_path:?}",
+                    target_files.len()
+                );
+                Ok(local_attempt_path)
+            }
+            Err(e) => {
+                error!("Failed to download checkpoint files to: {local_attempt_path:?}: {e}");
+                Err(e)
+            }
+        }
+    }
+
+    pub async fn is_available(&self) -> bool {
+        self.downloader.is_available().await
+    }
+}

--- a/rust/kafka-deduplicator/src/checkpoint/mod.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/mod.rs
@@ -1,8 +1,11 @@
 pub mod client;
 pub mod config;
+pub mod downloader;
 pub mod export;
+pub mod import;
 pub mod metadata;
 pub mod planner;
+pub mod s3_downloader;
 pub mod s3_uploader;
 pub mod uploader;
 pub mod worker;

--- a/rust/kafka-deduplicator/src/checkpoint/mod.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/mod.rs
@@ -12,9 +12,12 @@ pub mod worker;
 
 pub use client::CheckpointClient;
 pub use config::CheckpointConfig;
+pub use downloader::CheckpointDownloader;
 pub use export::CheckpointExporter;
+pub use import::CheckpointImporter;
 pub use metadata::{CheckpointFile, CheckpointInfo, CheckpointMetadata};
 pub use planner::{plan_checkpoint, CheckpointPlan, LocalCheckpointFile};
+pub use s3_downloader::S3Downloader;
 pub use s3_uploader::S3Uploader;
 pub use uploader::CheckpointUploader;
 pub use worker::CheckpointWorker;

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -1,0 +1,206 @@
+use std::path::Path;
+use std::time::Instant;
+
+use super::config::CheckpointConfig;
+use super::downloader::CheckpointDownloader;
+use super::metadata::{DATE_PLUS_HOURS_ONLY_FORMAT, METADATA_FILENAME};
+use crate::metrics_const::{CHECKPOINT_FILE_FETCH_HISTOGRAM, CHECKPOINT_LIST_METADATA_HISTOGRAM};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use aws_config::{meta::region::RegionProviderChain, Region};
+use aws_config::{retry::RetryConfig, timeout::TimeoutConfig, BehaviorVersion};
+use aws_sdk_s3::{Client, Config};
+use chrono::{Duration, Utc};
+use tracing::{error, info};
+
+#[derive(Debug, Clone)]
+pub struct S3Downloader {
+    client: Client,
+    config: CheckpointConfig,
+}
+
+impl S3Downloader {
+    pub async fn new(config: CheckpointConfig) -> Result<Self> {
+        let region_provider =
+            RegionProviderChain::default_provider().or_else(Region::new(config.aws_region.clone()));
+
+        let timeout_config = TimeoutConfig::builder()
+            .operation_timeout(config.s3_operation_timeout)
+            .operation_attempt_timeout(config.s3_attempt_timeout)
+            .build();
+
+        let aws_config = aws_config::defaults(BehaviorVersion::latest())
+            .region(region_provider)
+            .timeout_config(timeout_config)
+            .retry_config(RetryConfig::adaptive())
+            .load()
+            .await;
+
+        let s3_config = Config::from(&aws_config);
+        let client = Client::from_conf(s3_config);
+
+        Ok(Self { client, config })
+    }
+}
+
+#[async_trait]
+impl CheckpointDownloader for S3Downloader {
+    async fn download_file(&self, remote_key: &str) -> Result<Vec<u8>> {
+        let start_time = Instant::now();
+        let get_object = self
+            .client
+            .get_object()
+            .bucket(&self.config.s3_bucket)
+            .key(remote_key)
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to get object from S3 bucket: s3://{0}/{remote_key}",
+                    self.config.s3_bucket
+                )
+            })?;
+
+        let body = get_object.body.collect().await.with_context(|| {
+            format!(
+                "Failed to read body data from S3 object s3://{0}/{remote_key}",
+                self.config.s3_bucket,
+            )
+        })?;
+
+        let elapsed = start_time.elapsed();
+        metrics::histogram!(CHECKPOINT_FILE_FETCH_HISTOGRAM).record(elapsed.as_secs() as f64);
+        Ok(body.to_vec())
+    }
+
+    async fn download_files(&self, remote_keys: &[String], local_base_path: &Path) -> Result<()> {
+        tokio::fs::create_dir_all(local_base_path)
+            .await
+            .with_context(|| {
+                format!("Failed to create local base directory: {local_base_path:?}")
+            })?;
+
+        // TODO: get more sophisticated about partial fails, retries, etc.
+        let mut download_futures = Vec::with_capacity(remote_keys.len());
+        for remote_key in remote_keys {
+            let remote_filename = remote_key
+                .rsplit('/')
+                .next()
+                .with_context(|| format!("Failed to get remote filename from key: {remote_key}"))?
+                .to_string();
+
+            download_futures.push(async move {
+                match self.download_file(remote_key).await {
+                    Ok(contents) => Ok((remote_filename, contents)),
+                    Err(e) => Err(e),
+                }
+            });
+        }
+
+        let results: Vec<(String, Vec<u8>)> =
+            futures::future::try_join_all(download_futures).await?;
+        for (filename, contents) in results {
+            let local_filepath = local_base_path.join(filename);
+            tokio::fs::write(&local_filepath, contents)
+                .await
+                .with_context(|| {
+                    format!("Failed to write file contents to file: {local_filepath:?}")
+                })?;
+            info!("Downloaded remote file to {local_filepath:?}");
+        }
+
+        Ok(())
+    }
+
+    async fn list_recent_checkpoints(
+        &self,
+        topic: &str,
+        partition_number: i32,
+    ) -> Result<Vec<String>> {
+        let start_time = Instant::now();
+        let import_window_hours =
+            Duration::hours(self.config.checkpoint_import_window_hours as i64);
+        let remote_key_prefix = format!("{}/{topic}/{partition_number}", self.config.s3_key_prefix);
+        let yesterday_remote_key = format!(
+            "{}/{}",
+            remote_key_prefix,
+            (Utc::now() - import_window_hours).format(DATE_PLUS_HOURS_ONLY_FORMAT),
+        );
+
+        info!(
+            "Listing checkpoint files newer than {} from S3 bucket: {}",
+            yesterday_remote_key, self.config.s3_bucket
+        );
+
+        // list_objects_v2 returns results in *lexicographic sort order*
+        // but we want the most recent by timestamp path elem. So, we cheat and
+        // use prefix() and start_after() to pull a recent window, that we can
+        // hopefully sort in memory to obtain the most recent metadata.json files
+        let mut keys_found = Vec::new();
+        let mut continuation_token = None;
+        let base_request = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.config.s3_bucket)
+            .prefix(remote_key_prefix)
+            .start_after(&yesterday_remote_key);
+
+        loop {
+            let mut req = base_request.clone();
+            if let Some(token) = continuation_token {
+                req = req.continuation_token(&token);
+            }
+
+            let response = req.send().await.with_context(|| {
+                format!(
+                    "Failed to list remote objects after s3://{}/{yesterday_remote_key}",
+                    self.config.s3_bucket
+                )
+            })?;
+
+            response
+                .contents()
+                .iter()
+                .for_each(|object| match object.key() {
+                    Some(key) => {
+                        keys_found.push(key.to_string());
+                    }
+                    None => {
+                        error!("Failed to get object key from S3 object: {object:?}");
+                    }
+                });
+
+            if let Some(true) = response.is_truncated() {
+                if let Some(token) = response.next_continuation_token() {
+                    continuation_token = Some(token.to_string());
+                } else {
+                    error!("Expected continuation token not found in response: {response:?}");
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        // filter results down to only metadata.json files and sort by most recently uploaded
+        let total_keys = keys_found.len();
+        keys_found.retain(|k| k.ends_with(METADATA_FILENAME));
+        keys_found.reverse();
+
+        let elapsed = start_time.elapsed();
+        metrics::histogram!(CHECKPOINT_LIST_METADATA_HISTOGRAM).record(elapsed.as_secs() as f64);
+        info!(
+            "Found {} metadata.json files of {} total keys scanned at or after: {}",
+            keys_found.len(),
+            total_keys,
+            yesterday_remote_key
+        );
+
+        Ok(keys_found)
+    }
+
+    async fn is_available(&self) -> bool {
+        !self.config.s3_bucket.is_empty()
+    }
+}

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use aws_config::{meta::region::RegionProviderChain, Region};
+use aws_config::{
+    meta::region::RegionProviderChain, retry::RetryConfig, timeout::TimeoutConfig, BehaviorVersion,
+    Region,
+};
+
 use aws_sdk_s3::{Client, Config};
 use std::path::Path;
 use tokio::fs;
@@ -20,7 +24,17 @@ impl S3Uploader {
         let region_provider =
             RegionProviderChain::default_provider().or_else(Region::new(config.aws_region.clone()));
 
-        let aws_config = aws_config::from_env().region(region_provider).load().await;
+        let timeout_config = TimeoutConfig::builder()
+            .operation_timeout(config.s3_operation_timeout)
+            .operation_attempt_timeout(config.s3_attempt_timeout)
+            .build();
+
+        let aws_config = aws_config::defaults(BehaviorVersion::latest())
+            .region(region_provider)
+            .timeout_config(timeout_config)
+            .retry_config(RetryConfig::adaptive())
+            .load()
+            .await;
 
         let s3_config = Config::from(&aws_config);
         let client = Client::from_conf(s3_config);
@@ -33,19 +47,14 @@ impl S3Uploader {
             .await
             .with_context(|| format!("Failed to read file: {local_path:?}"))?;
 
-        let put_object = self
-            .client
+        self.client
             .put_object()
             .bucket(&self.config.s3_bucket)
             .key(s3_key)
-            .body(body.into());
-
-        // Apply timeout if configured
-        let result = tokio::time::timeout(self.config.s3_timeout, put_object.send())
+            .body(body.into())
+            .send()
             .await
-            .with_context(|| format!("S3 upload timeout for key: {s3_key}"))?;
-
-        result.with_context(|| format!("Failed to upload to S3 key: {s3_key}"))?;
+            .with_context(|| format!("Failed to upload to S3 key: {s3_key}"))?;
 
         info!(
             "Uploaded file {local_path:?} to s3://{0}/{s3_key}",
@@ -92,18 +101,14 @@ impl CheckpointUploader for S3Uploader {
         // Upload metadata.json - not using upload_file b/c meta is in memory and must be seriealized
         let metadata_json = plan.info.metadata.to_json()?;
         let metadata_key = plan.info.get_metadata_key();
-        let put_object = self
-            .client
+        self.client
             .put_object()
             .bucket(&self.config.s3_bucket)
             .key(&metadata_key)
-            .body(metadata_json.into_bytes().into());
-
-        let result = tokio::time::timeout(self.config.s3_timeout, put_object.send())
+            .body(metadata_json.into_bytes().into())
+            .send()
             .await
-            .with_context(|| format!("S3 upload timeout for key: {metadata_key}"))?;
-
-        result.with_context(|| format!("Failed to upload metadata to S3 key: {metadata_key}"))?;
+            .with_context(|| format!("Failed to upload metadata to S3 key: {metadata_key}"))?;
 
         info!(
             "Uploaded {} files and metadata file to s3://{}/{}",

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -131,11 +131,19 @@ pub struct Config {
     #[envconfig(default = "0")]
     pub checkpoint_full_upload_interval: u32,
 
+    // number of hours prior to "now" that the checkpoint import mechanism
+    // will search for valid checkpoint attempts in a DR recovery scenario
+    #[envconfig(default = "24")]
+    pub checkpoint_import_window_hours: u32,
+
     #[envconfig(default = "us-east-1")]
     pub aws_region: String,
 
-    #[envconfig(default = "300")] // 5 minutes in seconds
-    pub s3_timeout_secs: u64,
+    #[envconfig(default = "120")] // 2 minutes
+    pub s3_operation_timeout_secs: u64,
+
+    #[envconfig(default = "20")] // 20 seconds
+    pub s3_attempt_timeout_secs: u64,
 
     #[envconfig(default = "true")]
     pub export_prometheus: bool,
@@ -298,9 +306,14 @@ impl Config {
         Duration::from_secs(self.checkpoint_worker_shutdown_timeout_secs)
     }
 
-    /// Get S3 timeout as Duration
-    pub fn s3_timeout(&self) -> Duration {
-        Duration::from_secs(self.s3_timeout_secs)
+    /// Get S3 per-operation (including all retries) timeout as Duration
+    pub fn s3_operation_timeout(&self) -> Duration {
+        Duration::from_secs(self.s3_operation_timeout_secs)
+    }
+
+    /// Get S3 per-attempt timeout as Duration
+    pub fn s3_attempt_timeout(&self) -> Duration {
+        Duration::from_secs(self.s3_attempt_timeout_secs)
     }
 
     /// Build Kafka producer configuration

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -106,3 +106,9 @@ pub const CHECKPOINT_UPLOADS_COUNTER: &str = "checkpoint_upload_status";
 
 /// Counter for checkpoint files tracked in each attempt plan tagged by action taken
 pub const CHECKPOINT_PLAN_FILE_TRACKED_COUNTER: &str = "checkpoint_plan_file_tracked";
+
+/// Histogram for checkpoint metadata file fetch duration; only measured on success
+pub const CHECKPOINT_FILE_FETCH_HISTOGRAM: &str = "checkpoint_file_fetch_seconds";
+
+/// Histogram for checkpoint metadata file list duration; only measured on success
+pub const CHECKPOINT_LIST_METADATA_HISTOGRAM: &str = "checkpoint_list_metadata_seconds";

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -104,11 +104,22 @@ pub const CHECKPOINT_UPLOAD_DURATION_HISTOGRAM: &str = "checkpoint_upload_durati
 /// Counter for checkpoint upload outcome status
 pub const CHECKPOINT_UPLOADS_COUNTER: &str = "checkpoint_upload_status";
 
+/// Counter for checkpoint file downloads outcome status
+pub const CHECKPOINT_FILE_DOWNLOADS_COUNTER: &str = "checkpoint_file_downloads_status";
+
 /// Counter for checkpoint files tracked in each attempt plan tagged by action taken
 pub const CHECKPOINT_PLAN_FILE_TRACKED_COUNTER: &str = "checkpoint_plan_file_tracked";
 
 /// Histogram for checkpoint metadata file fetch duration; only measured on success
 pub const CHECKPOINT_FILE_FETCH_HISTOGRAM: &str = "checkpoint_file_fetch_seconds";
+
+/// Histogram for checkpoint total batch download_files duration; only measured on success.
+/// The individual file ops are parallelized - we're measuring total elapsed time for the fanout
+pub const CHECKPOINT_BATCH_FETCH_STORE_HISTOGRAM: &str =
+    "checkpoint_batch_file_fetch_and_store_seconds";
+
+/// Histogram for checkpoint file download and store duration; only measured on success
+pub const CHECKPOINT_FILE_FETCH_STORE_HISTOGRAM: &str = "checkpoint_file_fetch_and_store_seconds";
 
 /// Histogram for checkpoint metadata file list duration; only measured on success
 pub const CHECKPOINT_LIST_METADATA_HISTOGRAM: &str = "checkpoint_list_metadata_seconds";

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -105,7 +105,9 @@ impl KafkaDeduplicatorService {
             max_concurrent_checkpoints: config.max_concurrent_checkpoints,
             checkpoint_gate_interval: config.checkpoint_gate_interval(),
             checkpoint_worker_shutdown_timeout: config.checkpoint_worker_shutdown_timeout(),
-            s3_timeout: config.s3_timeout(),
+            checkpoint_import_window_hours: config.checkpoint_import_window_hours,
+            s3_operation_timeout: config.s3_operation_timeout(),
+            s3_attempt_timeout: config.s3_attempt_timeout(),
         };
 
         // Reset local checkpoint directory on startup (it's temporary storage)


### PR DESCRIPTION
## Problem
Prior to wiring up DR checks on pod startup, we must implement the modules that will download the most recent intact checkpoint available in remote storage.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement downloader modules and trait
* Implement import module with higher-level API for attempting to recover most recent intact checkpoint, falling back to next most recent over a time window on fail
* Related code and test updates

This is prep for the final step, adding a DR recovery module that the main codepath will use to recover data if a local (PV homed) store is found to be corrupt, missing, or stale on pod startup
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; will be lighting up export and testing this in `dev` and elsewhere once the code is landed.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No changelog update required
<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
