### PR TITLE
feat(customers): Add error tracking issues node to group feed

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11176,6 +11176,12 @@
                 "filterTestAccounts": {
                     "type": "boolean"
                 },
+                "groupKey": {
+                    "type": "string"
+                },
+                "groupTypeIndex": {
+                    "$ref": "#/definitions/integer"
+                },
                 "issueId": {
                     "type": "string"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2222,6 +2222,8 @@ export interface ErrorTrackingQuery extends DataNode<ErrorTrackingQueryResponse>
     limit?: integer
     offset?: integer
     personId?: string
+    groupKey?: string
+    groupTypeIndex?: integer
 }
 
 export interface ErrorTrackingSimilarIssuesQuery extends DataNode<ErrorTrackingSimilarIssuesQueryResponse> {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
@@ -37,6 +37,7 @@ const ContextualFilters = ({ children, nodeId }: PropsWithChildren<{ nodeId: str
 }
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttributes>): JSX.Element | null => {
+    const { personId, groupKey, groupTypeIndex } = attributes
     const { expanded } = useValues(notebookNodeLogic)
 
     if (!expanded) {
@@ -46,13 +47,19 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttribute
     return (
         <ContextualFilters nodeId={attributes.nodeId}>
             <ErrorTrackingSetupPrompt className="border-none">
-                <IssuesQuery personId={attributes.personId} />
+                <IssuesQuery personId={personId} groupKey={groupKey} groupTypeIndex={groupTypeIndex} />
             </ErrorTrackingSetupPrompt>
         </ContextualFilters>
     )
 }
 
-const IssuesQuery = ({ personId }: { personId: string }): JSX.Element => {
+interface IssuesQueryProps {
+    personId?: string
+    groupKey?: string
+    groupTypeIndex?: number
+}
+
+const IssuesQuery = ({ personId, groupKey, groupTypeIndex }: IssuesQueryProps): JSX.Element => {
     const { dateRange, filterTestAccounts, filterGroup, searchQuery } = useValues(issueFiltersLogic)
     const { assignee, orderBy, orderDirection, status } = useValues(issueQueryOptionsLogic)
 
@@ -68,9 +75,11 @@ const IssuesQuery = ({ personId }: { personId: string }): JSX.Element => {
         columns: ['error', 'volume', 'occurrences', 'sessions', 'users'],
         orderDirection,
         personId,
+        groupKey,
+        groupTypeIndex,
     })
     const insightProps: InsightLogicProps = {
-        dashboardItemId: `new-NotebookNodeIssues-${personId}`,
+        dashboardItemId: `new-NotebookNodeIssues-${personId || groupKey}`,
     }
 
     return (
@@ -94,7 +103,9 @@ export const Settings = ({
 }
 
 type NotebookNodeIssuesAttributes = {
-    personId: string
+    personId?: string
+    groupKey?: string
+    groupTypeIndex?: number
 }
 
 export const NotebookNodeIssues = createPostHogWidgetNode<NotebookNodeIssuesAttributes>({
@@ -107,5 +118,7 @@ export const NotebookNodeIssues = createPostHogWidgetNode<NotebookNodeIssuesAttr
     startExpanded: true,
     attributes: {
         personId: {},
+        groupKey: {},
+        groupTypeIndex: {},
     },
 })

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -13404,6 +13404,8 @@ class ErrorTrackingQuery(BaseModel):
     dateRange: DateRange
     filterGroup: Optional[PropertyGroupFilter] = None
     filterTestAccounts: Optional[bool] = None
+    groupKey: Optional[str] = None
+    groupTypeIndex: Optional[int] = None
     issueId: Optional[str] = None
     kind: Literal["ErrorTrackingQuery"] = "ErrorTrackingQuery"
     limit: Optional[int] = None

--- a/products/customer_analytics/frontend/components/GroupFeedCanvas/GroupFeedCanvas.tsx
+++ b/products/customer_analytics/frontend/components/GroupFeedCanvas/GroupFeedCanvas.tsx
@@ -9,6 +9,7 @@ type GroupFeedCanvas = {
 
 const GroupFeedCanvas = ({ group }: GroupFeedCanvas): JSX.Element => {
     const groupKey = group.group_key
+    const groupTypeIndex = group.group_type_index
 
     return (
         <Notebook
@@ -22,14 +23,14 @@ const GroupFeedCanvas = ({ group }: GroupFeedCanvas): JSX.Element => {
                         type: 'ph-usage-metrics',
                         attrs: {
                             groupKey,
-                            groupTypeIndex: group.group_type_index,
+                            groupTypeIndex,
                             nodeId: uuid(),
                             children: [
                                 {
                                     type: 'ph-group',
                                     attrs: {
                                         id: groupKey,
-                                        groupTypeIndex: group.group_type_index,
+                                        groupTypeIndex,
                                         nodeId: uuid(),
                                         title: 'Info',
                                     },
@@ -38,7 +39,7 @@ const GroupFeedCanvas = ({ group }: GroupFeedCanvas): JSX.Element => {
                                     type: 'ph-group-properties',
                                     attrs: {
                                         groupKey,
-                                        groupTypeIndex: group.group_type_index,
+                                        groupTypeIndex,
                                         nodeId: uuid(),
                                     },
                                 },
@@ -46,7 +47,7 @@ const GroupFeedCanvas = ({ group }: GroupFeedCanvas): JSX.Element => {
                                     type: 'ph-related-groups',
                                     attrs: {
                                         id: groupKey,
-                                        groupTypeIndex: group.group_type_index,
+                                        groupTypeIndex,
                                         nodeId: uuid(),
                                         title: 'Related people',
                                         type: 'person',
@@ -54,6 +55,10 @@ const GroupFeedCanvas = ({ group }: GroupFeedCanvas): JSX.Element => {
                                 },
                             ],
                         },
+                    },
+                    {
+                        type: 'ph-issues',
+                        attrs: { groupKey, groupTypeIndex, nodeId: uuid() },
                     },
                 ],
             }}

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -472,6 +472,15 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
                 )
             )
 
+        if self.query.groupKey and self.query.groupTypeIndex is not None:
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=[f"$group_{self.query.groupTypeIndex}"]),
+                    right=ast.Constant(value=self.query.groupKey),
+                )
+            )
+
         if self.query.searchQuery:
             # TODO: Refine this so it only searches the frames inside $exception_list
             # TODO: We'd eventually need a more efficient searching strategy

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -356,6 +356,126 @@
                     allow_experimental_join_condition=1
   '''
 # ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter
+  '''
+  SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')) AS id,
+         max(toTimeZone(e.timestamp, 'UTC')) AS last_seen,
+         min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
+         argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
+  FROM events AS e
+  LEFT OUTER JOIN
+    (SELECT argMax(error_tracking_issue_fingerprint_overrides.issue_id, error_tracking_issue_fingerprint_overrides.version) AS issue_id,
+            error_tracking_issue_fingerprint_overrides.fingerprint AS fingerprint
+     FROM error_tracking_issue_fingerprint_overrides
+     WHERE equals(error_tracking_issue_fingerprint_overrides.team_id, 99999)
+     GROUP BY error_tracking_issue_fingerprint_overrides.fingerprint
+     HAVING ifNull(equals(argMax(error_tracking_issue_fingerprint_overrides.is_deleted, error_tracking_issue_fingerprint_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__exception_issue_override ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), e__exception_issue_override.fingerprint)
+  WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID'))), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'org:acme'))
+  GROUP BY id
+  ORDER BY last_seen DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.1
+  '''
+  SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')) AS id,
+         max(toTimeZone(e.timestamp, 'UTC')) AS last_seen,
+         min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
+         argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
+  FROM events AS e
+  LEFT OUTER JOIN
+    (SELECT argMax(error_tracking_issue_fingerprint_overrides.issue_id, error_tracking_issue_fingerprint_overrides.version) AS issue_id,
+            error_tracking_issue_fingerprint_overrides.fingerprint AS fingerprint
+     FROM error_tracking_issue_fingerprint_overrides
+     WHERE equals(error_tracking_issue_fingerprint_overrides.team_id, 99999)
+     GROUP BY error_tracking_issue_fingerprint_overrides.fingerprint
+     HAVING ifNull(equals(argMax(error_tracking_issue_fingerprint_overrides.is_deleted, error_tracking_issue_fingerprint_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__exception_issue_override ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), e__exception_issue_override.fingerprint)
+  WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID'))), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'org:widgets'))
+  GROUP BY id
+  ORDER BY last_seen DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.2
+  '''
+  SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')) AS id,
+         max(toTimeZone(e.timestamp, 'UTC')) AS last_seen,
+         min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
+         argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
+  FROM events AS e
+  LEFT OUTER JOIN
+    (SELECT argMax(error_tracking_issue_fingerprint_overrides.issue_id, error_tracking_issue_fingerprint_overrides.version) AS issue_id,
+            error_tracking_issue_fingerprint_overrides.fingerprint AS fingerprint
+     FROM error_tracking_issue_fingerprint_overrides
+     WHERE equals(error_tracking_issue_fingerprint_overrides.team_id, 99999)
+     GROUP BY error_tracking_issue_fingerprint_overrides.fingerprint
+     HAVING ifNull(equals(argMax(error_tracking_issue_fingerprint_overrides.is_deleted, error_tracking_issue_fingerprint_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__exception_issue_override ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), e__exception_issue_override.fingerprint)
+  WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID'))), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_1`, 'project:alpha'))
+  GROUP BY id
+  ORDER BY last_seen DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.3
+  '''
+  SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')) AS id,
+         max(toTimeZone(e.timestamp, 'UTC')) AS last_seen,
+         min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
+         argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
+  FROM events AS e
+  LEFT OUTER JOIN
+    (SELECT argMax(error_tracking_issue_fingerprint_overrides.issue_id, error_tracking_issue_fingerprint_overrides.version) AS issue_id,
+            error_tracking_issue_fingerprint_overrides.fingerprint AS fingerprint
+     FROM error_tracking_issue_fingerprint_overrides
+     WHERE equals(error_tracking_issue_fingerprint_overrides.team_id, 99999)
+     GROUP BY error_tracking_issue_fingerprint_overrides.fingerprint
+     HAVING ifNull(equals(argMax(error_tracking_issue_fingerprint_overrides.is_deleted, error_tracking_issue_fingerprint_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__exception_issue_override ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), e__exception_issue_override.fingerprint)
+  WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID'))), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'nonexistent'))
+  GROUP BY id
+  ORDER BY last_seen DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestErrorTrackingQueryRunner.test_hogql_filters
   '''
   SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')) AS id,

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -160,6 +160,8 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, APIBaseTest):
         withAggregations=False,
         withFirstEvent=False,
         personId=None,
+        groupKey=None,
+        groupTypeIndex=None,
     ):
         return (
             ErrorTrackingQueryRunner(
@@ -180,6 +182,8 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     withFirstEvent=withFirstEvent,
                     withAggregations=withAggregations,
                     personId=personId,
+                    groupKey=groupKey,
+                    groupTypeIndex=groupTypeIndex,
                 ),
             )
             .calculate()
@@ -561,6 +565,52 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], issue_id)
+
+    @freeze_time("2022-01-10T12:11:00")
+    @snapshot_clickhouse_queries
+    def test_group_key_filter(self):
+        group_a_id = "org:acme"
+        group_b_id = "org:widgets"
+        project_1_id = "project:alpha"
+
+        issue_id_group_a = "784bd8ae-498f-4548-bc05-e621b5b5b9a1"
+        issue_id_group_b = "784bd8ae-498f-4548-bc05-e621b5b5b9a2"
+        issue_id_project_1 = "784bd8ae-498f-4548-bc05-e621b5b5b9a3"
+
+        self.create_events_and_issue(
+            issue_id=issue_id_group_a,
+            fingerprint="fingerprint_group_a",
+            distinct_ids=[self.distinct_id_one],
+            additional_properties={"$group_0": group_a_id},
+        )
+        self.create_events_and_issue(
+            issue_id=issue_id_group_b,
+            fingerprint="fingerprint_group_b",
+            distinct_ids=[self.distinct_id_two],
+            additional_properties={"$group_0": group_b_id},
+        )
+        self.create_events_and_issue(
+            issue_id=issue_id_project_1,
+            fingerprint="fingerprint_project_1",
+            distinct_ids=[self.distinct_id_one],
+            additional_properties={"$group_1": project_1_id},
+        )
+        flush_persons_and_events()
+
+        results = self._calculate(groupKey=group_a_id, groupTypeIndex=0)["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], issue_id_group_a)
+
+        results = self._calculate(groupKey=group_b_id, groupTypeIndex=0)["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], issue_id_group_b)
+
+        results = self._calculate(groupKey=project_1_id, groupTypeIndex=1)["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], issue_id_project_1)
+
+        results = self._calculate(groupKey="nonexistent", groupTypeIndex=0)["results"]
+        self.assertEqual(len(results), 0)
 
     @freeze_time("2020-01-10T12:11:00")
     @snapshot_clickhouse_queries

--- a/products/error_tracking/frontend/__snapshots__/queries.test.ts.snap
+++ b/products/error_tracking/frontend/__snapshots__/queries.test.ts.snap
@@ -26,6 +26,8 @@ exports[`queries errorTrackingQuery usage in web analytics should return a query
       ],
     },
     "filterTestAccounts": true,
+    "groupKey": undefined,
+    "groupTypeIndex": undefined,
     "kind": "ErrorTrackingQuery",
     "limit": 4,
     "orderBy": "users",

--- a/products/error_tracking/frontend/queries.ts
+++ b/products/error_tracking/frontend/queries.ts
@@ -40,6 +40,8 @@ export const errorTrackingQuery = ({
     columns,
     orderDirection,
     personId,
+    groupKey,
+    groupTypeIndex,
     limit = 50,
 }: Pick<
     ErrorTrackingQuery,
@@ -52,6 +54,8 @@ export const errorTrackingQuery = ({
     | 'searchQuery'
     | 'orderDirection'
     | 'personId'
+    | 'groupKey'
+    | 'groupTypeIndex'
 > & {
     filterGroup: UniversalFiltersGroup
     columns: string[]
@@ -74,6 +78,8 @@ export const errorTrackingQuery = ({
             withAggregations: true,
             withFirstEvent: false,
             personId,
+            groupKey,
+            groupTypeIndex,
             tags: {
                 productKey: ProductKey.ERROR_TRACKING,
             },


### PR DESCRIPTION
## Problem

Let's add a way to visualize the issues of a group in group feed.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Closes https://github.com/PostHog/posthog/issues/39970

## Changes

- Update `ErrorTrackingQueryRunner` to support filtering by group key + index
- Update `NotebookNodeIssues` to take in group props and pass it to the query
- Add `NotebookNodeIssues` to `GroupFeedCanvas`

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Unit tests for the backend
- Frontend - Ensuring issues node shows correct data
    - Navigated to a group with issues
    - Ensured the list showed issues
    - Expanded issue details
    - Opened event of last occurrence (it was the only)
    - Ensured the group key was correctly in `group_{index}` property
- Frontend - Ensuring issues node doesn't break when group has no issues
    - Navigated to group without issues
    - Ensured the node showed the empty state
- Frontend - Ensuring other scenes are working as before
    - Navigated to Error Tracking product and ensured the page was working as before
    - Navigated to person feed and ensured the issues node was working as before

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->