### PR TITLE
feat: support event restriction pipelines

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -158,6 +158,7 @@ export class IngestionConsumer {
             (x) => !!x
         )
         this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            pipeline: 'analytics',
             staticDropEventTokens: this.tokenDistinctIdsToDrop,
             staticSkipPersonTokens: this.tokenDistinctIdsToSkipPersons,
             staticForceOverflowTokens: this.tokenDistinctIdsToForceOverflow,

--- a/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
+++ b/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
@@ -166,9 +166,9 @@ describe('EventIngestionRestrictionManager', () => {
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1', analytics: true, session_recordings: false },
-                        { token: 'token2', distinct_id: 'user1', analytics: true, session_recordings: true },
-                        { token: 'token3', analytics: false, session_recordings: true },
+                        { token: 'token1', pipelines: ['analytics'] },
+                        { token: 'token2', distinct_id: 'user1', pipelines: ['analytics', 'session_recordings'] },
+                        { token: 'token3', pipelines: ['session_recordings'] },
                     ]),
                 ],
                 [null, null],
@@ -177,7 +177,7 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should only include token1 and token2 (analytics=true), not token3 (analytics=false)
+            // Should only include token1 and token2 (pipelines includes 'analytics'), not token3
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set(['token1', 'token2:user1']),
             })
@@ -186,27 +186,27 @@ describe('EventIngestionRestrictionManager', () => {
         it('handles new format with only session_recordings enabled (analytics pipeline)', async () => {
             pipelineMock.get.mockClear()
             pipelineMock.exec.mockResolvedValue([
-                [null, JSON.stringify([{ token: 'token1', analytics: false, session_recordings: true }])],
+                [null, JSON.stringify([{ token: 'token1', pipelines: ['session_recordings'] }])],
                 [null, null],
                 [null, null],
             ])
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should be empty because analytics=false for analytics pipeline
+            // Should be empty because pipelines doesn't include 'analytics'
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set([]),
             })
         })
 
-        it('excludes entries with both pipelines disabled', async () => {
+        it('excludes entries with empty pipelines array', async () => {
             pipelineMock.get.mockClear()
             pipelineMock.exec.mockResolvedValue([
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1', analytics: false, session_recordings: false },
-                        { token: 'token2', analytics: true, session_recordings: false },
+                        { token: 'token1', pipelines: [] },
+                        { token: 'token2', pipelines: ['analytics'] },
                     ]),
                 ],
                 [null, null],
@@ -228,8 +228,8 @@ describe('EventIngestionRestrictionManager', () => {
                     JSON.stringify([
                         'old-token1',
                         'old-token2:distinct1',
-                        { token: 'new-token1', analytics: true, session_recordings: false },
-                        { token: 'new-token2', distinct_id: 'user1', analytics: false, session_recordings: true },
+                        { token: 'new-token1', pipelines: ['analytics'] },
+                        { token: 'new-token2', distinct_id: 'user1', pipelines: ['session_recordings'] },
                     ]),
                 ],
                 [null, null],
@@ -238,8 +238,8 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should include old-token1, old-token2:distinct1 (old format defaults to analytics=true)
-            // and new-token1 (analytics=true), but NOT new-token2 (analytics=false)
+            // Should include old-token1, old-token2:distinct1 (old format defaults to analytics)
+            // and new-token1 (pipelines includes 'analytics'), but NOT new-token2
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set([
                     'old-token1',
@@ -255,8 +255,8 @@ describe('EventIngestionRestrictionManager', () => {
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1' }, // Missing both fields - will be excluded
-                        { token: 'token2', analytics: true }, // Has analytics field
+                        { token: 'token1' }, // Missing pipelines field - will be excluded
+                        { token: 'token2', pipelines: ['analytics'] }, // Has pipelines field
                     ]),
                 ],
                 [null, null],
@@ -265,7 +265,7 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should only include token2 (has analytics=true), token1 is excluded (missing field)
+            // Should only include token2 (pipelines includes 'analytics'), token1 is excluded (missing field)
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set(['token2']),
             })
@@ -277,9 +277,9 @@ describe('EventIngestionRestrictionManager', () => {
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1', analytics: true, session_recordings: false },
-                        { token: 'token2', analytics: false, session_recordings: true },
-                        { token: 'token3', analytics: true, session_recordings: true },
+                        { token: 'token1', pipelines: ['analytics'] },
+                        { token: 'token2', pipelines: ['session_recordings'] },
+                        { token: 'token3', pipelines: ['analytics', 'session_recordings'] },
                     ]),
                 ],
                 [null, null],
@@ -292,7 +292,7 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await manager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should only include token2 and token3 (session_recordings=true)
+            // Should only include token2 and token3 (pipelines includes 'session_recordings')
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set(['token2', 'token3']),
             })
@@ -305,7 +305,7 @@ describe('EventIngestionRestrictionManager', () => {
                     null,
                     JSON.stringify([
                         'old-token1', // Old format, should be excluded from session_recordings
-                        { token: 'new-token1', analytics: false, session_recordings: true },
+                        { token: 'new-token1', pipelines: ['session_recordings'] },
                     ]),
                 ],
                 [null, null],

--- a/plugin-server/src/utils/event-ingestion-restriction-manager.ts
+++ b/plugin-server/src/utils/event-ingestion-restriction-manager.ts
@@ -99,17 +99,19 @@ export class EventIngestionRestrictionManager {
                         if (Array.isArray(parsedArray)) {
                             // Convert array items to strings
                             // Old format: ["token1", "token2:distinct_id"]
-                            // New format: [{"token": "token1", "analytics": true, "session_recordings": false}, ...]
+                            // New format: [{"token": "token1", "pipelines": ["analytics", "session_recordings"]}, ...]
                             const items = parsedArray.flatMap((item) => {
                                 if (typeof item === 'string') {
-                                    // Old format - assume analytics=true, everything else=false
+                                    // Old format - assume applies to analytics only for backwards compatibility
                                     if (this.pipeline === 'analytics') {
                                         return [item]
                                     }
                                     return []
                                 } else if (typeof item === 'object' && item !== null && 'token' in item) {
-                                    // New format - check if the pipeline field is set to true
-                                    const appliesToPipeline = Boolean(item[this.pipeline])
+                                    // New format - check if this pipeline is in the pipelines array
+                                    const pipelines: unknown = item.pipelines
+                                    const appliesToPipeline =
+                                        Array.isArray(pipelines) && pipelines.includes(this.pipeline)
 
                                     if (appliesToPipeline) {
                                         if ('distinct_id' in item && item.distinct_id) {


### PR DESCRIPTION
## Problem

We want to add event restrictions to non-analytics pipelines, starting with session recordings.

## Changes

- Updates the event restriction manager to read both the old and new format
- Filters out the restrictions based on the pipeline

## How did you test this code?

Added new tests
