### PR TITLE
chore(flags): Remove `max_lifetime` from database connection pools

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -44,7 +44,6 @@ pub struct PoolConfig {
     pub max_connections: u32,
     pub acquire_timeout: Duration,
     pub idle_timeout: Option<Duration>,
-    pub max_lifetime: Option<Duration>,
     pub test_before_acquire: bool,
     /// PostgreSQL statement_timeout to set on each connection (in milliseconds)
     /// Set to None to use the database default
@@ -59,9 +58,8 @@ impl Default for PoolConfig {
             max_connections: 10,
             acquire_timeout: Duration::from_secs(10),
             idle_timeout: Some(Duration::from_secs(300)), // Close idle connections after 5 minutes
-            max_lifetime: Some(Duration::from_secs(1800)), // Force refresh connections after 30 minutes
-            test_before_acquire: true,                     // Test connection health before use
-            statement_timeout_ms: None,                    // Use database default
+            test_before_acquire: true,                    // Test connection health before use
+            statement_timeout_ms: None,                   // Use database default
         }
     }
 }
@@ -101,10 +99,6 @@ pub async fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPoo
 
     if let Some(idle_timeout) = config.idle_timeout {
         options = options.idle_timeout(idle_timeout);
-    }
-
-    if let Some(max_lifetime) = config.max_lifetime {
-        options = options.max_lifetime(max_lifetime);
     }
 
     // If statement_timeout is configured, set it via after_connect hook

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -201,19 +201,6 @@ pub struct Config {
     #[envconfig(default = "300")]
     pub idle_timeout_secs: u64,
 
-    // Force refresh connections after this many seconds regardless of activity
-    // - Set to 0 to disable (connections never refresh automatically)
-    // - Decrease for unreliable networks or frequent DB restarts (e.g., 600-900)
-    // - Increase for stable environments to reduce overhead (e.g., 3600-7200)
-    #[envconfig(default = "1800")]
-    pub max_lifetime_secs: u64,
-
-    // Additional maximum jitter to max_lifetime to avoid thundering herd.
-    // - Adds random amount of seconds [0, max_lifetime_jitter_secs) to max_lifetime_secs
-    // - Set to 0 to disable (uses fixed max_lifetime).
-    #[envconfig(default = "1800")]
-    pub max_lifetime_jitter_secs: u64,
-
     // Test connection health before returning from pool
     // - Set to true for production to catch stale connections
     // - Set to false in tests or very stable environments for slight performance gain
@@ -373,8 +360,6 @@ impl Config {
             max_pg_connections: 10,
             acquire_timeout_secs: 3,
             idle_timeout_secs: 300,
-            max_lifetime_secs: 1800,
-            max_lifetime_jitter_secs: 1800,
             test_before_acquire: FlexBool(true),
             non_persons_reader_statement_timeout_ms: 5000,
             persons_reader_statement_timeout_ms: 5000,

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -1,7 +1,6 @@
 use crate::api::errors::FlagError;
 use crate::config::Config;
 use common_database::{get_pool_with_config, PoolConfig};
-use rand::Rng;
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,16 +30,6 @@ impl DatabasePools {
             acquire_timeout: Duration::from_secs(config.acquire_timeout_secs),
             idle_timeout: if config.idle_timeout_secs > 0 {
                 Some(Duration::from_secs(config.idle_timeout_secs))
-            } else {
-                None
-            },
-            max_lifetime: if config.max_lifetime_secs > 0 {
-                let jitter = if config.max_lifetime_jitter_secs > 0 {
-                    rand::thread_rng().gen_range(0..config.max_lifetime_jitter_secs)
-                } else {
-                    0
-                };
-                Some(Duration::from_secs(config.max_lifetime_secs + jitter))
             } else {
                 None
             },
@@ -154,7 +143,6 @@ impl DatabasePools {
             max_connections = config.max_pg_connections,
             acquire_timeout_secs = config.acquire_timeout_secs,
             idle_timeout_secs = config.idle_timeout_secs,
-            max_lifetime_secs = config.max_lifetime_secs,
             test_before_acquire = config.test_before_acquire.0,
             non_persons_reader_statement_timeout_ms =
                 config.non_persons_reader_statement_timeout_ms,


### PR DESCRIPTION
## Problem

We see periodic latency spikes we believe to be caused by the [`max_lifetime`](https://docs.rs/sqlx/latest/sqlx/pool/struct.PoolOptions.html?utm_source=chatgpt.com#method.max_lifetime) setting in our database connection pools. Connections are being recycled every 30-60 minutes (base 30min + up to 30min jitter), causing temporary performance degradation.

Our infrastructure doesn't benefit from this setting:
- **Direct RDS access**: No pgbouncer, no connection pooler with TTL enforcement
- **No connection TTLs**: RDS doesn't kill long-lived connections
- **Static read replicas**: We don't use Aurora auto-scaling, so connections don't need to rebalance across new instances
- **Statement timeouts prevent session bloat**: We set `statement_timeout` per-connection rather than relying on session state

`max_lifetime` is useful when:
- Network infrastructure kills long-lived TCP sessions (_e.g. load balancers, NAT gateways, firewalls that silently drop connections after N minutes/hours_)
- DB provider enforces connection TTLs (match their TTL to close gracefully)
- Need connections to pick up new global settings
- Aurora auto-scaling adds/removes read replicas and connections need to rebalance

Since none of these apply to our setup, removing `max_lifetime` eliminates unnecessary connection churn while relying on `idle_timeout` to close unused connections.

## Changes

Removed `max_lifetime_secs` and `max_lifetime_jitter_secs` from:
- `rust/common/database/src/lib.rs` - pool configuration
- `rust/feature-flags/src/config.rs` - environment config
- `rust/feature-flags/src/database_pools.rs` - pool initialization

**Note**: If we enable Aurora auto-scaling in the future, we may need to re-add a long `max_lifetime` (4+ hours) to allow connections to redistribute across new read replicas.

## How did you test this code?

Manual testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
