### PR TITLE
fix: use expected backup bandwith

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -49,6 +49,7 @@ def get_max_backup_bandwidth() -> str:
 
 
 SHARDED_TABLES = [
+    "sharded_events",
     "sharded_app_metrics",
     "sharded_app_metrics2",
     "sharded_heatmaps",
@@ -58,7 +59,6 @@ SHARDED_TABLES = [
     "sharded_session_replay_embeddings",
     "sharded_session_replay_events",
     "sharded_sessions",
-    "sharded_events",
 ]
 
 NON_SHARDED_TABLES = [
@@ -141,6 +141,8 @@ class Backup:
         backup_settings = {
             "async": "1",
             "max_backup_bandwidth": get_max_backup_bandwidth(),
+            "s3_disable_checksum": "1",  # There is a CH issue that makes bandwith be half than what is configured: https://github.com/ClickHouse/ClickHouse/issues/78213
+            # According to CH docs, disabling this is safe enough as checksums are already made: https://clickhouse.com/docs/operations/settings/settings#s3_disable_checksum
         }
         if self.base_backup:
             backup_settings["base_backup"] = "S3('{bucket_base_path}/{path}')".format(


### PR DESCRIPTION
## Problem

Due to a CH issue with the S3 SDK (https://github.com/ClickHouse/ClickHouse/issues/78213), if the S3 checksum is enabled, it halves the expected used bandwidth for backups, taking them twice as much as expected.

## Changes

Disable the S3 checksum (https://clickhouse.com/docs/operations/settings/settings#s3_disable_checksum) as MergeTree tables already calculate them and we connect to S3 securely.

