### PR TITLE
fix(flags): Bump rate limits to match /decide

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -360,13 +360,13 @@ pub struct Config {
     pub flags_rate_limit_enabled: FlexBool,
 
     // Token bucket capacity (maximum burst size)
-    // Matches Python's DecideRateThrottle default of 100
-    #[envconfig(from = "FLAGS_BUCKET_CAPACITY", default = "100")]
+    // Matches Python's DecideRateThrottle default of 500
+    #[envconfig(from = "FLAGS_BUCKET_CAPACITY", default = "500")]
     pub flags_bucket_capacity: u32,
 
     // Token bucket replenish rate (tokens per second)
-    // Matches Python's DecideRateThrottle default of 5.0
-    #[envconfig(from = "FLAGS_BUCKET_REPLENISH_RATE", default = "5.0")]
+    // Matches Python's DecideRateThrottle default of 10.0
+    #[envconfig(from = "FLAGS_BUCKET_REPLENISH_RATE", default = "10.0")]
     pub flags_bucket_replenish_rate: f64,
 
     // IP-based rate limiting configuration
@@ -376,11 +376,12 @@ pub struct Config {
     pub flags_ip_rate_limit_enabled: FlexBool,
 
     // IP rate limit burst size (maximum requests per IP in a burst)
-    #[envconfig(from = "FLAGS_IP_BURST_SIZE", default = "100")]
+    #[envconfig(from = "FLAGS_IP_BURST_SIZE", default = "1000")]
     pub flags_ip_burst_size: u32,
 
     // IP rate limit replenish rate (requests per second per IP)
-    #[envconfig(from = "FLAGS_IP_REPLENISH_RATE", default = "20.0")]
+    // Set higher than token bucket rate to account for multiple users behind same IP
+    #[envconfig(from = "FLAGS_IP_REPLENISH_RATE", default = "50.0")]
     pub flags_ip_replenish_rate: f64,
 }
 
@@ -441,11 +442,11 @@ impl Config {
             object_storage_region: "us-east-1".to_string(),
             object_storage_endpoint: "".to_string(),
             flags_rate_limit_enabled: FlexBool(false),
-            flags_bucket_capacity: 100,
-            flags_bucket_replenish_rate: 5.0,
+            flags_bucket_capacity: 500,
+            flags_bucket_replenish_rate: 10.0,
             flags_ip_rate_limit_enabled: FlexBool(false),
-            flags_ip_burst_size: 100,
-            flags_ip_replenish_rate: 20.0,
+            flags_ip_burst_size: 500,
+            flags_ip_replenish_rate: 100.0,
         }
     }
 


### PR DESCRIPTION
## Problem

Somehow I chose the wrong values initially. It's fine, rate limiting is disabled by default. But when we enable it, might as well have the defaults make sense.

## Changes

Make the defaults match what we had on `/decide`

## How did you test this code?

Unit Tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
