### PR TITLE
fix: use batching to break up very long running activities

### DIFF
--- a/posthog/sync.py
+++ b/posthog/sync.py
@@ -42,7 +42,6 @@ class DatabaseSyncToAsync(SyncToAsync):
                 execution_time = time() - start_time
                 fun_name = getattr(self.func, "__name__", "unknown")
                 DATABASE_SYNC_TO_ASYNC_TIME.labels(function_name=fun_name).observe(execution_time)
-                logger.debug(f"database_sync_to_async {fun_name} took {execution_time} seconds")
 
     def thread_handler(self, loop, *args, **kwargs):
         # Don't close the connection in tests

--- a/posthog/temporal/weekly_digest/__init__.py
+++ b/posthog/temporal/weekly_digest/__init__.py
@@ -1,5 +1,6 @@
 from posthog.temporal.weekly_digest.activities import (
     count_organizations,
+    count_teams,
     generate_dashboard_lookup,
     generate_event_definition_lookup,
     generate_experiment_completed_lookup,
@@ -34,5 +35,6 @@ ACTIVITIES = [
     generate_user_notification_lookup,
     generate_organization_digest_batch,
     count_organizations,
+    count_teams,
     send_weekly_digest_batch,
 ]

--- a/posthog/temporal/weekly_digest/types.py
+++ b/posthog/temporal/weekly_digest/types.py
@@ -11,7 +11,7 @@ class CommonInput:
     redis_ttl: int = 3600 * 24 * 3  # 3 days
     redis_host: str | None = None
     redis_port: int | None = None
-    batch_size: int = 100
+    batch_size: int = 1000
 
 
 @dataclass
@@ -29,6 +29,13 @@ class WeeklyDigestInput:
 
 @dataclass
 class GenerateDigestDataInput:
+    digest: Digest
+    common: CommonInput
+
+
+@dataclass
+class GenerateDigestDataBatchInput:
+    batch: tuple[int, int]
     digest: Digest
     common: CommonInput
 


### PR DESCRIPTION
Initial batch of activites taking too long to run - break them up into many smaller activities and increase the concurrency.