### PR TITLE
fix(hogli): fix tab completion generation after move to common/

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -104,12 +104,12 @@ if [ -d "$UV_PROJECT_ENVIRONMENT/bin" ]; then
 fi
 
 # Install shell completions for hogli in flox environment cache
-# Must run after uv sync so hogli.completion module is available
+# Must run after symlink creation; PYTHONPATH mirrors what bin/hogli does
 HOGLI_COMPLETION_DIR="$FLOX_ENV_CACHE/completions"
 mkdir -p "$HOGLI_COMPLETION_DIR"
 if [ -d "$UV_PROJECT_ENVIRONMENT/bin" ]; then
-  "$UV_PROJECT_ENVIRONMENT/bin/python" -m hogli.completion --shell bash > "$HOGLI_COMPLETION_DIR/hogli.bash" 2>/dev/null || true
-  "$UV_PROJECT_ENVIRONMENT/bin/python" -m hogli.completion --shell zsh > "$HOGLI_COMPLETION_DIR/_hogli" 2>/dev/null || true
+  PYTHONPATH="$FLOX_ENV_PROJECT/common" "$UV_PROJECT_ENVIRONMENT/bin/python" -m hogli.core.completion --shell bash > "$HOGLI_COMPLETION_DIR/hogli.bash" 2>/dev/null || true
+  PYTHONPATH="$FLOX_ENV_PROJECT/common" "$UV_PROJECT_ENVIRONMENT/bin/python" -m hogli.core.completion --shell zsh > "$HOGLI_COMPLETION_DIR/_hogli" 2>/dev/null || true
 fi
 
 # Install top-level Node dependencies - This also sets up pre-commit hooks via Husky


### PR DESCRIPTION
## Summary
Tab completion stopped working after hogli was restructured to `common/hogli/`. This fixes it by updating the module path and setting PYTHONPATH.

## Problem
After the hogli restructuring (#39965):
1. Module path changed from `hogli.completion` → `hogli.core.completion`
2. hogli moved from `hogli/` → `common/hogli/`
3. Completion generation failed because Python couldn't find the module

## Solution
- Update module path to `hogli.core.completion`
- Set `PYTHONPATH="$FLOX_ENV_PROJECT/common"` to mirror what `bin/hogli` does
- This makes `hogli` available as a top-level module for imports

## Test plan
- [x] Tested completion generation manually with the fix
- [x] Fresh `flox activate` should generate working completions in `$FLOX_ENV_CACHE/completions/`
- [x] Tab completion should work for `hogli <TAB>` in bash/zsh