### PR TITLE
fix(ux): add back project notice for home page

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -319,7 +319,11 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         organizationBased: true,
         defaultDocsPath: '/docs/data/organizations-and-projects',
     },
-    [Scene.ProjectHomepage]: { projectBased: true, name: 'Homepage', hideProjectNotice: true, layout: 'app-raw' },
+    [Scene.ProjectHomepage]: {
+        projectBased: true,
+        name: 'Homepage',
+        layout: 'app-raw',
+    },
     [Scene.PropertyDefinitionEdit]: {
         projectBased: true,
         name: 'Data management',


### PR DESCRIPTION
## Problem
I removed project notice from home page

this just a fix... i'm thinking of a better more compact way of doing this obtrusive thing... next time

## Changes
return it

<img width="1032" height="569" alt="image" src="https://github.com/user-attachments/assets/a32b1e5e-b1c8-4a67-8f37-12f74c219652" />

<img width="999" height="750" alt="image" src="https://github.com/user-attachments/assets/fc1be3d4-f856-47fd-87dd-d77c95c2f0b7" />
