### PR TITLE
fix(max): less frequent use of the navigate tool

### DIFF
--- a/ee/hogai/eval/ci/max_tools/eval_navigate_tool.py
+++ b/ee/hogai/eval/ci/max_tools/eval_navigate_tool.py
@@ -1,0 +1,156 @@
+import pytest
+
+from braintrust import EvalCase
+from pydantic import BaseModel, Field
+
+from posthog.schema import AssistantMessage, AssistantNavigateUrl, AssistantToolCall, FailureMessage, HumanMessage
+
+from ee.hogai.django_checkpoint.checkpointer import DjangoCheckpointer
+from ee.hogai.graph import AssistantGraph
+from ee.hogai.utils.types import AssistantMessageUnion, AssistantNodeName, AssistantState
+from ee.models.assistant import Conversation
+
+from ...base import MaxPublicEval
+from ...scorers import ToolRelevance
+
+TOOLS_PROMPT = """
+- **actions**: Combine several related events into one, which you can then analyze in insights and dashboards as if it were a single event.
+- **cohorts**: A catalog of identified persons and your created cohorts.
+- **dashboards**: Create and manage your dashboards
+- **earlyAccessFeatures**: Allow your users to individually enable or disable features that are in public beta.
+- **errorTracking**: Track and analyze your error tracking data to understand and fix issues. [tools: Filter issues, Find impactful issues]
+- **experiments**: Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or if they are likely just a chance occurrence.
+- **featureFlags**: Use feature flags to safely deploy and roll back new features in an easy-to-manage way. Roll variants out to certain groups, a percentage of users, or everyone all at once.
+- **notebooks**: Notebooks are a way to organize your work and share it with others.
+- **persons**: A catalog of all the people behind your events
+- **insights**: Track, analyze, and experiment with user behavior.
+- **insightNew** [tools: Edit the insight]
+- **savedInsights**: Track, analyze, and experiment with user behavior.
+- **alerts**: Track, analyze, and experiment with user behavior.
+- **replay**: Replay recordings of user sessions to understand how users interact with your product or website. [tools: Search recordings]
+- **revenueAnalytics**: Track and analyze your revenue metrics to understand your business performance and growth. [tools: Filter revenue analytics]
+- **surveys**: Create surveys to collect feedback from your users [tools: Create surveys, Analyze survey responses]
+- **webAnalytics**: Analyze your web analytics data to understand website performance and user behavior.
+- **webAnalyticsWebVitals**: Analyze your web analytics data to understand website performance and user behavior.
+- **activity**: A catalog of all user interactions with your app or website.
+- **sqlEditor**: Write and execute SQL queries against your data warehouse [tools: Write and tweak SQL]
+- **heatmaps**: Heatmaps are a way to visualize user behavior on your website.
+""".strip()
+
+
+class EvalInput(BaseModel):
+    messages: str | list[AssistantMessageUnion]
+    current_page: str = Field(default="")
+
+
+@pytest.fixture
+def call_root(demo_org_team_user):
+    graph = (
+        AssistantGraph(demo_org_team_user[1], demo_org_team_user[2])
+        .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
+        .add_root(
+            {
+                "insights": AssistantNodeName.END,
+                "billing": AssistantNodeName.END,
+                "insights_search": AssistantNodeName.END,
+                "search_documentation": AssistantNodeName.END,
+                "root": AssistantNodeName.ROOT,
+                "end": AssistantNodeName.END,
+            }
+        )
+        # TRICKY: We need to set a checkpointer here because async tests create a new event loop.
+        .compile(checkpointer=DjangoCheckpointer())
+    )
+
+    async def callable(input: EvalInput) -> AssistantMessage:
+        conversation = await Conversation.objects.acreate(team=demo_org_team_user[1], user=demo_org_team_user[2])
+        initial_state = AssistantState(
+            messages=[HumanMessage(content=input.messages)] if isinstance(input.messages, str) else input.messages
+        )
+        raw_state = await graph.ainvoke(
+            initial_state,
+            {
+                "configurable": {
+                    "thread_id": conversation.id,
+                    "contextual_tools": {
+                        "navigate": {"scene_descriptions": TOOLS_PROMPT, "current_page": input.current_page}
+                    },
+                }
+            },
+        )
+        state = AssistantState.model_validate(raw_state)
+        assert isinstance(state.messages[-1], AssistantMessage)
+        return state.messages[-1]
+
+    return callable
+
+
+@pytest.mark.django_db
+async def eval_root_navigate_tool(call_root, pytestconfig):
+    await MaxPublicEval(
+        experiment_name="root_navigate_tool",
+        task=call_root,
+        scores=[ToolRelevance(semantic_similarity_args={"query_description"})],
+        data=[
+            # Shouldn't navigate to the insights page
+            EvalCase(
+                input=EvalInput(messages="build pageview insight"),
+                expected=AssistantToolCall(
+                    id="1",
+                    name="create_and_query_insight",
+                    args={
+                        "query_description": "Create a trends insight showing pageview events over time. Track the $pageview event to visualize how many pageviews are happening."
+                    },
+                ),
+            ),
+            # Should navigate to the persons page
+            EvalCase(
+                input=EvalInput(
+                    messages="I added tracking of persons, but I can't find where the persons are in the app"
+                ),
+                expected=AssistantToolCall(
+                    id="1",
+                    name="navigate",
+                    args={"page_key": AssistantNavigateUrl.PERSONS.value},
+                ),
+            ),
+            # Should navigate to the surveys page
+            EvalCase(
+                input=EvalInput(
+                    messages="were is my survey. I jsut created a survey and  save it as draft, I cannot find it now",
+                    current_page="/project/1/surveys/new",
+                ),
+                expected=AssistantToolCall(
+                    id="1",
+                    name="navigate",
+                    args={"page_key": AssistantNavigateUrl.SURVEYS.value},
+                ),
+            ),
+            # Should not navigate to the SQL editor
+            EvalCase(
+                input=EvalInput(
+                    messages="I need a query written in SQL to tell me what all of my identified events are for any given day."
+                ),
+                expected=AssistantToolCall(
+                    id="1",
+                    name="create_and_query_insight",
+                    args={"query_description": "All identified events for any given day"},
+                ),
+            ),
+            # Should just say that the query failed
+            EvalCase(
+                input=EvalInput(
+                    messages=[
+                        HumanMessage(
+                            content="I need a query written in SQL to tell me what all of my identified events are for any given day."
+                        ),
+                        FailureMessage(
+                            content="An unknown failure occurred while accessing the `events` table",
+                        ),
+                    ]
+                ),
+                expected=None,
+            ),
+        ],
+        pytestconfig=pytestconfig,
+    )

