### PR TITLE
feat(MA): disabling `all events` as a conversion goal in ma

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview.tsx
@@ -1,5 +1,5 @@
 import { BuiltLogic, LogicWrapper, useValues } from 'kea'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 
@@ -13,6 +13,10 @@ import {
 import { QueryContext } from '~/queries/types'
 
 import { marketingAnalyticsSettingsLogic } from '../../logic/marketingAnalyticsSettingsLogic'
+import {
+    MarketingAnalyticsValidationWarningBanner,
+    validateConversionGoals,
+} from '../MarketingAnalyticsValidationWarningBanner'
 
 const BASE_METRICS_COUNT = 6 // Total Cost, Total Clicks, CPC, CTR, Total Impressions, Reported Conversion
 
@@ -44,6 +48,8 @@ export function MarketingAnalyticsOverview(props: {
 
     const samplingRate = marketingOverviewQueryResponse?.samplingRate
 
+    const validationWarnings = useMemo(() => validateConversionGoals(conversion_goals), [conversion_goals])
+
     // Convert results dict to array for rendering and map to OverviewItem
     const overviewItems: OverviewItem[] = marketingOverviewQueryResponse?.results
         ? Object.entries(marketingOverviewQueryResponse.results).map(([key, item]) => ({
@@ -61,19 +67,24 @@ export function MarketingAnalyticsOverview(props: {
     const numSkeletons = BASE_METRICS_COUNT + conversionGoalMetrics
 
     return (
-        <OverviewGrid
-            items={overviewItems}
-            loading={responseLoading}
-            numSkeletons={numSkeletons}
-            samplingRate={samplingRate}
-            usedPreAggregatedTables={false}
-            labelFromKey={labelFromKey}
-            settingsLinkFromKey={() => null}
-            dashboardLinkFromKey={() => null}
-            filterEmptyItems={filterEmptyMetrics}
-            showBetaTags={() => false}
-            compact={true}
-        />
+        <>
+            {validationWarnings && validationWarnings.length > 0 && (
+                <MarketingAnalyticsValidationWarningBanner warnings={validationWarnings} />
+            )}
+            <OverviewGrid
+                items={overviewItems}
+                loading={responseLoading}
+                numSkeletons={numSkeletons}
+                samplingRate={samplingRate}
+                usedPreAggregatedTables={false}
+                labelFromKey={labelFromKey}
+                settingsLinkFromKey={() => null}
+                dashboardLinkFromKey={() => null}
+                filterEmptyItems={filterEmptyMetrics}
+                showBetaTags={() => false}
+                compact={true}
+            />
+        </>
     )
 }
 

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTable/MarketingAnalyticsTable.tsx
@@ -1,6 +1,7 @@
 import './MarketingAnalyticsTableStyleOverride.scss'
 
-import { BuiltLogic, LogicWrapper, useActions } from 'kea'
+import { BuiltLogic, LogicWrapper, useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { IconGear } from '@posthog/icons'
 import { LemonButton, LemonSwitch } from '@posthog/lemon-ui'
@@ -17,8 +18,13 @@ import { webAnalyticsDataTableQueryContext } from '~/scenes/web-analytics/tiles/
 import { InsightLogicProps } from '~/types'
 
 import { marketingAnalyticsLogic } from '../../logic/marketingAnalyticsLogic'
+import { marketingAnalyticsSettingsLogic } from '../../logic/marketingAnalyticsSettingsLogic'
 import { marketingAnalyticsTableLogic } from '../../logic/marketingAnalyticsTableLogic'
 import { MarketingAnalyticsCell } from '../../shared'
+import {
+    MarketingAnalyticsValidationWarningBanner,
+    validateConversionGoals,
+} from '../MarketingAnalyticsValidationWarningBanner'
 import { DraftConversionGoalControls } from './DraftConversionGoalControls'
 import { MarketingAnalyticsColumnConfigModal } from './MarketingAnalyticsColumnConfigModal'
 
@@ -35,6 +41,9 @@ export const MarketingAnalyticsTable = ({
 }: MarketingAnalyticsTableProps): JSX.Element => {
     const { setQuery } = useActions(marketingAnalyticsTableLogic)
     const { showColumnConfigModal } = useActions(marketingAnalyticsLogic)
+    const { conversion_goals } = useValues(marketingAnalyticsSettingsLogic)
+
+    const validationWarnings = useMemo(() => validateConversionGoals(conversion_goals), [conversion_goals])
 
     const handleIncludeAllConversionsChange = (checked: boolean): void => {
         const sourceQuery = query.source as MarketingAnalyticsTableQuery
@@ -96,6 +105,11 @@ export const MarketingAnalyticsTable = ({
                     </div>
                 </div>
             </div>
+            {validationWarnings && validationWarnings.length > 0 && (
+                <div className="pt-2">
+                    <MarketingAnalyticsValidationWarningBanner warnings={validationWarnings} />
+                </div>
+            )}
             <div className="relative marketing-analytics-table-container">
                 <Query
                     attachTo={attachTo}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsValidationWarningBanner.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsValidationWarningBanner.tsx
@@ -38,7 +38,7 @@ interface MarketingAnalyticsValidationWarningBannerProps {
     warnings: MarketingAnalyticsValidationWarning[]
 }
 
-const getLinkUrl = (link: ValidationWarningLink): JSX.Element => {
+const getLinkUrl = (link: ValidationWarningLink): JSX.Element | null => {
     switch (link) {
         case ValidationWarningLink.MarketingAnalyticsSettings:
             return (
@@ -52,16 +52,7 @@ const getLinkUrl = (link: ValidationWarningLink): JSX.Element => {
                 </>
             )
         default:
-            return (
-                <>
-                    Check{' '}
-                    <Link to={urls.settings('environment-marketing-analytics')} target="_blank">
-                        marketing analytics settings
-                        <IconExternal />
-                    </Link>{' '}
-                    for more details.
-                </>
-            )
+            return null
     }
 }
 

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsValidationWarningBanner.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsValidationWarningBanner.tsx
@@ -1,0 +1,84 @@
+import { IconExternal } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+
+enum ValidationWarningLink {
+    MarketingAnalyticsSettings = 'marketing_analytics_settings',
+}
+
+interface MarketingAnalyticsValidationWarning {
+    message: string
+    /** Link to navigate to fix the issue */
+    link?: ValidationWarningLink
+}
+
+export const validateConversionGoals = (goals: any[]): MarketingAnalyticsValidationWarning[] => {
+    const warnings: MarketingAnalyticsValidationWarning[] = []
+
+    for (const goal of goals) {
+        if (goal.kind === NodeKind.EventsNode) {
+            const event = 'event' in goal ? goal.event : null
+            if (event === null || event === '') {
+                warnings.push({
+                    message: `Conversion goal "${goal.conversion_goal_name}" uses "All Events" which is not supported.`,
+                    link: ValidationWarningLink.MarketingAnalyticsSettings,
+                } as MarketingAnalyticsValidationWarning)
+            }
+        }
+    }
+
+    return warnings
+}
+
+interface MarketingAnalyticsValidationWarningBannerProps {
+    warnings: MarketingAnalyticsValidationWarning[]
+}
+
+const getLinkUrl = (link: ValidationWarningLink): JSX.Element => {
+    switch (link) {
+        case ValidationWarningLink.MarketingAnalyticsSettings:
+            return (
+                <>
+                    Check{' '}
+                    <Link to={urls.settings('environment-marketing-analytics')} target="_blank">
+                        marketing analytics settings
+                        <IconExternal />
+                    </Link>{' '}
+                    for more details.
+                </>
+            )
+        default:
+            return (
+                <>
+                    Check{' '}
+                    <Link to={urls.settings('environment-marketing-analytics')} target="_blank">
+                        marketing analytics settings
+                        <IconExternal />
+                    </Link>{' '}
+                    for more details.
+                </>
+            )
+    }
+}
+
+export function MarketingAnalyticsValidationWarningBanner({
+    warnings,
+}: MarketingAnalyticsValidationWarningBannerProps): JSX.Element | null {
+    if (!warnings || warnings.length === 0) {
+        return null
+    }
+
+    return (
+        <>
+            {warnings.map((warning, index) => (
+                <LemonBanner key={index} type="warning" className="mb-2">
+                    {warning.message} {warning.link ? getLinkUrl(warning.link) : null}
+                </LemonBanner>
+            ))}
+        </>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { ActionFilter as ActionFilterComponent } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
@@ -29,6 +31,8 @@ interface ConversionGoalDropdownProps {
 }
 
 export function ConversionGoalDropdown({ value, onChange, typeKey }: ConversionGoalDropdownProps): JSX.Element {
+    const [error, setError] = useState<string | null>(null)
+
     // Create a proper ActionFilter-compatible filter object
     const currentFilter = {
         events:
@@ -67,85 +71,100 @@ export function ConversionGoalDropdown({ value, onChange, typeKey }: ConversionG
     }
 
     return (
-        <ActionFilterComponent
-            bordered
-            allowedMathTypes={[BaseMathType.TotalCount, BaseMathType.UniqueUsers, PropertyMathType.Sum]}
-            filters={currentFilter}
-            mathAvailability={MathAvailability.All}
-            setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
-                const series = actionsAndEventsToSeries(
-                    {
-                        actions: actions as ActionFilter[] | undefined,
-                        events: events as ActionFilter[] | undefined,
-                        data_warehouse: data_warehouse as DataWarehouseFilter[] | undefined,
-                    },
-                    true,
-                    MathAvailability.All
-                )
-
-                const firstSerie = series[0] || value
-
-                const newFilter: ConversionGoalFilter = {
-                    ...value,
-                    ...firstSerie,
-                    // Preserve the existing schema to keep UTM mappings
-                    schema_map: {
-                        ...value.schema_map,
-                    },
-                    properties: firstSerie?.properties || [], // if we clear the filter we need the properties to be set to an empty array
-                }
-
-                // Remove the event field from ActionsNode to prevent validation errors
-                if (newFilter.kind === NodeKind.ActionsNode && 'event' in newFilter) {
-                    const { event, ...rest } = newFilter as any
-                    Object.assign(newFilter, rest)
-                }
-
-                // Override the schema with the schema from the data warehouse
-                if (data_warehouse?.[0]?.type === EntityTypes.DATA_WAREHOUSE) {
-                    const dwNode = data_warehouse[0] as DataWarehouseFilter & Record<ConversionGoalSchema, string>
-                    const schema = dwNode
-                    const overrideSchema: Record<ConversionGoalSchema, string> = {
-                        utm_campaign_name: schema[UTM_CAMPAIGN_NAME_SCHEMA_FIELD],
-                        utm_source_name: schema[UTM_SOURCE_NAME_SCHEMA_FIELD],
-                        timestamp_field: schema[TIMESTAMP_FIELD_SCHEMA_FIELD],
-                        distinct_id_field: schema[DISTINCT_ID_FIELD_SCHEMA_FIELD],
-                    }
-                    newFilter.schema_map = overrideSchema
-
-                    // Cast to DataWarehouseNode for type safety
-                    const dwFilter = newFilter as DataWarehouseNode & ConversionGoalFilter
-                    // Remove the event field that causes validation to fail
-                    if ('event' in dwFilter) {
-                        delete (dwFilter as any).event
+        <div>
+            <ActionFilterComponent
+                bordered
+                allowedMathTypes={[BaseMathType.TotalCount, BaseMathType.UniqueUsers, PropertyMathType.Sum]}
+                filters={currentFilter}
+                mathAvailability={MathAvailability.All}
+                setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
+                    // Check if user is trying to select "All Events"
+                    if (events?.[0]?.id === null || events?.[0]?.id === '') {
+                        setError('`All events` cannot be used as a conversion goal. Please select a specific event.')
+                        return
                     }
 
-                    dwFilter.kind = NodeKind.DataWarehouseNode
+                    // Clear any previous errors
+                    setError(null)
 
-                    // Set all required ConversionGoalFilter3 fields
-                    dwFilter.id = dwNode.table_name || String(dwNode.id) || ''
-                    dwFilter.id_field = dwNode.id_field || schema[DISTINCT_ID_FIELD_SCHEMA_FIELD] || 'id'
-                    dwFilter.distinct_id_field =
-                        dwNode.distinct_id_field || schema[DISTINCT_ID_FIELD_SCHEMA_FIELD] || 'distinct_id'
-                    dwFilter.table_name = dwNode.table_name || ''
-                    dwFilter.timestamp_field =
-                        dwNode.timestamp_field || schema[TIMESTAMP_FIELD_SCHEMA_FIELD] || 'timestamp'
-                    dwFilter.dw_source_type = dwNode.dw_source_type
-                }
-                onChange(newFilter)
-            }}
-            typeKey={typeKey}
-            showSeriesIndicator={false}
-            entitiesLimit={1}
-            showNumericalPropsOnly={true}
-            hideRename={true}
-            actionsTaxonomicGroupTypes={[
-                TaxonomicFilterGroupType.Events,
-                TaxonomicFilterGroupType.Actions,
-                TaxonomicFilterGroupType.DataWarehouse,
-            ]}
-            dataWarehousePopoverFields={conversionGoalPopoverFields}
-        />
+                    const series = actionsAndEventsToSeries(
+                        {
+                            actions: actions as ActionFilter[] | undefined,
+                            events: events as ActionFilter[] | undefined,
+                            data_warehouse: data_warehouse as DataWarehouseFilter[] | undefined,
+                        },
+                        true,
+                        MathAvailability.All
+                    )
+
+                    const firstSerie = series[0] || value
+
+                    const newFilter: ConversionGoalFilter = {
+                        ...value,
+                        ...firstSerie,
+                        // Preserve the existing schema to keep UTM mappings
+                        schema_map: {
+                            ...value.schema_map,
+                        },
+                        properties: firstSerie?.properties || [], // if we clear the filter we need the properties to be set to an empty array
+                    }
+
+                    // Remove the event field from ActionsNode to prevent validation errors
+                    if (newFilter.kind === NodeKind.ActionsNode && 'event' in newFilter) {
+                        const { event, ...rest } = newFilter as any
+                        Object.assign(newFilter, rest)
+                    }
+
+                    // Override the schema with the schema from the data warehouse
+                    if (data_warehouse?.[0]?.type === EntityTypes.DATA_WAREHOUSE) {
+                        const dwNode = data_warehouse[0] as DataWarehouseFilter & Record<ConversionGoalSchema, string>
+                        const schema = dwNode
+                        const overrideSchema: Record<ConversionGoalSchema, string> = {
+                            utm_campaign_name: schema[UTM_CAMPAIGN_NAME_SCHEMA_FIELD],
+                            utm_source_name: schema[UTM_SOURCE_NAME_SCHEMA_FIELD],
+                            timestamp_field: schema[TIMESTAMP_FIELD_SCHEMA_FIELD],
+                            distinct_id_field: schema[DISTINCT_ID_FIELD_SCHEMA_FIELD],
+                        }
+                        newFilter.schema_map = overrideSchema
+
+                        // Cast to DataWarehouseNode for type safety
+                        const dwFilter = newFilter as DataWarehouseNode & ConversionGoalFilter
+                        // Remove the event field that causes validation to fail
+                        if ('event' in dwFilter) {
+                            delete (dwFilter as any).event
+                        }
+
+                        dwFilter.kind = NodeKind.DataWarehouseNode
+
+                        // Set all required ConversionGoalFilter3 fields
+                        dwFilter.id = dwNode.table_name || String(dwNode.id) || ''
+                        dwFilter.id_field = dwNode.id_field || schema[DISTINCT_ID_FIELD_SCHEMA_FIELD] || 'id'
+                        dwFilter.distinct_id_field =
+                            dwNode.distinct_id_field || schema[DISTINCT_ID_FIELD_SCHEMA_FIELD] || 'distinct_id'
+                        dwFilter.table_name = dwNode.table_name || ''
+                        dwFilter.timestamp_field =
+                            dwNode.timestamp_field || schema[TIMESTAMP_FIELD_SCHEMA_FIELD] || 'timestamp'
+                        dwFilter.dw_source_type = dwNode.dw_source_type
+                    }
+                    onChange(newFilter)
+                }}
+                typeKey={typeKey}
+                showSeriesIndicator={false}
+                entitiesLimit={1}
+                showNumericalPropsOnly={true}
+                hideRename={true}
+                actionsTaxonomicGroupTypes={[
+                    TaxonomicFilterGroupType.Events,
+                    TaxonomicFilterGroupType.Actions,
+                    TaxonomicFilterGroupType.DataWarehouse,
+                ]}
+                dataWarehousePopoverFields={conversionGoalPopoverFields}
+                excludedProperties={{
+                    [TaxonomicFilterGroupType.Events]: [null],
+                }}
+            />
+            {error && <div className="text-danger mt-2 text-sm">{error}</div>}
+        </div>
     )
 }
 

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import cached_property
-from typing import Generic, Optional, TypeVar
+from typing import Generic, Optional, TypeVar, cast
 
 import structlog
 
@@ -150,7 +150,7 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         valid_goals = []
         for goal in conversion_goals:
             # Skip "All Events" goals
-            if goal.kind == NodeKind.EVENTS_NODE:
+            if goal.kind == cast(str, NodeKind.EVENTS_NODE):
                 event_name = getattr(goal, "event", None)
                 if event_name is None or event_name == "":
                     logger.info(


### PR DESCRIPTION
## Problem

Using `all events` as a conversion goal is really expensive and not really useful actually so I will ignore it in the backend and disable it in the frontend. 

## Changes

- Ignoring in the backend `all events` conversion goal
- Putting a warning banner in the frontend for people that already have that conversion goal defined (I think currently there is only 1 team that added that conversion goal)
- not allowing adding `all events` as a conversion goal any more (removed from the dropdown)

## How did you test this code?
Adding a test and manually.

<img width="964" height="596" alt="Screenshot 2025-10-30 at 12 23 49 PM" src="https://github.com/user-attachments/assets/1d94b62b-88ef-4255-a139-dfb5f67adba0" />
<img width="1229" height="114" alt="Screenshot 2025-10-30 at 12 21 38 PM" src="https://github.com/user-attachments/assets/207c378e-86b8-4250-b765-08b19bc7325a" />

<img width="1235" height="260" alt="image" src="https://github.com/user-attachments/assets/a1a29d47-2954-4967-acc0-737fb485e5b4" />

before:
<img width="947" height="535" alt="image" src="https://github.com/user-attachments/assets/1c085daf-45f2-4fc1-9c6c-5000e030d01b" />
after:
<img width="820" height="488" alt="Screenshot 2025-10-30 at 10 52 06 AM" src="https://github.com/user-attachments/assets/5fcb1e6d-a530-40ce-a703-a8c552ca6843" />


This should never happen bc we already removed it from the dropdown, but still:
<img width="972" height="381" alt="Screenshot 2025-10-30 at 10 47 33 AM" src="https://github.com/user-attachments/assets/0d119906-aeb7-406f-abf6-1ec5e0e03e12" />
