### PR TITLE
fix(project-tree): search with quotes

### DIFF
--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -943,6 +943,26 @@ class TestFileSystemAPI(APIBaseTest):
             self.assertEqual(resp.json()["count"], 1, f"Failed for query: {query}")
             self.assertEqual(resp.json()["results"][0]["path"], "Banana/go\\/revenue")
 
+    def test_search_allows_apostrophes(self):
+        """
+        Plain-text tokens that contain apostrophes should not trigger a search parser error.
+        """
+        FileSystem.objects.create(
+            team=self.team,
+            path="What's my homepage",
+            type="doc",
+            created_by=self.user,
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/file_system/",
+            {"search": "what's home"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["path"], "What's my homepage")
+
 
 @pytest.mark.ee  # Mark these tests to run only if EE code is available (for AccessControl)
 class TestFileSystemAPIAdvancedPermissions(APIBaseTest):


### PR DESCRIPTION
## Problem

The file system API search failed if the search query contained a single apostrophe.

## Changes

Be more lenient towards random input.

## How did you test this code?

Added a tests that checks for what failed before.