### PR TITLE
fix(MA): when there is no column in the table it would fail dividing by zero

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
@@ -431,7 +431,7 @@ export function createMarketingTile(
         const hasCurrencyColumn = currencyColumn && table.fields && currencyColumn in table.fields
 
         if (hasCurrencyColumn) {
-            mathHogql = `SUM(toFloat(convertCurrency(${currencyColumn}, '${baseCurrency}', ${costExpr})))`
+            mathHogql = `SUM(toFloat(convertCurrency(coalesce(${currencyColumn}, '${baseCurrency}'), '${baseCurrency}', ${costExpr})))`
         } else if (fallbackCurrency) {
             mathHogql = `toFloat(convertCurrency('${fallbackCurrency}', '${baseCurrency}', SUM(${costExpr})))`
         } else {

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1736,6 +1736,17 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         response = execute_hogql_query(query, team=self.team)
         self.assertEqual(response.results, [(Decimal(amount),)])
 
+    def test_currency_conversion_same_currency(self):
+        query = "SELECT convertCurrency('USD', 'USD', 100, _toDate('2024-01-01'))"
+        response = execute_hogql_query(query, team=self.team)
+        self.assertEqual(response.results, [(Decimal("100.00"),)])
+
+    def test_currency_conversion_both_bogus(self):
+        # Regression test: ensure no division by zero when both currencies are missing from exchange rate dict
+        query = "SELECT convertCurrency('FAKE1', 'FAKE2', 100, _toDate('2024-01-01'))"
+        response = execute_hogql_query(query, team=self.team)
+        self.assertEqual(response.results, [(Decimal("0"),)])
+
     def test_metadata_handles_lazy_joins(self):
         query = "SELECT events.session.id from events"
         response = execute_hogql_query(query, team=self.team, modifiers=HogQLQueryModifiers(debug=True))

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1736,17 +1736,6 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         response = execute_hogql_query(query, team=self.team)
         self.assertEqual(response.results, [(Decimal(amount),)])
 
-    def test_currency_conversion_same_currency(self):
-        query = "SELECT convertCurrency('USD', 'USD', 100, _toDate('2024-01-01'))"
-        response = execute_hogql_query(query, team=self.team)
-        self.assertEqual(response.results, [(Decimal("100.00"),)])
-
-    def test_currency_conversion_both_bogus(self):
-        # Regression test: ensure no division by zero when both currencies are missing from exchange rate dict
-        query = "SELECT convertCurrency('FAKE1', 'FAKE2', 100, _toDate('2024-01-01'))"
-        response = execute_hogql_query(query, team=self.team)
-        self.assertEqual(response.results, [(Decimal("0"),)])
-
     def test_metadata_handles_lazy_joins(self):
         query = "SELECT events.session.id from events"
         response = execute_hogql_query(query, team=self.team, modifiers=HogQLQueryModifiers(debug=True))

--- a/products/marketing_analytics/backend/hogql_queries/adapters/google_ads.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/google_ads.py
@@ -92,9 +92,13 @@ class GoogleAdsAdapter(MarketingSourceAdapter[GoogleAdsConfig]):
             columns = getattr(self.config.stats_table, "columns", None)
             if columns and hasattr(columns, "__contains__") and "customer_currency_code" in columns:
                 # Convert each row's cost, then sum
+                # Use coalesce to handle NULL currency values - fallback to base_currency
                 currency_field = ast.Field(chain=[stats_table_name, "customer_currency_code"])
+                currency_with_fallback = ast.Call(
+                    name="coalesce", args=[currency_field, ast.Constant(value=base_currency)]
+                )
                 convert_currency = ast.Call(
-                    name="convertCurrency", args=[currency_field, ast.Constant(value=base_currency), cost_float]
+                    name="convertCurrency", args=[currency_with_fallback, ast.Constant(value=base_currency), cost_float]
                 )
                 convert_to_float = ast.Call(name="toFloat", args=[convert_currency])
                 return ast.Call(name="SUM", args=[convert_to_float])

--- a/products/marketing_analytics/backend/hogql_queries/adapters/tiktok_ads.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/tiktok_ads.py
@@ -76,9 +76,14 @@ class TikTokAdsAdapter(MarketingSourceAdapter[TikTokAdsConfig]):
             columns = getattr(self.config.stats_table, "columns", None)
             if columns and hasattr(columns, "__contains__") and "currency" in columns:
                 # Convert each row's spend, then sum
+                # Use coalesce to handle NULL currency values - fallback to base_currency
                 currency_field = ast.Field(chain=[stats_table_name, "currency"])
+                currency_with_fallback = ast.Call(
+                    name="coalesce", args=[currency_field, ast.Constant(value=base_currency)]
+                )
                 convert_currency = ast.Call(
-                    name="convertCurrency", args=[currency_field, ast.Constant(value=base_currency), spend_float]
+                    name="convertCurrency",
+                    args=[currency_with_fallback, ast.Constant(value=base_currency), spend_float],
                 )
                 convert_to_float = ast.Call(name="toFloat", args=[convert_currency])
                 return ast.Call(name="SUM", args=[convert_to_float])


### PR DESCRIPTION
## Problem

Error on marketing tiles and table. This happen when there is a column for the currency but not a value


## Changes
Handling default into base currency if it has currency column (but could have null value)

<img width="801" height="608" alt="Screenshot 2025-10-28 at 5 07 35 PM" src="https://github.com/user-attachments/assets/0e072d57-deaf-47fb-a672-c0ec7fe513d7" />

<img width="1224" height="541" alt="image" src="https://github.com/user-attachments/assets/1a6c778a-7ac8-4e49-b44c-4b0d5757f6af" />
