### PR TITLE
fix: Handle `last_called_at` in feature flag activity

### DIFF
--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -354,6 +354,7 @@ const featureFlagActionsMapping: Record<
     status: () => null,
     version: () => null,
     last_modified_by: () => null,
+    last_called_at: () => null,
     _create_in_folder: () => null,
     _should_create_usage_dashboard: () => null,
 }
@@ -402,7 +403,11 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
                 continue // feature flag updates have to have a "field" to be described
             }
 
-            const possibleLogItem = featureFlagActionsMapping[change.field as keyof FeatureFlagType](change, logItem)
+            const fieldHandler = featureFlagActionsMapping[change.field as keyof FeatureFlagType]
+            if (!fieldHandler) {
+                console.error({ field: change.field, change }, 'No activity describer found for feature flag field')
+            }
+            const possibleLogItem = fieldHandler ? fieldHandler(change, logItem) : null
             if (possibleLogItem) {
                 const { description, suffix } = possibleLogItem
                 if (description) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3464,6 +3464,7 @@ export interface FeatureFlagType extends Omit<FeatureFlagBasicType, 'id' | 'team
     _create_in_folder?: string | null
     evaluation_runtime: FeatureFlagEvaluationRuntime
     _should_create_usage_dashboard?: boolean
+    last_called_at?: string | null
 }
 
 export interface OrganizationFeatureFlag {


### PR DESCRIPTION
## Problem

We added `last_called_at` under https://github.com/PostHog/posthog/pull/38962. This appears to be causing https://github.com/PostHog/posthog/issues/40194 when `last_called_at` appears in the activity for a feature flag:

```
{
    "type": "FeatureFlag",
    "action": "changed",
    "field": "last_called_at",
    "before": "2025-10-21T17:29:53.741000+00:00",
    "after": "2025-10-21T16:59:16.615000+00:00"
}
```

I'm not sure why we didn't start seeing this sooner, but this change should guard against it happening.

Tested locally to verify that the feature flag history tab still loads - but I haven't been able to reproduce the actual issue locally.
