### PR TITLE
feat: add query log to debug scene

### DIFF
--- a/frontend/src/scenes/debug/DebugSceneQuery.tsx
+++ b/frontend/src/scenes/debug/DebugSceneQuery.tsx
@@ -76,6 +76,7 @@ export function DebugSceneQuery({ query, setQuery, queryKey }: DebugSceneQueryPr
                             queryKey={queryKey}
                             response={response}
                             setQuery={(query) => setQuery(JSON.stringify(query, null, 2))}
+                            onLoadQuery={setQuery}
                         />
                     ) : null}
                 </div>

--- a/frontend/src/scenes/debug/HogQLDebug.tsx
+++ b/frontend/src/scenes/debug/HogQLDebug.tsx
@@ -51,7 +51,22 @@ export function HogQLDebug({ query, setQuery, queryKey, modifiers }: HogQLDebugP
                     </>
                 ) : (
                     <>
-                        <QueryTabs query={query} response={response} setQuery={setQuery} queryKey={queryKey} />
+                        <QueryTabs
+                            query={query}
+                            response={response}
+                            setQuery={setQuery}
+                            queryKey={queryKey}
+                            onLoadQuery={(queryString) => {
+                                try {
+                                    const parsed = JSON.parse(queryString)
+                                    if (parsed.kind === 'HogQLQuery') {
+                                        setQuery(parsed)
+                                    }
+                                } catch (e) {
+                                    console.error('Failed to parse query from log', e)
+                                }
+                            }}
+                        />
                     </>
                 )}
             </div>

