### PR TITLE
chore(flags): Upgrade `common-redis` to redis 0.32.7

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6244,24 +6244,25 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.23.3"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
+checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
 dependencies = [
- "async-trait",
  "bytes",
+ "cfg-if",
  "combine",
  "crc16",
- "futures",
+ "futures-sink",
  "futures-util",
  "itoa",
  "log",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.9.1",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2 0.6.0",
  "tokio",
  "tokio-util",
  "url",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -118,6 +118,7 @@ aws-sdk-s3 = "1.58.0"
 mockall = "0.13.0"
 moka = { version = "0.12.8", features = ["sync", "future"] }
 posthog-rs = { version = "0.3.5", features = ["async-client"] }
+redis = { version = "0.32.7", features = ["tokio-comp", "cluster", "cluster-async"] }
 regex = "1.11.1"
 lz-str = "0.2.1"
 opentelemetry-proto = "0.29.0"

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -28,11 +28,7 @@ opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 rand = { workspace = true }
 rdkafka = { workspace = true }
-redis = { version = "0.32.7", features = [
-    "tokio-comp",
-    "cluster",
-    "cluster-async",
-] }
+redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -28,7 +28,7 @@ opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 rand = { workspace = true }
 rdkafka = { workspace = true }
-redis = { version = "0.23.3", features = [
+redis = { version = "0.32.7", features = [
     "tokio-comp",
     "cluster",
     "cluster-async",

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -8,11 +8,7 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-redis = { version = "0.32.7", features = [
-    "tokio-comp",
-    "cluster",
-    "cluster-async",
-] }
+redis = { workspace = true }
 serde-pickle = { version = "1.1.1" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-redis = { version = "0.23.3", features = [
+redis = { version = "0.32.7", features = [
     "tokio-comp",
     "cluster",
     "cluster-async",

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -338,7 +338,7 @@ impl MockRedisClient {
     }
 
     // Helper method to safely lock the calls mutex
-    fn lock_calls(&self) -> std::sync::MutexGuard<Vec<MockRedisCall>> {
+    fn lock_calls(&self) -> std::sync::MutexGuard<'_, Vec<MockRedisCall>> {
         match self.calls.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -26,7 +26,7 @@ bytes = { workspace = true }
 url = "2.5"
 once_cell = "1.18.0"
 rand = { workspace = true }
-redis = { version = "0.23.3", features = [
+redis = { version = "0.32.7", features = [
     "tokio-comp",
     "cluster",
     "cluster-async",

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -26,11 +26,7 @@ bytes = { workspace = true }
 url = "2.5"
 once_cell = "1.18.0"
 rand = { workspace = true }
-redis = { version = "0.32.7", features = [
-    "tokio-comp",
-    "cluster",
-    "cluster-async",
-] }
+redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 json5 = "0.4"

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -231,7 +231,8 @@ fn evaluate_cohort_values(
             for filter in &values.values {
                 if filter.is_cohort() {
                     // Handle cohort membership check
-                    if apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)? {
+                    if apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)?
+                    {
                         return Ok(true);
                     }
                 } else {
@@ -247,8 +248,10 @@ fn evaluate_cohort_values(
             for filter in &values.values {
                 if filter.is_cohort() {
                     // Handle cohort membership check with negation
-                    let cohort_result =
-                        apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)?;
+                    let cohort_result = apply_cohort_membership_logic(
+                        std::slice::from_ref(filter),
+                        cohort_matches,
+                    )?;
                     // Apply negation if specified
                     if cohort_result == filter.negation.unwrap_or(false) {
                         return Ok(false);

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -231,7 +231,7 @@ fn evaluate_cohort_values(
             for filter in &values.values {
                 if filter.is_cohort() {
                     // Handle cohort membership check
-                    if apply_cohort_membership_logic(&[filter.clone()], cohort_matches)? {
+                    if apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)? {
                         return Ok(true);
                     }
                 } else {
@@ -248,7 +248,7 @@ fn evaluate_cohort_values(
                 if filter.is_cohort() {
                     // Handle cohort membership check with negation
                     let cohort_result =
-                        apply_cohort_membership_logic(&[filter.clone()], cohort_matches)?;
+                        apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)?;
                     // Apply negation if specified
                     if cohort_result == filter.negation.unwrap_or(false) {
                         return Ok(false);

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -268,7 +268,7 @@ mod tests {
         let client =
             redis::Client::open("redis://localhost:6379/").expect("Failed to create redis client");
         let mut conn = client
-            .get_async_connection()
+            .get_multiplexed_async_connection()
             .await
             .expect("Failed to get redis connection");
         conn.set::<String, String, ()>(


### PR DESCRIPTION
## Problem

We're running on a very old version of `common-redis`.

## Changes

Updated redis dependency from 0.23.3 to 0.32.7 in common-redis. This replaces `get_async_connection` with `get_multiplexed_async_connection`

### Notes

The old `get_async_connection()` gave you a single, non-cloneable async connection that could handle one in-flight request per connection (you usually had to juggle a pool or guards to share it). The new `get_multiplexed_async_connection()` returns a `MultiplexedConnection` that’s `Clone + Send + Sync` and is designed for many concurrent requests over one underlying socket—so most apps can share a single connection safely across tasks/threads without a pool. 

## How did you test this code?

Unit Tests
Manual testing of /flgas

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
