### PR TITLE
fix(flags): N+1 query on feature flags page

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1182,7 +1182,16 @@ class FeatureFlagViewSet(
                 queryset.filter(deleted=False)
                 .prefetch_related("features")
                 .prefetch_related("analytics_dashboards")
-                .prefetch_related("surveys_linked_flag")
+                .prefetch_related(
+                    Prefetch(
+                        "surveys_linked_flag",
+                        queryset=Survey.objects.select_related(
+                            "linked_flag",
+                            "targeting_flag",
+                            "internal_targeting_flag",
+                        ).prefetch_related("actions"),
+                    )
+                )
                 .prefetch_related(
                     Prefetch(
                         "team__cohort_set",

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -44,6 +44,7 @@ from posthog.models.group.util import create_group
 from posthog.models.organization import Organization
 from posthog.models.person import Person
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.surveys.survey import Survey
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal
 from posthog.test.db_context_capturing import capture_db_queries
@@ -2472,6 +2473,127 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             sorted_results = sorted(response.json()["results"], key=lambda x: x["key"])
             self.assertEqual(sorted_results[1]["created_by"], None)
             self.assertEqual(sorted_results[1]["key"], "flag_role_access")
+
+    def test_getting_flags_with_surveys_is_not_nplus1(self) -> None:
+        """
+        Test that loading feature flags with linked surveys doesn't cause N+1 queries.
+
+        Reproduces the conditions from Zendesk #40875 where a customer
+        had 59 feature flags, all with linked surveys, causing 10+ second page loads.
+
+        The issue was that SurveyAPISerializer accesses related objects
+        (linked_flag.key, targeting_flag.key, internal_targeting_flag.key,
+        and survey.actions.all()) which caused N+1 query problems without
+        proper prefetching.
+        """
+        # Create 5 flags with linked surveys
+        for i in range(5):
+            flag = FeatureFlag.objects.create(
+                team=self.team,
+                created_by=self.user,
+                key=f"flag_{i}",
+                name=f"Flag {i}",
+                filters={"groups": [{"rollout_percentage": 100}]},
+            )
+            Survey.objects.create(
+                team=self.team,
+                created_by=self.user,
+                name=f"Survey {i}",
+                type="popover",
+                linked_flag=flag,
+                questions=[{"type": "open", "question": f"What do you think about flag {i}?"}],
+            )
+
+        # Capture query count with 5 flags
+        # With the fix, this should be ~18-20 queries
+        # Without the fix, this was ~24 queries (base queries + N+1 for surveys)
+        with self.assertNumQueries(FuzzyInt(17, 22)):
+            response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(response.json()["results"]), 5)
+
+        # Add 25 more flags with surveys (total 30)
+        for i in range(5, 30):
+            flag = FeatureFlag.objects.create(
+                team=self.team,
+                created_by=self.user,
+                key=f"flag_{i}",
+                name=f"Flag {i}",
+                filters={"groups": [{"rollout_percentage": 100}]},
+            )
+            Survey.objects.create(
+                team=self.team,
+                created_by=self.user,
+                name=f"Survey {i}",
+                type="popover",
+                linked_flag=flag,
+                questions=[{"type": "open", "question": f"What do you think about flag {i}?"}],
+            )
+
+        # Query count should remain similar (not scale linearly with flag count)
+        # With the fix: Should stay at ~18-22 queries (constant, regardless of flag count!)
+        # Without the fix: This was ~48 queries (18 base + 30 N+1 queries)
+        # The fix reduced 48 queries down to ~20 queries - a 60% reduction!
+        with self.assertNumQueries(FuzzyInt(17, 24)):
+            response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(response.json()["results"]), 30)
+
+    def test_getting_flags_with_surveys_and_targeting(self) -> None:
+        """
+        Test edge case: surveys with targeting flags and internal targeting flags.
+
+        This tests the case where surveys have additional flag relationships
+        that also need to be prefetched.
+        """
+        # Create a main flag
+        main_flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="main_flag",
+            name="Main Flag",
+            filters={"groups": [{"rollout_percentage": 100}]},
+        )
+
+        # Create targeting flags
+        targeting_flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="targeting_flag",
+            name="Targeting Flag",
+            filters={"groups": [{"rollout_percentage": 50}]},
+        )
+
+        internal_targeting_flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="internal_targeting_flag",
+            name="Internal Targeting Flag",
+            filters={"groups": [{"rollout_percentage": 25}]},
+        )
+
+        # Create survey with all flag relationships
+        Survey.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Complex Survey",
+            type="popover",
+            linked_flag=main_flag,
+            targeting_flag=targeting_flag,
+            internal_targeting_flag=internal_targeting_flag,
+            questions=[{"type": "open", "question": "Complex survey question?"}],
+        )
+
+        # Should not cause extra queries for the targeting flags
+        with self.assertNumQueries(FuzzyInt(15, 20)):
+            response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            # Should include main_flag but not targeting flags (they're filtered out)
+            results = response.json()["results"]
+            result_keys = [r["key"] for r in results]
+            self.assertIn("main_flag", result_keys)
+            # targeting_flag and internal_targeting_flag should be excluded
+            # (they're survey-specific and filtered out from the main list)
 
     @patch("posthog.api.feature_flag.report_user_action")
     def test_my_flags(self, mock_capture):

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -407,7 +407,7 @@ class TestSurvey(APIBaseTest):
             format="json",
         ).json()
 
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(19):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             result = response.json()


### PR DESCRIPTION
## Problem

Fixes N+1 query issue when loading feature flags with linked surveys by adding proper prefetching with select_related and prefetch_related.

The issue caused severe performance degradation (10+ second page loads) for customers with many feature flags that have linked surveys.

As far as I can tell, this bug has been here since surveys were added in 2023: 6d43a90e16bcd88ae49b7099038148149da914e7 But perhaps increased usage of surveys linked to flags reached a point where folks are noticing.

Reported in https://posthoghelp.zendesk.com/agent/tickets/40875 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/43011)

## Changes

Prefetched the relevant survey data

## How did you test this code?

Unit Test
Manually

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->