### PR TITLE
chore(oauth): support localhost callbacks

### DIFF
--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -2,7 +2,6 @@ import enum
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -73,10 +72,7 @@ class OAuthApplication(AbstractApplication):
 
             is_loopback = is_loopback_host(parsed_uri.hostname)
 
-            if settings.DEBUG:
-                allowed_schemes = ["http", "https"]
-            else:
-                allowed_schemes = ["http", "https"] if is_loopback else ["https"]
+            allowed_schemes = ["http", "https"] if is_loopback else ["https"]
 
             if parsed_uri.scheme not in allowed_schemes:
                 raise ValidationError(

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -27,6 +27,20 @@ class OAuthApplicationAccessLevel(enum.Enum):
     TEAM = "team"
 
 
+def is_loopback_host(hostname: str | None) -> bool:
+    """Check if hostname is a loopback address (localhost or 127.0.0.0/8)."""
+    if not hostname:
+        return False
+    if hostname == "localhost":
+        return True
+    # Check for IPv4 loopback range 127.0.0.0/8
+    if hostname.startswith("127.") and hostname.count(".") == 3:
+        parts = hostname.split(".")
+        if len(parts) == 4 and all(part.isdigit() and 0 <= int(part) <= 255 for part in parts):
+            return True
+    return False
+
+
 class OAuthApplication(AbstractApplication):
     class Meta(AbstractApplication.Meta):
         verbose_name = "OAuth Application"
@@ -48,13 +62,21 @@ class OAuthApplication(AbstractApplication):
     def clean(self):
         super().clean()
 
-        allowed_schemes = ["http", "https"] if settings.DEBUG else ["https"]
-
         for uri in self.redirect_uris.split(" "):
             if not uri:
                 continue
 
             parsed_uri = urlparse(uri)
+
+            if not parsed_uri.netloc:
+                raise ValidationError({"redirect_uris": f"Redirect URI {uri} must contain a host"})
+
+            is_loopback = is_loopback_host(parsed_uri.hostname)
+
+            if settings.DEBUG:
+                allowed_schemes = ["http", "https"]
+            else:
+                allowed_schemes = ["http", "https"] if is_loopback else ["https"]
 
             if parsed_uri.scheme not in allowed_schemes:
                 raise ValidationError(
@@ -63,10 +85,6 @@ class OAuthApplication(AbstractApplication):
                     }
                 )
 
-            if not parsed_uri.netloc:
-                raise ValidationError({"redirect_uris": f"Redirect URI {uri} must contain a host"})
-
-            # Note: URI fragments are not allowed in redirect URIs in the OAuth 2.0 specification
             if parsed_uri.fragment:
                 raise ValidationError({"redirect_uris": f"Redirect URI {uri} cannot contain fragments"})
 

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -2,12 +2,13 @@ import uuid
 from datetime import timedelta
 
 from freezegun import freeze_time
-from parameterized import parameterized
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.utils import timezone
+
+from parameterized import parameterized
 
 from posthog.api.test.test_oauth import generate_rsa_key
 from posthog.models import Organization, User

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -514,7 +514,9 @@ OAUTH2_PROVIDER = {
         "*": "Full access to all scopes",
         **get_scope_descriptions(),
     },
-    "ALLOWED_REDIRECT_URI_SCHEMES": ["https"],
+    # Allow both http and https schemes to support localhost callbacks
+    # Security validation in OAuthApplication.clean() ensures http is only allowed for loopback addresses (localhost, 127.0.0.0/8) in production
+    "ALLOWED_REDIRECT_URI_SCHEMES": ["http", "https"],
     "AUTHORIZATION_CODE_EXPIRE_SECONDS": 60
     * 5,  # client has 5 minutes to complete the OAuth flow before the authorization code expires
     "DEFAULT_SCOPES": ["openid"],
@@ -541,6 +543,3 @@ OAUTH2_PROVIDER_GRANT_MODEL = "posthog.OAuthGrant"
 
 # Sharing configuration settings
 SHARING_TOKEN_GRACE_PERIOD_SECONDS = 60 * 5  # 5 minutes
-
-if DEBUG:
-    OAUTH2_PROVIDER["ALLOWED_REDIRECT_URI_SCHEMES"] = ["http", "https"]


### PR DESCRIPTION
This is standard practice for supporting OAuth flows in environments like CLI’s or desktop applications.