### PR TITLE
test(temporal): Try to fix Temporal tests

### DIFF
--- a/docker/clickhouse/config.d/dev-memory.xml
+++ b/docker/clickhouse/config.d/dev-memory.xml
@@ -4,5 +4,4 @@
     <mark_cache_size>268435456</mark_cache_size> <!-- 256MB -->
     <uncompressed_cache_size>268435456</uncompressed_cache_size> <!-- 256MB -->
     <cache_size_to_ram_max_ratio>0.25</cache_size_to_ram_max_ratio>
-    <max_server_memory_usage_to_ram_ratio replace="true">0.6</max_server_memory_usage_to_ram_ratio>
 </clickhouse>

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -918,7 +918,7 @@ async def test_run_workflow_revert_materialization(
     workflow_id = str(uuid.uuid4())
     inputs = RunWorkflowInputs(team_id=ateam.pk)
 
-    async def mock_hogql_table(_query, _team, _logger):
+    def mock_hogql_table(_query, _team, _logger):
         raise Exception("Unknown table")
 
     with (

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -45,7 +45,7 @@ from posthog.temporal.data_modeling.run_workflow import (
     run_dag_activity,
     start_run_activity,
 )
-from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
+from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, truncate_table
 from posthog.warehouse.models.data_modeling_job import DataModelingJob
 from posthog.warehouse.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from posthog.warehouse.models.modeling import DataWarehouseModelPath
@@ -272,6 +272,8 @@ def mock_to_object_store_rs_credentials(class_self):
 
 @pytest_asyncio.fixture
 async def pageview_events(clickhouse_client, ateam):
+    # first truncate the table to ensure we have a clean slate
+    await truncate_table(clickhouse_client, "sharded_events")
     start_time, end_time = dt.datetime.now(dt.UTC) - dt.timedelta(days=1), dt.datetime.now(dt.UTC)
     events, _, events_from_other_team = await generate_test_events_in_clickhouse(
         clickhouse_client,

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -117,6 +117,10 @@ def generate_test_events(
     return events
 
 
+async def truncate_table(client: ClickHouseClient, table: str):
+    await execute_query(client, f"TRUNCATE TABLE IF EXISTS `{table}`")
+
+
 async def insert_event_values_in_clickhouse(
     client: ClickHouseClient, events: list[EventValues], table: str = "sharded_events", insert_sessions: bool = False
 ):


### PR DESCRIPTION
## Problem

Some Temporal tests are being flakey (mainly the materialization ones, however I did update some fixtures recently so maybe it's related 🤷 ).

## Changes

- Try truncating events table before inserting test data to prevent inconsistency issues. 
- Increase available ClickHouse memory.


## How did you test this code?

Ran tests locally