### PR TITLE
feat(sessions): Support running session backfill over a range of partitions

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -38,8 +38,9 @@ def sessions_v3_backfill(context: AssetExecutionContext):
     # as long as the backfill has run at least once for each partition, the data will be correct
     backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause)
 
+    partition_range = context.partition_key_range
     context.log.info(
-        f"Running backfill for {context.partition_key} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
+        f"Running backfill for {partition_range.start} to {partition_range.end} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
 
     cluster = get_cluster()


### PR DESCRIPTION
## Problem

I got this error:

```
dagster._core.errors.DagsterInvariantViolationError: Cannot access partition_key for a partitioned run with a range of partitions. Call partition_key_range instead.
```

## Changes
The fix was simple, instead of using `context.partition_key` we use `context.partition_key_range`

## How did you test this code?

n/a (it only affects the dagster job which is manually run by me)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
