### PR TITLE
chore(homepage): rms persons feature flag test

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -268,7 +268,6 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_EVALUATIONS: 'llm-analytics-evaluations', // owner: #team-llm-analytics
     USAGE_SPEND_DASHBOARDS: 'usage-spend-dashboards', // owner: @pawel-cebula #team-billing
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-workflows-cdp
-    PERSON_READ_TEST_FLAG: 'person-read-test-flag', // owner: @nickbest - #team-ingestion
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-workflows-cdp
     ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: @phixMe #team-data-warehouse

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -42,22 +42,12 @@ function HomePageContent(): JSX.Element {
     const aaTestBayesianLegacy = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_LEGACY]
     const aaTestBayesianNew = featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_NEW]
 
-    // #team-ingestion/nickbest TODO: remove after person database migration tests are complete
-    const personReadTestFlag = featureFlags[FEATURE_FLAGS.PERSON_READ_TEST_FLAG]
-
     return (
         <SceneContent className="ProjectHomepage">
             {/* TODO: Remove this after AA test is over. Just a hidden element. */}
             <span className="hidden" data-attr="aa-test-flag-result">
                 AA test flag result: {String(aaTestBayesianLegacy)} {String(aaTestBayesianNew)}
             </span>
-
-            {/* Hidden element for person read feature flag validation */}
-            {personReadTestFlag && (
-                <span className="hidden" data-attr="person-read-test-flag-active">
-                    Person read test flag is active: {String(personReadTestFlag)}
-                </span>
-            )}
 
             <SceneTitleSection
                 name={dashboard?.name ?? 'Project Homepage'}


### PR DESCRIPTION
## Problem

A test feature flag that was put in place to test feature flag's functionality during dual write phase of the persons migration. No longer needed, rm cruft.

## Changes

Rm the feature flag and hidden span that was added to homepage for testing purposes

## How did you test this code?

CI will test it. Removing a feature flag that decides whether or not to show a hidden span

