### PR TITLE
feat: enable materializing an Endpoint

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -9857,6 +9857,10 @@
             "required": ["key", "operator", "type"],
             "type": "object"
         },
+        "DataWarehouseSyncInterval": {
+            "enum": ["5min", "30min", "1hour", "6hour", "12hour", "24hour", "7day", "30day"],
+            "type": "string"
+        },
         "DataWarehouseViewLink": {
             "additionalProperties": false,
             "properties": {
@@ -10757,6 +10761,10 @@
                 "is_active": {
                     "type": "boolean"
                 },
+                "is_materialized": {
+                    "description": "Whether this endpoint's query results are materialized to S3",
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -10769,6 +10777,10 @@
                             "$ref": "#/definitions/InsightQueryNode"
                         }
                     ]
+                },
+                "sync_frequency": {
+                    "$ref": "#/definitions/DataWarehouseSyncInterval",
+                    "description": "How frequently should the underlying materialized view be updated"
                 }
             },
             "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -14,6 +14,7 @@ import {
     ChartDisplayCategory,
     ChartDisplayType,
     CountPerActorMathType,
+    DataWarehouseSyncInterval,
     DataWarehouseViewLink,
     EventPropertyFilter,
     EventType,
@@ -1569,6 +1570,10 @@ export interface EndpointRequest {
     query?: HogQLQuery | InsightQueryNode
     is_active?: boolean
     cache_age_seconds?: number
+    /** Whether this endpoint's query results are materialized to S3 */
+    is_materialized?: boolean
+    /** How frequently should the underlying materialized view be updated */
+    sync_frequency?: DataWarehouseSyncInterval
 }
 
 export interface EndpointRunRequest {

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -385,6 +385,9 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "sync_frequency_interval",
         "deleted_name",
     ],
+    "Endpoint": [
+        "saved_query",
+    ],
     "Organization": [
         "teams",
         "billing",

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -890,6 +890,17 @@ class DataWarehouseManagedViewsetKind(RootModel[Literal["revenue_analytics"]]):
     root: Literal["revenue_analytics"] = "revenue_analytics"
 
 
+class DataWarehouseSyncInterval(StrEnum):
+    FIELD_5MIN = "5min"
+    FIELD_30MIN = "30min"
+    FIELD_1HOUR = "1hour"
+    FIELD_6HOUR = "6hour"
+    FIELD_12HOUR = "12hour"
+    FIELD_24HOUR = "24hour"
+    FIELD_7DAY = "7day"
+    FIELD_30DAY = "30day"
+
+
 class DataWarehouseViewLinkConfiguration(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -15000,10 +15011,16 @@ class EndpointRequest(BaseModel):
     cache_age_seconds: Optional[float] = None
     description: Optional[str] = None
     is_active: Optional[bool] = None
+    is_materialized: Optional[bool] = Field(
+        default=None, description="Whether this endpoint's query results are materialized to S3"
+    )
     name: Optional[str] = None
     query: Optional[
         Union[HogQLQuery, Union[TrendsQuery, FunnelsQuery, RetentionQuery, PathsQuery, StickinessQuery, LifecycleQuery]]
     ] = None
+    sync_frequency: Optional[DataWarehouseSyncInterval] = Field(
+        default=None, description="How frequently should the underlying materialized view be updated"
+    )
 
 
 class FunnelCorrelationActorsQuery(BaseModel):

--- a/products/data_warehouse/backend/migrations/0007_alter_saved_query_origin_choices.py
+++ b/products/data_warehouse/backend/migrations/0007_alter_saved_query_origin_choices.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_warehouse", "0006_alter_externaldatasource_source_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="datawarehousesavedquery",
+            name="origin",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("data_warehouse", "Data Warehouse"),
+                    ("endpoint", "Endpoint"),
+                    ("managed_viewset", "Managed Viewset"),
+                ],
+                default=None,
+                help_text="Where this SavedQuery is created.",
+                null=True,
+            ),
+        ),
+    ]

--- a/products/data_warehouse/backend/migrations/max_migration.txt
+++ b/products/data_warehouse/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0006_alter_externaldatasource_source_type
+0007_alter_saved_query_origin_choices

--- a/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
@@ -92,7 +92,12 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
                 if saved_query:
                     created = False
                 else:
-                    saved_query = DataWarehouseSavedQuery(name=view.name, team=self.team, managed_viewset=self)
+                    saved_query = DataWarehouseSavedQuery(
+                        name=view.name,
+                        team=self.team,
+                        managed_viewset=self,
+                        origin=DataWarehouseSavedQuery.Origin.MANAGED_VIEWSET,
+                    )
                     created = True
 
                 # Do NOT use get_columns because it runs the query, and these are possibly heavy

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -62,7 +62,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
 
         DATA_WAREHOUSE = "data_warehouse"
         ENDPOINT = "endpoint"
-        REVENUE_ANALYTICS = "revenue_analytics"
+        MANAGED_VIEWSET = "managed_viewset"
 
     name = models.CharField(max_length=128, validators=[validate_saved_query_name])
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)

--- a/products/data_warehouse/backend/models/modeling.py
+++ b/products/data_warehouse/backend/models/modeling.py
@@ -416,6 +416,15 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
             saved_query_id=saved_query.id,
         )
 
