### PR TITLE
fix: reuse Slack AsyncWebClient across messages

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -28,7 +28,9 @@ from ee.tasks.subscriptions.subscription_utils import generate_assets, generate_
 logger = structlog.get_logger(__name__)
 
 # Slack errors that are user configuration issues, not system failures
-SLACK_USER_CONFIG_ERRORS = frozenset(["not_in_channel", "account_inactive", "is_archived", "channel_not_found"])
+SLACK_USER_CONFIG_ERRORS = frozenset(
+    ["not_in_channel", "account_inactive", "is_archived", "channel_not_found", "invalid_auth"]
+)
 
 # Prometheus metrics for Celery workers (web/worker pods)
 SUBSCRIPTION_QUEUED = Counter(

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -191,7 +191,7 @@ def send_slack_message_with_integration(
             slack_integration.client.chat_postMessage(channel=message_data.channel, thread_ts=thread_ts, **thread_msg)
 
 
-async def _send_slack_message_with_retry(client, max_retries: int = 2, **kwargs):
+async def _send_slack_message_with_retry(client, max_retries: int = 3, **kwargs):
     for attempt in range(max_retries):
         try:
             return await client.chat_postMessage(**kwargs)
@@ -223,9 +223,10 @@ async def send_slack_message_with_integration_async(
 ) -> SlackDeliveryResult:
     message_data = _prepare_slack_message(subscription, assets, total_asset_count, is_new_subscription)
     slack_integration = SlackIntegration(integration)
+    async_client = slack_integration.async_client
 
     message_res = await _send_slack_message_with_retry(
-        slack_integration.async_client,
+        async_client,
         channel=message_data.channel,
         blocks=message_data.blocks,
         text=message_data.title,
@@ -238,7 +239,7 @@ async def send_slack_message_with_integration_async(
         for idx, thread_msg in enumerate(message_data.thread_messages):
             try:
                 await _send_slack_message_with_retry(
-                    slack_integration.async_client,
+                    async_client,
                     channel=message_data.channel,
                     thread_ts=thread_ts,
                     **thread_msg,

--- a/ee/tasks/test/subscriptions/test_slack_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_slack_subscriptions.py
@@ -269,7 +269,8 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
             {"ts": "1.234"},  # Main message
             {"ts": "2.345"},  # First thread message (asset 2)
             TimeoutError(),  # Second thread message (asset 3) attempt 1
-            TimeoutError(),  # Second thread message (asset 3) attempt 2 (final failure)
+            TimeoutError(),  # Second thread message (asset 3) attempt 2
+            TimeoutError(),  # Second thread message (asset 3) attempt 3 (final failure)
             {"ts": "3.456"},  # Third thread message "Showing 3 of 10"
         ]
 
@@ -285,7 +286,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
             )
         )
 
-        assert mock_async_client.chat_postMessage.call_count == 5
+        assert mock_async_client.chat_postMessage.call_count == 6
         assert result.is_partial_failure
         assert not result.is_complete_success
         assert result.main_message_sent
@@ -304,7 +305,8 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
 
         mock_async_client.chat_postMessage.side_effect = [
             TimeoutError(),  # Attempt 1
-            TimeoutError(),  # Attempt 2 (final)
+            TimeoutError(),  # Attempt 2
+            TimeoutError(),  # Attempt 3 (final)
         ]
 
         assets = list(ExportedAsset.objects.filter(id=self.asset.id).select_related("insight")[:1])
@@ -316,7 +318,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
                 )
             )
 
-        assert mock_async_client.chat_postMessage.call_count == 2
+        assert mock_async_client.chat_postMessage.call_count == 3
 
     @patch("ee.tasks.subscriptions.slack_subscriptions.asyncio.sleep", new_callable=AsyncMock)
     def test_async_delivery_retry_succeeds_on_second_attempt(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Subscriptions are still getting some DNS timeouts when sending Slack messages. These seem to mainly happen when there are more than 20 subscriptions going out in the hour. 

https://grafana.prod-us.posthog.dev/goto/2K4KdhRvR?orgId=1

## Changes

Reuse the async Slack client across messages of the same subscription instead of creating it again for each message.

Also add another user configuration error and an extra retry when sending the slack message.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
