### PR TITLE
fix: Redshift do not remove duplicates if different schema

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1066,7 +1066,7 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
             # filter out fields that are not in the destination table
             try:
                 columns = await redshift_client.aget_table_columns(inputs.table.schema_name, inputs.table.name)
-                if len(columns) > len(table_schemas.table_schema):
+                if len(columns) > len(tuple(table_schemas.table_schema)):
                     # MERGE cannot remove duplicates if table columns don't match.
                     remove_duplicates = False
                     external_logger.warning(
@@ -1075,7 +1075,7 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
                         inputs.table.schema_name,
                         inputs.table.name,
                         len(columns),
-                        len(table_schemas.table_schema),
+                        len(tuple(table_schemas.table_schema)),
                     )
 
                 table_fields = [field for field in table_schemas.table_schema if field[0] in columns]
@@ -1411,7 +1411,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             # filter out fields that are not in the destination table
             try:
                 columns = await redshift_client.aget_table_columns(inputs.table.schema_name, inputs.table.name)
-                if len(columns) > len(table_schemas.table_schema):
+                if len(columns) > len(tuple(table_schemas.table_schema)):
                     # MERGE cannot remove duplicates if table columns don't match.
                     remove_duplicates = False
                     external_logger.warning(
@@ -1420,7 +1420,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                         inputs.table.schema_name,
                         inputs.table.name,
                         len(columns),
-                        len(table_schemas.table_schema),
+                        len(tuple(table_schemas.table_schema)),
                     )
 
                 table_fields = [field for field in table_schemas.table_schema if field[0] in columns]

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -216,6 +216,7 @@ class RedshiftClient(PostgreSQLClient):
         final_table_fields: Fields,
         update_when_matched: Fields = (),
         stage_fields_cast_to_super: collections.abc.Container[str] | None = None,
+        remove_duplicates: bool = True,
     ) -> None:
         """Merge two tables in Redshift.
 
@@ -289,13 +290,14 @@ class RedshiftClient(PostgreSQLClient):
         MERGE INTO {final_table}
         USING (SELECT {select_stage_table_fields} FROM {stage_table}) AS stage
         ON {merge_condition}
-        REMOVE DUPLICATES
+        {remove_duplicates}
         """
         ).format(
             final_table=final_table_identifier,
             select_stage_table_fields=select_stage_table_fields,
             stage_table=stage_table_identifier,
             merge_condition=merge_condition,
+            remove_duplicates=sql.SQL("REMOVE DUPLICATES") if remove_duplicates else sql.SQL(""),
         )
 
         async with self.connection.transaction():
@@ -713,6 +715,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> BatchEx
             try:
                 columns = await redshift_client.aget_table_columns(inputs.table.schema_name, inputs.table.name)
                 table_fields = [field for field in table_fields if field[0] in columns]
+
             except psycopg.errors.UndefinedTable:
                 pass
 
@@ -1037,9 +1040,22 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
         )
 
         async with RedshiftClient.from_inputs(inputs.connection).connect() as redshift_client:
+            remove_duplicates = True
             # filter out fields that are not in the destination table
             try:
                 columns = await redshift_client.aget_table_columns(inputs.table.schema_name, inputs.table.name)
+                if len(columns) != len(table_schemas.table_schema):
+                    # MERGE cannot remove duplicates if table columns don't match.
+                    remove_duplicates = False
+                    external_logger.warning(
+                        "Table %s.%s has %d columns instead of %d as expected. "
+                        "MERGE command may perform worse and not properly clean up duplicates",
+                        inputs.table.schema_name,
+                        inputs.table.name,
+                        len(columns),
+                        len(table_schemas.table_schema),
+                    )
+
                 table_fields = [field for field in table_schemas.table_schema if field[0] in columns]
             except psycopg.errors.UndefinedTable:
                 table_fields = list(table_schemas.table_schema)
@@ -1088,6 +1104,7 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
                         merge_key=merge_settings.merge_key,
                         update_key=merge_settings.update_key,
                         stage_fields_cast_to_super=table_schemas.super_columns if table_schemas.use_super else None,