+    def create_or_update_from_saved_query(
+        self, saved_query: DataWarehouseSavedQuery
+    ) -> "list[DataWarehouseModelPath] | None":
+        """Create or update model paths from a `DataWarehouseSavedQuery`."""
+        if self.filter(team=saved_query.team, saved_query=saved_query).exists():
+            self.update_from_saved_query(saved_query)
+            return None
+        return self.create_from_saved_query(saved_query)
+
     def update_paths_from_query(
         self,
         query: str,

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -1,4 +1,5 @@
 import re
+from datetime import timedelta
 from typing import Union, cast
 
 from django.core.cache import cache
@@ -13,6 +14,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.schema import (
+    DataWarehouseSyncInterval,
     EndpointLastExecutionTimesRequest,
     EndpointRequest,
     EndpointRunRequest,
@@ -45,6 +47,14 @@ from posthog.models.activity_logging.activity_log import Detail, changes_between
 from posthog.rate_limit import APIQueriesBurstThrottle, APIQueriesSustainedThrottle
 from posthog.schema_migrations.upgrade import upgrade
 from posthog.types import InsightQueryNode
+
+from products.data_warehouse.backend.data_load.saved_query_service import sync_saved_query_workflow
+from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+from products.data_warehouse.backend.models.external_data_schema import (
+    sync_frequency_interval_to_sync_frequency,
+    sync_frequency_to_sync_frequency_interval,
+)
+from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
 
 from common.hogvm.python.utils import HogVMException
 
@@ -83,49 +93,65 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             return new_val
         return False
 
+    def _serialize_endpoint(self, endpoint: Endpoint) -> dict:
+        result = {
+            "id": str(endpoint.id),
+            "name": endpoint.name,
+            "description": endpoint.description,
+            "query": endpoint.query,
+            "parameters": endpoint.parameters,
+            "is_active": endpoint.is_active,
+            "cache_age_seconds": endpoint.cache_age_seconds,
+            "endpoint_path": endpoint.endpoint_path,
+            "created_at": endpoint.created_at,
+            "updated_at": endpoint.updated_at,
+            "created_by": UserBasicSerializer(endpoint.created_by).data if hasattr(endpoint, "created_by") else None,
+            "is_materialized": endpoint.is_materialized,
+        }
+
+        if endpoint.is_materialized and endpoint.saved_query:
+            sync_freq_str = None
+            if endpoint.saved_query.sync_frequency_interval:
+                sync_freq_str = sync_frequency_interval_to_sync_frequency(endpoint.saved_query.sync_frequency_interval)
+
+            result["materialization"] = {
+                "status": endpoint.materialization_status,
+                "can_materialize": True,
+                "last_materialized_at": (
+                    endpoint.last_materialized_at.isoformat() if endpoint.last_materialized_at else None
+                ),
+                "error": endpoint.materialization_error,
+                "sync_frequency": sync_freq_str,
+            }
+        else:
+            can_mat, reason = endpoint.can_materialize()
+            result["materialization"] = {
+                "can_materialize": can_mat,
+                "reason": reason if not can_mat else None,
+            }
+
+        return result
+
     def list(self, request: Request, *args, **kwargs) -> Response:
         """List all endpoints for the team."""
-        queryset = self.filter_queryset(self.get_queryset())
-
-        results = []
-        for endpoint in queryset:
-            results.append(
-                {
-                    "id": str(endpoint.id),
-                    "name": endpoint.name,
-                    "description": endpoint.description,
-                    "query": endpoint.query,
-                    "parameters": endpoint.parameters,
-                    "is_active": endpoint.is_active,
-                    "cache_age_seconds": endpoint.cache_age_seconds,
-                    "endpoint_path": endpoint.endpoint_path,
-                    "created_at": endpoint.created_at,
-                    "updated_at": endpoint.updated_at,
-                    "created_by": UserBasicSerializer(endpoint.created_by).data,
-                }
-            )
-
+        queryset = self.filter_queryset(self.get_queryset()).select_related("saved_query")
+        results = [self._serialize_endpoint(endpoint) for endpoint in queryset]
         return Response({"results": results})
 
     def retrieve(self, request: Request, name=None, *args, **kwargs) -> Response:
         """Retrieve an endpoint."""
-        endpoint = get_object_or_404(Endpoint, team=self.team, name=name)
-        return Response(
-            {
-                "id": str(endpoint.id),
-                "name": endpoint.name,
-                "description": endpoint.description,
-                "query": endpoint.query,
-                "parameters": endpoint.parameters,
-                "is_active": endpoint.is_active,
-                "cache_age_seconds": endpoint.cache_age_seconds,
-                "endpoint_path": endpoint.endpoint_path,
-                "created_at": endpoint.created_at,
-                "updated_at": endpoint.updated_at,
-                "created_by": UserBasicSerializer(endpoint.created_by).data,
-            },
-            status=status.HTTP_200_OK,
-        )
+        endpoint = get_object_or_404(Endpoint.objects.select_related("saved_query"), team=self.team, name=name)
+        return Response(self._serialize_endpoint(endpoint), status=status.HTTP_200_OK)
+
+    def _validate_cache_age_seconds(self, cache_age_seconds: float | None) -> None:
+        """Validate cache_age_seconds is within allowed range."""
+        if cache_age_seconds is not None:
+            if cache_age_seconds < MIN_CACHE_AGE_SECONDS or cache_age_seconds > MAX_CACHE_AGE_SECONDS:
+                raise ValidationError(
+                    {
+                        "cache_age_seconds": f"Cache age must be between {MIN_CACHE_AGE_SECONDS} and {MAX_CACHE_AGE_SECONDS} seconds."
+                    }
+                )
 
     def validate_request(self, data: EndpointRequest, strict: bool = True) -> None:
         query = data.query
@@ -143,13 +169,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 "and be between 1 and 128 characters long."
             )
 
-        if data.cache_age_seconds is not None:
-            if data.cache_age_seconds < MIN_CACHE_AGE_SECONDS or data.cache_age_seconds > MAX_CACHE_AGE_SECONDS:
-                raise ValidationError(
-                    {
-                        "cache_age_seconds": f"Cache age must be between {MIN_CACHE_AGE_SECONDS} and {MAX_CACHE_AGE_SECONDS} seconds."
-                    }
-                )
+        self._validate_cache_age_seconds(data.cache_age_seconds)
 
     @extend_schema(
         request=EndpointRequest,
@@ -184,60 +204,53 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 detail=Detail(name=endpoint.name),
             )
 
-            return Response(
-                {
-                    "id": str(endpoint.id),
-                    "name": endpoint.name,
-                    "description": endpoint.description,
-                    "query": endpoint.query,
-                    "parameters": endpoint.parameters,
-                    "is_active": endpoint.is_active,
-                    "cache_age_seconds": endpoint.cache_age_seconds,
-                    "endpoint_path": endpoint.endpoint_path,
-                    "created_at": endpoint.created_at,
-                    "updated_at": endpoint.updated_at,
-                },
-                status=status.HTTP_201_CREATED,
-            )
+            return Response(self._serialize_endpoint(endpoint), status=status.HTTP_201_CREATED)
 
         # We should expose if the query name is duplicate
         except Exception as e:
             capture_exception(e)
             raise ValidationError("Failed to create endpoint.")
 
+    def validate_update_request(self, data: EndpointRequest, strict: bool = True) -> None:
+        self._validate_cache_age_seconds(data.cache_age_seconds)
+
+        if data.sync_frequency is not None:
+            if data.is_materialized is not None and not data.is_materialized:
+                raise ValidationError(
+                    {"sync_frequency": "sync_frequency can not be set when is_materialized is False."}
+                )
+
     @extend_schema(
         request=EndpointRequest,
         description="Update an existing endpoint. Parameters are optional.",
     )
-    def update(self, request: Request, name=None, *args, **kwargs) -> Response:
+    def update(self, request: Request, name: str | None = None, *args, **kwargs) -> Response:
         """Update an existing endpoint."""
         endpoint = get_object_or_404(Endpoint, team=self.team, name=name)
-        # Capture a snapshot for diffing
-        try:
-            before_update = Endpoint.objects.get(pk=endpoint.id)
-        except Endpoint.DoesNotExist:
-            before_update = None
+        before_update = Endpoint.objects.get(pk=endpoint.id)
 
         upgraded_query = upgrade(request.data)
         data = self.get_model(upgraded_query, EndpointRequest)
-        self.validate_request(data, strict=False)
+        self.validate_update_request(data, strict=False)
 
         try:
-            if data.name is not None:
-                endpoint.name = data.name
             if data.query is not None:
                 endpoint.query = data.query.model_dump()
             if data.description is not None:
                 endpoint.description = data.description
             if data.is_active is not None:
                 endpoint.is_active = data.is_active
-            # Allow explicitly setting cache_age_seconds to None
             if "cache_age_seconds" in request.data:
                 endpoint.cache_age_seconds = data.cache_age_seconds
 
+            if data.is_materialized is False:
+                self._disable_materialization(endpoint)
+            elif data.is_materialized is True or (endpoint.is_materialized and data.sync_frequency):
+                sync_frequency = data.sync_frequency or DataWarehouseSyncInterval.FIELD_24HOUR
+                self._enable_materialization(endpoint, sync_frequency, request)
+
             endpoint.save()
 
-            # Activity log: updated with field diffs
             changes = changes_between("Endpoint", previous=before_update, current=endpoint)
             log_activity(
                 organization_id=self.organization.id,
@@ -250,41 +263,176 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 detail=Detail(name=endpoint.name, changes=changes),
             )
 
-            return Response(
-                {
-                    "id": str(endpoint.id),
-                    "name": endpoint.name,
-                    "description": endpoint.description,
-                    "query": endpoint.query,
-                    "parameters": endpoint.parameters,
-                    "is_active": endpoint.is_active,
-                    "endpoint_path": endpoint.endpoint_path,
-                    "created_at": endpoint.created_at,
-                    "updated_at": endpoint.updated_at,
-                    "cache_age_seconds": endpoint.cache_age_seconds,
-                }
-            )
+            return Response(self._serialize_endpoint(endpoint))
 
         except Exception as e:
             capture_exception(e)
             raise ValidationError("Failed to update endpoint.")
 
+    def _enable_materialization(
+        self,
+        endpoint: Endpoint,
+        sync_frequency: DataWarehouseSyncInterval,
+        request: Request,
+    ) -> None:
+        """Enable materialization for an endpoint."""
+        can_mat, reason = endpoint.can_materialize()
+        if not can_mat:
+            raise ValidationError(f"Cannot materialize endpoint: {reason}")
+
+        saved_query = DataWarehouseSavedQuery.objects.filter(name=endpoint.name, team=self.team, deleted=False).first()
+        if saved_query:
+            created = False
+        else:
+            saved_query = DataWarehouseSavedQuery(
+                name=endpoint.name, team=self.team, origin=DataWarehouseSavedQuery.Origin.ENDPOINT
+            )
+            created = True
+
+        saved_query.query = endpoint.query
+        saved_query.external_tables = saved_query.s3_tables
+        saved_query.is_materialized = True
+        saved_query.sync_frequency_interval = (
+            sync_frequency_to_sync_frequency_interval(sync_frequency.value) if sync_frequency else timedelta(hours=12)
+        )
+        saved_query.save()
+
+        endpoint.saved_query = saved_query
+
+        DataWarehouseModelPath.objects.create_or_update_from_saved_query(saved_query)
+
+        if created:
+            try:
+                sync_saved_query_workflow(saved_query, create=True)
+            except Exception as e:
+                capture_exception(e, {"endpoint_id": endpoint.id, "saved_query_id": saved_query.id})
+                saved_query.is_materialized = False
+                saved_query.save(update_fields=["is_materialized"])
+
+    def _disable_materialization(self, endpoint: Endpoint) -> None:
+        """Disable materialization for an endpoint."""
+        if endpoint.saved_query:
+            endpoint.saved_query.revert_materialization()
+            endpoint.saved_query.soft_delete()
+            endpoint.saved_query = None
+            endpoint.save()
+
     def destroy(self, request: Request, name=None, *args, **kwargs) -> Response:
-        """Delete a endpoint."""
+        """Delete an endpoint and clean up materialized query."""
         endpoint = get_object_or_404(Endpoint, team=self.team, name=name)
+
+        if endpoint.saved_query:
+            self._disable_materialization(endpoint)
+
         endpoint.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @extend_schema(
-        request=EndpointRunRequest,
-        description="Update an existing endpoint. Parameters are optional.",
-    )
-    @action(methods=["GET", "POST"], detail=True)
-    def run(self, request: Request, name=None, *args, **kwargs) -> Response:
-        """Execute a endpoint with optional parameters."""
-        endpoint = get_object_or_404(Endpoint, team=self.team, name=name, is_active=True)
-        data = self.get_model(request.data, EndpointRunRequest)
+    def _should_use_materialized_table(self, endpoint: Endpoint, data: EndpointRunRequest) -> bool:
+        """
+        Decide whether to use materialized table or inline execution.
 
+        Returns False if:
+        - Not materialized
+        - Materialization incomplete/failed
+        - User overrides present (variables, filters, query)
+        - Force refresh requested
+        """
+        if not endpoint.is_materialized or not endpoint.saved_query:
+            return False
+
+        saved_query = endpoint.saved_query
+        if saved_query.status not in ["Completed"]:
+            return False
+
+        if not saved_query.table:
+            return False
+
+        if data.variables_values:
+            return False
+
+        if data.refresh in ["force_blocking"]:
+            return False
+
+        if data.query_override or data.filters_override:
+            return False
+
+        return True
+
+    def _execute_query_and_respond(
+        self,
+        query_request_data: dict,
+        client_query_id: str | None,
+        request: Request,
+        cache_age_seconds: int | None = None,
+        extra_result_fields: dict | None = None,
+    ) -> Response:
+        """Shared query execution logic."""
+        merged_data = self.get_model(query_request_data, QueryRequest)
+
+        query, client_query_id, execution_mode = _process_query_request(
+            merged_data, self.team, client_query_id, request.user
+        )
+        self._tag_client_query_id(client_query_id)
+
+        if execution_mode not in BLOCKING_EXECUTION_MODES:
+            raise ValidationError("Only sync modes are supported (refresh param)")
+
+        result = process_query_model(
+            self.team,
+            query,
+            execution_mode=execution_mode,
+            query_id=client_query_id,
+            user=cast(User, request.user),
+            is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
+            cache_age_seconds=cache_age_seconds,
+        )
+
+        if isinstance(result, BaseModel):
+            result = result.model_dump(by_alias=True)
+
+        if isinstance(result, dict) and extra_result_fields:
+            result.update(extra_result_fields)
+
+        response_status = (
+            status.HTTP_202_ACCEPTED
+            if result.get("query_status") and result["query_status"].get("complete") is False
+            else status.HTTP_200_OK
+        )
+        return Response(result, status=response_status)
+
+    def _execute_materialized_endpoint(
+        self, endpoint: Endpoint, data: EndpointRunRequest, request: Request
+    ) -> Response:
+        """Execute using materialized S3 table."""
+        from posthog.schema import RefreshType
+
+        saved_query = endpoint.saved_query
+        if not saved_query:
+            raise ValidationError("No materialized query found for this endpoint")
+
+        materialized_hogql_query = HogQLQuery(
+            query=f"SELECT * FROM {saved_query.name}",
+            modifiers=HogQLQueryModifiers(useMaterializedViews=True),
+        )
+
+        query_request_data = {
+            "client_query_id": data.client_query_id,
+            "name": f"{endpoint.name}_materialized",
+            "refresh": data.refresh or RefreshType.BLOCKING,
+            "query": materialized_hogql_query.model_dump(),
+        }
+
+        extra_fields = {
+            "_materialized": True,
+            "_materialized_at": saved_query.last_run_at.isoformat() if saved_query.last_run_at else None,
+        }
+
+        return self._execute_query_and_respond(
+            query_request_data, data.client_query_id, request, extra_result_fields=extra_fields
+        )
+
+    def _execute_inline_endpoint(self, endpoint: Endpoint, data: EndpointRunRequest, request: Request) -> Response:
+        """Execute using inline query (existing implementation)."""
         self.validate_run_request(data, endpoint)
         data.variables_values = data.variables_values or {}
 
@@ -303,40 +451,14 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 "client_query_id": data.client_query_id,
                 "filters_override": data.filters_override,
                 "name": endpoint.name,
-                "refresh": data.refresh,  # Allow overriding QueryRequest fields like refresh, client_query_id
+                "refresh": data.refresh,
                 "query": endpoint.query,
                 "variables_override": data.variables_override,
             }
 
