### PR TITLE
feat(create experiments): missing analytics and other fixes

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -316,7 +316,6 @@ export const FEATURE_FLAGS = {
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     SEEKBAR_PREVIEW_SCRUBBING: 'seekbar-preview-scrubbing', // owner: @pauldambra #team-replay
     EXPERIMENTS_BREAKDOWN_FILTER: 'experiments-breakdown-filter', // owner: @rodrigoi #team-experiments
-    EXPERIMENTS_UNIFIED_CREATE_FORM: 'experiments-unified-create-form', // owner: @rodrigoi #team-experiments
     TARGETED_PRODUCT_UPSELL: 'targeted-product-upsell', // owner: @raquelmsmith
     COHORT_CALCULATION_HISTORY: 'cohort-calculation-history', // owner: @gustavo #team-feature-flags
     DATA_IN_NEW_TAB_SCENE: 'data-in-new-tab-scene', // owner: @adamleithp #team-platform-ux
@@ -327,6 +326,7 @@ export const FEATURE_FLAGS = {
     ADVANCE_MARKETING_ANALYTICS_SETTINGS: 'advance-marketing-analytics-settings', // owner: @jabahamondes  #team-web-analytics
     DWH_FREE_SYNCS: 'dwh-free-syncs', // owner: @Gilbert09  #team-data-warehouse
     COPY_WEB_ANALYTICS_DATA: 'copy-web-analytics-data', // owner: @lricoy  #team-web-analytics
+    EXPERIMENTS_CREATE_FORM: 'experiments-create-form', // owner: @rodrigoi #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -433,6 +433,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportExperimentArchived: (experiment: Experiment) => ({ experiment }),
         reportExperimentReset: (experiment: Experiment) => ({ experiment }),
         reportExperimentCreated: (experiment: Experiment) => ({ experiment }),
+        reportExperimentUpdated: (experiment: Experiment) => ({ experiment }),
         reportExperimentViewed: (experiment: Experiment, duration: number | null) => ({ experiment, duration }),
         reportExperimentLaunched: (experiment: Experiment, launchDate: Dayjs) => ({ experiment, launchDate }),
         reportExperimentStartDateChange: (experiment: Experiment, newStartDate: string) => ({
@@ -1011,6 +1012,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 name: experiment.name,
                 type: experiment.type,
                 parameters: experiment.parameters,
+            })
+        },
+        reportExperimentUpdated: ({ experiment }) => {
+            posthog.capture('experiment updated', {
+                ...getEventPropertiesForExperiment(experiment),
             })
         },
         reportExperimentViewed: ({ experiment, duration }) => {

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -23,7 +23,7 @@ export const scene: SceneExport<ExperimentLogicProps> = {
 export function Experiment(): JSX.Element {
     const { formMode, experimentMissing, experimentId } = useValues(experimentLogic)
     const { currentTeamId } = useValues(teamLogic)
-    const isUnifiedCreateFormEnabled = useFeatureFlag('EXPERIMENTS_UNIFIED_CREATE_FORM', 'test')
+    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM')
 
     useFileSystemLogView({
         type: 'experiment',
@@ -36,7 +36,7 @@ export function Experiment(): JSX.Element {
         return <NotFound object="experiment" />
     }
 
-    if (isUnifiedCreateFormEnabled && formMode === FORM_MODES.create) {
+    if (isCreateFormEnabled && formMode === FORM_MODES.create) {
         return <CreateExperiment />
     }
 

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -222,12 +222,12 @@ export function ExperimentView(): JSX.Element {
      * We show the create form if the experiment is draft + has no metrics. Otherwise,
      * we show the experiment view.
      */
-    const isUnifiedCreateFormEnabled = useFeatureFlag('EXPERIMENTS_UNIFIED_CREATE_FORM', 'test')
+    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM')
     const allPrimaryMetrics = [...(experiment.metrics || []), ...(experiment.saved_metrics || [])]
 
     if (
         !experimentLoading &&
-        isUnifiedCreateFormEnabled &&
+        isCreateFormEnabled &&
         getExperimentStatus(experiment) === ProgressStatus.Draft &&
         allPrimaryMetrics.length === 0
     ) {

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -219,11 +219,14 @@ export function ExperimentView(): JSX.Element {
      * this has to be migrated into a scene with a proper path, and paramsToProps
      * so it works seamlesly with the toolbar and tab bar navigation.
      *
-     * We show the create form if the experiment is draft + has no metrics. Otherwise,
+     * We show the create form if the experiment is draft + has no primary metrics. Otherwise,
      * we show the experiment view.
      */
     const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM')
-    const allPrimaryMetrics = [...(experiment.metrics || []), ...(experiment.saved_metrics || [])]
+    const allPrimaryMetrics = [
+        ...(experiment.metrics || []),
+        ...(experiment.saved_metrics || []).filter((sm) => sm.metadata.type === 'primary'),
+    ]
 
     if (
         !experimentLoading &&

--- a/frontend/src/scenes/experiments/components/SelectableCard.tsx
+++ b/frontend/src/scenes/experiments/components/SelectableCard.tsx
@@ -12,7 +12,7 @@ type SelectableCardProps = {
     onClick: () => void
     className?: string
     'data-attr'?: string
-} & ({ disabled: true; disabledReason: string } | { disabled?: false; disabledReason?: never })
+} & ({ disabled?: false; disabledReason?: never } | { disabled: boolean; disabledReason: string })
 
 export function SelectableCard({
     title,

--- a/frontend/src/scenes/experiments/create/CreateExperiment.test.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.test.tsx
@@ -116,6 +116,7 @@ describe('CreateExperiment Integration', () => {
                     ...NEW_EXPERIMENT,
                     name: 'Test Experiment',
                     description: 'Test hypothesis',
+                    feature_flag_key: 'test-experiment',
                 })
                 logic.actions.submitExperiment()
             })
@@ -140,6 +141,7 @@ describe('CreateExperiment Integration', () => {
                     ...NEW_EXPERIMENT,
                     name: 'Valid Name',
                     description: 'Valid Description',
+                    feature_flag_key: 'valid-experiment',
                 })
                 logic.actions.submitExperiment()
             })

--- a/frontend/src/scenes/experiments/create/CreateExperiment.test.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.test.tsx
@@ -78,9 +78,9 @@ describe('CreateExperiment Integration', () => {
         it('validates and prevents submission with empty fields', async () => {
             await expectLogic(logic, () => {
                 logic.actions.setExperiment({ ...NEW_EXPERIMENT, name: '' })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['submitExperiment', 'submitExperimentFailure'])
+                .toDispatchActions(['saveExperiment', 'saveExperimentFailure'])
                 .toMatchValues({
                     experimentErrors: expect.objectContaining({
                         name: 'Name is required',
@@ -118,9 +118,9 @@ describe('CreateExperiment Integration', () => {
                     description: 'Test hypothesis',
                     feature_flag_key: 'test-experiment',
                 })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['submitExperiment', 'createExperimentSuccess'])
+                .toDispatchActions(['saveExperiment', 'createExperimentSuccess'])
                 .toFinishAllListeners()
 
             expect(routerPushSpy).toHaveBeenCalledWith('/experiments/123')
@@ -129,7 +129,7 @@ describe('CreateExperiment Integration', () => {
         it('clears errors after successful submission', async () => {
             await expectLogic(logic, () => {
                 logic.actions.setExperiment({ ...NEW_EXPERIMENT, name: '', description: '' })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             }).toMatchValues({
                 experimentErrors: expect.objectContaining({
                     name: 'Name is required',
@@ -143,9 +143,9 @@ describe('CreateExperiment Integration', () => {
                     description: 'Valid Description',
                     feature_flag_key: 'valid-experiment',
                 })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['submitExperiment', 'createExperimentSuccess'])
+                .toDispatchActions(['saveExperiment', 'createExperimentSuccess'])
                 .toMatchValues({
                     experimentErrors: {},
                 })

--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -1,12 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { Form } from 'kea-forms'
 import { router } from 'kea-router'
 import { useState } from 'react'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
-import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
@@ -39,18 +37,24 @@ type CreateExperimentProps = Partial<{
 }>
 
 export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JSX.Element => {
-    const { experiment, experimentErrors, canSubmitExperiment, sharedMetrics, isExperimentSubmitting } = useValues(
-        createExperimentLogic({ experiment: draftExperiment })
-    )
-    const { setExperimentValue, setExperiment, setSharedMetrics, setExposureCriteria, setFeatureFlagConfig } =
-        useActions(createExperimentLogic({ experiment: draftExperiment }))
+    const { experiment, experimentErrors, canSubmitExperiment, sharedMetrics, isExperimentSubmitting, isEditMode } =
+        useValues(createExperimentLogic({ experiment: draftExperiment }))
+    const {
+        setExperimentValue,
+        setExperiment,
+        setSharedMetrics,
+        setExposureCriteria,
+        setFeatureFlagConfig,
+        saveExperiment,
+        validateField,
+    } = useActions(createExperimentLogic({ experiment: draftExperiment }))
 
     const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
 
     return (
         <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
-            <Form logic={createExperimentLogic} formKey="experiment" enableFormOnSubmit>
-                <SceneContent className="max-w-none flex-1">
+            <div className="max-w-none flex-1">
+                <SceneContent>
                     <SceneTitleSection
                         name={experiment.name}
                         description={null}
@@ -63,7 +67,11 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                             experiment.user_access_level
                         )}
                         forceEdit
-                        onNameChange={(name) => setExperimentValue('name', name)}
+                        saveOnBlur
+                        onNameChange={(name) => {
+                            setExperimentValue('name', name)
+                            validateField('name')
+                        }}
                         actions={
                             <>
                                 <LemonButton
@@ -88,7 +96,7 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                         data-attr="save-experiment"
                                         type="primary"
                                         size="small"
-                                        htmlType="submit"
+                                        onClick={saveExperiment}
                                     >
                                         Save as draft
                                     </LemonButton>
@@ -101,16 +109,14 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                     )}
                     <SceneDivider />
                     <SceneSection title="Hypothesis" description="Describe your experiment in a few sentences.">
-                        <LemonField name="description">
-                            <LemonTextArea
-                                placeholder="The goal of this experiment is ..."
-                                data-attr="experiment-hypothesis"
-                                value={experiment.description}
-                                onChange={(value) => {
-                                    setExperimentValue('description', value)
-                                }}
-                            />
-                        </LemonField>
+                        <LemonTextArea
+                            placeholder="The goal of this experiment is ..."
+                            data-attr="experiment-hypothesis"
+                            value={experiment.description}
+                            onChange={(value) => {
+                                setExperimentValue('description', value)
+                            }}
+                        />
                     </SceneSection>
                     <SceneDivider />
                     <LemonCollapse
@@ -132,13 +138,14 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                             },
                             {
                                 key: 'experiment-variants',
-                                header: <VariantsPanelHeader experiment={experiment} />,
+                                header: <VariantsPanelHeader experiment={experiment} disabled={isEditMode} />,
                                 content: (
                                     <VariantsPanel
                                         experiment={experiment}
                                         updateFeatureFlag={setFeatureFlagConfig}
                                         onPrevious={() => setSelectedPanel('experiment-exposure')}
                                         onNext={() => setSelectedPanel('experiment-metrics')}
+                                        disabled={isEditMode}
                                     />
                                 ),
                             },
@@ -174,6 +181,10 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                                     [context.orderingField]: (
                                                         experiment[context.orderingField] ?? []
                                                     ).filter((uuid) => uuid !== metric.uuid),
+                                                    // Remove from saved_metrics so modal shows it as available again
+                                                    saved_metrics: (experiment.saved_metrics ?? []).filter(
+                                                        (sm) => sm.saved_metric !== metric.sharedMetricId
+                                                    ),
                                                 })
                                                 setSharedMetrics({
                                                     ...sharedMetrics,
@@ -250,14 +261,14 @@ export const CreateExperiment = ({ draftExperiment }: CreateExperimentProps): JS
                                 data-attr="save-experiment"
                                 type="primary"
                                 size="small"
-                                htmlType="submit"
+                                onClick={saveExperiment}
                             >
                                 Save as draft
                             </LemonButton>
                         </AccessControlAction>
                     </div>
                 </SceneContent>
-            </Form>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -26,11 +26,19 @@ interface VariantsPanelProps {
             ensure_experience_continuity?: boolean
         }
     }) => void
+    disabled?: boolean
 }
 
-export function VariantsPanel({ experiment, updateFeatureFlag, onPrevious, onNext }: VariantsPanelProps): JSX.Element {
-    const { mode, linkedFeatureFlag } = useValues(variantsPanelLogic({ experiment }))
-    const { setMode, setLinkedFeatureFlag } = useActions(variantsPanelLogic({ experiment }))
+export function VariantsPanel({
+    experiment,
+    updateFeatureFlag,
+    onPrevious,
+    onNext,
+    disabled = false,
+}: VariantsPanelProps): JSX.Element {
+    const isEditMode = disabled
+    const { mode, linkedFeatureFlag } = useValues(variantsPanelLogic({ experiment, disabled }))
+    const { setMode, setLinkedFeatureFlag } = useActions(variantsPanelLogic({ experiment, disabled }))
 
     const { openSelectExistingFeatureFlagModal, closeSelectExistingFeatureFlagModal } = useActions(
         selectExistingFeatureFlagModalLogic
@@ -47,23 +55,33 @@ export function VariantsPanel({ experiment, updateFeatureFlag, onPrevious, onNex
                     onClick={() => {
                         setMode('create')
                     }}
+                    disabled={disabled}
+                    disabledReason="You cannot change the mode when editing an experiment."
                 />
                 <SelectableCard
                     title="Link existing feature flag"
                     description="Use an existing multivariate feature flag and inherit its variants."
                     selected={mode === 'link'}
                     onClick={() => setMode('link')}
+                    disabled={disabled}
+                    disabledReason="You cannot change the mode when editing an experiment."
                 />
             </div>
 
             {match(mode)
                 .with('create', () => (
-                    <VariantsPanelCreateFeatureFlag experiment={experiment} onChange={updateFeatureFlag} />
+                    <VariantsPanelCreateFeatureFlag
+                        experiment={experiment}
+                        onChange={updateFeatureFlag}
+                        readOnly={isEditMode}
+                        disabled={disabled}
+                    />
                 ))
                 .with('link', () => (
                     <VariantsPanelLinkFeatureFlag
                         linkedFeatureFlag={linkedFeatureFlag}
                         setShowFeatureFlagSelector={openSelectExistingFeatureFlagModal}
+                        readOnly={isEditMode}
                     />
                 ))
                 .exhaustive()}

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -36,7 +36,6 @@ export function VariantsPanel({
     onNext,
     disabled = false,
 }: VariantsPanelProps): JSX.Element {
-    const isEditMode = disabled
     const { mode, linkedFeatureFlag } = useValues(variantsPanelLogic({ experiment, disabled }))
     const { setMode, setLinkedFeatureFlag } = useActions(variantsPanelLogic({ experiment, disabled }))
 
@@ -73,7 +72,6 @@ export function VariantsPanel({
                     <VariantsPanelCreateFeatureFlag
                         experiment={experiment}
                         onChange={updateFeatureFlag}
-                        readOnly={isEditMode}
                         disabled={disabled}
                     />
                 ))
@@ -81,7 +79,7 @@ export function VariantsPanel({
                     <VariantsPanelLinkFeatureFlag
                         linkedFeatureFlag={linkedFeatureFlag}
                         setShowFeatureFlagSelector={openSelectExistingFeatureFlagModal}
-                        readOnly={isEditMode}
+                        disabled={disabled}
                     />
                 ))
                 .exhaustive()}

--- a/frontend/src/scenes/experiments/create/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanel.tsx
@@ -4,6 +4,7 @@ import { match } from 'ts-pattern'
 import { LemonDivider } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 import { SelectableCard } from '~/scenes/experiments/components/SelectableCard'
 import type { Experiment, FeatureFlagType, MultivariateFlagVariant } from '~/types'
@@ -34,6 +35,7 @@ export function VariantsPanel({ experiment, updateFeatureFlag, onPrevious, onNex
     const { openSelectExistingFeatureFlagModal, closeSelectExistingFeatureFlagModal } = useActions(
         selectExistingFeatureFlagModalLogic
     )
+    const { reportExperimentFeatureFlagSelected } = useActions(eventUsageLogic)
 
     return (
         <>
@@ -80,6 +82,7 @@ export function VariantsPanel({ experiment, updateFeatureFlag, onPrevious, onNex
             <SelectExistingFeatureFlagModal
                 onClose={() => closeSelectExistingFeatureFlagModal()}
                 onSelect={(flag: FeatureFlagType) => {
+                    reportExperimentFeatureFlagSelected(flag.key)
                     setLinkedFeatureFlag(flag)
                     // Update experiment with linked flag's key and variants
                     updateFeatureFlag({

--- a/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelCreateFeatureFlag.tsx
@@ -46,14 +46,12 @@ interface VariantsPanelCreateFeatureFlagProps {
             ensure_experience_continuity?: boolean
         }
     }) => void
-    readOnly?: boolean
     disabled?: boolean
 }
 
 export const VariantsPanelCreateFeatureFlag = ({
     experiment,
     onChange,
-    readOnly = false,
     disabled = false,
 }: VariantsPanelCreateFeatureFlagProps): JSX.Element => {
     const { featureFlagKeyValidation, featureFlagKeyValidationLoading } = useValues(
@@ -152,7 +150,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                         placeholder="examples: new-landing-page, betaFeature, ab_test_1"
                         value={experiment.feature_flag_key || ''}
                         onChange={
-                            readOnly
+                            disabled
                                 ? undefined
                                 : (value) => {
                                       /**
@@ -168,7 +166,9 @@ export const VariantsPanelCreateFeatureFlag = ({
                                       debouncedValidateFeatureFlagKey(normalizedValue)
                                   }
                         }
-                        disabled={readOnly}
+                        disabledReason={
+                            disabled ? 'You cannot change the feature flag key when editing an experiment.' : undefined
+                        }
                         suffix={
                             featureFlagKeyValidationLoading ? (
                                 <Spinner size="small" />
@@ -199,7 +199,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                         <div className="col-span-6">Description</div>
                         <div className="col-span-3 flex justify-between items-center gap-1">
                             <span>Rollout</span>
-                            {!readOnly && (
+                            {!disabled && (
                                 <LemonButton
                                     onClick={() => distributeVariantsEqually()}
                                     tooltip="Normalize variant rollout percentages"
@@ -225,7 +225,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                                 <LemonInput
                                     value={variant.key}
                                     disabledReason={
-                                        readOnly
+                                        disabled
                                             ? 'Cannot edit feature flag in edit mode'
                                             : variant.key === 'control'
                                               ? 'Control variant cannot be changed'
@@ -246,7 +246,11 @@ export const VariantsPanelCreateFeatureFlag = ({
                                 <LemonInput
                                     value={variant.name || ''}
                                     onChange={(value) => updateVariant(index, { name: value })}
-                                    disabled={readOnly}
+                                    disabledReason={
+                                        disabled
+                                            ? 'You cannot change the variant name when editing an experiment.'
+                                            : undefined
+                                    }
                                     data-attr="experiment-variant-name"
                                     className="ph-ignore-input"
                                     placeholder="Description"
@@ -265,13 +269,17 @@ export const VariantsPanelCreateFeatureFlag = ({
                                                 : 0
                                         updateVariant(index, { rollout_percentage: valueInt })
                                     }}
-                                    disabled={readOnly}
+                                    disabledReason={
+                                        disabled
+                                            ? 'You cannot change the variant rollout percentage when editing an experiment.'
+                                            : undefined
+                                    }
                                     suffix={<span>%</span>}
                                     data-attr="experiment-variant-rollout-percentage-input"
                                 />
                             </div>
                             <div className="flex items-center justify-center">
-                                {!readOnly && variants.length > 2 && index > 0 && (
+                                {!disabled && variants.length > 2 && index > 0 && (
                                     <LemonButton
                                         icon={<IconTrash />}
                                         data-attr={`delete-prop-filter-${index}`}
@@ -294,7 +302,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                     {variants.length > 0 && hasDuplicateKeys && (
                         <p className="text-danger">Variant keys must be unique.</p>
                     )}
-                    {!readOnly && variants.length < MAX_EXPERIMENT_VARIANTS && (
+                    {!disabled && variants.length < MAX_EXPERIMENT_VARIANTS && (
                         <LemonButton type="secondary" onClick={addVariant} icon={<IconPlus />} center>
                             Add variant
                         </LemonButton>
@@ -315,7 +323,11 @@ export const VariantsPanelCreateFeatureFlag = ({
                     }}
                     fullWidth
                     checked={ensureExperienceContinuity}
-                    disabled={readOnly}
+                    disabledReason={
+                        disabled
+                            ? 'You cannot change the persist flag across authentication steps when editing an experiment.'
+                            : undefined
+                    }
                 />
                 <div className="text-secondary text-sm pl-6 mt-2">
                     If your feature flag is evaluated for anonymous users, use this option to ensure the flag value

--- a/frontend/src/scenes/experiments/create/VariantsPanelHeader.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelHeader.tsx
@@ -26,12 +26,12 @@ export const VariantsPanelHeader = ({
     experiment: Experiment
     disabled: boolean
 }): JSX.Element => {
-    const { featureFlagKeyValidation } = useValues(variantsPanelLogic({ experiment, disabled }))
+    const { featureFlagKeyValidation, mode } = useValues(variantsPanelLogic({ experiment, disabled }))
 
     const flagKey = experiment.feature_flag_key
     const variants = experiment.parameters?.feature_flag_variants || []
 
-    const result = validateVariants({ flagKey, variants, featureFlagKeyValidation })
+    const result = validateVariants({ flagKey, variants, featureFlagKeyValidation, mode })
 
     const { hasErrors, hasWarnings, rules } = result
     const { hasFlagKey, hasFlagKeyError } = rules

--- a/frontend/src/scenes/experiments/create/VariantsPanelHeader.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelHeader.tsx
@@ -19,8 +19,14 @@ const FlagKeyText = ({ flagKey }: { flagKey: string }): JSX.Element => (
     </LemonTag>
 )
 
-export const VariantsPanelHeader = ({ experiment }: { experiment: Experiment }): JSX.Element => {
-    const { featureFlagKeyValidation } = useValues(variantsPanelLogic({ experiment }))
+export const VariantsPanelHeader = ({
+    experiment,
+    disabled,
+}: {
+    experiment: Experiment
+    disabled: boolean
+}): JSX.Element => {
+    const { featureFlagKeyValidation } = useValues(variantsPanelLogic({ experiment, disabled }))
 
     const flagKey = experiment.feature_flag_key
     const variants = experiment.parameters?.feature_flag_variants || []

--- a/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
@@ -14,6 +14,7 @@ import type { FeatureFlagType } from '~/types'
 interface VariantsPanelLinkFeatureFlagProps {
     linkedFeatureFlag: FeatureFlagType | null
     setShowFeatureFlagSelector: () => void
+    readOnly?: boolean
 }
 
 const getTargetingSummary = (flag: FeatureFlagType): string[] => {
@@ -73,8 +74,13 @@ const TargetingSummary = ({ flag }: { flag: FeatureFlagType }): JSX.Element => {
 export const VariantsPanelLinkFeatureFlag = ({
     linkedFeatureFlag,
     setShowFeatureFlagSelector,
+    readOnly = false,
 }: VariantsPanelLinkFeatureFlagProps): JSX.Element => {
     if (!linkedFeatureFlag) {
+        if (readOnly) {
+            // Defensive: shouldn't happen in edit mode
+            return <div className="text-danger text-sm">No feature flag linked to this experiment</div>
+        }
         return (
             <div>
                 <label className="text-sm font-semibold">Selected Feature Flag</label>
@@ -114,9 +120,12 @@ export const VariantsPanelLinkFeatureFlag = ({
                             <IconOpenInNew />
                         </Link>
                     </div>
-                    <LemonButton type="secondary" size="small" onClick={setShowFeatureFlagSelector}>
-                        Change
-                    </LemonButton>
+                    {/* Only show Change button when not read-only */}
+                    {!readOnly && (
+                        <LemonButton type="secondary" size="small" onClick={setShowFeatureFlagSelector}>
+                            Change
+                        </LemonButton>
+                    )}
                 </div>
 
                 {/* Status */}

--- a/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/create/VariantsPanelLinkFeatureFlag.tsx
@@ -14,7 +14,7 @@ import type { FeatureFlagType } from '~/types'
 interface VariantsPanelLinkFeatureFlagProps {
     linkedFeatureFlag: FeatureFlagType | null
     setShowFeatureFlagSelector: () => void
-    readOnly?: boolean
+    disabled?: boolean
 }
 
 const getTargetingSummary = (flag: FeatureFlagType): string[] => {
@@ -74,12 +74,15 @@ const TargetingSummary = ({ flag }: { flag: FeatureFlagType }): JSX.Element => {
 export const VariantsPanelLinkFeatureFlag = ({
     linkedFeatureFlag,
     setShowFeatureFlagSelector,
-    readOnly = false,
+    disabled = false,
 }: VariantsPanelLinkFeatureFlagProps): JSX.Element => {
     if (!linkedFeatureFlag) {
-        if (readOnly) {
-            // Defensive: shouldn't happen in edit mode
-            return <div className="text-danger text-sm">No feature flag linked to this experiment</div>
+        if (disabled) {
+            return (
+                <div className="text-danger text-sm">
+                    You cannot change the feature flag when editing an experiment.
+                </div>
+            )
         }
         return (
             <div>
@@ -121,11 +124,17 @@ export const VariantsPanelLinkFeatureFlag = ({
                         </Link>
                     </div>
                     {/* Only show Change button when not read-only */}
-                    {!readOnly && (
-                        <LemonButton type="secondary" size="small" onClick={setShowFeatureFlagSelector}>
-                            Change
-                        </LemonButton>
-                    )}
+
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={setShowFeatureFlagSelector}
+                        disabledReason={
+                            disabled ? 'You cannot change the feature flag when editing an experiment.' : undefined
+                        }
+                    >
+                        Change
+                    </LemonButton>
                 </div>
 
                 {/* Status */}

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
@@ -75,9 +75,9 @@ describe('createExperimentLogic', () => {
                     name: '',
                     description: 'Valid hypothesis',
                 })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['setExperiment', 'submitExperiment', 'submitExperimentFailure'])
+                .toDispatchActions(['setExperiment', 'saveExperiment', 'saveExperimentFailure'])
                 .toMatchValues({
                     experimentErrors: partial({
                         name: 'Name is required',
@@ -91,13 +91,14 @@ describe('createExperimentLogic', () => {
                     ...NEW_EXPERIMENT,
                     name: 'Test Experiment',
                     description: 'Test hypothesis',
+                    feature_flag_key: 'test-experiment',
                 })
-                logic.actions.submitExperiment()
-            }).toDispatchActions(['setExperiment', 'submitExperiment', 'submitExperimentSuccess'])
+                logic.actions.saveExperiment()
+            }).toDispatchActions(['setExperiment', 'saveExperiment', 'createExperimentSuccess'])
         })
     })
 
-    describe('createExperiment', () => {
+    describe('saveExperiment', () => {
         it('successfully creates experiment and triggers success action', async () => {
             await expectLogic(logic, () => {
                 logic.actions.setExperiment({
@@ -107,9 +108,9 @@ describe('createExperimentLogic', () => {
                     type: 'product',
                     feature_flag_key: 'test-experiment',
                 })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['setExperiment', 'submitExperiment', 'createExperimentSuccess'])
+                .toDispatchActions(['setExperiment', 'saveExperiment', 'createExperimentSuccess'])
                 .toMatchValues({
                     experimentErrors: {},
                 })
@@ -123,9 +124,9 @@ describe('createExperimentLogic', () => {
                     description: 'Test hypothesis',
                     feature_flag_key: 'test-experiment',
                 })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['submitExperiment', 'createExperimentSuccess'])
+                .toDispatchActions(['saveExperiment', 'createExperimentSuccess'])
                 .toFinishAllListeners()
 
             expect(refreshTreeItem).toHaveBeenCalledWith('experiment', '123')
@@ -140,15 +141,15 @@ describe('createExperimentLogic', () => {
                     description: 'Test hypothesis',
                     feature_flag_key: 'test-experiment',
                 })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['submitExperiment', 'createExperimentSuccess'])
+                .toDispatchActions(['saveExperiment', 'createExperimentSuccess'])
                 .toFinishAllListeners()
 
             expect(routerPushSpy).toHaveBeenCalledWith('/experiments/123')
         })
 
-        it('shows success toast with view button', async () => {
+        it('shows success toast', async () => {
             routerPushSpy.mockClear()
 
             await expectLogic(logic, () => {
@@ -158,25 +159,14 @@ describe('createExperimentLogic', () => {
                     description: 'Test hypothesis',
                     feature_flag_key: 'test-experiment',
                 })
-                logic.actions.submitExperiment()
+                logic.actions.saveExperiment()
             })
-                .toDispatchActions(['submitExperiment', 'createExperimentSuccess'])
+                .toDispatchActions(['saveExperiment', 'createExperimentSuccess'])
                 .toFinishAllListeners()
 
-            expect(lemonToast.success).toHaveBeenCalledWith(
-                'Experiment created successfully!',
-                expect.objectContaining({
-                    button: expect.objectContaining({
-                        label: 'View it',
-                    }),
-                })
-            )
-
-            const toastCall = (lemonToast.success as jest.Mock).mock.calls[0]
-            const toastButton = toastCall[1].button
-            toastButton.action()
-
-            expect(routerPushSpy).toHaveBeenCalledTimes(2)
+            expect(lemonToast.success).toHaveBeenCalledWith('Experiment created successfully!')
+            expect(routerPushSpy).toHaveBeenCalledTimes(1)
+            expect(routerPushSpy).toHaveBeenCalledWith('/experiments/123')
         })
     })
 
@@ -421,8 +411,8 @@ describe('createExperimentLogic', () => {
                     description: 'Test hypothesis',
                     feature_flag_key: 'custom-flag-key',
                 })
-                logic.actions.submitExperiment()
-            }).toDispatchActions(['setExperiment', 'submitExperiment', 'createExperimentSuccess'])
+                logic.actions.saveExperiment()
+            }).toDispatchActions(['setExperiment', 'saveExperiment', 'createExperimentSuccess'])
         })
 
         it('includes variants in experiment submission', async () => {
@@ -439,8 +429,8 @@ describe('createExperimentLogic', () => {
                         ],
                     },
                 })
-                logic.actions.submitExperiment()
-            }).toDispatchActions(['setExperiment', 'submitExperiment', 'createExperimentSuccess'])
+                logic.actions.saveExperiment()
+            }).toDispatchActions(['setExperiment', 'saveExperiment', 'createExperimentSuccess'])
         })
 
         it('includes experience continuity setting in submission', async () => {
@@ -457,8 +447,8 @@ describe('createExperimentLogic', () => {
                         ],
                     },
                 })
-                logic.actions.submitExperiment()
-            }).toDispatchActions(['setExperiment', 'submitExperiment', 'createExperimentSuccess'])
+                logic.actions.saveExperiment()
+            }).toDispatchActions(['setExperiment', 'saveExperiment', 'createExperimentSuccess'])
         })
     })
 })

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.test.ts
@@ -14,6 +14,7 @@ import { createExperimentLogic } from './createExperimentLogic'
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     lemonToast: {
         success: jest.fn(),
+        error: jest.fn(),
     },
 }))
 
@@ -104,6 +105,7 @@ describe('createExperimentLogic', () => {
                     name: 'Test Experiment',
                     description: 'Test hypothesis',
                     type: 'product',
+                    feature_flag_key: 'test-experiment',
                 })
                 logic.actions.submitExperiment()
             })
@@ -119,6 +121,7 @@ describe('createExperimentLogic', () => {
                     ...NEW_EXPERIMENT,
                     name: 'Test Experiment',
                     description: 'Test hypothesis',
+                    feature_flag_key: 'test-experiment',
                 })
                 logic.actions.submitExperiment()
             })
@@ -135,6 +138,7 @@ describe('createExperimentLogic', () => {
                     ...NEW_EXPERIMENT,
                     name: 'Test Experiment',
                     description: 'Test hypothesis',
+                    feature_flag_key: 'test-experiment',
                 })
                 logic.actions.submitExperiment()
             })
@@ -152,6 +156,7 @@ describe('createExperimentLogic', () => {
                     ...NEW_EXPERIMENT,
                     name: 'Test Experiment',
                     description: 'Test hypothesis',
+                    feature_flag_key: 'test-experiment',
                 })
                 logic.actions.submitExperiment()
             })
@@ -444,6 +449,7 @@ describe('createExperimentLogic', () => {
                     ...NEW_EXPERIMENT,
                     name: 'Test Experiment',
                     description: 'Test hypothesis',
+                    feature_flag_key: 'test-experiment',
                     parameters: {
                         feature_flag_variants: [
                             { key: 'control', rollout_percentage: 50 },

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -112,7 +112,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 featureFlagLogic,
                 ['featureFlags'],
                 variantsPanelLogicInstance,
-                ['featureFlagKeyDirty', 'featureFlagKeyValidation', 'featureFlagKeyValidationLoading', 'mode'],
+                ['featureFlagKeyDirty', 'featureFlagKeyValidation', 'featureFlagKeyValidationLoading'],
             ],
             actions: [
                 eventUsageLogic,
@@ -243,6 +243,14 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             (experiment: Experiment) => experiment.id !== 'new' && experiment.id !== null,
         ],
         isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
+        mode: [
+            (s) => [s.experiment, (_, props) => props],
+            (experiment: Experiment, props: CreateExperimentLogicProps): 'create' | 'link' => {
+                const disabled = experiment.id !== 'new' && experiment.id !== null
+                return variantsPanelLogic({ experiment: props.experiment || { ...NEW_EXPERIMENT }, disabled }).values
+                    .mode
+            },
+        ],
     })),
     listeners(({ values, actions }) => ({
         setExperiment: () => {},

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -280,9 +280,6 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 return
             }
 
-            // Set loading state after all validation passes
-            actions.saveExperimentStarted()
-
             // Check if async validation is still loading
             if (values.featureFlagKeyValidationLoading) {
                 lemonToast.error('Please wait for validation to complete')
@@ -315,6 +312,9 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 actions.saveExperimentFailure()
                 return
             }
+
+            // Set loading state after all validation passes
+            actions.saveExperimentStarted()
 
             try {
                 const isEditMode = values.isEditMode

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -25,7 +25,8 @@ import { validateVariants } from './variantsPanelValidation'
 
 const validateExperiment = (
     experiment: Experiment,
-    featureFlagKeyValidation: { valid: boolean; error: string | null } | null
+    featureFlagKeyValidation: { valid: boolean; error: string | null } | null,
+    mode?: 'create' | 'link'
 ): boolean => {
     const validExperimentName = experiment.name !== null && experiment.name.trim().length > 0
 
@@ -33,6 +34,7 @@ const validateExperiment = (
         flagKey: experiment.feature_flag_key,
         variants: experiment.parameters.feature_flag_variants,
         featureFlagKeyValidation,
+        mode,
     })
 
     return validExperimentName && !variantsValidation.hasErrors
@@ -110,7 +112,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 featureFlagLogic,
                 ['featureFlags'],
                 variantsPanelLogicInstance,
-                ['featureFlagKeyDirty', 'featureFlagKeyValidation', 'featureFlagKeyValidationLoading'],
+                ['featureFlagKeyDirty', 'featureFlagKeyValidation', 'featureFlagKeyValidationLoading', 'mode'],
             ],
             actions: [
                 eventUsageLogic,
@@ -229,9 +231,12 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     })),
     selectors(() => ({
         canSubmitExperiment: [
-            (s) => [s.experiment, s.featureFlagKeyValidation],
-            (experiment: Experiment, featureFlagKeyValidation: { valid: boolean; error: string | null } | null) =>
-                validateExperiment(experiment, featureFlagKeyValidation),
+            (s) => [s.experiment, s.featureFlagKeyValidation, s.mode],
+            (
+                experiment: Experiment,
+                featureFlagKeyValidation: { valid: boolean; error: string | null } | null,
+                mode: 'create' | 'link'
+            ) => validateExperiment(experiment, featureFlagKeyValidation, mode),
         ],
         isEditMode: [
             (s) => [s.experiment],
@@ -288,6 +293,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                     flagKey: values.experiment.feature_flag_key,
                     variants: values.experiment.parameters.feature_flag_variants,
                     featureFlagKeyValidation: values.featureFlagKeyValidation,
+                    mode: values.mode,
                 })
                 if (validation.hasErrors) {
                     lemonToast.error('Please fix variants configuration')

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -272,6 +272,9 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 return
             }
 
+            // Set loading state after all validation passes
+            actions.saveExperimentStarted()
+
             // Check if async validation is still loading
             if (values.featureFlagKeyValidationLoading) {
                 lemonToast.error('Please wait for validation to complete')
@@ -304,9 +307,6 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 actions.saveExperimentFailure()
                 return
             }
-
-            // Set loading state after all validation passes
-            actions.saveExperimentStarted()
 
             try {
                 const isEditMode = values.isEditMode

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -92,6 +92,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             }
         }) => ({ config }),
         createExperiment: () => ({}),
+        createExperimentSuccess: true,
         setSharedMetrics: (sharedMetrics: { primary: ExperimentMetric[]; secondary: ExperimentMetric[] }) => ({
             sharedMetrics,
         }),
@@ -254,7 +255,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                         intent_context: ProductIntentContext.EXPERIMENT_CREATED,
                     })
 
-                    // Show success toast
+                    // Show success toast with view button
                     lemonToast.success('Experiment created successfully!')
 
                     // Reset form for next experiment (clear persisted state)

--- a/frontend/src/scenes/experiments/create/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/create/createExperimentLogic.ts
@@ -98,9 +98,11 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     key((props) => props.experiment?.id || 'create-experiment'),
     path((key) => ['scenes', 'experiments', 'create', 'createExperimentLogic', key]),
     connect((props: CreateExperimentLogicProps) => {
+        const experiment = props.experiment || { ...NEW_EXPERIMENT }
+        const disabled = experiment.id !== 'new' && experiment.id !== null
         const variantsPanelLogicInstance = variantsPanelLogic({
-            experiment: props.experiment || { ...NEW_EXPERIMENT },
-            disabled: (props.experiment?.id !== 'new' && props.experiment?.id !== null) || false,
+            experiment,
+            disabled,
         })
 
         return {

--- a/frontend/src/scenes/experiments/create/selectExistingFeatureFlagModalLogic.ts
+++ b/frontend/src/scenes/experiments/create/selectExistingFeatureFlagModalLogic.ts
@@ -1,10 +1,11 @@
-import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { PaginationManual } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { FLAGS_PER_PAGE } from 'scenes/feature-flags/featureFlagsLogic'
 
 import { FeatureFlagType } from '~/types'
@@ -31,6 +32,10 @@ const DEFAULT_FILTERS: FeatureFlagModalFilters = {
 
 export const selectExistingFeatureFlagModalLogic = kea<selectExistingFeatureFlagModalLogicType>([
     path(['scenes', 'experiments', 'create', 'selectExistingFeatureFlagModalLogic']),
+
+    connect({
+        actions: [eventUsageLogic, ['reportExperimentFeatureFlagModalOpened']],
+    }),
 
     actions({
         openSelectExistingFeatureFlagModal: true,
@@ -70,6 +75,7 @@ export const selectExistingFeatureFlagModalLogic = kea<selectExistingFeatureFlag
             actions.loadFeatureFlags()
         },
         openSelectExistingFeatureFlagModal: () => {
+            actions.reportExperimentFeatureFlagModalOpened()
             actions.loadFeatureFlags()
         },
     })),

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.test.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.test.ts
@@ -106,7 +106,7 @@ describe('variantsPanelLogic', () => {
         experimentsLogic.mount()
         experimentsLogic.actions.loadExperiments()
 
-        logic = variantsPanelLogic({ experiment: mockExperiment })
+        logic = variantsPanelLogic({ experiment: mockExperiment, disabled: false })
         logic.mount()
         jest.clearAllMocks()
     })

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
@@ -108,18 +108,4 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
             }
         },
     }),
-    propsChanged: (
-        {
-            props,
-            actions,
-        }: {
-            props: { experiment: Experiment }
-            actions: { validateFeatureFlagKey: (key: string) => void }
-        },
-        oldProps: { experiment: Experiment }
-    ) => {
-        if (props.experiment.feature_flag_key !== oldProps.experiment.feature_flag_key) {
-            actions.validateFeatureFlagKey(props.experiment.feature_flag_key)
-        }
-    },
 })

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
@@ -108,4 +108,18 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
             }
         },
     }),
