### PR TITLE
refactor: set up event restrictions for blobby

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -158,6 +158,7 @@ export class IngestionConsumer {
             (x) => !!x
         )
         this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            pipeline: 'analytics',
             staticDropEventTokens: this.tokenDistinctIdsToDrop,
             staticSkipPersonTokens: this.tokenDistinctIdsToSkipPersons,
             staticForceOverflowTokens: this.tokenDistinctIdsToForceOverflow,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -209,7 +209,7 @@ export class SessionRecordingIngester {
         // Apply event ingestion restrictions before parsing
         const messagesToProcess = await instrumentFn(
             `recordingingesterv2.handleEachBatch.applyRestrictions`,
-            async () => this.restrictionHandler!.applyRestrictions(messages)
+            async () => Promise.resolve(this.restrictionHandler!.applyRestrictions(messages))
         )
 
         const processedMessages = await instrumentFn(`recordingingesterv2.handleEachBatch.parseBatch`, async () => {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -8,8 +8,8 @@ import { KafkaConsumer } from '../../../kafka/consumer'
 import { KafkaProducerWrapper } from '../../../kafka/producer'
 import {
     HealthCheckResult,
+    Hub,
     PluginServerService,
-    PluginsServerConfig,
     RedisPool,
     SessionRecordingV2MetadataSwitchoverDate,
     ValueMatcher,
@@ -33,6 +33,7 @@ import { KafkaOffsetManager } from './kafka/offset-manager'
 import { SessionRecordingIngesterMetrics } from './metrics'
 import { RetentionAwareStorage } from './retention/retention-aware-batch-writer'
 import { RetentionService } from './retention/retention-service'
+import { SessionRecordingRestrictionHandler } from './session-recording-restriction-handler'
 import { BlackholeSessionBatchFileStorage } from './sessions/blackhole-session-batch-writer'
 import { SessionBatchFileStorage } from './sessions/session-batch-file-storage'
 import { SessionBatchManager } from './sessions/session-batch-manager'
@@ -61,9 +62,12 @@ export class SessionRecordingIngester {
     private readonly libVersionMonitor?: LibVersionMonitor
     private readonly fileStorage: SessionBatchFileStorage
     private readonly eventIngestionRestrictionManager: EventIngestionRestrictionManager
+    private restrictionHandler?: SessionRecordingRestrictionHandler
+    private kafkaOverflowProducer?: KafkaProducerWrapper
+    private readonly overflowTopic: string
 
     constructor(
-        private config: PluginsServerConfig,
+        private hub: Hub,
         private consumeOverflow: boolean,
         postgres: PostgresRouter,
         producer: KafkaProducerWrapper,
@@ -72,11 +76,12 @@ export class SessionRecordingIngester {
         this.topic = consumeOverflow
             ? KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_OVERFLOW
             : KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS
+        this.overflowTopic = KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_OVERFLOW
         this.consumerGroupId = this.consumeOverflow ? KAFKA_CONSUMER_GROUP_ID_OVERFLOW : KAFKA_CONSUMER_GROUP_ID
-        this.isDebugLoggingEnabled = buildIntegerMatcher(config.SESSION_RECORDING_DEBUG_PARTITION, true)
+        this.isDebugLoggingEnabled = buildIntegerMatcher(hub.SESSION_RECORDING_DEBUG_PARTITION, true)
 
         const metadataSwitchoverDate: SessionRecordingV2MetadataSwitchoverDate =
-            parseSessionRecordingV2MetadataSwitchoverDate(config.SESSION_RECORDING_V2_METADATA_SWITCHOVER)
+            parseSessionRecordingV2MetadataSwitchoverDate(hub.SESSION_RECORDING_V2_METADATA_SWITCHOVER)
 
         this.promiseScheduler = new PromiseScheduler()
 
@@ -90,21 +95,21 @@ export class SessionRecordingIngester {
 
         let s3Client: S3Client | null = null
         if (
-            config.SESSION_RECORDING_V2_S3_ENDPOINT &&
-            config.SESSION_RECORDING_V2_S3_REGION &&
-            config.SESSION_RECORDING_V2_S3_BUCKET &&
-            config.SESSION_RECORDING_V2_S3_PREFIX
+            hub.SESSION_RECORDING_V2_S3_ENDPOINT &&
+            hub.SESSION_RECORDING_V2_S3_REGION &&
+            hub.SESSION_RECORDING_V2_S3_BUCKET &&
+            hub.SESSION_RECORDING_V2_S3_PREFIX
         ) {
             const s3Config: S3ClientConfig = {
-                region: config.SESSION_RECORDING_V2_S3_REGION,
-                endpoint: config.SESSION_RECORDING_V2_S3_ENDPOINT,
+                region: hub.SESSION_RECORDING_V2_S3_REGION,
+                endpoint: hub.SESSION_RECORDING_V2_S3_ENDPOINT,
                 forcePathStyle: true,
             }
 
-            if (config.SESSION_RECORDING_V2_S3_ACCESS_KEY_ID && config.SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY) {
+            if (hub.SESSION_RECORDING_V2_S3_ACCESS_KEY_ID && hub.SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY) {
                 s3Config.credentials = {
-                    accessKeyId: config.SESSION_RECORDING_V2_S3_ACCESS_KEY_ID,
-                    secretAccessKey: config.SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY,
+                    accessKeyId: hub.SESSION_RECORDING_V2_S3_ACCESS_KEY_ID,
+                    secretAccessKey: hub.SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY,
                 }
             }
 
@@ -113,11 +118,11 @@ export class SessionRecordingIngester {
 
         this.kafkaParser = new KafkaMessageParser()
 
-        this.redisPool = createRedisPool(this.config, 'session-recording')
+        this.redisPool = createRedisPool(this.hub, 'session-recording')
 
         const teamService = new TeamService(postgres)
 
-        this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(this.config, {
+        this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(this.hub, {
             pipeline: 'session_recordings',
         })
 
@@ -134,27 +139,27 @@ export class SessionRecordingIngester {
         const offsetManager = new KafkaOffsetManager(this.commitOffsets.bind(this), this.topic)
         const metadataStore = new SessionMetadataStore(
             producer,
-            this.config.SESSION_RECORDING_V2_REPLAY_EVENTS_KAFKA_TOPIC
+            this.hub.SESSION_RECORDING_V2_REPLAY_EVENTS_KAFKA_TOPIC
         )
         const consoleLogStore = new SessionConsoleLogStore(
             producer,
-            this.config.SESSION_RECORDING_V2_CONSOLE_LOG_ENTRIES_KAFKA_TOPIC,
-            { messageLimit: this.config.SESSION_RECORDING_V2_CONSOLE_LOG_STORE_SYNC_BATCH_LIMIT }
+            this.hub.SESSION_RECORDING_V2_CONSOLE_LOG_ENTRIES_KAFKA_TOPIC,
+            { messageLimit: this.hub.SESSION_RECORDING_V2_CONSOLE_LOG_STORE_SYNC_BATCH_LIMIT }
         )
         this.fileStorage = s3Client
             ? new RetentionAwareStorage(
                   s3Client,
-                  this.config.SESSION_RECORDING_V2_S3_BUCKET,
-                  this.config.SESSION_RECORDING_V2_S3_PREFIX,
-                  this.config.SESSION_RECORDING_V2_S3_TIMEOUT_MS,
+                  this.hub.SESSION_RECORDING_V2_S3_BUCKET,
+                  this.hub.SESSION_RECORDING_V2_S3_PREFIX,
+                  this.hub.SESSION_RECORDING_V2_S3_TIMEOUT_MS,
                   retentionService
               )
             : new BlackholeSessionBatchFileStorage()
 
         this.sessionBatchManager = new SessionBatchManager({
-            maxBatchSizeBytes: this.config.SESSION_RECORDING_MAX_BATCH_SIZE_KB * 1024,
-            maxBatchAgeMs: this.config.SESSION_RECORDING_MAX_BATCH_AGE_MS,
-            maxEventsPerSessionPerBatch: this.config.SESSION_RECORDING_V2_MAX_EVENTS_PER_SESSION_PER_BATCH,
+            maxBatchSizeBytes: this.hub.SESSION_RECORDING_MAX_BATCH_SIZE_KB * 1024,
+            maxBatchAgeMs: this.hub.SESSION_RECORDING_MAX_BATCH_AGE_MS,
+            maxEventsPerSessionPerBatch: this.hub.SESSION_RECORDING_V2_MAX_EVENTS_PER_SESSION_PER_BATCH,
             offsetManager,
             fileStorage: this.fileStorage,
             metadataStore,
@@ -201,8 +206,14 @@ export class SessionRecordingIngester {
         SessionRecordingIngesterMetrics.observeKafkaBatchSize(batchSize)
         SessionRecordingIngesterMetrics.observeKafkaBatchSizeKb(batchSizeKb)
 
+        // Apply event ingestion restrictions before parsing
+        const messagesToProcess = await instrumentFn(
+            `recordingingesterv2.handleEachBatch.applyRestrictions`,
+            async () => this.restrictionHandler!.applyRestrictions(messages)
+        )
+
         const processedMessages = await instrumentFn(`recordingingesterv2.handleEachBatch.parseBatch`, async () => {
-            const parsedMessages = await this.kafkaParser.parseBatch(messages)
+            const parsedMessages = await this.kafkaParser.parseBatch(messagesToProcess)
             const messagesWithTeam = await this.teamFilter.filterBatch(parsedMessages)
             const processedMessages = this.libVersionMonitor
                 ? await this.libVersionMonitor.processBatch(messagesWithTeam)
@@ -270,6 +281,20 @@ export class SessionRecordingIngester {
             kafkaCapabilities: features,
         })
 
+        // Initialize overflow producer if not consuming from overflow
+        if (!this.consumeOverflow) {
+            this.kafkaOverflowProducer = await KafkaProducerWrapper.create(this.hub, 'CONSUMER')
+        }
+
+        // Initialize restriction handler with the overflow producer
+        this.restrictionHandler = new SessionRecordingRestrictionHandler(
+            this.eventIngestionRestrictionManager,
+            this.overflowTopic,
+            this.kafkaOverflowProducer,
+            this.promiseScheduler,
+            this.consumeOverflow
+        )
+
         // Check that the storage backend is healthy before starting the consumer
         // This is especially important in local dev with minio
         await this.fileStorage.checkHealth()
@@ -314,6 +339,10 @@ export class SessionRecordingIngester {
 
         const assignedPartitions = this.assignedTopicPartitions
         await this.kafkaConsumer.disconnect()
+
+        if (this.kafkaOverflowProducer) {
+            await this.kafkaOverflowProducer.disconnect()
+        }
 
         void this.promiseScheduler.schedule(this.onRevokePartitions(assignedPartitions))
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/metrics.ts
@@ -37,8 +37,26 @@ export class SessionRecordingIngesterMetrics {
         labelNames: ['partition'],
     })
 
+    private static readonly messagesDroppedByRestrictions = new Counter({
+        name: 'recording_blob_ingestion_v2_messages_dropped_by_restrictions',
+        help: 'The number of messages dropped due to event ingestion restrictions',
+    })
+
+    private static readonly messagesOverflowedByRestrictions = new Counter({
+        name: 'recording_blob_ingestion_v2_messages_overflowed_by_restrictions',
+        help: 'The number of messages redirected to overflow due to event ingestion restrictions',
+    })
+
     public static incrementMessageReceived(partition: number): void {
         this.messageReceived.labels(partition.toString()).inc()
+    }
+
+    public static observeDroppedByRestrictions(count: number): void {
+        this.messagesDroppedByRestrictions.inc(count)
+    }
+
+    public static observeOverflowedByRestrictions(count: number): void {
+        this.messagesOverflowedByRestrictions.inc(count)
     }
 
     public static resetSessionsRevoked(): void {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.test.ts
@@ -59,10 +59,10 @@ describe('SessionRecordingRestrictionHandler', () => {
             )
         })
 
-        it('passes through messages without token', async () => {
+        it('passes through messages without token', () => {
             const messages: Message[] = [createMessage()]
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toEqual(messages)
             expect(restrictionManager.shouldDropEvent).not.toHaveBeenCalled()
@@ -71,7 +71,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
         })
 
-        it('passes through messages when no restrictions match', async () => {
+        it('passes through messages when no restrictions match', () => {
             const messages: Message[] = [
                 createMessage({
                     headers: [{ token: 'token-1' }, { distinct_id: 'user-1' }],
@@ -81,7 +81,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(false)
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toEqual(messages)
             expect(restrictionManager.shouldDropEvent).toHaveBeenCalledWith('token-1', 'user-1')
@@ -90,7 +90,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
         })
 
-        it('filters out messages that should be dropped', async () => {
+        it('filters out messages that should be dropped', () => {
             const messages: Message[] = [
                 createMessage({
                     value: Buffer.from('test1'),
@@ -107,7 +107,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockImplementation((token) => token === 'drop-token')
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(false)
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toHaveLength(1)
             expect(result[0]).toBe(messages[1])
@@ -115,7 +115,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
         })
 
-        it('redirects messages to overflow when forced', async () => {
+        it('redirects messages to overflow when forced', () => {
             const messages: Message[] = [
                 createMessage({
                     headers: [{ token: 'overflow-token' }, { distinct_id: 'user-1' }],
@@ -125,7 +125,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toEqual([])
             expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).toHaveBeenCalledWith(1)
@@ -133,7 +133,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             expect(promiseScheduler.schedule).toHaveBeenCalled()
         })
 
-        it('handles mixed messages correctly', async () => {
+        it('handles mixed messages correctly', () => {
             const messages: Message[] = [
                 createMessage({
                     value: Buffer.from('test1'),
@@ -162,7 +162,7 @@ describe('SessionRecordingRestrictionHandler', () => {
                 (token) => token === 'overflow-token'
             )
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toHaveLength(2)
             expect(result[0]).toBe(messages[2])
@@ -182,7 +182,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
 
-            await handler.applyRestrictions(messages)
+            handler.applyRestrictions(messages)
 
             const scheduledPromise = jest.mocked(promiseScheduler.schedule).mock.calls[0][0]
             await scheduledPromise
@@ -199,7 +199,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             })
         })
 
-        it('preserves message order for filtered messages', async () => {
+        it('preserves message order for filtered messages', () => {
             const messages: Message[] = [
                 createMessage({
                     value: Buffer.from('msg1'),
@@ -226,7 +226,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(false)
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toHaveLength(4)
             expect(result[0]).toBe(messages[0])
@@ -260,7 +260,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
 
-            await handler.applyRestrictions(messages)
+            handler.applyRestrictions(messages)
 
             const scheduledPromise = jest.mocked(promiseScheduler.schedule).mock.calls[0][0]
             await scheduledPromise
@@ -276,7 +276,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             expect(produceCalls[2][0].key).toEqual(Buffer.from('key3'))
         })
 
-        it('throws error when overflow producer is undefined and message should overflow', async () => {
+        it('throws error when overflow producer is undefined and message should overflow', () => {
             const handlerWithoutProducer = new SessionRecordingRestrictionHandler(
                 restrictionManager,
                 overflowTopic,
@@ -294,7 +294,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
 
-            await expect(handlerWithoutProducer.applyRestrictions(messages)).rejects.toThrow(
+            expect(() => handlerWithoutProducer.applyRestrictions(messages)).toThrow(
                 'Cannot redirect 1 messages to overflow: no overflow producer available'
             )
         })
@@ -311,7 +311,7 @@ describe('SessionRecordingRestrictionHandler', () => {
             )
         })
 
-        it('does not redirect to overflow even when forced', async () => {
+        it('does not redirect to overflow even when forced', () => {
             const messages: Message[] = [
                 createMessage({
                     headers: [{ token: 'overflow-token' }, { distinct_id: 'user-1' }],
@@ -321,14 +321,14 @@ describe('SessionRecordingRestrictionHandler', () => {
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
             jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toEqual(messages)
             expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
             expect(promiseScheduler.schedule).not.toHaveBeenCalled()
         })
 
-        it('still drops messages that should be dropped', async () => {
+        it('still drops messages that should be dropped', () => {
             const messages: Message[] = [
                 createMessage({
                     headers: [{ token: 'drop-token' }, { distinct_id: 'user-1' }],
@@ -337,7 +337,7 @@ describe('SessionRecordingRestrictionHandler', () => {
 
             jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(true)
 
-            const result = await handler.applyRestrictions(messages)
+            const result = handler.applyRestrictions(messages)
 
             expect(result).toEqual([])
             expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).toHaveBeenCalledWith(1)

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.test.ts
@@ -1,0 +1,346 @@
+import { Message } from 'node-rdkafka'
+
+import { KafkaProducerWrapper } from '../../../kafka/producer'
+import { EventIngestionRestrictionManager } from '../../../utils/event-ingestion-restriction-manager'
+import { PromiseScheduler } from '../../../utils/promise-scheduler'
+import { SessionRecordingIngesterMetrics } from './metrics'
+import { SessionRecordingRestrictionHandler } from './session-recording-restriction-handler'
+
+function createMessage(overrides: Partial<Message> = {}): Message {
+    return {
+        value: Buffer.from('test'),
+        headers: [],
+        partition: 0,
+        offset: 100,
+        key: null,
+        size: 4,
+        topic: 'test-topic',
+        ...overrides,
+    } as Message
+}
+
+describe('SessionRecordingRestrictionHandler', () => {
+    let restrictionManager: EventIngestionRestrictionManager
+    let overflowProducer: KafkaProducerWrapper
+    let promiseScheduler: PromiseScheduler
+    let handler: SessionRecordingRestrictionHandler
+    const overflowTopic = 'test-overflow-topic'
+
+    beforeEach(() => {
+        restrictionManager = {
+            shouldDropEvent: jest.fn(),
+            shouldForceOverflow: jest.fn(),
+        } as unknown as EventIngestionRestrictionManager
+
+        overflowProducer = {
+            produce: jest.fn().mockResolvedValue(undefined),
+        } as unknown as KafkaProducerWrapper
+
+        promiseScheduler = {
+            schedule: jest.fn().mockResolvedValue(undefined),
+        } as unknown as PromiseScheduler
+
+        jest.spyOn(SessionRecordingIngesterMetrics, 'observeDroppedByRestrictions')
+        jest.spyOn(SessionRecordingIngesterMetrics, 'observeOverflowedByRestrictions')
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    describe('when not consuming from overflow', () => {
+        beforeEach(() => {
+            handler = new SessionRecordingRestrictionHandler(
+                restrictionManager,
+                overflowTopic,
+                overflowProducer,
+                promiseScheduler,
+                false
+            )
+        })
+
+        it('passes through messages without token', async () => {
+            const messages: Message[] = [createMessage()]
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toEqual(messages)
+            expect(restrictionManager.shouldDropEvent).not.toHaveBeenCalled()
+            expect(restrictionManager.shouldForceOverflow).not.toHaveBeenCalled()
+            expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).not.toHaveBeenCalled()
+            expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
+        })
+
+        it('passes through messages when no restrictions match', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    headers: [{ token: 'token-1' }, { distinct_id: 'user-1' }],
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(false)
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toEqual(messages)
+            expect(restrictionManager.shouldDropEvent).toHaveBeenCalledWith('token-1', 'user-1')
+            expect(restrictionManager.shouldForceOverflow).toHaveBeenCalledWith('token-1', 'user-1')
+            expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).not.toHaveBeenCalled()
+            expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
+        })
+
+        it('filters out messages that should be dropped', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    value: Buffer.from('test1'),
+                    headers: [{ token: 'drop-token' }, { distinct_id: 'user-1' }],
+                    offset: 100,
+                }),
+                createMessage({
+                    value: Buffer.from('test2'),
+                    headers: [{ token: 'keep-token' }, { distinct_id: 'user-2' }],
+                    offset: 101,
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockImplementation((token) => token === 'drop-token')
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(false)
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toHaveLength(1)
+            expect(result[0]).toBe(messages[1])
+            expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).toHaveBeenCalledWith(1)
+            expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
+        })
+
+        it('redirects messages to overflow when forced', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    headers: [{ token: 'overflow-token' }, { distinct_id: 'user-1' }],
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toEqual([])
+            expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).toHaveBeenCalledWith(1)
+            expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).not.toHaveBeenCalled()
+            expect(promiseScheduler.schedule).toHaveBeenCalled()
+        })
+
+        it('handles mixed messages correctly', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    value: Buffer.from('test1'),
+                    headers: [{ token: 'drop-token' }, { distinct_id: 'user-1' }],
+                    offset: 100,
+                }),
+                createMessage({
+                    value: Buffer.from('test2'),
+                    headers: [{ token: 'overflow-token' }, { distinct_id: 'user-2' }],
+                    offset: 101,
+                }),
+                createMessage({
+                    value: Buffer.from('test3'),
+                    headers: [{ token: 'keep-token' }, { distinct_id: 'user-3' }],
+                    offset: 102,
+                }),
+                createMessage({
+                    value: Buffer.from('test4'),
+                    headers: [],
+                    offset: 103,
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockImplementation((token) => token === 'drop-token')
+            jest.mocked(restrictionManager.shouldForceOverflow).mockImplementation(
+                (token) => token === 'overflow-token'
+            )
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toHaveLength(2)
+            expect(result[0]).toBe(messages[2])
+            expect(result[1]).toBe(messages[3])
+            expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).toHaveBeenCalledWith(1)
+            expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).toHaveBeenCalledWith(1)
+        })
+
+        it('produces overflow messages with correct topic and headers', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    headers: [{ token: 'overflow-token' }, { distinct_id: 'user-1' }, { timestamp: '2024-01-01' }],
+                    key: Buffer.from('key'),
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
+
+            await handler.applyRestrictions(messages)
+
+            const scheduledPromise = jest.mocked(promiseScheduler.schedule).mock.calls[0][0]
+            await scheduledPromise
+
+            expect(overflowProducer.produce).toHaveBeenCalledWith({
+                topic: overflowTopic,
+                value: messages[0].value,
+                key: messages[0].key,
+                headers: {
+                    token: 'overflow-token',
+                    distinct_id: 'user-1',
+                    timestamp: '2024-01-01',
+                },
+            })
+        })
+
+        it('preserves message order for filtered messages', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    value: Buffer.from('msg1'),
+                    headers: [{ token: 'token-1' }, { distinct_id: 'user-1' }],
+                    offset: 100,
+                }),
+                createMessage({
+                    value: Buffer.from('msg2'),
+                    headers: [{ token: 'token-2' }, { distinct_id: 'user-2' }],
+                    offset: 101,
+                }),
+                createMessage({
+                    value: Buffer.from('msg3'),
+                    headers: [{ token: 'token-3' }, { distinct_id: 'user-3' }],
+                    offset: 102,
+                }),
+                createMessage({
+                    value: Buffer.from('msg4'),
+                    headers: [{ token: 'token-4' }, { distinct_id: 'user-4' }],
+                    offset: 103,
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(false)
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toHaveLength(4)
+            expect(result[0]).toBe(messages[0])
+            expect(result[1]).toBe(messages[1])
+            expect(result[2]).toBe(messages[2])
+            expect(result[3]).toBe(messages[3])
+        })
+
+        it('preserves message order when producing to overflow', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    value: Buffer.from('overflow1'),
+                    headers: [{ token: 'overflow-1' }, { distinct_id: 'user-1' }],
+                    offset: 100,
+                    key: Buffer.from('key1'),
+                }),
+                createMessage({
+                    value: Buffer.from('overflow2'),
+                    headers: [{ token: 'overflow-2' }, { distinct_id: 'user-2' }],
+                    offset: 101,
+                    key: Buffer.from('key2'),
+                }),
+                createMessage({
+                    value: Buffer.from('overflow3'),
+                    headers: [{ token: 'overflow-3' }, { distinct_id: 'user-3' }],
+                    offset: 102,
+                    key: Buffer.from('key3'),
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
+
+            await handler.applyRestrictions(messages)
+
+            const scheduledPromise = jest.mocked(promiseScheduler.schedule).mock.calls[0][0]
+            await scheduledPromise
+
+            expect(overflowProducer.produce).toHaveBeenCalledTimes(3)
+
+            const produceCalls = jest.mocked(overflowProducer.produce).mock.calls
+            expect(produceCalls[0][0].value).toEqual(Buffer.from('overflow1'))
+            expect(produceCalls[0][0].key).toEqual(Buffer.from('key1'))
+            expect(produceCalls[1][0].value).toEqual(Buffer.from('overflow2'))
+            expect(produceCalls[1][0].key).toEqual(Buffer.from('key2'))
+            expect(produceCalls[2][0].value).toEqual(Buffer.from('overflow3'))
+            expect(produceCalls[2][0].key).toEqual(Buffer.from('key3'))
+        })
+
+        it('throws error when overflow producer is undefined and message should overflow', async () => {
+            const handlerWithoutProducer = new SessionRecordingRestrictionHandler(
+                restrictionManager,
+                overflowTopic,
+                undefined,
+                promiseScheduler,
+                false
+            )
+
+            const messages: Message[] = [
+                createMessage({
+                    headers: [{ token: 'overflow-token' }, { distinct_id: 'user-1' }],
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
+
+            await expect(handlerWithoutProducer.applyRestrictions(messages)).rejects.toThrow(
+                'Cannot redirect 1 messages to overflow: no overflow producer available'
+            )
+        })
+    })
+
+    describe('when consuming from overflow', () => {
+        beforeEach(() => {
+            handler = new SessionRecordingRestrictionHandler(
+                restrictionManager,
+                overflowTopic,
+                overflowProducer,
+                promiseScheduler,
+                true
+            )
+        })
+
+        it('does not redirect to overflow even when forced', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    headers: [{ token: 'overflow-token' }, { distinct_id: 'user-1' }],
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(false)
+            jest.mocked(restrictionManager.shouldForceOverflow).mockReturnValue(true)
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toEqual(messages)
+            expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
+            expect(promiseScheduler.schedule).not.toHaveBeenCalled()
+        })
+
+        it('still drops messages that should be dropped', async () => {
+            const messages: Message[] = [
+                createMessage({
+                    headers: [{ token: 'drop-token' }, { distinct_id: 'user-1' }],
+                }),
+            ]
+
+            jest.mocked(restrictionManager.shouldDropEvent).mockReturnValue(true)
+
+            const result = await handler.applyRestrictions(messages)
+
+            expect(result).toEqual([])
+            expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).toHaveBeenCalledWith(1)
+        })
+    })
+})

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.ts
@@ -1,0 +1,99 @@
+import { Message } from 'node-rdkafka'
+
+import { parseEventHeaders, parseKafkaHeaders } from '../../../kafka/consumer'
+import { KafkaProducerWrapper } from '../../../kafka/producer'
+import { EventIngestionRestrictionManager } from '../../../utils/event-ingestion-restriction-manager'
+import { logger } from '../../../utils/logger'
+import { PromiseScheduler } from '../../../utils/promise-scheduler'
+import { SessionRecordingIngesterMetrics } from './metrics'
+
+export class SessionRecordingRestrictionHandler {
+    constructor(
+        private restrictionManager: EventIngestionRestrictionManager,
+        private overflowTopic: string,
+        private overflowProducer: KafkaProducerWrapper | undefined,
+        private promiseScheduler: PromiseScheduler,
+        private consumeOverflow: boolean
+    ) {}
+
+    /**
+     * Apply event ingestion restrictions to session recording messages.
+     * Filters out dropped messages and redirects overflow messages.
+     * Returns only messages that should be processed normally.
+     */
+    async applyRestrictions(messages: Message[]): Promise<Message[]> {
+        const filteredMessages: Message[] = []
+        const overflowMessages: Message[] = []
+        let droppedCount = 0
+
+        for (const message of messages) {
+            const headers = parseEventHeaders(message.headers)
+            const { token, distinct_id } = headers
+
+            if (!token) {
+                // If there's no token, we can't check restrictions, so keep the message
+                filteredMessages.push(message)
+                continue
+            }
+
+            // Check if this message should be dropped
+            if (this.restrictionManager.shouldDropEvent(token, distinct_id)) {
+                logger.info('🚫', 'session_recording_dropped_by_restriction', {
+                    token,
+                    distinct_id,
+                    partition: message.partition,
+                    offset: message.offset,
+                })
+                droppedCount++
+                continue
+            }
+
+            // Check if this message should be forced to overflow
+            if (!this.consumeOverflow && this.restrictionManager.shouldForceOverflow(token, distinct_id)) {
+                overflowMessages.push(message)
+                continue
+            }
+
+            filteredMessages.push(message)
+        }
+
+        // Redirect overflow messages if any
+        if (overflowMessages.length > 0) {
+            if (!this.overflowProducer) {
+                throw new Error(
+                    `Cannot redirect ${overflowMessages.length} messages to overflow: no overflow producer available`
+                )
+            }
+            SessionRecordingIngesterMetrics.observeOverflowedByRestrictions(overflowMessages.length)
+            void this.promiseScheduler.schedule(this.emitToOverflow(overflowMessages))
+        }
+
+        if (droppedCount > 0) {
+            SessionRecordingIngesterMetrics.observeDroppedByRestrictions(droppedCount)
+        }
+
+        return filteredMessages
+    }
+
+    private async emitToOverflow(kafkaMessages: Message[]): Promise<void> {
+        if (!this.overflowProducer) {
+            logger.warn('🪣', 'No overflow producer available, cannot redirect messages')
+            return
+        }
+
+        await Promise.all(
+            kafkaMessages.map((message) => {
+                logger.info('🪣', 'session_recording_redirected_to_overflow', {
+                    partition: message.partition,
+                    offset: message.offset,
+                })
+                return this.overflowProducer!.produce({
+                    topic: this.overflowTopic,
+                    value: message.value,
+                    key: message.key ?? null,
+                    headers: parseKafkaHeaders(message.headers),
+                })
+            })
+        )
+    }
+}

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.ts
@@ -21,7 +21,7 @@ export class SessionRecordingRestrictionHandler {
      * Filters out dropped messages and redirects overflow messages.
      * Returns only messages that should be processed normally.
      */
-    async applyRestrictions(messages: Message[]): Promise<Message[]> {
+    applyRestrictions(messages: Message[]): Message[] {
         const filteredMessages: Message[] = []
         const overflowMessages: Message[] = []
         let droppedCount = 0

--- a/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
+++ b/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
@@ -166,9 +166,9 @@ describe('EventIngestionRestrictionManager', () => {
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1', analytics: true, session_recordings: false },
-                        { token: 'token2', distinct_id: 'user1', analytics: true, session_recordings: true },
-                        { token: 'token3', analytics: false, session_recordings: true },
+                        { token: 'token1', pipelines: ['analytics'] },
+                        { token: 'token2', distinct_id: 'user1', pipelines: ['analytics', 'session_recordings'] },
+                        { token: 'token3', pipelines: ['session_recordings'] },
                     ]),
                 ],
                 [null, null],
@@ -177,7 +177,7 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should only include token1 and token2 (analytics=true), not token3 (analytics=false)
+            // Should only include token1 and token2 (pipelines includes 'analytics'), not token3
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set(['token1', 'token2:user1']),
             })
@@ -186,27 +186,27 @@ describe('EventIngestionRestrictionManager', () => {
         it('handles new format with only session_recordings enabled (analytics pipeline)', async () => {
             pipelineMock.get.mockClear()
             pipelineMock.exec.mockResolvedValue([
-                [null, JSON.stringify([{ token: 'token1', analytics: false, session_recordings: true }])],
+                [null, JSON.stringify([{ token: 'token1', pipelines: ['session_recordings'] }])],
                 [null, null],
                 [null, null],
             ])
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should be empty because analytics=false for analytics pipeline
+            // Should be empty because pipelines doesn't include 'analytics'
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set([]),
             })
         })
 
-        it('excludes entries with both pipelines disabled', async () => {
+        it('excludes entries with empty pipelines array', async () => {
             pipelineMock.get.mockClear()
             pipelineMock.exec.mockResolvedValue([
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1', analytics: false, session_recordings: false },
-                        { token: 'token2', analytics: true, session_recordings: false },
+                        { token: 'token1', pipelines: [] },
+                        { token: 'token2', pipelines: ['analytics'] },
                     ]),
                 ],
                 [null, null],
@@ -228,8 +228,8 @@ describe('EventIngestionRestrictionManager', () => {
                     JSON.stringify([
                         'old-token1',
                         'old-token2:distinct1',
-                        { token: 'new-token1', analytics: true, session_recordings: false },
-                        { token: 'new-token2', distinct_id: 'user1', analytics: false, session_recordings: true },
+                        { token: 'new-token1', pipelines: ['analytics'] },
+                        { token: 'new-token2', distinct_id: 'user1', pipelines: ['session_recordings'] },
                     ]),
                 ],
                 [null, null],
@@ -238,8 +238,8 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should include old-token1, old-token2:distinct1 (old format defaults to analytics=true)
-            // and new-token1 (analytics=true), but NOT new-token2 (analytics=false)
+            // Should include old-token1, old-token2:distinct1 (old format defaults to analytics)
+            // and new-token1 (pipelines includes 'analytics'), but NOT new-token2
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set([
                     'old-token1',
@@ -255,8 +255,8 @@ describe('EventIngestionRestrictionManager', () => {
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1' }, // Missing both fields - will be excluded
-                        { token: 'token2', analytics: true }, // Has analytics field
+                        { token: 'token1' }, // Missing pipelines field - will be excluded
+                        { token: 'token2', pipelines: ['analytics'] }, // Has pipelines field
                     ]),
                 ],
                 [null, null],
@@ -265,7 +265,7 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await eventIngestionRestrictionManager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should only include token2 (has analytics=true), token1 is excluded (missing field)
+            // Should only include token2 (pipelines includes 'analytics'), token1 is excluded (missing field)
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set(['token2']),
             })
@@ -277,9 +277,9 @@ describe('EventIngestionRestrictionManager', () => {
                 [
                     null,
                     JSON.stringify([
-                        { token: 'token1', analytics: true, session_recordings: false },
-                        { token: 'token2', analytics: false, session_recordings: true },
-                        { token: 'token3', analytics: true, session_recordings: true },
+                        { token: 'token1', pipelines: ['analytics'] },
+                        { token: 'token2', pipelines: ['session_recordings'] },
+                        { token: 'token3', pipelines: ['analytics', 'session_recordings'] },
                     ]),
                 ],
                 [null, null],
@@ -292,7 +292,7 @@ describe('EventIngestionRestrictionManager', () => {
 
             const result = await manager.fetchDynamicEventIngestionRestrictionConfig()
 
-            // Should only include token2 and token3 (session_recordings=true)
+            // Should only include token2 and token3 (pipelines includes 'session_recordings')
             expect(result).toEqual({
                 [RestrictionType.DROP_EVENT_FROM_INGESTION]: new Set(['token2', 'token3']),
             })
@@ -305,7 +305,7 @@ describe('EventIngestionRestrictionManager', () => {
                     null,
                     JSON.stringify([
                         'old-token1', // Old format, should be excluded from session_recordings
-                        { token: 'new-token1', analytics: false, session_recordings: true },
+                        { token: 'new-token1', pipelines: ['session_recordings'] },
                     ]),
                 ],
                 [null, null],

--- a/plugin-server/src/utils/event-ingestion-restriction-manager.ts
+++ b/plugin-server/src/utils/event-ingestion-restriction-manager.ts
@@ -99,17 +99,19 @@ export class EventIngestionRestrictionManager {
                         if (Array.isArray(parsedArray)) {
                             // Convert array items to strings
                             // Old format: ["token1", "token2:distinct_id"]
-                            // New format: [{"token": "token1", "analytics": true, "session_recordings": false}, ...]
+                            // New format: [{"token": "token1", "pipelines": ["analytics", "session_recordings"]}, ...]
                             const items = parsedArray.flatMap((item) => {
                                 if (typeof item === 'string') {
-                                    // Old format - assume analytics=true, everything else=false
+                                    // Old format - assume applies to analytics only for backwards compatibility
                                     if (this.pipeline === 'analytics') {
                                         return [item]
                                     }
                                     return []
                                 } else if (typeof item === 'object' && item !== null && 'token' in item) {
-                                    // New format - check if the pipeline field is set to true
-                                    const appliesToPipeline = Boolean(item[this.pipeline])
+                                    // New format - check if this pipeline is in the pipelines array
+                                    const pipelines: unknown = item.pipelines
+                                    const appliesToPipeline =
+                                        Array.isArray(pipelines) && pipelines.includes(this.pipeline)
 
                                     if (appliesToPipeline) {
                                         if ('distinct_id' in item && item.distinct_id) {


### PR DESCRIPTION
## Problem

We want to shuffle some heavy sessions to overflow using the event restrictions.

## Changes

Adds support for drop and overflow event restrictions in blobby.

Needs to be deployed after:
- https://github.com/PostHog/posthog/pull/40429
- https://github.com/PostHog/posthog/pull/40430

## How did you test this code?

Added tests. 