--- a/frontend/src/scenes/debug/QueryLogTable.tsx
+++ b/frontend/src/scenes/debug/QueryLogTable.tsx
@@ -1,0 +1,134 @@
+import { useActions, useValues } from 'kea'
+
+import { IconArrowRight } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { humanFriendlyNumber } from '~/lib/utils'
+
+import { queryLogTableLogic } from './queryLogTableLogic'
+
+interface QueryLogTableProps {
+    queryKey: string
+    onLoadQuery: (query: string) => void
+}
+
+export function QueryLogTable({ queryKey, onLoadQuery }: QueryLogTableProps): JSX.Element {
+    const logic = queryLogTableLogic({ key: queryKey })
+    const { queryLogs, queryLogsLoading, moreQueryLogsLoading, hasMore } = useValues(logic)
+    const { loadQueryLogs, loadMoreQueryLogs } = useActions(logic)
+
+    return (
+        <div className="space-y-2">
+            <div className="flex justify-between items-center">
+                <span className="text-sm text-muted">
+                    Showing queries from the past 7 days for the current user (100 per page)
+                </span>
+                <LemonButton type="primary" size="small" onClick={loadQueryLogs} loading={queryLogsLoading}>
+                    Refresh
+                </LemonButton>
+            </div>
+            <LemonTable
+                dataSource={queryLogs}
+                loading={queryLogsLoading}
+                columns={[
+                    {
+                        title: '',
+                        key: 'load',
+                        width: 40,
+                        render: (_dataValue, record) => (
+                            <Tooltip title="Load query into editor">
+                                <LemonButton
+                                    size="xsmall"
+                                    icon={<IconArrowRight />}
+                                    onClick={() => {
+                                        const hogqlQuery = {
+                                            kind: 'HogQLQuery',
+                                            query: record.query,
+                                        }
+                                        onLoadQuery(JSON.stringify(hogqlQuery, null, 2))
+                                    }}
+                                />
+                            </Tooltip>
+                        ),
+                    },
+                    {
+                        title: 'Query ID',
+                        key: 'query_id',
+                        dataIndex: 'query_id',
+                        width: 200,
+                        render: (value) => (
+                            <div className="font-mono text-xs truncate" title={String(value)}>
+                                {value}
+                            </div>
+                        ),
+                    },
+                    {
+                        title: 'Time',
+                        key: 'query_start_time',
+                        dataIndex: 'query_start_time',
+                        width: 180,
+                        render: (value) => (value ? new Date(String(value)).toLocaleString() : ''),
+                    },
+                    {
+                        title: 'Duration',
+                        key: 'query_duration_ms',
+                        dataIndex: 'query_duration_ms',
+                        width: 100,
+                        render: (value) => `${value}ms`,
+                        sorter: (a, b) => a.query_duration_ms - b.query_duration_ms,
+                    },
+                    {
+                        title: 'Status',
+                        key: 'status',
+                        dataIndex: 'status',
+                        width: 120,
+                        render: (value, record) => (
+                            <LemonTag type={record.exception_code === 0 ? 'success' : 'danger'}>{value}</LemonTag>
+                        ),
+                    },
+                    {
+                        title: 'Rows Read',
+                        key: 'read_rows',
+                        dataIndex: 'read_rows',
+                        width: 100,
+                        render: (value) => humanFriendlyNumber(value as number),
+                        sorter: (a, b) => a.read_rows - b.read_rows,
+                    },
+                    {
+                        title: 'Bytes Read',
+                        key: 'read_bytes',
+                        dataIndex: 'read_bytes',
+                        width: 100,
+                        render: (value) => humanFriendlyNumber(value as number),
+                        sorter: (a, b) => a.read_bytes - b.read_bytes,
+                    },
+                    {
+                        title: 'Result Rows',
+                        key: 'result_rows',
+                        dataIndex: 'result_rows',
+                        width: 100,
+                        render: (value) => humanFriendlyNumber(value as number),
+                        sorter: (a, b) => a.result_rows - b.result_rows,
+                    },
+                    {
+                        title: 'Query',
+                        key: 'query',
+                        dataIndex: 'query',
+                        render: (value) => <div className="max-w-xl truncate font-mono text-xs">{value}</div>,
+                    },
+                ]}
+            />
+            {hasMore && (
+                <div className="flex justify-center mt-4">
+                    <LemonButton type="secondary" onClick={loadMoreQueryLogs} loading={moreQueryLogsLoading} center>
+                        Load more
+                    </LemonButton>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/debug/QueryTabs.tsx
+++ b/frontend/src/scenes/debug/QueryTabs.tsx
@@ -12,6 +12,8 @@ import { Timings } from '~/queries/nodes/DataNode/ElapsedTime'
 import { HogQLMetadataResponse, InsightVizNode, Node, NodeKind, QueryTiming } from '~/queries/schema/schema-general'
 import { isDataTableNode, isInsightQueryNode, isInsightVizNode } from '~/queries/utils'
 
+import { QueryLogTable } from './QueryLogTable'
+
 function toLineColumn(hogql: string, position: number): { line: number; column: number } {
     const lines = hogql.split('\n')
     let line = 0
@@ -39,8 +41,15 @@ interface QueryTabsProps<Q extends Node> {
     queryKey: `new-${string}`
     response?: Q['response'] | null
     setQuery: (query: Q) => void
+    onLoadQuery?: (query: string) => void
 }
-export function QueryTabs<Q extends Node>({ query, queryKey, setQuery, response }: QueryTabsProps<Q>): JSX.Element {
+export function QueryTabs<Q extends Node>({
+    query,
+    queryKey,
+    setQuery,
+    response,
+    onLoadQuery,
+}: QueryTabsProps<Q>): JSX.Element {
     const [tab, setTab] = useState<string | null>(null)
     const clickHouseTime = (response?.timings as QueryTiming[])?.find(({ k }) => k === './clickhouse_execute')?.t ?? 0
     const explainTime = (response?.timings as QueryTiming[])?.find(({ k }) => k === './explain')?.t ?? 0
@@ -204,6 +213,11 @@ export function QueryTabs<Q extends Node>({ query, queryKey, setQuery, response 
                           ]}
                       />
                   ),
+              },
+              onLoadQuery && {
+                  key: 'query_log',
+                  label: 'Query log',
+                  content: <QueryLogTable queryKey={queryKey} onLoadQuery={onLoadQuery} />,
               },
           ]
               .filter(Boolean)

--- a/frontend/src/scenes/debug/queryLogTableLogic.ts
+++ b/frontend/src/scenes/debug/queryLogTableLogic.ts
@@ -1,0 +1,171 @@
+import { actions, afterMount, connect, kea, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { userLogic } from 'scenes/userLogic'
+
+import { HogQLQueryResponse } from '~/queries/schema/schema-general'
+
+import type { queryLogTableLogicType } from './queryLogTableLogicType'
+
+export interface QueryLogEntry {
+    query_id: string
+    query: string
+    query_start_time: string
+    query_duration_ms: number
+    name: string
+    status: string
+    exception_code: number
+    read_rows: number
+    read_bytes: number
+    result_rows: number
+}
+
+export interface QueryLogTableLogicProps {
+    key: string
+}
+
+export const queryLogTableLogic = kea<queryLogTableLogicType>([
+    path(['scenes', 'debug', 'queryLogTableLogic']),
+    connect({
+        values: [userLogic, ['user']],
+    }),
+    actions({
+        loadQueryLogs: true,
+        loadMoreQueryLogs: true,
+    }),
+    loaders(({ values }) => ({
+        queryLogs: [
+            [] as QueryLogEntry[],
+            {
+                loadQueryLogs: async () => {
+                    try {
+                        if (!values.user?.id) {
+                            return []
+                        }
+                        // Query the query_log_archive for the current user's queries
+                        const response = (await api.query({
+                            kind: 'HogQLQuery',
+                            query: `
+                                SELECT
+                                    query_id,
+                                    query,
+                                    query_start_time,
+                                    query_duration_ms,
+                                    name,
+                                    status,
+                                    exception_code,
+                                    read_rows,
+                                    read_bytes,
+                                    result_rows
+                                FROM query_log
+                                WHERE created_by = {user_id}
+                                    AND event_date >= today() - INTERVAL 7 DAY
+                                    AND query != ''
+                                ORDER BY query_start_time DESC
+                                LIMIT {limit}
+                            `,
+                            values: {
+                                user_id: values.user.id,
+                                limit: values.limit,
+                            },
+                        })) as HogQLQueryResponse
+
+                        // Convert array of arrays to array of objects
+                        if (!response.results || !response.columns) {
+                            return []
+                        }
+
+                        return response.results.map((row: any[]) => {
+                            const obj: any = {}
+                            response.columns!.forEach((col: string, idx: number) => {
+                                obj[col] = row[idx]
+                            })
+                            return obj as QueryLogEntry
+                        })
+                    } catch (error) {
+                        console.error('Error loading query logs:', error)
+                        return []
+                    }
+                },
+            },
+        ],
+        moreQueryLogs: [
+            [] as QueryLogEntry[],
+            {
+                loadMoreQueryLogs: async () => {
+                    try {
+                        if (!values.user?.id) {
+                            return []
+                        }
+                        // Load more query logs with offset
+                        const response = (await api.query({
+                            kind: 'HogQLQuery',
+                            query: `
+                                SELECT
+                                    query_id,
+                                    query,
+                                    query_start_time,
+                                    query_duration_ms,
+                                    name,
+                                    status,
+                                    exception_code,
+                                    read_rows,
+                                    read_bytes,
+                                    result_rows
+                                FROM query_log
+                                WHERE created_by = {user_id}
+                                    AND event_date >= today() - INTERVAL 7 DAY
+                                    AND query != ''
+                                ORDER BY query_start_time DESC
+                                LIMIT {limit} OFFSET {offset}
+                            `,
+                            values: {
+                                user_id: values.user.id,
+                                limit: values.limit,
+                                offset: values.queryLogs.length,
+                            },
+                        })) as HogQLQueryResponse
+
+                        // Convert array of arrays to array of objects
+                        if (!response.results || !response.columns) {
+                            return []
+                        }
+
+                        return response.results.map((row: any[]) => {
+                            const obj: any = {}
+                            response.columns!.forEach((col: string, idx: number) => {
+                                obj[col] = row[idx]
+                            })
+                            return obj as QueryLogEntry
+                        })
+                    } catch (error) {
+                        console.error('Error loading more query logs:', error)
+                        return []
+                    }
+                },
+            },
+        ],
+    })),
+    reducers({
+        limit: [100, {}],
+        queryLogs: {
+            loadQueryLogsSuccess: (_, { queryLogs }) => queryLogs,
+            loadMoreQueryLogsSuccess: (state, { moreQueryLogs }) => [...state, ...moreQueryLogs],
+        },
+    }),
+    selectors({
+        queryLogsWithIndex: [
+            (s) => [s.queryLogs],
+            (queryLogs: QueryLogEntry[]): (QueryLogEntry & { index: number })[] =>
+                queryLogs.map((log, index) => ({ ...log, index })),
+        ],
+        hasMore: [
+            (s) => [s.moreQueryLogs, s.limit],
+            (moreQueryLogs: QueryLogEntry[], limit: number): boolean => moreQueryLogs.length === limit,
+        ],
+    }),
+    afterMount(({ actions }) => {
+        actions.loadQueryLogs()
+    }),
+])


### PR DESCRIPTION
## Problem

Users of the Debug scene (might) need a way to review their past queries and quickly load them into the SQL editor for further inspection or modification. This enhances the debugging workflow by providing a historical context of executed queries.

## Changes

This PR introduces a new "Query log" tab to the Debug scene. This tab displays the last 100 queries executed by the current user within the past 7 days, fetched from the `query_log_archive` table. Each row in the table includes a button to load the corresponding query directly into the SQL editor. The implementation follows Kea patterns for state management and data fetching.

<img width="1282" height="796" alt="image" src="https://github.com/user-attachments/assets/cb81807a-c34e-45d0-9f3c-8e9e83a1df34" />


## How did you test this code?

- locally

---
[Slack Thread](https://posthog.slack.com/archives/D09F4NR6W1L/p1761349868262929?thread_ts=1761349868.262929&cid=D09F4NR6W1L)

<a href="https://cursor.com/background-agent?bcId=bc-9bdc1d97-855a-4c62-a4f1-eafe851e40dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bdc1d97-855a-4c62-a4f1-eafe851e40dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

