### PR TITLE
chore: test web worker in prod

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -42,6 +42,13 @@ await buildInParallel(
             ...common,
         },
         {
+            name: 'Test Worker',
+            entryPoints: ['src/scenes/session-recordings/player/testWorker.ts'],
+            format: 'esm',
+            outfile: path.resolve(__dirname, 'dist', 'testWorker.js'),
+            ...common,
+        },
+        {
             name: 'Exporter',
             globalName: 'posthogExporter',
             entryPoints: ['src/exporter/index.tsx'],
@@ -149,6 +156,13 @@ await buildInParallel(
                     },
                 },
             ],
+            ...common,
+        },
+        {
+            name: 'Test Worker',
+            entryPoints: ['src/scenes/session-recordings/player/testWorker.ts'],
+            format: 'esm',
+            outfile: path.resolve(__dirname, 'dist', 'testWorker.js'),
             ...common,
         },
     ],

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -158,13 +158,6 @@ await buildInParallel(
             ],
             ...common,
         },
-        {
-            name: 'Test Worker',
-            entryPoints: ['src/scenes/session-recordings/player/testWorker.ts'],
-            format: 'esm',
-            outfile: path.resolve(__dirname, 'dist', 'testWorker.js'),
-            ...common,
-        },
     ],
     {
         async onBuildComplete(config, buildResponse) {

--- a/frontend/src/scenes/session-recordings/player/TestWorkerManager.ts
+++ b/frontend/src/scenes/session-recordings/player/TestWorkerManager.ts
@@ -1,0 +1,87 @@
+/* eslint-disable no-console */
+import type { TestWorkerMessage, TestWorkerResponse } from './testWorker'
+
+export class TestWorkerManager {
+    private worker: Worker | null = null
+    private workerBlobUrl: string | null = null
+    private messageId = 0
+
+    async initialize(): Promise<void> {
+        try {
+            this.worker = await this.createWorker()
+
+            this.worker.addEventListener('message', (event: MessageEvent<TestWorkerResponse>) => {
+                const { type, originalMessage, amendedMessage } = event.data
+
+                if (type === 'response') {
+                    console.log('[TestWorkerManager] Received response from worker')
+                    console.log('[TestWorkerManager] Original:', originalMessage)
+                    console.log('[TestWorkerManager] Amended:', amendedMessage)
+                }
+            })
+
+            this.worker.addEventListener('error', (error) => {
+                console.error('[TestWorkerManager] Worker error:', error)
+            })
+
+            this.sendTestMessage('Hello from session replay player!')
+        } catch (error) {
+            console.error('[TestWorkerManager] Failed to initialize worker:', error)
+        }
+    }
+
+    private async createWorker(): Promise<Worker> {
+        // Load the built worker file from /static/testWorker.js
+        // The worker is built by esbuild (see build.mjs) in both dev and prod
+        // In dev, esbuild watch mode rebuilds it when testWorker.ts changes
+        // Workers must be same-origin, so we use Django's origin (localhost:8010)
+        // not Vite's origin (localhost:8234)
+        const workerUrl = '/static/testWorker.js'
+        return new Worker(workerUrl, { type: 'module' })
+    }
+
+    sendTestMessage(message: string): void {
+        if (!this.worker) {
+            console.warn('[TestWorkerManager] Worker not initialized')
+            return
+        }
+
+        const msg: TestWorkerMessage = {
+            type: 'test',
+            message,
+        }
+
+        console.log('[TestWorkerManager] Sending message to worker:', message)
+        this.worker.postMessage(msg)
+        this.messageId++
+    }
+
+    terminate(): void {
+        if (this.worker) {
+            console.log('[TestWorkerManager] Terminating worker')
+            this.worker.terminate()
+            this.worker = null
+        }
+
+        if (this.workerBlobUrl) {
+            URL.revokeObjectURL(this.workerBlobUrl)
+            this.workerBlobUrl = null
+        }
+    }
+}
+
+let workerManager: TestWorkerManager | null = null
+
+export function getTestWorkerManager(): TestWorkerManager {
+    if (!workerManager) {
+        workerManager = new TestWorkerManager()
+    }
+    return workerManager
+}
+
+export function terminateTestWorker(): void {
+    if (workerManager) {
+        workerManager.terminate()
+        workerManager = null
+    }
+}

--- a/frontend/src/scenes/session-recordings/player/__mocks__/TestWorkerManager.ts
+++ b/frontend/src/scenes/session-recordings/player/__mocks__/TestWorkerManager.ts
@@ -1,0 +1,29 @@
+export class TestWorkerManager {
+    async initialize(): Promise<void> {
+        // No-op in tests
+    }
+
+    sendTestMessage(): void {
+        // No-op in tests
+    }
+
+    terminate(): void {
+        // No-op in tests
+    }
+}
+
+let workerManager: TestWorkerManager | null = null
+
+export function getTestWorkerManager(): TestWorkerManager {
+    if (!workerManager) {
+        workerManager = new TestWorkerManager()
+    }
+    return workerManager
+}
+
+export function terminateTestWorker(): void {
+    if (workerManager) {
+        workerManager.terminate()
+        workerManager = null
+    }
+}

--- a/frontend/src/scenes/session-recordings/player/__mocks__/test-setup.ts
+++ b/frontend/src/scenes/session-recordings/player/__mocks__/test-setup.ts
@@ -8,6 +8,8 @@ import recordingEventsJson from '../../__mocks__/recording_events_query'
 import { recordingMetaJson } from '../../__mocks__/recording_meta'
 import { snapshotsAsJSONLines } from '../../__mocks__/recording_snapshots'
 
+jest.mock('../TestWorkerManager')
+
 export const BLOB_SOURCE_V2: SessionRecordingSnapshotSource = {
     source: 'blob_v2',
     start_timestamp: '2023-08-11T12:03:36.097000Z',

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.test.ts
@@ -13,6 +13,8 @@ import recordingEventsJson from '../../__mocks__/recording_events_query'
 import { recordingMetaJson } from '../../__mocks__/recording_meta'
 import { snapshotsAsJSONLines } from '../../__mocks__/recording_snapshots'
 
+jest.mock('../TestWorkerManager')
+
 const playerProps = { sessionRecordingId: '1', playerKey: 'playlist' }
 
 describe('playerMetaLogic', () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -25,6 +25,8 @@ import {
 } from './__mocks__/test-setup'
 import { snapshotDataLogic } from './snapshotDataLogic'
 
+jest.mock('./TestWorkerManager')
+
 describe('sessionRecordingPlayerLogic', () => {
     let logic: ReturnType<typeof sessionRecordingPlayerLogic.build>
     const mockWarn = jest.fn()

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -43,6 +43,7 @@ import { AvailableFeature, ExporterFormat, RecordingSegment, SessionPlayerData, 
 
 import type { sessionRecordingsPlaylistLogicType } from '../playlist/sessionRecordingsPlaylistLogicType'
 import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLogic'
+import { getTestWorkerManager, terminateTestWorker } from './TestWorkerManager'
 import { playerCommentOverlayLogic } from './commenting/playerFrameCommentOverlayLogic'
 import { playerCommentOverlayLogicType } from './commenting/playerFrameCommentOverlayLogicType'
 import { playerSettingsLogic } from './playerSettingsLogic'
@@ -1809,6 +1810,12 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         values.player?.replayer?.destroy()
         actions.setPlayer(null)
 
+        try {
+            terminateTestWorker()
+        } catch (error) {
+            console.warn('[SessionRecordingPlayerLogic] Failed to terminate test worker:', error)
+        }
+
         const playTimeMs = values.playingTimeTracking.watchTime || 0
         const summaryAnalytics: RecordingViewedSummaryAnalytics = {
             viewed_time_ms: cache.openTime !== undefined ? performance.now() - cache.openTime : undefined,
@@ -1844,6 +1851,13 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             document.addEventListener('fullscreenchange', fullScreenListener)
             return () => document.removeEventListener('fullscreenchange', fullScreenListener)
         }, 'fullscreenListener')
+
+        try {
+            const testWorker = getTestWorkerManager()
+            void testWorker.initialize()
+        } catch (error) {
+            console.warn('[SessionRecordingPlayerLogic] Failed to initialize test worker:', error)
+        }
 
         if (props.sessionRecordingId) {
             actions.loadRecordingData()

--- a/frontend/src/scenes/session-recordings/player/testWorker.ts
+++ b/frontend/src/scenes/session-recordings/player/testWorker.ts
@@ -1,0 +1,31 @@
+/* eslint-disable no-console */
+export interface TestWorkerMessage {
+    type: 'test'
+    message: string
+}
+
+export interface TestWorkerResponse {
+    type: 'response'
+    originalMessage: string
+    amendedMessage: string
+}
+
+self.addEventListener('message', (event: MessageEvent<TestWorkerMessage>) => {
+    const { type, message } = event.data
+
+    if (type === 'test') {
+        console.log('[TestWorker] Received message:', message)
+
+        const amendedMessage = `${message} (processed by worker)`
+
+        const response: TestWorkerResponse = {
+            type: 'response',
+            originalMessage: message,
+            amendedMessage,
+        }
+
+        self.postMessage(response)
+    }
+})
+
+console.log('[TestWorker] Worker initialized and ready')

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -25,6 +25,7 @@ export function HogFlowFunctionConfiguration({
 
     const template = hogFunctionTemplatesById[templateId]
     useEffect(() => {
+        // oxlint-disable-next-line exhaustive-deps
         if (template && Object.keys(inputs ?? {}).length === 0) {
             setInputs(templateToConfiguration(template).inputs ?? {})
         }


### PR DESCRIPTION
we had a bad time figuring out how to get a web worker into replay

let's just get a tiny one up to prove we need an esbuild entrypoint in prod

locally i see this

![Screenshot 2025-10-27 at 10.37.43.png](https://app.graphite.dev/user-attachments/assets/432d34ea-2661-4372-aef6-129858d90759.png)

