### PR TITLE
feat(create experiments): show the experiment view only for experimen…

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -218,10 +218,19 @@ export function ExperimentView(): JSX.Element {
      * this is temporary, for testing purposes only.
      * this has to be migrated into a scene with a proper path, and paramsToProps
      * so it works seamlesly with the toolbar and tab bar navigation.
+     *
+     * We show the create form if the experiment is draft + has no metrics. Otherwise,
+     * we show the experiment view.
      */
     const isUnifiedCreateFormEnabled = useFeatureFlag('EXPERIMENTS_UNIFIED_CREATE_FORM', 'test')
+    const allPrimaryMetrics = [...(experiment.metrics || []), ...(experiment.saved_metrics || [])]
 
-    if (!experimentLoading && getExperimentStatus(experiment) === ProgressStatus.Draft && isUnifiedCreateFormEnabled) {
+    if (
+        !experimentLoading &&
+        isUnifiedCreateFormEnabled &&
+        getExperimentStatus(experiment) === ProgressStatus.Draft &&
+        allPrimaryMetrics.length === 0
+    ) {
         return <CreateExperiment draftExperiment={experiment} />
     }
 


### PR DESCRIPTION
## Problem

If an experiment is a _draft_, but has at least a single primary metric, we should show the experiment view.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've expanded the checks to include experiments without a primary metric into those that should load the create experiment form.
This is temporary. It should be removed if the experiment succeeded.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/f5491e09-2990-43b6-bf2a-ebb879844b0a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
