### PR TITLE
fix(workflows): fix hog function config infinite loop

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -28,7 +28,7 @@ export function HogFlowFunctionConfiguration({
         if (template && Object.keys(inputs ?? {}).length === 0) {
             setInputs(templateToConfiguration(template).inputs ?? {})
         }
-    }, [template, setInputs, inputs])
+    }, [templateId])
 
     if (hogFunctionTemplatesByIdLoading) {
         return (


### PR DESCRIPTION
## Problem

This week I received a report from a customer that their workflow editor sometimes gets laggy / freezes. While working on https://github.com/PostHog/posthog/pull/39597/files, I noticed that rendering some templates results in a `Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`. In development, this is an obvious full screen error. But in production, the browser tries its best and the tab's CPU usage maxes out + throttles rendering.

## Changes

I isolated the issue to the useEffect in the diff and fixed the bad useEffect dependency (the template object was the issue)

## How did you test this code?

Verified useEffect now runs once as expected, and config UX still renders correctly.