### PR TITLE
fix(batch-exports): add validation for HTTP batch exports to only allow events model

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -374,6 +374,17 @@ class BatchExportSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "team_id", "created_at", "last_updated_at", "latest_runs", "schema"]
 
+    def validate(self, attrs: dict) -> dict:
+        """Validate the batch export configuration."""
+        # HTTP batch exports only support the events model
+        destination = attrs.get("destination")
+        if destination and destination.get("type") == BatchExportDestination.Destination.HTTP:
+            model = attrs.get("model")
+            if model is not None and model != "events":
+                raise serializers.ValidationError("HTTP batch exports only support the events model")
+
+        return attrs
+
     # TODO: could this be moved inside BatchExportDestinationSerializer::validate?
     def validate_destination(self, destination_attrs: dict):
         destination_type = destination_attrs["type"]


### PR DESCRIPTION
## Problem

HTTP batch exports can be created using any supported batch exports model, including persons and sessions. This should not be allowed, as HTTP batch exports are only used for migrating data from one project to another, and only events need to be migrated (other data is derived from these, such as persons and sessions).

## Changes

- Implemented validation in `BatchExportSerializer` to ensure that HTTP batch exports only support the events model.


## How did you test this code?

- Added a new test to verify the behavior of the batch export creation process with different models.
- Existing tests to ensure nothing else breaks.
