### PR TITLE
fix: remove position: relative from LemonButton

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
@@ -71,11 +71,6 @@
     --lemon-button-icon-opacity: 0.8;
     --lemon-button-color: var(--text-3000);
 
-    // column-gap: 4px;
-    // flex-direction: row;
-    // justify-content: flex-start;
-    position: relative;
-
     // Make sure we override .Link's styles where needed, e.g. padding
     display: flex;
     flex-shrink: 0;


### PR DESCRIPTION
## Problem

The latest dev/beta releases of Chromium-based browsers cannot click any popovers with buttons. It seems to be a stacking context issue, as none of the hover effects are working. I've tried layering out on DevTools and checking the Popover/PopoverInner CSS, but could not find anything else that would really fix it. 

Hopefully fixes https://github.com/posthog/posthog/issues/39622 

## Changes

Remove `position: relative` from `LemonButton` so it does not create its own [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context). 

## How did you test this code?

Clicked around the app on my local env to check the styles.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
