### PR TITLE
fix(ph-ai): remove read_taxonomy prompt reference

### DIFF
--- a/ee/hogai/graph/root/tools/legacy.py
+++ b/ee/hogai/graph/root/tools/legacy.py
@@ -22,7 +22,7 @@ class create_and_query_insight(BaseModel):
 
     # Data schema
 
-    The subagent will have access to the read_taxonomy tool. You can pass events, actions, properties, and property values to this tool by specifying the "Data schema" section.
+    You can pass events, actions, properties, and property values to this tool by specifying the "Data schema" section.
 
     <example>
     User: Calculate onboarding completion rate for the last week.


### PR DESCRIPTION
## Problem
The `create_and_query_insight` prompt tells the agent that the subagent has access to `read_taxonomy`, so the agent doesn't check the taxonomy by itself first.

![image.png](https://app.graphite.dev/user-attachments/assets/b267014d-44e7-4748-a969-258fa3f09cac.png)

## Changes
- Remove the reference in the prompt

## How did you test this code?
Locally
