### PR TITLE
chore(plugin-server): Refactor personlessStep

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessStep.ts
@@ -1,0 +1,122 @@
+import LRU from 'lru-cache'
+import { DateTime } from 'luxon'
+
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { ONE_HOUR } from '../../../config/constants'
+import { PipelineResult, ok } from '../../../ingestion/pipelines/results'
+import { Person, Team } from '../../../types'
+import { uuidFromDistinctId } from '../person-uuid'
+import { PersonsStoreForBatch } from '../persons/persons-store-for-batch'
+
+// Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given
+// (team_id, distinct_id) pair. If we have, then we can skip the INSERT attempt.
+const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRU<string, boolean>({
+    max: 10_000,
+    maxAge: ONE_HOUR * 24, // cache up to 24h
+    updateAgeOnGet: true,
+})
+
+/**
+ * Pipeline step that handles personless event processing checks.
+ *
+ * This step runs when processPerson=false, and performs:
+ * 1. Database fetch for existing person
+ * 2. Insert into posthog_personlessdistinctid tracking table
+ * 3. Merge detection via race condition handling
+ * 4. force_upgrade flag calculation
+ * 5. Returns person (real or fake) with potential force_upgrade flag
+ *
+ * The caller should check person.force_upgrade to decide if full person processing is needed.
+ */
+export async function processPersonlessStep(
+    event: PluginEvent,
+    team: Team,
+    timestamp: DateTime,
+    personStoreBatch: PersonsStoreForBatch,
+    forceDisablePersonProcessing: boolean = false
+): Promise<PipelineResult<Person>> {
+    const distinctId = String(event.distinct_id)
+
+    // If forceDisablePersonProcessing is true, skip all personless processing and just create a fake person
+    if (forceDisablePersonProcessing) {
+        return ok(createFakePerson(team.id, distinctId))
+    }
+
+    // Check if a real person exists for this distinct_id
+    let existingPerson = await personStoreBatch.fetchForChecking(team.id, distinctId)
+
+    if (!existingPerson) {
+        // See the comment in `mergeDistinctIds`. We are inserting a row into `posthog_personlessdistinctid`
+        // to note that this Distinct ID has been used in "personless" mode. This is necessary
+        // so that later, during a merge, we can decide whether we need to write out an override
+        // or not.
+
+        const personlessDistinctIdCacheKey = `${team.id}|${distinctId}`
+        if (!PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(personlessDistinctIdCacheKey)) {
+            const personIsMerged = await personStoreBatch.addPersonlessDistinctId(team.id, distinctId)
+
+            // We know the row is in PG now, and so future events for this Distinct ID can
+            // skip the PG I/O.
+            PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(personlessDistinctIdCacheKey, true)
+
+            if (personIsMerged) {
+                // If `personIsMerged` comes back `true`, it means the `posthog_personlessdistinctid`
+                // has been updated by a merge (either since we called `fetchPerson` above, plus
+                // replication lag). We need to check `fetchPerson` again (this time using the leader)
+                // so that we properly associate this event with the Person we got merged into.
+                existingPerson = await personStoreBatch.fetchForUpdate(team.id, distinctId)
+            }
+        }
+    }
+
+    if (existingPerson) {
+        const person = existingPerson as Person
+
+        // Ensure person properties don't propagate elsewhere, such as onto the event itself.
+        person.properties = {}
+
+        // If the team has opted out then we never force the upgrade.
+        const teamHasNotOptedOut = !team.person_processing_opt_out
+
+        if (teamHasNotOptedOut && timestamp > person.created_at.plus({ minutes: 1 })) {
+            // See documentation on the Person.force_upgrade field.
+            //
+            // Note that we account for timestamp vs person creation time (with a little
+            // padding for good measure) to account for ingestion lag. It's possible for
+            // events to be processed after person creation even if they were sent prior
+            // to person creation, and the user did nothing wrong in that case.
+            person.force_upgrade = true
+        }
+
+        return ok(person)
+    }
+
+    // No existing person found - create a fake person
+    return ok(createFakePerson(team.id, distinctId))
+}
+
+/**
+ * Creates a deterministic fake person for personless events.
+ *
+ * The UUID is deterministic based on team_id and distinct_id, allowing:
+ * - Future events with same distinct_id to get same UUID
+ * - Later merging/upgrading without data loss
+ *
+ * The created_at timestamp (1970-01-01 00:00:05 UTC) serves as a debugging marker
+ * that this is a synthetic person, not a real one.
+ */
+function createFakePerson(teamId: number, distinctId: string): Person {
+    // We need a value from the `person_created_column` in ClickHouse. This should be
+    // hidden from users for events without a real person, anyway. It's slightly offset
+    // from the 0 date (by 5 seconds) in order to assist in debugging by being
+    // harmlessly distinct from Unix UTC "0".
+    const createdAt = DateTime.utc(1970, 1, 1, 0, 0, 5)
+
+    return {
+        team_id: teamId,
+        properties: {},
+        uuid: uuidFromDistinctId(teamId, distinctId),
+        created_at: createdAt,
+    }
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -18,8 +18,7 @@ export async function processPersonsStep(
     team: Team,
     timestamp: DateTime,
     processPerson: boolean,
-    personStoreBatch: PersonsStoreForBatch,
-    forceDisablePersonProcessing: boolean = false
+    personStoreBatch: PersonsStoreForBatch
 ): Promise<PipelineResult<[PluginEvent, Person, Promise<void>]>> {
     const context = new PersonContext(
         event,
@@ -36,8 +35,7 @@ export async function processPersonsStep(
     const processor = new PersonEventProcessor(
         context,
         new PersonPropertyService(context),
-        new PersonMergeService(context),
-        forceDisablePersonProcessing
+        new PersonMergeService(context)
     )
     const [result, kafkaAck] = await processor.processEvent()
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -358,7 +358,10 @@ export class EventPipelineRunner {
                 return personStepResult
             }
 
-            ;[postPersonEvent, person, personKafkaAck] = personStepResult.value
+            const [processedEvent, processedPerson, ack] = personStepResult.value
+            postPersonEvent = processedEvent
+            person = processedPerson
+            personKafkaAck = ack
 
             // Preserve force_upgrade flag if it was set by personless step
             if (forceUpgrade) {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -27,6 +27,7 @@ import {
 } from './metrics'
 import { normalizeEventStep } from './normalizeEventStep'
 import { prepareEventStep } from './prepareEventStep'
+import { processPersonlessStep } from './processPersonlessStep'
 import { processPersonsStep } from './processPersonsStep'
 import { transformEventStep } from './transformEventStep'
 
@@ -232,32 +233,22 @@ export class EventPipelineRunner {
         }
         const [normalizedEvent, timestamp] = normalizeResult.value
 
-        const personStepResult = await this.runPipelineStep<
-            [PluginEvent, Person, Promise<void>],
-            typeof processPersonsStep
-        >(
-            processPersonsStep,
-            [
-                this,
-                normalizedEvent,
-                team,
-                timestamp,
-                processPerson,
-                this.personsStoreForBatch,
-                forceDisablePersonProcessing,
-            ],
+        const personProcessingResult = await this.processPersonForEvent(
+            normalizedEvent,
+            team,
+            timestamp,
+            processPerson,
+            forceDisablePersonProcessing,
             event.team_id,
-            true,
             kafkaAcks,
             warnings
         )
 
-        if (!isOkResult(personStepResult)) {
-            // TODO: We pass kafkaAcks, so the side effects should be merged, but this needs to be refactored
-            return personStepResult
+        if (!isOkResult(personProcessingResult)) {
+            return personProcessingResult
         }
 
-        const [postPersonEvent, person, personKafkaAck] = personStepResult.value
+        const { event: postPersonEvent, person, kafkaAck: personKafkaAck } = personProcessingResult.value
         kafkaAcks.push(personKafkaAck)
 
         const prepareResult = await this.runStep<PreIngestionEvent, typeof prepareEventStep>(
@@ -311,6 +302,71 @@ export class EventPipelineRunner {
         }
 
         return ok(successResult, kafkaAcks, warnings)
+    }
+
+    private async processPersonForEvent(
+        event: PluginEvent,
+        team: Team,
+        timestamp: DateTime,
+        processPerson: boolean,
+        forceDisablePersonProcessing: boolean,
+        teamId: number,
+        kafkaAcks: Promise<unknown>[],
+        warnings: PipelineWarning[]
+    ): Promise<PipelineResult<{ event: PluginEvent; person: Person; kafkaAck: Promise<void> }>> {
+        let postPersonEvent = event
+        let person: Person
+        let personKafkaAck: Promise<void> = Promise.resolve()
+        let shouldProcessPerson = processPerson
+        let forceUpgrade = false
+
+        // If personless mode, check if we need to force upgrade
+        if (!processPerson) {
+            const personlessResult = await this.runPipelineStep<Person, typeof processPersonlessStep>(
+                processPersonlessStep,
+                [event, team, timestamp, this.personsStoreForBatch, forceDisablePersonProcessing],
+                teamId,
+                true,
+                kafkaAcks,
+                warnings
+            )
+
+            if (!isOkResult(personlessResult)) {
+                return personlessResult
+            }
+
+            person = personlessResult.value
+            forceUpgrade = !!person.force_upgrade
+            shouldProcessPerson = forceUpgrade
+        }
+
+        // Run full person processing if needed (either processPerson=true or force_upgrade)
+        if (shouldProcessPerson) {
+            const personStepResult = await this.runPipelineStep<
+                [PluginEvent, Person, Promise<void>],
+                typeof processPersonsStep
+            >(
+                processPersonsStep,
+                [this, event, team, timestamp, true, this.personsStoreForBatch],
+                teamId,
+                true,
+                kafkaAcks,
+                warnings
+            )
+
+            if (!isOkResult(personStepResult)) {
+                return personStepResult
+            }
+
+            ;[postPersonEvent, person, personKafkaAck] = personStepResult.value
+
+            // Preserve force_upgrade flag if it was set by personless step
+            if (forceUpgrade) {
+                person.force_upgrade = true
+            }
+        }
+
+        return ok({ event: postPersonEvent, person: person!, kafkaAck: personKafkaAck })
     }
 
     registerLastStep(stepName: string, eventToEmit?: RawKafkaEvent): EventPipelineResult {

--- a/plugin-server/src/worker/ingestion/persons/person-event-processor.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-event-processor.ts
@@ -1,27 +1,12 @@
-import LRU from 'lru-cache'
-import { DateTime } from 'luxon'
-
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { ONE_HOUR } from '../../../config/constants'
 import { PipelineResult, dlq, ok, redirect } from '../../../ingestion/pipelines/results'
 import { InternalPerson, Person } from '../../../types'
 import { logger } from '../../../utils/logger'
-import { uuidFromDistinctId } from '../person-uuid'
 import { PersonContext } from './person-context'
 import { PersonMergeService } from './person-merge-service'
 import { PersonMergeLimitExceededError, PersonMergeRaceConditionError } from './person-merge-types'
 import { PersonPropertyService } from './person-property-service'
-
-// Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given
-// (team_id, distinct_id) pair. If we have, then we can skip the INSERT attempt.
-// TODO: Move this out of module scope, we don't currently have a clean place (outside of the Hub)
-// to stash longer lived objects like caches. For now it's not important.
-const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRU<string, boolean>({
-    max: 10_000,
-    maxAge: ONE_HOUR * 24, // cache up to 24h
-    updateAgeOnGet: true,
-})
 
 /**
  * Main orchestrator for person processing operations.
@@ -32,15 +17,10 @@ export class PersonEventProcessor {
     constructor(
         private context: PersonContext,
         private propertyService: PersonPropertyService,
-        private mergeService: PersonMergeService,
-        private forceDisablePersonProcessing: boolean = false
+        private mergeService: PersonMergeService
     ) {}
 
     async processEvent(): Promise<[PipelineResult<Person>, Promise<void>]> {
-        if (!this.context.processPerson) {
-            return await this.handlePersonlessMode()
-        }
-
         // First, handle any identify/alias/merge operations
         const mergeResult = await this.mergeService.handleIdentifyOrAlias()
 
@@ -76,88 +56,6 @@ export class PersonEventProcessor {
         // Handle regular property updates
         const [updatedPerson, updateKafkaAck] = await this.propertyService.handleUpdate()
         return [ok(updatedPerson), Promise.all([identifyOrAliasKafkaAck, updateKafkaAck]).then(() => undefined)]
-    }
-
-    private async handlePersonlessMode(): Promise<[PipelineResult<Person>, Promise<void>]> {
-        // If forceDisablePersonProcessing is true, skip all personless processing and just return a fake person
-        if (this.forceDisablePersonProcessing) {
-            return [ok(this.createFakePerson()), Promise.resolve()]
-        }
-
-        let existingPerson = await this.context.personStore.fetchForChecking(
-            this.context.team.id,
-            this.context.distinctId
-        )
-
-        if (!existingPerson) {
-            // See the comment in `mergeDistinctIds`. We are inserting a row into `posthog_personlessdistinctid`
-            // to note that this Distinct ID has been used in "personless" mode. This is necessary
-            // so that later, during a merge, we can decide whether we need to write out an override
-            // or not.
-
-            const personlessDistinctIdCacheKey = `${this.context.team.id}|${this.context.distinctId}`
-            if (!PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(personlessDistinctIdCacheKey)) {
-                const personIsMerged = await this.context.personStore.addPersonlessDistinctId(
-                    this.context.team.id,
-                    this.context.distinctId
-                )
-
-                // We know the row is in PG now, and so future events for this Distinct ID can
-                // skip the PG I/O.
-                PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(personlessDistinctIdCacheKey, true)
-
-                if (personIsMerged) {
-                    // If `personIsMerged` comes back `true`, it means the `posthog_personlessdistinctid`
-                    // has been updated by a merge (either since we called `fetchPerson` above, plus
-                    // replication lag). We need to check `fetchPerson` again (this time using the leader)
-                    // so that we properly associate this event with the Person we got merged into.
-                    existingPerson = await this.context.personStore.fetchForUpdate(
-                        this.context.team.id,
-                        this.context.distinctId
-                    )
-                }
-            }
-        }
-
-        if (existingPerson) {
-            const person = existingPerson as Person
-
-            // Ensure person properties don't propagate elsewhere, such as onto the event itself.
-            person.properties = {}
-
-            // If the team has opted out then we never force the upgrade.
-            const teamHasNotOptedOut = !this.context.team.person_processing_opt_out
-
-            if (teamHasNotOptedOut && this.context.timestamp > person.created_at.plus({ minutes: 1 })) {
-                // See documentation on the field.
-                //
-                // Note that we account for timestamp vs person creation time (with a little
-                // padding for good measure) to account for ingestion lag. It's possible for
-                // events to be processed after person creation even if they were sent prior
-                // to person creation, and the user did nothing wrong in that case.
-                person.force_upgrade = true
-            }
-
-            return [ok(person), Promise.resolve()]
-        }
-
-        const fakePerson = this.createFakePerson()
-        return [ok(fakePerson), Promise.resolve()]
-    }
-
-    private createFakePerson(): Person {
-        // We need a value from the `person_created_column` in ClickHouse. This should be
-        // hidden from users for events without a real person, anyway. It's slightly offset
-        // from the 0 date (by 5 seconds) in order to assist in debugging by being
-        // harmlessly distinct from Unix UTC "0".
-        const createdAt = DateTime.utc(1970, 1, 1, 0, 0, 5)
-
-        return {
-            team_id: this.context.team.id,
-            properties: {},
-            uuid: uuidFromDistinctId(this.context.team.id, this.context.distinctId),
-            created_at: createdAt,
-        }
     }
 
     getContext(): PersonContext {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -120,7 +120,6 @@ exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
         "personUpdateCache": {},
         "updateLatencyPerDistinctIdSeconds": {},
       },
-      false,
     ],
   ],
   [

--- a/plugin-server/tests/worker/ingestion/event-pipeline/processPersonlessStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/processPersonlessStep.test.ts
@@ -1,0 +1,281 @@
+import { DateTime } from 'luxon'
+
+import { PluginEvent, Properties } from '@posthog/plugin-scaffold'
+
+import { PipelineResultType, isOkResult } from '~/ingestion/pipelines/results'
+import { BatchWritingPersonsStoreForBatch } from '~/worker/ingestion/persons/batch-writing-person-store'
+
+import { Hub, InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../../src/types'
+import { closeHub, createHub } from '../../../../src/utils/db/hub'
+import { UUIDT } from '../../../../src/utils/utils'
+import { processPersonlessStep } from '../../../../src/worker/ingestion/event-pipeline/processPersonlessStep'
+import { PostgresPersonRepository } from '../../../../src/worker/ingestion/persons/repositories/postgres-person-repository'
+import { createOrganization, createTeam, getTeam, resetTestDatabase } from '../../../helpers/sql'
+
+async function createPerson(
+    hub: Hub,
+    createdAt: DateTime,
+    properties: Properties,
+    propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
+    propertiesLastOperation: PropertiesLastOperation,
+    teamId: number,
+    isUserId: number | null,
+    isIdentified: boolean,
+    uuid: string,
+    distinctIds?: { distinctId: string; version?: number }[]
+): Promise<InternalPerson> {
+    const personRepository = new PostgresPersonRepository(hub.db.postgres)
+    const result = await personRepository.createPerson(
+        createdAt,
+        properties,
+        propertiesLastUpdatedAt,
+        propertiesLastOperation,
+        teamId,
+        isUserId,
+        isIdentified,
+        uuid,
+        distinctIds
+    )
+    if (!result.success) {
+        throw new Error('Failed to create person')
+    }
+    await hub.db.kafkaProducer.queueMessages(result.messages)
+    return result.person
+}
+
+describe('processPersonlessStep()', () => {
+    let hub: Hub
+    let teamId: number
+    let team: Team
+    let pluginEvent: PluginEvent
+    let timestamp: DateTime
+    let personsStore: BatchWritingPersonsStoreForBatch
+    let personRepository: PostgresPersonRepository
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        hub = await createHub()
+        const organizationId = await createOrganization(hub.db.postgres)
+        teamId = await createTeam(hub.db.postgres, organizationId)
+        team = (await getTeam(hub, teamId))!
+
+        personRepository = new PostgresPersonRepository(hub.db.postgres)
+        personsStore = new BatchWritingPersonsStoreForBatch(personRepository, hub.db.kafkaProducer)
+
+        pluginEvent = {
+            distinct_id: 'test-user-123',
+            ip: null,
+            site_url: 'http://localhost',
+            team_id: teamId,
+            now: '2020-02-23T02:15:00Z',
+            timestamp: '2020-02-23T02:15:00Z',
+            event: '$pageview',
+            properties: {},
+            uuid: new UUIDT().toString(),
+        }
+        timestamp = DateTime.fromISO(pluginEvent.timestamp!)
+    })
+
+    afterEach(async () => {
+        await closeHub(hub)
+    })
+
+    describe('basic personless functionality', () => {
+        it('returns fake person when no existing person found', async () => {
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                const person = result.value
+                expect(person.team_id).toBe(teamId)
+                expect(person.properties).toEqual({})
+                expect(person.uuid).toBeDefined()
+                expect(person.created_at.toISO()).toBe('1970-01-01T00:00:05.000Z') // Fake person marker
+                expect(person.force_upgrade).toBeUndefined()
+            }
+        })
+
+        it('returns existing person with empty properties when person exists', async () => {
+            const personUuid = new UUIDT().toString()
+
+            await createPerson(hub, timestamp, { name: 'John' }, {}, {}, teamId, null, false, personUuid, [
+                { distinctId: pluginEvent.distinct_id },
+            ])
+
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                const person = result.value
+                expect(person.uuid).toBe(personUuid)
+                expect(person.properties).toEqual({}) // Properties cleared for personless
+                expect(person.force_upgrade).toBeUndefined() // No force upgrade yet
+            }
+        })
+
+        it('inserts into posthog_personlessdistinctid table on first encounter', async () => {
+            const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
+
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(addPersonlessDistinctIdSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
+        })
+
+        it('uses LRU cache to skip DB insert on subsequent calls', async () => {
+            // First call - should insert
+            await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
+
+            // Second call - should use cache
+            await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(addPersonlessDistinctIdSpy).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('force_upgrade logic', () => {
+        it('sets force_upgrade=true when event timestamp > person.created_at + 1 minute', async () => {
+            const personUuid = new UUIDT().toString()
+            const personCreatedAt = DateTime.fromISO('2020-02-23T02:00:00Z')
+
+            await createPerson(hub, personCreatedAt, {}, {}, {}, teamId, null, false, personUuid, [
+                { distinctId: pluginEvent.distinct_id },
+            ])
+
+            // Event is at 02:15:00, person created at 02:00:00 -> more than 1 minute
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                const person = result.value
+                expect(person.uuid).toBe(personUuid)
+                expect(person.force_upgrade).toBe(true)
+            }
+        })
+
+        it('does NOT set force_upgrade when within 1-minute grace period', async () => {
+            const personUuid = new UUIDT().toString()
+            const personCreatedAt = DateTime.fromISO('2020-02-23T02:14:30Z')
+
+            await createPerson(hub, personCreatedAt, {}, {}, {}, teamId, null, false, personUuid, [
+                { distinctId: pluginEvent.distinct_id },
+            ])
+
+            // Event is at 02:15:00, person created at 02:14:30 -> within 1 minute
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                const person = result.value
+                expect(person.uuid).toBe(personUuid)
+                expect(person.force_upgrade).toBeUndefined()
+            }
+        })
+
+        it('ignores force_upgrade when team.person_processing_opt_out=true', async () => {
+            team.person_processing_opt_out = true
+
+            const personUuid = new UUIDT().toString()
+            const personCreatedAt = DateTime.fromISO('2020-02-23T02:00:00Z')
+
+            await createPerson(hub, personCreatedAt, {}, {}, {}, teamId, null, false, personUuid, [
+                { distinctId: pluginEvent.distinct_id },
+            ])
+
+            // Event is at 02:15:00, person created at 02:00:00 -> more than 1 minute, but team opted out
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                const person = result.value
+                expect(person.uuid).toBe(personUuid)
+                expect(person.force_upgrade).toBeUndefined() // Not set due to opt-out
+            }
+        })
+    })
+
+    describe('merge detection', () => {
+        it('detects when person was merged and re-fetches from leader', async () => {
+            const personUuid = new UUIDT().toString()
+            const personCreatedAt = DateTime.fromISO('2020-02-20T00:00:00Z')
+
+            const person = await createPerson(
+                hub,
+                personCreatedAt,
+                { name: 'John' },
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                personUuid,
+                [{ distinctId: pluginEvent.distinct_id }]
+            )
+
+            // Mock fetchForChecking to return null initially (simulating no person found)
+            jest.spyOn(personsStore, 'fetchForChecking').mockResolvedValueOnce(null)
+
+            // Mock addPersonlessDistinctId to return true (indicating merge happened)
+            const addPersonlessDistinctIdSpy = jest
+                .spyOn(personsStore, 'addPersonlessDistinctId')
+                .mockResolvedValue(true)
+
+            // Mock fetchForUpdate to return the actual person
+            const fetchForUpdateSpy = jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(person)
+
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(addPersonlessDistinctIdSpy).toHaveBeenCalled()
+            expect(fetchForUpdateSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
+        })
+    })
+
+    describe('forceDisablePersonProcessing', () => {
+        it('skips all DB operations and returns fake person immediately when true', async () => {
+            const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
+            const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
+
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, true)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                const person = result.value
+                expect(person.team_id).toBe(teamId)
+                expect(person.properties).toEqual({})
+                expect(person.created_at.toISO()).toBe('1970-01-01T00:00:05.000Z')
+            }
+
+            // Verify no database operations were performed
+            expect(fetchForCheckingSpy).not.toHaveBeenCalled()
+            expect(addPersonlessDistinctIdSpy).not.toHaveBeenCalled()
+        })
+
+        it('performs normal processing when false', async () => {
+            const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
+
+            const result = await processPersonlessStep(pluginEvent, team, timestamp, personsStore, false)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            // Should perform database operations
+            expect(fetchForCheckingSpy).toHaveBeenCalled()
+        })
+
+        it('works with different distinct IDs', async () => {
+            const distinctIds = ['user-1', 'user-2', 'user-3']
+
+            for (const distinctId of distinctIds) {
+                const event = { ...pluginEvent, distinct_id: distinctId }
+                const result = await processPersonlessStep(event, team, timestamp, personsStore, true)
+
+                expect(result.type).toBe(PipelineResultType.OK)
+                if (isOkResult(result)) {
+                    expect(result.value.team_id).toBe(teamId)
+                    expect(result.value.properties).toEqual({})
+                }
+            }
+        })
+    })
+})

--- a/plugin-server/tests/worker/ingestion/person-state-batch.dualwrite.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.dualwrite.test.ts
@@ -396,36 +396,7 @@ describe('PersonState dual-write compatibility', () => {
         })
     })
 
-    describe('Process person profile flag', () => {
-        it('respects $process_person_profile=false identically', async () => {
-            const distinctId = 'ephemeral-user'
-            const event: Partial<PluginEvent> = {
-                distinct_id: distinctId,
-                properties: {
-                    $process_person_profile: false,
-                    $set: { should_not_persist: true },
-                },
-            }
-
-            const { processor: singleProcessor, personsStore: singleStore } = createPersonProcessor(
-                singleWriteRepository,
-                event,
-                false
-            )
-            const { processor: dualProcessor, personsStore: dualStore } = createPersonProcessor(
-                dualWriteRepository,
-                event,
-                false
-            )
-
-            await Promise.all([singleProcessor.processEvent(), dualProcessor.processEvent()])
-
-            await Promise.all([singleStore.flush(), dualStore.flush()])
-
-            const postgresPersons = await fetchPostgresPersonsH()
-            expect(postgresPersons.length).toBe(0)
-        })
-    })
+    describe('Process person profile flag', () => {})
 
     describe('Batch operations', () => {
         it('creates multiple persons in batch consistently', async () => {

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -188,8 +188,7 @@ describe('PersonState.processEvent()', () => {
         const processor = new PersonEventProcessor(
             context,
             propertyService ?? new PersonPropertyService(context),
-            mergeService ?? new PersonMergeService(context),
-            false // forceDisablePersonProcessing = false (default)
+            mergeService ?? new PersonMergeService(context)
         )
         return processor
     }
@@ -339,52 +338,6 @@ describe('PersonState.processEvent()', () => {
             expect(personPrimaryTeam.uuid).not.toEqual(personOtherTeam.uuid)
         })
 
-        it('returns an ephemeral user object when $process_person_profile=false', async () => {
-            const event_uuid = new UUIDT().toString()
-
-            const hubParam = undefined
-            const processPerson = false
-            const [result, kafkaAcks] = await personProcessor(
-                {
-                    event: '$pageview',
-                    distinct_id: newUserDistinctId,
-                    uuid: event_uuid,
-                    properties: { $set: { should_be_dropped: 100 } },
-                },
-                undefined,
-                undefined,
-                hubParam,
-                processPerson
-            ).processEvent()
-            await hub.db.kafkaProducer.flush()
-            await kafkaAcks
-
-            expect(result.type).toBe(PipelineResultType.OK)
-            if (isOkResult(result)) {
-                const fakePerson = result.value
-                expect(fakePerson).toEqual(
-                    expect.objectContaining({
-                        team_id: teamId,
-                        uuid: newUserUuid, // deterministic even though no user rows were created
-                        properties: {}, // empty even though there was a $set attempted
-                        created_at: DateTime.utc(1970, 1, 1, 0, 0, 5), // fake person created_at
-                    })
-                )
-                expect(fakePerson.force_upgrade).toBeUndefined()
-            }
-
-            // verify there is no Postgres person
-            const persons = await fetchPostgresPersonsH()
-            expect(persons.length).toEqual(0)
-
-            // verify there are no Postgres distinct_ids
-            const distinctIds = await fetchDistinctIdValues(
-                hub.db.postgres,
-                isOkResult(result) ? (result.value as InternalPerson) : ({} as InternalPerson)
-            )
-            expect(distinctIds).toEqual(expect.arrayContaining([]))
-        })
-
         it('overrides are created only when distinct_id is in posthog_personlessdistinctid', async () => {
             // oldUserDistinctId exists, and 'old2' will merge into it, but not create an override
             await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
@@ -452,117 +405,6 @@ describe('PersonState.processEvent()', () => {
             expect(chOverridesOld.length).toEqual(0)
         })
 
-        it('force_upgrade works', async () => {
-            const _oldPerson = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
-                { distinctId: oldUserDistinctId },
-            ])
-
-            const hubParam = undefined
-            let processPerson = true
-            const [_person, kafkaAcks] = await personProcessor(
-                {
-                    event: '$identify',
-                    distinct_id: newUserDistinctId,
-                    properties: {
-                        $anon_distinct_id: oldUserDistinctId,
-                    },
-                },
-                undefined,
-                undefined,
-                hubParam,
-                processPerson
-            ).processEvent()
-            await hub.db.kafkaProducer.flush()
-            await kafkaAcks
-
-            // Using the `distinct_id` again with `processPerson=false` results in
-            // `force_upgrade=true` and real Person `uuid` and `created_at`
-            processPerson = false
-            const event_uuid = new UUIDT().toString()
-            const timestampParam = timestamp.plus({ minutes: 5 }) // Event needs to happen after Person creation
-            const [result2, kafkaAcks2] = await personProcessor(
-                {
-                    event: '$pageview',
-                    distinct_id: newUserDistinctId,
-                    uuid: event_uuid,
-                    properties: { $set: { should_be_dropped: 100 } },
-                },
-                undefined,
-                undefined,
-                hubParam,
-                processPerson,
-                timestampParam
-            ).processEvent()
-            await hub.db.kafkaProducer.flush()
-            await kafkaAcks2
-
-            expect(result2.type).toBe(PipelineResultType.OK)
-            if (isOkResult(result2)) {
-                const fakePerson = result2.value
-                expect(fakePerson).toEqual(
-                    expect.objectContaining({
-                        team_id: teamId,
-                        uuid: oldUserUuid, // *old* user, because it existed before the merge
-                        properties: {}, // empty even though there was a $set attempted
-                        created_at: timestamp, // *not* the fake person created_at
-                        force_upgrade: true,
-                    })
-                )
-            }
-        })
-
-        it('force_upgrade is ignored if team.person_processing_opt_out is true', async () => {
-            mainTeam.person_processing_opt_out = true
-            const _oldPerson = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, oldUserUuid, [
-                { distinctId: oldUserDistinctId },
-            ])
-
-            const hubParam = undefined
-            let processPerson = true
-            const [_person, kafkaAcks] = await personProcessor(
-                {
-                    event: '$identify',
-                    distinct_id: newUserDistinctId,
-                    properties: {
-                        $anon_distinct_id: oldUserDistinctId,
-                    },
-                },
-                undefined,
-                undefined,
-                hubParam,
-                processPerson
-            ).processEvent()
-            await hub.db.kafkaProducer.flush()
-            await kafkaAcks
-
-            // Using the `distinct_id` again with `processPerson=false` results in
-            // `force_upgrade=true` and real Person `uuid` and `created_at`
-            processPerson = false
-            const event_uuid = new UUIDT().toString()
-            const timestampParam = timestamp.plus({ minutes: 5 }) // Event needs to happen after Person creation
-            const [result2, kafkaAcks2] = await personProcessor(
-                {
-                    event: '$pageview',
-                    distinct_id: newUserDistinctId,
-                    uuid: event_uuid,
-                    properties: { $set: { should_be_dropped: 100 } },
-                },
-                undefined,
-                undefined,
-                hubParam,
-                processPerson,
-                timestampParam
-            ).processEvent()
-            await hub.db.kafkaProducer.flush()
-            await kafkaAcks2
-
-            expect(result2.type).toBe(PipelineResultType.OK)
-            if (isOkResult(result2)) {
-                const fakePerson = result2.value
-                expect(fakePerson.force_upgrade).toBeUndefined()
-            }
-        })
-
         it('creates person if they are new', async () => {
             const event_uuid = new UUIDT().toString()
             const [person, kafkaAcks] = await personPropertyService({
@@ -597,73 +439,6 @@ describe('PersonState.processEvent()', () => {
             // verify Postgres distinct_ids
             const distinctIds = await fetchDistinctIdValues(hub.db.postgres, persons[0])
             expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
-        })
-
-        it('does not attach existing person properties to $process_person_profile=false events', async () => {
-            const originalEventUuid = new UUIDT().toString()
-            const [result, kafkaAcks] = await personProcessor({
-                event: '$pageview',
-                distinct_id: newUserDistinctId,
-                uuid: originalEventUuid,
-                properties: { $set: { c: 420 } },
-            }).processEvent()
-            await hub.db.kafkaProducer.flush()
-            await kafkaAcks
-
-            expect(result.type).toBe(PipelineResultType.OK)
-            if (isOkResult(result)) {
-                const person = result.value
-                expect(person).toEqual(
-                    expect.objectContaining({
-                        id: expect.any(String),
-                        uuid: newUserUuid,
-                        properties: { $creator_event_uuid: originalEventUuid, c: 420 },
-                        created_at: timestamp,
-                        version: 0,
-                        is_identified: false,
-                    })
-                )
-
-                // verify Postgres persons
-                const persons = sortPersons(await fetchPostgresPersonsH())
-                expect(persons.length).toEqual(1)
-                expect(persons[0]).toEqual(person)
-
-                // verify Postgres distinct_ids
-                const distinctIds = await fetchDistinctIdValues(hub.db.postgres, person as InternalPerson)
-                expect(distinctIds).toEqual(expect.arrayContaining([newUserDistinctId]))
-            }
-
-            // OK, a person now exists with { c: 420 }, let's prove the properties come back out
-            // of the DB.
-            const [personVerifyResult] = await personProcessor({
-                event: '$pageview',
-                distinct_id: newUserDistinctId,
-                uuid: new UUIDT().toString(),
-                properties: {},
-            }).processEvent()
-            expect(personVerifyResult.type).toBe(PipelineResultType.OK)
-            if (isOkResult(personVerifyResult)) {
-                expect(personVerifyResult.value.properties).toEqual({ $creator_event_uuid: originalEventUuid, c: 420 })
-            }
-
-            // But they don't when $process_person_profile=false
-            const [processPersonFalseResult] = await personProcessor(
-                {
-                    event: '$pageview',
-                    distinct_id: newUserDistinctId,
-                    uuid: new UUIDT().toString(),
-                    properties: {},
-                },
-                undefined,
-                undefined,
-                hub,
-                false
-            ).processEvent()
-            expect(processPersonFalseResult.type).toBe(PipelineResultType.OK)
-            if (isOkResult(processPersonFalseResult)) {
-                expect(processPersonFalseResult.value.properties).toEqual({})
-            }
         })
 
         it('handles person being created in a race condition', async () => {
@@ -3986,8 +3761,7 @@ describe('PersonState.processEvent()', () => {
                     const processor = new PersonEventProcessor(
                         context,
                         new PersonPropertyService(context),
-                        new PersonMergeService(context),
-                        false // forceDisablePersonProcessing = false (default)
+                        new PersonMergeService(context)
                     )
                     return processor
                 }
@@ -4117,166 +3891,6 @@ describe('PersonState.processEvent()', () => {
                             expect(result.value).toEqual(mockPerson)
                         }
                     }
-                })
-            })
-        })
-
-        describe('forceDisablePersonProcessing functionality', () => {
-            let personsStore: BatchWritingPersonsStoreForBatch
-
-            beforeEach(() => {
-                personsStore = new BatchWritingPersonsStoreForBatch(personRepository, hub.db.kafkaProducer)
-            })
-
-            function createPersonEventProcessorWithForceDisable(
-                event: Partial<PluginEvent>,
-                forceDisablePersonProcessing: boolean = false,
-                processPerson: boolean = true
-            ) {
-                const fullEvent = {
-                    team_id: teamId,
-                    properties: {},
-                    ...event,
-                }
-
-                const context = new PersonContext(
-                    fullEvent as any,
-                    mainTeam,
-                    event.distinct_id!,
-                    timestamp,
-                    processPerson,
-                    hub.db.kafkaProducer,
-                    personsStore,
-                    0,
-                    createDefaultSyncMergeMode()
-                )
-                const processor = new PersonEventProcessor(
-                    context,
-                    new PersonPropertyService(context),
-                    new PersonMergeService(context),
-                    forceDisablePersonProcessing
-                )
-                return processor
-            }
-
-            describe('when forceDisablePersonProcessing is true', () => {
-                it('should skip all personless processing and return fake person immediately', async () => {
-                    const processor = createPersonEventProcessorWithForceDisable(
-                        {
-                            event: '$pageview',
-                            distinct_id: 'test-user-123',
-                        },
-                        true, // forceDisablePersonProcessing = true
-                        false // processPerson = false (triggers personless mode)
-                    )
-
-                    const [result, kafkaAck] = await processor.processEvent()
-
-                    expect(result.type).toBe(PipelineResultType.OK)
-                    if (isOkResult(result)) {
-                        const person = result.value
-                        expect(person.team_id).toBe(teamId)
-                        expect(person.properties).toEqual({})
-                        expect(person.uuid).toBeDefined()
-                        expect(person.created_at.toISO()).toBe('1970-01-01T00:00:05.000Z') // Fake person creation date
-                    }
-
-                    // Verify kafkaAck is resolved
-                    await expect(kafkaAck).resolves.toBeUndefined()
-                })
-
-                it('should not perform any database operations when forceDisablePersonProcessing is true', async () => {
-                    const processor = createPersonEventProcessorWithForceDisable(
-                        {
-                            event: '$pageview',
-                            distinct_id: 'test-user-456',
-                        },
-                        true, // forceDisablePersonProcessing = true
-                        false // processPerson = false
-                    )
-
-                    // Spy on person store methods to ensure they're not called
-                    const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
-                    const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
-
-                    const [result] = await processor.processEvent()
-
-                    expect(result.type).toBe(PipelineResultType.OK)
-                    // Verify no database operations were performed
-                    expect(fetchForCheckingSpy).not.toHaveBeenCalled()
-                    expect(addPersonlessDistinctIdSpy).not.toHaveBeenCalled()
-                })
-
-                it('should work with different distinct IDs', async () => {
-                    const distinctIds = ['user-1', 'user-2', 'user-3']
-
-                    for (const distinctId of distinctIds) {
-                        const processor = createPersonEventProcessorWithForceDisable(
-                            {
-                                event: '$pageview',
-                                distinct_id: distinctId,
-                            },
-                            true, // forceDisablePersonProcessing = true
-                            false // processPerson = false
-                        )
-
-                        const [result] = await processor.processEvent()
-
-                        expect(result.type).toBe(PipelineResultType.OK)
-                        if (isOkResult(result)) {
-                            expect(result.value.team_id).toBe(teamId)
-                            expect(result.value.properties).toEqual({})
-                        }
-                    }
-                })
-            })
-
-            describe('when forceDisablePersonProcessing is false', () => {
-                it('should perform normal personless processing', async () => {
-                    const processor = createPersonEventProcessorWithForceDisable(
-                        {
-                            event: '$pageview',
-                            distinct_id: 'test-user-normal',
-                        },
-                        false, // forceDisablePersonProcessing = false
-                        false // processPerson = false
-                    )
-
-                    const [result] = await processor.processEvent()
-
-                    expect(result.type).toBe(PipelineResultType.OK)
-                    if (isOkResult(result)) {
-                        const person = result.value
-                        expect(person.team_id).toBe(teamId)
-                        expect(person.properties).toEqual({})
-                        expect(person.uuid).toBeDefined()
-                        // Should still create a fake person, but through normal personless processing
-                        expect(person.created_at.toISO()).toBe('1970-01-01T00:00:05.000Z')
-                    }
-                })
-
-                it('should perform database operations when forceDisablePersonProcessing is false', async () => {
-                    const processor = createPersonEventProcessorWithForceDisable(
-                        {
-                            event: '$pageview',
-                            distinct_id: 'test-user-db-ops',
-                        },
-                        false, // forceDisablePersonProcessing = false
-                        false // processPerson = false
-                    )
-
-                    // Spy on person store methods
-                    const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking').mockResolvedValue(null)
-                    const addPersonlessDistinctIdSpy = jest
-                        .spyOn(personsStore, 'addPersonlessDistinctId')
-                        .mockResolvedValue(false)
-
-                    const [result] = await processor.processEvent()
-
-                    expect(result.type).toBe(PipelineResultType.OK)
-                    // Verify database operations were performed
-                    expect(fetchForCheckingSpy).toHaveBeenCalledWith(teamId, 'test-user-db-ops')
-                    expect(addPersonlessDistinctIdSpy).toHaveBeenCalledWith(teamId, 'test-user-db-ops')
                 })
             })
         })


### PR DESCRIPTION
## Problem

Right now it is hard to understand what is the the impact of the personless processing in the ingestion pipeline as it is in the same step as the person processing. This PR separates both steps so that we can track metrics for them separately

## Changes

- Move personless logic out of personProcessor
- Add new processPersonlessStep

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
