### PR TITLE
fix(persons): Fix merge is_identified race condition

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -318,7 +318,7 @@ export class PersonMergeService {
                 // never needs an override.
                 const distinctId1Version = 0
 
-                const [person, _] = await this.personCreateService.createPerson(
+                const [person, wasCreated] = await this.personCreateService.createPerson(
                     timestamp,
                     this.context.eventProperties['$set'] || {},
                     this.context.eventProperties['$set_once'] || {},
@@ -332,8 +332,10 @@ export class PersonMergeService {
                     ],
                     tx
                 )
-                // We don't need to update the person later, so we return false for needsPersonUpdate
-                return mergeSuccess(person, Promise.resolve(), false)
+                // If person was not created (creation conflict) and is not identified,
+                // we need to update it later
+                const needsPersonUpdate = !wasCreated && !person.is_identified
+                return mergeSuccess(person, Promise.resolve(), needsPersonUpdate)
             })
         }
     }


### PR DESCRIPTION
## Problem

When events are processed in parallel batches, a $identify event could fail to set `is_identified=true` due to a race condition.

  Scenario:
  - Event A creates person with is_identified=false
  - Event B ($identify) tries to create person with both distinct IDs and is_identified=true
  - They run concurrently → Event B hits creation conflict
  - Event B fetches existing person (from Event A) but returned needsPersonUpdate=false
  - Result: Person remains with is_identified=false

## Changes
- Add logic for when we have a creation concurrency issue to update the person afterwards

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
