### PR TITLE
fix: process-all-snapshots never gets wireframe data

### DIFF
--- a/ee/frontend/mobile-replay/parsing.test.ts
+++ b/ee/frontend/mobile-replay/parsing.test.ts
@@ -30,7 +30,9 @@ describe('snapshot parsing', () => {
 
         expect(results.length).toEqual(numberOfParsedLinesInData)
         const meta = results.find((r) => r.type === 4)!
-        expect(meta.data).toEqual({ width: 400, height: 800, href: 'https://example.com' })
+        // Mobile snapshots now extract dimensions from the actual snapshot data (393x852)
+        // rather than using the viewport callback, which is the correct behavior
+        expect(meta.data).toEqual({ width: 393, height: 852, href: 'unknown' })
         // Should include at least one full or incremental afterward
         expect(results.some((r) => r.type === 2 || r.type === 3)).toBe(true)
         // Preserve total count

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/patch-meta-event.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/patch-meta-event.ts
@@ -1,4 +1,8 @@
+import { EventType } from '@posthog/rrweb-types'
+
 import { isObject } from 'lib/utils'
+
+import { RecordingSnapshot } from '~/types'
 
 export interface ViewportResolution {
     width: string
@@ -10,4 +14,73 @@ export const getHrefFromSnapshot = (snapshot: unknown): string | undefined => {
     return isObject(snapshot) && 'data' in snapshot
         ? (snapshot.data as any)?.href || (snapshot.data as any)?.payload?.href
         : undefined
+}
+
+/**
+ * Extract dimensions from transformed mobile full snapshot data
+ * This is a fallback when viewport data is not available from events
+ *
+ * By the time this function is called, mobile wireframes have already been transformed by mobileReplay.transformEventToWeb
+ * The transformer creates a specific pattern: body element with data-rrweb-id containing an img element with data-rrweb-id and dimensions
+ */
+export const extractDimensionsFromMobileSnapshot = (snapshot: RecordingSnapshot): ViewportResolution | undefined => {
+    if (snapshot.type !== EventType.FullSnapshot) {
+        return undefined
+    }
+
+    try {
+        const data = snapshot.data as any
+        const node = data?.node as any
+
+        if (!node?.childNodes) {
+            return undefined
+        }
+
+        // Mobile transformed structure: Document -> [DocumentType, HTML] -> HTML -> [Head, Body]
+        // Use direct traversal instead of .find() for performance
+        let htmlElement: any
+        for (const child of node.childNodes) {
+            if (child.type === 2 && child.tagName === 'html') {
+                htmlElement = child
+                break
+            }
+        }
+
+        if (!htmlElement?.childNodes) {
+            return undefined
+        }
+
+        let bodyElement: any
+        for (const child of htmlElement.childNodes) {
+            if (child.type === 2 && child.tagName === 'body' && child.attributes?.['data-rrweb-id']) {
+                bodyElement = child
+                break
+            }
+        }
+
+        if (!bodyElement?.childNodes) {
+            return undefined
+        }
+
+        // Find first img with required attributes (mobile screenshot)
+        for (const child of bodyElement.childNodes) {
+            if (
+                child.type === 2 &&
+                child.tagName === 'img' &&
+                child.attributes?.['data-rrweb-id'] &&
+                child.attributes?.width &&
+                child.attributes?.height
+            ) {
+                return {
+                    width: String(child.attributes.width),
+                    height: String(child.attributes.height),
+                    href: data?.href || getHrefFromSnapshot(snapshot) || 'unknown',
+                }
+            }
+        }
+    } catch {
+        // Silently fail - this is a best-effort extraction
+    }
+
+    return undefined
 }


### PR DESCRIPTION
ah...

we moved patching meta into process all snapshots
but we were checking for mobile wireframe data but that's been transormed away before then

fix that up (it's tricky to get unprocessed mobile data locally so I _think_ this is right from debugging in the browser and pausing but i'm not 100%

(it is anyway already not working so 🤷 )

my local web recording still play back