### PR TITLE
feat(new-tab): add groups

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -40,7 +40,7 @@ export type TreeDataItem = {
     /** The name of the item. */
     name: string
     /** What to show as the name. */
-    displayName?: React.ReactElement
+    displayName?: React.ReactElement | string
     /** Passthrough metadata */
     record?: Record<string, any>
     /** The side action to render for the item. */

--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -26,6 +26,7 @@ import { urls } from 'scenes/urls'
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { MenuItems } from '~/layout/panel-layout/ProjectTree/menus/MenuItems'
+import { groupsModel } from '~/models/groupsModel'
 import { SidePanelTab } from '~/types'
 
 import { NoResultsFound } from './NoResultsFound'
@@ -37,6 +38,7 @@ export const getCategoryDisplayName = (category: string): string => {
         'data-management': 'Data management',
         recents: 'Recents',
         persons: 'Persons',
+        groups: 'Groups',
         eventDefinitions: 'Events',
         propertyDefinitions: 'Properties',
         askAI: 'Posthog AI',
@@ -128,6 +130,7 @@ function Category({
         newTabSceneDataInclude,
     } = useValues(newTabSceneLogic({ tabId }))
     const { showMoreInSection } = useActions(newTabSceneLogic({ tabId }))
+    const { groupTypes } = useValues(groupsModel)
 
     return (
         <>
@@ -151,7 +154,7 @@ function Category({
                         {category === 'recents' && isSearching && <Spinner size="small" />}
                         {/* Show "No results found" tag for other categories when empty and include is NOT 'all' */}
                         {newTabSceneData &&
-                            !['persons', 'eventDefinitions', 'propertyDefinitions'].includes(category) &&
+                            !['persons', 'groups', 'eventDefinitions', 'propertyDefinitions'].includes(category) &&
                             typedItems.length === 0 &&
                             !newTabSceneDataInclude.includes('all') && (
                                 <LemonTag className="text-xs text-tertiary" size="small">
@@ -333,6 +336,19 @@ function Category({
                                         }}
                                     >
                                         <IconArrowRight /> See all events
+                                    </Link>
+                                </ListBox.Item>
+                            )}
+                            {category === 'groups' && groupTypes.size > 0 && (
+                                <ListBox.Item asChild>
+                                    <Link
+                                        to={urls.groups(Array.from(groupTypes.keys())[0])}
+                                        buttonProps={{
+                                            size: 'sm',
+                                            className: 'w-full text-tertiary data-[focused=true]:text-primary',
+                                        }}
+                                    >
+                                        <IconArrowRight /> See all groups
                                     </Link>
                                 </ListBox.Item>
                             )}

--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useRef } from 'react'
+import { ReactNode, useEffect, useRef } from 'react'
 
-import { IconArrowRight, IconEllipsis, IconInfo, IconSparkles } from '@posthog/icons'
+import { IconArrowRight, IconEllipsis, IconExternal, IconInfo, IconSparkles } from '@posthog/icons'
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { Dayjs, dayjs } from 'lib/dayjs'
@@ -19,6 +19,7 @@ import {
 import { Label } from 'lib/ui/Label/Label'
 import { ListBox, ListBoxGroupHandle, ListBoxHandle } from 'lib/ui/ListBox/ListBox'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
+import { capitalizeFirstLetter } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import { NewTabTreeDataItem, newTabSceneLogic } from 'scenes/new-tab/newTabSceneLogic'
 import { urls } from 'scenes/urls'
@@ -189,6 +190,25 @@ function Category({
                                     (item.record as { last_viewed_at?: string | null } | undefined)?.last_viewed_at ??
                                     null
 
+                                const record = item.record as
+                                    | ({
+                                          groupNoun?: string
+                                          groupDisplayName?: string
+                                      } & Record<string, any>)
+                                    | undefined
+
+                                const groupNoun =
+                                    item.category === 'groups' ? record?.groupNoun || item.name.split(':')[0] : null
+                                const groupDisplayName =
+                                    item.category === 'groups'
+                                        ? typeof item.displayName === 'string'
+                                            ? item.displayName
+                                            : item.name.split(':').slice(1).join(':').trim()
+                                        : null
+
+                                const highlightText = (text: string): ReactNode =>
+                                    search ? <SearchHighlightMultiple string={text} substring={search} /> : text
+
                                 return (
                                     // If we have filtered results set virtual focus to first item
                                     <ButtonGroupPrimitive key={item.id} className="group w-full border-0">
@@ -212,16 +232,38 @@ function Category({
                                                     >
                                                         <span className="text-sm">{item.icon ?? item.name[0]}</span>
                                                         <span className="flex min-w-0 items-center gap-2">
-                                                            <span className="text-sm truncate text-primary">
-                                                                {search ? (
-                                                                    <SearchHighlightMultiple
-                                                                        string={item.name}
-                                                                        substring={search}
-                                                                    />
-                                                                ) : (
-                                                                    item.displayName || item.name
-                                                                )}
-                                                            </span>
+                                                            {groupNoun ? (
+                                                                <>
+                                                                    <span className="text-sm truncate text-primary">
+                                                                        {highlightText(
+                                                                            groupDisplayName &&
+                                                                                groupDisplayName.length > 0
+                                                                                ? groupDisplayName
+                                                                                : item.name
+                                                                        )}
+                                                                    </span>
+                                                                    <LemonTag
+                                                                        size="small"
+                                                                        type="muted"
+                                                                        className="shrink-0"
+                                                                    >
+                                                                        {highlightText(
+                                                                            capitalizeFirstLetter(groupNoun.trim())
+                                                                        )}
+                                                                    </LemonTag>
+                                                                </>
+                                                            ) : (
+                                                                <span className="text-sm truncate text-primary">
+                                                                    {search ? (
+                                                                        <SearchHighlightMultiple
+                                                                            string={item.name}
+                                                                            substring={search}
+                                                                        />
+                                                                    ) : (
+                                                                        item.displayName || item.name
+                                                                    )}
+                                                                </span>
+                                                            )}
                                                             {lastViewedAt ? (
                                                                 <span className="text-xs text-muted whitespace-nowrap">
                                                                     {formatRelativeTimeShort(lastViewedAt)}
@@ -322,7 +364,7 @@ function Category({
                                             className: 'w-full text-tertiary data-[focused=true]:text-primary',
                                         }}
                                     >
-                                        <IconArrowRight /> See all persons
+                                        <IconExternal /> See all persons
                                     </Link>
                                 </ListBox.Item>
                             )}
@@ -335,7 +377,7 @@ function Category({
                                             className: 'w-full text-tertiary data-[focused=true]:text-primary',
                                         }}
                                     >
-                                        <IconArrowRight /> See all events
+                                        <IconExternal /> See all events
                                     </Link>
                                 </ListBox.Item>
                             )}
@@ -348,7 +390,7 @@ function Category({
                                             className: 'w-full text-tertiary data-[focused=true]:text-primary',
                                         }}
                                     >
-                                        <IconArrowRight /> See all groups
+                                        <IconExternal /> See all groups
                                     </Link>
                                 </ListBox.Item>
                             )}
@@ -361,7 +403,7 @@ function Category({
                                             className: 'w-full text-tertiary data-[focused=true]:text-primary',
                                         }}
                                     >
-                                        <IconArrowRight /> See all properties
+                                        <IconExternal /> See all properties
                                     </Link>
                                 </ListBox.Item>
                             )}

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -2,7 +2,7 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
-import { IconApps, IconArrowRight, IconDatabase, IconHogQL, IconPerson, IconSparkles } from '@posthog/icons'
+import { IconApps, IconArrowRight, IconDatabase, IconHogQL, IconPeople, IconPerson, IconSparkles } from '@posthog/icons'
 
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -10,6 +10,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
+import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 import { urls } from 'scenes/urls'
 
 import {
@@ -23,8 +24,9 @@ import {
 import { SearchResults } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { splitPath } from '~/layout/panel-layout/ProjectTree/utils'
 import { TreeDataItem } from '~/lib/lemon-ui/LemonTree/LemonTree'
+import { groupsModel } from '~/models/groupsModel'
 import { FileSystemIconType, FileSystemImport } from '~/queries/schema/schema-general'
-import { EventDefinition, PersonType, PropertyDefinition } from '~/types'
+import { EventDefinition, Group, GroupTypeIndex, PersonType, PropertyDefinition } from '~/types'
 
 import { SearchInputCommand } from './components/SearchInput'
 import type { newTabSceneLogicType } from './newTabSceneLogicType'
@@ -36,6 +38,7 @@ export type NEW_TAB_CATEGORY_ITEMS =
     | 'data-management'
     | 'recents'
     | 'persons'
+    | 'groups'
     | 'eventDefinitions'
     | 'propertyDefinitions'
     | 'askAI'
@@ -47,6 +50,7 @@ export type NEW_TAB_COMMANDS =
     | 'data-management'
     | 'recents'
     | 'persons'
+    | 'groups'
     | 'eventDefinitions'
     | 'propertyDefinitions'
     | 'askAI'
@@ -58,6 +62,7 @@ export const NEW_TAB_COMMANDS_ITEMS: SearchInputCommand<NEW_TAB_COMMANDS>[] = [
     { value: 'data-management', displayName: 'Data management' },
     { value: 'recents', displayName: 'Recents files' },
     { value: 'persons', displayName: 'Persons' },
+    { value: 'groups', displayName: 'Groups' },
     { value: 'eventDefinitions', displayName: 'Events' },
     { value: 'propertyDefinitions', displayName: 'Properties' },
     { value: 'askAI', displayName: 'Posthog AI' },
@@ -77,6 +82,7 @@ export interface NewTabCategoryItem {
 }
 
 const PAGINATION_LIMIT = 10
+const GROUP_SEARCH_LIMIT = 5
 
 function getIconForFileSystemItem(fs: FileSystemImport): JSX.Element {
     // If the item has a direct icon property, use it with color wrapper
@@ -96,7 +102,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
     path(['scenes', 'new-tab', 'newTabSceneLogic']),
     props({} as { tabId?: string }),
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [featureFlagLogic, ['featureFlags'], groupsModel, ['groupTypes', 'aggregationLabel']],
     })),
     key((props) => props.tabId || 'default'),
     actions({
@@ -109,6 +115,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
         debouncedPersonSearch: (searchTerm: string) => ({ searchTerm }),
         debouncedEventDefinitionSearch: (searchTerm: string) => ({ searchTerm }),
         debouncedPropertyDefinitionSearch: (searchTerm: string) => ({ searchTerm }),
+        debouncedGroupSearch: (searchTerm: string) => ({ searchTerm }),
         setNewTabSceneDataInclude: (include: NEW_TAB_COMMANDS[]) => ({ include }),
         toggleNewTabSceneDataInclude: (item: NEW_TAB_COMMANDS) => ({ item }),
         triggerSearchForIncludedItems: true,
@@ -116,6 +123,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
         showMoreInSection: (section: string) => ({ section }),
         resetSectionLimits: true,
         askAI: (searchTerm: string) => ({ searchTerm }),
+        loadInitialGroups: true,
     }),
     loaders(({ values }) => ({
         recents: [
@@ -237,6 +245,70 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 },
             },
         ],
+        groupSearchResults: [
+            {} as Record<GroupTypeIndex, Group[]>,
+            {
+                loadGroupSearchResults: async ({ searchTerm }: { searchTerm: string }, breakpoint) => {
+                    const trimmed = searchTerm.trim()
+                    if (trimmed === '') {
+                        return {}
+                    }
+
+                    const groupTypesList = Array.from(values.groupTypes.values())
+                    if (groupTypesList.length === 0) {
+                        return {}
+                    }
+
+                    await breakpoint(200)
+
+                    const responses = await Promise.all(
+                        groupTypesList.map((groupType) =>
+                            api.groups.list({
+                                group_type_index: groupType.group_type_index,
+                                search: trimmed,
+                                limit: GROUP_SEARCH_LIMIT,
+                            })
+                        )
+                    )
+
+                    breakpoint()
+
+                    return Object.fromEntries(
+                        responses.map((response, index) => [
+                            groupTypesList[index].group_type_index,
+                            response.results.slice(0, GROUP_SEARCH_LIMIT),
+                        ])
+                    ) as Record<GroupTypeIndex, Group[]>
+                },
+                loadInitialGroups: async (_, breakpoint) => {
+                    const groupTypesList = Array.from(values.groupTypes.values())
+                    if (groupTypesList.length === 0) {
+                        return {}
+                    }
+
+                    await breakpoint(200)
+
+                    const responses = await Promise.all(
+                        groupTypesList.map((groupType) =>
+                            api.groups.list({
+                                group_type_index: groupType.group_type_index,
+                                search: '',
+                                limit: GROUP_SEARCH_LIMIT,
+                            })
+                        )
+                    )
+
+                    breakpoint()
+
+                    return Object.fromEntries(
+                        responses.map((response, index) => [
+                            groupTypesList[index].group_type_index,
+                            response.results.slice(0, GROUP_SEARCH_LIMIT),
+                        ])
+                    ) as Record<GroupTypeIndex, Group[]>
+                },
+            },
+        ],
     })),
     reducers({
         search: [
@@ -303,6 +375,15 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 loadPropertyDefinitionSearchResultsFailure: () => false,
             },
         ],
+        groupSearchPending: [
+            false,
+            {
+                debouncedGroupSearch: () => true,
+                loadGroupSearchResults: () => false,
+                loadGroupSearchResultsSuccess: () => false,
+                loadGroupSearchResultsFailure: () => false,
+            },
+        ],
         rawSelectedIndex: [
             0,
             {
@@ -360,6 +441,10 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         label: 'Persons',
                     })
                     categories.push({
+                        key: 'groups',
+                        label: 'Groups',
+                    })
+                    categories.push({
                         key: 'eventDefinitions',
                         label: 'Events',
                     })
@@ -384,6 +469,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 s.eventDefinitionSearchPending,
                 s.propertyDefinitionSearchResultsLoading,
                 s.propertyDefinitionSearchPending,
+                s.groupSearchResultsLoading,
+                s.groupSearchPending,
                 s.search,
             ],
             (
@@ -394,6 +481,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 eventDefinitionSearchPending: boolean,
                 propertyDefinitionSearchResultsLoading: boolean,
                 propertyDefinitionSearchPending: boolean,
+                groupSearchResultsLoading: boolean,
+                groupSearchPending: boolean,
                 search: string
             ): boolean =>
                 (recentsLoading ||
@@ -402,7 +491,9 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     eventDefinitionSearchResultsLoading ||
                     eventDefinitionSearchPending ||
                     propertyDefinitionSearchResultsLoading ||
-                    propertyDefinitionSearchPending) &&
+                    propertyDefinitionSearchPending ||
+                    groupSearchResultsLoading ||
+                    groupSearchPending) &&
                 search.trim() !== '',
         ],
         projectTreeSearchItems: [
@@ -490,6 +581,36 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     }
                     return item
                 })
