### PR TITLE
feat(MA): add MarketingAnalyticsSourceStatusBanner component into ma dash

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -48,6 +48,7 @@ import { WebAnalyticsExport } from './WebAnalyticsExport'
 import { WebAnalyticsFilters } from './WebAnalyticsFilters'
 import { WebAnalyticsPageReportsCTA } from './WebAnalyticsPageReportsCTA'
 import { MarketingAnalyticsFilters } from './tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/MarketingAnalyticsFilters'
+import { MarketingAnalyticsSourceStatusBanner } from './tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner'
 import { marketingAnalyticsLogic } from './tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic'
 import { marketingAnalyticsTilesLogic } from './tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic'
 import { webAnalyticsModalLogic } from './webAnalyticsModalLogic'
@@ -491,6 +492,7 @@ const MarketingDashboard = (): JSX.Element => {
     return (
         <>
             {feedbackBanner}
+            <MarketingAnalyticsSourceStatusBanner />
             {component}
         </>
     )

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
@@ -5,7 +5,58 @@ import { LemonBanner } from '@posthog/lemon-ui'
 import { Link } from 'lib/lemon-ui/Link/Link'
 import { urls } from 'scenes/urls'
 
+import { ExternalDataSchemaStatus } from '~/types'
+
 import { marketingAnalyticsLogic } from '../logic/marketingAnalyticsLogic'
+
+type StatusCount = Record<
+    ExternalDataSchemaStatus.Running | ExternalDataSchemaStatus.Failed | ExternalDataSchemaStatus.Paused,
+    number
+>
+
+const getStatusCounts = (sources: { status: string }[]): StatusCount => {
+    const counts: StatusCount = {
+        [ExternalDataSchemaStatus.Running]: 0,
+        [ExternalDataSchemaStatus.Failed]: 0,
+        [ExternalDataSchemaStatus.Paused]: 0,
+    }
+
+    for (const source of sources) {
+        if (source.status === ExternalDataSchemaStatus.Running) {
+            counts[ExternalDataSchemaStatus.Running] += 1
+        } else if (source.status === ExternalDataSchemaStatus.Failed) {
+            counts[ExternalDataSchemaStatus.Failed] += 1
+        } else if (source.status === ExternalDataSchemaStatus.Paused) {
+            counts[ExternalDataSchemaStatus.Paused] += 1
+        }
+    }
+
+    return counts
+}
+
+const SourceStatusMessage = ({
+    length,
+    singularVerb,
+    pluralVerb,
+    message,
+}: {
+    length: number
+    singularVerb: string
+    pluralVerb: string
+    message: string
+}): JSX.Element | null => {
+    if (length === 0) {
+        return null
+    }
+    return (
+        <>
+            <strong>
+                {length} source{length > 1 ? 's' : ''} {length > 1 ? pluralVerb : singularVerb} {message}
+            </strong>
+            .{' '}
+        </>
+    )
+}
 
 export const MarketingAnalyticsSourceStatusBanner = (): JSX.Element | null => {
     const { allAvailableSourcesWithStatus } = useValues(marketingAnalyticsLogic)
@@ -18,12 +69,10 @@ export const MarketingAnalyticsSourceStatusBanner = (): JSX.Element | null => {
         return null
     }
 
-    const runningSources = syncingOrFailedSources.filter((s) => s.status === 'Running')
-    const failedSources = syncingOrFailedSources.filter((s) => s.status === 'Failed')
-    const pausedSources = syncingOrFailedSources.filter((s) => s.status === 'Paused')
+    const statusCounts = getStatusCounts(syncingOrFailedSources)
 
     return (
-        <LemonBanner type={failedSources.length > 0 ? 'error' : 'info'} className="mb-2 mt-4">
+        <LemonBanner type={statusCounts[ExternalDataSchemaStatus.Failed] > 0 ? 'error' : 'info'} className="mb-2 mt-4">
             {syncingOrFailedSources.length === 1 ? (
                 <>
                     <strong>{syncingOrFailedSources[0].name}</strong> is currently{' '}
@@ -36,31 +85,24 @@ export const MarketingAnalyticsSourceStatusBanner = (): JSX.Element | null => {
                 </>
             ) : (
                 <>
-                    {runningSources.length > 0 && (
-                        <>
-                            <strong>
-                                {runningSources.length} source{runningSources.length > 1 ? 's are' : ' is'} syncing
-                            </strong>
-                            .{' '}
-                        </>
-                    )}
-                    {failedSources.length > 0 && (
-                        <>
-                            <strong>
-                                {failedSources.length} source{failedSources.length > 1 ? 's have' : ' has'} failed while
-                                syncing
-                            </strong>
-                            .{' '}
-                        </>
-                    )}
-                    {pausedSources.length > 0 && (
-                        <>
-                            <strong>
-                                {pausedSources.length} source{pausedSources.length > 1 ? 's are' : ' is'} paused
-                            </strong>
-                            .{' '}
-                        </>
-                    )}
+                    <SourceStatusMessage
+                        length={statusCounts[ExternalDataSchemaStatus.Running]}
+                        singularVerb="is"
+                        pluralVerb="are"
+                        message="syncing"
+                    />
+                    <SourceStatusMessage
+                        length={statusCounts[ExternalDataSchemaStatus.Failed]}
+                        singularVerb="has"
+                        pluralVerb="have"
+                        message="failed while syncing"
+                    />
+                    <SourceStatusMessage
+                        length={statusCounts[ExternalDataSchemaStatus.Paused]}
+                        singularVerb="is"
+                        pluralVerb="are"
+                        message="paused"
+                    />
                 </>
             )}{' '}
             Check{' '}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
@@ -1,0 +1,83 @@
+import { useValues } from 'kea'
+
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { Link } from 'lib/lemon-ui/Link/Link'
+import { urls } from 'scenes/urls'
+
+import { marketingAnalyticsLogic } from '../logic/marketingAnalyticsLogic'
+
+export const MarketingAnalyticsSourceStatusBanner = (): JSX.Element | null => {
+    const { allAvailableSourcesWithStatus } = useValues(marketingAnalyticsLogic)
+
+    const syncingOrFailedSources = allAvailableSourcesWithStatus.filter(
+        (source) => source.status === 'Running' || source.status === 'Failed' || source.status === 'Paused'
+    )
+
+    if (syncingOrFailedSources.length === 0) {
+        return null
+    }
+
+    return (
+        <LemonBanner
+            type={syncingOrFailedSources.some((s) => s.status === 'Failed') ? 'error' : 'info'}
+            className="mb-2 mt-4"
+        >
+            {syncingOrFailedSources.length === 1 ? (
+                <>
+                    <strong>{syncingOrFailedSources[0].name}</strong> is currently{' '}
+                    {syncingOrFailedSources[0].status === 'Running'
+                        ? 'syncing'
+                        : syncingOrFailedSources[0].status === 'Failed'
+                          ? 'failed'
+                          : 'paused'}
+                    . {syncingOrFailedSources[0].statusMessage}
+                </>
+            ) : (
+                <>
+                    {syncingOrFailedSources.filter((s) => s.status === 'Running').length > 0 && (
+                        <>
+                            <strong>
+                                {syncingOrFailedSources.filter((s) => s.status === 'Running').length} source
+                                {syncingOrFailedSources.filter((s) => s.status === 'Running').length > 1
+                                    ? 's are'
+                                    : ' is'}{' '}
+                                syncing
+                            </strong>
+                            .{' '}
+                        </>
+                    )}
+                    {syncingOrFailedSources.filter((s) => s.status === 'Failed').length > 0 && (
+                        <>
+                            <strong>
+                                {syncingOrFailedSources.filter((s) => s.status === 'Failed').length} source
+                                {syncingOrFailedSources.filter((s) => s.status === 'Failed').length > 1
+                                    ? 's have'
+                                    : ' has'}{' '}
+                                failed while syncing
+                            </strong>
+                            .{' '}
+                        </>
+                    )}
+                    {syncingOrFailedSources.filter((s) => s.status === 'Paused').length > 0 && (
+                        <>
+                            <strong>
+                                {syncingOrFailedSources.filter((s) => s.status === 'Paused').length} source
+                                {syncingOrFailedSources.filter((s) => s.status === 'Paused').length > 1
+                                    ? 's are'
+                                    : ' is'}{' '}
+                                paused
+                            </strong>
+                            .{' '}
+                        </>
+                    )}
+                </>
+            )}{' '}
+            Check{' '}
+            <Link to={urls.settings('environment-marketing-analytics')} target="_blank">
+                marketing analytics settings
+            </Link>{' '}
+            for more details.
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsSourceStatusBanner.tsx
@@ -18,11 +18,12 @@ export const MarketingAnalyticsSourceStatusBanner = (): JSX.Element | null => {
         return null
     }
 
+    const runningSources = syncingOrFailedSources.filter((s) => s.status === 'Running')
+    const failedSources = syncingOrFailedSources.filter((s) => s.status === 'Failed')
+    const pausedSources = syncingOrFailedSources.filter((s) => s.status === 'Paused')
+
     return (
-        <LemonBanner
-            type={syncingOrFailedSources.some((s) => s.status === 'Failed') ? 'error' : 'info'}
-            className="mb-2 mt-4"
-        >
+        <LemonBanner type={failedSources.length > 0 ? 'error' : 'info'} className="mb-2 mt-4">
             {syncingOrFailedSources.length === 1 ? (
                 <>
                     <strong>{syncingOrFailedSources[0].name}</strong> is currently{' '}
@@ -35,38 +36,27 @@ export const MarketingAnalyticsSourceStatusBanner = (): JSX.Element | null => {
                 </>
             ) : (
                 <>
-                    {syncingOrFailedSources.filter((s) => s.status === 'Running').length > 0 && (
+                    {runningSources.length > 0 && (
                         <>
                             <strong>
-                                {syncingOrFailedSources.filter((s) => s.status === 'Running').length} source
-                                {syncingOrFailedSources.filter((s) => s.status === 'Running').length > 1
-                                    ? 's are'
-                                    : ' is'}{' '}
+                                {runningSources.length} source{runningSources.length > 1 ? 's are' : ' is'} syncing
+                            </strong>
+                            .{' '}
+                        </>
+                    )}
+                    {failedSources.length > 0 && (
+                        <>
+                            <strong>
+                                {failedSources.length} source{failedSources.length > 1 ? 's have' : ' has'} failed while
                                 syncing
                             </strong>
                             .{' '}
                         </>
                     )}
-                    {syncingOrFailedSources.filter((s) => s.status === 'Failed').length > 0 && (
+                    {pausedSources.length > 0 && (
                         <>
                             <strong>
-                                {syncingOrFailedSources.filter((s) => s.status === 'Failed').length} source
-                                {syncingOrFailedSources.filter((s) => s.status === 'Failed').length > 1
-                                    ? 's have'
-                                    : ' has'}{' '}
-                                failed while syncing
-                            </strong>
-                            .{' '}
-                        </>
-                    )}
-                    {syncingOrFailedSources.filter((s) => s.status === 'Paused').length > 0 && (
-                        <>
-                            <strong>
-                                {syncingOrFailedSources.filter((s) => s.status === 'Paused').length} source
-                                {syncingOrFailedSources.filter((s) => s.status === 'Paused').length > 1
-                                    ? 's are'
-                                    : ' is'}{' '}
-                                paused
+                                {pausedSources.length} source{pausedSources.length > 1 ? 's are' : ' is'} paused
                             </strong>
                             .{' '}
                         </>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -485,45 +485,6 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
                 })
             },
         ],
-        nativeSourcesWithStatus: [
-            (s) => [s.nativeSources],
-            (nativeSources) => {
-                return nativeSources.map((source) => {
-                    const status = getSourceStatus(
-                        { id: source.id, name: source.source_type, type: 'native', prefix: source.prefix },
-                        nativeSources,
-                        []
-                    )
-                    return {
-                        ...source,
-                        status: status.status,
-                        statusMessage: status.message,
-                    }
-                })
-            },
-        ],
-        externalTablesWithStatus: [
-            (s) => [s.externalTables],
-            (externalTables) => {
-                return externalTables.map((table) => {
-                    const status = getSourceStatus(
-                        {
-                            id: table.source_map_id,
-                            name: table.schema_name,
-                            type: table.external_type,
-                            prefix: table.source_prefix,
-                        },
-                        [],
-                        externalTables
-                    )
-                    return {
-                        ...table,
-                        status: status.status,
-                        statusMessage: status.message,
-                    }
-                })
-            },
-        ],
         allExternalTablesWithStatus: [
             (s) => [s.externalTables, s.nativeSources],
             (externalTables, nativeSources) => {


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/39487

## Changes

- Introduced a new MarketingAnalyticsSourceStatusBanner component that shows the status of marketing analytics sources (syncing, failed, paused).
- Integrated the banner into the MarketingDashboard for better visibility of source statuses.
- Removed unused logic related to native and external sources' status from marketingAnalyticsLogic.

## How did you test this code?
Manually

<img width="1227" height="69" alt="Screenshot 2025-10-29 at 10 18 16 AM" src="https://github.com/user-attachments/assets/24f4476f-e253-4625-99b2-494eeb840fa4" />
<img width="1235" height="72" alt="Screenshot 2025-10-29 at 10 17 55 AM" src="https://github.com/user-attachments/assets/c92cb706-4909-4655-b7d6-deaadd6298f8" />
<img width="1221" height="69" alt="Screenshot 2025-10-29 at 10 17 41 AM" src="https://github.com/user-attachments/assets/19ad157e-976d-4e76-b187-6550782da29c" />
<img width="1229" height="76" alt="Screenshot 2025-10-29 at 10 15 46 AM" src="https://github.com/user-attachments/assets/8bae9591-bcb4-4b94-baf9-b0597432b87c" />
<img width="1237" height="72" alt="Screenshot 2025-10-29 at 10 15 42 AM" src="https://github.com/user-attachments/assets/6cd5f146-faba-4664-855a-7a697fa50daa" />
<img width="1239" height="71" alt="Screenshot 2025-10-29 at 10 15 39 AM" src="https://github.com/user-attachments/assets/981d9d42-fd7a-4114-910b-6ff3ba1d2f8e" />
<img width="1236" height="80" alt="Screenshot 2025-10-29 at 10 15 32 AM" src="https://github.com/user-attachments/assets/ae2dd393-782f-4293-a8ff-4a124ed93af5" />
<img width="1229" height="58" alt="Screenshot 2025-10-29 at 10 15 29 AM" src="https://github.com/user-attachments/assets/1df8a702-4751-40af-8511-86645e5dc58b" />
<img width="1235" height="77" alt="Screenshot 2025-10-29 at 10 15 27 AM" src="https://github.com/user-attachments/assets/9fd63b84-576c-4dea-9c77-ebb5e6d680c8" />
