### PR TITLE
chore: archive playwright reports when tests fail

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -462,7 +462,7 @@ jobs:
                   docker logs posthog-proxy-1
 
             - name: Archive Playwright report on failure
-              if: failure()
+              if: needs.changes.outputs.shouldRun == 'true' && steps.playwright-tests.outcome == 'failure'
               uses: actions/upload-artifact@v4
               with:
                   name: playwright-report


### PR DESCRIPTION
follow-up to https://app.graphite.dev/github/pr/PostHog/posthog/39833/fix-poking-monaco-with-a-stick

the playwright tests fail in that PR but not on my machine

so i'm exploding the changes to a stack to see where it starts to fail

---

in this PR we archive playwright reports when the tests fail, because the step no longer exits on fail so this never runs and we can't investigate failures