### PR TITLE
fix(devex): ensure worktrees can share docker containers

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -17,7 +17,7 @@ procs:
 
     docker-compose:
         # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed
-        shell: 'docker compose -f docker-compose.dev-minimal.yml up --pull always -d && docker compose -f docker-compose.dev-minimal.yml logs --tail=0 -f'
+        shell: 'docker compose -p $COMPOSE_PROJECT_NAME -f docker-compose.dev-minimal.yml up --pull always -d && docker compose -p $COMPOSE_PROJECT_NAME -f docker-compose.dev-minimal.yml logs --tail=0 -f'
 
     property-defs-rs:
         shell: |-

--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -59,7 +59,7 @@ procs:
             dagster dev --workspace $DAGSTER_HOME/workspace.yaml -p $DAGSTER_UI_PORT 2>&1 | tee /tmp/posthog-dagster.log
 
     docker-compose:
-        shell: 'docker compose -f docker-compose.dev.yml up --pull always -d && docker compose -f docker-compose.dev.yml logs --tail=0 -f 2>&1 | tee /tmp/posthog-docker-compose.log'
+        shell: 'docker compose -p $COMPOSE_PROJECT_NAME -f docker-compose.dev.yml up --pull always -d && docker compose -p $COMPOSE_PROJECT_NAME -f docker-compose.dev.yml logs --tail=0 -f 2>&1 | tee /tmp/posthog-docker-compose.log'
 
     cyclotron-janitor:
         shell: |-

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -60,7 +60,7 @@ procs:
 
     docker-compose:
         # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed
-        shell: 'docker compose -f docker-compose.dev.yml up --pull always -d && docker compose -f docker-compose.dev.yml logs --tail=0 -f'
+        shell: 'docker compose -p $COMPOSE_PROJECT_NAME -f docker-compose.dev.yml up --pull always -d && docker compose -p $COMPOSE_PROJECT_NAME -f docker-compose.dev.yml logs --tail=0 -f'
 
     cyclotron-janitor:
         shell: |-

--- a/bin/start
+++ b/bin/start
@@ -3,7 +3,7 @@
 set -e
 
 export REPOSITORY_ROOT=$(realpath "$(dirname "$0")/..")
-export GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
+export GIT_REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
 export COMPOSE_PROJECT_NAME=$(basename "$GIT_REPO_ROOT")
 export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}

--- a/bin/start
+++ b/bin/start
@@ -3,6 +3,8 @@
 set -e
 
 export REPOSITORY_ROOT=$(realpath "$(dirname "$0")/..")
+export GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
+export COMPOSE_PROJECT_NAME=$(basename "$GIT_REPO_ROOT")
 export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 


### PR DESCRIPTION
Had this idea here. Question is: is there anyone who does need e.g. separate databases per worktree 🙈 

## Summary

Fixes docker compose in worktrees to be able to share containers with main repo instead of creating duplicate infrastructure.

## Problem

Running `bin/start` from a worktree creates separate containers named after the worktree directory instead of reusing the main repo's containers. Only one PostHog instance can run at a time (port conflicts), but worktrees were creating duplicate infrastructure.

## Solution

Use explicit docker compose project name derived from git repository root directory name. All instances (main repo and worktrees) share the same project name.

## Supported workflows

All existing workflows continue to work:

- **Main repo only**: No change, uses repo directory name as project name
- **Worktrees**: Can now run `bin/start` from any worktree, shares same docker infrastructure if already up
- **Switching locations (stopped)**: Stop instance, switch worktrees, start again - can bring up or recreate existing containers
- **Switching locations (already running)**: If containers are already running and you start from different location, docker compose -d just leaves them be OR recreates them if any underlying config changed (think "last started wins")
- **Backwards compatible**: Uses main repo directory name as project, matches existing container names for folks

## Test plan

- [x] Tested in worktree - uses repo directory name as project
- [x] Containers shared between main repo and worktrees
- [x] Backwards compatible with existing setups