+                        remove_duplicates=remove_duplicates,
                     )
 
                 return result

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -319,8 +319,8 @@ class RedshiftClient(PostgreSQLClient):
                 """\
                 WHEN MATCHED THEN UPDATE SET {update_values}
                 WHEN NOT MATCHED THEN INSERT VALUES ({insert_values})
-                """.format(update_values=update_values, insert_values=insert_values)
-            )
+                """
+            ).format(update_values=update_values, insert_values=insert_values)
 
         async with self.connection.transaction():
             async with self.connection.cursor() as cursor:

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
@@ -597,7 +597,7 @@ async def test_insert_into_redshift_activity_inserts_data_with_extra_columns(
         async with psycopg_connection.cursor() as cursor:
             await cursor.execute(
                 sql.SQL("ALTER TABLE {} ADD COLUMN test INT DEFAULT NULL;").format(
-                    sql.Identifier(redshift_config["schema_name"], table_name)
+                    sql.Identifier(redshift_config["schema"], table_name)
                 )
             )
 

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
@@ -545,3 +545,74 @@ async def test_insert_into_redshift_activity_handles_person_schema_changes(
         use_internal_stage=use_internal_stage,
         expected_fields=expected_fields,
     )
+
+
+@pytest.mark.parametrize("exclude_events", [None], indirect=True)
+@pytest.mark.parametrize("properties_data_type", ["super"], indirect=True)
+@pytest.mark.parametrize("model", [TEST_MODELS[1]])
+async def test_insert_into_redshift_activity_inserts_data_with_extra_columns(
+    clickhouse_client,
+    activity_environment,
+    psycopg_connection,
+    redshift_config,
+    exclude_events,
+    model: BatchExportModel | BatchExportSchema | None,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    properties_data_type,
+    ateam,
+    use_internal_stage,
+):
+    """Test data is inserted even in the presence of additional columns.
+
+    Redshift's "MERGE" command can run in a simplified mode which performs better and
+    cleans up duplicates, but this requires a matching schema. We should assert we don't
+    fail when we can't use this mode.
+    """
+    if properties_data_type == "super" and MISSING_REQUIRED_ENV_VARS:
+        pytest.skip("SUPER type is only available in Redshift")
+
+    batch_export_model = model
+    table_name = f"test_insert_activity_extra_column_table__{ateam.pk}"
+    sort_key = "event"
+
+    await _run_activity(
+        activity_environment,
+        redshift_connection=psycopg_connection,
+        clickhouse_client=clickhouse_client,
+        team=ateam,
+        table_name=table_name,
+        properties_data_type=properties_data_type,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        exclude_events=exclude_events,
+        batch_export_model=batch_export_model,
+        redshift_config=redshift_config,
+        sort_key=sort_key,
+        use_internal_stage=use_internal_stage,
+    )
+
+    async with psycopg_connection.transaction():
+        async with psycopg_connection.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("ALTER TABLE {} ADD COLUMN test INT DEFAULT NULL;").format(
+                    sql.Identifier(redshift_config["schema_name"], table_name)
+                )
+            )
+
+    await _run_activity(
+        activity_environment,
+        redshift_connection=psycopg_connection,
+        clickhouse_client=clickhouse_client,
+        team=ateam,
+        table_name=table_name,
+        properties_data_type=properties_data_type,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        exclude_events=exclude_events,
+        batch_export_model=batch_export_model,
+        redshift_config=redshift_config,
+        sort_key=sort_key,
+        use_internal_stage=use_internal_stage,
+    )

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
@@ -56,6 +56,7 @@ async def _run_activity(
     expected_fields=None,
     expect_duplicates: bool = False,
     use_internal_stage: bool = False,
+    extra_fields=None,
 ):
     """Helper function to run Redshift main activity and assert records are exported.
 
@@ -133,6 +134,7 @@ async def _run_activity(
         properties_data_type=properties_data_type,
         sort_key=sort_key,
         expected_fields=expected_fields,
+        extra_fields=extra_fields,
     )
 
     return result
