### PR TITLE
fix(ux): new tab recents with pagination + prefetching 

### DIFF
--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -25,6 +25,7 @@ import { urls } from 'scenes/urls'
 
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { MenuItems } from '~/layout/panel-layout/ProjectTree/menus/MenuItems'
 import { SidePanelTab } from '~/types'
 
@@ -115,6 +116,7 @@ function Category({
     columnIndex: number
     isFirstCategoryWithResults: boolean
 }): JSX.Element {
+    const { mobileLayout } = useValues(navigationLogic)
     const groupRef = useRef<ListBoxGroupHandle>(null)
     const typedItems = items as NewTabTreeDataItem[]
     const isFirstCategory = columnIndex === 0
@@ -311,10 +313,13 @@ function Category({
                                                         onClick={() => {
                                                             const showMoreIndex = typedItems.length
                                                             showMoreInSection(category)
+
                                                             // Focus will be maintained automatically since the operation is now instant
-                                                            setTimeout(() => {
-                                                                groupRef.current?.resumeFocus(showMoreIndex)
-                                                            }, 0)
+                                                            if (mobileLayout) {
+                                                                setTimeout(() => {
+                                                                    groupRef.current?.resumeFocus(showMoreIndex)
+                                                                }, 0)
+                                                            }
                                                         }}
                                                         className="w-full text-tertiary data-[focused=true]:text-primary"
                                                     >
@@ -344,10 +349,11 @@ function Category({
 
                                                         showMoreInSection(category)
 
-                                                        // Restore focus to the item that replaces the "Show all" button
-                                                        setTimeout(() => {
-                                                            groupRef.current?.resumeFocus(showAllIndex)
-                                                        }, 0)
+                                                        if (mobileLayout) {
+                                                            setTimeout(() => {
+                                                                groupRef.current?.resumeFocus(showAllIndex)
+                                                            }, 0)
+                                                        }
                                                     }}
                                                     className="w-full text-tertiary data-[focused=true]:text-primary"
                                                 >

--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -314,11 +314,10 @@ function Category({
                                                             const showMoreIndex = typedItems.length
                                                             showMoreInSection(category)
 
-                                                            // Focus will be maintained automatically since the operation is now instant
-                                                            if (mobileLayout) {
+                                                            if (!mobileLayout) {
                                                                 setTimeout(() => {
                                                                     groupRef.current?.resumeFocus(showMoreIndex)
-                                                                }, 0)
+                                                                }, 10)
                                                             }
                                                         }}
                                                         className="w-full text-tertiary data-[focused=true]:text-primary"
@@ -346,13 +345,12 @@ function Category({
                                                     size="sm"
                                                     onClick={() => {
                                                         const showAllIndex = typedItems.length
-
                                                         showMoreInSection(category)
 
-                                                        if (mobileLayout) {
+                                                        if (!mobileLayout) {
                                                             setTimeout(() => {
                                                                 groupRef.current?.resumeFocus(showAllIndex)
-                                                            }, 0)
+                                                            }, 10)
                                                         }
                                                     }}
                                                     className="w-full text-tertiary data-[focused=true]:text-primary"

--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -25,7 +25,6 @@ import { urls } from 'scenes/urls'
 
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
-import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { MenuItems } from '~/layout/panel-layout/ProjectTree/menus/MenuItems'
 import { SidePanelTab } from '~/types'
 
@@ -116,7 +115,6 @@ function Category({
     columnIndex: number
     isFirstCategoryWithResults: boolean
 }): JSX.Element {
-    const { mobileLayout } = useValues(navigationLogic)
     const groupRef = useRef<ListBoxGroupHandle>(null)
     const typedItems = items as NewTabTreeDataItem[]
     const isFirstCategory = columnIndex === 0
@@ -314,11 +312,9 @@ function Category({
                                                             const showMoreIndex = typedItems.length
                                                             showMoreInSection(category)
 
-                                                            if (!mobileLayout) {
-                                                                setTimeout(() => {
-                                                                    groupRef.current?.resumeFocus(showMoreIndex)
-                                                                }, 10)
-                                                            }
+                                                            setTimeout(() => {
+                                                                groupRef.current?.resumeFocus(showMoreIndex)
+                                                            }, 0)
                                                         }}
                                                         className="w-full text-tertiary data-[focused=true]:text-primary"
                                                     >
@@ -347,11 +343,9 @@ function Category({
                                                         const showAllIndex = typedItems.length
                                                         showMoreInSection(category)
 
-                                                        if (!mobileLayout) {
-                                                            setTimeout(() => {
-                                                                groupRef.current?.resumeFocus(showAllIndex)
-                                                            }, 10)
-                                                        }
+                                                        setTimeout(() => {
+                                                            groupRef.current?.resumeFocus(showAllIndex)
+                                                        }, 0)
                                                     }}
                                                     className="w-full text-tertiary data-[focused=true]:text-primary"
                                                 >

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -1237,7 +1237,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
         loadRecentsSuccess: () => {
             // Prefetch next batch when recents load successfully and we have more
             const recents = values.recents
-            if (recents.hasMore && !values.recentsPrefetchedBatch && values.recentsExpanded) {
+            if (recents.hasMore && !values.recentsPrefetchedBatch) {
                 actions.prefetchNextRecents()
             }
         },

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -76,7 +76,7 @@ export interface NewTabCategoryItem {
     description?: string
 }
 
-const PAGINATION_LIMIT = 10
+const PAGINATION_LIMIT = 5
 
 function getIconForFileSystemItem(fs: FileSystemImport): JSX.Element {
     // If the item has a direct icon property, use it with color wrapper
@@ -144,7 +144,11 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     const searchTerm = values.search.trim()
                     const currentRecents = values.recents
                     const currentlyExpanded = values.recentsExpanded
-                    const currentTotalLoaded = currentlyExpanded ? currentRecents.totalLoaded : PAGINATION_LIMIT
+
+                    // For refresh: maintain current view, for initial load: use default limit
+                    const isRefresh = currentRecents.results.length > 0
+                    const currentTotalLoaded =
+                        isRefresh && currentlyExpanded ? currentRecents.totalLoaded : PAGINATION_LIMIT
 
                     const response = await api.fileSystem.list({
                         search: searchTerm,


### PR DESCRIPTION
## Problem
We want to keep expanding recents passed the current limit of 5 + 5 more...

![2025-10-24 15 34 14](https://github.com/user-attachments/assets/b74bb284-bf72-44e3-9fd4-06a3ab4dcb50)
![2025-10-25 06 35 16](https://github.com/user-attachments/assets/d872a835-98a2-41ed-aa59-de81c4a1fbf9)

## Changes
 -  Added refresh button to recents
  - Added prefetching system, get the next 5 items on load and always stay ahead so "show more" is near instant

## How did you test this code?
locally

- clicking refresh works, doesn't remove current pagination index
- searching works normally resetting to 5... returning to empty search cache kicks in and loads all recents after show more