### PR TITLE
fix(file-system): last_viewed_at optimization

### DIFF
--- a/posthog/models/file_system/file_system_view_log.py
+++ b/posthog/models/file_system/file_system_view_log.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional, cast
 
 from django.db import IntegrityError, models
-from django.db.models import OuterRef, Q, QuerySet, Subquery
+from django.db.models import FilteredRelation, Max, Q, QuerySet
 from django.utils import timezone
 
 from posthog.models.file_system.file_system import FileSystem
@@ -74,20 +74,18 @@ def annotate_file_system_with_view_logs(
     *, team_id: int, user_id: int, queryset: Optional[QuerySet] = None
 ) -> QuerySet[FileSystem]:
     queryset = queryset or FileSystem.objects.all()
-    base_qs = queryset.filter(team_id=team_id)
-
-    last_viewed_subquery = (
-        FileSystemViewLog.objects.filter(
-            team_id=team_id,
-            user_id=user_id,
-            type=OuterRef("type"),
-            ref=OuterRef("ref"),
+    base_qs = queryset.filter(team_id=team_id).alias(
+        matching_view_logs=FilteredRelation(
+            "team__filesystemviewlog",
+            condition=(
+                Q(team__filesystemviewlog__user_id=user_id)
+                & Q(team__filesystemviewlog__type=models.F("type"))
+                & Q(team__filesystemviewlog__ref=models.F("ref"))
+            ),
         )
-        .order_by("-viewed_at")
-        .values("viewed_at")[:1]
     )
 
-    return base_qs.annotate(last_viewed_at=Subquery(last_viewed_subquery))
+    return base_qs.annotate(last_viewed_at=Max("matching_view_logs__viewed_at"))
 
 
 def get_recent_file_system_items(*, team_id: int, user_id: int, limit: Optional[int] = None) -> QuerySet[FileSystem]:


### PR DESCRIPTION
## Problem

- `annotate_file_system_with_view_logs` uses `Max("team__filesystemviewlog__viewed_at", filter=…)`. Django translates this into a `GROUP BY` across `FileSystem` × `User`, forces an extra join through `Team`, and then sorts the grouped rows before applying `MAX`. That is why PostgreSQL is processing thousands of rows just to compute a single timestamp.

```sql
SELECT "posthog_filesystem"."team_id",
       "posthog_filesystem"."id",
       "posthog_filesystem"."path",
       "posthog_filesystem"."depth",
       "posthog_filesystem"."type",
       "posthog_filesystem"."ref",
       "posthog_filesystem"."href",
       "posthog_filesystem"."shortcut",
       "posthog_filesystem"."meta",
       "posthog_filesystem"."created_at",
       "posthog_filesystem"."created_by_id",
       "posthog_filesystem"."project_id",
       MAX("posthog_filesystemviewlog"."viewed_at") FILTER (WHERE ("posthog_filesystemviewlog"."user_id" = 1 AND
                                                                   "posthog_filesystemviewlog"."type" =
                                                                   ("posthog_filesystem"."type") AND
                                                                   "posthog_filesystemviewlog"."ref" =
                                                                   ("posthog_filesystem"."ref"))) AS "last_viewed_at",
       "posthog_user"."id",
       "posthog_user"."password",
       "posthog_user"."last_login",
       "posthog_user"."first_name",
       "posthog_user"."last_name",
       "posthog_user"."is_staff",
       "posthog_user"."date_joined",
       "posthog_user"."uuid",
       "posthog_user"."current_organization_id",
       "posthog_user"."current_team_id",
       "posthog_user"."email",
       "posthog_user"."pending_email",
       "posthog_user"."temporary_token",
       "posthog_user"."distinct_id",
       "posthog_user"."is_email_verified",
       "posthog_user"."requested_password_reset_at",
       "posthog_user"."has_seen_product_intro_for",
       "posthog_user"."strapi_id",
       "posthog_user"."is_active",
       "posthog_user"."role_at_organization",
       "posthog_user"."theme_mode",
       "posthog_user"."partial_notification_settings",
       "posthog_user"."anonymize_data",
       "posthog_user"."toolbar_mode",
       "posthog_user"."hedgehog_config",
       "posthog_user"."events_column_config",
       "posthog_user"."email_opt_in"
FROM "posthog_filesystem"
         INNER JOIN "posthog_team" ON ("posthog_filesystem"."team_id" = "posthog_team"."id")
         LEFT OUTER JOIN "posthog_user" ON ("posthog_filesystem"."created_by_id" = "posthog_user"."id")
         LEFT OUTER JOIN "posthog_filesystemviewlog" ON ("posthog_team"."id" = "posthog_filesystemviewlog"."team_id")
WHERE ("posthog_team"."project_id" = 1 AND
       ("posthog_filesystem"."team_id" = 1 OR NOT ("posthog_filesystem"."type"::text LIKE E'hog\\_function/%')) AND
       NOT ("posthog_filesystem"."type" = 'folder') AND "posthog_filesystem"."team_id" = 1 AND
       "posthog_team"."project_id" = 1)
GROUP BY "posthog_filesystem"."id", "posthog_user"."id"
ORDER BY 13 DESC NULLS LAST, "posthog_filesystem"."created_at" DESC
LIMIT 11;
```

## Changes

Use this instead:

```sql
SELECT "posthog_filesystem"."team_id",
       "posthog_filesystem"."id",
       "posthog_filesystem"."path",
       "posthog_filesystem"."depth",
       "posthog_filesystem"."type",
       "posthog_filesystem"."ref",
       "posthog_filesystem"."href",
       "posthog_filesystem"."shortcut",
       "posthog_filesystem"."meta",
       "posthog_filesystem"."created_at",
       "posthog_filesystem"."created_by_id",
       "posthog_filesystem"."project_id",
       MAX(matching_view_logs."viewed_at") AS "last_viewed_at",
       "posthog_user"."id",
       "posthog_user"."password",
       "posthog_user"."last_login",
       "posthog_user"."first_name",
       "posthog_user"."last_name",
       "posthog_user"."is_staff",
       "posthog_user"."date_joined",
       "posthog_user"."uuid",
       "posthog_user"."current_organization_id",
       "posthog_user"."current_team_id",
       "posthog_user"."email",
       "posthog_user"."pending_email",
       "posthog_user"."temporary_token",
       "posthog_user"."distinct_id",
       "posthog_user"."is_email_verified",
       "posthog_user"."requested_password_reset_at",
       "posthog_user"."has_seen_product_intro_for",
       "posthog_user"."strapi_id",
       "posthog_user"."is_active",
       "posthog_user"."role_at_organization",
       "posthog_user"."theme_mode",
       "posthog_user"."partial_notification_settings",
       "posthog_user"."anonymize_data",
       "posthog_user"."toolbar_mode",
       "posthog_user"."hedgehog_config",
       "posthog_user"."events_column_config",
       "posthog_user"."email_opt_in"
FROM "posthog_filesystem"
         INNER JOIN "posthog_team" ON ("posthog_filesystem"."team_id" = "posthog_team"."id")
         LEFT OUTER JOIN "posthog_user" ON ("posthog_filesystem"."created_by_id" = "posthog_user"."id")
         LEFT OUTER JOIN "posthog_filesystemviewlog" matching_view_logs
                         ON ("posthog_team"."id" = matching_view_logs."team_id" AND
                             ((matching_view_logs."user_id" = 1 AND
                               matching_view_logs."type" = ("posthog_filesystem"."type") AND
                               matching_view_logs."ref" = ("posthog_filesystem"."ref"))))
WHERE ("posthog_team"."project_id" = 1 AND
       ("posthog_filesystem"."team_id" = 1 OR NOT ("posthog_filesystem"."type"::text LIKE E'hog\\_function/%')) AND
       NOT ("posthog_filesystem"."type" = 'folder') AND "posthog_filesystem"."team_id" = 1 AND
       "posthog_team"."project_id" = 1)
GROUP BY "posthog_filesystem"."id", "posthog_user"."id"
ORDER BY 13 DESC NULLS LAST, "posthog_filesystem"."created_at" DESC
LIMIT 11;
```

## Testing

Everything kept working locally. The EXPLAIN command showed a new cost of 108 vs 3512 locally. GPT promises it's 20-100x better at scale. Assuming all backend tests pass.