### PR TITLE
chore(devex): expand CODEOWNERS-soft coverage for devex team

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -116,7 +116,11 @@ ee/session_recordings/**/*.py @PostHog/team-replay
 ee/frontend/mobile-replay @PostHog/team-replay
 
 # DevEx
-
-posthog/management/migration_analysis/ @PostHog/DevEx
-common/hogli/ @PostHog/DevEx
-bin/ @PostHog/DevEx
+Dockerfile @PostHog/team-devex
+docker-compose*.yml @PostHog/team-devex
+pyproject.toml @PostHog/team-devex
+.prettierrc @PostHog/team-devex
+mypy.ini @PostHog/team-devex
+posthog/management/migration_analysis/ @PostHog/team-devex
+common/hogli/ @PostHog/team-devex
+bin/ @PostHog/team-devex


### PR DESCRIPTION
## Summary
- Add devex team ownership for Docker configuration files (Dockerfile, docker-compose*.yml)
- Add devex team ownership for Python tooling (pyproject.toml, mypy.ini)
- Add devex team ownership for code formatting (.prettierrc)

## Why
Ensures devex team gets tagged on PRs touching build setup, dependencies, and dev tooling configuration so we can catch potential dev friction issues early.

## Test plan
- CODEOWNERS-soft file updated with additional patterns
- Follows existing file structure and conventions