### PR TITLE
fix(max): scroll jumps in the new UI

### DIFF
--- a/ee/hogai/assistant/main_assistant.py
+++ b/ee/hogai/assistant/main_assistant.py
@@ -22,7 +22,7 @@ from ee.hogai.graph import (
     TrendsGeneratorNode,
 )
 from ee.hogai.graph.base import BaseAssistantNode
-from ee.hogai.graph.taxonomy.types import TaxonomyNodeName
+from ee.hogai.graph.insights.nodes import InsightSearchNode
 from ee.hogai.utils.state import GraphValueUpdateTuple, validate_value_update
 from ee.hogai.utils.types import (
     AssistantMode,
@@ -78,6 +78,7 @@ class MainAssistant(BaseAssistant):
             AssistantNodeName.FUNNEL_GENERATOR: FunnelGeneratorNode,
             AssistantNodeName.RETENTION_GENERATOR: RetentionGeneratorNode,
             AssistantNodeName.SQL_GENERATOR: SQLGeneratorNode,
+            AssistantNodeName.INSIGHTS_SEARCH: InsightSearchNode,
         }
 
     @property
@@ -89,9 +90,6 @@ class MainAssistant(BaseAssistant):
             AssistantNodeName.MEMORY_INITIALIZER,
             AssistantNodeName.MEMORY_ONBOARDING_ENQUIRY,
             AssistantNodeName.MEMORY_ONBOARDING_FINALIZE,
-            TaxonomyNodeName.LOOP_NODE,
-            AssistantNodeName.SESSION_SUMMARIZATION,
-            AssistantNodeName.INSIGHTS_SEARCH,
             AssistantNodeName.DASHBOARD_CREATION,
         }
 

--- a/ee/hogai/graph/dashboards/nodes.py
+++ b/ee/hogai/graph/dashboards/nodes.py
@@ -441,7 +441,6 @@ class DashboardCreationNode(AssistantNode):
             model="gpt-4.1-mini",
             temperature=0.3,
             max_completion_tokens=500,
-            streaming=True,
-            stream_usage=True,
             max_retries=3,
+            disable_streaming=True,
         )

--- a/ee/hogai/graph/query_planner/nodes.py
+++ b/ee/hogai/graph/query_planner/nodes.py
@@ -160,6 +160,7 @@ class QueryPlannerNode(TaxonomyUpdateDispatcherNodeMixin, AssistantNode):
             # LangChain sometimes incorrectly handles reasoning items. They fixed it in the new output version.
             # Ref: https://forum.langchain.com/t/langgraph-openai-responses-api-400-error-web-search-call-was-provided-without-its-required-reasoning-item/1740/2
             output_version="responses/v1",
+            disable_streaming=True,
         ).bind_tools(
             [
                 retrieve_event_properties,

--- a/ee/hogai/graph/taxonomy/nodes.py
+++ b/ee/hogai/graph/taxonomy/nodes.py
@@ -74,7 +74,7 @@ class TaxonomyAgentNode(
 
     def _get_model(self, state: TaxonomyStateType):
         return MaxChatOpenAI(
-            model="gpt-4.1", streaming=False, temperature=0.3, user=self._user, team=self._team
+            model="gpt-4.1", streaming=False, temperature=0.3, user=self._user, team=self._team, disable_streaming=True
         ).bind_tools(
             self._toolkit.get_tools(),
             tool_choice="required",


### PR DESCRIPTION
## Problem

There were multiple issues in the new UI with scrolling that also partially exist in the old UI:
- Insight search emitted VisualizationMessages, but it didn't send them to the frontend.
- Loaders had been changed in VizNodes, so we don't get the static height. That was producing unwanted scroll behavior.
- VisualizationMessage was updating more than needed.
- Race condition between useEffect and useLayoutEffect.

## Changes

- Fix all the issues above.

**Demo**

https://posthog.slack.com/archives/C06NZEZ7V3Q/p1761647743858649?thread_ts=1761597684.054129&cid=C06NZEZ7V3Q

## How did you test this code?

Manual tests