### PR TITLE
fix: allow Temporal to retry when slack subscription fails

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -28,7 +28,9 @@ from ee.tasks.subscriptions.subscription_utils import generate_assets, generate_
 logger = structlog.get_logger(__name__)
 
 # Slack errors that are user configuration issues, not system failures
-SLACK_USER_CONFIG_ERRORS = frozenset(["not_in_channel", "account_inactive", "is_archived", "channel_not_found"])
+SLACK_USER_CONFIG_ERRORS = frozenset(
+    ["not_in_channel", "account_inactive", "is_archived", "channel_not_found", "invalid_auth"]
+)
 
 # Prometheus metrics for Celery workers (web/worker pods)
 SUBSCRIPTION_QUEUED = Counter(
@@ -233,6 +235,7 @@ async def deliver_subscription_report_async(
                 subscription_id=subscription.id,
                 next_delivery_date=subscription.next_delivery_date,
                 destination=subscription.target_type,
+                is_user_config_error=is_user_config_error,
                 exc_info=True,
             )
             capture_exception(e)

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -239,6 +239,10 @@ async def deliver_subscription_report_async(
                 exc_info=True,
             )
             capture_exception(e)
+
+            # Re-raise system failures to let Temporal retry, but not user config errors
+            if not is_user_config_error:
+                raise
     else:
         logger.error(
             "deliver_subscription_report_async.unsupported_target",

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -243,7 +243,7 @@ async def send_slack_message_with_integration_async(
                     thread_ts=thread_ts,
                     **thread_msg,
                 )
-            except TimeoutError:
+            except Exception:
                 logger.error(
                     "send_slack_message_with_integration_async.slack_thread_message_failed_after_retries",
                     subscription_id=subscription.id,

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -191,7 +191,7 @@ def send_slack_message_with_integration(
             slack_integration.client.chat_postMessage(channel=message_data.channel, thread_ts=thread_ts, **thread_msg)
 
 
-async def _send_slack_message_with_retry(client, max_retries: int = 2, **kwargs):
+async def _send_slack_message_with_retry(client, max_retries: int = 3, **kwargs):
     for attempt in range(max_retries):
         try:
             return await client.chat_postMessage(**kwargs)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Subscriptions getting timeouts on DNS when sending messages to slack. 

## Changes

- Increase the TimeoutError retries when sending Slack message from 1 retry to 2. 
- If we exhaust message retries, raise error to allow Temporal to retry the entire subscription again but don't allow Temporal to retry if we were able to send the main message but failed to send thread messages as we don't want to spam a channel with messages.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
