### PR TITLE
fix(persons): optimization on dual distinct id insertion

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -246,15 +246,13 @@ describe('PostgresPersonRepository', () => {
             expect(kafkaMessages[1].topic).toBe('clickhouse_person_distinct_id_test')
             expect(kafkaMessages[2].topic).toBe('clickhouse_person_distinct_id_test')
 
-            // Verify distinct IDs were actually inserted into the database
             const distinctIds = await fetchDistinctIdValues(hub.db.postgres, person)
             expect(distinctIds).toHaveLength(2)
             expect(distinctIds).toEqual(expect.arrayContaining(['distinct-1', 'distinct-2']))
 
-            // Verify versions were set correctly
             const distinctIdRecords = await fetchDistinctIds(hub.db.postgres, person)
-            expect(distinctIdRecords.find((d) => d.distinct_id === 'distinct-1')?.version).toBe(0)
-            expect(distinctIdRecords.find((d) => d.distinct_id === 'distinct-2')?.version).toBe(1)
+            expect(distinctIdRecords.find((d) => d.distinct_id === 'distinct-1')?.version).toBe('0')
+            expect(distinctIdRecords.find((d) => d.distinct_id === 'distinct-2')?.version).toBe('1')
         })
 
         it('creates a person without distinct IDs', async () => {

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -390,8 +390,14 @@ export class PostgresPersonRepository
                 query,
                 [
                     ...personParams,
-                    ...distinctIds.map(({ version }) => version),
-                    ...distinctIds.map(({ distinctId }) => distinctId),
+                    ...distinctIds
+                        .slice()
+                        .reverse()
+                        .map(({ version }) => version),
+                    ...distinctIds
+                        .slice()
+                        .reverse()
+                        .map(({ distinctId }) => distinctId),
                 ],
                 'insertPerson',
                 'warn'

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -357,8 +357,6 @@ export class PostgresPersonRepository
             const distinctIdVersionStartIndex = columns.length + 1
             const distinctIdStartIndex = distinctIdVersionStartIndex + distinctIds.length
 
-            // Build the distinct IDs CTE with a single INSERT statement for all distinct IDs
-            // This is more efficient than multiple separate CTEs as it performs a single batched insert
             const distinctIdsCTE =
                 distinctIds.length > 0
                     ? `, distinct_ids AS (
@@ -392,14 +390,8 @@ export class PostgresPersonRepository
                 query,
                 [
                     ...personParams,
-                    ...distinctIds
-                        .slice()
-                        .reverse()
-                        .map(({ version }) => version),
-                    ...distinctIds
-                        .slice()
-                        .reverse()
-                        .map(({ distinctId }) => distinctId),
+                    ...distinctIds.map(({ version }) => version),
+                    ...distinctIds.map(({ distinctId }) => distinctId),
                 ],
                 'insertPerson',
                 'warn'

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -123,7 +123,8 @@ describe('postgres parity', () => {
             },
         ])
         const clickHouseDistinctIds = await clickhouse.fetchDistinctIdValues(person)
-        expect(clickHouseDistinctIds).toEqual(['distinct1', 'distinct2'])
+        expect(clickHouseDistinctIds).toEqual(expect.arrayContaining(['distinct1', 'distinct2']))
+        expect(clickHouseDistinctIds).toHaveLength(2)
 
         const postgresPersons = await fetchPersons(hub.db.postgres)
         expect(postgresPersons).toEqual([
@@ -150,7 +151,8 @@ describe('postgres parity', () => {
             },
         ])
         const postgresDistinctIds = await fetchDistinctIdValues(hub.db.postgres, person)
-        expect(postgresDistinctIds).toEqual(['distinct1', 'distinct2'])
+        expect(postgresDistinctIds).toEqual(expect.arrayContaining(['distinct1', 'distinct2']))
+        expect(postgresDistinctIds).toHaveLength(2)
 
         const newClickHouseDistinctIdValues = await clickhouse.fetchDistinctIds(person)
         expect(newClickHouseDistinctIdValues).toMatchObject([


### PR DESCRIPTION
## Problem

When looking at our queries I noticed the person insert query that inserts two records into the distinct id table was particularly slow. This should optimize it by batching the distinct id inserts in a single transaction

## Changes

A change to how the person insert query is executed when we have to insert two distinct ids.

## How did you test this code?

Unit tests

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
