### PR TITLE
fix(batch-exports): Add timeouts for Snowflake queries

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -493,10 +493,10 @@ class SnowflakeClient:
                 # Get the final query status to provide context in the error message
                 final_status = await self.get_query_status(query_id, throw_if_error=False)
                 self.logger.warning(
-                    "Query '%s' timed out after %.2fs with status '%s'",
-                    query_id,
+                    "Query timed out after %.2fs with status '%s'",
                     timeout,
                     final_status.name if final_status else "UNKNOWN",
+                    query_id=query_id,
                 )
 
                 # Cancel the query in Snowflake to prevent it from continuing to run
@@ -513,20 +513,20 @@ class SnowflakeClient:
 
         query_execution_time = time.monotonic() - query_start_time
         self.logger.debug(
-            "Async query '%s' finished with status '%s' in %.2fs", query_id, query_status, query_execution_time
+            "Async query finished with status '%s' in %.2fs", query_status, query_execution_time, query_id=query_id
         )
 
         if fetch_results is False:
             return None
 
-        self.logger.debug("Fetching query results for query '%s'", query_id)
+        self.logger.debug("Fetching query results", query_id=query_id)
 
         with self.connection.cursor() as cursor:
             await asyncio.to_thread(cursor.get_results_from_sfqid, query_id)
             results = await asyncio.to_thread(cursor.fetchall)
             description = cursor.description
 
-        self.logger.debug("Finished fetching query results for %s", query)
+        self.logger.debug("Finished fetching query results", query_id=query_id)
 
         return results, description
 

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -170,11 +170,10 @@ class SnowflakeIncompatibleSchemaError(Exception):
 class SnowflakeQueryTimeoutError(Exception):
     """Raised when a Snowflake query times out."""
 
