### PR TITLE
fix(create experiments): add panel navigation buttons.

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -104,23 +104,30 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                     <LemonCollapse
                         activeKey={selectedPanel ?? undefined}
                         defaultActiveKey="experiment-exposure"
-                        onChange={(key) => {
-                            setSelectedPanel(key as string | null)
-                        }}
+                        onChange={setSelectedPanel}
                         className="bg-surface-primary"
                         panels={[
                             {
                                 key: 'experiment-exposure',
                                 header: <ExposureCriteriaPanelHeader experiment={experiment} />,
                                 content: (
-                                    <ExposureCriteriaPanel experiment={experiment} onChange={setExposureCriteria} />
+                                    <ExposureCriteriaPanel
+                                        experiment={experiment}
+                                        onChange={setExposureCriteria}
+                                        onNext={() => setSelectedPanel('experiment-variants')}
+                                    />
                                 ),
                             },
                             {
                                 key: 'experiment-variants',
                                 header: <VariantsPanelHeader experiment={experiment} />,
                                 content: (
-                                    <VariantsPanel experiment={experiment} updateFeatureFlag={setFeatureFlagConfig} />
+                                    <VariantsPanel
+                                        experiment={experiment}
+                                        updateFeatureFlag={setFeatureFlagConfig}
+                                        onPrevious={() => setSelectedPanel('experiment-exposure')}
+                                        onNext={() => setSelectedPanel('experiment-metrics')}
+                                    />
                                 ),
                             },
                             {
@@ -199,6 +206,7 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                                 [context.type]: [...sharedMetrics[context.type], ...metrics],
                                             })
                                         }}
+                                        onPrevious={() => setSelectedPanel('experiment-variants')}
                                     />
                                 ),
                             },

--- a/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
+++ b/frontend/src/scenes/experiments/create/ExposureCriteriaPanel.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { LemonSelect, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonSelect, LemonTag } from '@posthog/lemon-ui'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
@@ -18,9 +18,10 @@ import { exposureConfigToFilter, filterToExposureConfig } from '../utils'
 type ExposureCriteriaPanelProps = {
     experiment: Experiment
     onChange: (exposureCriteria: ExperimentExposureCriteria) => void
+    onNext: () => void
 }
 
