### PR TITLE
chore(ph-ai): hydrate person in `query_executor`

### DIFF
--- a/ee/hogai/graph/query_executor/nodes.py
+++ b/ee/hogai/graph/query_executor/nodes.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import posthoganalytics
 from langchain_core.runnables import RunnableConfig
 
 from posthog.schema import (
@@ -20,8 +21,6 @@ from posthog.schema import (
     TrendsQuery,
     VisualizationMessage,
 )
-
-from posthog.exceptions_capture import capture_exception
 
 from ee.hogai.graph.base import AssistantNode
 from ee.hogai.utils.types import AssistantNodeName, AssistantState, PartialAssistantState
@@ -70,7 +69,11 @@ class QueryExecutorNode(AssistantNode):
         except Exception as err:
             if isinstance(err, NotImplementedError):
                 raise
-            capture_exception(err, additional_properties=self._get_debug_props(config))
+            posthoganalytics.capture_exception(
+                err,
+                distinct_id=self._get_user_distinct_id(config),
+                properties=self._get_debug_props(config),
+            )
             return PartialAssistantState(messages=[FailureMessage(content=str(err), id=str(uuid4()))])
 
         query_result = QUERY_RESULTS_PROMPT.format(


### PR DESCRIPTION
## Problem

Exceptions in `query_executor` are showing random UUIDS since user's distinct IDs are not injected.
`Person`s are nice, let's fix this.

## Changes

* adding `distinct_id` to `capture_exception`, whilst keeping the `_get_debug_props`

## How did you test this code?

Locally it's tricky to ingest exceptions, let's see.