### PR TITLE
fix(ux): focus lost clicking "show more", focus styles buttons/links

### DIFF
--- a/frontend/src/lib/ui/Combobox/Combobox.tsx
+++ b/frontend/src/lib/ui/Combobox/Combobox.tsx
@@ -96,6 +96,9 @@ const InnerCombobox = forwardRef<ListBoxHandle, ComboboxProps>(
             recalculateFocusableElements: () => listboxRef.current?.recalculateFocusableElements(),
             focusFirstItem: () => listboxRef.current?.focusFirstItem(),
             getFocusableElementsCount: () => listboxRef.current?.getFocusableElementsCount() ?? 0,
+            focusItemByKey: (key: string) => listboxRef.current?.focusItemByKey(key) ?? false,
+            focusPrevious: (stepsBack?: number) => listboxRef.current?.focusPrevious(stepsBack) ?? false,
+            getFocusHistory: () => listboxRef.current?.getFocusHistory() ?? [],
         }))
 
         useEffect(() => {

--- a/frontend/src/lib/ui/Combobox/Combobox.tsx
+++ b/frontend/src/lib/ui/Combobox/Combobox.tsx
@@ -245,11 +245,13 @@ export type ComboboxType = React.ForwardRefExoticComponent<ComboboxProps & React
     Empty: typeof Empty
     Content: typeof Content
     Item: typeof ListBox.Item
+    ListGroup: typeof ListBox.Group
 }
 ;(InnerCombobox as ComboboxType).Search = Search
 ;(InnerCombobox as ComboboxType).Group = Group
 ;(InnerCombobox as ComboboxType).Empty = Empty
 ;(InnerCombobox as ComboboxType).Content = Content
 ;(InnerCombobox as ComboboxType).Item = ListBox.Item
+;(InnerCombobox as ComboboxType).ListGroup = ListBox.Group
 
 export const Combobox = InnerCombobox as ComboboxType

--- a/frontend/src/lib/ui/ListBox/ListBox.tsx
+++ b/frontend/src/lib/ui/ListBox/ListBox.tsx
@@ -34,7 +34,7 @@ export interface ListBoxGroupHandle {
 /** Context to expose container ref to child Items */
 interface ListBoxContextType {
     containerRef: React.RefObject<HTMLDivElement> | null
-    registerGroupItem?: (groupId: string, index: number, element: HTMLElement) => void
+    registerGroupItem?: (groupId: string, index: number, element: HTMLLIElement) => void
     unregisterGroupItem?: (groupId: string, index: number) => void
     focusGroupItem?: (groupId: string, index: number) => boolean
 }
@@ -44,7 +44,7 @@ const ListBoxContext = createContext<ListBoxContextType>({ containerRef: null })
 /** Context for ListBox.Group to track its own items */
 interface ListBoxGroupContextType {
     groupId: string
-    registerItem: (index: number, element: HTMLElement) => void
+    registerItem: (index: number, element: HTMLLIElement) => void
     unregisterItem: (index: number) => void
 }
 
@@ -304,7 +304,7 @@ const InnerListBox = forwardRef<ListBoxHandle, ListBoxProps>(function ListBox(
     }, [])
 
     // Group management functions
-    const registerGroupItem = useCallback((groupId: string, index: number, element: HTMLElement) => {
+    const registerGroupItem = useCallback((groupId: string, index: number, element: HTMLLIElement) => {
         if (!groups.current.has(groupId)) {
             groups.current.set(groupId, new Map())
         }
@@ -693,7 +693,7 @@ const ListBoxItem = forwardRef<HTMLLIElement, ListBoxItemProps>(
         }
 
         // Register with group if inside a group and index is provided
-        const elementRef = useRef<HTMLElement>(null)
+        const elementRef = useRef<HTMLLIElement>(null)
 
         useEffect(() => {
             if (groupContext && index !== undefined && elementRef.current) {
@@ -706,15 +706,15 @@ const ListBoxItem = forwardRef<HTMLLIElement, ListBoxItemProps>(
 
         // Callback ref to capture the actual DOM element
         const setElementRef = useCallback(
-            (element: HTMLElement | null) => {
-                elementRef.current = element
+            (element: HTMLLIElement | null) => {
+                ;(elementRef as React.MutableRefObject<HTMLLIElement | null>).current = element
 
                 // Also forward to the provided ref if it exists
                 if (ref) {
                     if (typeof ref === 'function') {
                         ref(element)
                     } else {
-                        ref.current = element
+                        ;(ref as React.MutableRefObject<HTMLLIElement | null>).current = element
                     }
                 }
             },
@@ -788,11 +788,11 @@ const ListBoxGroup = forwardRef<ListBoxGroupHandle, ListBoxGroupProps>(
     ({ children, groupId: providedGroupId }, ref): JSX.Element => {
         const { registerGroupItem, unregisterGroupItem, focusGroupItem } = useContext(ListBoxContext)
         const groupId = useMemo(() => providedGroupId || `group-${groupIdCounter++}`, [providedGroupId])
-        const groupItems = useRef<Map<number, HTMLElement>>(new Map())
+        const groupItems = useRef<Map<number, HTMLLIElement>>(new Map())
         const currentFocusedIndex = useRef<number | null>(null)
 
         const registerItem = useCallback(
-            (index: number, element: HTMLElement) => {
+            (index: number, element: HTMLLIElement) => {
                 groupItems.current.set(index, element)
                 registerGroupItem?.(groupId, index, element)
             },

--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { IconArrowRight, IconEllipsis, IconInfo, IconSparkles } from '@posthog/icons'
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
@@ -17,7 +17,7 @@ import {
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
-import { ListBox, ListBoxHandle } from 'lib/ui/ListBox/ListBox'
+import { ListBox, ListBoxGroupHandle, ListBoxHandle } from 'lib/ui/ListBox/ListBox'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
 import { NewTabTreeDataItem, newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
@@ -108,15 +108,14 @@ function Category({
     category,
     columnIndex,
     isFirstCategoryWithResults,
-    listboxRef,
 }: {
     tabId: string
     items: NewTabTreeDataItem[]
     category: string
     columnIndex: number
     isFirstCategoryWithResults: boolean
-    listboxRef: React.RefObject<ListBoxHandle>
 }): JSX.Element {
+    const groupRef = useRef<ListBoxGroupHandle>(null)
     const typedItems = items as NewTabTreeDataItem[]
     const isFirstCategory = columnIndex === 0
     const newTabSceneData = useFeatureFlag('DATA_IN_NEW_TAB_SCENE')
@@ -176,128 +175,143 @@ function Category({
                             </div>
                         ) : null
                     ) : (
-                        typedItems.map((item, index) => {
-                            const focusFirst =
-                                (newTabSceneData && isFirstCategoryWithResults && index === 0) ||
-                                (filteredItemsGrid.length > 0 && isFirstCategory && index === 0)
+                        <ListBox.Group ref={groupRef} groupId={`category-${category}`}>
+                            {typedItems.map((item, index) => {
+                                const focusFirst =
+                                    (newTabSceneData && isFirstCategoryWithResults && index === 0) ||
+                                    (filteredItemsGrid.length > 0 && isFirstCategory && index === 0)
 
-                            const lastViewedAt =
-                                item.lastViewedAt ??
-                                (item.record as { last_viewed_at?: string | null } | undefined)?.last_viewed_at ??
-                                null
+                                const lastViewedAt =
+                                    item.lastViewedAt ??
+                                    (item.record as { last_viewed_at?: string | null } | undefined)?.last_viewed_at ??
+                                    null
 
-                            return (
-                                // If we have filtered results set virtual focus to first item
-                                <ButtonGroupPrimitive key={item.id} className="group w-full border-0">
-                                    <ContextMenu>
-                                        <ContextMenuTrigger asChild>
+                                return (
+                                    // If we have filtered results set virtual focus to first item
+                                    <ButtonGroupPrimitive key={item.id} className="group w-full border-0">
+                                        <ContextMenu>
+                                            <ContextMenuTrigger asChild>
+                                                <ListBox.Item
+                                                    asChild
+                                                    focusFirst={focusFirst}
+                                                    row={index}
+                                                    column={columnIndex}
+                                                    focusKey={item.id}
+                                                    index={index}
+                                                >
+                                                    <Link
+                                                        to={item.href || '#'}
+                                                        className="w-full"
+                                                        buttonProps={{
+                                                            size: 'sm',
+                                                            hasSideActionRight: true,
+                                                            className:
+                                                                'data-[focused=true]:outline-2 data-[focused=true]:outline-accent',
+                                                        }}
+                                                    >
+                                                        <span className="text-sm">{item.icon ?? item.name[0]}</span>
+                                                        <span className="flex min-w-0 items-center gap-2">
+                                                            <span className="text-sm truncate text-primary">
+                                                                {search ? (
+                                                                    <SearchHighlightMultiple
+                                                                        string={item.name}
+                                                                        substring={search}
+                                                                    />
+                                                                ) : (
+                                                                    item.displayName || item.name
+                                                                )}
+                                                            </span>
+                                                            {lastViewedAt ? (
+                                                                <span className="text-xs text-muted whitespace-nowrap">
+                                                                    {formatRelativeTimeShort(lastViewedAt)}
+                                                                </span>
+                                                            ) : null}
+                                                        </span>
+                                                    </Link>
+                                                </ListBox.Item>
+                                            </ContextMenuTrigger>
+                                            <ContextMenuContent loop className="max-w-[250px]">
+                                                <ContextMenuGroup>
+                                                    <MenuItems
+                                                        item={convertToTreeDataItem(item)}
+                                                        type="context"
+                                                        root="project://"
+                                                        onlyTree={false}
+                                                        showSelectMenuOption={false}
+                                                    />
+                                                </ContextMenuGroup>
+                                            </ContextMenuContent>
+                                        </ContextMenu>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <ButtonPrimitive
+                                                    size="xs"
+                                                    iconOnly
+                                                    isSideActionRight
+                                                    className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
+                                                >
+                                                    <IconEllipsis className="size-3" />
+                                                </ButtonPrimitive>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent
+                                                loop
+                                                align="end"
+                                                side="bottom"
+                                                className="max-w-[250px]"
+                                            >
+                                                <DropdownMenuGroup>
+                                                    <MenuItems
+                                                        item={convertToTreeDataItem(item)}
+                                                        type="dropdown"
+                                                        root="project://"
+                                                        onlyTree={false}
+                                                        showSelectMenuOption={false}
+                                                    />
+                                                </DropdownMenuGroup>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </ButtonGroupPrimitive>
+                                )
+                            })}
+                            {newTabSceneData &&
+                                (() => {
+                                    const currentLimit = getSectionItemLimit(category)
+                                    const fullCount = newTabSceneDataGroupedItemsFullData[category] || 0
+                                    const hasMore = fullCount > currentLimit
+
+                                    return (
+                                        hasMore && (
                                             <ListBox.Item
                                                 asChild
-                                                focusFirst={focusFirst}
-                                                row={index}
-                                                column={columnIndex}
-                                                focusKey={item.id}
+                                                focusKey={`show-all-${category}`}
+                                                index={typedItems.length} // This button is at the end of the group
                                             >
-                                                <Link
-                                                    to={item.href || '#'}
-                                                    className="w-full"
-                                                    buttonProps={{
-                                                        size: 'sm',
-                                                        hasSideActionRight: true,
-                                                        className:
-                                                            'data-[focused=true]:outline-2 data-[focused=true]:outline-accent',
+                                                <ButtonPrimitive
+                                                    size="sm"
+                                                    onClick={() => {
+                                                        const showAllIndex = typedItems.length // The "Show all" button index
+
+                                                        showMoreInSection(category)
+
+                                                        // Restore focus to the item that replaces the "Show all" button
+                                                        setTimeout(() => {
+                                                            // Focus the item at the same index where the "Show all" button was
+                                                            groupRef.current?.resumeFocus(showAllIndex)
+                                                        }, 0)
                                                     }}
+                                                    className="w-full text-tertiary data-[focused=true]:outline-2 data-[focused=true]:outline-accent data-[focused=true]:text-primary"
                                                 >
-                                                    <span className="text-sm">{item.icon ?? item.name[0]}</span>
-                                                    <span className="flex min-w-0 items-center gap-2">
-                                                        <span className="text-sm truncate text-primary">
-                                                            {search ? (
-                                                                <SearchHighlightMultiple
-                                                                    string={item.name}
-                                                                    substring={search}
-                                                                />
-                                                            ) : (
-                                                                item.displayName || item.name
-                                                            )}
-                                                        </span>
-                                                        {lastViewedAt ? (
-                                                            <span className="text-xs text-muted whitespace-nowrap">
-                                                                {formatRelativeTimeShort(lastViewedAt)}
-                                                            </span>
-                                                        ) : null}
-                                                    </span>
-                                                </Link>
+                                                    <IconArrowRight className="rotate-90" /> Show all (
+                                                    {fullCount - currentLimit} more)
+                                                </ButtonPrimitive>
                                             </ListBox.Item>
-                                        </ContextMenuTrigger>
-                                        <ContextMenuContent loop className="max-w-[250px]">
-                                            <ContextMenuGroup>
-                                                <MenuItems
-                                                    item={convertToTreeDataItem(item)}
-                                                    type="context"
-                                                    root="project://"
-                                                    onlyTree={false}
-                                                    showSelectMenuOption={false}
-                                                />
-                                            </ContextMenuGroup>
-                                        </ContextMenuContent>
-                                    </ContextMenu>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <ButtonPrimitive
-                                                size="xs"
-                                                iconOnly
-                                                isSideActionRight
-                                                className="opacity-0 group-hover:opacity-100 group-has-[button[data-state=open]]:opacity-100 mt-px"
-                                            >
-                                                <IconEllipsis className="size-3" />
-                                            </ButtonPrimitive>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent loop align="end" side="bottom" className="max-w-[250px]">
-                                            <DropdownMenuGroup>
-                                                <MenuItems
-                                                    item={convertToTreeDataItem(item)}
-                                                    type="dropdown"
-                                                    root="project://"
-                                                    onlyTree={false}
-                                                    showSelectMenuOption={false}
-                                                />
-                                            </DropdownMenuGroup>
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
-                                </ButtonGroupPrimitive>
-                            )
-                        })
+                                        )
+                                    )
+                                })()}
+                        </ListBox.Group>
                     )}
                     {newTabSceneData && (
                         <>
-                            {(() => {
-                                const currentLimit = getSectionItemLimit(category)
-                                const fullCount = newTabSceneDataGroupedItemsFullData[category] || 0
-                                const hasMore = fullCount > currentLimit
-
-                                return (
-                                    hasMore && (
-                                        <ListBox.Item asChild focusKey={`show-all-${category}`}>
-                                            <ButtonPrimitive
-                                                size="sm"
-                                                onClick={() => {
-                                                    showMoreInSection(category)
-
-                                                    // Restore focus to the previous item after state update
-                                                    setTimeout(() => {
-                                                        // Go back 1 step in focus history (the last focused item before this button)
-                                                        listboxRef.current?.focusPrevious(1)
-                                                    }, 0)
-                                                }}
-                                                className="w-full text-tertiary data-[focused=true]:outline-2 data-[focused=true]:outline-accent data-[focused=true]:text-primary"
-                                            >
-                                                <IconArrowRight className="rotate-90" /> Show all (
-                                                {fullCount - currentLimit} more)
-                                            </ButtonPrimitive>
-                                        </ListBox.Item>
-                                    )
-                                )
-                            })()}
                             {category === 'persons' && (
                                 <ListBox.Item asChild>
                                     <Link
@@ -498,7 +512,6 @@ export function Results({
                     category={category}
                     columnIndex={columnIndex}
                     isFirstCategoryWithResults={category === firstCategoryWithResults}
-                    listboxRef={listboxRef}
                     key={category}
                 />
             ))}

--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -108,12 +108,14 @@ function Category({
     category,
     columnIndex,
     isFirstCategoryWithResults,
+    listboxRef,
 }: {
     tabId: string
     items: NewTabTreeDataItem[]
     category: string
     columnIndex: number
     isFirstCategoryWithResults: boolean
+    listboxRef: React.RefObject<ListBoxHandle>
 }): JSX.Element {
     const typedItems = items as NewTabTreeDataItem[]
     const isFirstCategory = columnIndex === 0
@@ -194,6 +196,7 @@ function Category({
                                                 focusFirst={focusFirst}
                                                 row={index}
                                                 column={columnIndex}
+                                                focusKey={item.id}
                                             >
                                                 <Link
                                                     to={item.href || '#'}
@@ -274,10 +277,18 @@ function Category({
 
                                 return (
                                     hasMore && (
-                                        <ListBox.Item asChild>
+                                        <ListBox.Item asChild focusKey={`show-all-${category}`}>
                                             <ButtonPrimitive
                                                 size="sm"
-                                                onClick={() => showMoreInSection(category)}
+                                                onClick={() => {
+                                                    showMoreInSection(category)
+
+                                                    // Restore focus to the previous item after state update
+                                                    setTimeout(() => {
+                                                        // Go back 1 step in focus history (the last focused item before this button)
+                                                        listboxRef.current?.focusPrevious(1)
+                                                    }, 0)
+                                                }}
                                                 className="w-full text-tertiary data-[focused=true]:outline-2 data-[focused=true]:outline-accent data-[focused=true]:text-primary"
                                             >
                                                 <IconArrowRight className="rotate-90" /> Show all (
@@ -409,6 +420,7 @@ export function Results({
                                                 focusFirst={filteredItemsGrid.length > 0 && index === 0}
                                                 row={index}
                                                 column={0}
+                                                focusKey={item.id}
                                             >
                                                 <Link
                                                     to={item.href || '#'}
@@ -486,6 +498,7 @@ export function Results({
                     category={category}
                     columnIndex={columnIndex}
                     isFirstCategoryWithResults={category === firstCategoryWithResults}
+                    listboxRef={listboxRef}
                     key={category}
                 />
             ))}


### PR DESCRIPTION
## Problem
When navigating the new scene tab (under flag), keyboard navigation (enter) on "show more" lost focus
Focus styles were introduced to the new scene tab... people like it? and so it goes _everywhere_!!!!! this is huge UX improvement

![2025-10-23 22 30 02](https://github.com/user-attachments/assets/86905ca6-41b9-42eb-80a6-da98c65904f5)

## Changes
Vibed some listbox changes to support group, and resume focus
Remove hardcoded focus styles in new tab components and add them to base.scss for global styling

## How did you test this code?
locally
