### PR TITLE
fix(logs): fix logs timezone issues with inconsistent utc/project timezones

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -1,6 +1,5 @@
 import json
 import datetime as dt
-from zoneinfo import ZoneInfo
 
 from posthog.schema import (
     CachedLogsQueryResponse,
@@ -86,7 +85,6 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
                 )
 
     def _calculate(self) -> LogsQueryResponse:
-        self.modifiers.convertToProjectTimezone = False
         self.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
         response = self.paginator.execute_hogql_query(
             query_type="LogsQuery",
@@ -109,8 +107,8 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
                     "span_id": result[2],
                     "body": result[3],
                     "attributes": {k: json.loads(v) for k, v in result[4].items()},
-                    "timestamp": result[5].replace(tzinfo=ZoneInfo("UTC")),
-                    "observed_timestamp": result[6].replace(tzinfo=ZoneInfo("UTC")),
+                    "timestamp": result[5],
+                    "observed_timestamp": result[6],
                     "severity_text": result[7],
                     "severity_number": result[8],
                     "level": result[9],
@@ -288,5 +286,4 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
             interval=interval_type,
             interval_count=int(interval_count),
             now=dt.datetime.now(),
-            timezone_info=ZoneInfo("UTC"),
         )

--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -11,7 +11,6 @@ from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQuery
 
 class SparklineQueryRunner(LogsQueryRunner):
     def _calculate(self) -> LogsQueryResponse:
