### PR TITLE
feat(sessions): Remove team id condition, limit to 1 partiton per run

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -35,9 +35,9 @@ def sessions_v3_backfill(context: AssetExecutionContext):
     backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause)
 
     partition_range = context.partition_key_range
-    range = f"{partition_range.start} to {partition_range.end}"
+    partition_range_str = f"{partition_range.start} to {partition_range.end}"
     context.log.info(
-        f"Running backfill for {range} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
+        f"Running backfill for {partition_range_str} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
 
     cluster = get_cluster()
@@ -47,6 +47,6 @@ def sessions_v3_backfill(context: AssetExecutionContext):
 
     cluster.map_one_host_per_shard(backfill_per_shard)
 
-    context.log.info(f"Successfully backfilled sessions_v3 for {range}")
+    context.log.info(f"Successfully backfilled sessions_v3 for {partition_range_str}")
 
-    return f"Backfilled for {range}"
+    return f"Backfilled for {partition_range_str}"

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -6,9 +6,7 @@ from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import RAW_SESSION_TABLE_BACKFILL_SQL_V3
 
 # Each partition is pretty heavy, as it's an entire month of events, so this number doesn't need to be high
-MAX_PARTITIONS_PER_RUN = 3
-
-RESTRICTED_TEAM_IDS = [1, 2]  # only run the backfill on posthog teams for now
+MAX_PARTITIONS_PER_RUN = 1
 
 monthly_partitions = MonthlyPartitionsDefinition(
     start_date="2019-01-01",  # this is a year before posthog was founded, so should be early enough even including data imports
@@ -31,16 +29,15 @@ def get_partion_where_clause(context: AssetExecutionContext) -> str:
 )
 def sessions_v3_backfill(context: AssetExecutionContext):
     where_clause = get_partion_where_clause(context)
-    if RESTRICTED_TEAM_IDS:
-        where_clause += f" AND team_id IN ({', '.join(str(t) for t in RESTRICTED_TEAM_IDS)})"
 
     # note that this is idempotent, so we don't need to worry about running it multiple times for the same partition
     # as long as the backfill has run at least once for each partition, the data will be correct
     backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause)
 
     partition_range = context.partition_key_range
+    range = f"{partition_range.start} to {partition_range.end}"
     context.log.info(
-        f"Running backfill for {partition_range.start} to {partition_range.end} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
+        f"Running backfill for {range} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
 
     cluster = get_cluster()
@@ -50,6 +47,6 @@ def sessions_v3_backfill(context: AssetExecutionContext):
 
     cluster.map_one_host_per_shard(backfill_per_shard)
 
-    context.log.info(f"Successfully backfilled sessions_v3 for {context.partition_key}")
+    context.log.info(f"Successfully backfilled sessions_v3 for {range}")
 
-    return f"Backfilled {context.partition_key}"
+    return f"Backfilled for {range}"


### PR DESCRIPTION
## Problem

* We're ready to start backfilling for real


## Changes

* Remove the team id filter
* Reduce the amount of work that happens in one go, by reducing the partition count per run from 3 to 1
* Fix an exception when logging a successful run 🤦 

## How did you test this code?

n/a (it's a dagster job to be manually run by me)

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
