### PR TITLE
fix: Raise non-retryable exception on 'UndefinedFunction' error

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -221,6 +221,8 @@ class PostgreSQLClient:
         self.has_self_signed_cert = has_self_signed_cert
         self.connection_timeout = connection_timeout
 
+        self.logger = LOGGER.bind(host=host, port=port, database=database, user=user)
+        self.external_logger = EXTERNAL_LOGGER.bind(host=host, port=port, database=database, user=user)
         self._connection: None | psycopg.AsyncConnection = None
 
     @classmethod

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -349,6 +349,7 @@ class RedshiftClient(PostgreSQLClient):
                         schema,
                         final_table_name,
                     )
+                    raise
 
                 await cursor.execute(merge_query)
 

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -341,9 +341,9 @@ class RedshiftClient(PostgreSQLClient):
                     self.external_logger.error(  # noqa: TRY400
                         "A non-retryable 'UndefinedFunction' error happened when attempting to"
                         " delete existing rows from '%s.%s' before a 'MERGE' command can be executed."
-                        "This can indicate that the schema of the table does not match what the"
+                        " This can indicate that the schema of the table does not match what the"
                         " batch export expects."
-                        "Please review the table schema before retrying again, there may be fields"
+                        " Please review the table schema before retrying again, there may be fields"
                         " that have been created with incorrect types. The batch export will always"
                         " create a table with the correct schema if it doesn't already exist.",
                         schema,

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
@@ -497,7 +497,12 @@ async def test_redshift_export_workflow_handles_undefined_function_error(
             )
 
             await cursor.execute(
-                sql.SQL("ALTER TABLE {} ALTER COLUMN timestamp TYPE SUPER;").format(
+                sql.SQL("ALTER TABLE {} DROP COLUMN timestamp;").format(
+                    sql.Identifier(redshift_config["schema"], table_name)
+                )
+            )
+            await cursor.execute(
+                sql.SQL("ALTER TABLE {} ADD COLUMN timestamp SUPER DEFAULT NULL;").format(
                     sql.Identifier(redshift_config["schema"], table_name)
                 )
             )

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
@@ -408,9 +408,6 @@ async def test_redshift_export_workflow_handles_undefined_function_error(
         pytest.skip("MERGE of events only happens in internal stage activity")
 
     if mode == "COPY":
-        if use_internal_stage is False:
-            pytest.skip("Testing COPY mode requires internal stage")
-
         if not aws_credentials or not bucket_name or not bucket_region:
             pytest.skip("Testing COPY mode requires S3 variables to be configured")
 
@@ -543,5 +540,5 @@ async def test_redshift_export_workflow_handles_undefined_function_error(
 
     run = runs[0]
     assert run.status == "Failed"
-    assert run.latest_error.startswith("UndefinedFunction")
+    assert run.latest_error is not None and run.latest_error.startswith("UndefinedFunction")
     assert run.records_completed is None

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
@@ -435,6 +435,7 @@ async def test_redshift_export_workflow_handles_undefined_function_error(
         batch_export_model=batch_export_model,
         mode=mode,
         copy_inputs=copy_inputs,
+        properties_data_type="SUPER",
         **redshift_batch_export.destination.config,
     )
 
@@ -487,6 +488,7 @@ async def test_redshift_export_workflow_handles_undefined_function_error(
         batch_export_model=model,
         exclude_events=exclude_events,
         sort_key=sort_key,
+        properties_data_type="SUPER",
         copy=mode == "COPY",
     )
 

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_workflow.py
@@ -534,7 +534,10 @@ async def test_redshift_export_workflow_handles_undefined_function_error(
                     )
 
     runs = await afetch_batch_export_runs(batch_export_id=redshift_batch_export.id)
-    assert len(runs) == 1
+    assert len(runs) == 2
+
+    failed_runs = [run for run in runs if run.status == "Failed"]
+    assert len(failed_runs) == 1
 
     run = runs[0]
     assert run.status == "Failed"


### PR DESCRIPTION
## Problem

Schema errors when destination tables have incompatible schemas can lead to `UndefinedFunction` errors in Redshift batch export.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Handle `UndefinedFunction` errors when running a delete query.
* Treat errors as non-retryable.
* Provide users with context on what went wrong.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test, ran manually.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
