### PR TITLE
feat: Include git commit hash in sessions dag logs

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -1,6 +1,7 @@
 from dagster import AssetExecutionContext, BackfillPolicy, MonthlyPartitionsDefinition, asset
 
 from posthog.clickhouse.client import sync_execute
+from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import RAW_SESSION_TABLE_BACKFILL_SQL_V3
 
 # Each partition is pretty heavy, as it's an entire month of events, so this number doesn't need to be high
@@ -36,7 +37,9 @@ def sessions_v3_backfill(context: AssetExecutionContext):
     # as long as the backfill has run at least once for each partition, the data will be correct
     backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause)
 
-    context.log.info(f"Running backfill for {context.partition_key} (where='{where_clause}')")
+    context.log.info(
+        f"Running backfill for {context.partition_key} (where='{where_clause}') using commit {get_git_commit_short()} "
+    )
 
     sync_execute(backfill_sql)
 

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -38,7 +38,7 @@ def sessions_v3_backfill(context: AssetExecutionContext):
     backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause)
 
     context.log.info(
-        f"Running backfill for {context.partition_key} (where='{where_clause}') using commit {get_git_commit_short()} "
+        f"Running backfill for {context.partition_key} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
 
     sync_execute(backfill_sql)


### PR DESCRIPTION
## Problem

I want to be confident that the dagster code is the right version, especially if I'm re-running something shortly after pushing a new commit.

## Changes

This commit just adds the commit hash to the log message

## How did you test this code?

n/a (it's pretty straightforward, and the dag is only manually triggered)

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
