### PR TITLE
chore(api): prefetch project in api/organization

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -171,7 +171,9 @@ class OrganizationSerializer(
             else instance.teams.none()
         )
         # Support old access control system
-        visible_teams = visible_teams.filter(id__in=self.user_permissions.team_ids_visible_for_user)
+        visible_teams = visible_teams.filter(id__in=self.user_permissions.team_ids_visible_for_user).select_related(
+            "project"
+        )
         return TeamBasicSerializer(visible_teams, context=self.context, many=True).data  # type: ignore
 
     def get_projects(self, instance: Organization) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Problem

When switching projects, we get an n + 1 query situation, as we are not fetching `project` and need to look it up with individual queries for every project the user is part of.

## Changes

Prefetch `project` so django does not have to look this up with individual queries. This should improve performance for users that have access to lots of projects.

## How did you test this code?

- tests passes
- tested locally and verified that number of sql queries went down
