### PR TITLE
chore(flags): Add per-pool `min_connections` configuration

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -41,6 +41,7 @@ pub struct PoolStats {
 /// Each service should provide its own configuration based on its needs
 #[derive(Debug, Clone)]
 pub struct PoolConfig {
+    pub min_connections: u32,
     pub max_connections: u32,
     pub acquire_timeout: Duration,
     pub idle_timeout: Option<Duration>,
@@ -55,6 +56,7 @@ impl Default for PoolConfig {
     /// Services can override these with their own environment-based configs
     fn default() -> Self {
         Self {
+            min_connections: 0, // Start with 0 connections by default
             max_connections: 10,
             acquire_timeout: Duration::from_secs(10),
             idle_timeout: Some(Duration::from_secs(300)), // Close idle connections after 5 minutes
@@ -93,6 +95,7 @@ pub async fn get_pool_with_timeout(
 /// This is the recommended function for services to use
 pub async fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sqlx::Error> {
     let mut options = PgPoolOptions::new()
+        .min_connections(config.min_connections)
         .max_connections(config.max_connections)
         .acquire_timeout(config.acquire_timeout)
         .test_before_acquire(config.test_before_acquire);


### PR DESCRIPTION
## Problem

During deployments, we always get a spike in query times etc. We believe that setting a min connection to pre-warm connections could help mitigate these spikes.

## Changes

Adds support for configuring minimum connections for each of the 4 database pools to pre-warm connections at startup and eliminate cold-start query latency after deploys.

Changes:
- Add `min_connections` field to `PoolConfig` in `common-database`
- Add 4 new config variables for per-pool `min_connections:`
  - `MIN_NON_PERSONS_READER_CONNECTIONS` (default: 0)
  - `MIN_NON_PERSONS_WRITER_CONNECTIONS` (default: 0)
  - `MIN_PERSONS_READER_CONNECTIONS` (default: 0)
  - `MIN_PERSONS_WRITER_CONNECTIONS` (default: 0)
- Extract helper function to reduce code duplication in pool config
- Update comments to clarify connection count with/without persons routing
- Add comprehensive test coverage

## How did you test this code?

Unit Tests
Manually

Quick Test (Recommended)

```bash
cd rust/feature-flags

# Start with min_connections configured
MIN_NON_PERSONS_READER_CONNECTIONS=5 \
MIN_NON_PERSONS_WRITER_CONNECTIONS=3 \
RUST_LOG=info \
cargo run --package feature-flags
```

__What to look for in the logs:__
You should see a line like this early in startup:

```
Database pool configuration max_connections=10
min_non_persons_reader_connections=5 min_non_persons_writer_connections=3
min_persons_reader_connections=0 min_persons_writer_connections=0
```

__While the server is running, in another terminal:__

```bash
psql posthog -c "SELECT count(*), state FROM pg_stat_activity WHERE
application_name LIKE '%' GROUP BY state;"
```

With min_connections > 0, you should see idle connections right after startup, even before making any requests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
