### PR TITLE
chore: checkout minimal commit history

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -18,7 +18,9 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
+                  # fetch enough commits to include the BASE_SHA, without fetching the full repo history.
+                  # note: it's possible a PR will have more than 1000 commits, but extremely unlikely.
+                  fetch-depth: 1000
                   ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Setup Node.js

--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -15,8 +15,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
 
             - name: Configure git
               run: |

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -14,7 +14,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   path: posthog
-                  fetch-depth: 0
 
             - name: Install pnpm
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4

--- a/.github/workflows/update-bot-ips.yml
+++ b/.github/workflows/update-bot-ips.yml
@@ -19,7 +19,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   token: ${{ secrets.POSTHOG_BOT_PAT }}
-                  fetch-depth: 0
 
             - name: Run update script
               run: |


### PR DESCRIPTION
## Problem

Checking out the entire commit history currently takes ~3.5 minutes. This is not necessary.

## Changes

Only checkout the last commit.

## How did you test this code?

It's GitHub Actions - we test in prod.
