### PR TITLE
fix: correctly detect DROP COLUMN vs DROP TABLE in migration analyzer

### DIFF
--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -6,7 +6,11 @@ from typing import Any, Optional
 from django.db import models
 
 from posthog.management.migration_analysis.models import OperationRisk
-from posthog.management.migration_analysis.utils import VolatileFunctionDetector, check_drop_table_properly_staged
+from posthog.management.migration_analysis.utils import (
+    VolatileFunctionDetector,
+    check_drop_properly_staged,
+    check_drop_table_properly_staged,
+)
 
 # Base URL for migration safety documentation
 SAFE_MIGRATIONS_DOCS_URL = "https://github.com/PostHog/posthog/blob/master/docs/safe-django-migrations.md"
@@ -452,6 +456,53 @@ class RunSQLAnalyzer(OperationAnalyzer):
             )
 
         if "DROP" in sql:
+            # Check for DROP COLUMN first (before DROP TABLE check)
+            # ALTER TABLE ... DROP COLUMN can contain both "TABLE" and "DROP" keywords
+            if "COLUMN" in sql:
+                # Parse table and column name from: ALTER TABLE <table> DROP COLUMN IF EXISTS <column>
+                # Pattern: ALTER TABLE table_name DROP COLUMN [IF EXISTS] column_name
+                column_match = re.search(
+                    r"ALTER\s+TABLE\s+([a-zA-Z0-9_]+)\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?([a-zA-Z0-9_]+)", sql
+                )
+
+                if column_match and migration and loader:
+                    table_name = column_match.group(1).lower()
+                    column_name = column_match.group(2).lower()
+
+                    # Check if properly staged (field removed from state in prior migration)
+                    if check_drop_properly_staged("column", table_name, migration, loader, field_name=column_name):
+                        return OperationRisk(
+                            type=self.operation_type,
+                            score=2,
+                            reason="DROP COLUMN IF EXISTS - properly staged (prior state removal found)",
+                            details={"sql": sql, "table": table_name, "column": column_name},
+                            guidance=f"""✅ **Validated staged drop:** Found prior SeparateDatabaseAndState that removed field from state.
+
+Remaining checklist:
+- Ensure all code references removed (models, serializers, API)
+- Waited at least one full deployment cycle since state removal
+- Verify column is not used in queries or indexes
+
+[See the migration safety guide]({SAFE_MIGRATIONS_DOCS_URL}#dropping-columns)""",
+                        )
+
+                # Not properly staged or can't validate
+                return OperationRisk(
+                    type=self.operation_type,
+                    score=5,
+                    reason="DROP COLUMN - no prior state removal found",
+                    details={"sql": sql},
+                    guidance=f"""❌ **Missing state removal:** Could not find prior SeparateDatabaseAndState that removed this field.
+
+Safe pattern requires:
+1. Prior migration with SeparateDatabaseAndState removes field from Django state
+2. All code references removed (models, serializers, API)
+3. Wait at least one full deployment cycle
+4. Then DROP COLUMN in later migration with RunSQL
+
+[See the migration safety guide]({SAFE_MIGRATIONS_DOCS_URL}#dropping-columns)""",
+                )
+
             # Special case: DROP TABLE IF EXISTS may be safe if following proper staging pattern
             if "TABLE" in sql and "IF EXISTS" in sql:
                 # Extract table name from the DROP statement

--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -454,14 +454,13 @@ class RunSQLAnalyzer(OperationAnalyzer):
         if "DROP" in sql:
             # Check for DROP COLUMN first (before DROP TABLE check)
             # ALTER TABLE ... DROP COLUMN can contain both "TABLE" and "DROP" keywords
-            if "COLUMN" in sql:
-                # Parse table and column name from: ALTER TABLE <table> DROP COLUMN IF EXISTS <column>
-                # Pattern: ALTER TABLE table_name DROP COLUMN [IF EXISTS] column_name
-                column_match = re.search(
-                    r"ALTER\s+TABLE\s+([a-zA-Z0-9_]+)\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?([a-zA-Z0-9_]+)", sql
-                )
+            # Use regex to verify it's actually ALTER TABLE ... DROP COLUMN (not just "COLUMN" in table name)
+            column_match = re.search(
+                r"ALTER\s+TABLE\s+([a-zA-Z0-9_]+)\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?([a-zA-Z0-9_]+)", sql
+            )
 
