### PR TITLE
fix(cohorts): fails to get chunk size in cohort calculation

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -923,7 +923,7 @@ def _get_cohort_chunking_config(
         return None
 
     try:
-        payload = posthoganalytics.get_feature_flag_payload(
+        result = posthoganalytics.get_feature_flag_result(
             "cohort-calculation-chunked",
             str(team_uuid),
             groups={"organization": str(organization_id)},
@@ -932,10 +932,10 @@ def _get_cohort_chunking_config(
             send_feature_flag_events=False,
         )
 
-        if payload is None or not isinstance(payload, dict):
+        if result is None or not result.enabled or result.payload is None:
             return None
 
-        chunk_size = payload.get("chunk_size", TARGET_CHUNK_SIZE)
+        chunk_size = result.payload.get("chunk_size")
 
         if isinstance(chunk_size, int) and chunk_size > 0:
             return chunk_size

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -932,7 +932,7 @@ def _get_cohort_chunking_config(
             send_feature_flag_events=False,
         )
 
-        if payload is None:
+        if payload is None or not isinstance(payload, dict):
             return None
 
         chunk_size = payload.get("chunk_size", TARGET_CHUNK_SIZE)

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -1,4 +1,3 @@
-import json
 import math
 import uuid
 from datetime import datetime, timedelta
@@ -924,7 +923,7 @@ def _get_cohort_chunking_config(
         return None
 
     try:
-        config_json = posthoganalytics.get_feature_flag_payload(
+        payload = posthoganalytics.get_feature_flag_payload(
             "cohort-calculation-chunked",
             str(team_uuid),
             groups={"organization": str(organization_id)},
@@ -933,15 +932,13 @@ def _get_cohort_chunking_config(
             send_feature_flag_events=False,
         )
 
-        if config_json is None:
+        if payload is None:
             return None
 
-        config_payload = json.loads(config_json)
-        if config_payload and isinstance(config_payload, dict):
-            chunk_size = config_payload.get("chunk_size", TARGET_CHUNK_SIZE)
+        chunk_size = payload.get("chunk_size", TARGET_CHUNK_SIZE)
 
-            if isinstance(chunk_size, int) and chunk_size > 0:
-                return chunk_size
+        if isinstance(chunk_size, int) and chunk_size > 0:
+            return chunk_size
 
         return TARGET_CHUNK_SIZE
 


### PR DESCRIPTION
## Problem

PR #40260 introduced a bug as the payload from the feature flag is already a dict, not a json.

## Changes

- Changed from `get_feature_flag_payload` to `get_feature_flag_result`.

## How did you test this code?

- Manual

It was necessary to call this in the celery task, otherwise it didn't work.

```
        posthoganalytics.api_key = '<LOCAL_API_KEY>'
        posthoganalytics.disabled = False
        posthoganalytics.host = settings.SITE_URL
```