+                return items
+            },
+        ],
+        groupSearchItems: [
+            (s) => [s.groupSearchResults, s.aggregationLabel],
+            (groupSearchResults: Record<GroupTypeIndex, Group[]>, aggregationLabel): NewTabTreeDataItem[] => {
+                const items: NewTabTreeDataItem[] = []
+                for (const [groupTypeIndexString, groups] of Object.entries(groupSearchResults)) {
+                    const groupTypeIndex = parseInt(groupTypeIndexString, 10) as GroupTypeIndex
+                    const noun = aggregationLabel(groupTypeIndex).singular
+                    groups.forEach((group) => {
+                        const display = groupDisplayId(group.group_key, group.group_properties || {})
+                        const href = urls.group(groupTypeIndex, group.group_key)
+                        items.push({
+                            id: `group-${groupTypeIndex}-${group.group_key}`,
+                            name: `${noun}: ${display}`,
+                            category: 'groups' as NEW_TAB_CATEGORY_ITEMS,
+                            href,
+                            icon: <IconPeople />,
+                            record: {
+                                type: 'group',
+                                path: `${noun}: ${display}`,
+                                href,
+                                groupTypeIndex,
+                                groupKey: group.group_key,
+                            },
+                        })
+                    })
+                }
+
                 return items
             },
         ],