+    propsChanged: (
+        {
+            props,
+            actions,
+        }: {
+            props: { experiment: Experiment }
+            actions: { validateFeatureFlagKey: (key: string) => void }
+        },
+        oldProps: { experiment: Experiment }
+    ) => {
+        if (props.experiment.feature_flag_key !== oldProps.experiment.feature_flag_key) {
+            actions.validateFeatureFlagKey(props.experiment.feature_flag_key)
+        }
+    },
 })

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
@@ -27,6 +27,7 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
     actions: {
         setMode: (mode: 'create' | 'link') => ({ mode }),
         validateFeatureFlagKey: (key: string) => ({ key }),
+        clearFeatureFlagKeyValidation: true,
 
         setFeatureFlagKeyDirty: true,
         setLinkedFeatureFlag: (flag: FeatureFlagType | null) => ({ flag }),
@@ -96,6 +97,7 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
 
                     return { valid: true, error: null }
                 },
+                clearFeatureFlagKeyValidation: () => null,
             },
         ],
     }),
@@ -113,12 +115,21 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
     },
     listeners: ({ props, actions }) => ({
         setMode: ({ mode }) => {
-            // When switching from link to create, validate the current key to show it's taken
-            // Note: We use values.experiment (from createExperimentLogic connection) instead of props.experiment
-            // because props are captured at mount time and don't update when the parent logic changes state
-            if (mode === 'create' && props.experiment.feature_flag_key) {
+            if (mode === 'link') {
+                // When switching to link mode, clear validation
+                // In link mode, we're using an existing flag, so the key validation doesn't apply
+                actions.clearFeatureFlagKeyValidation()
+            } else if (mode === 'create' && props.experiment.feature_flag_key) {
+                // When switching from link to create, validate the current key to show it's taken
+                // Note: We use values.experiment (from createExperimentLogic connection) instead of props.experiment
+                // because props are captured at mount time and don't update when the parent logic changes state
                 actions.validateFeatureFlagKey(props.experiment.feature_flag_key)
             }
+        },
+        setLinkedFeatureFlag: () => {
+            // When selecting a linked flag, clear validation
+            // The linked flag's key already exists (that's the point!), so validation doesn't apply
+            actions.clearFeatureFlagKeyValidation()
         },
     }),
 })

