### PR TITLE
fix: Fix wording and layout of verification page

### DIFF
--- a/frontend/src/scenes/authentication/EmailMFAVerify.tsx
+++ b/frontend/src/scenes/authentication/EmailMFAVerify.tsx
@@ -12,11 +12,11 @@ export function EmailMFAVerify(): JSX.Element {
     const { verifyAndLogin } = useActions(emailMFAVerifyLogic)
 
     return (
-        <BridgePage view="login" hedgehog>
-            <div className="px-12 py-8 text-center flex flex-col items-center max-w-160 w-full">
+        <BridgePage view="login" fixedWidth={false}>
+            <div className="px-12 py-8 text-center flex flex-col items-center max-w-320 w-full">
                 {view === 'ready' ? (
                     <>
-                        <h1 className="text-3xl font-bold">Almost in - just verify below!</h1>
+                        <h1 className="text-3xl font-bold">Almost in - just click below!</h1>
                         <div className="max-w-60 mb-12">
                             <HeartHog className="w-full h-full" />
                         </div>

--- a/frontend/src/scenes/authentication/EmailMFAVerify.tsx
+++ b/frontend/src/scenes/authentication/EmailMFAVerify.tsx
@@ -21,7 +21,6 @@ export function EmailMFAVerify(): JSX.Element {
                             <HeartHog className="w-full h-full" />
                         </div>
                         <p className="mb-6">Click below to verify your email address.</p>
-                        <p className="text-muted text-sm mb-6">This device will be remembered for 30 days</p>
                         <LemonButton
                             type="primary"
                             size="large"
@@ -32,6 +31,7 @@ export function EmailMFAVerify(): JSX.Element {
                         >
                             Login to PostHog
                         </LemonButton>
+                        <p className="text-muted text-sm mt-6">This device will be remembered for 30 days</p>
                     </>
                 ) : view === 'invalid' ? (
                     <>

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -96,7 +96,7 @@ export function Login(): JSX.Element {
         >
             {preflight?.cloud && <RedirectIfLoggedInOtherInstance />}
             <div className="deprecated-space-y-4">
-                <h2>Log in</h2>
+                <h2>{isEmailVerificationSent ? 'Check your email' : 'Log in'}</h2>
                 {generalError && (
                     <LemonBanner type={generalError.code === 'email_verification_sent' ? 'warning' : 'error'}>
                         {generalError.detail || ERROR_MESSAGES[generalError.code] || (
@@ -110,19 +110,21 @@ export function Login(): JSX.Element {
                 )}
                 {isEmailVerificationSent ? (
                     <div className="deprecated-space-y-4">
-                        <LemonButton
-                            type="secondary"
-                            fullWidth
-                            center
-                            size="large"
-                            loading={resendResponseLoading}
-                            onClick={() => resendEmailMFA(null)}
-                        >
-                            Resend verification email
-                        </LemonButton>
-                        <LemonButton type="tertiary" fullWidth center size="large" onClick={() => clearGeneralError()}>
-                            Back to login
-                        </LemonButton>
+                        <div className="flex justify-center">
+                            <LemonButton
+                                type="tertiary"
+                                size="small"
+                                loading={resendResponseLoading}
+                                onClick={() => resendEmailMFA(null)}
+                            >
+                                Resend verification email
+                            </LemonButton>
+                        </div>
+                        <div className="text-center">
+                            <Link onClick={() => clearGeneralError()} className="text-muted">
+                                Back to login
+                            </Link>
+                        </div>
                     </div>
                 ) : (
                     <Form logic={loginLogic} formKey="login" enableFormOnSubmit className="deprecated-space-y-4">

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -147,7 +147,8 @@ export const loginLogic = kea<loginLogicType>([
                         const emailAddress = detail?.email || email
                         actions.setGeneralError(
                             'email_verification_sent',
-                            `Check your email! We've sent a verification link to ${emailAddress}. Click the link to complete your login.`
+                            `For your security, we've sent a verification link to ${emailAddress}. Please check your inbox and click the link to complete
+  your login.`
                         )
                         throw e
                     }

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -251,7 +251,7 @@ class LoginSerializer(serializers.Serializer):
                 if email_mfa_sent:
                     # Increment the resend throttle counter so the initial send counts towards the limit
                     resend_throttle = EmailMFAResendThrottle()
-                    resend_throttle.allow_request(request, None)
+                    resend_throttle.allow_request(request, None)  # type: ignore[arg-type]
                     raise EmailMFARequired(user.email)
                 else:
                     # if we failed to send the email, we should fall through to allow login without MFA

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -249,6 +249,9 @@ class LoginSerializer(serializers.Serializer):
                 # Email MFA flow
                 email_mfa_sent = email_mfa_verifier.create_token_and_send_email_mfa_verification(request, user)
                 if email_mfa_sent:
+                    # Increment the resend throttle counter so the initial send counts towards the limit
+                    resend_throttle = EmailMFAResendThrottle()
+                    resend_throttle.allow_request(request, None)
                     raise EmailMFARequired(user.email)
                 else:
                     # if we failed to send the email, we should fall through to allow login without MFA


### PR DESCRIPTION
## Problem

- Users are confused with the new MFA verification screen

## Changes

- Fix resend throttle to allow resend after 60sec from the initial send.
- Change login page verification notice to be more explicit what's expected + make the resend smaller.
<img width="1085" height="716" alt="image" src="https://github.com/user-attachments/assets/f746ba4c-240f-4183-b614-becb65a5708e" />

- Change the verification page to be a single-hedgehog only :( :
<img width="1085" height="733" alt="image" src="https://github.com/user-attachments/assets/dd095765-f14e-4e9e-892f-fce44a2a8f5e" />


