### PR TITLE
fix(hogli): restore symlink and use bin/hogli for non-Flox compatibility

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -98,6 +98,11 @@ echo -e "    \033[1;33m📦 Setting up Python environment...\033[0m"
 uv sync --quiet
 echo -e "    \033[32m✅ Python environment ready\033[0m"
 
+# Expose hogli CLI on PATH via the uv-managed virtualenv
+if [ -d "$UV_PROJECT_ENVIRONMENT/bin" ]; then
+  ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+fi
+
 # Install shell completions for hogli in flox environment cache
 # Must run after uv sync so hogli.completion module is available
 HOGLI_COMPLETION_DIR="$FLOX_ENV_CACHE/completions"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "packageManager": "pnpm@9.15.5+sha256.8472168c3e1fd0bff287e694b053fccbbf20579a3ff9526b6333beab8df65a8d",
     "scripts": {
         "prepare": "husky install",
-        "schema:build": "hogli build:schema",
+        "schema:build": "bin/hogli build:schema",
         "schema:build:python": "bash bin/build-schema-python.sh",
         "taxonomy:build": "pnpm run taxonomy:build:json",
         "taxonomy:build:json": "python bin/build-taxonomy-json.py",
-        "grammar:build": "hogli build:grammar",
+        "grammar:build": "bin/hogli build:grammar",
         "grammar:build:python": "cd posthog/hogql/grammar && cat HogQLLexer.python.g4 > HogQLLexer.g4 && tail -n +2 HogQLLexer.common.g4 |sed s/isOpeningTag/self.isOpeningTag/ >> HogQLLexer.g4 && antlr -Dlanguage=Python3 HogQLLexer.g4 && rm HogQLLexer.g4 && antlr -visitor -no-listener -Dlanguage=Python3 HogQLParser.g4",
         "grammar:build:cpp": "cd posthog/hogql/grammar && cat HogQLLexer.cpp.g4 > HogQLLexer.g4 && tail -n +2 HogQLLexer.common.g4 >> HogQLLexer.g4 && antlr -o ../../../common/hogql_parser -Dlanguage=Cpp HogQLLexer.g4 && rm HogQLLexer.g4 && antlr -o ../../../common/hogql_parser -visitor -no-listener -Dlanguage=Cpp HogQLParser.g4",
         "generate:source-configs": "DEBUG=1 python manage.py generate_source-configs",
@@ -81,16 +81,16 @@
         }
     },
     "lint-staged": {
-        "*.{json,yaml,yml}": "hogli format:yaml",
-        "*.{css,scss}": "hogli format:css",
-        "{playwright,frontend,products,common,ee}/**/*.{js,jsx,mjs,ts,tsx}": "hogli format:js",
-        "plugin-server/**/*.{js,jsx,mjs,ts,tsx}": "hogli format:plugin-server",
-        "funnel-udf/**/*.rs": "hogli format:rust",
+        "*.{json,yaml,yml}": "bin/hogli format:yaml",
+        "*.{css,scss}": "bin/hogli format:css",
+        "{playwright,frontend,products,common,ee}/**/*.{js,jsx,mjs,ts,tsx}": "bin/hogli format:js",
+        "plugin-server/**/*.{js,jsx,mjs,ts,tsx}": "bin/hogli format:plugin-server",
+        "funnel-udf/**/*.rs": "bin/hogli format:rust",
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
-            "hogli lint:python:fix",
-            "hogli format:python"
+            "bin/hogli lint:python:fix",
+            "bin/hogli format:python"
         ],
-        "*.{md,mdx}": "hogli format:markdown"
+        "*.{md,mdx}": "bin/hogli format:markdown"
     },
     "browserslist": {
         "development": [


### PR DESCRIPTION
## Summary
- Restore accidentally removed symlink creation in Flox venv
- Change package.json to use `bin/hogli` for non-Flox environments

## Changes
1. **Restore symlink in Flox manifest**: Re-add the `ln -sf` command that creates a symlink from the venv's bin to project's bin/hogli (accidentally removed in 1cac027999)
2. **Use bin/hogli in package.json**: Change all hogli invocations in npm scripts and lint-staged to use `bin/hogli` explicitly

## Why both changes?
- **With Flox**: Symlink makes `hogli` available in PATH after venv activation (clean DX)
- **Without Flox**: `bin/hogli` works directly without any PATH setup needed

## Test plan
- [x] Verify `hogli` works in Flox environment after `flox activate`
- [x] Verify `bin/hogli` works without Flox
- [x] Verify lint-staged hooks work (ran successfully in commit)