-        self.modifiers.convertToProjectTimezone = False
         self.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
         response = execute_hogql_query(
             query_type="LogsQuery",

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -226,18 +226,7 @@ export const logsLogic = kea<logsLogicType>([
                             limit: 99,
                             offset: values.logs.length,
                             orderBy: values.orderBy,
-                            dateRange: {
-                                // convert to naive timezone in the project's timezone which is what the backend requires
-                                date_from: dayjs(values.dateRange.date_from).isValid()
-                                    ? dayjs(values.dateRange.date_from)
-                                          .tz(values.timezone)
-                                          .format('YYYY-MM-DD HH:mm:ss')
-                                    : values.dateRange.date_from,
-                                date_to: dayjs(values.dateRange.date_to).isValid()
-                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD HH:mm:ss')
-                                    : values.dateRange.date_to,
-                                explicitDate: values.dateRange.explicitDate,
-                            },
+                            dateRange: values.projectDateRange,
                             searchTerm: values.searchTerm,
                             filterGroup: values.filterGroup as PropertyGroupFilter,
                             severityLevels: values.severityLevels,
@@ -267,18 +256,7 @@ export const logsLogic = kea<logsLogicType>([
                     const response = await api.logs.sparkline({
                         query: {
                             orderBy: values.orderBy,
-                            dateRange: {
-                                // convert to naive timezone in the project's timezone which is what the backend requires
-                                date_from: dayjs(values.dateRange.date_from).isValid()
-                                    ? dayjs(values.dateRange.date_from)
-                                          .tz(values.timezone)
-                                          .format('YYYY-MM-DD HH:mm:ss')
-                                    : values.dateRange.date_from,
-                                date_to: dayjs(values.dateRange.date_to).isValid()
-                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD HH:mm:ss')
-                                    : values.dateRange.date_to,
-                                explicitDate: values.dateRange.explicitDate,
-                            },
+                            dateRange: values.projectDateRange,
                             searchTerm: values.searchTerm,
                             filterGroup: values.filterGroup as PropertyGroupFilter,
                             severityLevels: values.severityLevels,
@@ -294,6 +272,19 @@ export const logsLogic = kea<logsLogicType>([
     })),
 
     selectors(() => ({
+        // convert the dateRange to be in the project's timezone
+        projectDateRange: [
+            (s) => [s.dateRange, s.timezone],
+            (dateRange, timezone) => ({
+                date_from: dayjs(dateRange.date_from).isValid()
+                    ? dayjs(dateRange.date_from).tz(timezone).format('YYYY-MM-DD HH:mm:ss')
+                    : dateRange.date_from,
+                date_to: dayjs(dateRange.date_to).isValid()
+                    ? dayjs(dateRange.date_to).tz(timezone).format('YYYY-MM-DD HH:mm:ss')
+                    : dateRange.date_to,
+                explicitDate: dateRange.explicitDate,
+            }),
+        ],
         sparklineData: [
             (s) => [s.sparkline],
             (sparkline) => {

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
@@ -7,8 +7,10 @@ import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tr
 
 import api from 'lib/api'
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { dayjs } from 'lib/dayjs'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { Params } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { DateRange, LogMessage, LogsQuery } from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
@@ -23,6 +25,10 @@ const DEFAULT_SERVICE_NAMES = [] as LogsQuery['serviceNames']
 
 export const logsLogic = kea<logsLogicType>([
     path(['products', 'logs', 'frontend', 'logsLogic']),
+
+    connect(() => ({
+        values: [teamLogic, ['timezone']],
+    })),
 
     urlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
@@ -220,7 +226,18 @@ export const logsLogic = kea<logsLogicType>([
                             limit: 99,
                             offset: values.logs.length,
                             orderBy: values.orderBy,
-                            dateRange: values.dateRange,
+                            dateRange: {
+                                // convert to naive timezone in the project's timezone which is what the backend requires
+                                date_from: dayjs(values.dateRange.date_from).isValid()
+                                    ? dayjs(values.dateRange.date_from)
+                                          .tz(values.timezone)
+                                          .format('YYYY-MM-DD hh:mm:ss')
+                                    : values.dateRange.date_from,
+                                date_to: dayjs(values.dateRange.date_to).isValid()
+                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD hh:mm:ss')
+                                    : values.dateRange.date_to,
+                                explicitDate: values.dateRange.explicitDate,
+                            },
                             searchTerm: values.searchTerm,
                             filterGroup: values.filterGroup as PropertyGroupFilter,
                             severityLevels: values.severityLevels,
@@ -250,7 +267,18 @@ export const logsLogic = kea<logsLogicType>([
                     const response = await api.logs.sparkline({
                         query: {
                             orderBy: values.orderBy,
-                            dateRange: values.dateRange,
+                            dateRange: {
+                                // convert to naive timezone in the project's timezone which is what the backend requires
+                                date_from: dayjs(values.dateRange.date_from).isValid()
+                                    ? dayjs(values.dateRange.date_from)
+                                          .tz(values.timezone)
+                                          .format('YYYY-MM-DD hh:mm:ss')
+                                    : values.dateRange.date_from,
+                                date_to: dayjs(values.dateRange.date_to).isValid()
+                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD hh:mm:ss')
+                                    : values.dateRange.date_to,
+                                explicitDate: values.dateRange.explicitDate,
+                            },
                             searchTerm: values.searchTerm,
                             filterGroup: values.filterGroup as PropertyGroupFilter,
                             severityLevels: values.severityLevels,

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -231,10 +231,10 @@ export const logsLogic = kea<logsLogicType>([
                                 date_from: dayjs(values.dateRange.date_from).isValid()
                                     ? dayjs(values.dateRange.date_from)
                                           .tz(values.timezone)
-                                          .format('YYYY-MM-DD hh:mm:ss')
+                                          .format('YYYY-MM-DD HH:mm:ss')
                                     : values.dateRange.date_from,
                                 date_to: dayjs(values.dateRange.date_to).isValid()
-                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD hh:mm:ss')
+                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD HH:mm:ss')
                                     : values.dateRange.date_to,
                                 explicitDate: values.dateRange.explicitDate,
                             },
@@ -272,10 +272,10 @@ export const logsLogic = kea<logsLogicType>([
                                 date_from: dayjs(values.dateRange.date_from).isValid()
                                     ? dayjs(values.dateRange.date_from)
                                           .tz(values.timezone)
-                                          .format('YYYY-MM-DD hh:mm:ss')
+                                          .format('YYYY-MM-DD HH:mm:ss')
                                     : values.dateRange.date_from,
                                 date_to: dayjs(values.dateRange.date_to).isValid()
-                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD hh:mm:ss')
+                                    ? dayjs(values.dateRange.date_to).tz(values.timezone).format('YYYY-MM-DD HH:mm:ss')
                                     : values.dateRange.date_to,
                                 explicitDate: values.dateRange.explicitDate,
                             },


### PR DESCRIPTION
## Problem

some parts of the query backend clobber any given timezone with the project timezone

to fix that would require a scary PR which would impact all queries, this only touches logs stuff so is much less dangerous

this causes issues with absolute times as the date picker is in local time but the backend expects project time

## Changes

switch to using project timezone everywhere in the backend instead of UTC

## How did you test this code?

ran locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
