### PR TITLE
fix: improved performance and UX for loading related flags

### DIFF
--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -38,8 +38,7 @@ const featureFlagMatchMapping = {
 
 export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Props): JSX.Element {
     const relatedFlagsLogic = relatedFeatureFlagsLogic({ distinctId, groupTypeIndex, groups })
-    const { filteredMappedFlags, relatedFeatureFlagsLoading, searchTerm, filters, pagination } =
-        useValues(relatedFlagsLogic)
+    const { filteredMappedFlags, isLoading, searchTerm, filters, pagination } = useValues(relatedFlagsLogic)
     const { setSearchTerm, setFilters } = useActions(relatedFlagsLogic)
 
     const columns: LemonTableColumns<RelatedFeatureFlag> = [
@@ -236,7 +235,7 @@ export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Prop
             </div>
             <LemonTable
                 columns={columns}
-                loading={relatedFeatureFlagsLoading}
+                loading={isLoading}
                 dataSource={filteredMappedFlags}
                 pagination={pagination}
             />

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -47,7 +47,12 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
     ),
     key((props) => `${props.distinctId}`),
     connect(() => ({
-        values: [projectLogic, ['currentProjectId'], featureFlagsLogic, ['featureFlags', 'pagination']],
+        values: [
+            projectLogic,
+            ['currentProjectId'],
+            featureFlagsLogic,
+            ['featureFlags', 'pagination', 'featureFlagsLoading'],
+        ],
         actions: [featureFlagsLogic, ['setFeatureFlagsFilters', 'loadFeatureFlagsSuccess']],
     })),
     actions({
@@ -93,7 +98,13 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
             },
         ],
     }),
-    selectors(({ props }) => ({
+    selectors(({ props, selectors }) => ({
+        isLoading: [
+            () => [selectors.relatedFeatureFlagsLoading, featureFlagsLogic.selectors.featureFlagsLoading],
+            (relatedLoading: boolean, featureFlagsLoading: boolean): boolean => {
+                return relatedLoading || featureFlagsLoading
+            },
+        ],
         mappedRelatedFeatureFlags: [
             (selectors) => [selectors.relatedFeatureFlags, selectors.featureFlags],
             (relatedFlags, featureFlags): RelatedFeatureFlag[] => {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -189,7 +189,7 @@ class EvaluationTagSerializerMixin(serializers.Serializer):
 
         # If user doesn't have access to TAGGING feature or FLAG_EVALUATION_TAGS is disabled, skip validation
         # Evaluation tags are preserved in DB but hidden from user (like regular tags)
-        if not self._is_licensed_for_tagging() or not self._is_evaluation_tags_feature_enabled():
+        if not self._is_evaluation_tags_feature_enabled():
             return attrs
 
         # Get evaluation_tags from the request
@@ -220,14 +220,6 @@ class EvaluationTagSerializerMixin(serializers.Serializer):
                 )
 
         return attrs
-
-    def _is_licensed_for_tagging(self):
-        """Check if user has access to TAGGING feature."""
-        return (
-            "request" in self.context
-            and not self.context["request"].user.is_anonymous
-            and self.context["request"].user.organization.is_feature_available(AvailableFeature.TAGGING)
-        )
 
     def _is_evaluation_tags_feature_enabled(self):
         """Check if FLAG_EVALUATION_TAGS feature flag is enabled."""
@@ -298,11 +290,8 @@ class EvaluationTagSerializerMixin(serializers.Serializer):
         ret = super().to_representation(obj)
 
         # Include evaluation tags in the serialized output
-        # Hide evaluation_tags if:
-        # 1. User doesn't have TAGGING access (like TaggedItemSerializerMixin does for tags)
-        if not self._is_licensed_for_tagging():
-            ret["evaluation_tags"] = []
-        elif hasattr(obj, "evaluation_tags"):
+        # The evaluation_tags are hidden (if user doesn't have access) in list and retrieve methods
+        if hasattr(obj, "evaluation_tags"):
             # Django's prefetch_related creates a cache in _prefetched_objects_cache.
             # If the viewset used prefetch_related (which it should for performance),
             # we can access the tags without hitting the database again.


### PR DESCRIPTION
Follow up on PR #40501 to improve performance of loading feature flags.

## Changes

- Stopped evaluating `_is_licensed_for_tagging` in the serializer
- Improved loading UX of feature flags (the loading was only related to the `evaluation_reasons` request, ignoring the `feature_flags` request.

## How did you test this code?

Manual