-            merged_data = self.get_model(query_request_data, QueryRequest)
-
-            query, client_query_id, execution_mode = _process_query_request(
-                merged_data, self.team, data.client_query_id, request.user
+            return self._execute_query_and_respond(
+                query_request_data, data.client_query_id, request, cache_age_seconds=endpoint.cache_age_seconds
             )
-            self._tag_client_query_id(client_query_id)
-
-            if execution_mode not in BLOCKING_EXECUTION_MODES:
-                raise ValidationError("only sync modes are supported (refresh param)")
-
-            result = process_query_model(
-                self.team,
-                query,
-                execution_mode=execution_mode,
-                query_id=client_query_id,
-                user=cast(User, request.user),
-                is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
-                cache_age_seconds=endpoint.cache_age_seconds,
-            )
-
-            if isinstance(result, BaseModel):
-                result = result.model_dump(by_alias=True)
-
-            response_status = (
-                status.HTTP_202_ACCEPTED
-                if result.get("query_status") and result["query_status"].get("complete") is False
-                else status.HTTP_200_OK
-            )
-            return Response(result, status=response_status)
 
         except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
@@ -349,12 +471,29 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             capture_exception(e)
             raise
 
+    @extend_schema(
+        request=EndpointRunRequest,
+        description="Execute endpoint with optional materialization.",
+    )
+    @action(methods=["GET", "POST"], detail=True)
+    def run(self, request: Request, name=None, *args, **kwargs) -> Response:
+        """Execute endpoint with optional parameters."""
+        endpoint = get_object_or_404(Endpoint, team=self.team, name=name, is_active=True)
+        data = self.get_model(request.data, EndpointRunRequest)
+
+        use_materialized = self._should_use_materialized_table(endpoint, data)
+
+        if use_materialized:
+            return self._execute_materialized_endpoint(endpoint, data, request)
+        else:
+            return self._execute_inline_endpoint(endpoint, data, request)
+
     def validate_run_request(self, data: EndpointRunRequest, endpoint: Endpoint) -> None:
         if endpoint.query.get("kind") == "HogQLQuery" and data.query_override:
             raise ValidationError("Query override is not supported for HogQL queries")
 
     @extend_schema(
-        description="Get the last execution times in the past 6 monthsfor multiple endpoints.",
+        description="Get the last execution times in the past 6 months for multiple endpoints.",
         request=EndpointLastExecutionTimesRequest,
         responses={200: QueryStatusResponse},
     )

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -138,3 +138,20 @@ class Endpoint(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
         if not self.saved_query:
             return ""
         return self.saved_query.latest_error or ""
+
+    def can_materialize(self) -> tuple[bool, str]:
+        """Check if endpoint can be materialized.
+
+        Returns: (can_materialize: bool, reason: str)
+        """
+        if self.query.get("kind") != "HogQLQuery":
+            return False, "Only HogQL queries can be materialized."
+
+        if self.query.get("variables"):
+            return False, "Queries with variables cannot be materialized."
+
+        hogql_query = self.query.get("query")
+        if not hogql_query or not isinstance(hogql_query, str):
+            return False, "Query is empty or invalid."
+
+        return True, ""

--- a/products/endpoints/backend/tests/conftest.py
+++ b/products/endpoints/backend/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest_asyncio
+from asgiref.sync import sync_to_async
+
+# Import temporal test fixtures directly
+from posthog.temporal.tests.conftest import aorganization, ateam, auser, temporal_client  # noqa: F401
+
+from products.endpoints.backend.models import Endpoint
+
+
+@pytest_asyncio.fixture
+async def endpoint(ateam, auser):  # noqa: F811
+    """Create a test endpoint."""
+    endpoint = await sync_to_async(Endpoint.objects.create)(
+        name="test_temporal_endpoint",
+        team=ateam,
+        query={
+            "kind": "HogQLQuery",
+            "query": "SELECT event, distinct_id FROM events WHERE event = '$pageview' LIMIT 10",
+        },
+        created_by=auser,
+        is_active=True,
+    )
+    yield endpoint
+    await sync_to_async(endpoint.delete)()

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1,21 +1,15 @@
-import uuid
 from datetime import timedelta
 
 import pytest
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest import mock
 
-from django.conf import settings
-
 import pytest_asyncio
-import temporalio.common
-import temporalio.worker
 from asgiref.sync import sync_to_async
 from rest_framework import status
 
 from posthog.schema import DataWarehouseSyncInterval
 
-from posthog.models.team import Team
 from posthog.settings.temporal import DATA_MODELING_TASK_QUEUE
 from posthog.sync import database_sync_to_async
 
@@ -320,7 +314,7 @@ class TestEndpointMaterializationTemporal:
         schedule = get_saved_query_schedule(saved_query)
 
         # Verify schedule configuration
-        from temporalio.client import ScheduleActionStartWorkflow
+        from temporalio.client import ScheduleActionStartWorkflow, ScheduleOverlapPolicy
 
         assert isinstance(schedule.action, ScheduleActionStartWorkflow)
         assert schedule.action.id == str(saved_query.id)
@@ -332,7 +326,7 @@ class TestEndpointMaterializationTemporal:
         assert intervals[0].every == timedelta(hours=12)
 
         # Verify schedule policy
-        assert schedule.policy.overlap == temporalio.client.ScheduleOverlapPolicy.SKIP
+        assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP
 
     async def test_sync_frequency_affects_schedule_interval(self, materialized_endpoint):
         """Test that different sync_frequency values create schedules with correct intervals."""

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1,0 +1,357 @@
+import uuid
+from datetime import timedelta
+
+import pytest
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest import mock
+
+from django.conf import settings
+
+import pytest_asyncio
+import temporalio.common
+import temporalio.worker
+from asgiref.sync import sync_to_async
+from rest_framework import status
+
+from posthog.schema import DataWarehouseSyncInterval
+
+from posthog.models.team import Team
+from posthog.settings.temporal import DATA_MODELING_TASK_QUEUE
+from posthog.sync import database_sync_to_async
+
+from products.data_warehouse.backend.data_load.saved_query_service import get_saved_query_schedule
+from products.data_warehouse.backend.models import DataWarehouseModelPath
+from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.endpoints.backend.models import Endpoint
+
+pytestmark = [pytest.mark.django_db]
+
+
+class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
+    """Test suite for materialized endpoints."""
+
+    ENDPOINT = "endpoints"
+
+    def setUp(self):
+        super().setUp()
+        self.sample_hogql_query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT event, distinct_id FROM events WHERE event = '$pageview' LIMIT 100",
+        }
+        # Mock sync_saved_query_workflow to avoid Temporal connection
+        self.sync_workflow_patcher = mock.patch(
+            "products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"
+        )
+        self.mock_sync_workflow = self.sync_workflow_patcher.start()
+
+    def tearDown(self):
+        self.sync_workflow_patcher.stop()
+        super().tearDown()
+
+    def test_enable_materialization_creates_saved_query(self):
+        """Test that enabling materialization creates a SavedQuery."""
+        # Create an endpoint
+        endpoint = Endpoint.objects.create(
+            name="test_materialized_endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Verify no saved_query exists yet
+        self.assertIsNone(endpoint.saved_query)
+
+        # Update endpoint to enable materialization
+        updated_data = {
+            "is_materialized": True,
+            "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+        }
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/", updated_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        response_data = response.json()
+        self.assertTrue(response_data["is_materialized"])
+
+        # Verify SavedQuery was created
+        endpoint.refresh_from_db()
+        self.assertIsNotNone(endpoint.saved_query)
+        saved_query = endpoint.saved_query
+        assert saved_query is not None
+        self.assertEqual(saved_query.name, endpoint.name)
+        self.assertEqual(saved_query.query, endpoint.query)
+        self.assertTrue(saved_query.is_materialized)
+        self.assertEqual(saved_query.origin, DataWarehouseSavedQuery.Origin.ENDPOINT)
+
+        # Verify sync_frequency_interval is set
+        self.assertEqual(saved_query.sync_frequency_interval, timedelta(hours=24))
+
+        # Verify ModelPath was created
+        self.assertTrue(
+            DataWarehouseModelPath.objects.filter(team=self.team, saved_query=saved_query).exists(),
+            "DataWarehouseModelPath should be created for the saved_query",
+        )
+
+    def test_update_sync_frequency_updates_saved_query_sync_interval(self):
+        """Test that updating sync_frequency updates the SavedQuery's sync_interval."""
+        # Create and materialize an endpoint
+        endpoint = Endpoint.objects.create(
+            name="test_sync_frequency",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+        )
+
+        # Enable materialization with 24-hour frequency
+        self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+            },
+            format="json",
+        )
+
+        endpoint.refresh_from_db()
+        saved_query = endpoint.saved_query
+        assert saved_query is not None
+        self.assertEqual(saved_query.sync_frequency_interval, timedelta(hours=24))
+
+        # Update to 12-hour frequency
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_12HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Verify sync_interval was updated
+        saved_query.refresh_from_db()
+        self.assertEqual(saved_query.sync_frequency_interval, timedelta(hours=12))
+
+        # Update to 1-hour frequency
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_1HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Verify sync_interval was updated
+        saved_query.refresh_from_db()
+        self.assertEqual(saved_query.sync_frequency_interval, timedelta(hours=1))
+
+    def test_disable_materialization_removes_saved_query(self):
+        """Test that disabling materialization removes the SavedQuery."""
+        # Create and materialize an endpoint
+        endpoint = Endpoint.objects.create(
+            name="test_disable_materialization",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+        )
+
+        self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+            },
+            format="json",
+        )
+
+        endpoint.refresh_from_db()
+        self.assertIsNotNone(endpoint.saved_query)
+        assert endpoint.saved_query is not None
+        saved_query_id = endpoint.saved_query.id
+
+        # Disable materialization
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": False},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertFalse(response_data["is_materialized"])
+
+        # Verify saved_query is removed from endpoint
+        endpoint.refresh_from_db()
+        self.assertIsNone(endpoint.saved_query)
+
+        # Verify SavedQuery is soft-deleted
+        saved_query = DataWarehouseSavedQuery.objects.get(id=saved_query_id)
+        self.assertTrue(saved_query.deleted)
+
+    def test_cannot_materialize_query_with_variables(self):
+        """Test that queries with variables cannot be materialized."""
+        endpoint = Endpoint.objects.create(
+            name="test_variables",
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": "SELECT * FROM events WHERE event = {variables.event_name}",
+                "variables": {"event_name": {"value": "$pageview"}},
+            },
+            created_by=self.user,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # The API wraps validation errors in a generic message
+        self.assertIn("Failed to update endpoint", response.json()["detail"])
+
+    def test_cannot_materialize_non_hogql_query(self):
+        """Test that only HogQL queries can be materialized."""
+        endpoint = Endpoint.objects.create(
+            name="test_trends_query",
+            team=self.team,
+            query={
+                "kind": "TrendsQuery",
+                "series": [{"kind": "EventsNode", "event": "$pageview", "math": "total"}],
+                "dateRange": {"date_from": "-7d"},
+                "interval": "day",
+            },
+            created_by=self.user,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # The API wraps validation errors in a generic message
+        self.assertIn("Failed to update endpoint", response.json()["detail"])
+
+    def test_materialization_status_in_response(self):
+        """Test that materialization status is included in endpoint response."""
+        endpoint = Endpoint.objects.create(
+            name="test_status",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+        )
+
+        # Before materialization
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertFalse(response_data["is_materialized"])
+        self.assertIn("materialization", response_data)
+        self.assertTrue(response_data["materialization"]["can_materialize"])
+
+        # After materialization
+        self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_12HOUR,
+            },
+            format="json",
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertTrue(response_data["is_materialized"])
+        self.assertIn("materialization", response_data)
+        self.assertTrue(response_data["materialization"]["can_materialize"])
+        self.assertIn("status", response_data["materialization"])
+        self.assertIn("sync_frequency", response_data["materialization"])
+        self.assertEqual(response_data["materialization"]["sync_frequency"], "12hour")
+
+
+@pytest.mark.asyncio
+class TestEndpointMaterializationTemporal:
+    """Test suite for endpoint materialization with Temporal workflows."""
+
+    @pytest_asyncio.fixture
+    async def materialized_endpoint(self, ateam, endpoint):
+        """Create a materialized endpoint with saved_query."""
+        saved_query = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
+            team=ateam,
+            name=endpoint.name,
+            query=endpoint.query,
+            is_materialized=True,
+            sync_frequency_interval=timedelta(hours=12),
+            origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
+        )
+        saved_query.columns = await sync_to_async(saved_query.get_columns)()
+        await sync_to_async(saved_query.save)()
+
+        await database_sync_to_async(DataWarehouseModelPath.objects.create_from_saved_query)(saved_query)
+
+        endpoint.saved_query = saved_query
+        await sync_to_async(endpoint.save)()
+
+        yield endpoint
+
+    async def test_saved_query_temporal_schedule_created(self, materialized_endpoint):
+        """Test that a Temporal schedule is created for the SavedQuery."""
+        saved_query = materialized_endpoint.saved_query
+        assert saved_query is not None
+
+        # Get the schedule that should be created
+        schedule = get_saved_query_schedule(saved_query)
+
+        # Verify schedule configuration
+        from temporalio.client import ScheduleActionStartWorkflow
+
+        assert isinstance(schedule.action, ScheduleActionStartWorkflow)
+        assert schedule.action.id == str(saved_query.id)
+        assert schedule.action.task_queue == DATA_MODELING_TASK_QUEUE
+
+        # Verify schedule interval matches sync_frequency_interval
+        intervals = schedule.spec.intervals
+        assert len(intervals) == 1
+        assert intervals[0].every == timedelta(hours=12)
+
+        # Verify schedule policy
+        assert schedule.policy.overlap == temporalio.client.ScheduleOverlapPolicy.SKIP
+
+    async def test_sync_frequency_affects_schedule_interval(self, materialized_endpoint):
+        """Test that different sync_frequency values create schedules with correct intervals."""
+        saved_query = materialized_endpoint.saved_query
+
+        # Test 1-hour frequency
+        saved_query.sync_frequency_interval = timedelta(hours=1)
+        schedule = get_saved_query_schedule(saved_query)
+        assert schedule.spec.intervals[0].every == timedelta(hours=1)
+        assert schedule.spec.jitter == timedelta(minutes=1)
+
+        # Test 12-hour frequency
+        saved_query.sync_frequency_interval = timedelta(hours=12)
+        schedule = get_saved_query_schedule(saved_query)
+        assert schedule.spec.intervals[0].every == timedelta(hours=12)
+        assert schedule.spec.jitter == timedelta(minutes=30)
+
+        # Test 24-hour frequency
+        saved_query.sync_frequency_interval = timedelta(hours=24)
+        schedule = get_saved_query_schedule(saved_query)
+        assert schedule.spec.intervals[0].every == timedelta(hours=24)
+        assert schedule.spec.jitter == timedelta(hours=1)

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_gross_revenue_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_gross_revenue_query_runner.ambr
@@ -1278,6 +1278,54 @@
 # name: TestRevenueAnalyticsGrossRevenueQueryRunner.test_with_data_with_managed_viewsets_ff
   '''
   SELECT revenue_analytics_revenue_item.source_label AS breakdown_by,
+         toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')) AS period_start,
+         sum(revenue_analytics_revenue_item.amount) AS amount
+  FROM
+    (SELECT toString(events.uuid) AS id,
+            toString(events.uuid) AS invoice_item_id,
+            'revenue_analytics.events.purchase' AS source_label,
+            toTimeZone(events.timestamp, 'UTC') AS timestamp,
+            timestamp AS created_at,
+            isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id,
+            toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+            events.`$group_0` AS group_0_key,
+            events.`$group_1` AS group_1_key,
+            events.`$group_2` AS group_2_key,
+            events.`$group_3` AS group_3_key,
+            events.`$group_4` AS group_4_key,
+            NULL AS invoice_id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '') AS subscription_id,
+            toString(events.`$session_id`) AS session_id,
+            events.event AS event_name,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'coupon'), ''), 'null'), '^"|"$', '') AS coupon,
+            coupon AS coupon_id,
+            upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+            accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+            1 AS enable_currency_aware_divider,
+            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+            'GBP' AS currency,
+            if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+     ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+  WHERE and(greaterOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2026-05-01 23:59:59', 'UTC'))))
+  GROUP BY breakdown_by,
+           period_start
+  ORDER BY amount DESC,
+           breakdown_by ASC,
+           period_start ASC
+  LIMIT 10000
+  UNION ALL
+  SELECT revenue_analytics_revenue_item.source_label AS breakdown_by,
          toStartOfMonth(revenue_analytics_revenue_item.timestamp) AS period_start,
          sum(revenue_analytics_revenue_item.amount) AS amount
   FROM
@@ -1358,54 +1406,6 @@
      FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_charges/posthog_test_stripe_charge/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `paid` Int8, `amount` Int64, `object` String, `source` String, `status` String, `created` DateTime, `invoice` String, `outcome` String, `captured` Int8, `currency` String, `customer` String, `disputed` Int8, `livemode` Int8, `metadata` String, `refunded` Int8, `description` String, `receipt_url` String, `failure_code` String, `fraud_details` String, `radar_options` String, `receipt_email` String, `payment_intent` String, `payment_method` String, `amount_captured` Int64, `amount_refunded` Int64, `billing_details` String, `failure_message` String, `balance_transaction` String, `statement_descriptor` String, `payment_method_details` String, `calculated_statement_descriptor` String') AS posthog_test_stripe_charge
      WHERE and(or(isNull(invoice_id), empty(invoice_id)), equals(posthog_test_stripe_charge.status, 'succeeded'))) AS revenue_analytics_revenue_item
   WHERE and(ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, assumeNotNull(toDateTime('2024-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_revenue_item.timestamp, assumeNotNull(toDateTime('2026-05-01 23:59:59', 'UTC'))), 0))
-  GROUP BY breakdown_by,
-           period_start
-  ORDER BY amount DESC,
-           breakdown_by ASC,
-           period_start ASC
-  LIMIT 10000
-  UNION ALL
-  SELECT revenue_analytics_revenue_item.source_label AS breakdown_by,
-         toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')) AS period_start,
-         sum(revenue_analytics_revenue_item.amount) AS amount
-  FROM
-    (SELECT toString(events.uuid) AS id,
-            toString(events.uuid) AS invoice_item_id,
-            'revenue_analytics.events.purchase' AS source_label,
-            toTimeZone(events.timestamp, 'UTC') AS timestamp,
-            timestamp AS created_at,
-            isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id,
-            toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-            events.`$group_0` AS group_0_key,
-            events.`$group_1` AS group_1_key,
-            events.`$group_2` AS group_2_key,
-            events.`$group_3` AS group_3_key,
-            events.`$group_4` AS group_4_key,
-            NULL AS invoice_id,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '') AS subscription_id,
-            toString(events.`$session_id`) AS session_id,
-            events.event AS event_name,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'coupon'), ''), 'null'), '^"|"$', '') AS coupon,
-            coupon AS coupon_id,
-            upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
-            accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-            1 AS enable_currency_aware_divider,
-            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-            'GBP' AS currency,
-            if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-     ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-  WHERE and(greaterOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2026-05-01 23:59:59', 'UTC'))))
   GROUP BY breakdown_by,
            period_start
   ORDER BY amount DESC,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_gross_revenue_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_gross_revenue_query_runner.ambr
@@ -1278,54 +1278,6 @@
 # name: TestRevenueAnalyticsGrossRevenueQueryRunner.test_with_data_with_managed_viewsets_ff
   '''
   SELECT revenue_analytics_revenue_item.source_label AS breakdown_by,
