### PR TITLE
chore(web-analytics): add scene-based concurrency control

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -166,6 +166,7 @@ export const FEATURE_FLAGS = {
     FF_DASHBOARD_TEMPLATES: 'ff-dashboard-templates', // owner: @EDsCODE
     ARTIFICIAL_HOG: 'artificial-hog', // owner: #team-posthog-ai
     SIDEBAR_ANALYTICS_PRIORITIZATION: 'sidebar-analytics-prioritization', // owner: @lricoy #team-web-analytics
+    WEB_ANALYTICS_HIGHER_CONCURRENCY: 'web-analytics-higher-concurrency', // owner: @lricoy #team-web-analytics
     MAX_AI_INSIGHT_SEARCH: 'max-ai-insight-search', // owner: #team-posthog-ai
     PRODUCT_SPECIFIC_ONBOARDING: 'product-specific-onboarding', // owner: @raquelmsmith
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -25,6 +25,7 @@ import { ConcurrencyController } from 'lib/utils/concurrencyController'
 import { UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES } from 'scenes/insights/insightLogic'
 import { compareDataNodeQuery, haveVariablesOrFiltersChanged, validateQuery } from 'scenes/insights/utils/queryUtils'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -108,9 +109,24 @@ export const AUTOLOAD_INTERVAL = 30000
 const LOAD_MORE_ROWS_LIMIT = 10000
 
 const concurrencyController = new ConcurrencyController(1)
+const webAnalyticsConcurrencyController = new ConcurrencyController(3)
 const webAnalyticsPreAggConcurrencyController = new ConcurrencyController(5)
 
-function getConcurrencyController(query: DataNode, currentTeam: TeamType): ConcurrencyController {
+function getConcurrencyController(
+    query: DataNode,
+    currentTeam: TeamType,
+    featureFlags: Record<string, boolean | string>
+): ConcurrencyController {
+    const mountedSceneLogic = sceneLogic.findMounted()
+    const activeScene = mountedSceneLogic?.values.activeSceneId
+    if (
+        activeScene === Scene.WebAnalytics &&
+        featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_HIGHER_CONCURRENCY] &&
+        !currentTeam?.modifiers?.useWebAnalyticsPreAggregatedTables
+    ) {
+        return webAnalyticsConcurrencyController
+    }
+
     if (
         currentTeam?.modifiers?.useWebAnalyticsPreAggregatedTables &&
         [NodeKind.WebOverviewQuery, NodeKind.WebStatsTableQuery, NodeKind.InsightVizNode].includes(query.kind)
@@ -303,7 +319,11 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                     }
                     try {
                         // For shared contexts, create a minimal team object if needed
-                        const response = await getConcurrencyController(query, values.currentTeam as TeamType).run({
+                        const response = await getConcurrencyController(
+                            query,
+                            values.currentTeam as TeamType,
+                            values.featureFlags
+                        ).run({
                             debugTag: query.kind,
                             abortController,
                             priority: props.loadPriority,


### PR DESCRIPTION
## Problem

We're currently capped at 1 concurrent request when not using the new query engine, which isn't always what we want, specially for bigger queries.

We can leverage higher concurrency on our internal team, as there are also slots on the `/query` endpoint handling. Let's see how the query scheduling behaves with more concurrency on the frontend. 

## Changes

- If we're on the web analytics scene and have the flag enabled, use a concurrency controller with 3 slots.

## How did you test this code?

Running it locally. 

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

No. It's still hidden behind a feature flag.
