### PR TITLE
fix(flags): Add `statement_timeout` for reader and writer pools

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -111,6 +111,8 @@ pub async fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPoo
     if let Some(timeout_ms) = config.statement_timeout_ms {
         options = options.after_connect(move |conn, _meta| {
             Box::pin(async move {
+                // Note: SET statement_timeout does not support parameterized queries ($1),
+                // so we use format!(). This is safe because timeout_ms is typed as u64.
                 sqlx::query(&format!("SET statement_timeout = {timeout_ms}"))
                     .execute(&mut *conn)
                     .await?;

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -46,6 +46,9 @@ pub struct PoolConfig {
     pub idle_timeout: Option<Duration>,
     pub max_lifetime: Option<Duration>,
     pub test_before_acquire: bool,
+    /// PostgreSQL statement_timeout to set on each connection (in milliseconds)
+    /// Set to None to use the database default
+    pub statement_timeout_ms: Option<u64>,
 }
 
 impl Default for PoolConfig {
@@ -58,6 +61,7 @@ impl Default for PoolConfig {
             idle_timeout: Some(Duration::from_secs(300)), // Close idle connections after 5 minutes
             max_lifetime: Some(Duration::from_secs(1800)), // Force refresh connections after 30 minutes
             test_before_acquire: true,                     // Test connection health before use
+            statement_timeout_ms: None,                    // Use database default
         }
     }
 }
@@ -101,6 +105,18 @@ pub async fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPoo
 
     if let Some(max_lifetime) = config.max_lifetime {
         options = options.max_lifetime(max_lifetime);
+    }
+
+    // If statement_timeout is configured, set it via after_connect hook
+    if let Some(timeout_ms) = config.statement_timeout_ms {
+        options = options.after_connect(move |conn, _meta| {
+            Box::pin(async move {
+                sqlx::query(&format!("SET statement_timeout = {timeout_ms}"))
+                    .execute(&mut *conn)
+                    .await?;
+                Ok(())
+            })
+        });
     }
 
     options.connect(url).await

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -221,25 +221,28 @@ pub struct Config {
     pub test_before_acquire: FlexBool,
 
     // PostgreSQL statement_timeout for non-persons reader queries (milliseconds)
-    // - None or unset to use database default (typically unlimited)
+    // - Set to 0 to use database default (typically unlimited)
     // - Non-persons readers may run longer analytical queries
-    // - Recommended: Some(60000-300000) for 1-5 minutes, or None for analytics workloads
+    // - Default: 5000ms (5 seconds)
     // - This timeout is enforced server-side and properly kills queries
-    pub non_persons_reader_statement_timeout_ms: Option<u64>,
+    #[envconfig(default = "5000")]
+    pub non_persons_reader_statement_timeout_ms: u64,
 
     // PostgreSQL statement_timeout for persons reader queries (milliseconds)
-    // - None or unset to use database default (typically unlimited)
+    // - Set to 0 to use database default (typically unlimited)
     // - Persons readers may run longer analytical queries
-    // - Recommended: Some(60000-300000) for 1-5 minutes, or None for analytics workloads
+    // - Default: 5000ms (5 seconds)
     // - This timeout is enforced server-side and properly kills queries
-    pub persons_reader_statement_timeout_ms: Option<u64>,
+    #[envconfig(default = "5000")]
+    pub persons_reader_statement_timeout_ms: u64,
 
     // PostgreSQL statement_timeout for writer database queries (milliseconds)
-    // - None or unset to use database default (typically unlimited)
+    // - Set to 0 to use database default (typically unlimited)
     // - Writers should be fast transactional operations
-    // - Recommended: Some(30000) for 30 seconds for transactional queries
+    // - Default: 10000ms (10 seconds)
     // - This timeout is enforced server-side and properly kills queries
-    pub writer_statement_timeout_ms: Option<u64>,
+    #[envconfig(default = "10000")]
+    pub writer_statement_timeout_ms: u64,
 
     // How often to report database pool metrics (seconds)
     // - Decrease for more granular monitoring (e.g., 10-15)
@@ -373,9 +376,9 @@ impl Config {
             max_lifetime_secs: 1800,
             max_lifetime_jitter_secs: 1800,
             test_before_acquire: FlexBool(true),
-            non_persons_reader_statement_timeout_ms: None,
-            persons_reader_statement_timeout_ms: None,
-            writer_statement_timeout_ms: None,
+            non_persons_reader_statement_timeout_ms: 5000,
+            persons_reader_statement_timeout_ms: 5000,
+            writer_statement_timeout_ms: 5000,
             db_monitor_interval_secs: 30,
             db_pool_warn_utilization: 0.8,
             billing_limiter_cache_ttl_secs: 5,

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -220,6 +220,27 @@ pub struct Config {
     #[envconfig(default = "true")]
     pub test_before_acquire: FlexBool,
 
+    // PostgreSQL statement_timeout for non-persons reader queries (milliseconds)
+    // - None or unset to use database default (typically unlimited)
+    // - Non-persons readers may run longer analytical queries
+    // - Recommended: Some(60000-300000) for 1-5 minutes, or None for analytics workloads
+    // - This timeout is enforced server-side and properly kills queries
+    pub non_persons_reader_statement_timeout_ms: Option<u64>,
+
+    // PostgreSQL statement_timeout for persons reader queries (milliseconds)
+    // - None or unset to use database default (typically unlimited)
+    // - Persons readers may run longer analytical queries
+    // - Recommended: Some(60000-300000) for 1-5 minutes, or None for analytics workloads
+    // - This timeout is enforced server-side and properly kills queries
+    pub persons_reader_statement_timeout_ms: Option<u64>,
+
+    // PostgreSQL statement_timeout for writer database queries (milliseconds)
+    // - None or unset to use database default (typically unlimited)
+    // - Writers should be fast transactional operations
+    // - Recommended: Some(30000) for 30 seconds for transactional queries
+    // - This timeout is enforced server-side and properly kills queries
+    pub writer_statement_timeout_ms: Option<u64>,
+
     // How often to report database pool metrics (seconds)
     // - Decrease for more granular monitoring (e.g., 10-15)
     // - Increase to reduce metric volume (e.g., 60-120)
@@ -352,6 +373,9 @@ impl Config {
             max_lifetime_secs: 1800,
             max_lifetime_jitter_secs: 1800,
             test_before_acquire: FlexBool(true),
+            non_persons_reader_statement_timeout_ms: None,
+            persons_reader_statement_timeout_ms: None,
+            writer_statement_timeout_ms: None,
             db_monitor_interval_secs: 30,
             db_pool_warn_utilization: 0.8,
             billing_limiter_cache_ttl_secs: 5,

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -50,7 +50,11 @@ impl DatabasePools {
 
         // Non-persons reader pool config (may allow longer queries for analytics)
         let non_persons_reader_pool_config = PoolConfig {
-            statement_timeout_ms: config.non_persons_reader_statement_timeout_ms,
+            statement_timeout_ms: if config.non_persons_reader_statement_timeout_ms > 0 {
+                Some(config.non_persons_reader_statement_timeout_ms)
+            } else {
+                None
+            },
             ..base_pool_config.clone()
         };
         info!(
@@ -61,7 +65,11 @@ impl DatabasePools {
 
         // Persons reader pool config (may allow longer queries for analytics)
         let persons_reader_pool_config = PoolConfig {
-            statement_timeout_ms: config.persons_reader_statement_timeout_ms,
+            statement_timeout_ms: if config.persons_reader_statement_timeout_ms > 0 {
+                Some(config.persons_reader_statement_timeout_ms)
+            } else {
+                None
+            },
             ..base_pool_config.clone()
         };
         info!(
@@ -72,7 +80,11 @@ impl DatabasePools {
 
         // Writer pool config (should be fast transactional operations)
         let writer_pool_config = PoolConfig {
-            statement_timeout_ms: config.writer_statement_timeout_ms,
+            statement_timeout_ms: if config.writer_statement_timeout_ms > 0 {
+                Some(config.writer_statement_timeout_ms)
+            } else {
+                None
+            },
             ..base_pool_config
         };
         info!(

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -25,7 +25,8 @@ impl DatabasePools {
             ));
         }
 
-        let pool_config = PoolConfig {
+        // Create base pool config (used for both readers and writers)
+        let base_pool_config = PoolConfig {
             max_connections: config.max_pg_connections,
             acquire_timeout: Duration::from_secs(config.acquire_timeout_secs),
             idle_timeout: if config.idle_timeout_secs > 0 {
@@ -44,10 +45,44 @@ impl DatabasePools {
                 None
             },
             test_before_acquire: *config.test_before_acquire,
+            statement_timeout_ms: None, // Set per pool type below
         };
 
+        // Non-persons reader pool config (may allow longer queries for analytics)
+        let non_persons_reader_pool_config = PoolConfig {
+            statement_timeout_ms: config.non_persons_reader_statement_timeout_ms,
+            ..base_pool_config.clone()
+        };
+        info!(
+            pool = "non_persons_reader",
+            statement_timeout_ms = ?config.non_persons_reader_statement_timeout_ms,
+            "Creating non-persons reader pool"
+        );
+
+        // Persons reader pool config (may allow longer queries for analytics)
+        let persons_reader_pool_config = PoolConfig {
+            statement_timeout_ms: config.persons_reader_statement_timeout_ms,
+            ..base_pool_config.clone()
+        };
+        info!(
+            pool = "persons_reader",
+            statement_timeout_ms = ?config.persons_reader_statement_timeout_ms,
+            "Creating persons reader pool config"
+        );
+
+        // Writer pool config (should be fast transactional operations)
+        let writer_pool_config = PoolConfig {
+            statement_timeout_ms: config.writer_statement_timeout_ms,
+            ..base_pool_config
+        };
+        info!(
+            pool = "writer",
+            statement_timeout_ms = ?config.writer_statement_timeout_ms,
+            "Creating writer pool"
+        );
+
         let non_persons_reader = Arc::new(
-            get_pool_with_config(&config.read_database_url, pool_config.clone())
+            get_pool_with_config(&config.read_database_url, non_persons_reader_pool_config)
                 .await
                 .map_err(|e| {
                     FlagError::DatabaseError(
@@ -58,7 +93,7 @@ impl DatabasePools {
         );
 
         let non_persons_writer = Arc::new(
-            get_pool_with_config(&config.write_database_url, pool_config.clone())
+            get_pool_with_config(&config.write_database_url, writer_pool_config.clone())
                 .await
                 .map_err(|e| {
                     FlagError::DatabaseError(
@@ -71,14 +106,17 @@ impl DatabasePools {
         // Create persons pools if configured, otherwise reuse the non-persons pools
         let persons_reader = if config.is_persons_db_routing_enabled() {
             Arc::new(
-                get_pool_with_config(&config.get_persons_read_database_url(), pool_config.clone())
-                    .await
-                    .map_err(|e| {
-                        FlagError::DatabaseError(
-                            e,
-                            Some("Failed to create persons reader pool".to_string()),
-                        )
-                    })?,
+                get_pool_with_config(
+                    &config.get_persons_read_database_url(),
+                    persons_reader_pool_config,
+                )
+                .await
+                .map_err(|e| {
+                    FlagError::DatabaseError(
+                        e,
+                        Some("Failed to create persons reader pool".to_string()),
+                    )
+                })?,
             )
         } else {
             non_persons_reader.clone()
@@ -86,17 +124,14 @@ impl DatabasePools {
 
         let persons_writer = if config.is_persons_db_routing_enabled() {
             Arc::new(
-                get_pool_with_config(
-                    &config.get_persons_write_database_url(),
-                    pool_config.clone(),
-                )
-                .await
-                .map_err(|e| {
-                    FlagError::DatabaseError(
-                        e,
-                        Some("Failed to create persons writer pool".to_string()),
-                    )
-                })?,
+                get_pool_with_config(&config.get_persons_write_database_url(), writer_pool_config)
+                    .await
+                    .map_err(|e| {
+                        FlagError::DatabaseError(
+                            e,
+                            Some("Failed to create persons writer pool".to_string()),
+                        )
+                    })?,
             )
         } else {
             non_persons_writer.clone()
@@ -109,6 +144,10 @@ impl DatabasePools {
             idle_timeout_secs = config.idle_timeout_secs,
             max_lifetime_secs = config.max_lifetime_secs,
             test_before_acquire = config.test_before_acquire.0,
+            non_persons_reader_statement_timeout_ms =
+                config.non_persons_reader_statement_timeout_ms,
+            persons_reader_statement_timeout_ms = config.persons_reader_statement_timeout_ms,
+            writer_statement_timeout_ms = config.writer_statement_timeout_ms,
             persons_routing_enabled = config.is_persons_db_routing_enabled(),
             "Database pool configuration"
         );

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -26,10 +26,9 @@ use crate::{
     flags::flag_models::FeatureFlagId,
     metrics::consts::{
         FLAG_ACQUIRE_TIMEOUT_COUNTER, FLAG_CLIENT_TIMEOUT_COUNTER, FLAG_COHORT_PROCESSING_TIME,
-        FLAG_COHORT_QUERY_TIME, FLAG_CONNECTION_HOLD_TIME, FLAG_CONNECTION_OVERLAP_TIME_MS,
-        FLAG_DATABASE_ERROR_COUNTER, FLAG_DB_CONNECTION_TIME, FLAG_DEFINITION_QUERY_TIME,
-        FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME, FLAG_HASH_KEY_RETRIES_COUNTER,
-        FLAG_MULTI_CONNECTION_OPERATION_COUNTER, FLAG_PERSON_PROCESSING_TIME,
+        FLAG_COHORT_QUERY_TIME, FLAG_CONNECTION_HOLD_TIME, FLAG_DATABASE_ERROR_COUNTER,
+        FLAG_DB_CONNECTION_TIME, FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME,
+        FLAG_GROUP_QUERY_TIME, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
         FLAG_PERSON_QUERY_TIME, FLAG_POOL_UTILIZATION_GAUGE,
         FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER,
     },
@@ -1120,9 +1119,13 @@ async fn try_should_write_hash_key_override(
         let persons_reader_stats = router.get_persons_reader().get_pool_stats();
         let non_persons_reader_stats = router.get_non_persons_reader().get_pool_stats();
 
-        if let (Some(pr_stats), Some(npr_stats)) = (&persons_reader_stats, &non_persons_reader_stats) {
-            let pr_utilization = (pr_stats.size - pr_stats.num_idle as u32) as f64 / pr_stats.size as f64;
-            let npr_utilization = (npr_stats.size - npr_stats.num_idle as u32) as f64 / npr_stats.size as f64;
+        if let (Some(pr_stats), Some(npr_stats)) =
+            (&persons_reader_stats, &non_persons_reader_stats)
+        {
+            let pr_utilization =
+                (pr_stats.size - pr_stats.num_idle as u32) as f64 / pr_stats.size as f64;
+            let npr_utilization =
+                (npr_stats.size - npr_stats.num_idle as u32) as f64 / npr_stats.size as f64;
 
             if pr_utilization > 0.8 || npr_utilization > 0.8 {
                 warn!(
@@ -1150,157 +1153,148 @@ async fn try_should_write_hash_key_override(
             );
         }
 
-        // Get connection from persons pool for person data
-        let persons_labels = [
-            ("pool".to_string(), "persons_reader".to_string()),
-            (
-                "operation".to_string(),
-                "should_write_hash_key_override".to_string()),
-        ];
-        let persons_conn_start = Instant::now();
-        let persons_conn_timer =
-            common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &persons_labels);
-        let mut persons_conn = router
-            .get_persons_reader()
-            .get_connection()
-            .await
-            .map_err(FlagError::from)?;
-        persons_conn_timer.fin();
-        let persons_conn_acquisition_time = persons_conn_start.elapsed();
+        // Step 1: Get person data and existing overrides (scoped connection)
+        let person_data_rows = {
+            let persons_labels = [
+                ("pool".to_string(), "persons_reader".to_string()),
+                (
+                    "operation".to_string(),
+                    "should_write_hash_key_override".to_string(),
+                ),
+            ];
+            let persons_conn_start = Instant::now();
+            let persons_conn_timer =
+                common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &persons_labels);
+            let mut persons_conn = router
+                .get_persons_reader()
+                .get_connection()
+                .await
+                .map_err(FlagError::from)?;
+            persons_conn_timer.fin();
+            let persons_conn_acquisition_time = persons_conn_start.elapsed();
 
-        if persons_conn_acquisition_time > Duration::from_millis(100) {
-            warn!(
-                team_id = %team_id,
-                pool = "persons_reader",
-                acquisition_ms = persons_conn_acquisition_time.as_millis(),
-                "Slow connection acquisition from persons_reader pool"
+            if persons_conn_acquisition_time > Duration::from_millis(100) {
+                warn!(
+                    team_id = %team_id,
+                    pool = "persons_reader",
+                    acquisition_ms = persons_conn_acquisition_time.as_millis(),
+                    "Slow connection acquisition from persons_reader pool"
+                );
+            }
+
+            let person_query_labels = [
+                (
+                    "query".to_string(),
+                    "person_data_with_overrides".to_string(),
+                ),
+                ("operation".to_string(), "should_write_check".to_string()),
+            ];
+            let person_query_timer =
+                common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &person_query_labels);
+            let person_data_rows = sqlx::query(person_data_query)
+                .bind(team_id)
+                .bind(distinct_ids)
+                .fetch_all(&mut *persons_conn)
+                .await
+                .map_err(|e| {
+                    FlagError::DatabaseError(e, Some("Failed to fetch person data".to_string()))
+                })?;
+            person_query_timer.fin();
+
+            // Record connection hold time for persons_reader pool
+            common_metrics::histogram(
+                FLAG_CONNECTION_HOLD_TIME,
+                &[
+                    ("pool".to_string(), "persons_reader".to_string()),
+                    ("operation".to_string(), "should_write_check".to_string()),
+                ],
+                persons_conn_start.elapsed().as_millis() as f64,
             );
-        }
 
-        // Step 1: Get person data and existing overrides
-        let person_query_labels = [
-            (
-                "query".to_string(),
-                "person_data_with_overrides".to_string(),
-            ),
-            ("operation".to_string(), "should_write_check".to_string()),
-        ];
-        let person_query_timer =
-            common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &person_query_labels);
-        let person_data_rows = sqlx::query(person_data_query)
-            .bind(team_id)
-            .bind(distinct_ids)
-            .fetch_all(&mut *persons_conn)
-            .await
-            .map_err(|e| {
-                FlagError::DatabaseError(e, Some("Failed to fetch person data".to_string()))
-            })?;
-        person_query_timer.fin();
+            person_data_rows
+            // Connection automatically released here when persons_conn goes out of scope
+        };
 
         // If no person_ids found, there's nothing to check
         if person_data_rows.is_empty() {
             return Ok(false);
         }
 
-        // Extract existing flag keys from overrides
+        // Step 2: Process data without holding any connections
         let existing_flag_keys: HashSet<String> = person_data_rows
             .iter()
             .filter_map(|row| row.try_get::<String, _>("feature_flag_key").ok())
             .collect();
 
-        // Step 2: Get active feature flags with experience continuity from non-persons pool
-        // Get connection from non-persons pool for flag data
-        let non_persons_labels = [
-            ("pool".to_string(), "non_persons_reader".to_string()),
-            (
-                "operation".to_string(),
-                "should_write_hash_key_override".to_string(),
-            ),
-        ];
+        // Step 3: Get active feature flags with experience continuity (scoped connection)
+        let flag_rows = {
+            let non_persons_labels = [
+                ("pool".to_string(), "non_persons_reader".to_string()),
+                (
+                    "operation".to_string(),
+                    "should_write_hash_key_override".to_string(),
+                ),
+            ];
 
-        // Track that we're about to hold multiple connections
-        common_metrics::inc(
-            FLAG_MULTI_CONNECTION_OPERATION_COUNTER,
-            &[
-                ("operation".to_string(), "should_write_hash_key_override".to_string()),
-                ("connection_count".to_string(), "2".to_string()),
-            ],
-            1,
-        );
+            let non_persons_conn_start = Instant::now();
+            let non_persons_conn_timer =
+                common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &non_persons_labels);
+            let mut non_persons_conn = router
+                .get_non_persons_reader()
+                .get_connection()
+                .await
+                .map_err(FlagError::from)?;
+            non_persons_conn_timer.fin();
+            let non_persons_conn_acquisition_time = non_persons_conn_start.elapsed();
 
-        // Start tracking connection overlap time
-        let overlap_start = persons_conn_start;
+            if non_persons_conn_acquisition_time > Duration::from_millis(100) {
+                warn!(
+                    team_id = %team_id,
+                    pool = "non_persons_reader",
+                    acquisition_ms = non_persons_conn_acquisition_time.as_millis(),
+                    "Slow connection acquisition from non_persons_reader pool"
+                );
+            }
 
-        // Log that we're holding one connection while acquiring another
-        info!(
-            team_id = %team_id,
-            persons_conn_held_ms = persons_conn_start.elapsed().as_millis(),
-            "Acquiring non_persons_reader connection while holding persons_reader connection"
-        );
+            let flags_labels = [
+                (
+                    "query".to_string(),
+                    "active_flags_with_continuity".to_string(),
+                ),
+                ("operation".to_string(), "should_write_check".to_string()),
+            ];
+            let flags_query_timer =
+                common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
+            let rows = sqlx::query(flags_query)
+                .bind(project_id)
+                .fetch_all(&mut *non_persons_conn)
+                .await
+                .map_err(|e| {
+                    FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string()))
+                })?;
+            flags_query_timer.fin();
 
-        let non_persons_conn_start = Instant::now();
-        let non_persons_conn_timer =
-            common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &non_persons_labels);
-        let mut non_persons_conn = router
-            .get_non_persons_reader()
-            .get_connection()
-            .await
-            .map_err(FlagError::from)?;
-        non_persons_conn_timer.fin();
-        let non_persons_conn_acquisition_time = non_persons_conn_start.elapsed();
-
-        if non_persons_conn_acquisition_time > Duration::from_millis(100) {
-            warn!(
-                team_id = %team_id,
-                pool = "non_persons_reader",
-                acquisition_ms = non_persons_conn_acquisition_time.as_millis(),
-                persons_conn_held_ms = persons_conn_start.elapsed().as_millis(),
-                "Slow connection acquisition from non_persons_reader pool while holding persons_reader connection"
+            // Record connection hold time for non_persons_reader pool
+            common_metrics::histogram(
+                FLAG_CONNECTION_HOLD_TIME,
+                &[
+                    ("pool".to_string(), "non_persons_reader".to_string()),
+                    ("operation".to_string(), "should_write_check".to_string()),
+                ],
+                non_persons_conn_start.elapsed().as_millis() as f64,
             );
-        }
-        let flags_labels = [
-            (
-                "query".to_string(),
-                "active_flags_with_continuity".to_string(),
-            ),
-            ("operation".to_string(), "should_write_check".to_string()),
-        ];
-        let flags_query_timer =
-            common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
-        let flag_rows = sqlx::query(flags_query)
-            .bind(project_id)
-            .fetch_all(&mut *non_persons_conn)
-            .await
-            .map_err(|e| FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string())))?;
-        flags_query_timer.fin();
 
-        // Check if there are any flags that don't have overrides
+            rows
+            // Connection automatically released here when non_persons_conn goes out of scope
+        };
+
+        // Step 4: Check if there are any flags that don't have overrides
         for row in flag_rows {
             let flag_key: String = row.get("key");
             if !existing_flag_keys.contains(&flag_key) {
                 return Ok(true); // Found a flag without override
             }
         }
-
-        // Record connection overlap time (time holding both connections)
-        common_metrics::histogram(
-            FLAG_CONNECTION_OVERLAP_TIME_MS,
-            &[
-                ("operation".to_string(), "should_write_hash_key_override".to_string()),
-                ("connection_count".to_string(), "2".to_string()),
-            ],
-            overlap_start.elapsed().as_millis() as f64,
-        );
-
-        // Record how long both connections were held
-        common_metrics::histogram(
-            FLAG_CONNECTION_HOLD_TIME,
-            &[
-                ("pool".to_string(), "persons_reader".to_string()),
-                ("operation".to_string(), "should_write_check".to_string()),
-            ],
-            persons_conn_start.elapsed().as_millis() as f64,
-        );
 
         Ok::<bool, FlagError>(false) // All flags have overrides
     })

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -13,7 +13,6 @@ use common_types::{PersonId, ProjectId, TeamId};
 use serde_json::Value;
 use sha1::{Digest, Sha1};
 use sqlx::{Acquire, Row};
-use tokio::time::timeout;
 use tracing::{info, instrument, warn};
 
 // Add thread-local imports for test-specific counter
@@ -25,12 +24,11 @@ use crate::{
     cohorts::cohort_models::CohortId,
     flags::flag_models::FeatureFlagId,
     metrics::consts::{
-        FLAG_ACQUIRE_TIMEOUT_COUNTER, FLAG_CLIENT_TIMEOUT_COUNTER, FLAG_COHORT_PROCESSING_TIME,
-        FLAG_COHORT_QUERY_TIME, FLAG_CONNECTION_HOLD_TIME, FLAG_DATABASE_ERROR_COUNTER,
-        FLAG_DB_CONNECTION_TIME, FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME,
-        FLAG_GROUP_QUERY_TIME, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
-        FLAG_PERSON_QUERY_TIME, FLAG_POOL_UTILIZATION_GAUGE,
-        FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER,
+        FLAG_ACQUIRE_TIMEOUT_COUNTER, FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME,
+        FLAG_CONNECTION_HOLD_TIME, FLAG_DATABASE_ERROR_COUNTER, FLAG_DB_CONNECTION_TIME,
+        FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
+        FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME, FLAG_PERSON_QUERY_TIME,
+        FLAG_POOL_UTILIZATION_GAUGE,
     },
     properties::{
         property_matching::match_property,
@@ -1090,9 +1088,6 @@ async fn try_should_write_hash_key_override(
     distinct_ids: &[String],
     project_id: ProjectId,
 ) -> Result<bool, FlagError> {
-    const QUERY_TIMEOUT: Duration = Duration::from_millis(1000);
-    let operation_start = Instant::now();
-
     // Query 1: Get person_ids and existing overrides from person pool in one shot
     let person_data_query = r#"
         SELECT DISTINCT
@@ -1114,275 +1109,240 @@ async fn try_should_write_hash_key_override(
             AND flag.deleted = FALSE
     "#;
 
-    let result = timeout(QUERY_TIMEOUT, async {
-        // Log pool states before attempting connections
-        let persons_reader_stats = router.get_persons_reader().get_pool_stats();
-        let non_persons_reader_stats = router.get_non_persons_reader().get_pool_stats();
+    // Log pool states before attempting connections
+    let persons_reader_stats = router.get_persons_reader().get_pool_stats();
+    let non_persons_reader_stats = router.get_non_persons_reader().get_pool_stats();
 
-        if let (Some(pr_stats), Some(npr_stats)) =
-            (&persons_reader_stats, &non_persons_reader_stats)
-        {
-            let pr_utilization =
-                (pr_stats.size - pr_stats.num_idle as u32) as f64 / pr_stats.size as f64;
-            let npr_utilization =
-                (npr_stats.size - npr_stats.num_idle as u32) as f64 / npr_stats.size as f64;
+    if let (Some(pr_stats), Some(npr_stats)) = (&persons_reader_stats, &non_persons_reader_stats) {
+        let pr_utilization =
+            (pr_stats.size - pr_stats.num_idle as u32) as f64 / pr_stats.size as f64;
+        let npr_utilization =
+            (npr_stats.size - npr_stats.num_idle as u32) as f64 / npr_stats.size as f64;
 
-            if pr_utilization > 0.8 || npr_utilization > 0.8 {
-                warn!(
-                    team_id = %team_id,
-                    distinct_ids = ?distinct_ids,
-                    persons_reader_pool_size = pr_stats.size,
-                    persons_reader_idle = pr_stats.num_idle,
-                    persons_reader_utilization_pct = pr_utilization * 100.0,
-                    non_persons_reader_pool_size = npr_stats.size,
-                    non_persons_reader_idle = npr_stats.num_idle,
-                    non_persons_reader_utilization_pct = npr_utilization * 100.0,
-                    "High pool utilization before should_write_hash_key_override"
-                );
-            }
-
-            common_metrics::gauge(
-                FLAG_POOL_UTILIZATION_GAUGE,
-                &[("pool".to_string(), "persons_reader".to_string())],
-                pr_utilization,
-            );
-            common_metrics::gauge(
-                FLAG_POOL_UTILIZATION_GAUGE,
-                &[("pool".to_string(), "non_persons_reader".to_string())],
-                npr_utilization,
+        if pr_utilization > 0.8 || npr_utilization > 0.8 {
+            warn!(
+                team_id = %team_id,
+                distinct_ids = ?distinct_ids,
+                persons_reader_pool_size = pr_stats.size,
+                persons_reader_idle = pr_stats.num_idle,
+                persons_reader_utilization_pct = pr_utilization * 100.0,
+                non_persons_reader_pool_size = npr_stats.size,
+                non_persons_reader_idle = npr_stats.num_idle,
+                non_persons_reader_utilization_pct = npr_utilization * 100.0,
+                "High pool utilization before should_write_hash_key_override"
             );
         }
 
-        // Step 1: Get person data and existing overrides (scoped connection)
-        let person_data_rows = {
-            let persons_labels = [
+        common_metrics::gauge(
+            FLAG_POOL_UTILIZATION_GAUGE,
+            &[("pool".to_string(), "persons_reader".to_string())],
+            pr_utilization,
+        );
+        common_metrics::gauge(
+            FLAG_POOL_UTILIZATION_GAUGE,
+            &[("pool".to_string(), "non_persons_reader".to_string())],
+            npr_utilization,
+        );
+    }
+
+    // Step 1: Get person data and existing overrides (scoped connection)
+    let person_data_rows = {
+        let persons_labels = [
+            ("pool".to_string(), "persons_reader".to_string()),
+            (
+                "operation".to_string(),
+                "should_write_hash_key_override".to_string(),
+            ),
+        ];
+        let persons_conn_start = Instant::now();
+        let persons_conn_timer =
+            common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &persons_labels);
+        let mut persons_conn = router
+            .get_persons_reader()
+            .get_connection()
+            .await
+            .map_err(FlagError::from)?;
+        persons_conn_timer.fin();
+        let persons_conn_acquisition_time = persons_conn_start.elapsed();
+
+        if persons_conn_acquisition_time > Duration::from_millis(100) {
+            warn!(
+                team_id = %team_id,
+                pool = "persons_reader",
+                acquisition_ms = persons_conn_acquisition_time.as_millis(),
+                "Slow connection acquisition from persons_reader pool"
+            );
+        }
+
+        let person_query_labels = [
+            (
+                "query".to_string(),
+                "person_data_with_overrides".to_string(),
+            ),
+            ("operation".to_string(), "should_write_check".to_string()),
+        ];
+        let person_query_timer =
+            common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &person_query_labels);
+        let person_data_rows = sqlx::query(person_data_query)
+            .bind(team_id)
+            .bind(distinct_ids)
+            .fetch_all(&mut *persons_conn)
+            .await
+            .map_err(|e| {
+                // Track timeout errors with detailed context
+                if common_database::is_timeout_error(&e) {
+                    let timeout_type =
+                        common_database::extract_timeout_type(&e).unwrap_or("unknown_timeout");
+
+                    common_metrics::inc(
+                        FLAG_DATABASE_ERROR_COUNTER,
+                        &[
+                            ("error_type".to_string(), "timeout".to_string()),
+                            ("timeout_type".to_string(), timeout_type.to_string()),
+                            ("pool".to_string(), "persons_reader".to_string()),
+                            (
+                                "operation".to_string(),
+                                "should_write_hash_key_override".to_string(),
+                            ),
+                        ],
+                        1,
+                    );
+
+                    warn!(
+                        team_id = %team_id,
+                        pool = "persons_reader",
+                        timeout_type = timeout_type,
+                        error = ?e,
+                        "Query timed out on persons_reader pool"
+                    );
+                }
+                FlagError::DatabaseError(e, Some("Failed to fetch person data".to_string()))
+            })?;
+        person_query_timer.fin();
+
+        // Record connection hold time for persons_reader pool
+        common_metrics::histogram(
+            FLAG_CONNECTION_HOLD_TIME,
+            &[
                 ("pool".to_string(), "persons_reader".to_string()),
-                (
-                    "operation".to_string(),
-                    "should_write_hash_key_override".to_string(),
-                ),
-            ];
-            let persons_conn_start = Instant::now();
-            let persons_conn_timer =
-                common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &persons_labels);
-            let mut persons_conn = router
-                .get_persons_reader()
-                .get_connection()
-                .await
-                .map_err(FlagError::from)?;
-            persons_conn_timer.fin();
-            let persons_conn_acquisition_time = persons_conn_start.elapsed();
-
-            if persons_conn_acquisition_time > Duration::from_millis(100) {
-                warn!(
-                    team_id = %team_id,
-                    pool = "persons_reader",
-                    acquisition_ms = persons_conn_acquisition_time.as_millis(),
-                    "Slow connection acquisition from persons_reader pool"
-                );
-            }
-
-            let person_query_labels = [
-                (
-                    "query".to_string(),
-                    "person_data_with_overrides".to_string(),
-                ),
                 ("operation".to_string(), "should_write_check".to_string()),
-            ];
-            let person_query_timer =
-                common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &person_query_labels);
-            let person_data_rows = sqlx::query(person_data_query)
-                .bind(team_id)
-                .bind(distinct_ids)
-                .fetch_all(&mut *persons_conn)
-                .await
-                .map_err(|e| {
-                    FlagError::DatabaseError(e, Some("Failed to fetch person data".to_string()))
-                })?;
-            person_query_timer.fin();
+            ],
+            persons_conn_start.elapsed().as_millis() as f64,
+        );
 
-            // Record connection hold time for persons_reader pool
-            common_metrics::histogram(
-                FLAG_CONNECTION_HOLD_TIME,
-                &[
-                    ("pool".to_string(), "persons_reader".to_string()),
-                    ("operation".to_string(), "should_write_check".to_string()),
-                ],
-                persons_conn_start.elapsed().as_millis() as f64,
+        person_data_rows
+        // Connection automatically released here when persons_conn goes out of scope
+    };
+
+    // If no person_ids found, there's nothing to check
+    if person_data_rows.is_empty() {
+        return Ok(false);
+    }
+
+    // Step 2: Process data without holding any connections
+    let existing_flag_keys: HashSet<String> = person_data_rows
+        .iter()
+        .filter_map(|row| row.try_get::<String, _>("feature_flag_key").ok())
+        .collect();
+
+    // Step 3: Get active feature flags with experience continuity (scoped connection)
+    let flag_rows = {
+        let non_persons_labels = [
+            ("pool".to_string(), "non_persons_reader".to_string()),
+            (
+                "operation".to_string(),
+                "should_write_hash_key_override".to_string(),
+            ),
+        ];
+
+        let non_persons_conn_start = Instant::now();
+        let non_persons_conn_timer =
+            common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &non_persons_labels);
+        let mut non_persons_conn = router
+            .get_non_persons_reader()
+            .get_connection()
+            .await
+            .map_err(FlagError::from)?;
+        non_persons_conn_timer.fin();
+        let non_persons_conn_acquisition_time = non_persons_conn_start.elapsed();
+
+        if non_persons_conn_acquisition_time > Duration::from_millis(100) {
+            warn!(
+                team_id = %team_id,
+                pool = "non_persons_reader",
+                acquisition_ms = non_persons_conn_acquisition_time.as_millis(),
+                "Slow connection acquisition from non_persons_reader pool"
             );
-
-            person_data_rows
-            // Connection automatically released here when persons_conn goes out of scope
-        };
-
-        // If no person_ids found, there's nothing to check
-        if person_data_rows.is_empty() {
-            return Ok(false);
         }
 
-        // Step 2: Process data without holding any connections
-        let existing_flag_keys: HashSet<String> = person_data_rows
-            .iter()
-            .filter_map(|row| row.try_get::<String, _>("feature_flag_key").ok())
-            .collect();
+        let flags_labels = [
+            (
+                "query".to_string(),
+                "active_flags_with_continuity".to_string(),
+            ),
+            ("operation".to_string(), "should_write_check".to_string()),
+        ];
+        let flags_query_timer =
+            common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
+        let rows = sqlx::query(flags_query)
+            .bind(project_id)
+            .fetch_all(&mut *non_persons_conn)
+            .await
+            .map_err(|e| {
+                // Track timeout errors with detailed context
+                if common_database::is_timeout_error(&e) {
+                    let timeout_type =
+                        common_database::extract_timeout_type(&e).unwrap_or("unknown_timeout");
 
-        // Step 3: Get active feature flags with experience continuity (scoped connection)
-        let flag_rows = {
-            let non_persons_labels = [
+                    common_metrics::inc(
+                        FLAG_DATABASE_ERROR_COUNTER,
+                        &[
+                            ("error_type".to_string(), "timeout".to_string()),
+                            ("timeout_type".to_string(), timeout_type.to_string()),
+                            ("pool".to_string(), "non_persons_reader".to_string()),
+                            (
+                                "operation".to_string(),
+                                "should_write_hash_key_override".to_string(),
+                            ),
+                        ],
+                        1,
+                    );
+
+                    warn!(
+                        team_id = %team_id,
+                        pool = "non_persons_reader",
+                        timeout_type = timeout_type,
+                        error = ?e,
+                        "Query timed out on non_persons_reader pool"
+                    );
+                }
+                FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string()))
+            })?;
+        flags_query_timer.fin();
+
+        // Record connection hold time for non_persons_reader pool
+        common_metrics::histogram(
+            FLAG_CONNECTION_HOLD_TIME,
+            &[
                 ("pool".to_string(), "non_persons_reader".to_string()),
-                (
-                    "operation".to_string(),
-                    "should_write_hash_key_override".to_string(),
-                ),
-            ];
-
-            let non_persons_conn_start = Instant::now();
-            let non_persons_conn_timer =
-                common_metrics::timing_guard(FLAG_DB_CONNECTION_TIME, &non_persons_labels);
-            let mut non_persons_conn = router
-                .get_non_persons_reader()
-                .get_connection()
-                .await
-                .map_err(FlagError::from)?;
-            non_persons_conn_timer.fin();
-            let non_persons_conn_acquisition_time = non_persons_conn_start.elapsed();
-
-            if non_persons_conn_acquisition_time > Duration::from_millis(100) {
-                warn!(
-                    team_id = %team_id,
-                    pool = "non_persons_reader",
-                    acquisition_ms = non_persons_conn_acquisition_time.as_millis(),
-                    "Slow connection acquisition from non_persons_reader pool"
-                );
-            }
-
-            let flags_labels = [
-                (
-                    "query".to_string(),
-                    "active_flags_with_continuity".to_string(),
-                ),
                 ("operation".to_string(), "should_write_check".to_string()),
-            ];
-            let flags_query_timer =
-                common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
-            let rows = sqlx::query(flags_query)
-                .bind(project_id)
-                .fetch_all(&mut *non_persons_conn)
-                .await
-                .map_err(|e| {
-                    FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string()))
-                })?;
-            flags_query_timer.fin();
+            ],
+            non_persons_conn_start.elapsed().as_millis() as f64,
+        );
 
-            // Record connection hold time for non_persons_reader pool
-            common_metrics::histogram(
-                FLAG_CONNECTION_HOLD_TIME,
-                &[
-                    ("pool".to_string(), "non_persons_reader".to_string()),
-                    ("operation".to_string(), "should_write_check".to_string()),
-                ],
-                non_persons_conn_start.elapsed().as_millis() as f64,
-            );
+        rows
+        // Connection automatically released here when non_persons_conn goes out of scope
+    };
 
-            rows
-            // Connection automatically released here when non_persons_conn goes out of scope
-        };
-
-        // Step 4: Check if there are any flags that don't have overrides
-        for row in flag_rows {
-            let flag_key: String = row.get("key");
-            if !existing_flag_keys.contains(&flag_key) {
-                return Ok(true); // Found a flag without override
-            }
-        }
-
-        Ok::<bool, FlagError>(false) // All flags have overrides
-    })
-    .await;
-
-    let total_operation_time = operation_start.elapsed();
-
-    match result {
-        Ok(Ok(flags_present)) => {
-            if total_operation_time > Duration::from_millis(500) {
-                warn!(
-                    team_id = %team_id,
-                    distinct_ids = ?distinct_ids,
-                    operation_ms = total_operation_time.as_millis(),
-                    result = flags_present,
-                    "Slow should_write_hash_key_override operation completed"
-                );
-            }
-            Ok(flags_present)
-        }
-        Ok(Err(e)) => {
-            tracing::error!(
-                team_id = %team_id,
-                distinct_ids = ?distinct_ids,
-                operation_ms = total_operation_time.as_millis(),
-                error = ?e,
-                "should_write_hash_key_override failed with error"
-            );
-            Err(e)
-        }
-        Err(_) => {
-            // Track client timeout
-            common_metrics::inc(
-                FLAG_CLIENT_TIMEOUT_COUNTER,
-                &[
-                    (
-                        "operation".to_string(),
-                        "should_write_hash_key_override".to_string(),
-                    ),
-                    (
-                        "timeout_ms".to_string(),
-                        QUERY_TIMEOUT.as_millis().to_string(),
-                    ),
-                ],
-                1,
-            );
-
-            // Capture all pool states on timeout
-            let persons_reader_stats = router.get_persons_reader().get_pool_stats();
-            let non_persons_reader_stats = router.get_non_persons_reader().get_pool_stats();
-            let persons_writer_stats = router.get_persons_writer().get_pool_stats();
-            let non_persons_writer_stats = router.get_non_persons_writer().get_pool_stats();
-
-            tracing::error!(
-                team_id = %team_id,
-                distinct_ids = ?distinct_ids,
-                timeout_after_ms = QUERY_TIMEOUT.as_millis(),
-                operation_elapsed_ms = total_operation_time.as_millis(),
-                persons_reader_pool = ?persons_reader_stats,
-                non_persons_reader_pool = ?non_persons_reader_stats,
-                persons_writer_pool = ?persons_writer_stats,
-                non_persons_writer_pool = ?non_persons_writer_stats,
-                "should_write_hash_key_override timed out - capturing all pool states"
-            );
-
-            // Emit metrics for timeout with pool states
-            if let Some(stats) = persons_writer_stats {
-                common_metrics::inc(
-                    FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER,
-                    &[
-                        (
-                            "writer_pool_busy".to_string(),
-                            (stats.num_idle == 0).to_string(),
-                        ),
-                        (
-                            "writer_utilization_pct".to_string(),
-                            ((((stats.size - stats.num_idle as u32) as f64 / stats.size as f64)
-                                * 100.0) as i64)
-                                .to_string(),
-                        ),
-                    ],
-                    1,
-                );
-            }
-
-            Err(FlagError::TimeoutError(Some("query_timeout".to_string())))
+    // Step 4: Check if there are any flags that don't have overrides
+    for row in flag_rows {
+        let flag_key: String = row.get("key");
+        if !existing_flag_keys.contains(&flag_key) {
+            return Ok(true); // Found a flag without override
         }
     }
+
+    Ok::<bool, FlagError>(false) // All flags have overrides
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -52,8 +52,6 @@ pub const FLAG_REQUEST_KLUDGE_COUNTER: &str = "flags_request_kludge_total";
 pub const FLAG_POOL_UTILIZATION_GAUGE: &str = "flags_pool_utilization_ratio";
 pub const FLAG_CONNECTION_HOLD_TIME: &str = "flags_connection_hold_time_ms";
 pub const FLAG_CONNECTION_QUEUE_DEPTH_GAUGE: &str = "flags_connection_queue_depth";
-pub const FLAG_READER_TIMEOUT_WITH_WRITER_STATE_COUNTER: &str =
-    "flags_reader_timeout_with_writer_state_total";
 pub const FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER: &str =
     "flags_experience_continuity_requests_total";
 
@@ -62,12 +60,7 @@ pub const FLAG_DEFINITIONS_RATE_LIMITED_COUNTER: &str = "flags_flag_definitions_
 pub const FLAG_DEFINITIONS_REQUESTS_COUNTER: &str = "flags_flag_definitions_requests_total";
 
 // Timeout tracking and classification
-pub const FLAG_CLIENT_TIMEOUT_COUNTER: &str = "flags_client_timeout_total";
 pub const FLAG_ACQUIRE_TIMEOUT_COUNTER: &str = "flags_acquire_timeout_total";
-
-// Multi-connection operation tracking
-pub const FLAG_MULTI_CONNECTION_OPERATION_COUNTER: &str = "flags_multi_connection_operation_total";
-pub const FLAG_CONNECTION_OVERLAP_TIME_MS: &str = "flags_connection_overlap_time_ms";
 
 // Error classification
 pub const FLAG_DATABASE_ERROR_COUNTER: &str = "flags_database_error_total";


### PR DESCRIPTION
## Problem

Our Postgres databases have a `statement_timeout` set to 30 minutes, but our feature flag queries should timeout much sooner to prevent connection pool exhaustion.

Additionally, the `should_write_hash_key_override` function was holding connections from one pool while acquiring connections from another, which could lead to pool exhaustion under load when multiple operations compete for connections.

The previous client-side timeout (`tokio::time::timeout`) didn't actually kill queries on the database - it just gave up waiting for results while the query continued running, polluting the connection pool.

## Changes

### 1. Configurable Statement Timeouts

Added two new environment variables for server-side query timeouts:

- **`READER_STATEMENT_TIMEOUT_MS`** - Timeout for reader pools (default: `0` = disabled)
  - Recommended: `60000-300000ms` (1-5 minutes) or `0` for analytics workloads
- **`WRITER_STATEMENT_TIMEOUT_MS`** - Timeout for writer pools (default: `0` = disabled)
  - Recommended: `30000ms` (30 seconds) for transactional operations

These are enforced server-side via PostgreSQL's `SET statement_timeout`, ensuring queries are actually killed and connections properly freed.

### 2. Scoped Connection Management

Refactored database operations to use scoped blocks that automatically release connections after each query instead of holding them for the entire operation:

**Before:**
```rust
// Acquire both connections
let persons_conn = get_connection().await?;
let flags_conn = get_connection().await?;
// Both held until end of function
```

**After:**
```rust
// Scoped block 1
let data = {
    let conn = get_connection().await?;
    query().await?
    // Connection released here
};

// Scoped block 2
let flags = {
    let conn = get_connection().await?;
    query().await?
    // Connection released here
};
```

### 3. Enhanced Timeout Metrics

Replaced client-side timeout tracking with detailed server-side timeout metrics:

**Metrics emitted on timeout:**
```
FLAG_DATABASE_ERROR_COUNTER {
    error_type: "timeout",
    timeout_type: "query_canceled",  // or "lock_not_available", etc.
    pool: "persons_reader",           // or "non_persons_reader"
    operation: "should_write_hash_key_override"
}
```

**Plus warning logs with full context:**
- Which pool timed out
- Timeout type (statement_timeout vs lock_timeout, etc.)
- Team ID and operation details

## Benefits

- **Prevents pool exhaustion** - Connections released immediately after use
- **Proper query timeouts** - PostgreSQL kills slow queries server-side
- **No zombie queries** - Queries actually stop when timeout fires
- **No dirty connections** - Pool stays clean
- **Better observability** - Detailed metrics with pool and timeout type
- **Flexible configuration** - Tune timeouts per pool type (readers vs writers)
- **Backward compatible** - Defaults maintain current behavior (no timeout)

## How did you test this code?

Unit Tests.

Manually:

### Timeout Testing

Added a `pg_sleep()` call to a query (temporarily) and ran:

```bash
NON_PERSONS_READER_STATEMENT_TIMEOUT_MS=51 \
PERSONS_READER_STATEMENT_TIMEOUT_MS=52 \
WRITER_STATEMENT_TIMEOUT_MS=53 \
RUST_LOG=DEBUG \
cargo run -p feature-flags
```

Made a request to ensure that we got a timeout:

```
2025-10-23T18:17:35.782351Z ERROR ThreadId(08) request{method=POST uri=/flags?v=2 version=HTTP/1.1}:request{user_agent=PostmanRuntime/7.49.0 content_encoding=none content_type=application/json version=2 lib_version=unknown compression=none method=POST path=/flags ip=127.0.0.1 sent_at=0 request_id=41908baa-79c1-48e3-acc8-4bd541c9676f}:process_request{request_id=41908baa-79c1-48e3-acc8-4bd541c9676f}:evaluate_all_feature_flags{team_id=2 project_id=2 distinct_id=fred@example.com flags_len=2}:process_hash_key_override{team_id=2 project_id=2 distinct_id=fred@example.com}: feature_flags::flags::flag_matching: Failed to check if hash key override should be written for team 2 project 2 distinct_id fred@example.com: DatabaseError(Database(PgDatabaseError { severity: Error, code: "57014", message: "canceling statement due to statement timeout", detail: None, hint: None, position: None, where: None, schema: None, table: None, column: None, data_type: None, constraint: None, file: Some("postgres.c"), line: Some(3130), routine: Some("ProcessInterrupts") }), Some("Failed to fetch person data"))
```

### Scoped Connection Management Testing

```bash
curl -X POST 'http://localhost:8010/flags?v=2' \
	-H "Content-Type: application/json" \
	-d '{
	  "token": "phc_B68sepGbwNPUIwg6tYHi0D3dEdpkNgnmUk87G5Cmujc",
	  "distinct_id": "test_hash_key_user",
	  "anon_distinct_id": "anon_abc123"
}' 
```

And then:

```sql
SELECT * FROM posthog_featureflaghashkeyoverride
```

And saw the hash override.

This requires that you have a feature flag with experience continuity enabled.

## Changelog: (features only) Is this feature complete?

No - This is an infrastructure improvement. The statement_timeout values need to be configured via environment variables in deployment configs before timeouts will take effect.