-         toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')) AS period_start,
-         sum(revenue_analytics_revenue_item.amount) AS amount
-  FROM
-    (SELECT toString(events.uuid) AS id,
-            toString(events.uuid) AS invoice_item_id,
-            'revenue_analytics.events.purchase' AS source_label,
-            toTimeZone(events.timestamp, 'UTC') AS timestamp,
-            timestamp AS created_at,
-            isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id,
-            toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-            events.`$group_0` AS group_0_key,
-            events.`$group_1` AS group_1_key,
-            events.`$group_2` AS group_2_key,
-            events.`$group_3` AS group_3_key,
-            events.`$group_4` AS group_4_key,
-            NULL AS invoice_id,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '') AS subscription_id,
-            toString(events.`$session_id`) AS session_id,
-            events.event AS event_name,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'coupon'), ''), 'null'), '^"|"$', '') AS coupon,
-            coupon AS coupon_id,
-            upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
-            accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-            1 AS enable_currency_aware_divider,
-            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-            'GBP' AS currency,
-            if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-     ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-  WHERE and(greaterOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2026-05-01 23:59:59', 'UTC'))))
-  GROUP BY breakdown_by,
-           period_start
-  ORDER BY amount DESC,
-           breakdown_by ASC,
-           period_start ASC
-  LIMIT 10000
-  UNION ALL
-  SELECT revenue_analytics_revenue_item.source_label AS breakdown_by,
          toStartOfMonth(revenue_analytics_revenue_item.timestamp) AS period_start,
          sum(revenue_analytics_revenue_item.amount) AS amount
   FROM
@@ -1406,6 +1358,54 @@
      FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_charges/posthog_test_stripe_charge/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `paid` Int8, `amount` Int64, `object` String, `source` String, `status` String, `created` DateTime, `invoice` String, `outcome` String, `captured` Int8, `currency` String, `customer` String, `disputed` Int8, `livemode` Int8, `metadata` String, `refunded` Int8, `description` String, `receipt_url` String, `failure_code` String, `fraud_details` String, `radar_options` String, `receipt_email` String, `payment_intent` String, `payment_method` String, `amount_captured` Int64, `amount_refunded` Int64, `billing_details` String, `failure_message` String, `balance_transaction` String, `statement_descriptor` String, `payment_method_details` String, `calculated_statement_descriptor` String') AS posthog_test_stripe_charge
      WHERE and(or(isNull(invoice_id), empty(invoice_id)), equals(posthog_test_stripe_charge.status, 'succeeded'))) AS revenue_analytics_revenue_item
   WHERE and(ifNull(greaterOrEquals(revenue_analytics_revenue_item.timestamp, assumeNotNull(toDateTime('2024-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(revenue_analytics_revenue_item.timestamp, assumeNotNull(toDateTime('2026-05-01 23:59:59', 'UTC'))), 0))
+  GROUP BY breakdown_by,
+           period_start
+  ORDER BY amount DESC,
+           breakdown_by ASC,
+           period_start ASC
+  LIMIT 10000
+  UNION ALL
+  SELECT revenue_analytics_revenue_item.source_label AS breakdown_by,
+         toStartOfMonth(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC')) AS period_start,
+         sum(revenue_analytics_revenue_item.amount) AS amount
+  FROM
+    (SELECT toString(events.uuid) AS id,
+            toString(events.uuid) AS invoice_item_id,
+            'revenue_analytics.events.purchase' AS source_label,
+            toTimeZone(events.timestamp, 'UTC') AS timestamp,
+            timestamp AS created_at,
+            isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'product'), ''), 'null'), '^"|"$', '') AS product_id,
+            toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+            events.`$group_0` AS group_0_key,
+            events.`$group_1` AS group_1_key,
+            events.`$group_2` AS group_2_key,
+            events.`$group_3` AS group_3_key,
+            events.`$group_4` AS group_4_key,
+            NULL AS invoice_id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription'), ''), 'null'), '^"|"$', '') AS subscription_id,
+            toString(events.`$session_id`) AS session_id,
+            events.event AS event_name,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'coupon'), ''), 'null'), '^"|"$', '') AS coupon,
+            coupon AS coupon_id,
+            upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+            accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+            1 AS enable_currency_aware_divider,
+            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+            'GBP' AS currency,
+            if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+     ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+  WHERE and(greaterOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), assumeNotNull(toDateTime('2026-05-01 23:59:59', 'UTC'))))
   GROUP BY breakdown_by,
            period_start
   ORDER BY amount DESC,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
An Endpoint should be materializable.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

~Uses ManagedViewSet to create a single view from a qualifying Endpoint (limited for the time being). Adds a new Kind to the ManagedViewSet.~

Update: Not using the above, instead creates a SavedQuery on its own and sync the schedule.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

- [x] unit tests