### PR TITLE
feat(ai): enable parallel tool calling

### DIFF
--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -108,6 +108,10 @@ The user is a product engineer and will primarily request you perform product ma
 - Tool results and user messages may include <system_reminder> tags. <system_reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
 </doing_tasks>
 
+<tool_usage_policy>
+- You can invoke multiple tools within a single response. When a request involves several independent pieces of information, batch your tool calls together for optimal performance
+</tool_usage_policy>
+
 {{{billing_context}}}
 
 {{{core_memory_prompt}}}

--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -527,12 +527,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         graph = (
             AssistantGraph(self.team, self.user)
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
-            .add_root(
-                {
-                    "root": AssistantNodeName.ROOT,
-                    "end": AssistantNodeName.END,
-                }
-            )
+            .add_root()
             .compile()
         )
 
@@ -1245,7 +1240,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         graph = (
             AssistantGraph(self.team, self.user)
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
-            .add_root({"root": AssistantNodeName.ROOT, "end": AssistantNodeName.END})
+            .add_root()
             .compile()
         )
         self.assertEqual(self.conversation.status, Conversation.Status.IDLE)
@@ -1265,7 +1260,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         graph = (
             AssistantGraph(self.team, self.user)
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
-            .add_root({"root": AssistantNodeName.ROOT, "end": AssistantNodeName.END})
+            .add_root()
             .compile()
         )
 
@@ -1316,12 +1311,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         graph = (
             AssistantGraph(self.team, self.user)
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
-            .add_root(
-                {
-                    "root": AssistantNodeName.ROOT,
-                    "end": AssistantNodeName.END,
-                }
-            )
+            .add_root()
             .compile()
         )
 
@@ -1662,12 +1652,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         output, assistant = await self._run_assistant_graph(
             test_graph=AssistantGraph(self.team, self.user)
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
-            .add_root(
-                {
-                    "root": AssistantNodeName.ROOT,
-                    "end": AssistantNodeName.END,
-                }
-            )
+            .add_root()
             .compile(),
             conversation=self.conversation,
             is_new_conversation=True,
@@ -1733,7 +1718,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         graph = (
             AssistantGraph(self.team, self.user)
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
-            .add_root({"root": AssistantNodeName.ROOT, "end": AssistantNodeName.END})
+            .add_root()
             .compile()
         )
 
@@ -2045,12 +2030,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         test_graph = (
             AssistantGraph(self.team, self.user)
             .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
-            .add_root(
-                {
-                    "root": AssistantNodeName.ROOT,
-                    "end": AssistantNodeName.END,
-                }
-            )
+            .add_root()
             .compile()
         )
 

--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -2301,3 +2301,88 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         assistant_output = [(event_type, msg) for event_type, msg in output if isinstance(msg, AssistantMessage)]
         self.assertEqual(len(assistant_output), 1)
         self.assertEqual(cast(AssistantMessage, assistant_output[0][1]).id, message_id_2)
+
+    @patch("ee.hogai.graph.root.tools.search.SearchTool._arun_impl", return_value=("Docs doubt it", None))
+    @patch(
+        "ee.hogai.graph.root.tools.read_taxonomy.ReadTaxonomyTool._run_impl",
+        return_value=("Hedgehogs have not talked yet", None),
+    )
+    @patch("ee.hogai.graph.root.nodes.RootNode._get_model")
+    async def test_root_node_can_execute_multiple_tool_calls(self, root_mock, search_mock, read_taxonomy_mock):
+        """Test that the root node can execute multiple tool calls in parallel."""
+        tool_call_id1, tool_call_id2 = [str(uuid4()), str(uuid4())]
+
+        def root_side_effect(msgs: list[BaseMessage]):
+            # Check if we've already received a tool result
+            last_message = msgs[-1]
+            if (
+                isinstance(last_message.content, list)
+                and isinstance(last_message.content[-1], dict)
+                and last_message.content[-1]["type"] == "tool_result"
+            ):
+                # After tool execution, respond with final message
+                return messages.AIMessage(content="No")
+
+            return messages.AIMessage(
+                content="Not sure. Let me check.",
+                tool_calls=[
+                    {
+                        "id": tool_call_id1,
+                        "name": "search",
+                        "args": {"kind": "docs", "query": "Do hedgehogs speak?"},
+                    },
+                    {
+                        "id": tool_call_id2,
+                        "name": "read_taxonomy",
+                        "args": {"query": {"kind": "events"}},
+                    },
+                ],
+            )
+
+        root_mock.return_value = FakeAnthropicRunnableLambdaWithTokenCounter(root_side_effect)
+
+        # Create a minimal test graph
+        graph = (
+            AssistantGraph(self.team, self.user)
+            .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
+            .add_root()
+            .compile()
+        )
+
+        expected_output = [
+            (AssistantEventType.MESSAGE, HumanMessage(content="Do hedgehogs speak?")),
+            (
+                AssistantEventType.MESSAGE,
+                AssistantMessage(
+                    content="Not sure. Let me check.",
+                    tool_calls=[
+                        {
+                            "id": tool_call_id1,
+                            "name": "search",
+                            "args": {"kind": "docs", "query": "Do hedgehogs speak?"},
+                        },
+                        {
+                            "id": tool_call_id2,
+                            "name": "read_taxonomy",
+                            "args": {"query": {"kind": "events"}},
+                        },
+                    ],
+                ),
+            ),
+            (AssistantEventType.MESSAGE, ReasoningMessage(content="Searching for information")),
+            (AssistantEventType.MESSAGE, ReasoningMessage(content="Searching for information")),
+            (
+                AssistantEventType.MESSAGE,
+                AssistantToolCallMessage(content="Docs doubt it", tool_call_id=tool_call_id1),
+            ),
+            (
+                AssistantEventType.MESSAGE,
+                AssistantToolCallMessage(content="Hedgehogs have not talked yet", tool_call_id=tool_call_id2),
+            ),
+            (AssistantEventType.MESSAGE, AssistantMessage(content="No")),
+        ]
+        output, _ = await self._run_assistant_graph(
+            graph, message="Do hedgehogs speak?", conversation=self.conversation
+        )
+
+        self.assertConversationEqual(output, expected_output)

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -292,7 +292,7 @@ class _SharedAssistantState(BaseStateWithMessages, BaseStateWithIntermediateStep
     """
     The ID of the message to start from to keep the message window short enough.
     """
-    root_tool_call_id: Optional[str] = Field(default=None)
+    root_tool_call_id: Annotated[Optional[str], replace] = Field(default=None)
     """
     The ID of the tool call from the root node.
     """
@@ -304,7 +304,7 @@ class _SharedAssistantState(BaseStateWithMessages, BaseStateWithIntermediateStep
     """
     The type of insight to generate.
     """
-    root_tool_calls_count: Optional[int] = Field(default=None)
+    root_tool_calls_count: Annotated[Optional[int], replace] = Field(default=None)
     """
     Tracks the number of tool calls made by the root node to terminate the loop.
     """


### PR DESCRIPTION
## Problem

Since we want to parallelize tool calls, we would like to split the monolithic graph into subgraphs or MaxTools, allowing the tools to be easily parallelized. This PR focuses on tool parallelization.

## Changes

- Parallelized execution of MaxTools through LangGraph.
- Merged the result state.
- Tested changes.

## How did you test this code?

Manual tests & unit tests
