### PR TITLE
chore: sync PostHog django middleware

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -21,6 +21,7 @@ from django.utils.cache import add_never_cache_headers
 import structlog
 from django_prometheus.middleware import Metrics
 from loginas.utils import is_impersonated_session, restore_original_login
+from posthoganalytics.integrations.django import PosthogContextMiddleware
 from rest_framework import status
 from social_core.exceptions import AuthFailed
 from statshog.defaults.django import statsd
@@ -776,3 +777,8 @@ class SocialAuthExceptionMiddleware:
 
         # Handle other exceptions with existing middleware
         return None
+
+
+class SyncPostHogContextMiddleware(PosthogContextMiddleware):
+    # Our middlewares are synchronous, but PostHog middleware supports async.
+    async_capable = False

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -110,7 +110,7 @@ MIDDLEWARE = [
     "posthog.middleware.CHQueries",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
     "posthog.middleware.PostHogTokenCookieMiddleware",
-    "posthoganalytics.integrations.django.PosthogContextMiddleware",
+    "posthog.middleware.SyncPostHogContextMiddleware",
 ]
 
 DJANGO_STRUCTLOG_CELERY_ENABLED = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
     "pdpyras==5.4.1",
     "phonenumberslite==8.13.6",
     "pillow==10.2.0",
-    "posthoganalytics>=6.7.4",
+    "posthoganalytics>=6.7.9",
     "psutil==6.0.0",
     "psycopg2-binary==2.9.10",
     "psycopg[binary]==3.2.4",

--- a/uv.lock
+++ b/uv.lock
@@ -4492,7 +4492,7 @@ requires-dist = [
     { name = "phonenumberslite", specifier = "==8.13.6" },
     { name = "pillow", specifier = "==10.2.0" },
     { name = "playwright", specifier = ">=1.54.0" },
-    { name = "posthoganalytics", specifier = ">=6.7.4" },
+    { name = "posthoganalytics", specifier = ">=6.7.9" },
     { name = "psutil", specifier = "==6.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.4" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },
@@ -4622,7 +4622,7 @@ dev = [
 
 [[package]]
 name = "posthoganalytics"
-version = "6.7.4"
+version = "6.7.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -4632,9 +4632,9 @@ dependencies = [
     { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/3e/8a6896a2e998a0e82f0eae74e1dfaf958a80117cb4ddf5653af5e4abb74d/posthoganalytics-6.7.4.tar.gz", hash = "sha256:fe63d288c76b983ff9a5c849d1ea2dafbb1bdd9e1140929008589315747cfd03", size = 118715, upload-time = "2025-09-05T15:29:24.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/50/dd77d74f4ed8496e715e42d3fc94f63c2d2fb63bffddd07f2c663e7900bd/posthoganalytics-6.7.9.tar.gz", hash = "sha256:f2442b81f56b06190a93cac883fdf8df0c057ee53f704ce41bf5a9d84840fb02", size = 120686, upload-time = "2025-10-22T20:53:43.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/af/1088ecedc1191ea0435d7e430c911338f9524255e5ae7a58d8cae9c88dcb/posthoganalytics-6.7.4-py3-none-any.whl", hash = "sha256:ecba38780c263282df2cd1f3b5f14d822cbab7779b66a0d1cf58ce6525614c98", size = 137701, upload-time = "2025-09-05T15:29:23.75Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f4/598c4ff39315154fa6e159983b64f552aa75583da0138458bcc1d204f6fe/posthoganalytics-6.7.9-py3-none-any.whl", hash = "sha256:340b77df7d53f50ac985e8763004335cae53c412e1d891aa2878865ab8931b49", size = 139768, upload-time = "2025-10-22T20:53:41.813Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`posthog-python` ships the [async middleware](https://github.com/PostHog/posthog-python/pull/328/files#diff-2535fcbdba1f6b0f83c106f97c77ab7d9529bf6b0e9de28df63794b56d57d58eR46). When we upgrade `posthoganalytics` to a new version, Django can't handle a request because all our middleware is sync. Either all middleware should be async or sync.

[More context](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1760722812575849)

## Changes

- Make PostHog Django middleware sync.

## How did you test this code?

Manual testing only