### PR TITLE
fix(billing): correct query count assertion in quota limiting test

### DIFF
--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -222,7 +222,7 @@ class TestQuotaLimiting(BaseTest):
         self.organization.save()
 
         time.sleep(1)
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             quota_limited_orgs, quota_limiting_suspended_orgs = update_all_orgs_billing_quotas()
         # Shouldn't be called due to lazy evaluation of the conditional
         patch_feature_enabled.assert_not_called()


### PR DESCRIPTION
## Problem
The test `test_quota_limit_feature_flag_not_on` was asserting 4 database queries but only 3 are actually executed during `update_all_orgs_billing_quotas()`:

1. Batch exports query (rows exported in period)
2. Teams and organizations query (without customer_trust_scores in .only())
3. Deferred field query for customer_trust_scores (lazily loaded when accessed)

For some reason this has been merged to prod.

## Changes
The test assertion was incorrect and has been updated to expect 3 queries.

## How did you test this code?
Fixed the test
