### PR TITLE
feat: add cache_age_seconds on process_query_model

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -116,6 +116,7 @@ def process_query_model(
     insight_id: Optional[int] = None,
     dashboard_id: Optional[int] = None,
     is_query_service: bool = False,
+    cache_age_seconds: Optional[int] = None,
 ) -> dict | BaseModel:
     result: dict | BaseModel
 
@@ -135,6 +136,7 @@ def process_query_model(
                 insight_id=insight_id,
                 dashboard_id=dashboard_id,
                 is_query_service=is_query_service,
+                cache_age_seconds=cache_age_seconds,
             )
         elif execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
             # Caching is handled by query runners, so in this case we can only return a cache miss
@@ -197,6 +199,7 @@ def process_query_model(
             query_id=query_id,
             insight_id=insight_id,
             dashboard_id=dashboard_id,
+            cache_age_seconds=cache_age_seconds,
         )
 
     return result

--- a/posthog/caching/test/test_stale_utils.py
+++ b/posthog/caching/test/test_stale_utils.py
@@ -55,3 +55,43 @@ def test_is_stale(team, date_to, interval, last_refresh, expected):
     with pytest.MonkeyPatch.context() as m:
         m.setattr("posthog.caching.utils.stale_cache_invalidation_disabled", lambda t: team.name == "B")
         assert is_stale(team, date_to, interval, datetime.now(UTC) - last_refresh) == expected