-    def __init__(self, operation: str, timeout: float, query_id: str, query_status: str):
+    def __init__(self, timeout: float, query_id: str, query_status: str):
         """Initialize the exception with context about the timeout.
 
         Args:
-            operation: The operation that timed out (e.g., "COPY INTO", "MERGE")
             timeout: The timeout duration in seconds
             query_id: The Snowflake query ID for debugging
             query_status: The status of the query when timeout occurred
@@ -190,9 +189,7 @@ class SnowflakeQueryTimeoutError(Exception):
 
         guidance = status_guidance.get(query_status, f"Query status: {query_status}")
 
-        super().__init__(
-            f"{operation} operation timed out after {timeout:.0f} seconds (query_id: {query_id}). {guidance}"
-        )
+        super().__init__(f"Query timed out after {timeout:.0f} seconds (query_id: {query_id}). {guidance}")
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -497,7 +494,6 @@ class SnowflakeClient:
                 await self.abort_query(query_id)
 
                 raise SnowflakeQueryTimeoutError(
-                    operation="Query",
                     timeout=timeout,
                     query_id=query_id,
                     query_status=final_status.name if final_status else "UNKNOWN",

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
@@ -1,0 +1,101 @@
+"""
+Test SnowflakeClient timeout behavior.
+
+Note: This module uses a real Snowflake connection.
+"""
+
+import datetime as dt
+
+import pytest
+
+from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import (
+    SnowflakeClient,
+    SnowflakeInsertInputs,
+    SnowflakeQueryTimeoutError,
+)
+from products.batch_exports.backend.tests.temporal.destinations.snowflake.utils import SKIP_IF_MISSING_REQUIRED_ENV_VARS
+
+pytestmark = [
+    pytest.mark.asyncio,
+    SKIP_IF_MISSING_REQUIRED_ENV_VARS,
+]
+
+
+@pytest.fixture
+async def snowflake_client_with_test_schema(snowflake_config, database, schema):
+    """Create a SnowflakeClient with a test database and schema set up and cleaned up after tests."""
+
+    inputs = SnowflakeInsertInputs(
+        team_id=1,  # not important for this test
+        data_interval_start=(
+            dt.datetime.now(dt.UTC) - dt.timedelta(hours=1)
+        ).isoformat(),  # not important for this test
+        data_interval_end=(dt.datetime.now(dt.UTC)).isoformat(),  # not important for this test
+        table_name="test_table",  # not important for this test
+        **snowflake_config,
+    )
+
+    async with SnowflakeClient.from_inputs(inputs).connect(use_namespace=False) as client:
+        # Set up: Create database and schema
+        await client.execute_async_query(f'CREATE DATABASE IF NOT EXISTS "{database}"', fetch_results=False)
+        await client.execute_async_query(f'CREATE SCHEMA IF NOT EXISTS "{database}"."{schema}"', fetch_results=False)
+        await client.execute_async_query(f'USE SCHEMA "{database}"."{schema}"', fetch_results=False)
+
+        yield client
+
+        # Tear down: Clean up database
+        await client.execute_async_query(f'DROP DATABASE IF EXISTS "{database}" CASCADE', fetch_results=False)
+
+
+async def test_execute_async_query_with_timeout_raises_error(snowflake_client_with_test_schema):
+    """Test that execute_async_query raises SnowflakeQueryTimeoutError when timeout is exceeded.
+
+    This test uses a real Snowflake connection and runs a query that will take longer than
+    the specified timeout. We use a SYSTEM$WAIT() call to simulate a long-running query.
+    """
+    # Execute a query that will sleep for 10 seconds but with a 1 second timeout
+    # This should raise a SnowflakeQueryTimeoutError
+    with pytest.raises(SnowflakeQueryTimeoutError) as exc_info:
+        await snowflake_client_with_test_schema.execute_async_query(
+            "CALL SYSTEM$WAIT(120)",  # Sleep for 10 seconds
+            timeout=1.0,  # Timeout after 1 second
+        )
+
+    # Verify the exception has the correct information
+    error_message = str(exc_info.value)
+    assert "Query operation timed out after 1 seconds" in error_message
+    assert "query_id:" in error_message
+    # The query status should be RUNNING since the sleep is still executing
+    assert (
+        "Query is still running but exceeded timeout" in error_message
+        or "Warehouse is overloaded" in error_message
+        or "Warehouse is resuming" in error_message
+    )
+
+
+async def test_execute_async_query_without_timeout_completes(snowflake_client_with_test_schema):
+    """Test that execute_async_query completes successfully when no timeout is specified."""
+    # Execute a simple query without a timeout - should complete successfully
+    result = await snowflake_client_with_test_schema.execute_async_query("SELECT 1 AS test_column")
+
+    # Verify the query completed successfully
+    assert result is not None
+    results, description = result
+    assert len(results) == 1
+    assert results[0][0] == 1
+    assert description[0].name.upper() == "TEST_COLUMN"
+
+
+async def test_execute_async_query_completes_within_timeout(snowflake_client_with_test_schema):
+    """Test that execute_async_query completes successfully when query finishes before timeout."""
+    # Execute a quick query with a generous timeout - should complete successfully
+    result = await snowflake_client_with_test_schema.execute_async_query(
+        "SELECT 1 AS test_column",
+        timeout=60.0,  # 60 second timeout, query should complete in < 1 second
+    )
+
+    # Verify the query completed successfully
+    assert result is not None
+    results, _description = result
+    assert len(results) == 1
+    assert results[0][0] == 1

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
@@ -65,7 +65,7 @@ async def test_execute_async_query_with_timeout_raises_error(snowflake_client):
 
     # Verify the exception has the correct information
     error_message = str(exc_info.value)
-    assert "Query operation timed out after 1 seconds" in error_message
+    assert "Query timed out after 1 seconds" in error_message
     assert "query_id:" in error_message
     # The query status should be RUNNING since the sleep is still executing
     assert (

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_utils.py
@@ -1,0 +1,69 @@
+import datetime as dt
+
+import pytest
+
+from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import (
+    SnowflakeQueryTimeoutError,
+    _get_snowflake_query_timeout,
+)
+
+
+@pytest.mark.parametrize(
+    "data_interval_start, data_interval_end, expected_timeout",
+    [
+        # when no data interval start is provided, we use the max timeout of 6 hours
+        (None, dt.datetime(2025, 1, 1, 12, 0, 0), 6 * 60 * 60),
+        # when the interval is 1 day we use the max timeout of 6 hours
+        (dt.datetime(2025, 1, 1, 0, 0, 0), dt.datetime(2025, 1, 2, 0, 0, 0), 6 * 60 * 60),
+        # when the interval is 1 hour we expect the timeout to be 48 minutes (as we multiply the interval by 0.8)
+        (dt.datetime(2025, 1, 1, 12, 0, 0), dt.datetime(2025, 1, 1, 13, 0, 0), 48 * 60),
+        # when interval is 5 minutes, we expect the timeout to be the minimum timeout of 20 minutes
+        (dt.datetime(2025, 1, 1, 12, 0, 0), dt.datetime(2025, 1, 1, 12, 5, 0), 20 * 60),
+    ],
+)
+def test_get_snowflake_query_timeout(data_interval_start, data_interval_end, expected_timeout):
+    assert _get_snowflake_query_timeout(data_interval_start, data_interval_end) == expected_timeout
+
+
+@pytest.mark.parametrize(
+    "query_status, expected_guidance",
+    [
+        (
+            "QUEUED",
+            "Warehouse is overloaded with queued queries. Consider scaling up warehouse or reducing concurrent queries.",
+        ),
+        (
+            "RESUMING_WAREHOUSE",
+            "Warehouse is resuming from suspended state. Consider keeping warehouse running or using larger warehouse.",
+        ),
+        (
+            "QUEUED_REPARING_WAREHOUSE",
+            "Warehouse is repairing. Retry later or contact Snowflake support.",
+        ),
+        (
+            "BLOCKED",
+            "Query is blocked. Check for locks or resource contention.",
+        ),
+        (
+            "RUNNING",
+            "Query is still running but exceeded timeout. Consider using a larger warehouse or reducing the number of concurrent queries.",
+        ),
+        (
+            "UNKNOWN_STATUS",
+            "Query status: UNKNOWN_STATUS",
+        ),
+    ],
+)
+def test_snowflake_query_timeout_error_message(query_status, expected_guidance):
+    """Test that SnowflakeQueryTimeoutError provides helpful context based on query status."""
+    error = SnowflakeQueryTimeoutError(
+        operation="COPY INTO",
+        timeout=1800.0,
+        query_id="abc123",
+        query_status=query_status,
+    )
+
+    error_message = str(error)
+    assert "COPY INTO operation timed out after 1800 seconds" in error_message
+    assert "query_id: abc123" in error_message
+    assert expected_guidance in error_message

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_utils.py
@@ -2,10 +2,7 @@ import datetime as dt
 
 import pytest
 
-from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import (
-    SnowflakeQueryTimeoutError,
-    _get_snowflake_query_timeout,
-)
+from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import _get_snowflake_query_timeout
 
 
 @pytest.mark.parametrize(
@@ -23,47 +20,3 @@ from products.batch_exports.backend.temporal.destinations.snowflake_batch_export
 )
 def test_get_snowflake_query_timeout(data_interval_start, data_interval_end, expected_timeout):
     assert _get_snowflake_query_timeout(data_interval_start, data_interval_end) == expected_timeout
-
-
-@pytest.mark.parametrize(
-    "query_status, expected_guidance",
-    [
-        (
-            "QUEUED",
-            "Warehouse is overloaded with queued queries. Consider scaling up warehouse or reducing concurrent queries.",
-        ),
-        (
-            "RESUMING_WAREHOUSE",
-            "Warehouse is resuming from suspended state. Consider keeping warehouse running or using larger warehouse.",
-        ),
-        (
-            "QUEUED_REPARING_WAREHOUSE",
-            "Warehouse is repairing. Retry later or contact Snowflake support.",
-        ),
-        (
-            "BLOCKED",
-            "Query is blocked. Check for locks or resource contention.",
-        ),
-        (
-            "RUNNING",
-            "Query is still running but exceeded timeout. Consider using a larger warehouse or reducing the number of concurrent queries.",
-        ),
-        (
-            "UNKNOWN_STATUS",
-            "Query status: UNKNOWN_STATUS",
-        ),
-    ],
-)
-def test_snowflake_query_timeout_error_message(query_status, expected_guidance):
-    """Test that SnowflakeQueryTimeoutError provides helpful context based on query status."""
-    error = SnowflakeQueryTimeoutError(
-        operation="COPY INTO",
-        timeout=1800.0,
-        query_id="abc123",
-        query_status=query_status,
-    )
-
-    error_message = str(error)
-    assert "COPY INTO operation timed out after 1800 seconds" in error_message
-    assert "query_id: abc123" in error_message
-    assert expected_guidance in error_message


### PR DESCRIPTION
## Problem

Currently, we don't set any timeout for Snowflake queries in batch exports. This can be a problem if the warehouse being used is over-utilised and queries are being queued, because these queries could take hours to complete, in which case we will continually retry, causing additional compute resources to be consumed, the warehouse queue becoming longer, and SLAs being breached.

## Changes

- Add a query timeout for certain queries (`COPY INTO` and `MERGE`)
  - this timeout is based on the data interval of the batch export
- Ensure we abort any queries before we raise a timeout error
- Raise a new non-retryable exception: `SnowflakeQueryTimeoutError`
  - in this error we provide useful context to the user based on what the final query status was before we timed out 

## How did you test this code?

Added new tests.

Ran existing tests using real Snowflake instance.
