### PR TITLE
fix: there's an unmount race - oh no!

### DIFF
--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -94,8 +94,10 @@ export function cleanupTooltip(id: string): void {
         if (instance.hideTimeout) {
             clearTimeout(instance.hideTimeout)
         }
-        instance.root.unmount()
-        instance.element.remove()
+        queueMicrotask(() => {
+            instance.root.unmount()
+            instance.element.remove()
+        })
         tooltipInstances.delete(id)
     }
 }


### PR DESCRIPTION
every so often I'd spot this message in the console

```
Warning: Attempted to synchronously unmount a root while React was already rendering. React cannot finish unmounting the root until the current render has completed, which may lead to a race condition.
    at LineGraph_ (http://localhost:8234/src/scenes/insights/views/LineGraph/LineGraph.tsx:167:13)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=fb1edf98:279:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx:25:33)
    at LineGraph (http://localhost:8234/src/scenes/insights/views/LineGraph/LineGraph.tsx:150:108)
    at ActionsLineGraph (http://localhost:8234/src/scenes/trends/viz/ActionsLineGraph.tsx:34:3)
    at div
    at TrendInsight (http://localhost:8234/src/scenes/trends/Trends.tsx:28:32)
    at div
    at div
    at InsightVizDisplay (http://localhost:8234/src/queries/nodes/InsightViz/InsightVizDisplay.tsx:54:3)
    at div
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-WJC6LIR2.js?v=fb1edf98:2350:20)
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-WJC6LIR2.js?v=fb1edf98:2350:20)
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-WJC6LIR2.js?v=fb1edf98:2350:20)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=fb1edf98:279:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx:25:33)
    at InsightViz (http://localhost:8234/src/queries/nodes/InsightViz/InsightViz.tsx:41:3)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=fb1edf98:279:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx:25:33)
    at Query (http://localhost:8234/src/queries/Query/Query.tsx:58:12)
    at div
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-WJC6LIR2.js?v=fb1edf98:2350:20)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=fb1edf98:279:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx:25:33)
```

the robot tells me this is the fix
i can't reliably reproduce it so 🤷 