### PR TITLE
feat(saved_queries): refactor saved query handling by consolidating model path setup and materialization logic

### DIFF
--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -41,13 +41,9 @@ from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.temporal.common.client import sync_connect
 
 from products.data_warehouse.backend.data_load.saved_query_service import (
-    delete_saved_query_schedule,
     pause_saved_query_schedule,
     recreate_model_paths,
-    saved_query_workflow_exists,
-    sync_saved_query_workflow,
     trigger_saved_query_schedule,
-    unpause_saved_query_schedule,
 )
 from products.data_warehouse.backend.models import (
     CLICKHOUSE_HOGQL_MAPPING,
@@ -195,7 +191,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
         with transaction.atomic():
             view.save()
             try:
-                DataWarehouseModelPath.objects.create_from_saved_query(view)
+                view.setup_model_paths()
             except Exception:
                 # For now, do not fail saved query creation if we cannot model-ize it.
                 # Later, after bugs and errors have been ironed out, we may tie these two
@@ -305,7 +301,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
                 view.save()
 
             try:
-                DataWarehouseModelPath.objects.update_from_saved_query(view)
+                view.setup_model_paths()
             except Exception:
                 logger.exception("Failed to update model path when updating view %s", view.name)
 
@@ -339,10 +335,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
                 recreate_model_paths(view)
 
         if was_sync_frequency_updated:
-            schedule_exists = saved_query_workflow_exists(str(instance.id))
-            if schedule_exists and before_update and before_update.sync_frequency_interval is None:
-                unpause_saved_query_schedule(str(instance.id))
-            sync_saved_query_workflow(view, create=not schedule_exists)
+            view.enable_materialization(unpause=before_update and before_update.sync_frequency_interval is None)
 
         return view
 
@@ -496,8 +489,6 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
                 "Cannot delete a query from a managed viewset directly. Disable the managed viewset instead."
             )
 
-        delete_saved_query_schedule(str(instance.id))
-
         for join in DataWarehouseJoin.objects.filter(
             Q(team_id=instance.team_id) & (Q(source_table_name=instance.name) | Q(joining_table_name=instance.name))
         ).exclude(deleted=True):
@@ -506,6 +497,7 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
         if instance.table is not None:
             instance.table.soft_delete()
 
+        instance.revert_materialization()
         instance.soft_delete()
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -494,9 +494,6 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
         ).exclude(deleted=True):
             join.soft_delete()
 
-        if instance.table is not None:
-            instance.table.soft_delete()
-
         instance.revert_materialization()
         instance.soft_delete()
 

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -335,7 +335,9 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
                 recreate_model_paths(view)
 
         if was_sync_frequency_updated:
-            view.enable_materialization(unpause=before_update and before_update.sync_frequency_interval is None)
+            view.enable_materialization(
+                unpause=before_update is not None and before_update.sync_frequency_interval is None
+            )
 
         return view
 

--- a/products/data_warehouse/backend/api/test/test_saved_query.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query.py
@@ -86,8 +86,11 @@ class TestSavedQuery(APIBaseTest):
         assert saved_query_id is not None
 
         with (
-            patch("products.data_warehouse.backend.api.saved_query.sync_saved_query_workflow"),
-            patch("products.data_warehouse.backend.api.saved_query.saved_query_workflow_exists", return_value=False),
+            patch("products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"),
+            patch(
+                "products.data_warehouse.backend.data_load.saved_query_service.saved_query_workflow_exists",
+                return_value=False,
+            ),
         ):
             response = self.client.patch(
                 f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_id}",