@@ -691,6 +812,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 s.search,
                 s.newTabSceneDataInclude,
                 s.personSearchItems,
+                s.groupSearchItems,
                 s.eventDefinitionSearchItems,
                 s.propertyDefinitionSearchItems,
                 s.aiSearchItems,
@@ -702,6 +824,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 search: string,
                 newTabSceneDataInclude: NEW_TAB_COMMANDS[],
                 personSearchItems: NewTabTreeDataItem[],
+                groupSearchItems: NewTabTreeDataItem[],
                 eventDefinitionSearchItems: NewTabTreeDataItem[],
                 propertyDefinitionSearchItems: NewTabTreeDataItem[],
                 aiSearchItems: NewTabTreeDataItem[],
@@ -738,6 +861,10 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 if (showAll || newTabSceneDataInclude.includes('persons')) {
                     const limit = getSectionItemLimit('persons')
                     grouped['persons'] = personSearchItems.slice(0, limit)
+                }
+                if (showAll || newTabSceneDataInclude.includes('groups')) {
+                    const limit = getSectionItemLimit('groups')
+                    grouped['groups'] = groupSearchItems.slice(0, limit)
                 }
                 // Add event definitions section if filter is enabled
                 if (showAll || newTabSceneDataInclude.includes('eventDefinitions')) {
@@ -797,6 +924,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 s.search,
                 s.newTabSceneDataInclude,
                 s.personSearchItems,
+                s.groupSearchItems,
                 s.eventDefinitionSearchItems,
                 s.propertyDefinitionSearchItems,
                 s.aiSearchItems,
@@ -807,6 +935,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 search: string,
                 newTabSceneDataInclude: NEW_TAB_COMMANDS[],
                 personSearchItems: NewTabTreeDataItem[],
+                groupSearchItems: NewTabTreeDataItem[],
                 eventDefinitionSearchItems: NewTabTreeDataItem[],
                 propertyDefinitionSearchItems: NewTabTreeDataItem[],
                 aiSearchItems: NewTabTreeDataItem[],
@@ -841,6 +970,9 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 // Add persons section if filter is enabled
                 if (showAll || newTabSceneDataInclude.includes('persons')) {
                     fullCounts['persons'] = personSearchItems.length
+                }
+                if (showAll || newTabSceneDataInclude.includes('groups')) {
+                    fullCounts['groups'] = groupSearchItems.length
                 }
                 // Add event definitions section if filter is enabled
                 if (showAll || newTabSceneDataInclude.includes('eventDefinitions')) {
@@ -910,6 +1042,9 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 if (showAll || newTabSceneDataInclude.includes('persons')) {
                     orderedSections.push('persons')
                 }
+                if (showAll || newTabSceneDataInclude.includes('groups')) {
+                    orderedSections.push('groups')
+                }
                 if (showAll || newTabSceneDataInclude.includes('eventDefinitions')) {
                     orderedSections.push('eventDefinitions')
                 }
@@ -978,13 +1113,15 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
 
                 // Expand 'all' to include all data types
                 const itemsToProcess = values.newTabSceneDataInclude.includes('all')
-                    ? ['persons', 'eventDefinitions', 'propertyDefinitions', 'askAI']
+                    ? ['persons', 'groups', 'eventDefinitions', 'propertyDefinitions', 'askAI']
                     : values.newTabSceneDataInclude
 
                 itemsToProcess.forEach((item) => {
                     if (searchTerm !== '') {
                         if (item === 'persons') {
                             actions.debouncedPersonSearch(searchTerm)
+                        } else if (item === 'groups') {
+                            actions.debouncedGroupSearch(searchTerm)
                         } else if (item === 'eventDefinitions') {
                             actions.debouncedEventDefinitionSearch(searchTerm)
                         } else if (item === 'propertyDefinitions') {
@@ -994,6 +1131,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         // Load initial data when no search term
                         if (item === 'persons') {
                             actions.loadInitialPersons({})
+                        } else if (item === 'groups') {
+                            actions.loadInitialGroups({})
                         } else if (item === 'eventDefinitions') {
                             actions.loadInitialEventDefinitions({})
                         } else if (item === 'propertyDefinitions') {
@@ -1023,13 +1162,15 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
 
                 // Expand 'all' to include all data types
                 const itemsToProcess = values.newTabSceneDataInclude.includes('all')
-                    ? ['persons', 'eventDefinitions', 'propertyDefinitions', 'askAI']
+                    ? ['persons', 'groups', 'eventDefinitions', 'propertyDefinitions', 'askAI']
                     : values.newTabSceneDataInclude
 
                 itemsToProcess.forEach((item) => {
                     if (searchTerm !== '') {
                         if (item === 'persons') {
                             actions.debouncedPersonSearch(searchTerm)
+                        } else if (item === 'groups') {
+                            actions.debouncedGroupSearch(searchTerm)
                         } else if (item === 'eventDefinitions') {
                             actions.debouncedEventDefinitionSearch(searchTerm)
                         } else if (item === 'propertyDefinitions') {
@@ -1039,6 +1180,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         // Load initial data when no search term
                         if (item === 'persons') {
                             actions.loadInitialPersons({})
+                        } else if (item === 'groups') {
+                            actions.loadInitialGroups({})
                         } else if (item === 'eventDefinitions') {
                             actions.loadInitialEventDefinitions({})
                         } else if (item === 'propertyDefinitions') {
@@ -1125,6 +1268,11 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                 actions.loadPropertyDefinitionSearchResultsFailure(error as string)
             }
         },
+        debouncedGroupSearch: async ({ searchTerm }, breakpoint) => {
+            await breakpoint(300)
+
+            actions.loadGroupSearchResults({ searchTerm })
+        },
     })),
     tabAwareActionToUrl(({ values }) => ({
         setSearch: () => [
@@ -1198,12 +1346,14 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     if (searchTerm !== '') {
                         // Expand 'all' to include all data types
                         const itemsToProcess = values.newTabSceneDataInclude.includes('all')
-                            ? ['persons', 'eventDefinitions', 'propertyDefinitions']
+                            ? ['persons', 'groups', 'eventDefinitions', 'propertyDefinitions']
                             : values.newTabSceneDataInclude
 
                         itemsToProcess.forEach((item) => {
                             if (item === 'persons') {
                                 actions.debouncedPersonSearch(searchTerm)
+                            } else if (item === 'groups') {
+                                actions.debouncedGroupSearch(searchTerm)
                             } else if (item === 'eventDefinitions') {
                                 actions.debouncedEventDefinitionSearch(searchTerm)
                             } else if (item === 'propertyDefinitions') {
@@ -1231,6 +1381,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                               'data-management',
                               'recents',
                               'persons',
+                              'groups',
                               'eventDefinitions',
                               'propertyDefinitions',
                               'askAI',
@@ -1249,7 +1400,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
 
                 // Expand 'all' to include all data types
                 const itemsToProcess = includeFromUrl.includes('all')
-                    ? ['persons', 'eventDefinitions', 'propertyDefinitions', 'askAI']
+                    ? ['persons', 'groups', 'eventDefinitions', 'propertyDefinitions', 'askAI']
                     : includeFromUrl
 
                 itemsToProcess.forEach((item) => {
@@ -1257,6 +1408,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         // If there's a search term, trigger search for data items only
                         if (item === 'persons') {
                             actions.debouncedPersonSearch(searchTerm)
+                        } else if (item === 'groups') {
+                            actions.debouncedGroupSearch(searchTerm)
                         } else if (item === 'eventDefinitions') {
                             actions.debouncedEventDefinitionSearch(searchTerm)
                         } else if (item === 'propertyDefinitions') {
@@ -1267,6 +1420,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         // Load initial data when no search term for data items only
                         if (item === 'persons') {
                             actions.loadInitialPersons({})
+                        } else if (item === 'groups') {
+                            actions.loadInitialGroups({})
                         } else if (item === 'eventDefinitions') {
                             actions.loadInitialEventDefinitions({})
                         } else if (item === 'propertyDefinitions') {
@@ -1298,6 +1453,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
         const newTabSceneData = values.featureFlags[FEATURE_FLAGS.DATA_IN_NEW_TAB_SCENE]
         if (newTabSceneData && values.newTabSceneDataInclude.includes('all')) {
             actions.loadInitialPersons({})
+            actions.loadInitialGroups({})
             actions.loadInitialEventDefinitions({})
             actions.loadInitialPropertyDefinitions({})
         }

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -1135,7 +1135,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         if (item === 'persons') {
                             actions.loadInitialPersons({})
                         } else if (item === 'groups') {
-                            actions.loadInitialGroups({})
+                            actions.loadInitialGroups()
                         } else if (item === 'eventDefinitions') {
                             actions.loadInitialEventDefinitions({})
                         } else if (item === 'propertyDefinitions') {
@@ -1184,7 +1184,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         if (item === 'persons') {
                             actions.loadInitialPersons({})
                         } else if (item === 'groups') {
-                            actions.loadInitialGroups({})
+                            actions.loadInitialGroups()
                         } else if (item === 'eventDefinitions') {
                             actions.loadInitialEventDefinitions({})
                         } else if (item === 'propertyDefinitions') {
@@ -1213,6 +1213,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         actions.loadEventDefinitionSearchResultsSuccess([])
                     } else if (item === 'propertyDefinitions') {
                         actions.loadPropertyDefinitionSearchResultsSuccess([])
+                    } else if (item === 'groups') {
+                        actions.loadGroupSearchResultsSuccess({})
                     }
                 }
             }
@@ -1424,7 +1426,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         if (item === 'persons') {
                             actions.loadInitialPersons({})
                         } else if (item === 'groups') {
-                            actions.loadInitialGroups({})
+                            actions.loadInitialGroups()
                         } else if (item === 'eventDefinitions') {
                             actions.loadInitialEventDefinitions({})
                         } else if (item === 'propertyDefinitions') {
@@ -1456,7 +1458,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
         const newTabSceneData = values.featureFlags[FEATURE_FLAGS.DATA_IN_NEW_TAB_SCENE]
         if (newTabSceneData && values.newTabSceneDataInclude.includes('all')) {
             actions.loadInitialPersons({})
-            actions.loadInitialGroups({})
+            actions.loadInitialGroups()
             actions.loadInitialEventDefinitions({})
             actions.loadInitialPropertyDefinitions({})
         }

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -246,7 +246,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
             },
         ],
         groupSearchResults: [
-            {} as Record<GroupTypeIndex, Group[]>,
+            {} as Partial<Record<GroupTypeIndex, Group[]>>,
             {
                 loadGroupSearchResults: async ({ searchTerm }: { searchTerm: string }, breakpoint) => {
                     const trimmed = searchTerm.trim()

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -597,6 +597,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         items.push({
                             id: `group-${groupTypeIndex}-${group.group_key}`,
                             name: `${noun}: ${display}`,
+                            displayName: display,
                             category: 'groups' as NEW_TAB_CATEGORY_ITEMS,
                             href,
                             icon: <IconPeople />,
@@ -606,6 +607,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                                 href,
                                 groupTypeIndex,
                                 groupKey: group.group_key,
+                                groupNoun: noun,
+                                groupDisplayName: display,
                             },
                         })
                     })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1372,7 +1372,7 @@ export type SearchResponse = {
     counts: Record<SearchableEntity, number | null>
 }
 
-export type GroupListParams = { group_type_index: GroupTypeIndex; search: string }
+export type GroupListParams = { group_type_index: GroupTypeIndex; search: string; limit?: number }
 
 export type CreateGroupParams = {
     group_type_index: GroupTypeIndex


### PR DESCRIPTION
## Changes

Support groups on the new tab page.

<img width="627" height="282" alt="image" src="https://github.com/user-attachments/assets/b060535b-7689-4696-9f60-c23fdc6011cc" />


## How did you test this code?

Searched for them locally, see image above. 