@@ -615,4 +617,5 @@ async def test_insert_into_redshift_activity_inserts_data_with_extra_columns(
         redshift_config=redshift_config,
         sort_key=sort_key,
         use_internal_stage=use_internal_stage,
+        extra_fields=["test"],
     )

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_activity.py
@@ -558,7 +558,7 @@ async def test_insert_into_redshift_activity_inserts_data_with_extra_columns(
     psycopg_connection,
     redshift_config,
     exclude_events,
-    model: BatchExportModel | BatchExportSchema | None,
+    model: BatchExportModel,
     generate_test_data,
     data_interval_start,
     data_interval_end,
@@ -571,9 +571,16 @@ async def test_insert_into_redshift_activity_inserts_data_with_extra_columns(
     Redshift's "MERGE" command can run in a simplified mode which performs better and
     cleans up duplicates, but this requires a matching schema. We should assert we don't
     fail when we can't use this mode.
+
+    This test only runs for `use_internal_stage=True` as we don't merge the events model
+    with the old activity. Once we clean up the old activity, this disclaimer, together
+    with the `use_internal_stage` parameter, can be deleted.
     """
     if properties_data_type == "super" and MISSING_REQUIRED_ENV_VARS:
         pytest.skip("SUPER type is only available in Redshift")
+
+    if not use_internal_stage:
+        pytest.skip("MERGE of events only happens in internal stage activity")
 
     batch_export_model = model
     table_name = f"test_insert_activity_extra_column_table__{ateam.pk}"

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -580,3 +580,80 @@ async def test_copy_into_redshift_activity_handles_person_schema_changes(
         sort_key="person_id",
         expected_fields=expected_fields,
     )
+
+
+@pytest.mark.parametrize("exclude_events", [None], indirect=True)
+@pytest.mark.parametrize("properties_data_type", ["super"], indirect=True)
+@pytest.mark.parametrize("model", [TEST_MODELS[1]])
+async def test_copy_into_redshift_activity_inserts_data_with_extra_columns(
+    clickhouse_client,
+    activity_environment,
+    psycopg_connection,
+    redshift_config,
+    bucket_name,
+    bucket_region,
+    exclude_events,
+    model: BatchExportModel | BatchExportSchema | None,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    properties_data_type,
+    aws_credentials,
+    key_prefix,
+    ateam,
+):
+    """Test data is inserted even in the presence of additional columns.
+
+    Redshift's "MERGE" command can run in a simplified mode which performs better and
+    cleans up duplicates, but this requires a matching schema. We should assert we don't
+    fail when we can't use this mode.
+    """
+    batch_export_model = model
+    table_name = f"test_copy_activity_table_extra_columns__{ateam.pk}"
+    sort_key = "event"
+
+    await _run_activity(
+        activity_environment,
+        redshift_connection=psycopg_connection,
+        clickhouse_client=clickhouse_client,
+        team=ateam,
+        table_name=table_name,
+        bucket_name=bucket_name,
+        bucket_region=bucket_region,
+        key_prefix=key_prefix,
+        credentials=aws_credentials,
+        properties_data_type=properties_data_type,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        exclude_events=exclude_events,
+        batch_export_model=batch_export_model,
+        redshift_config=redshift_config,
+        sort_key=sort_key,
+    )
+
+    async with psycopg_connection.transaction():
+        async with psycopg_connection.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("ALTER TABLE {} ADD COLUMN test INT DEFAULT NULL;").format(
+                    sql.Identifier(redshift_config["schema_name"], table_name)
+                )
+            )
+
+    await _run_activity(
+        activity_environment,
+        redshift_connection=psycopg_connection,
+        clickhouse_client=clickhouse_client,
+        team=ateam,
+        table_name=table_name,
+        bucket_name=bucket_name,
+        bucket_region=bucket_region,
+        key_prefix=key_prefix,
+        credentials=aws_credentials,
+        properties_data_type=properties_data_type,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        exclude_events=exclude_events,
+        batch_export_model=batch_export_model,
+        redshift_config=redshift_config,
+        sort_key=sort_key,
+    )

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -635,7 +635,7 @@ async def test_copy_into_redshift_activity_inserts_data_with_extra_columns(
         async with psycopg_connection.cursor() as cursor:
             await cursor.execute(
                 sql.SQL("ALTER TABLE {} ADD COLUMN test INT DEFAULT NULL;").format(
-                    sql.Identifier(redshift_config["schema_name"], table_name)
+                    sql.Identifier(redshift_config["schema"], table_name)
                 )
             )
 

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -595,7 +595,7 @@ async def test_copy_into_redshift_activity_inserts_data_with_extra_columns(
     bucket_name,
     bucket_region,
     exclude_events,
-    model: BatchExportModel | BatchExportSchema | None,
+    model: BatchExportModel,
     generate_test_data,
     data_interval_start,
     data_interval_end,

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -76,6 +76,7 @@ async def _run_activity(
     sort_key: str = "event",
     expected_fields=None,
     expect_duplicates: bool = False,
+    extra_fields=None,
 ):
     """Helper function to run Redshift main COPY activity and assert records exported.
 
@@ -157,6 +158,7 @@ async def _run_activity(
         sort_key=sort_key,
         expected_fields=expected_fields,
         copy=True,
+        extra_fields=extra_fields,
     )
 
     return result
@@ -656,4 +658,5 @@ async def test_copy_into_redshift_activity_inserts_data_with_extra_columns(
         batch_export_model=batch_export_model,
         redshift_config=redshift_config,
         sort_key=sort_key,
+        extra_fields=["test"],
     )

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/utils.py
@@ -141,6 +141,10 @@ async def assert_clickhouse_records_in_redshift(
                     else:
                         event[column] = load_result
 
+            if extra_fields:
+                for column in extra_fields:
+                    event.pop(column)
+
             inserted_records.append(event)
 
     if batch_export_model is not None:
@@ -222,9 +226,6 @@ async def assert_clickhouse_records_in_redshift(
 
     inserted_column_names = list(inserted_records[0].keys())
     expected_column_names = list(expected_records[0].keys())
-
-    if extra_fields:
-        expected_column_names = expected_column_names + extra_fields
 
     inserted_column_names.sort()
     expected_column_names.sort()

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/utils.py
@@ -75,6 +75,7 @@ async def assert_clickhouse_records_in_redshift(
     expected_fields: list[str] | None = None,
     primary_key: collections.abc.Sequence[str] | None = None,
     copy: bool = False,
+    extra_fields: list[str] | None = None,
 ):
     """Assert expected records are written to a given Redshift table.
 
@@ -102,6 +103,7 @@ async def assert_clickhouse_records_in_redshift(
         expected_fields: The expected fields to be exported.
         copy: Whether using Redshift's COPY or not. This impacts handling of special
             characters as Parquet+COPY can handle a lot more than JSON.
+        extra_fields: Additional fields present in the Redshift table.
     """
     super_columns = ["properties", "set", "set_once", "person_properties"]
     array_super_columns = ["urls"]
@@ -220,6 +222,10 @@ async def assert_clickhouse_records_in_redshift(
 
     inserted_column_names = list(inserted_records[0].keys())
     expected_column_names = list(expected_records[0].keys())
+
+    if extra_fields:
+        expected_column_names = expected_column_names + extra_fields
+
     inserted_column_names.sort()
     expected_column_names.sort()
 


### PR DESCRIPTION
## Problem

Since moving to an internal stage activity, Redshift batch export has been executing a `MERGE` query when targeting a table with `SUPER` column type. This is done as the `MERGE` allows us to bypass some of the stricter limits related to column sizes for `SUPER` types.

However, this had the unintended consequence of breaking the batch export when the target table has additional columns not present in the batch export model. This is because the `MERGE` query runs in so-called "simplified mode" with the `REMOVE DUPLICATES` clause. This is the recommended mode by Redshift, as it performs better and guarantees duplicates are cleaned up, but it does have stricter requirements, one of them being that the tables have the same number of columns.

We are already checking the table columns when it already exists, so we can opt-out of the "simplified mode" if there is a difference in column counts.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Run `MERGE` query without `REMOVE DUPLICATES` if number of columns in table doesn't match schema.
  * This requires adding `WHEN MATCHED` and `WHEN NOT MATCHED` clauses.
* Log a warning for the user that this may have unintended consequences (worse performance, duplicates).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added two new unit tests. Verified they fail without the changes. Ran them with changes and they are passing.


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
