### PR TITLE
fix(flags): Add `organization_id` to `CachingTeamSerializer.fields` 

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -77,11 +77,14 @@ class CachingTeamSerializer(serializers.ModelSerializer):
     Has all parameters needed for a successful decide request.
     """
 
+    organization_id = serializers.UUIDField(read_only=True)
+
     class Meta:
         model = Team
         fields = [
             "id",
             "project_id",
+            "organization_id",
             "uuid",
             "name",
             "api_token",


### PR DESCRIPTION
## Problem

The Rust feature-flags service validates that `organization_id` is present when reading teams from Redis cache. Without this field in the cached data, the Rust service treats Django-written cache entries as invalid.

## Changes

Add `organization_id` to `CachingTeamSerializer.fields` 

## How did you test this code?

Manually.
- Checked Redis key `posthog:1:team_token:{PROJECT_API_KEY}`. Noted `organization_id` missing.
- Changed Team and saved.
- Checked Redis key to see organization_id present.

Unit Tests.

## Timeline

- September 24, 2020: The organization ForeignKey field was added to the Team model in commit 8a629179a9 (PR #1674)
- January 18, 2023: `CachingTeamSerializer` was introduced in commit 0a1831b141 (PR #13708)
- October 17, 2025: `organization_id: Option<Uuid>` was added to the Rust Team struct in commit d5c1ff0bb4 (PR #39591) as part of porting local evaluation to Rust. This also treated a missing `organization_id` as a cache miss so we could cache it.
