### PR TITLE
fix: plugin server temporal creds

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -118,7 +118,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         EVENT_PROPERTY_LRU_SIZE: 10000,
         HEALTHCHECK_MAX_STALE_SECONDS: 2 * 60 * 60, // 2 hours
         SITE_URL: isDevEnv() ? 'http://localhost:8000' : '',
-        TEMPORAL_HOST: 'localhost:7233',
+        TEMPORAL_HOST: 'localhost',
+        TEMPORAL_PORT: '7233',
         TEMPORAL_NAMESPACE: 'default',
         TEMPORAL_CLIENT_ROOT_CA: undefined,
         TEMPORAL_CLIENT_CERT: undefined,

--- a/plugin-server/src/llm-analytics/services/temporal.service.test.ts
+++ b/plugin-server/src/llm-analytics/services/temporal.service.test.ts
@@ -16,7 +16,8 @@ describe('TemporalService', () => {
 
     beforeEach(async () => {
         hub = await createHub()
-        hub.TEMPORAL_HOST = 'localhost:7233'
+        hub.TEMPORAL_HOST = 'localhost'
+        hub.TEMPORAL_PORT = '7233'
         hub.TEMPORAL_NAMESPACE = 'test-namespace'
 
         mockWorkflowHandle = {

--- a/plugin-server/src/llm-analytics/services/temporal.service.ts
+++ b/plugin-server/src/llm-analytics/services/temporal.service.ts
@@ -47,11 +47,11 @@ export class TemporalService {
             }
         }
 
+        const port = this.hub.TEMPORAL_PORT || '7233'
+        const address = `${this.hub.TEMPORAL_HOST}:${port}`
+
         // Create connection first
-        const connection = await Connection.connect({
-            address: this.hub.TEMPORAL_HOST || 'localhost:7233',
-            tls,
-        })
+        const connection = await Connection.connect({ address, tls })
 
         // Then create client with connection
         const client = new Client({
@@ -60,7 +60,7 @@ export class TemporalService {
         })
 
         logger.info('✅ Connected to Temporal', {
-            address: this.hub.TEMPORAL_HOST,
+            address,
             namespace: this.hub.TEMPORAL_NAMESPACE,
             tlsEnabled: tls !== false,
         })

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -352,6 +352,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig,
     HEALTHCHECK_MAX_STALE_SECONDS: number // maximum number of seconds the plugin server can go without ingesting events before the healthcheck fails
     SITE_URL: string
     TEMPORAL_HOST: string
+    TEMPORAL_PORT: string | undefined
     TEMPORAL_NAMESPACE: string
     TEMPORAL_CLIENT_ROOT_CA: string | undefined
     TEMPORAL_CLIENT_CERT: string | undefined


### PR DESCRIPTION
Matches the way we pass them in production.