### PR TITLE
fix(hogli): use bin/hogli for composite command steps to support non-Flox users

### DIFF
--- a/common/hogli/core/command_types.py
+++ b/common/hogli/core/command_types.py
@@ -202,10 +202,15 @@ class CompositeCommand(Command):
 
     def execute(self, *args: str) -> None:
         """Execute each step in sequence."""
+        from hogli.core.manifest import REPO_ROOT
+
         steps = self.config.get("steps", [])
+        bin_hogli = str(REPO_ROOT / "bin" / "hogli")
+
         for step in steps:
             click.echo(f"✨ Executing: {step}")
             try:
-                _run(["hogli", step])
+                # Use bin/hogli for both Flox and non-Flox compatibility
+                _run([bin_hogli, step])
             except SystemExit:
                 raise

--- a/common/hogli/tests/test_command_types.py
+++ b/common/hogli/tests/test_command_types.py
@@ -72,6 +72,10 @@ class TestCompositeCommandExecution:
     @patch("hogli.core.command_types._run")
     def test_executes_all_steps_in_sequence(self, mock_run: MagicMock) -> None:
         """Test all steps are executed in order."""
+        from hogli.core.manifest import REPO_ROOT
+
+        bin_hogli = str(REPO_ROOT / "bin" / "hogli")
+
         cmd = CompositeCommand(
             "reset",
             {"steps": ["docker:services:down", "docker:services:up", "migrations:run"]},
@@ -82,9 +86,9 @@ class TestCompositeCommandExecution:
         assert mock_run.call_count == 3
         calls = [call[0][0] for call in mock_run.call_args_list]
         assert calls == [
-            ["hogli", "docker:services:down"],
-            ["hogli", "docker:services:up"],
-            ["hogli", "migrations:run"],
+            [bin_hogli, "docker:services:down"],
+            [bin_hogli, "docker:services:up"],
+            [bin_hogli, "migrations:run"],
         ]
 
     @patch("hogli.core.command_types._run")


### PR DESCRIPTION
## Summary

Fix composite commands (commands using `steps:` in manifest) to work for non-Flox users.

## Problem

`CompositeCommand.execute()` was calling `hogli` directly via subprocess, which fails for non-Flox users since `hogli` is not in PATH without Flox environment activation.

This broke commands like:
- `pnpm schema:build` → calls `bin/hogli build:schema` → internally tries to run `hogli build:schema-json`, `hogli build:schema-python`, etc. → fails with "command not found"

## Solution

Changed `CompositeCommand.execute()` to call `bin/hogli` instead of `hogli` directly. The `bin/hogli` script handles sys.path setup and works for both Flox and non-Flox users.

## Affected commands

All commands using `steps:` in manifest:
- `build:schema` (compose schema-json, schema-python, schema-latest-versions)
- `dev:reset` (compose services down/up, migrations, demo data)
- `services:ready` (compose clickhouse, postgres, temporal checks)

## Testing

Verified `bin/hogli build:schema --help` works correctly.