### PR TITLE
fix(subscriptions): reuse session per sub

### DIFF
--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -4,7 +4,9 @@ from typing import Any
 
 from django.conf import settings
 
+import aiohttp
 import structlog
+from slack_sdk.web.async_client import AsyncWebClient
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.integration import Integration, SlackIntegration
@@ -223,38 +225,43 @@ async def send_slack_message_with_integration_async(
 ) -> SlackDeliveryResult:
     message_data = _prepare_slack_message(subscription, assets, total_asset_count, is_new_subscription)
     slack_integration = SlackIntegration(integration)
-    async_client = slack_integration.async_client
 
-    message_res = await _send_slack_message_with_retry(
-        async_client,
-        channel=message_data.channel,
-        blocks=message_data.blocks,
-        text=message_data.title,
-    )
+    async with aiohttp.ClientSession() as slack_session:
+        async_client = AsyncWebClient(
+            token=slack_integration.integration.sensitive_config["access_token"],
+            session=slack_session,
+        )
 
-    thread_ts = message_res.get("ts")
-    failed_thread_messages = []
+        message_res = await _send_slack_message_with_retry(
+            async_client,
+            channel=message_data.channel,
+            blocks=message_data.blocks,
+            text=message_data.title,
+        )
 
-    if thread_ts:
-        for idx, thread_msg in enumerate(message_data.thread_messages):
-            try:
-                await _send_slack_message_with_retry(
-                    async_client,
-                    channel=message_data.channel,
-                    thread_ts=thread_ts,
-                    **thread_msg,
-                )
-            except TimeoutError:
-                logger.error(
-                    "send_slack_message_with_integration_async.slack_thread_message_failed_after_retries",
-                    subscription_id=subscription.id,
-                    channel=message_data.channel,
-                    thread_index=idx,
-                    total_thread_messages=len(message_data.thread_messages),
-                    thread_ts=thread_ts,
-                    exc_info=True,
-                )
-                failed_thread_messages.append(idx)
+        thread_ts = message_res.get("ts")
+        failed_thread_messages = []
+
+        if thread_ts:
+            for idx, thread_msg in enumerate(message_data.thread_messages):
+                try:
+                    await _send_slack_message_with_retry(
+                        async_client,
+                        channel=message_data.channel,
+                        thread_ts=thread_ts,
+                        **thread_msg,
+                    )
+                except TimeoutError:
+                    logger.error(
+                        "send_slack_message_with_integration_async.slack_thread_message_failed_after_retries",
+                        subscription_id=subscription.id,
+                        channel=message_data.channel,
+                        thread_index=idx,
+                        total_thread_messages=len(message_data.thread_messages),
+                        thread_ts=thread_ts,
+                        exc_info=True,
+                    )
+                    failed_thread_messages.append(idx)
 
     return SlackDeliveryResult(
         main_message_sent=True,

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -6,7 +6,6 @@ from django.conf import settings
 
 import aiohttp
 import structlog
-from slack_sdk.web.async_client import AsyncWebClient
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.integration import Integration, SlackIntegration
@@ -227,10 +226,7 @@ async def send_slack_message_with_integration_async(
     slack_integration = SlackIntegration(integration)
 
     async with aiohttp.ClientSession() as slack_session:
-        async_client = AsyncWebClient(
-            token=slack_integration.integration.sensitive_config["access_token"],
-            session=slack_session,
-        )
+        async_client = slack_integration.async_client(session=slack_session)
 
         message_res = await _send_slack_message_with_retry(
             async_client,

--- a/ee/tasks/test/subscriptions/test_slack_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_slack_subscriptions.py
@@ -233,7 +233,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         MockSlackIntegration.return_value = mock_slack_integration
 
         mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = mock_async_client
+        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
         mock_async_client.chat_postMessage.return_value = {"ts": "1.234"}
 
         asset2 = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
@@ -263,7 +263,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         MockSlackIntegration.return_value = mock_slack_integration
 
         mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = mock_async_client
+        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
 
         mock_async_client.chat_postMessage.side_effect = [
             {"ts": "1.234"},  # Main message
@@ -301,7 +301,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         MockSlackIntegration.return_value = mock_slack_integration
 
         mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = mock_async_client
+        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
 
         mock_async_client.chat_postMessage.side_effect = [
             TimeoutError(),  # Attempt 1
@@ -329,7 +329,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         MockSlackIntegration.return_value = mock_slack_integration
 
         mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = mock_async_client
+        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
 
         # Main message times out once, then succeeds
         mock_async_client.chat_postMessage.side_effect = [

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -6,8 +6,11 @@ import socket
 import hashlib
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from urllib.parse import urlencode
+
+if TYPE_CHECKING:
+    import aiohttp
 
 from django.conf import settings
 from django.db import models
@@ -701,9 +704,8 @@ class SlackIntegration:
     def client(self) -> WebClient:
         return WebClient(self.integration.sensitive_config["access_token"])
 
-    @property
-    def async_client(self) -> AsyncWebClient:
-        return AsyncWebClient(self.integration.sensitive_config["access_token"])
+    def async_client(self, session: Optional["aiohttp.ClientSession"] = None) -> AsyncWebClient:
+        return AsyncWebClient(self.integration.sensitive_config["access_token"], session=session)
 
     def list_channels(self, should_include_private_channels: bool, authed_user: str) -> list[dict]:
         # NOTE: Annoyingly the Slack API has no search so we have to load all channels...


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The subscriptions workflow is getting DNS timeouts when trying to resolve www.slack.com during peak hours. I think this is partly because the Slack SDK recreates the `aiohttp.ClientSession` on every reqyest when one isn't provided 

https://github.com/slackapi/python-slack-sdk/blob/e9e64d82997fa1d827b1838ac0c67e5aa15bd70e/slack_sdk/web/async_internal_utils.py#L61-L68

Our error logs show that `current_session` is none: 
```
"locals": {"current_session": "None", "timeout": "30", "logger": "<_FixedFindCallerLogger slack_sdk.web.async_base_client
```

This means we will recreate the session per message, so up to 6 times per subscription. During peak hours, there are 60+ subscriptions going out. My guess is that recreating the session excessively can lead to dns timeouts. 

https://github.com/PostHog/posthog/issues/39055

## Changes

Reuse ClientSession per subscription

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