--- a/ee/hogai/graph/root/tools/navigate.py
+++ b/ee/hogai/graph/root/tools/navigate.py
@@ -24,7 +24,7 @@ Make sure that the state is aligned with the user's request using the tools avai
 - If the user asks to do something fun in the platform, you can navigate them to the `game368hedgehogs` page.
 
 # When NOT to use this tool:
-- If the currently definied tools can be used to assist the user. For example, if a SQL query fails, the tools of the SQL Editor page will not fix the query.
+- If the currently defined tools can be used to assist the user. For example, if a SQL query fails, the tools of the SQL Editor page will not fix the query.
 
 # List of pages and the tools available on a page
 {{{scene_descriptions}}}

--- a/ee/hogai/graph/root/tools/navigate.py
+++ b/ee/hogai/graph/root/tools/navigate.py
@@ -18,12 +18,16 @@ These pages are tied to PostHog's products and/or functionalities and provide to
 After navigating to a page, you can use the tools available there to retrieve information or perform actions.
 Make sure that the state is aligned with the user's request using the tools available.
 
-Some of the pages in the app have helpful descriptions. Some have tools that you can use only there. See the following list:
-{{{scene_descriptions}}}
+# When to use this tool
+- To access tools that are only available on specific pages.
+- To navigate to a page that the user is looking for.
+- If the user asks to do something fun in the platform, you can navigate them to the `game368hedgehogs` page.
 
-General rules for navigation:
-- If you don't have tools available for a specific functionality, navigate to the relevant product page to get access to its tools.
-- If a user asks to do something fun in the platform you can navigate them to the `game368hedgehogs` page.
+# When NOT to use this tool:
+- If the currently definied tools can be used to assist the user. For example, if a SQL query fails, the tools of the SQL Editor page will not fix the query.
+
+# List of pages and the tools available on a page
+{{{scene_descriptions}}}
 """.strip()
 
 


### PR DESCRIPTION
## Problem

Claude just loves the navigation tool, so sometimes it uses the tool too proactively. This PR adds prompts with examples of when to use the tool and when not to.

[Relevant traces](https://us.posthog.com/project/2/llm-analytics/traces?date_from=-7d&filters=%5B%7B%22key%22:%22$ai_error%22,%22value%22:%22Interrupt%22,%22operator%22:%22icontains%22,%22type%22:%22event%22%7D%5D)

## Changes

- Explain when to use the tool and when not.
- Add evals.

## How did you test this code?

Evals based on traces & manual testing
