### PR TITLE
chore(flags): Make `cookieless_server_hash_mode` nullable

### DIFF
--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -277,7 +277,7 @@ mod tests {
             session_recording_event_trigger_config: None,
             session_recording_trigger_match_type_config: None,
             recording_domains: None,
-            cookieless_server_hash_mode: 0,
+            cookieless_server_hash_mode: Some(0),
             timezone: "UTC".to_string(),
         }
     }

--- a/rust/feature-flags/src/handler/cookieless.rs
+++ b/rust/feature-flags/src/handler/cookieless.rs
@@ -36,7 +36,7 @@ pub async fn handle_distinct_id(
         team_id: team.id,
         timezone: team.timezone.clone(),
         cookieless_server_hash_mode: CookielessServerHashMode::from(
-            team.cookieless_server_hash_mode,
+            team.cookieless_server_hash_mode.unwrap_or(0),
         ),
     };
 

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -44,7 +44,7 @@ pub struct Team {
     pub session_recording_trigger_match_type_config: Option<String>, // character varying(24) in postgres
     pub recording_domains: Option<Vec<String>>, // character varying(200)[] in postgres
     #[serde(with = "option_i16_as_i16")]
-    pub cookieless_server_hash_mode: i16,
+    pub cookieless_server_hash_mode: Option<i16>,
     #[serde(default = "default_timezone")]
     pub timezone: String,
 }
@@ -56,18 +56,18 @@ fn default_timezone() -> String {
 mod option_i16_as_i16 {
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(value: &i16, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(value: &Option<i16>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_i16(*value)
+        serializer.serialize_i16(value.unwrap_or(0))
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<i16, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<i16>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Option::<i16>::deserialize(deserializer).map(|opt| opt.unwrap_or(0))
+        Option::<i16>::deserialize(deserializer)
     }
 }
 

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -297,7 +297,7 @@ mod tests {
             project_id: i64::from(id) - 1,
             name: "team".to_string(),
             api_token: token,
-            cookieless_server_hash_mode: 0,
+            cookieless_server_hash_mode: Some(0),
             timezone: "UTC".to_string(),
             ..Default::default()
         };
@@ -339,7 +339,7 @@ mod tests {
             project_id: 0,
             uuid: Uuid::nil(),
             session_recording_opt_in: false,
-            cookieless_server_hash_mode: 0,
+            cookieless_server_hash_mode: Some(0),
             timezone: "UTC".to_string(),
             ..Default::default()
         };
@@ -361,7 +361,7 @@ mod tests {
         assert_eq!(team_from_redis.api_token, target_token);
         assert_eq!(team_from_redis.id, 343);
         assert_eq!(team_from_redis.project_id, 343); // Same as `id`
-        assert_eq!(team_from_redis.cookieless_server_hash_mode, 0);
+        assert_eq!(team_from_redis.cookieless_server_hash_mode, Some(0));
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -38,7 +38,7 @@ pub async fn insert_new_team_in_redis(
         project_id: i64::from(id),
         name: "team".to_string(),
         api_token: token,
-        cookieless_server_hash_mode: 0,
+        cookieless_server_hash_mode: Some(0),
         timezone: "UTC".to_string(),
         ..Default::default()
     };
@@ -321,7 +321,7 @@ pub async fn insert_new_team_in_pg(
         project_id: id as i64,
         name: "Test Team".to_string(),
         api_token: token.clone(),
-        cookieless_server_hash_mode: 0,
+        cookieless_server_hash_mode: Some(0),
         timezone: "UTC".to_string(),
         ..Default::default()
     };
@@ -348,7 +348,7 @@ pub async fn insert_new_team_in_pg(
         r#"INSERT INTO posthog_team
         (id, uuid, organization_id, project_id, api_token, name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical, cookieless_server_hash_mode, base_currency, session_recording_retention_period, web_analytics_pre_aggregated_tables_enabled) VALUES
         ($1, $2, $3::uuid, $4, $5, $6, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]', $7, 'USD', '30d', false)"#
-    ).bind(team.id).bind(uuid).bind(org_id).bind(team.project_id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode).execute(&mut *non_persons_conn).await?;
+    ).bind(team.id).bind(uuid).bind(org_id).bind(team.project_id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode.unwrap_or(0)).execute(&mut *non_persons_conn).await?;
     assert_eq!(res.rows_affected(), 1);
 
     // Insert group type mappings
@@ -1123,7 +1123,7 @@ impl TestContext {
             project_id: id as i64,
             name: "Test Team".to_string(),
             api_token: public_token.clone(),
-            cookieless_server_hash_mode: 0,
+            cookieless_server_hash_mode: Some(0),
             timezone: "UTC".to_string(),
             ..Default::default()
         };
@@ -1179,7 +1179,7 @@ impl TestContext {
 
         query = query
             .bind(&team.name)
-            .bind(team.cookieless_server_hash_mode);
+            .bind(team.cookieless_server_hash_mode.unwrap_or(0));
 
         let res = query.execute(&mut *conn).await?;
         assert_eq!(res.rows_affected(), 1);

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -60,7 +60,7 @@ impl ServerHandle {
                 project_id: team_id as i64,
                 name: "Test Team".to_string(),
                 api_token: token.clone(),
-                cookieless_server_hash_mode: 0,
+                cookieless_server_hash_mode: Some(0),
                 timezone: "UTC".to_string(),
                 ..Default::default()
             };


### PR DESCRIPTION
This matches what we have in Django and fixes a 500 error we get.

## Problem

Saw a small number of 500 errors in EU: 

```
{“timestamp”:“2025-10-30T00:11:25.285493Z”,“level”:“ERROR”,“fields”:{“message”:“Database error: error occurred while decoding column \“cookieless_server_hash_mode\“: unexpected null; try decoding as an `Option`“},“target”:“feature_flags::api::errors”,“threadId”:“ThreadId(8)“}
```

This is because the Rust model has `cookieless_server_hash_mode` as `i16` but the `team_model.py` has it as a nullable column. This has always been this way.

## Changes

Changed `cookieless_server_hash_mode` to be `Option<i16>`.

## How did you test this code?

Unit Tests
Manual:

1. Ran `UPDATE posthog_team SET cookieless_server_hash_mode = NULL`
2. Made `/flags` request
3. No crash, results good.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
