### PR TITLE
chore(flags): Add automatic cache warming on cache miss for /flags/definitions

### DIFF
--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -45,9 +45,9 @@ QUEUE_DEPTH_WARNING_THRESHOLD = get_from_env("FLAG_CACHE_MISS_QUEUE_DEPTH_WARNIN
 
 
 # Note: This task polls a Redis list (not a Celery queue), so the queue parameter
-# only affects where this lightweight polling task runs. DEFAULT queue is appropriate
-# for this minimal work (RPOP + rate limit check). The actual cache rebuilds are
-# dispatched as separate tasks with appropriate queue assignments.
+# only affects where this lightweight polling task runs. The polling work itself
+# (RPOP + rate limit check) is minimal. Cache rebuilds are dispatched to separate
+# update_team_flags_cache tasks which also run on DEFAULT queue.
 @shared_task(ignore_result=True, max_retries=0, queue=CeleryQueue.DEFAULT.value)
 def process_flag_cache_miss_queue() -> None:
     """

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -1,8 +1,13 @@
+import json
+
 import structlog
 from celery import shared_task
+from statshog.defaults.django import statsd
 
 from posthog.models.feature_flag.local_evaluation import update_flag_caches
 from posthog.models.team import Team
+from posthog.redis import get_client
+from posthog.settings.utils import get_from_env
 from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
@@ -26,3 +31,100 @@ def sync_all_flags_cache() -> None:
     # Only select the id from the team queryset
     for team_id in Team.objects.values_list("id", flat=True):
         update_team_flags_cache.delay(team_id)
+
+
+# Cache miss notification queue constants
+CACHE_MISS_QUEUE_KEY = "posthog:flag_cache_miss_queue"
+RATE_LIMIT_KEY_TEMPLATE = "posthog:flag_cache_rebuild_rate_limit:{team_id}"
+
+# Configurable operational parameters
+RATE_LIMIT_WINDOW = get_from_env("FLAG_CACHE_MISS_RATE_LIMIT_WINDOW", 60, type_cast=int)
+MAX_REBUILDS_PER_WINDOW = get_from_env("FLAG_CACHE_MISS_MAX_REBUILDS", 2, type_cast=int)
+BATCH_SIZE = get_from_env("FLAG_CACHE_MISS_BATCH_SIZE", 10, type_cast=int)
+QUEUE_DEPTH_WARNING_THRESHOLD = get_from_env("FLAG_CACHE_MISS_QUEUE_DEPTH_WARNING", 1000, type_cast=int)
+
+
+@shared_task(ignore_result=True, max_retries=0, queue=CeleryQueue.DEFAULT.value)
+def process_flag_cache_miss_queue() -> None:
+    """
+    Processes flag cache miss notifications from the Redis queue.
+
+    This task is run periodically (every 1 second) by Celery Beat.
+    It polls the Redis list for cache miss notifications from the Rust service,
+    applies rate limiting, and dispatches cache rebuild tasks.
+
+    Environment variables:
+    - FLAG_CACHE_MISS_RATE_LIMIT_WINDOW: Rate limit window in seconds (default: 60)
+    - FLAG_CACHE_MISS_MAX_REBUILDS: Max rebuilds per window per team (default: 2)
+    - FLAG_CACHE_MISS_BATCH_SIZE: Max messages to process per run (default: 10)
+    - FLAG_CACHE_MISS_QUEUE_DEPTH_WARNING: Queue depth warning threshold (default: 1000)
+    """
+    redis = get_client()
+
+    # Monitor queue depth to detect potential issues
+    queue_depth = redis.llen(CACHE_MISS_QUEUE_KEY)
+    statsd.gauge("flag_cache_miss_queue_depth", queue_depth)
+
+    if queue_depth > QUEUE_DEPTH_WARNING_THRESHOLD:
+        logger.warning(
+            "Cache miss queue depth is high",
+            queue_depth=queue_depth,
+            threshold=QUEUE_DEPTH_WARNING_THRESHOLD,
+        )
+
+    processed = 0
+    rate_limited = 0
+    dispatched = 0
+    errors = 0
+
+    for _ in range(BATCH_SIZE):
+        message = redis.rpop(CACHE_MISS_QUEUE_KEY)
+        if not message:
+            break
+
+        try:
+            data = json.loads(message)
+            team_id = data["team_id"]
+
+            # Rate limiting - don't rebuild too frequently for same team
+            rate_limit_key = RATE_LIMIT_KEY_TEMPLATE.format(team_id=team_id)
+
+            # Increment counter and check if we're under the rate limit
+            current_count = redis.incr(rate_limit_key)
+
+            # Set expiry on first increment
+            if current_count == 1:
+                redis.expire(rate_limit_key, RATE_LIMIT_WINDOW)
+
+            if current_count <= MAX_REBUILDS_PER_WINDOW:
+                logger.info(
+                    "Triggering cache rebuild from cache miss",
+                    team_id=team_id,
+                    timestamp=data.get("timestamp"),
+                )
+                update_team_flags_cache.delay(team_id)
+                dispatched += 1
+            else:
+                logger.info(
+                    "Rate limit exceeded, skipping cache rebuild",
+                    team_id=team_id,
+                    rate_limit=f"{current_count}/{MAX_REBUILDS_PER_WINDOW}",
+                )
+                rate_limited += 1
+
+            processed += 1
+
+        except Exception as e:
+            logger.exception("Error processing cache miss notification", error=str(e), message=message)
+            errors += 1
+
+    # Record metrics
+    if processed > 0:
+        logger.info("Processed cache miss notifications", count=processed)
+        statsd.incr("flag_cache_miss_queue_processed", processed)
+    if dispatched > 0:
+        statsd.incr("flag_cache_miss_queue_dispatched", dispatched)
+    if rate_limited > 0:
+        statsd.incr("flag_cache_miss_queue_rate_limited", rate_limited)
+    if errors > 0:
+        statsd.incr("flag_cache_miss_queue_errors", errors)

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -44,6 +44,10 @@ BATCH_SIZE = get_from_env("FLAG_CACHE_MISS_BATCH_SIZE", 10, type_cast=int)
 QUEUE_DEPTH_WARNING_THRESHOLD = get_from_env("FLAG_CACHE_MISS_QUEUE_DEPTH_WARNING", 1000, type_cast=int)
 
 
+# Note: This task polls a Redis list (not a Celery queue), so the queue parameter
+# only affects where this lightweight polling task runs. DEFAULT queue is appropriate
+# for this minimal work (RPOP + rate limit check). The actual cache rebuilds are
+# dispatched as separate tasks with appropriate queue assignments.
 @shared_task(ignore_result=True, max_retries=0, queue=CeleryQueue.DEFAULT.value)
 def process_flag_cache_miss_queue() -> None:
     """

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -15,6 +15,7 @@ from posthog.tasks.alerts.checks import (
     reset_stuck_alerts_task,
 )
 from posthog.tasks.email import send_hog_functions_daily_digest
+from posthog.tasks.feature_flags import process_flag_cache_miss_queue
 from posthog.tasks.integrations import refresh_integrations
 from posthog.tasks.periodic_digest.periodic_digest import send_all_periodic_digest_reports
 from posthog.tasks.remote_config import sync_all_remote_configs
@@ -96,6 +97,9 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     # Heartbeat every 10sec to make sure the worker is alive
     add_periodic_task_with_expiry(sender, 10, redis_heartbeat.s(), "10 sec heartbeat")
+
+    # Process flag cache miss queue every 1 second
+    add_periodic_task_with_expiry(sender, 1, process_flag_cache_miss_queue.s(), "process flag cache miss queue")
 
     add_periodic_task_with_expiry(sender, 20, start_poll_query_performance.s(), "20 sec query performance heartbeat")
 

--- a/posthog/tasks/test/test_feature_flags.py
+++ b/posthog/tasks/test/test_feature_flags.py
@@ -1,0 +1,218 @@
+import json
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from posthog.tasks.feature_flags import (
+    BATCH_SIZE,
+    CACHE_MISS_QUEUE_KEY,
+    MAX_REBUILDS_PER_WINDOW,
+    RATE_LIMIT_KEY_TEMPLATE,
+    RATE_LIMIT_WINDOW,
+    process_flag_cache_miss_queue,
+)
+
+
+class TestFlagCacheMissQueue(TestCase):
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_processes_message_from_queue(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        notification = {"team_id": 123, "timestamp": 1234567890}
+        mock_redis.llen.return_value = 0  # Queue is empty
+        mock_redis.rpop.side_effect = [json.dumps(notification), None]
+        mock_redis.incr.return_value = 1
+
+        process_flag_cache_miss_queue()
+
+        self.assertEqual(mock_redis.rpop.call_count, 2)
+        mock_redis.incr.assert_called_once_with(RATE_LIMIT_KEY_TEMPLATE.format(team_id=123))
+        mock_redis.expire.assert_called_once_with(RATE_LIMIT_KEY_TEMPLATE.format(team_id=123), RATE_LIMIT_WINDOW)
+        mock_update_task.assert_called_once_with(123)
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_stops_processing_when_queue_is_empty(
+        self, mock_update_task: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+        mock_redis.llen.return_value = 0
+        mock_redis.rpop.return_value = None
+
+        process_flag_cache_miss_queue()
+
+        mock_redis.rpop.assert_called_once_with(CACHE_MISS_QUEUE_KEY)
+        mock_update_task.assert_not_called()
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_respects_batch_size_limit(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        mock_redis.llen.return_value = BATCH_SIZE + 5
+        # Return BATCH_SIZE + 5 messages to ensure we only process BATCH_SIZE
+        messages = [json.dumps({"team_id": i, "timestamp": 1234567890}) for i in range(BATCH_SIZE + 5)]
+        mock_redis.rpop.side_effect = messages
+        mock_redis.incr.return_value = 1
+
+        process_flag_cache_miss_queue()
+
+        # Should only call rpop BATCH_SIZE times (not BATCH_SIZE + 5)
+        self.assertEqual(mock_redis.rpop.call_count, BATCH_SIZE)
+        self.assertEqual(mock_update_task.call_count, BATCH_SIZE)
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_applies_rate_limiting(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        notification = {"team_id": 456, "timestamp": 1234567890}
+        mock_redis.llen.return_value = 1
+        mock_redis.rpop.side_effect = [json.dumps(notification), None]
+        # Simulate that this is the 3rd rebuild (exceeds limit of 2)
+        mock_redis.incr.return_value = MAX_REBUILDS_PER_WINDOW + 1
+
+        process_flag_cache_miss_queue()
+
+        self.assertEqual(mock_redis.rpop.call_count, 2)
+        mock_redis.incr.assert_called_once_with(RATE_LIMIT_KEY_TEMPLATE.format(team_id=456))
+        # Should NOT dispatch the task because rate limit was exceeded
+        mock_update_task.assert_not_called()
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_sets_expiry_on_first_increment(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        notification = {"team_id": 789, "timestamp": 1234567890}
+        mock_redis.llen.return_value = 1
+        mock_redis.rpop.side_effect = [json.dumps(notification), None]
+        # First increment - should set expiry
+        mock_redis.incr.return_value = 1
+
+        process_flag_cache_miss_queue()
+
+        mock_redis.expire.assert_called_once_with(RATE_LIMIT_KEY_TEMPLATE.format(team_id=789), RATE_LIMIT_WINDOW)
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_does_not_set_expiry_on_subsequent_increments(
+        self, mock_update_task: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        notification = {"team_id": 999, "timestamp": 1234567890}
+        mock_redis.llen.return_value = 1
+        mock_redis.rpop.return_value = json.dumps(notification)
+        # Second increment - should NOT set expiry
+        mock_redis.incr.return_value = 2
+
+        process_flag_cache_miss_queue()
+
+        mock_redis.expire.assert_not_called()
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_handles_malformed_json_gracefully(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # First message is malformed, second is valid
+        valid_notification = {"team_id": 111, "timestamp": 1234567890}
+        mock_redis.llen.return_value = 2
+        mock_redis.rpop.side_effect = ["not valid json", json.dumps(valid_notification), None]
+        mock_redis.incr.return_value = 1
+
+        # Should not raise an exception
+        process_flag_cache_miss_queue()
+
+        # Should still process the valid message
+        mock_update_task.assert_called_once_with(111)
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_handles_missing_team_id_field(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # Message missing team_id field
+        invalid_notification = {"timestamp": 1234567890}
+        valid_notification = {"team_id": 222, "timestamp": 1234567890}
+        mock_redis.llen.return_value = 2
+        mock_redis.rpop.side_effect = [json.dumps(invalid_notification), json.dumps(valid_notification), None]
+        mock_redis.incr.return_value = 1
+
+        # Should not raise an exception
+        process_flag_cache_miss_queue()
+
+        # Should still process the valid message
+        mock_update_task.assert_called_once_with(222)
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_processes_multiple_teams(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        notifications = [
+            json.dumps({"team_id": 100, "timestamp": 1234567890}),
+            json.dumps({"team_id": 200, "timestamp": 1234567891}),
+            json.dumps({"team_id": 300, "timestamp": 1234567892}),
+            None,
+        ]
+        mock_redis.llen.return_value = 3
+        mock_redis.rpop.side_effect = notifications
+        mock_redis.incr.return_value = 1
+
+        process_flag_cache_miss_queue()
+
+        # Should process all three teams
+        self.assertEqual(mock_update_task.call_count, 3)
+        mock_update_task.assert_any_call(100)
+        mock_update_task.assert_any_call(200)
+        mock_update_task.assert_any_call(300)
+
+    @patch("posthog.tasks.feature_flags.get_client")
+    @patch("posthog.tasks.feature_flags.update_team_flags_cache.delay")
+    def test_rate_limits_per_team(self, mock_update_task: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # Team 100 has 3 messages (should process first 2, skip 3rd)
+        # Team 200 has 1 message (should process it)
+        notifications = [
+            json.dumps({"team_id": 100, "timestamp": 1234567890}),
+            json.dumps({"team_id": 100, "timestamp": 1234567891}),
+            json.dumps({"team_id": 100, "timestamp": 1234567892}),
+            json.dumps({"team_id": 200, "timestamp": 1234567893}),
+            None,
+        ]
+        mock_redis.llen.return_value = 4
+        mock_redis.rpop.side_effect = notifications
+
+        # Mock incr to return increasing counts for team 100, but 1 for team 200
+        team_100_count = 0
+
+        def incr_with_state(key: str) -> int:
+            nonlocal team_100_count
+            if "100" in key:
+                team_100_count += 1
+                return team_100_count
+            else:
+                return 1
+
+        mock_redis.incr.side_effect = incr_with_state
+
+        process_flag_cache_miss_queue()
+
+        # Should dispatch task for team 100 twice (first two messages)
+        # and once for team 200
+        self.assertEqual(mock_update_task.call_count, 3)

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -101,7 +101,9 @@ pub async fn flags_definitions(
             Ok((
                 StatusCode::SERVICE_UNAVAILABLE,
                 [(RETRY_AFTER, retry_after.to_string())],
-                "Flag definitions cache is warming. Please retry after the specified duration.",
+                format!(
+                    "Flag definitions cache is warming. Please retry after {retry_after} seconds."
+                ),
             )
                 .into_response())
         }

--- a/rust/feature-flags/src/cache/mod.rs
+++ b/rust/feature-flags/src/cache/mod.rs
@@ -1,0 +1,1 @@
+pub mod notification;

--- a/rust/feature-flags/src/cache/notification.rs
+++ b/rust/feature-flags/src/cache/notification.rs
@@ -1,0 +1,167 @@
+use common_metrics::inc;
+use common_redis::Client as RedisClient;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::{info, warn};
+
+use crate::metrics::consts::{
+    FLAG_CACHE_MISS_NOTIFICATION_DROPPED_COUNTER, FLAG_CACHE_MISS_NOTIFICATION_ERROR_COUNTER,
+    FLAG_CACHE_MISS_NOTIFICATION_SENT_COUNTER,
+};
+
+pub const CACHE_MISS_QUEUE_KEY: &str = "posthog:flag_cache_miss_queue";
+
+// Maximum queue depth before dropping notifications
+static MAX_QUEUE_DEPTH: Lazy<u64> = Lazy::new(|| {
+    std::env::var("FLAG_CACHE_MISS_MAX_QUEUE_DEPTH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10000)
+});
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CacheMissNotification {
+    pub team_id: i32,
+    pub timestamp: i64,
+}
+
+/// Notifies the Django/Celery system about a cache miss by pushing a message to a Redis list.
+///
+/// This is a fire-and-forget operation that does not block the request. If the notification
+/// fails, it logs a warning but does not return an error to avoid failing the entire request.
+///
+/// # Arguments
+///
+/// * `redis` - Redis client (should be redis_writer for write operations)
+/// * `team_id` - The team ID that experienced the cache miss
+///
+/// # Returns
+///
+/// Returns `Ok(())` on success or if notification fails (fire-and-forget pattern)
+pub async fn notify_cache_miss(
+    redis: Arc<dyn RedisClient + Send + Sync>,
+    team_id: i32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Check queue depth to prevent unbounded growth
+    let queue_size = redis
+        .llen(CACHE_MISS_QUEUE_KEY.to_string())
+        .await
+        .unwrap_or(0);
+
+    if queue_size >= *MAX_QUEUE_DEPTH {
+        warn!(
+            team_id = team_id,
+            queue_size = queue_size,
+            max_depth = *MAX_QUEUE_DEPTH,
+            "Cache miss queue overflow, dropping notification"
+        );
+        inc(FLAG_CACHE_MISS_NOTIFICATION_DROPPED_COUNTER, &[], 1);
+        return Ok(());
+    }
+
+    let notification = CacheMissNotification {
+        team_id,
+        timestamp: chrono::Utc::now().timestamp(),
+    };
+
+    let message = serde_json::to_string(&notification)?;
+
+    match redis.lpush(CACHE_MISS_QUEUE_KEY.to_string(), message).await {
+        Ok(_) => {
+            info!(team_id = team_id, "Queued cache rebuild notification");
+            inc(FLAG_CACHE_MISS_NOTIFICATION_SENT_COUNTER, &[], 1);
+            Ok(())
+        }
+        Err(e) => {
+            warn!(
+                team_id = team_id,
+                error = %e,
+                "Failed to queue cache rebuild notification"
+            );
+            inc(FLAG_CACHE_MISS_NOTIFICATION_ERROR_COUNTER, &[], 1);
+            // Don't fail the request if notification fails
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common_redis::MockRedisClient;
+
+    #[tokio::test]
+    async fn test_notify_cache_miss_sends_to_redis() {
+        let mut mock_redis = MockRedisClient::new();
+        mock_redis.llen_ret(CACHE_MISS_QUEUE_KEY, Ok(0)); // Queue is empty
+        mock_redis.lpush_ret(CACHE_MISS_QUEUE_KEY, Ok(()));
+        let redis = Arc::new(mock_redis.clone());
+
+        let result = notify_cache_miss(redis.clone(), 123).await;
+
+        assert!(result.is_ok());
+
+        let calls = mock_redis.get_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].op, "llen");
+        assert_eq!(calls[0].key, CACHE_MISS_QUEUE_KEY);
+        assert_eq!(calls[1].op, "lpush");
+        assert_eq!(calls[1].key, CACHE_MISS_QUEUE_KEY);
+    }
+
+    #[tokio::test]
+    async fn test_notify_cache_miss_serializes_notification() {
+        let mut mock_redis = MockRedisClient::new();
+        mock_redis.llen_ret(CACHE_MISS_QUEUE_KEY, Ok(0)); // Queue is empty
+        mock_redis.lpush_ret(CACHE_MISS_QUEUE_KEY, Ok(()));
+        let redis = Arc::new(mock_redis.clone());
+
+        notify_cache_miss(redis.clone(), 456).await.unwrap();
+
+        let calls = mock_redis.get_calls();
+        let message = match &calls[1].value {
+            // calls[1] is lpush, calls[0] is llen
+            common_redis::MockRedisValue::String(s) => s,
+            _ => panic!("Expected string value"),
+        };
+
+        // Verify it's valid JSON
+        let parsed: CacheMissNotification = serde_json::from_str(message).unwrap();
+        assert_eq!(parsed.team_id, 456);
+        assert!(parsed.timestamp > 0);
+    }
+
+    #[tokio::test]
+    async fn test_notify_cache_miss_handles_redis_failure() {
+        let mut mock_redis = MockRedisClient::new();
+        mock_redis.llen_ret(CACHE_MISS_QUEUE_KEY, Ok(0)); // Queue is empty
+        mock_redis.lpush_ret(
+            CACHE_MISS_QUEUE_KEY,
+            Err(common_redis::CustomRedisError::Other(
+                "Connection failed".to_string(),
+            )),
+        );
+        let redis = Arc::new(mock_redis);
+
+        // Should not fail even if Redis fails (fire-and-forget)
+        let result = notify_cache_miss(redis, 789).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_notify_cache_miss_drops_when_queue_full() {
+        let mut mock_redis = MockRedisClient::new();
+        mock_redis.llen_ret(CACHE_MISS_QUEUE_KEY, Ok(*MAX_QUEUE_DEPTH)); // Queue is at max
+        let redis = Arc::new(mock_redis.clone());
+
+        let result = notify_cache_miss(redis.clone(), 999).await;
+
+        assert!(result.is_ok());
+
+        // Should only call llen, not lpush (notification was dropped)
+        let calls = mock_redis.get_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].op, "llen");
+    }
+}

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -382,6 +382,15 @@ pub struct Config {
     #[envconfig(from = "FLAG_DEFINITIONS_RATE_LIMITS", default = "")]
     pub flag_definitions_rate_limits: FlagDefinitionsRateLimits,
 
+    // Retry-After header value (seconds) returned on cache miss
+    // Tells clients how long to wait before retrying when cache is being warmed
+    // Default: 2 seconds (covers celery beat interval + cache rebuild time)
+    #[envconfig(
+        from = "FLAG_DEFINITIONS_CACHE_MISS_RETRY_AFTER_SECONDS",
+        default = "2"
+    )]
+    pub flag_definitions_cache_miss_retry_after_seconds: u32,
+
     // OpenTelemetry configuration
     #[envconfig(from = "OTEL_EXPORTER_OTLP_ENDPOINT")]
     pub otel_url: Option<String>,
@@ -489,6 +498,7 @@ impl Config {
             flags_session_replay_quota_check: false,
             flag_definitions_default_rate_per_minute: 600,
             flag_definitions_rate_limits: FlagDefinitionsRateLimits::default(),
+            flag_definitions_cache_miss_retry_after_seconds: 2,
             otel_url: None,
             otel_sampling_rate: 1.0,
             otel_service_name: "posthog-feature-flags".to_string(),

--- a/rust/feature-flags/src/lib.rs
+++ b/rust/feature-flags/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod billing_limiters;
+pub mod cache;
 pub mod cohorts;
 pub mod config;
 pub mod database;

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -64,3 +64,11 @@ pub const FLAG_ACQUIRE_TIMEOUT_COUNTER: &str = "flags_acquire_timeout_total";
 
 // Error classification
 pub const FLAG_DATABASE_ERROR_COUNTER: &str = "flags_database_error_total";
+
+// Cache miss notification metrics
+pub const FLAG_CACHE_MISS_NOTIFICATION_SENT_COUNTER: &str =
+    "flags_cache_miss_notification_sent_total";
+pub const FLAG_CACHE_MISS_NOTIFICATION_ERROR_COUNTER: &str =
+    "flags_cache_miss_notification_error_total";
+pub const FLAG_CACHE_MISS_NOTIFICATION_DROPPED_COUNTER: &str =
+    "flags_cache_miss_notification_dropped_total";

--- a/rust/feature-flags/tests/test_cache_warming.rs
+++ b/rust/feature-flags/tests/test_cache_warming.rs
@@ -145,6 +145,7 @@ async fn test_s3_cache_hit_triggers_cache_warming() {
         .unwrap();
 
     let status = response.status();
+    let body = response.text().await.unwrap();
 
     // Note: This test will return 503 in environments without MinIO configured
     // In production/staging with real S3, it would return 200
@@ -155,10 +156,8 @@ async fn test_s3_cache_hit_triggers_cache_warming() {
     }
 
     assert_eq!(
-        status,
-        200,
-        "Should return 200 when S3 has data. Response body: {}",
-        response.text().await.unwrap()
+        status, 200,
+        "Should return 200 when S3 has data. Response body: {body}"
     );
 
     // Give the async task a moment to write to Redis

--- a/rust/feature-flags/tests/test_cache_warming.rs
+++ b/rust/feature-flags/tests/test_cache_warming.rs
@@ -1,0 +1,297 @@
+mod common;
+
+use redis::Commands;
+
+/// Test that a total cache miss (Redis + S3) returns 503 and triggers cache warming
+#[tokio::test]
+async fn test_total_cache_miss_triggers_cache_warming() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team with secret API token
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // DO NOT populate cache - we want to test cache miss behavior
+    // Clear Redis queue before test
+    let mut redis_conn = redis::Client::open(config.redis_url.clone())
+        .unwrap()
+        .get_connection()
+        .unwrap();
+    drop(redis_conn.del::<_, ()>("posthog:flag_cache_miss_queue"));
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Request should return 503 when cache is empty
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body_text = response.text().await.unwrap();
+
+    assert_eq!(
+        status, 503,
+        "Should return 503 on total cache miss. Body: {body_text}"
+    );
+
+    // Verify Retry-After header is present
+    assert!(
+        headers.contains_key("retry-after"),
+        "Should include Retry-After header"
+    );
+    let retry_after = headers.get("retry-after").unwrap().to_str().unwrap();
+    assert_eq!(retry_after, "2", "Default Retry-After should be 2 seconds");
+
+    // Give the async task a moment to write to Redis
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Verify that cache warming notification was queued
+    let queue_length: i32 = redis_conn
+        .llen("posthog:flag_cache_miss_queue")
+        .expect("Failed to get queue length");
+    assert_eq!(
+        queue_length, 1,
+        "Cache warming notification should be queued"
+    );
+
+    // Verify the notification content
+    let notification: String = redis_conn
+        .lindex("posthog:flag_cache_miss_queue", 0)
+        .expect("Failed to get notification");
+    let notification_json: serde_json::Value =
+        serde_json::from_str(&notification).expect("Failed to parse notification JSON");
+
+    assert_eq!(
+        notification_json["team_id"], team.id,
+        "Notification should contain correct team_id"
+    );
+    assert!(
+        notification_json["timestamp"].is_number(),
+        "Notification should contain timestamp as a number"
+    );
+}
+
+/// Test that S3 cache hit returns 200 and triggers cache warming to populate Redis
+#[tokio::test]
+async fn test_s3_cache_hit_triggers_cache_warming() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let mut config = Config::default_test_config();
+    // Configure MinIO/S3 endpoint for local testing
+    config.object_storage_endpoint = "http://localhost:19000".to_string();
+
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team with secret API token
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // Populate ONLY S3 cache (not Redis) to simulate Redis restart scenario
+    // This would require MinIO to be running and properly configured
+    // For now, we'll simulate by:
+    // 1. Populating cache (goes to both Redis and S3)
+    // 2. Clearing Redis
+    // 3. Making request (should hit S3 and trigger warming)
+
+    context
+        .populate_cache_for_team(team.id)
+        .await
+        .expect("Failed to populate cache");
+
+    // Clear only Redis cache, leaving S3 intact
+    let mut redis_conn = redis::Client::open(config.redis_url.clone())
+        .unwrap()
+        .get_connection()
+        .unwrap();
+
+    let redis_key = format!(
+        "posthog:1:cache/teams/{}/feature_flags/flags_with_cohorts.json",
+        team.id
+    );
+    drop(redis_conn.del::<_, ()>(&redis_key));
+
+    // Clear the cache warming queue before test
+    drop(redis_conn.del::<_, ()>("posthog:flag_cache_miss_queue"));
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Request should return 200 from S3 fallback
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+
+    // Note: This test will return 503 in environments without MinIO configured
+    // In production/staging with real S3, it would return 200
+    if status == 503 {
+        // Expected in test environment without MinIO
+        println!("Note: S3 fallback not available in test environment (expected)");
+        return;
+    }
+
+    assert_eq!(
+        status,
+        200,
+        "Should return 200 when S3 has data. Response body: {}",
+        response.text().await.unwrap()
+    );
+
+    // Give the async task a moment to write to Redis
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Verify that cache warming notification was queued
+    let queue_length: i32 = redis_conn
+        .llen("posthog:flag_cache_miss_queue")
+        .expect("Failed to get queue length");
+    assert_eq!(
+        queue_length, 1,
+        "Cache warming notification should be queued when serving from S3"
+    );
+
+    // Verify the notification content
+    let notification: String = redis_conn
+        .lindex("posthog:flag_cache_miss_queue", 0)
+        .expect("Failed to get notification");
+    let notification_json: serde_json::Value =
+        serde_json::from_str(&notification).expect("Failed to parse notification JSON");
+
+    assert_eq!(
+        notification_json["team_id"], team.id,
+        "Notification should contain correct team_id"
+    );
+}
+
+/// Test that Redis cache hit does NOT trigger cache warming
+#[tokio::test]
+async fn test_redis_cache_hit_does_not_trigger_cache_warming() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team with secret API token
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // Populate cache (goes to Redis)
+    context
+        .populate_cache_for_team(team.id)
+        .await
+        .expect("Failed to populate cache");
+
+    // Clear the cache warming queue before test
+    let mut redis_conn = redis::Client::open(config.redis_url.clone())
+        .unwrap()
+        .get_connection()
+        .unwrap();
+    drop(redis_conn.del::<_, ()>("posthog:flag_cache_miss_queue"));
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Request should return 200 from Redis
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Should return 200 from Redis cache. Response body: {}",
+        response.text().await.unwrap()
+    );
+
+    // Give any potential async tasks a moment
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Verify that NO cache warming notification was queued
+    let queue_length: i32 = redis_conn
+        .llen("posthog:flag_cache_miss_queue")
+        .expect("Failed to get queue length");
+    assert_eq!(
+        queue_length, 0,
+        "Cache warming should NOT be triggered when serving from Redis"
+    );
+}
+
+/// Test that Retry-After header value is configurable
+#[tokio::test]
+async fn test_retry_after_header_configurable() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let mut config = Config::default_test_config();
+    config.flag_definitions_cache_miss_retry_after_seconds = 5; // Custom value
+
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team with secret API token
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // DO NOT populate cache - we want cache miss
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Request should return 503 with custom Retry-After
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 503, "Should return 503 on cache miss");
+
+    // Verify custom Retry-After header value
+    let headers = response.headers();
+    let retry_after = headers
+        .get("retry-after")
+        .expect("Should include Retry-After header")
+        .to_str()
+        .unwrap();
+    assert_eq!(
+        retry_after, "5",
+        "Retry-After should use configured value of 5 seconds"
+    );
+}

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -737,14 +737,14 @@ async fn test_cache_miss_returns_503() {
             body["detail"]
                 .as_str()
                 .unwrap()
-                .contains("Required data not found in cache"),
-            "Error message should mention cache miss"
+                .contains("Flag definitions cache is warming"),
+            "Error message should mention cache warming"
         );
     } else {
-        // If not JSON, verify the error message mentions cache
+        // If not JSON, verify the error message mentions cache warming
         assert!(
-            body_text.contains("Required data not found in cache"),
-            "Body should mention cache miss. Got: {body_text}"
+            body_text.contains("Flag definitions cache is warming"),
+            "Body should mention cache warming. Got: {body_text}"
         );
     }
 }


### PR DESCRIPTION
## Problem

The `/flags/definitions` endpoint is a Rust port of the `/local_evaluation` endpoint from Django. However, it does *not* implement building the response. Instead, it returns a HyperCached response built by the Django code.

We use Django signals to try and make sure we never have a cache miss, but any number of reasons could still lead to a cache miss such as pressure on Redis causing key evictions, etc.

## Changes

When the `/flags/definitions` endpoint encounters a cache miss, automatically trigger a cache rebuild via Redis queue. On the Django side, we have a celery-heartbeat running every second. When it sees the Redis queue entry, it rebuilds the cache.

**Cache rebuild mechanism:**
- Push notification to Redis list `posthog:flag_cache_miss_queue` with `team_id` and `timestamp`
- Celery task `process_flag_cache_miss_queue` polls this queue every second
- Rate limiting prevents excessive rebuilds (max 2 rebuilds per team per 60-second window by default)
- Cache rebuild is fire-and-forget - doesn't block the request response

**Response behavior:**
- **Total cache miss** (Redis + S3): Return HTTP 503 with `Retry-After: 2` header (configurable via
`FLAG_DEFINITIONS_CACHE_MISS_RETRY_AFTER_SECONDS`)
- **Partial cache miss** (Redis miss, S3 hit): Return HTTP 200 with S3 data, but still trigger cache warming to populate Redis
- **Redis cache hit**: Return HTTP 200, no cache warming needed

The 2-second interval was chosen because it covers the 1-second Celery beat interval + typical cache rebuild time (~276ms based on our testing). It's configurable via the `FLAG_DEFINITIONS_CACHE_MISS_RETRY_AFTER_SECONDS` setting.

## How did you test this code?

Unit Tests
Manually: (I tried all the cache scenarios: no cache, s3 only, fully cached).

## Changelog: (features only) Is this feature complete?

No