### PR TITLE
fix(flags): Stop treating missing organization_id as cache miss

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -208,7 +208,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
                 }
             }
 
-            // Validate organization access (MANDATORY)
+            // Validate organization access (MANDATORY for teams with organization_id)
             // Personal API keys can only access teams in organizations where the user is a member,
             // unless explicitly scoped to specific organizations via scoped_organizations
             let user_id: i32 = row.get("user_id");
@@ -216,50 +216,56 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
             let scoped_organizations: Option<Vec<String>> =
                 row.try_get("scoped_organizations").ok();
 
-            // Get the team's organization_id (guaranteed to be present)
-            let team_organization_id = team
-                .organization_id
-                .expect("organization_id should always be present");
-            let team_organization_id_str = team_organization_id.to_string();
+            // Handle teams with or without organization_id
+            if let Some(team_organization_id) = team.organization_id {
+                let team_organization_id_str = team_organization_id.to_string();
 
-            // Check organization access:
-            // - If scoped_organizations has entries: team's org must be in the list
-            // - Otherwise (NULL or empty): user must be a member of the team's org
-            let has_org_access = match scoped_organizations.as_ref() {
-                Some(orgs) if !orgs.is_empty() => orgs.contains(&team_organization_id_str),
-                _ => {
-                    // Check if user is a member of the team's organization
-                    let is_member: bool = sqlx::query_scalar(
-                        "SELECT EXISTS(SELECT 1 FROM posthog_organizationmembership WHERE user_id = $1 AND organization_id = $2)"
-                    )
-                    .bind(user_id)
-                    .bind(team_organization_id)
-                    .fetch_one(&mut *conn)
-                    .await?;
-                    is_member
+                // Check organization access:
+                // - If scoped_organizations has entries: team's org must be in the list
+                // - Otherwise (NULL or empty): user must be a member of the team's org
+                let has_org_access = match scoped_organizations.as_ref() {
+                    Some(orgs) if !orgs.is_empty() => orgs.contains(&team_organization_id_str),
+                    _ => {
+                        // Check if user is a member of the team's organization
+                        let is_member: bool = sqlx::query_scalar(
+                            "SELECT EXISTS(SELECT 1 FROM posthog_organizationmembership WHERE user_id = $1 AND organization_id = $2)"
+                        )
+                        .bind(user_id)
+                        .bind(team_organization_id)
+                        .fetch_one(&mut *conn)
+                        .await?;
+                        is_member
+                    }
+                };
+
+                if !has_org_access {
+                    warn!(
+                        user_organization_id = %user_organization_id,
+                        team_organization_id = %team_organization_id_str,
+                        scoped_organizations = ?scoped_organizations,
+                        "Personal API key does not have access to this organization"
+                    );
+                    return Err(FlagError::PersonalApiKeyInvalid(
+                        "Authorization header".to_string(),
+                    ));
                 }
-            };
-
-            if !has_org_access {
-                warn!(
+            } else {
+                // Legacy team without organization_id - skip organization validation
+                debug!(
+                    team_id = team.id,
                     user_organization_id = %user_organization_id,
-                    team_organization_id = %team_organization_id_str,
-                    scoped_organizations = ?scoped_organizations,
-                    "Personal API key does not have access to this organization"
+                    "Team has no organization_id, skipping organization validation (legacy team)"
                 );
-                return Err(FlagError::PersonalApiKeyInvalid(
-                    "Authorization header".to_string(),
-                ));
             }
 
             debug!(
                 user_id = user_id,
                 team_id = team.id,
                 user_organization_id = %user_organization_id,
-                team_organization_id = %team_organization_id_str,
+                team_organization_id = ?team.organization_id,
                 scoped_teams = ?scoped_teams,
                 scoped_organizations = ?scoped_organizations,
-                "Personal API key validated successfully with org membership check"
+                "Personal API key validated successfully"
             );
 
             return Ok(());

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -33,30 +33,9 @@ where
 {
     // Try to get team from cache first
     match Team::from_redis(redis_reader.clone(), token).await {
-        Ok(team) if team.organization_id.is_some() => {
-            debug!(team_id = team.id, "Found complete team in Redis cache");
-            Ok(team)
-        }
         Ok(team) => {
-            debug!(
-                team_id = team.id,
-                "Team in cache missing organization_id, treating as cache miss"
-            );
-            // Treat as cache miss - fetch complete team from database
-            match db_lookup().await {
-                Ok(team) => {
-                    debug!(team_id = team.id, "Found team in PostgreSQL");
-                    // Update Redis cache with complete team
-                    if let Err(e) = Team::update_redis_cache(redis_writer, &team).await {
-                        warn!(team_id = team.id, error = %e, "Failed to update Redis cache");
-                    }
-                    Ok(team)
-                }
-                Err(e) => {
-                    warn!(error = %e, "Team not found in PostgreSQL");
-                    Err(e)
-                }
-            }
+            debug!(team_id = team.id, "Found team in Redis cache");
+            Ok(team)
         }
         Err(e) => {
             debug!(error = %e, "Team not found in Redis cache");


### PR DESCRIPTION
## Problem

Previously, teams without `organization_id` in cache were treated as cache misses, triggering unnecessary database queries and cache updates.

## Changes

Now we accept cached teams regardless of organization_id presence, eliminating these unnecessary operations.

Only /flags/definitions needed the `organization_id` and that isn't generally released yet, so this is safe to do. /flags doesn't need `organization_id`.

## How did you test this code?

Unit Tests

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
