### PR TITLE
style(ai): Align "Fix with SQL" style with broader PostHog AI

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/components/FixErrorButton.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/components/FixErrorButton.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useMemo } from 'react'
 
-import { IconMagicWand, IconWarning } from '@posthog/icons'
+import { IconSparkles, IconWarning } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { LemonButton, LemonButtonProps } from 'lib/lemon-ui/LemonButton'
@@ -36,7 +36,7 @@ export function FixErrorButton({ type, size, contentOverride, source }: FixError
             return <IconWarning className="text-warning" />
         }
 
-        return <IconMagicWand />
+        return <IconSparkles />
     }, [fixHogQLErrorsLoading, fixErrorsError])
 
     const disabledReason = useMemo(() => {
@@ -60,7 +60,7 @@ export function FixErrorButton({ type, size, contentOverride, source }: FixError
             return "Can't fix"
         }
 
-        return contentOverride ?? 'Fix errors'
+        return contentOverride ?? 'Fix errors with AI'
     }, [fixErrorsError, fixHogQLErrorsLoading, contentOverride])
 
     return (


### PR DESCRIPTION
## Changes

As suggested by @annikaschmid, aligning the style of the "Fix SQL" button with PostHog AI, which it's part of pricing-wise. (And it'll actually invoke the chat very soon, when we make the chat's ability to fix errors _exactly_ as fast as the "Fix SQL" button)