### PR TITLE
fix: capture exception to posthog if we clobber tzinfo in hog filters

### DIFF
--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -10,6 +10,7 @@ from posthog.hogql.errors import QueryError
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.visitor import CloningVisitor
 
+from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.utils import relative_date_parse
 
@@ -114,6 +115,13 @@ class ReplaceFilters(CloningVisitor):
             if dateTo is not None:
                 try:
                     parsed_date = isoparse(dateTo).replace(tzinfo=self.team.timezone_info)
+                    if isoparse(dateTo).tzinfo is None:
+                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
+                        # create a temporary exception just to capture it and make debugging easier
+                        try:
+                            raise Exception("timezone would be overridden")
+                        except Exception as e:
+                            capture_exception(e)
                 except ValueError:
                     parsed_date = relative_date_parse(dateTo, self.team.timezone_info)
                 exprs.append(
@@ -129,6 +137,13 @@ class ReplaceFilters(CloningVisitor):
             if dateFrom is not None and dateFrom != "all":
                 try:
                     parsed_date = isoparse(dateFrom).replace(tzinfo=self.team.timezone_info)
+                    if isoparse(dateFrom).tzinfo is None:
+                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
+                        # create a temporary exception just to capture it and make debugging easier
+                        try:
+                            raise Exception("timezone would be overridden")
+                        except Exception as e:
+                            capture_exception(e)
                 except ValueError:
                     parsed_date = relative_date_parse(dateFrom, self.team.timezone_info)
                 exprs.append(
@@ -161,6 +176,13 @@ class ReplaceFilters(CloningVisitor):
             if dateFrom is not None and dateFrom != "all":
                 try:
                     parsed_date = isoparse(dateFrom).replace(tzinfo=self.team.timezone_info)
+                    if isoparse(dateFrom).tzinfo is None:
+                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
+                        # create a temporary exception just to capture it and make debugging easier
+                        try:
+                            raise Exception("timezone would be overridden")
+                        except Exception as e:
+                            capture_exception(e)
                 except ValueError:
                     parsed_date = relative_date_parse(dateFrom, self.team.timezone_info)
 
@@ -181,6 +203,13 @@ class ReplaceFilters(CloningVisitor):
             if dateTo is not None:
                 try:
                     parsed_date = isoparse(dateTo).replace(tzinfo=self.team.timezone_info)
+                    if isoparse(dateTo).tzinfo is None:
+                        # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
+                        # create a temporary exception just to capture it and make debugging easier
+                        try:
+                            raise Exception("timezone would be overridden")
+                        except Exception as e:
+                            capture_exception(e)
                 except ValueError:
                     parsed_date = relative_date_parse(dateTo, self.team.timezone_info)
                 return ast.Constant(value=parsed_date)


### PR DESCRIPTION

## Problem

i want to merge #39975 but i'm scared

i suspect that we should not be overriding the timezone here - before i fix this i want to make sure we don't rely on this weird behaviour anywhere

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
