### PR TITLE
fix(kafka-deduplicator): Add missing duplicate event fields

### DIFF
--- a/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
@@ -395,7 +395,10 @@ async fn test_basic_deduplication() -> Result<()> {
             duplicate_event.get("distinct_fields").is_some(),
             "Missing distinct_fields"
         );
-        assert!(duplicate_event.get("dedup_type").is_some(), "Missing dedup_type field");
+        assert!(
+            duplicate_event.get("dedup_type").is_some(),
+            "Missing dedup_type field"
+        );
         assert!(
             duplicate_event.get("is_confirmed").is_some(),
             "Missing is_confirmed"

--- a/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
@@ -395,18 +395,37 @@ async fn test_basic_deduplication() -> Result<()> {
             duplicate_event.get("distinct_fields").is_some(),
             "Missing distinct_fields"
         );
-        assert!(duplicate_event.get("type").is_some(), "Missing type field");
+        assert!(duplicate_event.get("dedup_type").is_some(), "Missing dedup_type field");
         assert!(
             duplicate_event.get("is_confirmed").is_some(),
             "Missing is_confirmed"
         );
         assert!(duplicate_event.get("version").is_some(), "Missing version");
 
+        // Check new fields added for ClickHouse schema
+        assert!(
+            duplicate_event.get("distinct_id").is_some(),
+            "Missing distinct_id"
+        );
+        assert!(duplicate_event.get("event").is_some(), "Missing event");
+        assert!(
+            duplicate_event.get("source_uuid").is_some(),
+            "Missing source_uuid"
+        );
+        assert!(
+            duplicate_event.get("duplicate_uuid").is_some(),
+            "Missing duplicate_uuid"
+        );
+        assert!(
+            duplicate_event.get("inserted_at").is_some(),
+            "Missing inserted_at"
+        );
+
         // Verify type is timestamp (since we're sending same timestamp)
         let dedup_type = duplicate_event
-            .get("type")
+            .get("dedup_type")
             .and_then(|v| v.as_str())
-            .expect("type should be a string");
+            .expect("dedup_type should be a string");
         assert_eq!(
             dedup_type, "timestamp",
             "Expected timestamp deduplication type"
@@ -415,9 +434,9 @@ async fn test_basic_deduplication() -> Result<()> {
         // Verify these are confirmed duplicates with OnlyUuidDifferent reason
         let is_confirmed = duplicate_event
             .get("is_confirmed")
-            .and_then(|v| v.as_bool())
-            .expect("is_confirmed should be a boolean");
-        assert!(is_confirmed, "All duplicates should be confirmed");
+            .and_then(|v| v.as_u64())
+            .expect("is_confirmed should be a u64");
+        assert_eq!(is_confirmed, 1, "All duplicates should be confirmed");
 
         let reason = duplicate_event.get("reason").and_then(|v| v.as_str());
         assert_eq!(


### PR DESCRIPTION
## Problem

We are missing some fields that exist in clickhouse, additionally it would be great to add more information to the duplicate events when properties differ

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
