### PR TITLE
fix(sql-editor): view save state

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1229,7 +1229,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                     actions.createTab(hashParams.q)
                     tabAdded = true
                 } else if (values.queryInput === null) {
-                    actions.createTab(values.queryInput)
+                    actions.createTab('')
                     tabAdded = true
                 }
             }

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -552,11 +552,11 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             actions.createTab(query, undefined, insight)
         },
         createTab: async ({ query = '', view, insight, draft }) => {
-            const currentModelCount = 1
+            // Use tabId to ensure each browser tab has its own unique Monaco model
             const tabName = draft?.name || view?.name || insight?.name || NEW_QUERY
 
             if (props.monaco) {
-                const uri = props.monaco.Uri.parse(currentModelCount.toString())
+                const uri = props.monaco.Uri.parse(`tab-${props.tabId}`)
                 let model = props.monaco.editor.getModel(uri)
                 if (!model) {
                     model = props.monaco.editor.createModel(query, 'hogQL', uri)
@@ -1106,7 +1106,8 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                 !searchParams.output_tab &&
                 !hashParams.q &&
                 !hashParams.view &&
-                !hashParams.insight
+                !hashParams.insight &&
+                values.queryInput !== null
             ) {
                 return
             }
@@ -1226,6 +1227,9 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                 } else if (hashParams.q && values.queryInput === null) {
                     // only when opening the tab
                     actions.createTab(hashParams.q)
+                    tabAdded = true
+                } else if (values.queryInput === null) {
+                    actions.createTab(values.queryInput)
                     tabAdded = true
                 }
             }

--- a/playwright/e2e/sql-editor.spec.ts
+++ b/playwright/e2e/sql-editor.spec.ts
@@ -35,6 +35,7 @@ test.describe('SQL Editor', () => {
         await page.getByText('Submit').click()
 
         await expect(page.getByText('test_view successfully created')).toBeVisible()
+        await expect(page.getByText('Editing view "test_view"')).toBeVisible()
     })
 
     test('Materialize view pane', async ({ page }) => {


### PR DESCRIPTION
## Problem

- view saving state is not showing the banner and being mixed up with other tab state

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- make sure new monaco models are created with unique ids

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
