### PR TITLE
refactor: throttle person properties at batch level

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -1426,12 +1426,9 @@ describe('BatchWritingPersonStore', () => {
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc).toHaveBeenCalledTimes(
                 1
             )
-            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledTimes(2)
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledTimes(1)
             expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
                 property: '$geoip_city_name',
-            })
-            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
-                property: '$geoip_country_code',
             })
             // personPropertyKeyUpdateCounter should NOT be called for 'ignored' outcomes
             expect(mockPersonPropertyKeyUpdateCounter.labels).not.toHaveBeenCalled()

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -6,6 +6,11 @@ import { MessageSizeTooLarge } from '~/utils/db/error'
 
 import { captureIngestionWarning } from '../utils'
 import { BatchWritingPersonsStore, BatchWritingPersonsStoreForBatch } from './batch-writing-person-store'
+import {
+    personProfileBatchIgnoredPropertiesCounter,
+    personProfileBatchUpdateOutcomeCounter,
+    personPropertyKeyUpdateCounter,
+} from './metrics'
 import { fromInternalPerson } from './person-update-batch'
 
 // Mock the utils module
@@ -27,6 +32,8 @@ jest.mock('./metrics', () => ({
     personFlushOperationsCounter: { inc: jest.fn() },
     personMethodCallsPerBatchHistogram: { observe: jest.fn() },
     personOptimisticUpdateConflictsPerBatchCounter: { inc: jest.fn() },
+    personProfileBatchIgnoredPropertiesCounter: { labels: jest.fn().mockReturnValue({ inc: jest.fn() }) },
+    personProfileBatchUpdateOutcomeCounter: { labels: jest.fn().mockReturnValue({ inc: jest.fn() }) },
     personPropertyKeyUpdateCounter: { labels: jest.fn().mockReturnValue({ inc: jest.fn() }) },
     personRetryAttemptsHistogram: { observe: jest.fn() },
     personWriteMethodAttemptCounter: { inc: jest.fn() },
@@ -1343,6 +1350,404 @@ describe('BatchWritingPersonStore', () => {
 
             // Verify the repository was NOT called
             expect(mockRepo.updateCohortsAndFeatureFlagsForMerge).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('property filtering at batch level', () => {
+        const mockPersonProfileBatchUpdateOutcomeCounter = personProfileBatchUpdateOutcomeCounter as jest.Mocked<
+            typeof personProfileBatchUpdateOutcomeCounter
+        >
+        const mockPersonProfileBatchIgnoredPropertiesCounter =
+            personProfileBatchIgnoredPropertiesCounter as jest.Mocked<typeof personProfileBatchIgnoredPropertiesCounter>
+        const mockPersonPropertyKeyUpdateCounter = personPropertyKeyUpdateCounter as jest.Mocked<
+            typeof personPropertyKeyUpdateCounter
+        >
+
+        it('should skip database write when only eventToPersonProperties are updated', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            // Update person with only filtered properties (existing properties being updated)
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                { ...person, properties: { $browser: 'Firefox', utm_source: 'twitter' } },
+                { $browser: 'Chrome', utm_source: 'google' },
+                [],
+                {},
+                'test'
+            )
+
+            // Flush should skip the database write since only filtered properties changed
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).not.toHaveBeenCalled()
+            expect(mockRepo.updatePersonAssertVersion).not.toHaveBeenCalled()
+
+            // Verify metrics
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'ignored' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledTimes(2)
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
+                property: '$browser',
+            })
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
+                property: 'utm_source',
+            })
+            // personPropertyKeyUpdateCounter should NOT be called for 'ignored' outcomes
+            expect(mockPersonPropertyKeyUpdateCounter.labels).not.toHaveBeenCalled()
+        })
+
+        it('should skip database write when only $geoip_* properties are updated', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            // Update person with only geoip properties (existing properties being updated)
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                { ...person, properties: { $geoip_city_name: 'New York', $geoip_country_code: 'US' } },
+                { $geoip_city_name: 'San Francisco', $geoip_country_code: 'US' },
+                [],
+                {},
+                'test'
+            )
+
+            // Flush should skip the database write
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).not.toHaveBeenCalled()
+            expect(mockRepo.updatePersonAssertVersion).not.toHaveBeenCalled()
+
+            // Verify metrics
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'ignored' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledTimes(2)
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
+                property: '$geoip_city_name',
+            })
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
+                property: '$geoip_country_code',
+            })
+            // personPropertyKeyUpdateCounter should NOT be called for 'ignored' outcomes
+            expect(mockPersonPropertyKeyUpdateCounter.labels).not.toHaveBeenCalled()
+        })
+
+        it('should write to database when filtered properties are NEW (not in existing properties)', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            // Person without browser property
+            const personWithoutBrowser = { ...person, properties: { name: 'John' } }
+
+            // Update person with NEW eventToPersonProperty
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithoutBrowser,
+                { $browser: 'Chrome' },
+                [],
+                {},
+                'test'
+            )
+
+            // Flush SHOULD write to database since it's a new property
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    properties: { name: 'John', $browser: 'Chrome' },
+                }),
+                expect.anything(),
+                'updatePersonNoAssert'
+            )
+
+            // Verify metrics - should be 'changed' since new property triggers write
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            // Note: $browser would be ignored at event level (see person-update.ts), but filtering happens at batch level
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            // personPropertyKeyUpdateCounter should be called for new property
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$browser' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels({ key: '$browser' }).inc).toHaveBeenCalledTimes(1)
+        })
+
+        it('should write to database when mixing filtered and non-filtered properties', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            // Update person with both filtered and non-filtered properties
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                { ...person, properties: { $browser: 'Firefox', name: 'Jane' } },
+                { $browser: 'Chrome', name: 'John' },
+                [],
+                {},
+                'test'
+            )
+
+            // Flush SHOULD write to database because name is not filtered
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+
+            // Verify metrics - should be 'changed' since non-filtered property triggers write
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            // Note: $browser would be ignored at event level (see person-update.ts), but filtering happens at batch level
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            // personPropertyKeyUpdateCounter should be called for both properties
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledTimes(2)
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$browser' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: 'other' })
+        })
+
+        it('should write to database when unsetting any property', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            // Unset a filtered property
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                { ...person, properties: { $browser: 'Chrome' } },
+                {},
+                ['$browser'],
+                {},
+                'test'
+            )
+
+            // Flush SHOULD write to database because unsetting always triggers a write
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+
+            // Verify metrics - should be 'changed' since unsetting triggers write
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            // Note: $browser would be ignored at event level (see person-update.ts), but filtering happens at batch level
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            // personPropertyKeyUpdateCounter should be called for unset property
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$browser' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels({ key: '$browser' }).inc).toHaveBeenCalledTimes(1)
+        })
+
+        it('integration: multiple events with only filtered properties should not trigger database write', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            const personWithFiltered = {
+                ...person,
+                properties: {
+                    $browser: 'Firefox',
+                    utm_source: 'twitter',
+                    $geoip_city_name: 'New York',
+                },
+            }
+
+            // Event 1: Update browser
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithFiltered,
+                { $browser: 'Chrome' },
+                [],
+                {},
+                'test'
+            )
+
+            // Event 2: Update UTM source
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithFiltered,
+                { utm_source: 'google' },
+                [],
+                {},
+                'test'
+            )
+
+            // Event 3: Update geoip
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithFiltered,
+                { $geoip_city_name: 'Los Angeles' },
+                [],
+                {},
+                'test'
+            )
+
+            // Flush should NOT write to database - all properties are filtered
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).not.toHaveBeenCalled()
+            expect(mockRepo.updatePersonAssertVersion).not.toHaveBeenCalled()
+
+            // Verify metrics - should be 'ignored' since all properties are filtered
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'ignored' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledTimes(3)
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
+                property: '$browser',
+            })
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
+                property: 'utm_source',
+            })
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).toHaveBeenCalledWith({
+                property: '$geoip_city_name',
+            })
+            // personPropertyKeyUpdateCounter should NOT be called for 'ignored' outcomes
+            expect(mockPersonPropertyKeyUpdateCounter.labels).not.toHaveBeenCalled()
+        })
+
+        it('integration: filtered properties then non-filtered property should trigger database write', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            const personWithFiltered = {
+                ...person,
+                properties: {
+                    $browser: 'Firefox',
+                    utm_source: 'twitter',
+                    $os: 'Windows',
+                    name: 'Jane',
+                },
+            }
+
+            // Event 1: Update browser (filtered)
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithFiltered,
+                { $browser: 'Chrome' },
+                [],
+                {},
+                'test'
+            )
+
+            // Event 2: Update UTM source (filtered)
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithFiltered,
+                { utm_source: 'google' },
+                [],
+                {},
+                'test'
+            )
+
+            // Event 3: Update name (NOT filtered)
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithFiltered,
+                { name: 'John' },
+                [],
+                {},
+                'test'
+            )
+
+            // Event 4: Update more filtered properties
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                personWithFiltered,
+                { $os: 'macOS' },
+                [],
+                {},
+                'test'
+            )
+
+            // Flush SHOULD write to database because event 3 has non-filtered property
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    properties: {
+                        $browser: 'Chrome',
+                        utm_source: 'google',
+                        $os: 'macOS',
+                        name: 'John',
+                    },
+                }),
+                expect.anything(),
+                'updatePersonNoAssert'
+            )
+
+            // Verify metrics - should be 'changed' since non-filtered property triggers write
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            // Note: some properties would be ignored at event level (see person-update.ts), but filtering happens at batch level
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            // personPropertyKeyUpdateCounter should be called for all 4 properties
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledTimes(4)
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$browser' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: 'utm_source' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$os' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: 'other' })
+        })
+
+        it('integration: normal events for regression - custom properties always trigger writes', async () => {
+            const mockRepo = createMockRepository()
+            const testPersonStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer)
+            const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
+
+            // Event 1: Normal custom property
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                person,
+                { plan: 'premium' },
+                [],
+                {},
+                'test'
+            )
+
+            // Event 2: Another custom property
+            await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
+                person,
+                { subscription_status: 'active' },
+                [],
+                {},
+                'test'
+            )
+
+            // Flush SHOULD write to database
+            await personStoreForBatch.flush()
+
+            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    properties: {
+                        test: 'test',
+                        plan: 'premium',
+                        subscription_status: 'active',
+                    },
+                }),
+                expect.anything(),
+                'updatePersonNoAssert'
+            )
+
+            // Verify metrics - should be 'changed' since custom properties trigger write
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
+            expect(mockPersonProfileBatchUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc).toHaveBeenCalledTimes(
+                1
+            )
+            // Note: custom properties are never ignored at event level (see person-update.ts)
+            expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            // personPropertyKeyUpdateCounter should be called once for 'other' (deduplicated by Set)
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledTimes(1)
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: 'other' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels({ key: 'other' }).inc).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -191,10 +191,17 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         const ignoredProperties: string[] = []
         const hasPropertyTriggeringUpdate = Object.keys(update.properties_to_set).some((key) => {
             // Check if this is a new property (not in current properties)
-            if (!(key in update.properties)) {
+            const isNewProperty = !(key in update.properties)
+            const valueChanged = update.properties[key] !== update.properties_to_set[key]
+
+            if (!valueChanged) {
+                return false
+            }
+
+            if (isNewProperty) {
                 return true
             }
-            // Check if this property should trigger an update
+
             const isFiltered = eventToPersonProperties.has(key) || key.startsWith('$geoip_')
             if (isFiltered) {
                 ignoredProperties.push(key)

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -167,6 +167,14 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
      * Also tracks metrics for ignored properties at the batch level.
      */
     private getPersonUpdateOutcome(update: PersonUpdate): 'changed' | 'ignored' | 'no_change' {
+        const hasNonPropertyChanges =
+            update.is_identified !== update.original_is_identified ||
+            !update.created_at.equals(update.original_created_at)
+
+        if (hasNonPropertyChanges) {
+            return 'changed'
+        }
+
         const hasPropertyChanges =
             Object.keys(update.properties_to_set).length > 0 || update.properties_to_unset.length > 0
 
@@ -1250,6 +1258,8 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             needs_write: personUpdate.needs_write,
             properties_to_set: personUpdate.properties_to_set,
             properties_to_unset: personUpdate.properties_to_unset,
+            original_is_identified: personUpdate.original_is_identified,
+            original_created_at: personUpdate.original_created_at,
         }
 
         return updatedPersonUpdate

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -829,10 +829,14 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
 
         if (existingPersonUpdate) {
             // Merge the properties and changesets from both updates
-            const mergedPersonUpdate = this.mergeUpdateIntoPersonUpdate(existingPersonUpdate, {
-                properties: person.properties,
-                is_identified: person.is_identified,
-            } as Partial<InternalPerson>)
+            const mergedPersonUpdate = this.mergeUpdateIntoPersonUpdate(
+                existingPersonUpdate,
+                {
+                    properties: person.properties,
+                    is_identified: person.is_identified,
+                } as Partial<InternalPerson>,
+                false
+            )
 
             // Handle fields that are specific to PersonUpdate - merge properties_to_set and properties_to_unset
             mergedPersonUpdate.properties_to_set = {
@@ -844,6 +848,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
             ]
 
             mergedPersonUpdate.created_at = DateTime.min(existingPersonUpdate.created_at, person.created_at)
+            mergedPersonUpdate.needs_write = existingPersonUpdate.needs_write || person.needs_write
 
             this.personUpdateCache.set(this.getPersonIdCacheKey(teamId, person.id), mergedPersonUpdate)
         } else {

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -186,12 +186,24 @@ export function observeLatencyByVersion(person: InternalPerson | undefined, star
 
 export const personProfileUpdateOutcomeCounter = new Counter({
     name: 'person_profile_update_outcome_total',
-    help: 'Outcome of person profile update operations',
+    help: 'Outcome of person profile update operations at event level',
     labelNames: ['outcome'], // outcome: changed, ignored, no_change, unsupported
 })
 
 export const personProfileIgnoredPropertiesCounter = new Counter({
     name: 'person_profile_ignored_properties_total',
-    help: 'Count of specific properties that were ignored during person profile updates',
+    help: 'Count of specific properties that were ignored during person profile updates at event level',
+    labelNames: ['property'],
+})
+
+export const personProfileBatchUpdateOutcomeCounter = new Counter({
+    name: 'person_profile_batch_update_outcome_total',
+    help: 'Outcome of person profile update operations at batch level',
+    labelNames: ['outcome'], // outcome: changed, ignored, no_change
+})
+
+export const personProfileBatchIgnoredPropertiesCounter = new Counter({
+    name: 'person_profile_batch_ignored_properties_total',
+    help: 'Count of specific properties that were ignored during person profile updates at batch level',
     labelNames: ['property'],
 })

--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -153,7 +153,7 @@ export class PersonMergeService {
             clearTimeout(timeout)
         }
         // For non-merge events or when no merge conditions are met, return success with no person
-        return mergeSuccess(undefined, Promise.resolve())
+        return mergeSuccess(undefined, Promise.resolve(), true)
     }
 
     public async merge(
@@ -165,7 +165,7 @@ export class PersonMergeService {
         // No reason to alias person against itself. Done by posthog-node when updating user properties
         if (mergeIntoDistinctId === otherPersonDistinctId) {
             // Create a success result with undefined person to indicate no merge was needed
-            return mergeSuccess(undefined, Promise.resolve())
+            return mergeSuccess(undefined, Promise.resolve(), true)
         }
         if (isDistinctIdIllegal(mergeIntoDistinctId)) {
             await captureIngestionWarning(
@@ -179,7 +179,7 @@ export class PersonMergeService {
                 },
                 { alwaysSend: true }
             )
-            return mergeSuccess(undefined, Promise.resolve())
+            return mergeSuccess(undefined, Promise.resolve(), true)
         }
         if (isDistinctIdIllegal(otherPersonDistinctId)) {
             await captureIngestionWarning(
@@ -193,7 +193,7 @@ export class PersonMergeService {
                 },
                 { alwaysSend: true }
             )
-            return mergeSuccess(undefined, Promise.resolve())
+            return mergeSuccess(undefined, Promise.resolve(), true)
         }
 
         const result = await promiseRetry(
@@ -259,14 +259,14 @@ export class PersonMergeService {
 
                 const kafkaMessages = await tx.addDistinctId(existingPerson, distinctIdToAdd, distinctIdVersion)
                 await this.context.kafkaProducer.queueMessages(kafkaMessages)
-                return mergeSuccess(existingPerson, Promise.resolve())
+                return mergeSuccess(existingPerson, Promise.resolve(), true)
             })
         } else if (otherPerson && mergeIntoPerson) {
             // Both Distinct IDs point at an existing Person
 
             if (otherPerson.id == mergeIntoPerson.id) {
                 // Nothing to do, they are the same Person
-                return mergeSuccess(mergeIntoPerson, Promise.resolve())
+                return mergeSuccess(mergeIntoPerson, Promise.resolve(), true)
             }
 
             const result = await this.mergePeople({
@@ -319,7 +319,6 @@ export class PersonMergeService {
                 const distinctId1Version = 0
 
                 const [person, _] = await this.personCreateService.createPerson(
-                    // TODO: in this case we could skip the properties updates later
                     timestamp,
                     this.context.eventProperties['$set'] || {},
                     this.context.eventProperties['$set_once'] || {},
@@ -333,7 +332,8 @@ export class PersonMergeService {
                     ],
                     tx
                 )
-                return mergeSuccess(person, Promise.resolve())
+                // We don't need to update the person later, so we return false for needsPersonUpdate
+                return mergeSuccess(person, Promise.resolve(), false)
             })
         }
     }
@@ -368,7 +368,7 @@ export class PersonMergeService {
             logger.warn('🤔', 'refused to merge an already identified user via an $identify or $create_alias call', {
                 team_id: this.context.team.id,
             })
-            return mergeSuccess(mergeInto, Promise.resolve())
+            return mergeSuccess(mergeInto, Promise.resolve(), true)
         }
 
         // How the merge works:
@@ -422,7 +422,7 @@ export class PersonMergeService {
             logger.warn('🤔', 'merge race condition detected, too many concurrent merges', {
                 team_id: this.context.team.id,
             })
-            return mergeSuccess(mergeInto, Promise.resolve())
+            return mergeSuccess(mergeInto, Promise.resolve(), true)
         }
 
         // For other errors (PersonMergeLimitExceededError, etc.), return the error result
@@ -509,7 +509,7 @@ export class PersonMergeService {
                 .inc()
 
             const kafkaAck = this.context.kafkaProducer.queueMessages(kafkaMessages)
-            return mergeSuccess(mergedPerson, kafkaAck)
+            return mergeSuccess(mergedPerson, kafkaAck, true)
         } catch (error) {
             // Map exceptions to result types - these will cause transaction rollback
             if (error instanceof SourcePersonNotFoundError) {
@@ -685,7 +685,7 @@ export class PersonMergeService {
                     )
 
                     if (!refreshedPerson) {
-                        return mergeSuccess(currentTargetPerson, Promise.resolve())
+                        return mergeSuccess(currentTargetPerson, Promise.resolve(), true)
                     }
 
                     currentSourcePerson = refreshedPerson
@@ -699,7 +699,7 @@ export class PersonMergeService {
                     )
 
                     if (!refreshedPerson) {
-                        return mergeSuccess(currentTargetPerson, Promise.resolve())
+                        return mergeSuccess(currentTargetPerson, Promise.resolve(), true)
                     }
 
                     currentTargetPerson = refreshedPerson

--- a/plugin-server/src/worker/ingestion/persons/person-merge-types.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-types.ts
@@ -86,6 +86,7 @@ export type PersonMergeResult =
           success: true
           person: InternalPerson | undefined
           kafkaAck: Promise<void>
+          needsPersonUpdate: boolean
       }
     | {
           success: false
@@ -113,11 +114,16 @@ export type MergeMode =
 /**
  * Helper function to create a successful merge result
  */
-export function mergeSuccess(person: InternalPerson | undefined, kafkaAck: Promise<void>): PersonMergeResult {
+export function mergeSuccess(
+    person: InternalPerson | undefined,
+    kafkaAck: Promise<void>,
+    needsPersonUpdate: boolean
+): PersonMergeResult {
     return {
         success: true,
         person,
         kafkaAck,
+        needsPersonUpdate,
     }
 }
 

--- a/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
@@ -75,37 +75,3 @@ export function toInternalPerson(personUpdate: PersonUpdate): InternalPerson {
         is_user_id: personUpdate.is_user_id,
     }
 }
-
-export function calculatePersonPropertyUpdate(
-    currentProperties: Properties,
-    currentPropertiesLastUpdatedAt: PropertiesLastUpdatedAt,
-    currentPropertiesLastOperation: PropertiesLastOperation,
-    propertiesToSet: Properties,
-    propertiesToUnset: string[],
-    _timestamp: DateTime
-): PersonPropertyUpdate {
-    const result: PersonPropertyUpdate = {
-        updated: false,
-        properties: { ...currentProperties },
-        properties_last_updated_at: { ...currentPropertiesLastUpdatedAt },
-        properties_last_operation: { ...currentPropertiesLastOperation },
-    }
-
-    // Set new properties
-    Object.entries(propertiesToSet).forEach(([key, value]) => {
-        if (!(key in result.properties) || value !== result.properties[key]) {
-            result.updated = true
-            result.properties[key] = value
-        }
-    })
-
-    // Unset properties
-    propertiesToUnset.forEach((propertyKey) => {
-        if (propertyKey in result.properties) {
-            result.updated = true
-            delete result.properties[propertyKey]
-        }
-    })
-
-    return result
-}

--- a/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
@@ -20,6 +20,8 @@ export interface PersonUpdate {
     // Fine-grained property tracking
     properties_to_set: Properties // Properties to set/update
     properties_to_unset: string[] // Property keys to unset
+    original_is_identified: boolean
+    original_created_at: DateTime
 }
 
 export interface PersonPropertyUpdate {
@@ -35,7 +37,7 @@ export function fromInternalPerson(person: InternalPerson, distinctId: string): 
         team_id: person.team_id,
         uuid: person.uuid,
         distinct_id: distinctId,
-        properties: person.properties, // Original properties from database
+        properties: person.properties,
         properties_last_updated_at: person.properties_last_updated_at,
         properties_last_operation: person.properties_last_operation || {},
         created_at: person.created_at,
@@ -45,6 +47,8 @@ export function fromInternalPerson(person: InternalPerson, distinctId: string): 
         needs_write: false,
         properties_to_set: {},
         properties_to_unset: [],
+        original_is_identified: person.is_identified,
+        original_created_at: person.created_at,
     }
 }
 

--- a/plugin-server/src/worker/ingestion/persons/person-update.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.ts
@@ -4,11 +4,7 @@ import { cloneObject } from '~/utils/utils'
 
 import { InternalPerson } from '../../../types'
 import { logger } from '../../../utils/logger'
-import {
-    personProfileIgnoredPropertiesCounter,
-    personProfileUpdateOutcomeCounter,
-    personPropertyKeyUpdateCounter,
-} from './metrics'
+import { personProfileIgnoredPropertiesCounter, personProfileUpdateOutcomeCounter } from './metrics'
 import { eventToPersonProperties, initialEventToPersonProperties } from './person-property-utils'
 
 export interface PropertyUpdates {
@@ -24,7 +20,7 @@ const PERSON_EVENTS = new Set(['$identify', '$create_alias', '$merge_dangerously
 
 // For tracking what property keys cause us to update persons
 // tracking all properties we add from the event, 'geoip' for '$geoip_*' or '$initial_geoip_*' and 'other' for anything outside of those
-function getMetricKey(key: string): string {
+export function getMetricKey(key: string): string {
     if (key.startsWith('$geoip_') || key.startsWith('$initial_geoip_')) {
         return 'geoIP'
     }
@@ -55,20 +51,32 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
     const unsetProperties: Array<string> = Array.isArray(unsetProps) ? unsetProps : Object.keys(unsetProps || {}) || []
 
     let hasChanges = false
+    let hasNonFilteredChanges = false
     const toSet: Properties = {}
     const toUnset: string[] = []
+    const ignoredProperties: string[] = []
 
     Object.entries(propertiesOnce).forEach(([key, value]) => {
         if (typeof personProperties[key] === 'undefined') {
             hasChanges = true
             toSet[key] = value
+            if (shouldUpdatePersonIfOnlyChange(event, key)) {
+                hasNonFilteredChanges = true
+            }
         }
     })
 
     Object.entries(properties).forEach(([key, value]) => {
         if (personProperties[key] !== value) {
-            if (typeof personProperties[key] === 'undefined' || shouldUpdatePersonIfOnlyChange(event, key)) {
+            const isNewProperty = typeof personProperties[key] === 'undefined'
+            const shouldUpdate = isNewProperty || shouldUpdatePersonIfOnlyChange(event, key)
+
+            if (shouldUpdate) {
                 hasChanges = true
+                hasNonFilteredChanges = true
+            } else {
+                hasChanges = true
+                ignoredProperties.push(key)
             }
             toSet[key] = value
         }
@@ -78,21 +86,23 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
         if (propertyKey in personProperties) {
             if (typeof propertyKey === 'string') {
                 hasChanges = true
+                hasNonFilteredChanges = true
                 toUnset.push(propertyKey)
             }
         }
     })
 
-    // Track person profile update outcomes
+    // Track person profile update outcomes at event level
     const hasPropertyChanges = Object.keys(toSet).length > 0 || toUnset.length > 0
-    if (hasChanges) {
-        personProfileUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc()
-    } else if (hasPropertyChanges) {
-        personProfileUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc()
-        // Track which specific properties were ignored
-        Object.keys(toSet).forEach((propertyName) => {
-            personProfileIgnoredPropertiesCounter.labels({ property: propertyName }).inc()
-        })
+    if (hasPropertyChanges) {
+        if (hasNonFilteredChanges) {
+            personProfileUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc()
+        } else {
+            personProfileUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc()
+            ignoredProperties.forEach((property) => {
+                personProfileIgnoredPropertiesCounter.labels({ property }).inc()
+            })
+        }
     } else {
         personProfileUpdateOutcomeCounter.labels({ outcome: 'no_change' }).inc()
     }
@@ -110,7 +120,6 @@ export function applyEventPropertyUpdates(
     person: InternalPerson
 ): [InternalPerson, boolean] {
     let updated = false
-    const metricsKeys = new Set<string>()
 
     // Create a copy of the person with copied properties
     const updatedPerson = cloneObject(person)
@@ -120,7 +129,6 @@ export function applyEventPropertyUpdates(
         if (updatedPerson.properties[key] !== value) {
             updated = true
         }
-        metricsKeys.add(getMetricKey(key))
         updatedPerson.properties[key] = value
     })
 
@@ -132,12 +140,10 @@ export function applyEventPropertyUpdates(
                 return
             }
             updated = true
-            metricsKeys.add(getMetricKey(propertyKey))
             delete updatedPerson.properties[propertyKey]
         }
     })
 
-    metricsKeys.forEach((key) => personPropertyKeyUpdateCounter.labels({ key: key }).inc())
     return [updatedPerson, updated]
 }
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository-2pc.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository-2pc.test.ts
@@ -1192,6 +1192,8 @@ describe('PostgresDualWritePersonRepository 2PC Dual-Write Tests', () => {
                 needs_write: true,
                 properties_to_set: { x: 2 },
                 properties_to_unset: [],
+                original_is_identified: false,
+                original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
             })
             expect(version).toBe(person.version + 1)
 
@@ -1240,6 +1242,8 @@ describe('PostgresDualWritePersonRepository 2PC Dual-Write Tests', () => {
                     needs_write: true,
                     properties_to_set: { x: 2 },
                     properties_to_unset: [],
+                    original_is_identified: false,
+                    original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 })
             ).rejects.toThrow('secondary assert-version failure')
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -1283,6 +1283,8 @@ describe('PostgresPersonRepository', () => {
                 needs_write: true,
                 properties_to_set: { name: 'Jane', age: 30 },
                 properties_to_unset: [],
+                original_is_identified: false,
+                original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
             }
 
             // First update should succeed
@@ -1317,6 +1319,8 @@ describe('PostgresPersonRepository', () => {
                 needs_write: true,
                 properties_to_set: { name: 'Jane', age: 30 },
                 properties_to_unset: [],
+                original_is_identified: false,
+                original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
             }
 
             // Update should fail due to version mismatch
@@ -1350,6 +1354,8 @@ describe('PostgresPersonRepository', () => {
                 needs_write: true,
                 properties_to_set: { name: 'Jane' },
                 properties_to_unset: [],
+                original_is_identified: false,
+                original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
             }
 
             // Update should fail because person doesn't exist
@@ -1949,6 +1955,8 @@ describe('PostgresPersonRepository', () => {
                     needs_write: true,
                     properties_to_set: { description: 'x'.repeat(150) },
                     properties_to_unset: [],
+                    original_is_identified: false,
+                    original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 }
 
                 await expect(oversizedRepository.updatePersonAssertVersion(personUpdate)).rejects.toThrow(
@@ -2201,6 +2209,8 @@ describe('PostgresPersonRepository', () => {
                 needs_write: true,
                 properties_to_set: { name: 'Jane', age: 30, data: 'y'.repeat(2500) },
                 properties_to_unset: [],
+                original_is_identified: false,
+                original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
             })
 
             const personUpdate1 = createPersonUpdate(person1, 'test-assert-1')

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -920,7 +920,7 @@ describe('PersonState.processEvent()', () => {
             ])
         })
 
-        it('updates person properties - always update for person events', async () => {
+        it('skips database write when only filtered properties change (batch-level filtering)', async () => {
             await createPerson(hub, timestamp, { $current_url: 123 }, {}, {}, teamId, null, false, newUserUuid, [
                 { distinctId: newUserDistinctId },
             ])
@@ -940,7 +940,7 @@ describe('PersonState.processEvent()', () => {
                 expect.objectContaining({
                     id: expect.any(String),
                     uuid: newUserUuid,
-                    properties: { $current_url: 4 }, // Here we keep 4 for passing forward to PoE
+                    properties: { $current_url: 4 },
                     created_at: timestamp,
                     is_identified: false,
                 })
@@ -948,7 +948,6 @@ describe('PersonState.processEvent()', () => {
 
             expect(personRepository.fetchPerson).toHaveBeenCalledTimes(1)
 
-            // verify Postgres persons
             const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(
@@ -957,10 +956,52 @@ describe('PersonState.processEvent()', () => {
                     uuid: newUserUuid,
                     created_at: timestamp,
                     is_identified: false,
-                    properties: { $current_url: 4 },
+                    properties: { $current_url: 123 },
+                    version: 0,
+                })
+            )
+        })
+
+        it('writes to database when non-filtered properties change', async () => {
+            await createPerson(hub, timestamp, { name: 'John' }, {}, {}, teamId, null, false, newUserUuid, [
+                { distinctId: newUserDistinctId },
+            ])
+
+            const propertyService = personPropertyService({
+                event: '$pageview',
+                distinct_id: newUserDistinctId,
+                properties: {
+                    $set: { name: 'Jane' },
+                },
+            })
+            const [person, kafkaAcks] = await propertyService.updateProperties()
+            const context = propertyService.getContext()
+            await flushPersonStoreToKafka(hub, context.personStore, kafkaAcks)
+
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(String),
+                    uuid: newUserUuid,
+                    properties: { name: 'Jane' },
+                    created_at: timestamp,
+                    is_identified: false,
+                })
+            )
+
+            expect(personRepository.fetchPerson).toHaveBeenCalledTimes(1)
+
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(1)
+            expect(persons[0]).toEqual(
+                expect.objectContaining({
+                    id: person.id,
+                    uuid: newUserUuid,
+                    created_at: timestamp,
+                    is_identified: false,
+                    properties: { name: 'Jane' },
                     version: 1,
                 })
-            ) // We updated PG as it's a person event
+            )
         })
 
         it('updates person properties - always update if undefined before', async () => {
@@ -1352,7 +1393,7 @@ describe('PersonState.processEvent()', () => {
             expect(distinctIds).toEqual(expect.arrayContaining([oldUserDistinctId, newUserDistinctId]))
         })
 
-        it(`marks is_identified to be updated when no changes to distinct_ids but $anon_distinct_id passe`, async () => {
+        it(`skips database write when is_identified doesn't change (batch-level filtering)`, async () => {
             await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, newUserUuid, [
                 { distinctId: newUserDistinctId },
                 { distinctId: oldUserDistinctId },
@@ -1384,7 +1425,6 @@ describe('PersonState.processEvent()', () => {
             })
             expect(mergeService.getUpdateIsIdentified()).toBeTruthy()
 
-            // verify Postgres persons
             const persons = await fetchPostgresPersonsH()
             expect(persons.length).toEqual(1)
             expect(persons[0]).toMatchObject({
@@ -1393,7 +1433,7 @@ describe('PersonState.processEvent()', () => {
                 created_at: timestamp,
                 is_identified: false,
                 properties: {},
-                version: 1,
+                version: 0,
             })
         })
 


### PR DESCRIPTION
## Problem

We throttle some person properties to reduce the amount of update queries, but we do it at the event level, whereas we batch queries, so we're unnecessarily drop some property updates.

## Changes

- Moves the property throttling to the batch person store flush 
- Adds a new batch-level set of metrics
- Removes throttling at the event while keeping the old metrics for comparison

## How did you test this code?

- Added a bunch of new tests at the batch level
- Regression tests