### PR TITLE
fix(hogli): break circular dependency in grammar:build

### DIFF
--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -40,6 +40,7 @@ jobs:
                         - 'posthog/hogql/**/*'
                         - 'bin/hog'
                         - 'bin/hoge'
+                        - 'package.json'
                         - requirements.txt
                         - requirements-dev.txt
                         - .github/workflows/ci-hog.yml

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "schema:build:python": "bash bin/build-schema-python.sh",
         "taxonomy:build": "pnpm run taxonomy:build:json",
         "taxonomy:build:json": "python bin/build-taxonomy-json.py",
-        "grammar:build": "bin/hogli build:grammar",
+        "grammar:build": "pnpm grammar:build:python && pnpm grammar:build:cpp",
         "grammar:build:python": "cd posthog/hogql/grammar && cat HogQLLexer.python.g4 > HogQLLexer.g4 && tail -n +2 HogQLLexer.common.g4 |sed s/isOpeningTag/self.isOpeningTag/ >> HogQLLexer.g4 && antlr -Dlanguage=Python3 HogQLLexer.g4 && rm HogQLLexer.g4 && antlr -visitor -no-listener -Dlanguage=Python3 HogQLParser.g4",
         "grammar:build:cpp": "cd posthog/hogql/grammar && cat HogQLLexer.cpp.g4 > HogQLLexer.g4 && tail -n +2 HogQLLexer.common.g4 >> HogQLLexer.g4 && antlr -o ../../../common/hogql_parser -Dlanguage=Cpp HogQLLexer.g4 && rm HogQLLexer.g4 && antlr -o ../../../common/hogql_parser -visitor -no-listener -Dlanguage=Cpp HogQLParser.g4",
         "generate:source-configs": "DEBUG=1 python manage.py generate_source-configs",


### PR DESCRIPTION
## Problem
CI was failing due to a circular dependency in grammar:build:
1. `package.json`: `grammar:build` → `bin/hogli build:grammar`
2. `hogli manifest`: `build:grammar` → `pnpm grammar:build`
3. This creates an infinite loop: pnpm → hogli → pnpm → hogli...

Additionally, the ci-hog workflow didn't trigger on package.json changes, so the grammar build check wasn't running when the command definition changed.

## Solution
1. **Restore package.json** to call sub-commands directly (as it was before hogli):
   ```json
   "grammar:build": "pnpm grammar:build:python && pnpm grammar:build:cpp"
   ```

2. **Update hogli manifest** to delegate to pnpm:
   ```yaml
   build:grammar:
     cmd: pnpm grammar:build
   ```

3. **Add package.json to ci-hog triggers** so grammar build changes are tested

This gives us clean delegation: hogli → pnpm → actual commands, with no loops.

## Test plan
- [x] Tested locally - no infinite loop
- [x] CI Hog tests should now run on this PR (package.json changed)
- [x] Grammar build check should pass

## Related
- Introduced in #40406 when we changed package.json to use `bin/hogli`
- Fixes CI failures like https://github.com/PostHog/posthog/actions/runs/18871232621/job/53849974737