### PR TITLE
chore(llma): add schedule for update-ai-costs.yml

### DIFF
--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -2,6 +2,10 @@ name: Update AI Costs
 
 on:
     workflow_dispatch: # Allow manual triggering
+    schedule:
+        # Run at 10am UTC and 8pm UTC on weekdays (Monday-Friday)
+        - cron: '0 10 * * 1-5' # 10am UTC
+        - cron: '0 20 * * 1-5' # 8pm UTC
 
 permissions:
     contents: read

--- a/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
+++ b/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
@@ -225,11 +225,12 @@ const generateCanonicalProviders = (models: ModelRow[]): void => {
     const providers = allProviders.includes('default') ? ['default', ...otherProviders] : otherProviders
 
     // Generate TypeScript file content
-    const timestamp = new Date().toISOString().split('T')[0]
+    const now = new Date()
+    const timestamp = `${now.toISOString().split('.')[0].replace('T', ' ')} UTC`
     const typeUnion = providers.map((p) => `    | '${p}'`).join('\n')
 
     const fileContent = `// Auto-generated from OpenRouter API - Do not edit manually
-// Generated on: ${timestamp}
+// Generated at: ${timestamp}
 
 export type CanonicalProvider =
 ${typeUnion}


### PR DESCRIPTION
This adds a schedule for running the update-ai-costs workflow every weekday at 10am and 8pm UTC.

Example PR it generates: https://github.com/PostHog/posthog/pull/40394

If a previously generated PR is still open, it updates it.