-                if column_match and migration and loader:
+            if column_match:
+                if migration and loader:
                     table_name = column_match.group(1).lower()
                     column_name = column_match.group(2).lower()
 

--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -6,11 +6,7 @@ from typing import Any, Optional
 from django.db import models
 
 from posthog.management.migration_analysis.models import OperationRisk
-from posthog.management.migration_analysis.utils import (
-    VolatileFunctionDetector,
-    check_drop_properly_staged,
-    check_drop_table_properly_staged,
-)
+from posthog.management.migration_analysis.utils import VolatileFunctionDetector, check_drop_properly_staged
 
 # Base URL for migration safety documentation
 SAFE_MIGRATIONS_DOCS_URL = "https://github.com/PostHog/posthog/blob/master/docs/safe-django-migrations.md"
@@ -511,7 +507,7 @@ Safe pattern requires:
                     table_name = table_name_match.group(1).lower()
 
                     # Check if properly staged (model removed from state in prior migration)
-                    if check_drop_table_properly_staged(table_name, migration, loader):
+                    if check_drop_properly_staged("table", table_name, migration, loader):
                         return OperationRisk(
                             type=self.operation_type,
                             score=2,

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -467,6 +467,23 @@ class TestRunSQLOperations:
         # Should NOT mention column
         assert "column" not in risk.reason.lower()
 
+    def test_run_sql_drop_table_with_column_in_name(self):
+        """Test that DROP TABLE with 'column' in table name doesn't trigger DROP COLUMN logic."""
+        op = create_mock_operation(
+            migrations.RunSQL,
+            sql="DROP TABLE IF EXISTS column_data;",
+        )
+
+        risk = self.analyzer.analyze_operation(op)
+
+        # Should be recognized as DROP TABLE (not DROP COLUMN)
+        # Even though SQL contains the word "COLUMN"
+        assert risk.score == 5
+        assert risk.level == RiskLevel.BLOCKED
+        assert "drop table" in risk.reason.lower()
+        # Should NOT be classified as DROP COLUMN
+        assert "drop column" not in risk.reason.lower()
+
     def test_run_sql_comment_on(self):
         """Test COMMENT ON - metadata only (score 0)."""
         op = create_mock_operation(

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -434,6 +434,39 @@ class TestRunSQLOperations:
         assert risk.level == RiskLevel.NEEDS_REVIEW
         assert "cascade" in risk.reason.lower()
 
+    def test_run_sql_alter_table_drop_column_if_exists(self):
+        """Test ALTER TABLE DROP COLUMN IF EXISTS - should be dangerous (score 5), not confused with DROP TABLE."""
+        op = create_mock_operation(
+            migrations.RunSQL,
+            sql="ALTER TABLE llm_analytics_evaluation DROP COLUMN IF EXISTS prompt;",
+        )
+
+        risk = self.analyzer.analyze_operation(op)
+
+        # Should be score 5 (BLOCKED) for dropping a column
+        assert risk.score == 5
+        assert risk.level == RiskLevel.BLOCKED
+        # Should NOT be classified as DROP TABLE
+        assert "drop table" not in risk.reason.lower()
+        # Should indicate it's a DROP COLUMN operation
+        assert "column" in risk.reason.lower() or "drop" in risk.reason.lower()
+
+    def test_run_sql_drop_table_not_confused_with_drop_column(self):
+        """Test that DROP TABLE IF EXISTS (without COLUMN keyword) is still recognized as table drop."""
+        op = create_mock_operation(
+            migrations.RunSQL,
+            sql="DROP TABLE IF EXISTS old_table;",
+        )
+
+        risk = self.analyzer.analyze_operation(op)
+
+        # Should be recognized as DROP TABLE (not DROP COLUMN)
+        assert risk.score == 5
+        assert risk.level == RiskLevel.BLOCKED
+        assert "drop table" in risk.reason.lower()
+        # Should NOT mention column
+        assert "column" not in risk.reason.lower()
+
     def test_run_sql_comment_on(self):
         """Test COMMENT ON - metadata only (score 0)."""
         op = create_mock_operation(
@@ -763,6 +796,55 @@ class TestDropTableValidation:
         # Should be BLOCKED (score 5) when we can't validate
         assert migration_risk.level == RiskLevel.BLOCKED
         assert migration_risk.max_score == 5
+
+    def test_drop_column_with_prior_state_removal(self):
+        """
+        Valid pattern: Prior migration removes field from state, then drop column.
+
+        Migration 0006: SeparateDatabaseAndState removes Evaluation.prompt
+        Migration 0007: ALTER TABLE ... DROP COLUMN IF EXISTS prompt
+        """
+        # Create mock migration graph with proper staging
+        mock_migration = MagicMock()
+        mock_migration.app_label = "llm_analytics"
+        mock_migration.name = "0007_drop_evaluation_prompt_column"
+        mock_migration.dependencies = [("llm_analytics", "0006_remove_evaluation_prompt")]
+
+        # Create the DROP COLUMN operation
+        drop_op = create_mock_operation(
+            migrations.RunSQL,
+            sql="ALTER TABLE llm_analytics_evaluation DROP COLUMN IF EXISTS prompt;",
+        )
+        mock_migration.operations = [drop_op]
+
+        # Create parent migration with SeparateDatabaseAndState
+        parent_migration = MagicMock()
+        parent_migration.app_label = "llm_analytics"
+        parent_migration.name = "0006_remove_evaluation_prompt"
+
+        remove_field_op = create_mock_operation(migrations.RemoveField, model_name="Evaluation", name="prompt")
+        separate_op = create_mock_operation(
+            migrations.SeparateDatabaseAndState,
+            state_operations=[remove_field_op],
+            database_operations=[],
+        )
+        parent_migration.operations = [separate_op]
+
+        # Create mock loader
+        mock_loader = MagicMock()
+        mock_loader.disk_migrations = {
+            ("llm_analytics", "0006_remove_evaluation_prompt"): parent_migration,
+            ("llm_analytics", "0007_drop_evaluation_prompt_column"): mock_migration,
+        }
+
+        # Analyze with migration context
+        migration_risk = self.analyzer.analyze_migration_with_context(
+            mock_migration, "llm_analytics/migrations/0007_drop_evaluation_prompt_column.py", mock_loader
+        )
+
+        # Should be NEEDS_REVIEW (score 2) since properly staged
+        assert migration_risk.level == RiskLevel.NEEDS_REVIEW
+        assert migration_risk.max_score == 2
 
 
 class TestRunPythonOperations:

--- a/posthog/management/migration_analysis/utils.py
+++ b/posthog/management/migration_analysis/utils.py
@@ -206,15 +206,6 @@ def check_drop_properly_staged(
     return False
 
 
-def check_drop_table_properly_staged(table_name: str, migration: Any, loader: Any) -> bool:
-    """
-    Backward compatibility wrapper for check_drop_properly_staged.
-
-    Check if a DROP TABLE operation was preceded by proper state removal.
-    """
-    return check_drop_properly_staged("table", table_name, migration, loader)
-
-
 def _extract_model_name_from_table(table_name: str, app_label: Optional[str] = None) -> Optional[str]:
     """
     Extract Django model name from table name.

--- a/posthog/management/migration_analysis/utils.py
+++ b/posthog/management/migration_analysis/utils.py
@@ -142,31 +142,40 @@ class OperationCategorizer:
         return ", ".join(f"#{idx+1} {op.type}" for idx, op in ops)
 
 
-def check_drop_table_properly_staged(table_name: str, migration: Any, loader: Any) -> bool:
+def check_drop_properly_staged(
+    target_type: str, table_name: str, migration: Any, loader: Any, field_name: Optional[str] = None
+) -> bool:
     """
-    Check if a DROP TABLE operation was preceded by proper state removal.
+    Check if a DROP operation (table or column) was preceded by proper state removal.
 
     Args:
-        table_name: Name of table being dropped (e.g., "posthog_namedquery")
-        migration: The migration object containing the DROP TABLE
+        target_type: Either "table" or "column"
+        table_name: Name of table (e.g., "posthog_namedquery" or "llm_analytics_evaluation")
+        migration: The migration object containing the DROP operation
         loader: Django MigrationLoader with migration history
+        field_name: Column name (required for target_type="column", e.g., "prompt")
 
     Returns:
-        True if model was properly removed from state in migration history,
+        True if drop was properly staged (state removed in prior migration),
         False otherwise
 
-    Pattern being checked:
-    1. Earlier migration used SeparateDatabaseAndState to remove model from state
-    2. That migration had DeleteModel for the model matching the table name
+    Patterns checked:
+    - For "table": SeparateDatabaseAndState with DeleteModel for the model
+    - For "column": SeparateDatabaseAndState with RemoveField for the model+field
     """
     if not loader or not hasattr(loader, "disk_migrations"):
         return False
 
     # Extract model name from table name
     # posthog_namedquery -> NamedQuery
-    # Strip app prefix and convert to PascalCase
-    model_name = _extract_model_name_from_table(table_name)
+    # llm_analytics_evaluation (app=llm_analytics) -> Evaluation
+    app_label = getattr(migration, "app_label", None)
+    model_name = _extract_model_name_from_table(table_name, app_label)
     if not model_name:
+        return False
+
+    # For column drops, field_name is required
+    if target_type == "column" and not field_name:
         return False
 
     # Walk back through migration history via dependencies
@@ -186,8 +195,8 @@ def check_drop_table_properly_staged(table_name: str, migration: Any, loader: An
         if not parent_migration:
             continue
 
-        # Check if this migration removed the model from state
-        if _migration_removed_model_from_state(parent_migration, model_name):
+        # Check if this migration removed the target from state
+        if _migration_removed_from_state(parent_migration, target_type, model_name, field_name):
             return True
 
         # Continue walking back through dependencies
@@ -197,33 +206,65 @@ def check_drop_table_properly_staged(table_name: str, migration: Any, loader: An
     return False
 
 
-def _extract_model_name_from_table(table_name: str) -> Optional[str]:
+def check_drop_table_properly_staged(table_name: str, migration: Any, loader: Any) -> bool:
+    """
+    Backward compatibility wrapper for check_drop_properly_staged.
+
+    Check if a DROP TABLE operation was preceded by proper state removal.
+    """
+    return check_drop_properly_staged("table", table_name, migration, loader)
+
+
+def _extract_model_name_from_table(table_name: str, app_label: Optional[str] = None) -> Optional[str]:
     """
     Extract Django model name from table name.
 
     Examples:
         posthog_namedquery -> NamedQuery
         posthog_old_model -> OldModel
+        llm_analytics_evaluation (app=llm_analytics) -> Evaluation
         my_app_some_table -> SomeTable
+
+    Args:
+        table_name: Database table name (e.g., "posthog_namedquery", "llm_analytics_evaluation")
+        app_label: Optional app label to strip (e.g., "llm_analytics"). If not provided, assumes single-word app.
     """
-    # Remove common prefixes (app_label)
     parts = table_name.split("_")
     if len(parts) < 2:
         return None
 
-    # Skip first part (assumed to be app label like 'posthog')
+    # If app_label provided, strip it from the table name
+    if app_label:
+        # app_label might be multi-word (e.g., "llm_analytics")
+        app_parts = app_label.split("_") if "_" in app_label else [app_label]
+        # Check if table starts with app parts
+        if parts[: len(app_parts)] == app_parts:
+            model_parts = parts[len(app_parts) :]
+        else:
+            # Fallback: assume single-word app
+            model_parts = parts[1:]
+    else:
+        # Skip first part (assumed to be app label like 'posthog')
+        model_parts = parts[1:]
+
+    if not model_parts:
+        return None
+
     # Join remaining parts and convert to PascalCase
-    model_parts = parts[1:]
     model_name = "".join(word.capitalize() for word in model_parts)
 
     return model_name
 
 
-def _migration_removed_model_from_state(migration: Any, model_name: str) -> bool:
+def _migration_removed_from_state(
+    migration: Any, target_type: str, model_name: str, field_name: Optional[str] = None
+) -> bool:
     """
-    Check if a migration removed a specific model from Django state.
+    Check if a migration removed a model or field from Django state.
 
-    Looks for SeparateDatabaseAndState operations with DeleteModel in state_operations.
+    Looks for SeparateDatabaseAndState operations with:
+    - DeleteModel (for target_type="table")
+    - RemoveField (for target_type="column")
     """
     if not hasattr(migration, "operations"):
         return False
@@ -237,12 +278,30 @@ def _migration_removed_model_from_state(migration: Any, model_name: str) -> bool
             continue
 
         for state_op in op.state_operations:
-            if state_op.__class__.__name__ != "DeleteModel":
-                continue
+            if target_type == "table":
+                # Check for DeleteModel
+                if state_op.__class__.__name__ != "DeleteModel":
+                    continue
 
-            # Check if the model name matches (case-insensitive)
-            deleted_model_name = getattr(state_op, "name", "")
-            if deleted_model_name.lower() == model_name.lower():
-                return True
+                # Check if the model name matches (case-insensitive)
+                deleted_model_name = getattr(state_op, "name", "")
+                if deleted_model_name.lower() == model_name.lower():
+                    return True
+
+            elif target_type == "column":
+                # Check for RemoveField
+                if state_op.__class__.__name__ != "RemoveField":
+                    continue
+
+                # Check if both model and field match (case-insensitive)
+                removed_model_name = getattr(state_op, "model_name", "")
+                removed_field_name = getattr(state_op, "name", "")
+
+                if (
+                    removed_model_name.lower() == model_name.lower()
+                    and field_name
+                    and removed_field_name.lower() == field_name.lower()
+                ):
+                    return True
 
     return False


### PR DESCRIPTION
## Summary

Fixed migration analyzer bug where `ALTER TABLE ... DROP COLUMN IF EXISTS` was incorrectly classified as `DROP TABLE`, and aligned DROP COLUMN validation with DROP TABLE pattern.

## Changes

### Bug Fix
- Fixed keyword matching order in RunSQLAnalyzer - check for "COLUMN" before "TABLE"
- `ALTER TABLE foo DROP COLUMN IF EXISTS bar` now correctly identified as DROP COLUMN

### Alignment with DROP TABLE Pattern
- Properly staged column drops (with prior SeparateDatabaseAndState + RemoveField) get score 2 (NEEDS_REVIEW) instead of always score 5 (BLOCKED)
- Refactored `check_drop_table_properly_staged()` to `check_drop_properly_staged()` supporting both tables and columns
- Added regex parsing to extract table and column names from SQL
- Enhanced model name extraction for multi-word app labels (e.g., `llm_analytics`)

### Test Coverage
- `test_run_sql_alter_table_drop_column_if_exists` - DROP COLUMN not confused with DROP TABLE
- `test_run_sql_drop_table_not_confused_with_drop_column` - DROP TABLE still works
- `test_drop_column_with_prior_state_removal` - properly staged drops get score 2
- All 63 tests passing

## Validation

Properly staged column drop (example from PR #40533):
```python
# Migration 0006: Remove from state
migrations.SeparateDatabaseAndState(
    state_operations=[migrations.RemoveField(model_name="Evaluation", name="prompt")],
    database_operations=[],
)

# Migration 0007: Drop column (now gets score 2 instead of 5)
migrations.RunSQL("ALTER TABLE llm_analytics_evaluation DROP COLUMN IF EXISTS prompt;")
```

## Test Plan
- [x] All existing tests pass (63/63)
- [x] Added 3 new tests for DROP COLUMN detection
- [x] Verified DROP TABLE validation still works correctly
- [x] Tested multi-word app label extraction