### PR TITLE
chore(flags): Only write team to redis when it's not already there

### DIFF
--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -33,30 +33,9 @@ where
 {
     // Try to get team from cache first
     match Team::from_redis(redis_reader.clone(), token).await {
-        Ok(team) if team.organization_id.is_some() => {
-            debug!(team_id = team.id, "Found complete team in Redis cache");
-            Ok(team)
-        }
         Ok(team) => {
-            debug!(
-                team_id = team.id,
-                "Team in cache missing organization_id, treating as cache miss"
-            );
-            // Treat as cache miss - fetch complete team from database
-            match db_lookup().await {
-                Ok(team) => {
-                    debug!(team_id = team.id, "Found team in PostgreSQL");
-                    // Update Redis cache with complete team
-                    if let Err(e) = Team::update_redis_cache(redis_writer, &team).await {
-                        warn!(team_id = team.id, error = %e, "Failed to update Redis cache");
-                    }
-                    Ok(team)
-                }
-                Err(e) => {
-                    warn!(error = %e, "Team not found in PostgreSQL");
-                    Err(e)
-                }
-            }
+            debug!(team_id = team.id, "Found team in Redis cache");
+            Ok(team)
         }
         Err(e) => {
             debug!(error = %e, "Team not found in Redis cache");

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -38,6 +38,7 @@ pub async fn insert_new_team_in_redis(
         project_id: i64::from(id),
         name: "team".to_string(),
         api_token: token,
+        organization_id: Some(uuid::Uuid::new_v4()),
         cookieless_server_hash_mode: 0,
         timezone: "UTC".to_string(),
         ..Default::default()


### PR DESCRIPTION

## Problem

Prior to this change, every time a pod starts up, we'd unnecessarily write a Team to the Redis cache on a cache-miss.

_New Pod #1 (cold start):_

1. Try Redis: Team::from_redis() → MISS (empty cache)
2. Fallback to PostgreSQL: Team::from_pg() → SUCCESS
3. Write to Redis: Team::update_redis_cache() → WRITE ✅

In theory, this shouldn't be so bad. But if we're having trouble reading from Redis during an outage, we shouldn't write to Redis as it could exacerbate the issue.

## Changes

- Consolidate code to retrieve team from cache.
- When fetching team, we check if the key exists before writing to the cache.
- Stop treating missing `organization_id` as a cache miss.

Rationale: We rely on Django signals on team updates to keep the team fresh in the cache. The `/flags` service doesn't need to be the one doing that. Also, we were treating a missing `organization_id` as a cache miss. Let's stop doing that. 


## How did you test this code?

Manually.
Unit Tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
