### PR TITLE
feat(web-analytics): add share button to copy dashboard URL

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import React, { useState } from 'react'
 
-import { IconExpand45, IconInfo, IconLineGraph, IconOpenSidebar, IconX } from '@posthog/icons'
+import { IconExpand45, IconInfo, IconLineGraph, IconOpenSidebar, IconShare, IconX } from '@posthog/icons'
 import { LemonBanner, LemonSegmentedButton, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
@@ -19,6 +19,7 @@ import { Popover } from 'lib/lemon-ui/Popover'
 import { IconOpenInNew, IconTableChart } from 'lib/lemon-ui/icons'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isNotNil } from 'lib/utils'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { ProductIntentContext, addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { urls } from 'scenes/urls'
 import { PageReports, PageReportsFilters } from 'scenes/web-analytics/PageReports'
@@ -562,6 +563,10 @@ const WebAnalyticsTabs = (): JSX.Element => {
 
     const { setProductTab } = useActions(webAnalyticsLogic)
 
+    const handleShare = (): void => {
+        void copyToClipboard(window.location.href, 'link')
+    }
+
     return (
         <LemonTabs<ProductTab>
             activeKey={productTab}
@@ -574,6 +579,17 @@ const WebAnalyticsTabs = (): JSX.Element => {
             ]}
             sceneInset
             className="-mt-4"
+            rightSlot={
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    icon={<IconShare />}
+                    onClick={handleShare}
+                    data-attr="web-analytics-share-button"
+                >
+                    Share
+                </LemonButton>
+            }
         />
     )
 }


### PR DESCRIPTION
## Problem

Context here: https://posthog.slack.com/archives/C05LJK1N3CP/p1761707892656049?thread_ts=1761707283.284979&cid=C05LJK1N3CP

Just a button to copy the URL in a more actionable way.

## Changes

I will follow up with another PR to change the look of the new query engine toggle, as this is ugly now.

<img width="1244" height="637" alt="image" src="https://github.com/user-attachments/assets/512fe61a-7f3a-4da4-a2a9-ab9ca422233d" />


## How did you test this code?

Running it locally.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
