### PR TITLE
fix: Remove team id check

### DIFF
--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -1,6 +1,5 @@
 # ruff: noqa: T201 allow print statements
 
-import os
 import logging
 import secrets
 import datetime as dt
@@ -117,11 +116,6 @@ class Command(BaseCommand):
             except Team.DoesNotExist:
                 print(f"Team with ID {options['team_id']} does not exist!")
                 return
-
-        if os.environ.get("CI") is None and existing_team_id is None and Team.objects.count() != 0:
-            print("No team ID provided and database is not empty. Aborting.")
-            print("Either pass a team ID or reset your database before running this command.")
-            return
 
         print("Instantiating the Matrix...")
         try:


### PR DESCRIPTION
This was added to avoid us from running seed twice because it's usually not what you want locally but this is breaking in CI. We've added an `ENV["CI"]` check but that's not working, just remove it