### PR TITLE
chore: Move CH team back to code owners for CH migrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,9 @@
 # If a file is set here, then PRs will require that team's approval to get that code merged.
 
+# ClickHouse team owns Clickhouse migrations
+
+posthog/clickhouse/migrations/** @PostHog/clickhouse
+
+# HogQL team owns HogQL changes 
+
 posthog/hogql/** @PostHog/hogql

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -24,10 +24,6 @@ plugin-server/src/ingestion/ @PostHog/team-ingestion
 plugin-server/src/cdp/ @PostHog/team-workflows
 plugin-server/src/ingestion/ai-costs/ @PostHog/team-llm-analytics
 
-# ClickHouse team owns Clickhouse migrations
-
-posthog/clickhouse/migrations/** @PostHog/clickhouse
-
 # Web Analytics team owns web analytics code
 
 products/web_analytics/** @PostHog/team-web-analytics


### PR DESCRIPTION
## Problem

Migrations for CH are very delicate right now and require complex understanding of context

## Changes

Require CH team to stamp CH migrations to ensure settings are correct

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
