### PR TITLE
feat(logs): add bytes headers to log capture producer

### DIFF
--- a/rust/log-capture/src/avro_schema.rs
+++ b/rust/log-capture/src/avro_schema.rs
@@ -125,22 +125,6 @@ pub const AVRO_SCHEMA: &str = r#"
         }
     }],
     "doc": "Map of custom timestamp-valued attributes."
-    },
-    {
-    "name": "attribute_keys",
-    "type": ["null", {
-        "type": "array",
-        "items": "string"
-    }],
-    "doc": "An ordered list of attribute keys."
-    },
-    {
-    "name": "attribute_values",
-    "type": ["null", {
-        "type": "array",
-        "items": "string"
-    }],
-    "doc": "An ordered list of attribute values, corresponding to attribute_keys."
     }
 ]
 }"#;

--- a/rust/log-capture/src/kafka.rs
+++ b/rust/log-capture/src/kafka.rs
@@ -188,7 +188,12 @@ impl KafkaSink {
         self.producer.flush(Duration::new(30, 0))
     }
 
-    pub async fn write(&self, token: &str, rows: Vec<KafkaLogRow>, uncompressed_bytes: u64) -> Result<(), anyhow::Error> {
+    pub async fn write(
+        &self,
+        token: &str,
+        rows: Vec<KafkaLogRow>,
+        uncompressed_bytes: u64,
+    ) -> Result<(), anyhow::Error> {
         let schema = Schema::parse_str(AVRO_SCHEMA)?;
         let mut writer = Writer::with_codec(
             &schema,
@@ -208,16 +213,21 @@ impl KafkaSink {
             partition: None,
             key: None::<Vec<u8>>.as_ref(),
             timestamp: None,
-            headers: Some(OwnedHeaders::new().insert(Header {
-                key: "token",
-                value: Some(&token.to_string()),
-            }).insert(Header {
-                key: "bytes_uncompressed",
-                value: Some(&uncompressed_bytes.to_string()),
-            }).insert(Header {
-                key: "bytes_compressed",
-                value: Some(&payload.len().to_string()),
-            })),
+            headers: Some(
+                OwnedHeaders::new()
+                    .insert(Header {
+                        key: "token",
+                        value: Some(&token.to_string()),
+                    })
+                    .insert(Header {
+                        key: "bytes_uncompressed",
+                        value: Some(&uncompressed_bytes.to_string()),
+                    })
+                    .insert(Header {
+                        key: "bytes_compressed",
+                        value: Some(&payload.len().to_string()),
+                    }),
+            ),
         }) {
             Err((err, _)) => Err(anyhow!(format!("kafka error: {}", err))),
             Ok(delivery_future) => Ok(delivery_future),

--- a/rust/log-capture/src/log_record.rs
+++ b/rust/log-capture/src/log_record.rs
@@ -44,8 +44,6 @@ pub struct KafkaLogRow {
     pub attributes_map_str: HashMap<String, String>,
     pub attributes_map_float: HashMap<String, f64>,
     pub attributes_map_datetime: HashMap<String, f64>,
-    pub attribute_keys: Vec<String>,
-    pub attribute_values: Vec<String>,
 }
 
 impl KafkaLogRow {
@@ -148,8 +146,6 @@ impl KafkaLogRow {
                 .map(|(k, v)| (k + "__float", v.unwrap()))
                 .collect(),
             attributes_map_datetime: HashMap::new(),
-            attribute_keys: attributes.keys().cloned().collect(),
-            attribute_values: attributes.values().cloned().collect(),
         };
         debug!("log: {:?}", log_row);
 

--- a/rust/log-capture/src/service.rs
+++ b/rust/log-capture/src/service.rs
@@ -81,7 +81,7 @@ pub async fn export_logs_http(
         }
     }
 
-    if let Err(e) = service.sink.write(token.unwrap(), rows).await {
+    if let Err(e) = service.sink.write(token.unwrap(), rows, body.len() as u64).await {
         error!("Failed to send logs to Kafka: {}", e);
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/rust/log-capture/src/service.rs
+++ b/rust/log-capture/src/service.rs
@@ -81,7 +81,11 @@ pub async fn export_logs_http(
         }
     }
 
-    if let Err(e) = service.sink.write(token.unwrap(), rows, body.len() as u64).await {
+    if let Err(e) = service
+        .sink
+        .write(token.unwrap(), rows, body.len() as u64)
+        .await
+    {
         error!("Failed to send logs to Kafka: {}", e);
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION

## Problem

we have no way to know how many bytes people are sending for e.g. billing and rate limiting, first step for these features is to add it

## Changes

add bytes_compressed and bytes_uncompressed headers to kafka messages

also removed unused attribute_keys and attribute_values

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
