### PR TITLE
revert(sql-editor): "fix(sql-editor): add default case"

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1227,9 +1227,6 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                     // only when opening the tab
                     actions.createTab(hashParams.q)
                     tabAdded = true
-                } else {
-                    actions.createTab('')
-                    tabAdded = true
                 }
             }
 


### PR DESCRIPTION
Reverts PostHog/posthog#40483

- See https://posthog.slack.com/archives/C019RAX2XBN/p1761730582161769
- I think this may be the cause - unverified, but its the only thing thats changed from what I can tell 
- Plus pricing is launching in an hour, soooo... revert