### PR TITLE
chore: simplify membership calculation

### DIFF
--- a/posthog/temporal/messaging/actions_workflow.py
+++ b/posthog/temporal/messaging/actions_workflow.py
@@ -105,16 +105,9 @@ def process_actions_activity(inputs: ActionsWorkflowInputs) -> ProcessActionsRes
                     CASE
                         WHEN
                             cmc.person_id IS NULL -- Does not exist in cohort_membership_changed
-                            THEN 'entered' -- so, new member
+                            THEN 'entered' -- so, new member (or re-entered, as we filter members who left)
                         WHEN
-                            cmc.person_id IS NOT NULL -- Exists in cohort_membership_changed
-                            AND cmc.status = 'left' -- it left the cohort at some point
-                            AND bcm.person_id IS NOT NULL -- but now there is a match in behavioral_cohorts_matches
-                            THEN 'entered' -- so, it re-entered the cohort
-                        WHEN
-                            cmc.person_id IS NOT NULL -- Exists in cohort_membership_changed
-                            AND cmc.status = 'entered' -- it is a member at some point
-                            AND bcm.person_id IS NULL -- but there is no match in behavioral_cohorts_matches
+                            bcm.person_id IS NULL -- There is no match in behavioral_cohorts_matches
                             THEN 'left' -- so, it left the cohort
                         ELSE
                             'unchanged' -- for all other cases, the membership did not change
@@ -138,6 +131,7 @@ def process_actions_activity(inputs: ActionsWorkflowInputs) -> ProcessActionsRes
                         team_id = %(team_id)s
                         AND cohort_id = %(action_id)s
                     GROUP BY team_id, person_id
+                    HAVING status = 'entered'
                 ) cmc ON bcm.team_id = cmc.team_id AND bcm.person_id = cmc.person_id
                 WHERE status != 'unchanged'
                 SETTINGS join_use_nulls = 1;


### PR DESCRIPTION
## Problem

We are joining members who left the cohort.

But, we actually don't care if they left the cohort, we only need to know that they left so we can calculate the current snapshot and compare it with the updated snapshot.

## Changes

When getting the current members snapshot, filter out all those members who are in left state. That means that when we do the join, we only check that:

- if the current snapshot does not contain the members from the updated one, they enter the cohort. 
- if the updated snapshot does not contain the members from the current one, they left the cohort. 

We join much less data with this approach. For queries with a lot of members, this improves performance by 4x in some cases. From:

<img width="1094" height="60" alt="image" src="https://github.com/user-attachments/assets/9a63a673-54af-4690-821e-9753697ee449" />

To:

<img width="1111" height="76" alt="image" src="https://github.com/user-attachments/assets/5795c18c-1bf5-4af3-8dab-0b78ab1e3389" />
