### PR TITLE
fix(ph-ai): unsetting message id on chunks

### DIFF
--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -265,8 +265,8 @@ def extract_thinking_from_ai_message(response: BaseMessage) -> list[dict[str, An
 
 
 def normalize_ai_message(message: AIMessage | AIMessageChunk) -> AssistantMessage:
-    message_id = None
-    if isinstance(message, AIMessage):
+    message_id: str | None = None
+    if not isinstance(message, AIMessageChunk):
         message_id = str(uuid4())
     tool_calls = [
         AssistantToolCall(id=tool_call["id"], name=tool_call["name"], args=tool_call["args"] or {})


### PR DESCRIPTION
## Problem
LangChain is idiotic and defines `AIMessageChunk` as a subclass of `AIMessage`, so we were setting ids on chunks by mistake.

## Changes
- Change instance check

## How did you test this code?
Locally