+
+
+@pytest.mark.parametrize(
+    "team, date_to, interval, last_refresh, target_age, expected",
+    [
+        # target_age in the future -> not stale (even though minute interval would make it stale)
+        (
+            team_a,
+            None,
+            "minute",
+            datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+            datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC),
+            False,
+        ),
+        # target_age in the past -> stale (even though day interval would keep it fresh)
+        (
+            team_a,
+            None,
+            "day",
+            datetime(2024, 12, 31, 22, 0, 0, tzinfo=UTC),
+            datetime(2024, 12, 31, 23, 0, 0, tzinfo=UTC),
+            True,
+        ),
+        # target_age exactly at current time -> not stale (boundary case)
+        (
+            team_a,
+            None,
+            "hour",
+            datetime(2024, 12, 31, 23, 0, 0, tzinfo=UTC),
+            datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+            False,
+        ),
+    ],
+)
+@freeze_time("2025-01-01T00:00:00Z")
+def test_is_stale_with_target_age(team, date_to, interval, last_refresh, target_age, expected):
+    """Test that target_age parameter overrides interval-based staleness calculation."""
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("posthog.caching.utils.stale_cache_invalidation_disabled", lambda t: False)
+        assert is_stale(team, date_to, interval, last_refresh, target_age=target_age) == expected

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -164,6 +164,7 @@ def is_stale(
     interval: Optional[str],
     last_refresh: Optional[datetime],
     mode: ThresholdMode = ThresholdMode.DEFAULT,
+    target_age: Optional[datetime] = None,
 ) -> bool:
     """
     Indicates whether a cache item is obviously outdated based on the last_refresh date, the last
@@ -175,6 +176,9 @@ def is_stale(
 
     if last_refresh is None:
         raise ValueError("Cached results require a last_refresh")
+
+    if target_age is not None:
+        return datetime.now(UTC) > target_age
 
     # If the date_to is in the past of the last refresh, the data cannot be stale
     # Use a buffer in case last_refresh from cache.set happened slightly after the actual query

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -45,6 +45,11 @@ class HogQLQueryRunner(AnalyticsQueryRunner[HogQLQueryResponse]):
     def cache_target_age(self, last_refresh: Optional[datetime], lazy: bool = False) -> Optional[datetime]:
         if last_refresh is None:
             return None
+
+        override = self._get_cache_age_override(last_refresh)
+        if override is not None:
+            return override
+
         return last_refresh + staleness_threshold_map[ThresholdMode.LAZY if lazy else ThresholdMode.DEFAULT]["day"]
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -983,6 +983,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         query_id: Optional[str] = None,
         insight_id: Optional[int] = None,
         dashboard_id: Optional[int] = None,
+        cache_age_seconds: Optional[int] = None,
     ) -> CR | CacheMissResponse | QueryStatusResponse:
         start_time = perf_counter()
         cache_key = self.get_cache_key()
@@ -1030,6 +1031,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             trigger: str | None = get_query_tag_value("trigger")
 
             self.query_id = query_id or self.query_id
+            self._cache_age_override = cache_age_seconds
             CachedResponse: type[CR] = self.cached_response_type
             cache_manager = get_query_cache_manager(
                 team=self.team,
@@ -1252,9 +1254,32 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     def get_cache_key(self) -> str:
         return generate_cache_key(f"query_{bytes.decode(to_json(self.get_cache_payload()))}")
 
+    def _get_cache_age_override(self, last_refresh: Optional[datetime]) -> Optional[datetime]:
+        """
+        Helper method for subclasses that override cache_target_age().
+        Returns the custom cache target age if _cache_age_override is set, otherwise None.
+
+        Subclasses can call this first in their cache_target_age() implementation:
+        ```
+        override = self._get_cache_age_override(last_refresh)
+        if override is not None:
+            return override
+        # ... custom logic
+        ```
+        """
+        if hasattr(self, "_cache_age_override") and self._cache_age_override is not None and last_refresh is not None:
+            return last_refresh + timedelta(seconds=self._cache_age_override)
+        return None
+
     def cache_target_age(self, last_refresh: Optional[datetime], lazy: bool = False) -> Optional[datetime]:
         if last_refresh is None:
             return None
+
+        # Check for custom cache age override (e.g., from Endpoint)
+        override_target_age = self._get_cache_age_override(last_refresh)
+        if override_target_age is not None:
+            return override_target_age
+
         query_date_range = getattr(self, "query_date_range", None)
         interval = query_date_range.interval_name if query_date_range else "minute"
         mode = ThresholdMode.LAZY if lazy else ThresholdMode.DEFAULT
@@ -1298,11 +1323,20 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         return True
 
     def _is_stale(self, last_refresh: Optional[datetime], lazy: bool = False) -> bool:
+        # If a custom cache age was provided (e.g., from Endpoint), use our override logic
+        target_age = None
+        if hasattr(self, "_cache_age_override") and self._cache_age_override is not None:
+            target_age = self.cache_target_age(last_refresh, lazy=lazy)
+            if not target_age:
+                return False
+
         query_date_range = getattr(self, "query_date_range", None)
         date_to = query_date_range.date_to() if query_date_range else None
         interval = query_date_range.interval_name if query_date_range else "minute"
         mode = ThresholdMode.LAZY if lazy else ThresholdMode.DEFAULT
-        return is_stale(self.team, date_to=date_to, interval=interval, last_refresh=last_refresh, mode=mode)
+        return is_stale(
+            self.team, date_to=date_to, interval=interval, last_refresh=last_refresh, mode=mode, target_age=target_age
+        )
 
     def _refresh_frequency(self) -> timedelta:
         return timedelta(minutes=1)

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -325,7 +325,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 query_id=client_query_id,
                 user=cast(User, request.user),
                 is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
-                # cache_age_seconds=endpoint.cache_age_seconds,
+                cache_age_seconds=endpoint.cache_age_seconds,
             )
 
             if isinstance(result, BaseModel):

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -2,8 +2,10 @@ from datetime import datetime
 from time import sleep
 from typing import Any
 
+from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.schema import EndpointLastExecutionTimesRequest
@@ -716,3 +718,162 @@ class TestEndpoint(ClickhouseTestMixin, APIBaseTest):
         query_status = response_data["query_status"]
         self.assertIsInstance(query_status["results"], list)
         self.assertEqual(len(query_status["results"]), 0, query_status)
+
+    @parameterized.expand(
+        [
+            ("valid_300s", 300, status.HTTP_201_CREATED, None),
+            ("valid_86400s", 86400, status.HTTP_201_CREATED, None),
+            ("too_small_30s", 30, status.HTTP_400_BAD_REQUEST, "between 300 and 86400"),
+            ("too_small_299s", 299, status.HTTP_400_BAD_REQUEST, "between 300 and 86400"),
+            ("too_large_100000s", 100000, status.HTTP_400_BAD_REQUEST, "between 300 and 86400"),
+            ("too_large_86401s", 86401, status.HTTP_400_BAD_REQUEST, "between 300 and 86400"),
+            ("null_uses_defaults", None, status.HTTP_201_CREATED, None),
+        ]
+    )
+    def test_cache_age_seconds_validation(self, name, cache_age_seconds, expected_status, expected_error_text):
+        """Test validation of cache_age_seconds field with various inputs."""
+        data = {
+            "name": f"cache_test_{name}",
+            "query": self.sample_query,
+            "cache_age_seconds": cache_age_seconds,
+        }
+        response = self.client.post(f"/api/environments/{self.team.id}/endpoints/", data, format="json")
+        self.assertEqual(response.status_code, expected_status)
+
+        if expected_status == status.HTTP_201_CREATED:
+            self.assertEqual(response.json()["cache_age_seconds"], cache_age_seconds)
+        elif expected_error_text:
+            self.assertIn(expected_error_text, str(response.json()))
+
+    @parameterized.expand(
+        [
+            (
+                "hogql_5min",
+                {"kind": "HogQLQuery", "query": "SELECT 1 as result"},
+                300,  # 5 minute cache age
+                4,  # Time within cache (minutes)
+                6,  # Time past cache (minutes)
+            ),
+            (
+                "trends_10min",
+                {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview", "math": "total"}],
+                    "dateRange": {"date_from": "-7d", "date_to": None},
+                    "interval": "day",
+                },
+                600,  # 10 minute cache age
+                8,  # Time within cache (minutes)
+                12,  # Time past cache (minutes)
+            ),
+        ]
+    )
+    @freeze_time("2025-01-01 12:00:00")
+    def test_custom_cache_age_behavior(self, name, query, cache_age_seconds, time_within_cache, time_past_cache):
+        """Test that custom cache_age_seconds affects cache staleness for different query types."""
+        # Create endpoint with custom cache age
+        endpoint = Endpoint.objects.create(
+            name=f"custom_cache_{name}",
+            team=self.team,
+            query=query,
+            created_by=self.user,
+            is_active=True,
+            cache_age_seconds=cache_age_seconds,
+        )
+
+        # First execution - should calculate fresh
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+
+        # Verify it was cached
+        self.assertIn("cache_key", response_data)
+        self.assertIn("last_refresh", response_data)
+        cache_key = response_data["cache_key"]
+
+        # Second execution immediately - should use cache
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["cache_key"], cache_key)
+        self.assertTrue(response_data.get("is_cached", False))
+
+        # Move time forward (still within cache age)
+        with freeze_time(f"2025-01-01 12:{time_within_cache:02d}:00"):
+            response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_data = response.json()
+            self.assertTrue(
+                response_data.get("is_cached", False),
+                f"Should still use cache at {time_within_cache} minutes",
+            )
+
+        # Move time forward (past cache age) - should recalculate
+        with freeze_time(f"2025-01-01 12:{time_past_cache:02d}:00"):
+            response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_data = response.json()
+            # Should have recalculated with fresh data
+            self.assertFalse(
+                response_data.get("is_cached", True),
+                f"Should recalculate after {time_past_cache} minutes",
+            )
+
+    @freeze_time("2025-01-01 12:00:00")
+    def test_default_cache_age_when_not_set(self):
+        """Test that endpoints without cache_age_seconds use default interval-based caching."""
+        # Create endpoint WITHOUT custom cache age - should use default (6 hours for day interval)
+        endpoint = Endpoint.objects.create(
+            name="default_cache_age",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 2 as result"},
+            created_by=self.user,
+            is_active=True,
+            cache_age_seconds=None,  # Use defaults
+        )
+
+        # First execution
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        cache_key = response_data.get("cache_key")
+
+        # Move time forward 5 minutes - should still use cache (default is much longer)
+        with freeze_time("2025-01-01 12:05:00"):
+            response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_data = response.json()
+            self.assertTrue(response_data.get("is_cached", False), "Should use cache with default timing")
+            self.assertEqual(response_data.get("cache_key"), cache_key)
+
+    def test_update_cache_age_seconds(self):
+        """Test updating cache_age_seconds on an existing endpoint."""
+        endpoint = Endpoint.objects.create(
+            name="update_cache_test",
+            team=self.team,
+            query=self.sample_query,
+            created_by=self.user,
+            cache_age_seconds=300,
+        )
+
+        # Update to different cache age
+        updated_data: dict[str, int | None] = {"cache_age_seconds": 600}
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/", updated_data, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["cache_age_seconds"], 600)
+
+        endpoint.refresh_from_db()
+        self.assertEqual(endpoint.cache_age_seconds, 600)
+
+        # Update to None (use defaults)
+        updated_data = {"cache_age_seconds": None}
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/", updated_data, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.json()["cache_age_seconds"])
+
+        endpoint.refresh_from_db()
+        self.assertIsNone(endpoint.cache_age_seconds)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Part 2 of splitting up #40230 
Endpoints can now set custom cache age 🎉

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- modifies the process_query_model and the whole flow downstream to allow custom cache age

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
- unit tests and locally creating stuff
