### PR TITLE
fix(ux): new scene tab events and properties urls

### DIFF
--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -457,12 +457,12 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         id: `event-definition-${eventDef.id}`,
                         name: eventDef.name,
                         category: 'eventDefinitions' as NEW_TAB_CATEGORY_ITEMS,
-                        href: `events://${eventDef.name}`,
+                        href: urls.eventDefinition(eventDef.id),
                         icon: <IconToggle />,
                         record: {
                             type: 'event-definition',
                             path: `Event: ${eventDef.name}`,
-                            href: `events://${eventDef.name}`,
+                            href: urls.eventDefinition(eventDef.id),
                         },
                     }
                     return item

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -478,12 +478,12 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         id: `property-definition-${propDef.id}`,
                         name: propDef.name,
                         category: 'propertyDefinitions' as NEW_TAB_CATEGORY_ITEMS,
-                        href: `properties://${propDef.name}`,
+                        href: urls.propertyDefinition(propDef.id),
                         icon: <IconApps />,
                         record: {
                             type: 'property-definition',
                             path: `Property: ${propDef.name}`,
-                            href: `properties://${propDef.name}`,
+                            href: urls.propertyDefinition(propDef.id),
                         },
                     }
                     return item

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -2,7 +2,7 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
-import { IconApps, IconArrowRight, IconDatabase, IconHogQL, IconPerson, IconSparkles, IconToggle } from '@posthog/icons'
+import { IconApps, IconArrowRight, IconDatabase, IconHogQL, IconPerson, IconSparkles } from '@posthog/icons'
 
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -458,7 +458,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         name: eventDef.name,
                         category: 'eventDefinitions' as NEW_TAB_CATEGORY_ITEMS,
                         href: urls.eventDefinition(eventDef.id),
-                        icon: <IconToggle />,
+                        icon: <IconApps />,
                         record: {
                             type: 'event-definition',
                             path: `Event: ${eventDef.name}`,

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -168,7 +168,6 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Event definitions',
         activityScope: ActivityScope.EVENT_DEFINITION,
         defaultDocsPath: '/docs/data/events',
-        description: 'Event definitions are a way to define events that can be used in your app or website.',
         iconType: 'event_definition',
     },
     [Scene.Experiment]: {


### PR DESCRIPTION
## Problem
both event and property urls are broken
events have wrong icon
both event and property definition scenes had a generic scene title description, which is not intended

![2025-10-24 09 34 18](https://github.com/user-attachments/assets/7848b7e3-726d-44fc-bc7f-c1f2c9df4642)

## Changes
fixed those things