@@ -146,10 +149,13 @@ class TestSavedQuery(APIBaseTest):
             mock_pause_saved_query_schedule.assert_called()
 
         with (
-            patch("products.data_warehouse.backend.api.saved_query.sync_saved_query_workflow"),
-            patch("products.data_warehouse.backend.api.saved_query.saved_query_workflow_exists", return_value=True),
+            patch("products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"),
             patch(
-                "products.data_warehouse.backend.api.saved_query.unpause_saved_query_schedule"
+                "products.data_warehouse.backend.data_load.saved_query_service.saved_query_workflow_exists",
+                return_value=True,
+            ),
+            patch(
+                "products.data_warehouse.backend.data_load.saved_query_service.unpause_saved_query_schedule"
             ) as mock_unpause_saved_query_schedule,
         ):
             response = self.client.patch(
@@ -267,7 +273,7 @@ class TestSavedQuery(APIBaseTest):
         saved_query = DataWarehouseSavedQuery.objects.create(team=self.team, name=query_name)
 
         with patch(
-            "products.data_warehouse.backend.api.saved_query.delete_saved_query_schedule"
+            "products.data_warehouse.backend.data_load.saved_query_service.delete_saved_query_schedule"
         ) as mock_delete_saved_query_schedule:
             response = self.client.delete(
                 f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query.id}",
@@ -366,13 +372,13 @@ class TestSavedQuery(APIBaseTest):
 
         with (
             patch(
-                "products.data_warehouse.backend.api.saved_query.sync_saved_query_workflow"
+                "products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"
             ) as mock_sync_saved_query_workflow,
             patch(
-                "products.data_warehouse.backend.api.saved_query.saved_query_workflow_exists"
+                "products.data_warehouse.backend.data_load.saved_query_service.saved_query_workflow_exists"
             ) as mock_saved_query_workflow_exists,
             patch(
-                "products.data_warehouse.backend.api.saved_query.unpause_saved_query_schedule"
+                "products.data_warehouse.backend.data_load.saved_query_service.unpause_saved_query_schedule"
             ) as mock_unpause_saved_query_schedule,
         ):
             mock_saved_query_workflow_exists.return_value = True
@@ -456,7 +462,7 @@ class TestSavedQuery(APIBaseTest):
         saved_query = response.json()
 
         with patch(
-            "products.data_warehouse.backend.api.saved_query.delete_saved_query_schedule"
+            "products.data_warehouse.backend.data_load.saved_query_service.delete_saved_query_schedule"
         ) as mock_delete_saved_query_schedule:
             response = self.client.delete(
                 f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",

--- a/products/data_warehouse/backend/data_load/saved_query_service.py
+++ b/products/data_warehouse/backend/data_load/saved_query_service.py
@@ -28,13 +28,11 @@ from posthog.temporal.common.schedule import (
     unpause_schedule,
     update_schedule,
 )
-from posthog.temporal.data_modeling.run_workflow import RunWorkflowInputs, Selector
 
 from products.data_warehouse.backend.models import DataWarehouseModelPath
-from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 
 if TYPE_CHECKING:
-    from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+    from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 
 
 def get_sync_frequency(saved_query: "DataWarehouseSavedQuery") -> tuple[timedelta, timedelta]:
@@ -49,6 +47,8 @@ def get_sync_frequency(saved_query: "DataWarehouseSavedQuery") -> tuple[timedelt
 
 
 def get_saved_query_schedule(saved_query: "DataWarehouseSavedQuery") -> Schedule:
+    from posthog.temporal.data_modeling.run_workflow import RunWorkflowInputs, Selector
+
     inputs = RunWorkflowInputs(
         team_id=saved_query.team_id,
         select=[Selector(label=saved_query.id.hex, ancestors=0, descendants=0)],
@@ -123,7 +123,7 @@ def trigger_saved_query_schedule(saved_query: "DataWarehouseSavedQuery"):
     trigger_schedule(temporal, schedule_id=str(saved_query.id))
 
 
-def recreate_model_paths(saved_query: DataWarehouseSavedQuery) -> None:
+def recreate_model_paths(saved_query: "DataWarehouseSavedQuery") -> None:
     """
     Recreate model paths for a saved query after materialization.
     After a query has been reverted and then re-materialized, we need to ensure

--- a/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
@@ -104,9 +104,8 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
                 saved_query.external_tables = saved_query.s3_tables
                 saved_query.is_materialized = True
                 saved_query.sync_frequency_interval = timedelta(hours=12)
-                saved_query.save()
 
-                saved_query.setup_model_paths()
+                saved_query.save()
                 saved_query.enable_materialization()
 
                 if created:

--- a/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
@@ -21,7 +21,6 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 
 from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
 from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind
 from products.revenue_analytics.backend.views.schemas import SCHEMAS as REVENUE_ANALYTICS_SCHEMAS
 
@@ -68,7 +67,6 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
         Deletes views that are no longer referenced.
         Materializes views by default.
         """
-        from products.data_warehouse.backend.data_load.saved_query_service import sync_saved_query_workflow
 
         expected_views: list[ExpectedView] = []
         if self.kind == DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS:
@@ -108,35 +106,13 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
                 saved_query.sync_frequency_interval = timedelta(hours=12)
                 saved_query.save()
 
-                # Make sure paths properly exist both on creation and update
-                # This is required for Temporal to properly build the DAG
-                if not DataWarehouseModelPath.objects.filter(team=saved_query.team, saved_query=saved_query).exists():
-                    DataWarehouseModelPath.objects.create_from_saved_query(saved_query)
-                else:
-                    DataWarehouseModelPath.objects.update_from_saved_query(saved_query)
+                saved_query.setup_model_paths()
+                saved_query.enable_materialization()
 
                 if created:
                     views_created += 1
                 else:
                     views_updated += 1
-
-                if created:
-                    try:
-                        sync_saved_query_workflow(saved_query, create=True)
-                    except Exception as e:
-                        capture_exception(e, {"managed_viewset_id": self.id, "view_name": saved_query.name})
-                        logger.warning(
-                            "failed_to_schedule_saved_query",
-                            team_id=self.team_id,
-                            saved_query_id=str(saved_query.id),
-                            error=str(e),
-                        )
-
-                        # Disable materialization for this view if we failed to schedule the workflow
-                        # TODO: Should we have a cron job that re-enables materialization for managed viewset-based views
-                        # that failed to schedule?
-                        saved_query.is_materialized = False
-                        saved_query.save(update_fields=["is_materialized"])
 
             views_deleted = 0
             orphaned_views = self.saved_queries.exclude(name__in=expected_view_names).exclude(deleted=True)

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -131,11 +131,11 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
 
     def enable_materialization(self, unpause: bool = False):
         """
-        Should be called for an already saved query with model paths already setup - see `setup_model_paths`.
         It will schedule the saved query workflow to run at the configured frequency.
         If unpause is True, it will unpause the saved query workflow if it already exists.
 
         If the workflow fails to schedule, it will disable materialization for this view.
+        This also guarantees model paths are properly created or updated.
         """
         from products.data_warehouse.backend.data_load.saved_query_service import (
             saved_query_workflow_exists,
@@ -144,6 +144,8 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
         )
 
         try:
+            self.setup_model_paths()
+
             schedule_exists = saved_query_workflow_exists(str(self.id))
             if schedule_exists and unpause:
                 unpause_saved_query_schedule(str(self.id))

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 
+import structlog
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.schema import HogQLQueryModifiers
@@ -17,15 +18,24 @@ from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import FieldOrTable, SavedQuery
 from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWarehouseTable
 
+from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UUIDTModel
 from posthog.sync import database_sync_to_async
 
+from products.data_warehouse.backend.data_load.saved_query_service import (
+    saved_query_workflow_exists,
+    sync_saved_query_workflow,
+    unpause_saved_query_schedule,
+)
+from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
 from products.data_warehouse.backend.models.util import (
     CLICKHOUSE_HOGQL_MAPPING,
     STR_TO_HOGQL_MAPPING,
     clean_type,
     remove_named_tuples,
 )
+
+logger = structlog.get_logger(__name__)
 
 
 def validate_saved_query_name(value):
@@ -116,6 +126,40 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
     @property
     def name_chain(self) -> list[str]:
         return self.name.split(".")
+
+    def setup_model_paths(self):
+        if not DataWarehouseModelPath.objects.filter(team=self.team, saved_query=self).exists():
+            DataWarehouseModelPath.objects.create_from_saved_query(self)
+        else:
+            DataWarehouseModelPath.objects.update_from_saved_query(self)
+
+    def enable_materialization(self, unpause: bool = False):
+        """
+        Should be called for an already saved query with model paths already setup - see `setup_model_paths`.
+        It will schedule the saved query workflow to run at the configured frequency.
+        If unpause is True, it will unpause the saved query workflow if it already exists.
+
+        If the workflow fails to schedule, it will disable materialization for this view.
+        """
+        try:
+            schedule_exists = saved_query_workflow_exists(str(self.id))
+            if schedule_exists and unpause:
+                unpause_saved_query_schedule(str(self.id))
+            sync_saved_query_workflow(self, create=not schedule_exists)
+        except Exception as e:
+            capture_exception(e, {"saved_query_id": self.id, "saved_query_name": self.name})
+            logger.warning(
+                "failed_to_schedule_saved_query",
+                team_id=self.team_id,
+                saved_query_id=str(self.id),
+                error=str(e),
+            )
+
+            # Disable materialization for this view if we failed to schedule the workflow
+            # TODO: Should we have a cron job that re-enables materialization for managed viewset-based views
+            # that failed to schedule?
+            self.is_materialized = False
+            self.save(update_fields=["is_materialized"])
 
     def revert_materialization(self):
         from products.data_warehouse.backend.data_load.saved_query_service import delete_saved_query_schedule

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -22,11 +22,6 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UUIDTModel
 from posthog.sync import database_sync_to_async
 
-from products.data_warehouse.backend.data_load.saved_query_service import (
-    saved_query_workflow_exists,
-    sync_saved_query_workflow,
-    unpause_saved_query_schedule,
-)
 from products.data_warehouse.backend.models.util import (
     CLICKHOUSE_HOGQL_MAPPING,
     STR_TO_HOGQL_MAPPING,
@@ -142,6 +137,12 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
 
         If the workflow fails to schedule, it will disable materialization for this view.
         """
+        from products.data_warehouse.backend.data_load.saved_query_service import (
+            saved_query_workflow_exists,
+            sync_saved_query_workflow,
+            unpause_saved_query_schedule,
+        )
+
         try:
             schedule_exists = saved_query_workflow_exists(str(self.id))
             if schedule_exists and unpause:

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -27,7 +27,6 @@ from products.data_warehouse.backend.data_load.saved_query_service import (
     sync_saved_query_workflow,
     unpause_saved_query_schedule,
 )
-from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
 from products.data_warehouse.backend.models.util import (
     CLICKHOUSE_HOGQL_MAPPING,
     STR_TO_HOGQL_MAPPING,
@@ -128,6 +127,8 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
         return self.name.split(".")
 
     def setup_model_paths(self):
+        from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
+
         if not DataWarehouseModelPath.objects.filter(team=self.team, saved_query=self).exists():
             DataWarehouseModelPath.objects.create_from_saved_query(self)
         else:
@@ -163,7 +164,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
 
     def revert_materialization(self):
         from products.data_warehouse.backend.data_load.saved_query_service import delete_saved_query_schedule
-        from products.data_warehouse.backend.models import DataWarehouseModelPath
+        from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
 
         with transaction.atomic():
             self.sync_frequency_interval = None

--- a/products/endpoints/backend/tests/test_endpoint_versioning.py
+++ b/products/endpoints/backend/tests/test_endpoint_versioning.py
@@ -447,7 +447,7 @@ class TestEndpointVersioning(ClickhouseTestMixin, APIBaseTest):
         old_saved_query_id = old_saved_query.id
 
         # Mock the sync workflow to avoid triggering actual workflow
-        with patch("products.data_warehouse.backend.api.saved_query.sync_saved_query_workflow"):
+        with patch("products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"):
             # Update query (which should create new version and transfer materialization)
             new_query = {"kind": "HogQLQuery", "query": "SELECT * FROM events WHERE timestamp > now() - INTERVAL 1 DAY"}
             response = self.client.put(


### PR DESCRIPTION
- Replaced direct calls to `DataWarehouseModelPath` methods with a new `setup_model_paths` method in `DataWarehouseSavedQuery`.
- Introduced `enable_materialization` method to manage scheduling and unpausing of saved query workflows.