### PR TITLE
fix: 0164_sessions_v3_replay_events migration needs to run alters correctly

### DIFF
--- a/posthog/clickhouse/migrations/0164_sessions_v3_replay_events.py
+++ b/posthog/clickhouse/migrations/0164_sessions_v3_replay_events.py
@@ -10,7 +10,9 @@ from posthog.models.raw_sessions.sessions_v3 import (
 operations = [
     # drop person ID
     run_sql_with_exceptions(
-        DROP_PERSON_ID.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()), node_roles=[NodeRole.DATA]
+        DROP_PERSON_ID.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        run_sql_with_exceptions=True,
     ),
     run_sql_with_exceptions(
         DROP_PERSON_ID.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()), node_roles=[NodeRole.DATA]

--- a/posthog/clickhouse/migrations/0164_sessions_v3_replay_events.py
+++ b/posthog/clickhouse/migrations/0164_sessions_v3_replay_events.py
@@ -12,7 +12,7 @@ operations = [
     run_sql_with_exceptions(
         DROP_PERSON_ID.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
         node_roles=[NodeRole.DATA],
-        run_sql_with_exceptions=True,
+        is_alter_on_replicated_table=True,
     ),
     run_sql_with_exceptions(
         DROP_PERSON_ID.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()), node_roles=[NodeRole.DATA]
@@ -23,7 +23,9 @@ operations = [
     ),
     # add has_replay_events
     run_sql_with_exceptions(
-        ADD_HAS_REPLAY_EVENTS.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()), node_roles=[NodeRole.DATA]
+        ADD_HAS_REPLAY_EVENTS.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        is_alter_on_replicated_table=True,
     ),
     run_sql_with_exceptions(
         ADD_HAS_REPLAY_EVENTS.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()), node_roles=[NodeRole.DATA]


### PR DESCRIPTION
## Problem

The migration attempted to apply `ALTER` statements simultaniously on members of the same replica causing nodes to panic about ZK state

## Changes

set `is_alter_on_replicated_table = True` 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
