### PR TITLE
test(batch-exports): Fix tests when using real S3 bucket

### DIFF
--- a/products/batch_exports/backend/tests/temporal/utils/s3.py
+++ b/products/batch_exports/backend/tests/temporal/utils/s3.py
@@ -1,49 +1,27 @@
-import os
 import gzip
 import json
 import datetime as dt
 
-from django.conf import settings
-
 import brotli
-import aioboto3
-import botocore
 import pyarrow.parquet as pq
 from pyarrow import fs
+from types_aiobotocore_s3.client import S3Client
 
 
 async def read_parquet_from_s3(
+    s3_client: S3Client,
     bucket_name: str,
     key: str,
     json_columns,
-    access_key="object_storage_root_user",
-    secret_key="object_storage_root_password",
 ) -> list:
-    async with aioboto3.Session().client("sts") as sts:
-        try:
-            await sts.get_caller_identity()
-        except botocore.exceptions.ClientError:
-            s3 = fs.S3FileSystem(
-                access_key=access_key,
-                secret_key=secret_key,
-                endpoint_override=settings.OBJECT_STORAGE_ENDPOINT,
-            )
-        except botocore.exceptions.NoCredentialsError:
-            s3 = fs.S3FileSystem(
-                access_key=access_key,
-                secret_key=secret_key,
-                endpoint_override=settings.OBJECT_STORAGE_ENDPOINT,
-            )
+    credentials = s3_client._request_signer._credentials  # type: ignore
+    endpoint_url = s3_client.meta.endpoint_url
 
-        else:
-            if os.getenv("S3_TEST_BUCKET") is not None:
-                s3 = fs.S3FileSystem()
-            else:
-                s3 = fs.S3FileSystem(
-                    access_key=access_key,
-                    secret_key=secret_key,
-                    endpoint_override=settings.OBJECT_STORAGE_ENDPOINT,
-                )
+    s3 = fs.S3FileSystem(
+        access_key=credentials.access_key,
+        secret_key=credentials.secret_key,
+        endpoint_override=endpoint_url,
+    )
 
     table = pq.read_table(f"{bucket_name}/{key}", filesystem=s3)
 


### PR DESCRIPTION
## Problem

At the moment when running S3 tests against a real S3 bucket, the tests that run against a MinIO bucket fail.

## Changes

Update the `read_parquet_from_s3` to get connection details from a provided S3 client, rather than trying to assume them from environment variables.

Also move these S3 utils into the batch exports product folder, as this is the only place they're used.

## How did you test this code?

These are tests ;)

Ran S3 tests locally using env vars and ensured all tests pass.

