### PR TITLE
feat(customers): Group feed

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -18,6 +18,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { GroupLogicProps, groupLogic } from 'scenes/groups/groupLogic'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { NotebookNodeType } from 'scenes/notebooks/types'
+import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 import { RelatedFeatureFlags } from 'scenes/persons/RelatedFeatureFlags'
 import { SceneExport } from 'scenes/sceneTypes'
 import { SessionRecordingsPlaylist } from 'scenes/session-recordings/playlist/SessionRecordingsPlaylist'
@@ -97,7 +98,7 @@ export function Group(): JSX.Element {
     return (
         <SceneContent>
             <SceneTitleSection
-                name={groupData.group_key}
+                name={groupDisplayId(groupData.group_key, groupData.group_properties)}
                 resourceType={{ type: 'group' }}
                 forceBackTo={{
                     name: capitalizeFirstLetter(aggregationLabel(groupTypeIndex).plural),

--- a/frontend/src/scenes/groups/components/GroupCaption.tsx
+++ b/frontend/src/scenes/groups/components/GroupCaption.tsx
@@ -1,0 +1,35 @@
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { TZLabel } from 'lib/components/TZLabel'
+
+import { Group } from '~/types'
+
+interface GroupCaptionProps {
+    groupData: Group
+    groupTypeName: string
+    displayType?: 'col' | 'wrap'
+}
+
+export function GroupCaption({ groupData, groupTypeName, displayType = 'wrap' }: GroupCaptionProps): JSX.Element {
+    const className = displayType === 'col' ? 'flex flex-col' : 'flex items-center flex-wrap'
+    return (
+        <div className={className}>
+            <div className="mr-4">
+                <span className="text-secondary">Type:</span> {groupTypeName}
+            </div>
+            <div className="mr-4">
+                <span className="text-secondary">Key:</span>{' '}
+                <CopyToClipboardInline
+                    tooltipMessage={null}
+                    description="group key"
+                    style={{ display: 'inline-flex', justifyContent: 'flex-end' }}
+                >
+                    {groupData.group_key}
+                </CopyToClipboardInline>
+            </div>
+            <div>
+                <span className="text-secondary">First seen:</span>{' '}
+                {groupData.created_at ? <TZLabel time={groupData.created_at} /> : 'unknown'}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
@@ -74,7 +74,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes
                         <LemonSkeleton className="h-4 w-20 mb-2" />
                         <LemonSkeleton className="h-3 w-32" />
                         <LemonSkeleton className="h-3 w-40" />
-                        <LemonSkeleton className="h-3 w-42" />
+                        <LemonSkeleton className="h-3 w-44" />
                     </div>
                 ) : groupData ? (
                     <>

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
@@ -1,10 +1,9 @@
-import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { NotFound } from 'lib/components/NotFound'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
-import { GroupCaption } from 'scenes/groups/Group'
+import { GroupCaption } from 'scenes/groups/components/GroupCaption'
 import { groupLogic } from 'scenes/groups/groupLogic'
 import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
@@ -18,13 +17,14 @@ import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes>): JSX.Element => {
-    const { id, groupTypeIndex } = attributes
+    const { id, groupTypeIndex, title } = attributes
 
     const logic = groupLogic({ groupKey: id, groupTypeIndex: groupTypeIndex })
     const { groupData, groupDataLoading, groupTypeName } = useValues(logic)
     const { setActions, insertAfter, setTitlePlaceholder } = useActions(notebookNodeLogic)
 
     const groupDisplay = groupData ? groupDisplayId(groupData.group_key, groupData.group_properties) : 'Group'
+    const inGroupFeed = title === 'Info'
 
     useEffect(() => {
         const title = groupData ? `${groupTypeName}: ${groupDisplay}` : 'Group'
@@ -68,13 +68,22 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes
 
     return (
         <div className="flex flex-col overflow-hidden">
-            <div className={clsx('p-4 flex-0 flex gap-2 justify-between flex-wrap')}>
+            <div className={`p-4 flex-0 flex gap-2 justify-between ${inGroupFeed ? 'flex-col' : 'flex-wrap'}`}>
                 {groupDataLoading ? (
-                    <LemonSkeleton className="h-6" />
+                    <div className={`flex flex-1 gap-2 ${inGroupFeed ? 'flex-col' : 'flex-wrap'}`}>
+                        <LemonSkeleton className="h-4 w-20 mb-2" />
+                        <LemonSkeleton className="h-3 w-32" />
+                        <LemonSkeleton className="h-3 w-40" />
+                        <LemonSkeleton className="h-3 w-42" />
+                    </div>
                 ) : groupData ? (
                     <>
                         <div className="flex-1 font-semibold truncate">{groupDisplay}</div>
-                        <GroupCaption groupData={groupData} groupTypeName={groupTypeName} />
+                        <GroupCaption
+                            groupData={groupData}
+                            groupTypeName={groupTypeName}
+                            displayType={inGroupFeed ? 'col' : 'wrap'}
+                        />
                     </>
                 ) : null}
             </div>
@@ -85,6 +94,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes
 type NotebookNodeGroupAttributes = {
     id: string
     groupTypeIndex: number
+    placement?: string
 }
 
 export const NotebookNodeGroup = createPostHogWidgetNode<NotebookNodeGroupAttributes>({
@@ -99,6 +109,7 @@ export const NotebookNodeGroup = createPostHogWidgetNode<NotebookNodeGroupAttrib
     attributes: {
         id: {},
         groupTypeIndex: {},
+        placement: {},
     },
     pasteOptions: {
         find: urls.groups('(.+)'),

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -17,14 +17,26 @@ import { notebookNodeLogic } from './notebookNodeLogic'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAttributes>): JSX.Element | null => {
     const { expanded } = useValues(notebookNodeLogic)
-    const { personId } = attributes
-    const logic = dataNodeLogic({
-        query: {
-            kind: NodeKind.UsageMetricsQuery,
-            person_id: personId,
-        },
-        key: personId,
-    })
+    const { personId, groupKey, groupTypeIndex } = attributes
+    const dataNodeLogicProps = personId
+        ? {
+              query: {
+                  kind: NodeKind.UsageMetricsQuery,
+                  person_id: personId,
+              },
+              key: personId,
+          }
+        : groupKey
+          ? {
+                query: {
+                    kind: NodeKind.UsageMetricsQuery,
+                    group_key: groupKey,
+                    group_type_index: groupTypeIndex,
+                },
+                key: groupKey,
+            }
+          : { key: 'error', query: { kind: NodeKind.UsageMetricsQuery } }
+    const logic = dataNodeLogic(dataNodeLogicProps)
     const { response, responseLoading, responseError } = useValues(logic)
 
     if (!expanded) {
@@ -69,7 +81,9 @@ const Settings = ({ attributes }: NotebookNodeAttributeProperties<NotebookNodeUs
 }
 
 type NotebookNodeUsageMetricsAttributes = {
-    personId: string
+    personId?: string
+    groupKey?: string
+    groupTypeIndex?: number
 }
 
 export const NotebookNodeUsageMetrics = createPostHogWidgetNode<NotebookNodeUsageMetricsAttributes>({
@@ -83,5 +97,7 @@ export const NotebookNodeUsageMetrics = createPostHogWidgetNode<NotebookNodeUsag
     startExpanded: true,
     attributes: {
         personId: {},
+        groupKey: {},
+        groupTypeIndex: {},
     },
 })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1521,6 +1521,7 @@ export enum PersonsTabType {
 }
 
 export enum GroupsTabType {
+    FEED = 'feed',
     NOTES = 'notes',
     OVERVIEW = 'overview',
 }

--- a/products/customer_analytics/frontend/components/GroupFeedCanvas/GroupFeedCanvas.tsx
+++ b/products/customer_analytics/frontend/components/GroupFeedCanvas/GroupFeedCanvas.tsx
@@ -1,0 +1,46 @@
+import { uuid } from 'lib/utils'
+import { Notebook } from 'scenes/notebooks/Notebook/Notebook'
+
+import { Group } from '~/types'
+
+type GroupFeedCanvas = {
+    group: Group
+}
+
+const GroupFeedCanvas = ({ group }: GroupFeedCanvas): JSX.Element => {
+    const key = group.group_key
+
+    return (
+        <Notebook
+            editable={false}
+            shortId={`canvas-${key}`}
+            mode="canvas"
+            initialContent={{
+                type: 'doc',
+                content: [
+                    {
+                        type: 'ph-usage-metrics',
+                        attrs: {
+                            groupKey: key,
+                            groupTypeIndex: group.group_type_index,
+                            nodeId: uuid(),
+                            children: [
+                                {
+                                    type: 'ph-group',
+                                    attrs: {
+                                        id: key,
+                                        groupTypeIndex: group.group_type_index,
+                                        nodeId: uuid(),
+                                        title: 'Info',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }}
+        />
+    )
+}
+
+export default GroupFeedCanvas


### PR DESCRIPTION
## Problem

Let's add a nice feed for groups, the same way we now have for people.

Closes https://github.com/PostHog/posthog/issues/39968
Closes https://github.com/PostHog/posthog/issues/39971

## Changes

- Added a new "Feed" tab to the Group page when the CUSTOMER_ANALYTICS feature flag is enabled
- Created a new `GroupFeedCanvas` component that displays group information and usage metrics
- Refactored `GroupCaption` into its own component file for better reusability
- Extended `NotebookNodeUsageMetrics` to support group data in addition to person data
- Updated the group display to show a more user-friendly identifier

## How did you test this code?
- Enabling the CUSTOMER_ANALYTICS feature flag and verifying the Feed tab appears
- Checking that the GroupFeedCanvas renders correctly with group information
- Ensuring the GroupCaption displays properly in both column and wrap layouts
- Verifying that usage metrics load correctly for groups
- Testing the component with various group types and properties
