### PR TITLE
chore(flags): Add configurable TTL support for Redis caching

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -43,6 +43,7 @@ pub async fn validate_secret_api_token(state: &AppState, token: &str) -> Result<
         state.redis_reader.clone(),
         state.redis_writer.clone(),
         token,
+        Some(state.config.team_cache_ttl_seconds),
         || async move {
             Team::from_pg_by_secret_token(pg_reader, &token_str)
                 .await

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -108,6 +108,7 @@ async fn fetch_team_by_token(state: &AppState, token: &str) -> Result<Team, Flag
         state.redis_reader.clone(),
         state.redis_writer.clone(),
         token,
+        Some(state.config.team_cache_ttl_seconds),
         || async move {
             Team::from_pg(pg_reader, &token_str)
                 .await

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -294,6 +294,42 @@ pub struct Config {
     #[envconfig(from = "CACHE_TTL_SECONDS", default = "300")]
     pub cache_ttl_seconds: u64,
 
+    /// Redis TTL for team cache entries in seconds
+    ///
+    /// Controls how long team data is cached in Redis before expiring.
+    /// This prevents indefinite cache growth and ensures stale data is refreshed.
+    ///
+    /// Default: 432000 seconds (5 days) - matches Django's FIVE_DAYS constant
+    /// Environment variable: TEAM_CACHE_TTL_SECONDS
+    ///
+    /// Common values:
+    /// - 3600 (1 hour) - For frequently changing team data
+    /// - 86400 (1 day) - For moderate refresh rate
+    /// - 432000 (5 days) - Default, balances performance and freshness
+    ///
+    /// Minimum value: 1 second (Redis setex does not accept 0 or negative values)
+    #[envconfig(from = "TEAM_CACHE_TTL_SECONDS", default = "432000")]
+    pub team_cache_ttl_seconds: u64,
+
+    /// Redis TTL for feature flags cache entries in seconds
+    ///
+    /// Controls how long feature flag data is cached in Redis before expiring.
+    /// This prevents indefinite cache growth and ensures flag changes are visible
+    /// within a reasonable time.
+    ///
+    /// Default: 432000 seconds (5 days) - matches Django's FIVE_DAYS constant
+    /// Environment variable: FLAGS_CACHE_TTL_SECONDS
+    ///
+    /// Common values:
+    /// - 300 (5 minutes) - For rapid flag development/testing
+    /// - 3600 (1 hour) - For frequently changing flags
+    /// - 86400 (1 day) - For stable flag deployments
+    /// - 432000 (5 days) - Default, balances performance and freshness
+    ///
+    /// Minimum value: 1 second (Redis setex does not accept 0 or negative values)
+    #[envconfig(from = "FLAGS_CACHE_TTL_SECONDS", default = "432000")]
+    pub flags_cache_ttl_seconds: u64,
+
     // cookieless, should match the values in plugin-server/src/types.ts, except we don't use sessions here
     #[envconfig(from = "COOKIELESS_DISABLED", default = "false")]
     pub cookieless_disabled: bool,
@@ -436,6 +472,8 @@ impl Config {
             team_ids_to_track: TeamIdCollection::All,
             cache_max_cohort_entries: 100_000,
             cache_ttl_seconds: 300,
+            team_cache_ttl_seconds: 432000,
+            flags_cache_ttl_seconds: 432000,
             cookieless_disabled: false,
             cookieless_force_stateless: false,
             cookieless_identifies_ttl_seconds: 7200,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -157,6 +157,7 @@ impl FeatureFlagList {
         client: Arc<dyn RedisClient + Send + Sync>,
         project_id: i64,
         flags: &FeatureFlagList,
+        ttl_seconds: Option<u64>,
     ) -> Result<(), FlagError> {
         let payload = serde_json::to_string(&flags.flags).map_err(|e| {
             tracing::error!(
@@ -168,24 +169,41 @@ impl FeatureFlagList {
             FlagError::RedisDataParsingError
         })?;
 
-        tracing::info!(
-            "Writing flags to Redis at key '{}{}': {} flags",
-            TEAM_FLAGS_CACHE_PREFIX,
-            project_id,
-            flags.flags.len()
-        );
+        let cache_key = format!("{TEAM_FLAGS_CACHE_PREFIX}{project_id}");
 
-        client
-            .set(format!("{TEAM_FLAGS_CACHE_PREFIX}{project_id}"), payload)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to update Redis cache for project {}: {}",
-                    project_id,
-                    e
+        match ttl_seconds {
+            Some(ttl) => {
+                tracing::info!(
+                    "Writing flags to Redis at key '{}' with TTL {} seconds: {} flags",
+                    cache_key,
+                    ttl,
+                    flags.flags.len()
                 );
-                FlagError::CacheUpdateError
-            })?;
+                client.setex(cache_key, payload, ttl).await.map_err(|e| {
+                    tracing::error!(
+                        "Failed to update Redis cache with TTL for project {}: {}",
+                        project_id,
+                        e
+                    );
+                    FlagError::CacheUpdateError
+                })?;
+            }
+            None => {
+                tracing::info!(
+                    "Writing flags to Redis at key '{}' without TTL: {} flags",
+                    cache_key,
+                    flags.flags.len()
+                );
+                client.set(cache_key, payload).await.map_err(|e| {
+                    tracing::error!(
+                        "Failed to update Redis cache for project {}: {}",
+                        project_id,
+                        e
+                    );
+                    FlagError::CacheUpdateError
+                })?;
+            }
+        }
 
         Ok(())
     }

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -199,6 +199,9 @@ mod tests {
     use bytes::Bytes;
     use serde_json::json;
 
+    // Default cache TTL for tests: 5 days in seconds
+    const DEFAULT_CACHE_TTL_SECONDS: u64 = 432000;
+
     #[test]
     fn empty_distinct_id_is_accepted() {
         let json = json!({
@@ -479,8 +482,8 @@ mod tests {
             redis_client.clone(),
             redis_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
-            432000, // flags_cache_ttl_seconds
+            DEFAULT_CACHE_TTL_SECONDS,
+            DEFAULT_CACHE_TTL_SECONDS,
         );
 
         match flag_service.verify_token(&token).await {
@@ -508,8 +511,8 @@ mod tests {
             redis_reader_client.clone(),
             redis_writer_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
-            432000, // flags_cache_ttl_seconds
+            DEFAULT_CACHE_TTL_SECONDS,
+            DEFAULT_CACHE_TTL_SECONDS,
         );
         assert!(matches!(
             flag_service.verify_token(&result).await,

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -479,6 +479,8 @@ mod tests {
             redis_client.clone(),
             redis_client.clone(),
             pg_client.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
         );
 
         match flag_service.verify_token(&token).await {
@@ -506,6 +508,8 @@ mod tests {
             redis_reader_client.clone(),
             redis_writer_client.clone(),
             pg_client.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
         );
         assert!(matches!(
             flag_service.verify_token(&result).await,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -26,6 +26,8 @@ pub struct FlagService {
     redis_reader: Arc<dyn RedisClient + Send + Sync>,
     redis_writer: Arc<dyn RedisClient + Send + Sync>,
     pg_client: PostgresReader,
+    team_cache_ttl_seconds: u64,
+    flags_cache_ttl_seconds: u64,
 }
 
 impl FlagService {
@@ -33,11 +35,15 @@ impl FlagService {
         redis_reader: Arc<dyn RedisClient + Send + Sync>,
         redis_writer: Arc<dyn RedisClient + Send + Sync>,
         pg_client: PostgresReader,
+        team_cache_ttl_seconds: u64,
+        flags_cache_ttl_seconds: u64,
     ) -> Self {
         Self {
             redis_reader,
             redis_writer,
             pg_client,
+            team_cache_ttl_seconds,
+            flags_cache_ttl_seconds,
         }
     }
 
@@ -46,14 +52,18 @@ impl FlagService {
     /// and the result will be cached in redis.
     pub async fn verify_token(&self, token: &str) -> Result<String, FlagError> {
         let (result, cache_hit) = match Team::from_redis(self.redis_reader.clone(), token).await {
-            Ok(_) => (Ok(token), true),
+            Ok(_) => (Ok(token.to_string()), true),
             Err(_) => {
                 match Team::from_pg(self.pg_client.clone(), token).await {
                     Ok(team) => {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // Token found in PostgreSQL, update Redis cache so that we can verify it from Redis next time
-                        if let Err(e) =
-                            Team::update_redis_cache(self.redis_writer.clone(), &team).await
+                        if let Err(e) = Team::update_redis_cache(
+                            self.redis_writer.clone(),
+                            &team,
+                            Some(self.team_cache_ttl_seconds),
+                        )
+                        .await
                         {
                             tracing::warn!("Failed to update Redis cache: {}", e);
                             inc(
@@ -62,7 +72,7 @@ impl FlagService {
                                 1,
                             );
                         }
-                        (Ok(token), false)
+                        (Ok(token.to_string()), false)
                     }
                     Err(e) => {
                         tracing::warn!("Token validation failed for token '{}': {:?}", token, e);
@@ -83,7 +93,7 @@ impl FlagService {
             1,
         );
 
-        result.map(|token| token.to_string())
+        result
     }
 
     /// Fetches the team from the cache or the database.
@@ -97,9 +107,13 @@ impl FlagService {
                     Ok(team) => {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // If we have the team in postgres, but not redis, update redis so we're faster next time
-                        if Team::update_redis_cache(self.redis_writer.clone(), &team)
-                            .await
-                            .is_err()
+                        if Team::update_redis_cache(
+                            self.redis_writer.clone(),
+                            &team,
+                            Some(self.team_cache_ttl_seconds),
+                        )
+                        .await
+                        .is_err()
                         {
                             inc(
                                 TEAM_CACHE_ERRORS_COUNTER,
@@ -145,6 +159,7 @@ impl FlagService {
                         self.redis_writer.clone(),
                         project_id,
                         &flags_from_pg,
+                        Some(self.flags_cache_ttl_seconds),
                     )
                     .await)
                         .is_err()
@@ -187,7 +202,9 @@ mod tests {
             FeatureFlag, FlagFilters, FlagPropertyGroup, TEAM_FLAGS_CACHE_PREFIX,
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
-        utils::test_utils::{insert_new_team_in_redis, setup_pg_reader_client, setup_redis_client},
+        utils::test_utils::{
+            insert_new_team_in_redis, setup_pg_reader_client, setup_redis_client, TestContext,
+        },
     };
 
     use super::*;
@@ -204,6 +221,8 @@ mod tests {
             redis_client.clone(),
             redis_client.clone(),
             pg_client.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
         );
 
         // Test valid token in Redis
@@ -243,6 +262,8 @@ mod tests {
             redis_client.clone(),
             redis_client.clone(),
             pg_client.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
         );
 
         // Test fetching from Redis
@@ -263,6 +284,8 @@ mod tests {
             redis_client.clone(),
             redis_client.clone(),
             pg_client.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
         );
 
         let result = flag_service
@@ -372,14 +395,21 @@ mod tests {
             ],
         };
 
-        FeatureFlagList::update_flags_in_redis(redis_client.clone(), team.project_id, &mock_flags)
-            .await
-            .expect("Failed to insert mock flags in Redis");
+        FeatureFlagList::update_flags_in_redis(
+            redis_client.clone(),
+            team.project_id,
+            &mock_flags,
+            None,
+        )
+        .await
+        .expect("Failed to insert mock flags in Redis");
 
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
             pg_client.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
         );
 
         // Test fetching from Redis
@@ -451,5 +481,163 @@ mod tests {
         let redis_flags = FeatureFlagList::from_redis(redis_client.clone(), team.project_id).await;
         assert!(redis_flags.is_ok());
         assert_eq!(redis_flags.unwrap().flags.len(), mock_flags.flags.len());
+    }
+
+    #[tokio::test]
+    async fn test_get_flags_from_cache_or_pg_skips_cache_write_on_redis_timeout() {
+        use common_redis::{CustomRedisError, MockRedisClient};
+
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        // Set up mock redis_reader to return Timeout
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(
+            &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.project_id),
+            Err(CustomRedisError::Timeout),
+        );
+
+        // Set up mock redis_writer to track SET calls
+        let mock_writer = MockRedisClient::new();
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        let flag_service = FlagService::new(
+            reader,
+            writer,
+            context.non_persons_reader.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
+        );
+
+        let result = flag_service
+            .get_flags_from_cache_or_pg(team.project_id)
+            .await;
+
+        // Should succeed despite Redis timeout
+        assert!(result.is_ok());
+        let flag_result = result.unwrap();
+        assert!(!flag_result.was_cache_hit);
+
+        // Verify SET was NOT called (cache write was skipped)
+        let writer_calls = mock_writer.get_calls();
+        assert!(
+            !writer_calls.iter().any(|call| call.op == "set"),
+            "Expected SET to NOT be called for Timeout error, but it was"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_flags_from_cache_or_pg_skips_cache_write_on_redis_unavailable() {
+        use common_redis::{CustomRedisError, MockRedisClient};
+
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        // Set up mock redis_reader to return Other error (maps to RedisUnavailable)
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(
+            &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.project_id),
+            Err(CustomRedisError::Other("Connection refused".to_string())),
+        );
+
+        // Set up mock redis_writer to track SET calls
+        let mock_writer = MockRedisClient::new();
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        let flag_service = FlagService::new(
+            reader,
+            writer,
+            context.non_persons_reader.clone(),
+            432000, // team_cache_ttl_seconds
+            432000, // flags_cache_ttl_seconds
+        );
+
+        let result = flag_service
+            .get_flags_from_cache_or_pg(team.project_id)
+            .await;
+
+        // Should succeed despite Redis being unavailable
+        assert!(result.is_ok());
+        let flag_result = result.unwrap();
+        assert!(!flag_result.was_cache_hit);
+
+        // Verify SET was NOT called (cache write was skipped)
+        let writer_calls = mock_writer.get_calls();
+        assert!(
+            !writer_calls.iter().any(|call| call.op == "set"),
+            "Expected SET to NOT be called for RedisUnavailable error, but it was"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_ttl_values_are_used() {
+        use common_redis::{CustomRedisError, MockRedisClient, MockRedisValue};
+
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        // Set up mock redis_reader to return NotFound (cache miss)
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(&team.api_token, Err(CustomRedisError::NotFound));
+
+        // Set up mock redis_writer to track setex calls
+        let mock_writer = MockRedisClient::new();
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        // Test with custom TTL values (different from default 432000)
+        let custom_team_ttl = 7200u64; // 2 hours
+        let custom_flags_ttl = 1800u64; // 30 minutes
+
+        let flag_service = FlagService::new(
+            reader,
+            writer,
+            context.non_persons_reader.clone(),
+            custom_team_ttl,
+            custom_flags_ttl,
+        );
+
+        // Trigger team cache operation
+        let _result = flag_service
+            .get_team_from_cache_or_pg(&team.api_token)
+            .await;
+
+        // Verify setex was called with the custom team TTL
+        let writer_calls = mock_writer.get_calls();
+        let setex_calls: Vec<_> = writer_calls
+            .iter()
+            .filter(|call| call.op == "setex")
+            .collect();
+
+        assert!(!setex_calls.is_empty(), "Expected setex to be called");
+
+        // Verify the TTL value used matches our custom config
+        let team_setex_call = setex_calls
+            .iter()
+            .find(|call| call.key.contains(&team.api_token))
+            .expect("Expected setex call for team token");
+
+        if let MockRedisValue::StringWithTTL(_, ttl) = &team_setex_call.value {
+            assert_eq!(
+                *ttl, custom_team_ttl,
+                "Expected team cache TTL to be {custom_team_ttl} but got {ttl}",
+            );
+        } else {
+            panic!("Expected setex call to have TTL value");
+        }
     }
 }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -96,6 +96,8 @@ async fn process_request_inner(
             context.state.redis_reader.clone(),
             context.state.redis_writer.clone(),
             context.state.database_pools.non_persons_reader.clone(),
+            context.state.config.team_cache_ttl_seconds,
+            context.state.config.flags_cache_ttl_seconds,
         );
 
         let (original_distinct_id, verified_token, request) =

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1152,6 +1152,8 @@ async fn test_fetch_and_filter_flags() {
         redis_reader_client.clone(),
         redis_writer_client.clone(),
         reader.clone(),
+        432000, // team_cache_ttl_seconds
+        432000, // flags_cache_ttl_seconds
     );
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await.unwrap();

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -21,10 +21,12 @@ use tracing::{debug, warn};
 /// * `redis_writer` - Redis client for cache writes
 /// * `token` - Token to use for cache key lookup
 /// * `db_lookup` - Async function to fetch team from PostgreSQL on cache miss
+/// * `cache_ttl_seconds` - Optional TTL for Redis cache entries in seconds
 pub async fn fetch_team_from_redis_with_fallback<F, Fut>(
     redis_reader: Arc<dyn RedisClient + Send + Sync>,
     redis_writer: Arc<dyn RedisClient + Send + Sync>,
     token: &str,
+    cache_ttl_seconds: Option<u64>,
     db_lookup: F,
 ) -> Result<Team, FlagError>
 where
@@ -44,7 +46,9 @@ where
                 Ok(team) => {
                     debug!(team_id = team.id, "Found team in PostgreSQL");
                     // Update Redis cache for next time
-                    if let Err(e) = Team::update_redis_cache(redis_writer, &team).await {
+                    if let Err(e) =
+                        Team::update_redis_cache(redis_writer, &team, cache_ttl_seconds).await
+                    {
                         warn!(team_id = team.id, error = %e, "Failed to update Redis cache");
                     }
                     Ok(team)
@@ -133,6 +137,7 @@ impl Team {
     pub async fn update_redis_cache(
         client: Arc<dyn RedisClient + Send + Sync>,
         team: &Team,
+        ttl_seconds: Option<u64>,
     ) -> Result<(), FlagError> {
         let serialized_team = serde_json::to_string(&team).map_err(|e| {
             tracing::error!(
@@ -144,28 +149,46 @@ impl Team {
             FlagError::RedisDataParsingError
         })?;
 
-        tracing::info!(
-            "Writing team to Redis at key '{}{}': team_id={}",
-            TEAM_TOKEN_CACHE_PREFIX,
-            team.api_token,
-            team.id
-        );
+        let cache_key = format!("{TEAM_TOKEN_CACHE_PREFIX}{}", team.api_token);
 
-        client
-            .set(
-                format!("{TEAM_TOKEN_CACHE_PREFIX}{}", team.api_token),
-                serialized_team,
-            )
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to update Redis cache for team {} (token {}): {}",
-                    team.id,
-                    team.api_token,
-                    e
+        match ttl_seconds {
+            Some(ttl) => {
+                tracing::info!(
+                    "Writing team to Redis at key '{}' with TTL {} seconds: team_id={}",
+                    cache_key,
+                    ttl,
+                    team.id
                 );
-                FlagError::CacheUpdateError
-            })?;
+                client
+                    .setex(cache_key, serialized_team, ttl)
+                    .await
+                    .map_err(|e| {
+                        tracing::error!(
+                            "Failed to update Redis cache with TTL for team {} (token {}): {}",
+                            team.id,
+                            team.api_token,
+                            e
+                        );
+                        FlagError::CacheUpdateError
+                    })?;
+            }
+            None => {
+                tracing::info!(
+                    "Writing team to Redis at key '{}' without TTL: team_id={}",
+                    cache_key,
+                    team.id
+                );
+                client.set(cache_key, serialized_team).await.map_err(|e| {
+                    tracing::error!(
+                        "Failed to update Redis cache for team {} (token {}): {}",
+                        team.id,
+                        team.api_token,
+                        e
+                    );
+                    FlagError::CacheUpdateError
+                })?;
+            }
+        }
 
         Ok(())
     }
@@ -407,5 +430,148 @@ mod tests {
         assert_eq!(config[1], Some("valid_event".to_string()));
         assert_eq!(config[2], None);
         assert_eq!(config[3], Some("another_event".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_team_from_redis_with_fallback_writes_on_not_found() {
+        use common_redis::{CustomRedisError, MockRedisClient};
+
+        let team_id = rand::thread_rng().gen_range(1..10_000_000);
+        let token = random_string("phc_", 12);
+        let test_team = Team {
+            id: team_id,
+            project_id: i64::from(team_id),
+            name: "team".to_string(),
+            api_token: token.clone(),
+            organization_id: Some(Uuid::new_v4()),
+            ..Default::default()
+        };
+
+        // Set up mock redis_reader to return NotFound (which maps to TokenValidationError)
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(
+            &format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"),
+            Err(CustomRedisError::NotFound),
+        );
+
+        // Set up mock redis_writer to track SET calls
+        // Note: We don't need to set up exists/set return values - the mock
+        // will track calls and we just check if SET was invoked
+        let mock_writer = MockRedisClient::new();
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        // Call the function with a DB lookup that returns the team
+        let result =
+            fetch_team_from_redis_with_fallback(reader, writer, &token, Some(3600), || async {
+                Ok(test_team.clone())
+            })
+            .await;
+
+        // Should succeed and return the team
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, team_id);
+
+        // Verify SETEX was called (cache write happened with TTL)
+        let writer_calls = mock_writer.get_calls();
+        assert!(
+            writer_calls.iter().any(|call| call.op == "setex"),
+            "Expected SETEX to be called for NotFound error, but it wasn't"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_team_from_redis_with_fallback_skips_write_on_timeout() {
+        use common_redis::{CustomRedisError, MockRedisClient};
+
+        let team_id = rand::thread_rng().gen_range(1..10_000_000);
+        let token = random_string("phc_", 12);
+        let test_team = Team {
+            id: team_id,
+            project_id: i64::from(team_id),
+            name: "team".to_string(),
+            api_token: token.clone(),
+            organization_id: Some(Uuid::new_v4()),
+            ..Default::default()
+        };
+
+        // Set up mock redis_reader to return Timeout
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(
+            &format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"),
+            Err(CustomRedisError::Timeout),
+        );
+
+        // Set up mock redis_writer to track SET calls
+        let mock_writer = MockRedisClient::new();
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        // Call the function with a DB lookup that returns the team
+        let result =
+            fetch_team_from_redis_with_fallback(reader, writer, &token, Some(3600), || async {
+                Ok(test_team.clone())
+            })
+            .await;
+
+        // Should succeed and return the team
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, team_id);
+
+        // Verify SET was NOT called (cache write was skipped)
+        let writer_calls = mock_writer.get_calls();
+        assert!(
+            !writer_calls.iter().any(|call| call.op == "set"),
+            "Expected SET to NOT be called for Timeout error, but it was"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_team_from_redis_with_fallback_skips_write_on_redis_unavailable() {
+        use common_redis::{CustomRedisError, MockRedisClient};
+
+        let team_id = rand::thread_rng().gen_range(1..10_000_000);
+        let token = random_string("phc_", 12);
+        let test_team = Team {
+            id: team_id,
+            project_id: i64::from(team_id),
+            name: "team".to_string(),
+            api_token: token.clone(),
+            organization_id: Some(Uuid::new_v4()),
+            ..Default::default()
+        };
+
+        // Set up mock redis_reader to return Other (unavailable)
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(
+            &format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"),
+            Err(CustomRedisError::Other("Connection refused".to_string())),
+        );
+
+        // Set up mock redis_writer to track SET calls
+        let mock_writer = MockRedisClient::new();
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        // Call the function with a DB lookup that returns the team
+        let result =
+            fetch_team_from_redis_with_fallback(reader, writer, &token, Some(3600), || async {
+                Ok(test_team.clone())
+            })
+            .await;
+
+        // Should succeed and return the team
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, team_id);
+
+        // Verify SET was NOT called (cache write was skipped)
+        let writer_calls = mock_writer.get_calls();
+        assert!(
+            !writer_calls.iter().any(|call| call.op == "set"),
+            "Expected SET to NOT be called for Redis unavailable error, but it was"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The `/flags` code does not set a TTL when writing to Redis like `/decide` did. This means when Redis is under severe load and tries to evict keys, it won't evict our cached data. 

## Changes

Add configurable TTLs for team and flag caching to match Django's behavior and prevent indefinite cache growth. 
Default TTL is `5` days (`432000` seconds) to maintain consistency with Django's `FIVE_DAYS` constant.

These defaults are configurable from env vars:

* `TEAM_CACHE_TTL_SECONDS` - controls team cache ttl
* `FLAGS_CACHE_TTL_SECONDS` - controls flags cache ttl

## How did you test this code?

Manually:

__With Defaults__

1. Run `redis-cli FLUSHALL`
2. Run the service `RUST_LOG=debug cargo run --package feature-flags`
3. Make a `/flags` request
4. Run these commands:
  a. `redis-cli TTL "posthog:1:team_feature_flags_1` (result `431957` or 5 days)
  b. `redis-cli TTL "posthog:1:team_token:{phc_PROJECT_API_TOKEN}"` (result `431957` or 5 days)
  c. `redis-cli TTL "posthog:decide_requests:1"` (result `-1` or never)

That last one is a billing counter so we're fine with an unlimited TTL.

__With Low TTLs__

1. Run `redis-cli FLUSHALL`
2. Run the service: `RUST_LOG=debug TEAM_CACHE_TTL_SECONDS=11 FLAGS_CACHE_TTL_SECONDS=10 cargo run --package feature-flags`
3. Make a `/flags` request.
4. Look for log entries like:
  a. "Writing flags to Redis at key 'team_flags:456' with TTL 10 seconds"
  b. "Writing team to Redis at key 'team:your_token_here' with TTL 11 seconds: team_id=123"
5. Make another `/flags` request within 10 seconds.
6. Look for log entries like:
  a. "Successfully read team 1 from Redis at key 'posthog:1:team_token:{your token}'"
  b. "Successfully read 50 flags from Redis at key 'posthog:1:team_feature_flags_{your team id}'"

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
