### PR TITLE
chore: remove goals tile on pre-agg

### DIFF
--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -141,7 +141,6 @@ export const TILES_ALLOWED_ON_PRE_AGGREGATED = [
     TileId.PATHS,
     TileId.SOURCES,
     TileId.DEVICES,
-    TileId.GOALS,
 
     // Not 100% supported yet but they are fast enough that we can show them
     TileId.GRAPHS,


### PR DESCRIPTION
## Problem

I did not change the `WebGoals` query when adding support for conversion goals, so this will hang for large teams until the query is optimized. Let's go ahead and remove it for now.

