### PR TITLE
feat: Update sessions v3 backfill to run on every shard

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2937,9 +2937,9 @@
       team_id,
       `$session_id_uuid` AS session_id_v7,
   
-      initializeAggregation('argMaxState', sharded_events.distinct_id, timestamp) as distinct_id,
+      initializeAggregation('argMaxState', source_table.distinct_id, timestamp) as distinct_id,
       initializeAggregation('argMaxState', person_id, timestamp) as person_id,
-      initializeAggregation('groupUniqArrayState', sharded_events.distinct_id) as distinct_ids,
+      initializeAggregation('groupUniqArrayState', source_table.distinct_id) as distinct_ids,
   
       timestamp AS min_timestamp,
       timestamp AS max_timestamp,
@@ -3000,7 +3000,7 @@
   
       --flags
       initializeAggregation('groupUniqArrayMapState', properties_group_feature_flags) as flag_values
-  FROM posthog_test.sharded_events
+  FROM posthog_test.sharded_events AS source_table
   WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
   AND TRUE
       

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -254,7 +254,7 @@ PROPERTIES = f"""
         ]) AS Array(String)) as ad_ids_set"""
 
 
-def RAW_SESSION_TABLE_MV_SELECT_SQL_V3(where="TRUE"):
+def RAW_SESSION_TABLE_MV_SELECT_SQL_V3(source_table, where="TRUE"):
     return """
 WITH
     {PROPERTIES},
@@ -328,11 +328,11 @@ SELECT
 
     --flags
     initializeAggregation('groupUniqArrayMapState', properties_group_feature_flags) as flag_values
-FROM {database}.sharded_events
+FROM {source_table}
 WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
 AND {where}
     """.format(
-        database=settings.CLICKHOUSE_DATABASE,
+        source_table=source_table,
         where=where,
         PROPERTIES=PROPERTIES,
     )
@@ -348,20 +348,23 @@ AS
         table_name=f"{TABLE_BASE_NAME_V3}_mv",
         target_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         database=settings.CLICKHOUSE_DATABASE,
-        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(where),
+        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
+            where=where, source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events"
+        ),
     )
 
 
-RAW_SESSION_TABLE_UPDATE_SQL_V3 = (
-    lambda: """
+def RAW_SESSION_TABLE_MV_UPDATE_SQL_V3(where="TRUE"):
+    return """
 ALTER TABLE {table_name}
 MODIFY QUERY
 {select_sql}
 """.format(
         table_name=f"{TABLE_BASE_NAME_V3}_mv",
-        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(),
+        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
+            where=where, source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events"
+        ),
     )
-)
 
 
 def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where="TRUE"):
@@ -371,7 +374,9 @@ INSERT INTO {database}.{writable_table}
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
-        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(where=where),
+        select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
+            where=where, source_table=f"{settings.CLICKHOUSE_DATABASE}.events"
+        ),
     )
 
 

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -349,7 +349,9 @@ AS
         target_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         database=settings.CLICKHOUSE_DATABASE,
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
-            where=where, source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events"
+            where=where,
+            # use sharded_events, this means that the mv MUST be created on every data node
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events",
         ),
     )
 
@@ -375,7 +377,9 @@ INSERT INTO {database}.{writable_table}
         database=settings.CLICKHOUSE_DATABASE,
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
-            where=where, source_table=f"{settings.CLICKHOUSE_DATABASE}.events"
+            where=where,
+            # use sharded_events for the source table, this means that the backfill MUST run on every shard
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events",
         ),
     )
 

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -265,9 +265,9 @@ SELECT
     team_id,
     `$session_id_uuid` AS session_id_v7,
 
-    initializeAggregation('argMaxState', sharded_events.distinct_id, timestamp) as distinct_id,
+    initializeAggregation('argMaxState', source_table.distinct_id, timestamp) as distinct_id,
     initializeAggregation('argMaxState', person_id, timestamp) as person_id,
-    initializeAggregation('groupUniqArrayState', sharded_events.distinct_id) as distinct_ids,
+    initializeAggregation('groupUniqArrayState', source_table.distinct_id) as distinct_ids,
 
     timestamp AS min_timestamp,
     timestamp AS max_timestamp,
@@ -328,7 +328,7 @@ SELECT
 
     --flags
     initializeAggregation('groupUniqArrayMapState', properties_group_feature_flags) as flag_values
-FROM {source_table}
+FROM {source_table} AS source_table
 WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
 AND {where}
     """.format(


### PR DESCRIPTION
## Problem
See https://posthog.slack.com/archives/C076R4753Q8/p1761231886937019

## Changes

Change the backfill sql to use run once per shard, which should solve the problem of missing data

## How did you test this code?

n/a, I need to merge this before it can be tested

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
