### PR TITLE
fix: fix backwards logic on whether timezone was overridden

### DIFF
--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -115,7 +115,7 @@ class ReplaceFilters(CloningVisitor):
             if dateTo is not None:
                 try:
                     parsed_date = isoparse(dateTo).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateTo).tzinfo is None:
+                    if isoparse(dateTo).tzinfo is not None:
                         # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
                         # create a temporary exception just to capture it and make debugging easier
                         try:
@@ -137,7 +137,7 @@ class ReplaceFilters(CloningVisitor):
             if dateFrom is not None and dateFrom != "all":
                 try:
                     parsed_date = isoparse(dateFrom).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateFrom).tzinfo is None:
+                    if isoparse(dateFrom).tzinfo is not None:
                         # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
                         # create a temporary exception just to capture it and make debugging easier
                         try:
@@ -176,7 +176,7 @@ class ReplaceFilters(CloningVisitor):
             if dateFrom is not None and dateFrom != "all":
                 try:
                     parsed_date = isoparse(dateFrom).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateFrom).tzinfo is None:
+                    if isoparse(dateFrom).tzinfo is not None:
                         # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
                         # create a temporary exception just to capture it and make debugging easier
                         try:

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -203,7 +203,7 @@ class ReplaceFilters(CloningVisitor):
             if dateTo is not None:
                 try:
                     parsed_date = isoparse(dateTo).replace(tzinfo=self.team.timezone_info)
-                    if isoparse(dateTo).tzinfo is None:
+                    if isoparse(dateTo).tzinfo is not None:
                         # Check if we have overridden the timezone, this likely indicates a bug somewhere if we have
                         # create a temporary exception just to capture it and make debugging easier
                         try:


### PR DESCRIPTION


## Problem
the exception is firing when the timezone _isn't_ overridden :(

it's just informational so no customer impact

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
