### PR TITLE
feat(plux): track scene views

### DIFF
--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -2,21 +2,28 @@ import { DependencyList, useEffect } from 'react'
 
 import api from 'lib/api'
 
-type FileSystemLogViewType = 'experiment' | 'feature_flag' | 'insight' | 'dashboard'
+type FileSystemLogViewType = 'experiment' | 'feature_flag' | 'insight' | 'dashboard' | 'scene'
 
-export interface UseFileSystemLogViewOptions {
+interface TrackFileSystemLogViewOptions {
     type: FileSystemLogViewType
     ref: string | number | null | undefined
     enabled?: boolean
+}
+
+export interface UseFileSystemLogViewOptions extends TrackFileSystemLogViewOptions {
     deps: DependencyList
 }
 
-export function useFileSystemLogView({ type, ref, enabled = true, deps }: UseFileSystemLogViewOptions): void {
-    useEffect(() => {
-        if (!enabled || ref === null || ref === undefined) {
-            return
-        }
+export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileSystemLogViewOptions): void {
+    if (!enabled || ref === null || ref === undefined) {
+        return
+    }
 
-        void api.fileSystemLogView.create({ type, ref: String(ref) })
+    void api.fileSystemLogView.create({ type, ref: String(ref) })
+}
+
+export function useFileSystemLogView({ deps, ...options }: UseFileSystemLogViewOptions): void {
+    useEffect(() => {
+        trackFileSystemLogView(options)
     }, deps)
 }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -221,7 +221,6 @@ export const defaultMocks: Mocks = {
         'api/projects/:team_id/notebooks/recording_comments': EMPTY_PAGINATED_RESPONSE,
         '/api/sdk_versions/': sdkVersions,
         '/api/team_sdk_versions/': teamSdkVersions,
-        '/api/environments/:team_id/file_system/log_view/': {},
     },
     post: {
         'https://us.i.posthog.com/e/': (req, res, ctx): MockSignature => posthogCORSResponse(req, res, ctx),
@@ -233,6 +232,7 @@ export const defaultMocks: Mocks = {
         'https://us.i.posthog.com/engage/': (req, res, ctx): MockSignature => posthogCORSResponse(req, res, ctx),
         '/api/environments/:team_id/insights/viewed/': (): MockSignature => [201, null],
         'api/environments/:team_id/query': [200, { results: [] }],
+        '/api/environments/:team_id/file_system/log_view/': {},
     },
     patch: {
         '/api/projects/:team_id/session_recording_playlists/:playlist_id/': {},

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -221,6 +221,7 @@ export const defaultMocks: Mocks = {
         'api/projects/:team_id/notebooks/recording_comments': EMPTY_PAGINATED_RESPONSE,
         '/api/sdk_versions/': sdkVersions,
         '/api/team_sdk_versions/': teamSdkVersions,
+        '/api/environments/:team_id/file_system/log_view/': {},
     },
     post: {
         'https://us.i.posthog.com/e/': (req, res, ctx): MockSignature => posthogCORSResponse(req, res, ctx),


### PR DESCRIPTION
## Problem

We would like to show you relevant things in the interface.

## Changes

Keep track of the apps you visit, so we could show them higher up in the list.

Send a file system log view tracking request every time you open a new scene. The "type" is "scene", and the "ref" is the name of the scene.

We don't use this information anywhere yet. We just track it.

## How did you test this code?

Clicked around locally, saw all the `log_view` API requests whenever I first opened a scene, or whenever I changed it.