--- a/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelLogic.ts
@@ -41,7 +41,7 @@ export const variantsPanelLogic = kea<variantsPanelLogicType>({
         ],
         mode: [
             // if disabled, we've default to 'link' mode
-            props.disabled ? ('link' as const) : ('create' as const),
+            (props.disabled ? 'link' : 'create') as 'create' | 'link',
             {
                 setMode: (state: 'create' | 'link', { mode }: { mode: 'create' | 'link' }) => {
                     // Prevent mode changes when editing

--- a/frontend/src/scenes/experiments/create/variantsPanelValidation.ts
+++ b/frontend/src/scenes/experiments/create/variantsPanelValidation.ts
@@ -20,13 +20,16 @@ export const validateVariants = ({
     flagKey,
     variants,
     featureFlagKeyValidation,
+    mode,
 }: {
     flagKey: string | null
     variants: MultivariateFlagVariant[]
     featureFlagKeyValidation: { valid: boolean; error: string | null } | null
+    mode?: 'create' | 'link'
 }): VariantValidationResult => {
     const hasFlagKey = !!flagKey
-    const hasFlagKeyError = featureFlagKeyValidation?.valid === false
+    // In 'link' mode, we're using an existing flag, so don't validate key availability
+    const hasFlagKeyError = mode === 'link' ? false : featureFlagKeyValidation?.valid === false
     const hasEnoughVariants = variants.length >= 2
     const totalRollout = variants.reduce((sum, v) => sum + (v.rollout_percentage || 0), 0)
     const isValidRollout = totalRollout === 100


### PR DESCRIPTION
## Problem

The new form was failing to edit an experiment and was missing analytics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Analytics: adds a missing "experiment updated" event, and replicates the events from the old form for testing purposes.
- Uses a new boolean feature flag. For testing, we'll change it to a multivariate flag.
- Small type change on the `SelectableCard` component to support `boolean` instead of `true | false`.
- Now we have _Save_ and _Cancel_ buttons at the bottom of the page too.
- Removed `kea-forms` for simplicity; we were using it for just one field.
- The `createExperimentLogic` now handles all validations and supports the case of editing an experiment.
- The `VariantsPanel` is disabled when editing an experiment for backwards compatibility.
- Fixes conflicts between kea logic because of key differences.

| Footer save buttons |
| - |
| <img width="1643" height="626" alt="image" src="https://github.com/user-attachments/assets/3ef52942-7222-4b2d-8914-e346a7815bdb" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/create/*.test.tsx
```

![cat-type-small](https://github.com/user-attachments/assets/dbc883cb-019c-4957-a05c-f87ab96635ed)

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->