### PR TITLE
chore: Bump `posthog-node` to v5+

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -107,7 +107,7 @@
         "p-limit": "3.1.0",
         "pg": "^8.6.0",
         "pino": "^8.6.0",
-        "posthog-node": "4.14.0",
+        "posthog-node": "5.10.4",
         "pretty-bytes": "^5.6.0",
         "prom-client": "^14.2.0",
         "re2": "^1.22.1",

--- a/plugin-server/src/utils/posthog.ts
+++ b/plugin-server/src/utils/posthog.ts
@@ -1,5 +1,4 @@
 import { PostHog } from 'posthog-node'
-import { SeverityLevel } from 'posthog-node/src/extensions/error-tracking/types'
 
 import { defaultConfig } from '../config/config'
 import { Team } from '../types'
@@ -75,7 +74,6 @@ export function flush(): void {
 // so define a type for them that we can flatten internally
 type Primitive = number | string | boolean | bigint | symbol | null | undefined
 interface ExceptionHint {
-    level: SeverityLevel
     tags: Record<string, Primitive>
     extra: Record<string, any>
 }
@@ -85,11 +83,11 @@ export function captureException(exception: any, hint?: Partial<ExceptionHint>):
         let additionalProperties = {}
         if (hint) {
             additionalProperties = {
-                ...(hint.level ? { level: hint.level } : {}),
                 ...(hint.tags || {}),
                 ...(hint.extra || {}),
             }
         }
+
         posthog.captureException(exception, undefined, additionalProperties)
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1371,8 +1371,8 @@ importers:
         specifier: ^8.6.0
         version: 8.11.0
       posthog-node:
-        specifier: 4.14.0
-        version: 4.14.0
+        specifier: 5.10.4
+        version: 5.10.4
       pretty-bytes:
         specifier: ^5.6.0
         version: 5.6.0
@@ -6452,6 +6452,9 @@ packages:
 
   '@poppinss/exception@1.2.2':
     resolution: {integrity: sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==}
+
+  '@posthog/core@1.4.0':
+    resolution: {integrity: sha512-jmW8/I//YOHAfjzokqas+Qtc2T57Ux8d2uIJu7FLcMGxywckHsl6od59CD18jtUzKToQdjQhV6Y3429qj+KeNw==}
 
   '@posthog/core@1.5.3':
     resolution: {integrity: sha512-1cHCMR2uS/rAdBIFlBPJ4rPYaw1O42VkFy/LwQLtoy2hMQb2DdhCoSHfgA66R9TvcOybZsSANlbuihmGEZUKVQ==}
@@ -16449,13 +16452,13 @@ packages:
   posthog-js@1.297.0:
     resolution: {integrity: sha512-+kHHe3oTRLPBokks5E2pojDfx0yAzkXLeN8BCfVY9kZ7eaaHuezpFb4DQ7i4hzI5nMFDe5qWotsUO73/GR6lmw==}
 
-  posthog-node@4.14.0:
-    resolution: {integrity: sha512-PitSiuxGiVFl0ItuhIfi3Sq1tcaMU4vlbPu1wv0qufTJGDjWthOOr4vYfFIs1xkbJFOQcfGczMXkr44kX5TDDg==}
-    engines: {node: '>=15.0.0'}
-
   posthog-node@4.18.0:
     resolution: {integrity: sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==}
     engines: {node: '>=15.0.0'}
+
+  posthog-node@5.10.4:
+    resolution: {integrity: sha512-sy020/Q4mt18eCkVo/cGEJD+wgdxeg5DTgNUaA85awBCbuEP43BOdCTOOw/K2Tvgw2oZfag3PFyhkVuQ6nJfBg==}
+    engines: {node: '>=20'}
 
   posthtml-parser@0.11.0:
     resolution: {integrity: sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==}
@@ -25627,6 +25630,8 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
+  '@posthog/core@1.4.0': {}
+
   '@posthog/core@1.5.3':
     dependencies:
       cross-spawn: 7.0.6
@@ -28376,7 +28381,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -35018,7 +35023,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -35298,7 +35303,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -38280,17 +38285,15 @@ snapshots:
       preact: 10.27.2
       web-vitals: 4.2.4
 
-  posthog-node@4.14.0:
-    dependencies:
-      axios: 1.9.0
-    transitivePeerDependencies:
-      - debug
-
   posthog-node@4.18.0:
     dependencies:
       axios: 1.9.0
     transitivePeerDependencies:
       - debug
+
+  posthog-node@5.10.4:
+    dependencies:
+      '@posthog/core': 1.4.0
 
   posthtml-parser@0.11.0:
     dependencies:


### PR DESCRIPTION
SDK Doctor was complaining we're in an outdated version of `posthog-node`, and we definitely are! Let's upgrade.

Breaking changes don't affect us (Node v20+) so this should be very safe. There's a bunch of error tracking upgrades as well so we might be able to start tracking these now - not changing anything on this PR