### PR TITLE
fix(web-analytics): show proper no data state for web vitals

### DIFF
--- a/frontend/src/queries/nodes/WebVitals/WebVitals.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitals.tsx
@@ -74,24 +74,28 @@ export function WebVitals(props: {
                         value={INP}
                         isActive={webVitalsTab === 'INP'}
                         setTab={() => setWebVitalsTab('INP')}
+                        isLoading={responseLoading}
                     />
                     <WebVitalsTab
                         metric="LCP"
                         value={LCP}
                         isActive={webVitalsTab === 'LCP'}
                         setTab={() => setWebVitalsTab('LCP')}
+                        isLoading={responseLoading}
                     />
                     <WebVitalsTab
                         metric="FCP"
                         value={FCP}
                         isActive={webVitalsTab === 'FCP'}
                         setTab={() => setWebVitalsTab('FCP')}
+                        isLoading={responseLoading}
                     />
                     <WebVitalsTab
                         metric="CLS"
                         value={CLS}
                         isActive={webVitalsTab === 'CLS'}
                         setTab={() => setWebVitalsTab('CLS')}
+                        isLoading={responseLoading}
                     />
                 </div>
                 <span className="text-xs text-text-tertiary self-center sm:self-end">
@@ -103,7 +107,7 @@ export function WebVitals(props: {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-2">
-                <WebVitalsContent webVitalsQueryResponse={webVitalsQueryResponse} />
+                <WebVitalsContent webVitalsQueryResponse={webVitalsQueryResponse} isLoading={responseLoading} />
                 <div className="flex flex-col flex-1 bg-surface-primary rounded border p-4">
                     <Query
                         query={webVitalsMetricQuery}

--- a/frontend/src/queries/nodes/WebVitals/WebVitalsContent.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsContent.tsx
@@ -25,9 +25,10 @@ import {
 
 type WebVitalsContentProps = {
     webVitalsQueryResponse?: WebVitalsQueryResponse
+    isLoading: boolean
 }
 
-export const WebVitalsContent = ({ webVitalsQueryResponse }: WebVitalsContentProps): JSX.Element => {
+export const WebVitalsContent = ({ webVitalsQueryResponse, isLoading }: WebVitalsContentProps): JSX.Element => {
     const { webVitalsTab, webVitalsPercentile } = useValues(webAnalyticsLogic)
 
     const value = useMemo(
@@ -41,10 +42,18 @@ export const WebVitalsContent = ({ webVitalsQueryResponse }: WebVitalsContentPro
     const color = getThresholdColor(value, webVitalsTab)
     const band = getMetricBand(value, webVitalsTab)
 
-    // NOTE: `band` will only return `none` if the value is undefined,
-    // so this is basically the same check twice, but we need that to make TS happy
-    if (value === undefined || band === 'none') {
+    // Show skeleton only when loading
+    if (isLoading) {
         return <LemonSkeleton fade className="w-full h-full rounded sm:w-[30%]" />
+    }
+
+    // Show no data message when not loading and value is undefined
+    if (value === undefined || band === 'none') {
+        return (
+            <div className="w-full p-4 sm:w-[30%] flex flex-col gap-2 bg-surface-primary rounded border items-center justify-center">
+                <span className="text-sm text-text-tertiary">No data for the selected date range</span>
+            </div>
+        )
     }
 
     const grade = GRADE_PER_BAND[band]

--- a/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
@@ -13,13 +13,16 @@ type WebVitalsTabProps = {
     metric: WebVitalsMetric
     isActive: boolean
     setTab?: () => void
+    isLoading: boolean
 }
 
-export function WebVitalsTab({ value, metric, isActive, setTab }: WebVitalsTabProps): JSX.Element {
+export function WebVitalsTab({ value, metric, isActive, setTab, isLoading }: WebVitalsTabProps): JSX.Element {
     const label = LONG_METRIC_NAME[metric]
 
     const { value: parsedValue, unit } = getValueWithUnit(value, metric)
     const color = getThresholdColor(value, metric)
+
+    const showNoData = !isLoading && value === undefined
 
     return (
         <div
@@ -43,14 +46,22 @@ export function WebVitalsTab({ value, metric, isActive, setTab }: WebVitalsTabPr
             </div>
 
             <div className="flex flex-row items-end">
-                <span
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{ color }}
-                    className="text-2xl"
-                >
-                    {parsedValue || <LemonSkeleton fade className="w-20 h-8" />}
-                </span>
-                <span className="text-xs ml-1 mb-1">{unit}</span>
+                {isLoading ? (
+                    <LemonSkeleton fade className="w-20 h-8" />
+                ) : showNoData ? (
+                    <span className="text-xs text-text-tertiary">No data for this range</span>
+                ) : (
+                    <>
+                        <span
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ color }}
+                            className="text-2xl"
+                        >
+                            {parsedValue}
+                        </span>
+                        <span className="text-xs ml-1 mb-1">{unit}</span>
+                    </>
+                )}
             </div>
 
             <div className="w-full mt-2 hidden sm:block">

--- a/frontend/src/queries/nodes/WebVitals/definitions.ts
+++ b/frontend/src/queries/nodes/WebVitals/definitions.ts
@@ -71,13 +71,19 @@ export const getMetric = (
         ?.filter((result) => result.action.custom_name === metric) // Filter to the right metric
         .find((result) => result.action.math === percentile)?.data // Get the right percentile // Get the actual data array
 
-    // If CLS, just return last value, it can be 0
+    if (!data || data.length === 0) {
+        return undefined
+    }
+
+    // If CLS, return last value only if there's any non-zero data
+    // (CLS can legitimately be 0, but if ALL values are 0, there's no data)
     if (metric === 'CLS') {
-        return data?.slice(-1)[0]
+        const hasAnyData = data.some((value) => value !== 0)
+        return hasAnyData ? data.slice(-1)[0] : undefined
     }
 
     // Else, return the last non-0 value
-    return data?.filter((value) => value !== 0).slice(-1)[0] // Get the last non-0 value
+    return data.filter((value) => value !== 0).slice(-1)[0] // Get the last non-0 value
 }
 
 export const getMetricBand = (value: number | undefined, metric: WebVitalsMetric): WebVitalsMetricBand | 'none' => {


### PR DESCRIPTION
## Problem

We were not clearing the empty state in WebVitals when the query returned no results. 0 is a valid value for some of those metrics, so it is better to show "no data in range". 

This is somewhat misleading for people that have already ingested $web_vitals events, but don't have them on the selected date as the `health check warning ` won't show up.

We have plans to improve WebVitals this quarter, so this is just a quick fix to not keep an infinite skeleton.

<img width="948" height="224" alt="image" src="https://github.com/user-attachments/assets/a6b9c40c-1f7b-4a2e-96a5-c2f0b5bfb695" />


## Changes

- Pass in the loading indicator downstream to check it

## How did you test this code?


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
