### PR TITLE
fix(workflows): allow reverting hogflow trigger masking

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -351,10 +351,15 @@ function FrequencySection(): JSX.Element {
                         options={FREQUENCY_OPTIONS}
                         value={workflow.trigger_masking?.hash ?? null}
                         onChange={(val) =>
-                            setWorkflowValue('trigger_masking', {
-                                hash: val,
-                                ttl: workflow.trigger_masking?.ttl ?? 60 * 30,
-                            })
+                            setWorkflowValue(
+                                'trigger_masking',
+                                val
+                                    ? {
+                                          hash: val,
+                                          ttl: workflow.trigger_masking?.ttl ?? 60 * 30,
+                                      }
+                                    : null
+                            )
                         }
                     />
                     {workflow.trigger_masking?.hash ? (


### PR DESCRIPTION
## Problem

Noticed a bug that blocks from saving when you had a trigger mask set (selected "One time per ___"), but then later switch back to no trigger mask ("Every time the trigger fires")

<img width="346" height="221" alt="image" src="https://github.com/user-attachments/assets/03288e16-6063-4396-a3e3-679821f9421f" />


## Changes

Fixes the bug

## How did you test this code?

Validated successful save after reverting
