### PR TITLE
refactor: Sync Rev Analytics managed viewsets less often

### DIFF
--- a/posthog/warehouse/models/datawarehouse_managed_viewset.py
+++ b/posthog/warehouse/models/datawarehouse_managed_viewset.py
@@ -93,7 +93,7 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
                 saved_query.columns = view.columns
                 saved_query.external_tables = saved_query.s3_tables
                 saved_query.is_materialized = True
-                saved_query.sync_frequency_interval = timedelta(hours=6)
+                saved_query.sync_frequency_interval = timedelta(hours=12)
                 saved_query.save()
 
                 # Make sure paths properly exist both on creation and update


### PR DESCRIPTION
This is incurring some Temporal costs, let's bring them down for now. We can make this customizable in the future once we start charging for materialized views.