-export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteriaPanelProps): JSX.Element {
+export function ExposureCriteriaPanel({ experiment, onChange, onNext }: ExposureCriteriaPanelProps): JSX.Element {
     // Derive exposure type from experiment state
     const selectedExposureType = experiment.exposure_criteria?.exposure_config ? 'custom' : 'default'
 
@@ -153,6 +154,13 @@ export function ExposureCriteriaPanel({ experiment, onChange }: ExposureCriteria
                     }}
                     fullWidth
                 />
+            </div>
+
+            <LemonDivider />
+            <div className="flex justify-end pt-2">
+                <LemonButton type="primary" size="small" onClick={onNext}>
+                    Next
+                </LemonButton>
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
@@ -89,8 +89,8 @@ export const MetricsPanel = ({
                 <EmptyMetricsPanel className="mt-6" metricContext={METRIC_CONTEXTS.secondary} />
             )}
 
-            <LemonDivider />
-            <div className="flex justify-end pt-2 gap-2">
+            <LemonDivider className="mt-4" />
+            <div className="flex justify-end pt-4">
                 <LemonButton type="primary" size="small" onClick={onPrevious}>
                     Previous
                 </LemonButton>

--- a/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/MetricsPanel/MetricsPanel.tsx
@@ -1,5 +1,8 @@
 import { useActions } from 'kea'
 
+import { LemonDivider } from '@posthog/lemon-ui'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { SharedMetric } from 'scenes/experiments/SharedMetrics/sharedMetricLogic'
 
 import type { ExperimentMetric } from '~/queries/schema/schema-general'
@@ -24,6 +27,7 @@ export type MetricsPanelProps = {
     onSaveMetric: (metric: ExperimentMetric, context: MetricContext) => void
     onDeleteMetric: (metric: ExperimentMetric, context: MetricContext) => void
     onSaveSharedMetrics: (metrics: ExperimentMetric[], context: MetricContext) => void
+    onPrevious: () => void
 }
 
 const sortMetrics = (metrics: ExperimentMetric[], orderedUuids: string[]): ExperimentMetric[] =>
@@ -43,6 +47,7 @@ export const MetricsPanel = ({
     onSaveMetric,
     onDeleteMetric,
     onSaveSharedMetrics,
+    onPrevious,
 }: MetricsPanelProps): JSX.Element => {
     const { closeExperimentMetricModal } = useActions(experimentMetricModalLogic)
     const { closeSharedMetricModal } = useActions(sharedMetricModalLogic)
@@ -83,6 +88,13 @@ export const MetricsPanel = ({
             ) : (
                 <EmptyMetricsPanel className="mt-6" metricContext={METRIC_CONTEXTS.secondary} />
             )}
+
+            <LemonDivider />
+            <div className="flex justify-end pt-2 gap-2">
+                <LemonButton type="primary" size="small" onClick={onPrevious}>
+                    Previous
+                </LemonButton>
+            </div>
 
             <MetricSourceModal />
             <ExperimentMetricModal

--- a/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.test.tsx
@@ -105,7 +105,14 @@ describe('VariantsPanel', () => {
 
     describe('rendering', () => {
         it('renders mode selection cards', () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             expect(screen.getByText('Create new feature flag')).toBeInTheDocument()
             expect(screen.getByText('Link existing feature flag')).toBeInTheDocument()
@@ -113,7 +120,12 @@ describe('VariantsPanel', () => {
 
         it('defaults to create mode', () => {
             const { container } = render(
-                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
             )
 
             const cards = container.querySelectorAll('[role="button"]')
@@ -125,7 +137,14 @@ describe('VariantsPanel', () => {
         })
 
         it('renders create feature flag panel in create mode', () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             expect(screen.getByText('Feature flag key')).toBeInTheDocument()
             expect(screen.getByText('Variant keys')).toBeInTheDocument()
@@ -135,7 +154,12 @@ describe('VariantsPanel', () => {
     describe('mode switching', () => {
         it('switches to link mode when clicking link card', async () => {
             const { container } = render(
-                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
             )
 
             const cards = container.querySelectorAll('[role="button"]')
@@ -150,7 +174,12 @@ describe('VariantsPanel', () => {
 
         it('switches back to create mode when clicking create card', async () => {
             const { container } = render(
-                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
             )
 
             const cards = container.querySelectorAll('[role="button"]')
@@ -169,7 +198,12 @@ describe('VariantsPanel', () => {
 
         it('highlights selected mode card', async () => {
             const { container } = render(
-                <VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
             )
 
             const cards = container.querySelectorAll('[role="button"]')
@@ -192,7 +226,14 @@ describe('VariantsPanel', () => {
 
     describe('link existing feature flag', () => {
         it('shows select button in empty state', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode
             const cards = screen.getAllByRole('button')
@@ -204,7 +245,14 @@ describe('VariantsPanel', () => {
         })
 
         it('opens modal when clicking select button', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode
             const cards = screen.getAllByRole('button')
@@ -220,7 +268,14 @@ describe('VariantsPanel', () => {
         })
 
         it('displays available feature flags in modal', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode and open modal
             const cards = screen.getAllByRole('button')
@@ -238,7 +293,14 @@ describe('VariantsPanel', () => {
         })
 
         it('filters feature flags by search', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode and open modal
             const cards = screen.getAllByRole('button')
@@ -264,7 +326,14 @@ describe('VariantsPanel', () => {
         })
 
         it('selects feature flag and closes modal', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode and open modal
             const cards = screen.getAllByRole('button')
@@ -292,7 +361,14 @@ describe('VariantsPanel', () => {
         })
 
         it('displays selected flag with variants', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode and open modal
             const cards = screen.getAllByRole('button')
@@ -324,7 +400,14 @@ describe('VariantsPanel', () => {
         })
 
         it('shows change button for selected flag', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode and open modal
             const cards = screen.getAllByRole('button')
@@ -349,7 +432,14 @@ describe('VariantsPanel', () => {
         })
 
         it('reopens modal when clicking change button', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode, open modal, select flag
             const cards = screen.getAllByRole('button')
@@ -390,7 +480,14 @@ describe('VariantsPanel', () => {
                 },
             })
 
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode and open modal
             const cards = screen.getAllByRole('button')
@@ -412,7 +509,14 @@ describe('VariantsPanel', () => {
                 name: 'Test',
             }
 
-            render(<VariantsPanel experiment={experimentWithoutKey} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={experimentWithoutKey}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Should still render without errors
             expect(screen.getByText('Create new feature flag')).toBeInTheDocument()
@@ -433,7 +537,14 @@ describe('VariantsPanel', () => {
                 },
             }
 
-            render(<VariantsPanel experiment={experimentWithEmptyKey} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={experimentWithEmptyKey}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Should show error message
             expect(screen.getByText('All variants must have a key.')).toBeInTheDocument()
@@ -452,7 +563,14 @@ describe('VariantsPanel', () => {
                 },
             }
 
-            render(<VariantsPanel experiment={experimentWithDuplicateKeys} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={experimentWithDuplicateKeys}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Should show error message
             expect(screen.getByText('Variant keys must be unique.')).toBeInTheDocument()
@@ -471,7 +589,14 @@ describe('VariantsPanel', () => {
                 },
             }
 
-            render(<VariantsPanel experiment={experimentWithZeroRollout} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={experimentWithZeroRollout}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Should show error message
             expect(screen.getByText('All variants must have a rollout percentage greater than 0.')).toBeInTheDocument()
@@ -491,7 +616,12 @@ describe('VariantsPanel', () => {
             }
 
             render(
-                <VariantsPanel experiment={experimentWithValidZeroRollout} updateFeatureFlag={mockUpdateFeatureFlag} />
+                <VariantsPanel
+                    experiment={experimentWithValidZeroRollout}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
             )
 
             // Should not show zero rollout error
@@ -514,7 +644,12 @@ describe('VariantsPanel', () => {
             }
 
             const { container } = render(
-                <VariantsPanel experiment={experimentWithEmptyKey} updateFeatureFlag={mockUpdateFeatureFlag} />
+                <VariantsPanel
+                    experiment={experimentWithEmptyKey}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
             )
 
             // Find variant rows
@@ -531,7 +666,14 @@ describe('VariantsPanel', () => {
 
     describe('callback payloads', () => {
         it('calls updateFeatureFlag with correct structure when selecting linked flag', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             // Switch to link mode and select a flag
             const cards = screen.getAllByRole('button')
@@ -567,7 +709,14 @@ describe('VariantsPanel', () => {
 
     describe('state restoration', () => {
         it('persists linked flag selection when switching link→create→link', async () => {
-            render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
+            render(
+                <VariantsPanel
+                    experiment={defaultExperiment}
+                    updateFeatureFlag={mockUpdateFeatureFlag}
+                    onPrevious={() => {}}
+                    onNext={() => {}}
+                />
+            )
 
             const cards = screen.getAllByRole('button')
             const linkCard = cards.find((card) => card.textContent?.includes('Link existing'))!

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -1,6 +1,10 @@
 import { useActions, useValues } from 'kea'
 import { match } from 'ts-pattern'
 
+import { LemonDivider } from '@posthog/lemon-ui'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+
 import { SelectableCard } from '~/scenes/experiments/components/SelectableCard'
 import type { Experiment, FeatureFlagType, MultivariateFlagVariant } from '~/types'
 
@@ -12,6 +16,8 @@ import { variantsPanelLogic } from './variantsPanelLogic'
 
 interface VariantsPanelProps {
     experiment: Experiment
+    onPrevious: () => void
+    onNext: () => void
     updateFeatureFlag: (featureFlag: {
         feature_flag_key?: string
         parameters?: {
@@ -21,7 +27,7 @@ interface VariantsPanelProps {
     }) => void
 }
 
-export function VariantsPanel({ experiment, updateFeatureFlag }: VariantsPanelProps): JSX.Element {
+export function VariantsPanel({ experiment, updateFeatureFlag, onPrevious, onNext }: VariantsPanelProps): JSX.Element {
     const { mode, linkedFeatureFlag } = useValues(variantsPanelLogic)
     const { setMode, setLinkedFeatureFlag } = useActions(variantsPanelLogic)
 
@@ -59,6 +65,16 @@ export function VariantsPanel({ experiment, updateFeatureFlag }: VariantsPanelPr
                     />
                 ))
                 .exhaustive()}
+
+            <LemonDivider />
+            <div className="flex justify-end pt-2 gap-2">
+                <LemonButton type="secondary" size="small" onClick={onPrevious}>
+                    Previous
+                </LemonButton>
+                <LemonButton type="primary" size="small" onClick={onNext}>
+                    Next
+                </LemonButton>
+            </div>
 
             {/* Feature Flag Selection Modal */}
             <SelectExistingFeatureFlagModal

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -66,8 +66,8 @@ export function VariantsPanel({ experiment, updateFeatureFlag, onPrevious, onNex
                 ))
                 .exhaustive()}
 
-            <LemonDivider />
-            <div className="flex justify-end pt-2 gap-2">
+            <LemonDivider className="mt-4" />
+            <div className="flex justify-end pt-4 gap-2">
                 <LemonButton type="secondary" size="small" onClick={onPrevious}>
                     Previous
                 </LemonButton>


### PR DESCRIPTION
## Problem

On the new create experiment form, moving between panels could be confusing.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added _previous_/_next_ buttons to the panels.

| new panel navigation |
| - |
| ![pev-next](https://github.com/user-attachments/assets/226961f3-700a-4f84-acb9-d2a84b660301)|

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/7e6f448d-da74-478b-a48e-853c3bd8e262)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
