### PR TITLE
fix(max): Fix the missing tool call message

### DIFF
--- a/ee/hogai/graph/taxonomy/nodes.py
+++ b/ee/hogai/graph/taxonomy/nodes.py
@@ -189,9 +189,15 @@ class TaxonomyAgentToolsNode(
                 continue
             else:
                 if tool_input.name == "final_answer":
+                    tool_msg = LangchainToolMessage(
+                        content=tool_input.arguments.answer,  # type: ignore
+                        tool_call_id=action.log,
+                    )
+                    old_msg = state.tool_progress_messages or []
                     return self._partial_state_class(
                         output=tool_input.arguments.answer,  # type: ignore
                         intermediate_steps=None,
+                        tool_progress_messages=[*old_msg, tool_msg],
                     )
 
                 if tool_input.name == "ask_user_for_help":

--- a/ee/hogai/graph/taxonomy/test/test_nodes.py
+++ b/ee/hogai/graph/taxonomy/test/test_nodes.py
@@ -194,7 +194,7 @@ class TestTaxonomyAgentToolsNode(BaseTest):
         result = await self.node.arun(state, RunnableConfig())
 
         self.assertIsInstance(result, TaxonomyAgentState)
-        self.assertEqual(len(result.tool_progress_messages), 0)
+        self.assertEqual(len(result.tool_progress_messages), 1)
 
     @patch.object(MockTaxonomyAgentToolkit, "get_tool_input_model")
     async def test_run_final_answer(self, mock_get_tool_input):


### PR DESCRIPTION
## Problem
We recently merged the parallelisation of the taxonomy tool calls and broke the return of partial state for validation errors

## Changes
Added the missing `LangchainToolMessage` to the partial state when validation error happens for the return message

## How did you test this code?
Manually

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
