### PR TITLE
refactor: Move formula removal logic to Kea action

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
@@ -14,7 +14,7 @@ const ALLOWED_FORMULA_CHARACTERS = /^[a-zA-Z \-*^0-9+/().]+$/
 
 export function TrendsFormula({ insightProps }: EditorFilterProps): JSX.Element | null {
     const { formulaNodes, hasFormula } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter, toggleFormulaMode } = useActions(insightVizDataLogic(insightProps))
+    const { updateInsightFilter, removeFormulaNode } = useActions(insightVizDataLogic(insightProps))
 
     // Initialize with at least one empty value
     const [values, setValues] = useState<TrendsFormulaNode[]>(formulaNodes)
@@ -107,18 +107,10 @@ export function TrendsFormula({ insightProps }: EditorFilterProps): JSX.Element 
 
     const removeFormula = (index: number): void => {
         const newValues = localValues.filter((_, i) => i !== index)
-
-        // If this was the last formula, turn off formula mode
-        if (newValues.length === 0) {
-            toggleFormulaMode()
-            return
-        }
-
         setLocalValues(newValues)
-        // Only update if there are non-empty values
-        if (newValues.some((v) => v.formula.trim() !== '')) {
-            updateFormulas(newValues)
-        }
+
+        // Delegate to Kea action to handle business logic
+        removeFormulaNode(index, localValues)
     }
 
     return hasFormula ? (

--- a/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
@@ -110,7 +110,7 @@ export function TrendsFormula({ insightProps }: EditorFilterProps): JSX.Element 
         setLocalValues(newValues)
 
         // Delegate to Kea action to handle business logic
-        removeFormulaNode(index, localValues)
+        removeFormulaNode(newValues)
     }
 
     return hasFormula ? (

--- a/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
@@ -108,8 +108,6 @@ export function TrendsFormula({ insightProps }: EditorFilterProps): JSX.Element 
     const removeFormula = (index: number): void => {
         const newValues = localValues.filter((_, i) => i !== index)
         setLocalValues(newValues)
-
-        // Delegate to Kea action to handle business logic
         removeFormulaNode(newValues)
     }
 

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -115,6 +115,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         setTimedOutQueryId: (id: string | null) => ({ id }),
         setIsIntervalManuallySet: (isIntervalManuallySet: boolean) => ({ isIntervalManuallySet }),
         toggleFormulaMode: true,
+        removeFormulaNode: (index: number, currentFormulas: TrendsFormulaNode[]) => ({ index, currentFormulas }),
         setDetailedResultsAggregationType: (detailedResultsAggregationType: AggregationType) => ({
             detailedResultsAggregationType,
         }),
@@ -611,6 +612,25 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             // Only if formula mode is already open should we trigger a query.
             if (values.hasFormula) {
                 actions.updateInsightFilter({ formula: undefined, formulas: undefined, formulaNodes: [] })
+            }
+        },
+        removeFormulaNode: ({ index, currentFormulas }) => {
+            const newFormulas = currentFormulas.filter((_, i) => i !== index)
+
+            // If this was the last formula, turn off formula mode
+            if (newFormulas.length === 0) {
+                actions.toggleFormulaMode()
+                return
+            }
+
+            // Otherwise, update with the remaining formulas
+            const filledFormulas = newFormulas.filter((v) => v.formula.trim() !== '')
+            if (filledFormulas.length > 0) {
+                actions.updateInsightFilter({
+                    formula: undefined,
+                    formulas: undefined,
+                    formulaNodes: filledFormulas,
+                })
             }
         },
     })),

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -615,13 +615,11 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             }
         },
         removeFormulaNode: ({ formulas }) => {
-            // If no formulas remain, turn off formula mode
             if (formulas.length === 0) {
                 actions.toggleFormulaMode()
                 return
             }
 
-            // Otherwise, update with the remaining formulas
             const filledFormulas = formulas.filter((v) => v.formula.trim() !== '')
             if (filledFormulas.length > 0) {
                 actions.updateInsightFilter({

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -115,7 +115,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         setTimedOutQueryId: (id: string | null) => ({ id }),
         setIsIntervalManuallySet: (isIntervalManuallySet: boolean) => ({ isIntervalManuallySet }),
         toggleFormulaMode: true,
-        removeFormulaNode: (index: number, currentFormulas: TrendsFormulaNode[]) => ({ index, currentFormulas }),
+        removeFormulaNode: (formulas: TrendsFormulaNode[]) => ({ formulas }),
         setDetailedResultsAggregationType: (detailedResultsAggregationType: AggregationType) => ({
             detailedResultsAggregationType,
         }),
@@ -614,17 +614,15 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                 actions.updateInsightFilter({ formula: undefined, formulas: undefined, formulaNodes: [] })
             }
         },
-        removeFormulaNode: ({ index, currentFormulas }) => {
-            const newFormulas = currentFormulas.filter((_, i) => i !== index)
-
-            // If this was the last formula, turn off formula mode
-            if (newFormulas.length === 0) {
+        removeFormulaNode: ({ formulas }) => {
+            // If no formulas remain, turn off formula mode
+            if (formulas.length === 0) {
                 actions.toggleFormulaMode()
                 return
             }
 
             // Otherwise, update with the remaining formulas
-            const filledFormulas = newFormulas.filter((v) => v.formula.trim() !== '')
+            const filledFormulas = formulas.filter((v) => v.formula.trim() !== '')
             if (filledFormulas.length > 0) {
                 actions.updateInsightFilter({
                     formula: undefined,


### PR DESCRIPTION
## Problem

Following up on [this review comment](https://github.com/PostHog/posthog/pull/40595/files#r2475457462) from @rafaeelaudibert on PR #40595, the formula removal logic in the TrendsFormula component was mixing UI concerns with business logic. When removing a formula, the component was directly deciding whether to toggle formula mode and calling different actions based on conditions.

This violates the separation of concerns principle - business logic (state management decisions) should live in the Kea logic layer, not in React components.

## Changes

- **Added `removeFormulaNode` action** to `insightVizDataLogic.ts` that encapsulates all business logic for removing formulas
- **Implemented listener** that handles:
  - Filtering out the formula at the specified index
  - Automatically toggling formula mode off when the last formula is removed (by calling `toggleFormulaMode()`)
  - Updating the insight filter with remaining formulas
- **Simplified `TrendsFormula.tsx`** component to delegate all business logic to the new Kea action

### Benefits

1. **Better separation of concerns**: UI components handle presentation, Kea logic handles state management
2. **More testable**: The `removeFormulaNode` action can be unit tested independently without rendering React components
3. **More maintainable**: If other components need to remove formulas, they can reuse this action
4. **Clearer intent**: The action name explicitly documents the behavior, including conditional formula mode toggling

## How did you test this code?

- Generated TypeScript types using `pnpm typegen:write` - no TypeScript errors in modified files
- Pre-commit hooks passed successfully (formatting, linting)
- Verified the logic matches the original implementation in PR #40595
- Manual testing:
  - Created a trend insight
  - Enabled formula mode
  - Added a formula
  - Verified the delete button appears
  - Clicked delete button and confirmed it:
    - Deleted the formula
    - Disabled formula mode automatically
- The action correctly:
  - Calls `toggleFormulaMode()` when removing the last formula
  - Updates `formulaNodes` with remaining formulas otherwise

## Changelog: (features only) Is this feature complete?

No - this is a refactor with no user-facing changes.