### PR TITLE
fix: Remove duplicate evaluation_reasons API call

### DIFF
--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
 
@@ -189,9 +189,6 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
         loadFeatureFlagsSuccess: () => {
             actions.loadRelatedFeatureFlags()
         },
-    })),
-    events(({ actions }) => ({
-        afterMount: actions.loadRelatedFeatureFlags,
     })),
     urlToAction(({ actions }) => ({
         [urls.personByUUID('*', false)]: async (_, searchParams) => {


### PR DESCRIPTION
## Problem

The relatedFeatureFlagsLogic was making duplicate calls to the evaluation_reasons endpoint because it had two triggers:
1. afterMount event that called loadRelatedFeatureFlags
2. loadFeatureFlagsSuccess listener that also called loadRelatedFeatureFlags

Since featureFlagsLogic is connected and loads automatically on mount, both triggers would fire in succession, causing duplicate API calls.

The afterMount trigger is redundant because the loadFeatureFlagsSuccess listener will always fire when the connected featureFlagsLogic finishes its initial load. Removed the afterMount event to ensure only one API call is made.

## Changes

Removed afterMount event.

## How did you test this code?

Manual.
