### PR TITLE
fix(cdp): pull compilation step out of beforeEach block

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -1036,9 +1036,10 @@ describe('IngestionConsumer', () => {
         const TRANSFORMATION_TEST_TIMEOUT = 30000
         let compiledGeoipBytecode: any
 
+        // Ensure longer timeout applies to hooks in this block too
+        jest.setTimeout(TRANSFORMATION_TEST_TIMEOUT)
+
         beforeAll(async () => {
-            jest.setTimeout(TRANSFORMATION_TEST_TIMEOUT)
-            // Compile once to avoid per-test overhead
             compiledGeoipBytecode = await compileHog(geoipTemplate.code)
         })
 

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -1034,9 +1034,12 @@ describe('IngestionConsumer', () => {
     describe('transformations', () => {
         let transformationFunction: HogFunctionType
         const TRANSFORMATION_TEST_TIMEOUT = 30000
+        let compiledGeoipBytecode: any
 
-        beforeAll(() => {
+        beforeAll(async () => {
             jest.setTimeout(TRANSFORMATION_TEST_TIMEOUT)
+            // Compile once to avoid per-test overhead
+            compiledGeoipBytecode = await compileHog(geoipTemplate.code)
         })
 
         afterAll(() => {
@@ -1056,11 +1059,10 @@ describe('IngestionConsumer', () => {
 
         beforeEach(async () => {
             // Create a transformation function using the geoip template as an example
-            const hogByteCode = await compileHog(geoipTemplate.code)
             transformationFunction = await insertHogFunction({
                 name: 'GeoIP Transformation',
                 hog: geoipTemplate.code,
-                bytecode: hogByteCode,
+                bytecode: compiledGeoipBytecode,
             })
 
             ingester = await createIngestionConsumer(hub)


### PR DESCRIPTION
## Problem

Tests are flakey due to taking too long. We get this error

```
FAIL src/ingestion/ingestion-consumer.test.ts (17.402 s)
  ● IngestionConsumer › transformations › should call hogwatcher state caching methods and observe results when hogwatcher is enabled (sample rate = 1)

    thrown: "Exceeded timeout of 5000 ms for a hook.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
```
so seems like the default 5s timeout applied  for hooks although we should have a 30s timeout for transformation functions as the compilation step might take long. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Compile GeoIP Hog template once in beforeAll (although it should be cached)
- Use describe-level jest.setTimeout(30000) so hooks (beforeAll/beforeEach) get the longer timeout.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
