### PR TITLE
fix(llma): update ai costs workflow

### DIFF
--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -27,9 +27,11 @@ jobs:
                   cache: 'pnpm'
 
             - name: Install dependencies
+              env:
+                  HUSKY: 0
               run: |
                   cd plugin-server
-                  pnpm install --frozen-lockfile
+                  pnpm install --frozen-lockfile --ignore-scripts
 
             - name: Update AI costs
               run: |


### PR DESCRIPTION
The pull request creation failed because the script to create the pull request triggers the pre-commit hook while being on master. This disables it because it's not really needed here.