### PR TITLE
chore(customers): Add setup prompt to NotebookNodeIssues

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
@@ -7,6 +7,7 @@ import { InsightLogicProps } from '~/types'
 
 import { issueFiltersLogic } from 'products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic'
 import { issueQueryOptionsLogic } from 'products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic'
+import { ErrorTrackingSetupPrompt } from 'products/error_tracking/frontend/components/SetupPrompt/SetupPrompt'
 import { issuesDataNodeLogic } from 'products/error_tracking/frontend/logics/issuesDataNodeLogic'
 import { errorTrackingQuery } from 'products/error_tracking/frontend/queries'
 import { IssuesFilters } from 'products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesFilters'
@@ -44,7 +45,9 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttribute
 
     return (
         <ContextualFilters nodeId={attributes.nodeId}>
-            <IssuesQuery personId={attributes.personId} />
+            <ErrorTrackingSetupPrompt className="border-none">
+                <IssuesQuery personId={attributes.personId} />
+            </ErrorTrackingSetupPrompt>
         </ContextualFilters>
     )
 }

--- a/products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx
+++ b/products/error_tracking/frontend/components/SetupPrompt/SetupPrompt.tsx
@@ -11,7 +11,13 @@ import { ProductKey } from '~/types'
 
 import { exceptionIngestionLogic } from './exceptionIngestionLogic'
 
-export const ErrorTrackingSetupPrompt = ({ children }: { children: React.ReactNode }): JSX.Element => {
+export const ErrorTrackingSetupPrompt = ({
+    children,
+    className,
+}: {
+    children: React.ReactNode
+    className?: string
+}): JSX.Element => {
     const { hasSentExceptionEvent, hasSentExceptionEventLoading } = useValues(exceptionIngestionLogic)
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const exceptionAutocaptureEnabled = currentTeam && currentTeam.autocapture_exceptions_opt_in
@@ -21,13 +27,13 @@ export const ErrorTrackingSetupPrompt = ({ children }: { children: React.ReactNo
             <Spinner />
         </div>
     ) : !hasSentExceptionEvent && !exceptionAutocaptureEnabled ? (
-        <IngestionStatusCheck />
+        <IngestionStatusCheck className={className} />
     ) : (
         <>{children}</>
     )
 }
 
-const IngestionStatusCheck = (): JSX.Element | null => {
+const IngestionStatusCheck = ({ className }: { className?: string }): JSX.Element | null => {
     const { addProductIntent, updateCurrentTeam } = useActions(teamLogic)
 
     return (
@@ -38,6 +44,7 @@ const IngestionStatusCheck = (): JSX.Element | null => {
             description="To start capturing exceptions you need to enable exception autocapture. Exception autocapture only applies to the JS SDK. Installation for other platforms are described in the docs."
             isEmpty={true}
             productKey={ProductKey.ERROR_TRACKING}
+            className={className}
             actionElementOverride={
                 <>
                     <LemonButton


### PR DESCRIPTION
## Problem

The Error Tracking setup prompt wasn't being shown in the Notebook Issues node, which meant users might not understand why they weren't seeing any error data or how to enable it.

Part of https://github.com/PostHog/posthog/issues/40328

## Changes

Added the `ErrorTrackingSetupPrompt` component to wrap the `IssuesQuery` component in the Notebook Node Issues view. This ensures users are prompted to enable exception autocapture if they haven't already.

Also enhanced the `ErrorTrackingSetupPrompt` component to accept an optional `className` prop, allowing for better styling control. This prop is passed through to the `IngestionStatusCheck` component.

<img width="1624" height="982" alt="image" src="https://github.com/user-attachments/assets/bc83421f-8584-434c-b75c-fe07d1816ff3" />

## How did you test this code?

Tested by:

1. Creating a new project with Error Tracking not configured
2. Verifying the setup prompt appears when exception autocapture is disabled
3. Enabling exception autocapture and confirming the issues view appears correctly