### PR TITLE
fix(ph-ai): fix flickering on empty conversation history

### DIFF
--- a/frontend/src/scenes/max/HistoryPreview.tsx
+++ b/frontend/src/scenes/max/HistoryPreview.tsx
@@ -17,12 +17,13 @@ export function HistoryPreview({ sidePanel = false }: HistoryPreviewProps): JSX.
     const { conversationHistory, conversationHistoryLoading } = useValues(maxLogic)
     const { toggleConversationHistory, openConversation } = useActions(maxLogic)
 
-    if (!conversationHistory.length && !conversationHistoryLoading) {
+    // No need to render if we do not have any conversations to show.
+    if (!conversationHistory.length) {
         return null
     }
 
     return (
-        <div className="max-w-120 w-full self-center flex flex-col gap-2">
+        <div className="max-w-120 w-full self-center flex flex-col gap-2 min-h-[6rem]">
             <div className="flex items-center justify-between gap-2 -mr-2">
                 <h3 className="text-sm font-medium text-secondary mb-0">Recent chats</h3>
                 <LemonButton
@@ -34,7 +35,7 @@ export function HistoryPreview({ sidePanel = false }: HistoryPreviewProps): JSX.
                     View all
                 </LemonButton>
             </div>
-            {conversationHistoryLoading && !conversationHistory.length ? (
+            {conversationHistoryLoading ? (
                 <>
                     <LemonSkeleton className="h-5 w-full" />
                     <LemonSkeleton className="h-5 w-full" />


### PR DESCRIPTION
## Problem

I broke `prod` with https://github.com/PostHog/posthog/pull/40292, later reverted on https://github.com/PostHog/posthog/pull/40391. 

The `HistoryPreview` fix is sound, was already on `production` and worked fine. Flicker is not present anymore on empty conversations.

## Changes

* reinstated changes from https://github.com/PostHog/posthog/pull/40292, early return on empty `conversationHistory`.

## How did you test this code?

**Before**:

https://github.com/user-attachments/assets/0501944a-3fb9-424c-a311-e865774d8572

**After**:

https://github.com/user-attachments/assets/ca8952c0-1ca4-44fb-aa90-ed5f589cdd2d
