### PR TITLE
fix: ensure server-side enforcement of reauthentication

### DIFF
--- a/ee/api/rbac/role.py
+++ b/ee/api/rbac/role.py
@@ -10,6 +10,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.models import OrganizationMembership
 from posthog.models.user import User
+from posthog.permissions import TimeSensitiveActionPermission
 
 from ee.models.rbac.role import Role, RoleMembership
 
@@ -80,7 +81,7 @@ class RoleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "organization"
     serializer_class = RoleSerializer
     queryset = Role.objects.all()
-    permission_classes = [RolePermissions]
+    permission_classes = [RolePermissions, TimeSensitiveActionPermission]
 
     def safely_get_queryset(self, queryset):
         return queryset.filter(**self.request.GET.dict())
@@ -131,7 +132,7 @@ class RoleMembershipViewSet(
     viewsets.GenericViewSet,
 ):
     scope_object = "organization"
-    permission_classes = [RolePermissions]
+    permission_classes = [RolePermissions, TimeSensitiveActionPermission]
     serializer_class = RoleMembershipSerializer
     queryset = RoleMembership.objects.select_related("role")
     filter_rewrite_rules = {"organization_id": "role__organization_id"}

--- a/ee/api/rbac/role.py
+++ b/ee/api/rbac/role.py
@@ -107,7 +107,7 @@ class RoleMembershipSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Role does not exist.")
 
         if role.organization_id != self.context["organization_id"]:
-            raise serializers.ValidationError("Role does not belong to the specified organization.")
+            raise serializers.ValidationError("Role does not exist.")
 
         try:
             validated_data["organization_member"] = OrganizationMembership.objects.select_related("user").get(

--- a/posthog/api/organization_domain.py
+++ b/posthog/api/organization_domain.py
@@ -12,7 +12,7 @@ from posthog.constants import AvailableFeature
 from posthog.event_usage import groups
 from posthog.models import OrganizationDomain
 from posthog.models.organization import Organization
-from posthog.permissions import OrganizationAdminWritePermissions
+from posthog.permissions import OrganizationAdminWritePermissions, TimeSensitiveActionPermission
 
 DOMAIN_REGEX = r"^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$"
 
@@ -102,7 +102,7 @@ class OrganizationDomainSerializer(serializers.ModelSerializer):
 class OrganizationDomainViewset(TeamAndOrgViewSetMixin, ModelViewSet):
     scope_object = "organization"
     serializer_class = OrganizationDomainSerializer
-    permission_classes = [OrganizationAdminWritePermissions]
+    permission_classes = [OrganizationAdminWritePermissions, TimeSensitiveActionPermission]
     queryset = OrganizationDomain.objects.order_by("domain").all()
 
     @action(methods=["POST"], detail=True)

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -18,7 +18,7 @@ from posthog.models import OrganizationInvite, OrganizationMembership
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
-from posthog.permissions import OrganizationMemberPermissions, UserCanInvitePermission
+from posthog.permissions import OrganizationMemberPermissions, TimeSensitiveActionPermission, UserCanInvitePermission
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.tasks.email import send_invite
 
@@ -304,7 +304,12 @@ class OrganizationInviteViewSet(
         if self.action in ["create", "bulk"]:
             write_permissions = [
                 permission()
-                for permission in [permissions.IsAuthenticated, OrganizationMemberPermissions, UserCanInvitePermission]
+                for permission in [
+                    permissions.IsAuthenticated,
+                    OrganizationMemberPermissions,
+                    UserCanInvitePermission,
+                    TimeSensitiveActionPermission,
+                ]
             ]
             return write_permissions
 
@@ -318,6 +323,7 @@ class OrganizationInviteViewSet(
                     permissions.IsAuthenticated,
                     OrganizationMemberPermissions,
                     OrganizationAdminWritePermissions,
+                    TimeSensitiveActionPermission,
                 ]
             ]
             return delete_permissions

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -301,7 +301,7 @@ class OrganizationInviteViewSet(
     ordering = "-created_at"
 
     def dangerously_get_permissions(self):
-        if self.action in ["create", "bulk"]:
+        if self.action in ["create", "bulk", "update", "partial_update"]:
             write_permissions = [
                 permission()
                 for permission in [

--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -13,7 +13,7 @@ from posthog.constants import GENERAL_PURPOSE_TASK_QUEUE
 from posthog.event_usage import groups
 from posthog.models import ProxyRecord
 from posthog.models.organization import Organization
-from posthog.permissions import OrganizationAdminWritePermissions
+from posthog.permissions import OrganizationAdminWritePermissions, TimeSensitiveActionPermission
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.proxy_service import CreateManagedProxyInputs, DeleteManagedProxyInputs
 
@@ -59,7 +59,7 @@ class ProxyRecordSerializer(serializers.ModelSerializer):
 class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
     scope_object = "organization"
     serializer_class = ProxyRecordSerializer
-    permission_classes = [OrganizationAdminWritePermissions]
+    permission_classes = [OrganizationAdminWritePermissions, TimeSensitiveActionPermission]
 
     def list(self, request, *args, **kwargs):
         queryset = self.organization.proxy_records.order_by("-created_at")

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -58,7 +58,7 @@ from posthog.middleware import get_impersonated_session_expires_at
 from posthog.models import Dashboard, Team, User, UserScenePersonalisation
 from posthog.models.organization import Organization
 from posthog.models.user import NOTIFICATION_DEFAULTS, ROLE_CHOICES, Notifications
-from posthog.permissions import APIScopePermission, UserNoOrgMembershipDeletePermission
+from posthog.permissions import APIScopePermission, TimeSensitiveActionPermission, UserNoOrgMembershipDeletePermission
 from posthog.rate_limit import UserAuthenticationThrottle, UserEmailVerificationThrottle
 from posthog.tasks import user_identify
 from posthog.tasks.email import (
@@ -406,7 +406,12 @@ class UserViewSet(
     throttle_classes = [UserAuthenticationThrottle]
     serializer_class = UserSerializer
     authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication]
-    permission_classes = [IsAuthenticated, APIScopePermission, UserNoOrgMembershipDeletePermission]
+    permission_classes = [
+        IsAuthenticated,
+        APIScopePermission,
+        UserNoOrgMembershipDeletePermission,
+        TimeSensitiveActionPermission,
+    ]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["is_staff", "email"]
     queryset = User.objects.filter(is_active=True)


### PR DESCRIPTION
## Problem

User and organization scoped view sets should enforce reauthentication server-side to match the client-side modal. This was present for some, but not all, view sets.

## Changes

All user and organization view sets now properly enforce reauthentication server-side.

## How did you test this code?

Added test for `/api/users/@me` endpoint and manually tested remaining endpoints that require scale/boost add-on.
