### PR TITLE
fix(web-analytics): enable persons modal in Page Reports trend charts

### DIFF
--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -355,7 +355,6 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                         properties: pageUrl ? [createUrlPropertyFilter(pageUrl, stripQueryParams)] : [],
                         tags: WEB_ANALYTICS_DEFAULT_QUERY_TAGS,
                     },
-                    hidePersonsModal: true,
                     embedded: true,
                 }),
         ],

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -42,7 +42,7 @@ import {
     WebVitalsPathBreakdownQuery,
 } from '~/queries/schema/schema-general'
 import { QueryContext, QueryContextColumnComponent, QueryContextColumnTitleComponent } from '~/queries/types'
-import { InsightLogicProps, ProductKey, PropertyFilterType } from '~/types'
+import { ChartDisplayType, InsightLogicProps, ProductKey, PropertyFilterType } from '~/types'
 
 import { NewActionButton } from 'products/actions/frontend/components/NewActionButton'
 
@@ -474,18 +474,31 @@ export const WebStatsTrendTile = ({
     )
 
     const context = useMemo((): QueryContext => {
-        return {
+        const baseContext: QueryContext = {
             ...webAnalyticsDataTableQueryContext,
-            onDataPointClick({ breakdown }, data) {
-                if (breakdown === 'string' && data && (data.count > 0 || data.aggregated_value > 0)) {
-                    onWorldMapClick(breakdown)
-                }
-            },
             insightProps: {
                 ...insightProps,
                 query,
             },
         }
+
+        // World maps need custom click handler for country filtering, trend lines use default persons modal
+        const isWorldMap =
+            query.source?.kind === NodeKind.TrendsQuery &&
+            query.source.trendsFilter?.display === ChartDisplayType.WorldMap
+
+        if (isWorldMap) {
+            return {
+                ...baseContext,
+                onDataPointClick({ breakdown }, data) {
+                    if (typeof breakdown === 'string' && data && (data.count > 0 || data.aggregated_value > 0)) {
+                        onWorldMapClick(breakdown)
+                    }
+                },
+            }
+        }
+
+        return baseContext
     }, [onWorldMapClick, insightProps, query])
 
     return (


### PR DESCRIPTION
## Problem

In Page Reports, clicking on data points in the "Trends over time" chart didn't open the persons modal to view the list of people. The issue was caused by:

1. `hidePersonsModal: true` flag preventing the modal from appearing
2. A custom `onDataPointClick` context handler (meant for world maps) overriding the default persons modal behavior for all chart types

## Solution

**1. Removed `hidePersonsModal: true`** from `pageReportsLogic.ts` (line 358)

**2. Fixed `WebStatsTrendTile` context in `WebAnalyticsTile.tsx`**:
- Conditionally include `onDataPointClick` ONLY for world map visualizations
- Check: `query.source?.kind === NodeKind.TrendsQuery && query.source.trendsFilter?.display === ChartDisplayType.WorldMap`
- For world maps: Include the click handler for country filtering
- For trend lines: Omit the handler to allow default persons modal behavior
- Fixed type check: `typeof breakdown === 'string'` (was incorrectly `breakdown === 'string'`)

## Testing

1. Navigate to Web Analytics → Page Reports
2. Select a page URL from the dropdown
3. Click on any data point in the "Trends over time" chart
4. ✅ Persons modal now opens showing the list of people who visited during that period
5. ✅ Cursor changes to pointer on hover
6. ✅ World map country clicks still work for filtering

## Files Changed

- `frontend/src/scenes/web-analytics/pageReportsLogic.ts` - Removed hidePersonsModal flag
- `frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx` - Conditional context handler

Fixes #39617

🤖 Generated with [Claude Code](https://claude.com/claude-code)