### PR TITLE
fix(flags): Only write to Redis when cached item not found or parse error

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1791,6 +1791,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-cache"
+version = "0.1.0"
+dependencies = [
+ "common-redis",
+ "moka",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "common-compression"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "serde-pickle",
  "thiserror 2.0.16",
  "tokio",
+ "tracing",
  "zstd",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "serde-pickle",
  "thiserror 2.0.16",
  "tokio",
+ "zstd",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "bytes",
  "chrono",
  "common-alloc",
+ "common-cache",
  "common-compression",
  "common-cookieless",
  "common-database",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "batch-import-worker",
     "capture",
     "common/alloc",
+    "common/cache",
     "common/cookieless",
     "common/database",
     "common/dns",

--- a/rust/common/cache/Cargo.toml
+++ b/rust/common/cache/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "common-cache"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+common-redis = { path = "../redis" }
+moka = { version = "0.12", features = ["sync"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }

--- a/rust/common/cache/src/lib.rs
+++ b/rust/common/cache/src/lib.rs
@@ -1,0 +1,51 @@
+//! Generic cache system for PostHog services
+//!
+//! This crate provides a generic read-through cache implementation that can be used
+//! across all PostHog services. It supports:
+//!
+//! - Generic key-value caching with Redis
+//! - Configurable TTL and cache prefixes
+//! - Optional negative caching with Moka
+//! - Rich return types indicating cache source for observability
+//! - Function-based fallback API (no trait implementations required)
+//! - User-defined error types
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use common_cache::{ReadThroughCache, CacheConfig, CacheSource};
+//!
+//! let cache = ReadThroughCache::new(
+//!     redis_reader,
+//!     redis_writer,
+//!     CacheConfig::with_ttl("my_data:", 300),
+//!     None, // negative_cache
+//! );
+//!
+//! let result = cache
+//!     .get_or_load(&key, |key| async {
+//!         load_from_source(key).await
+//!     })
+//!     .await?;
+//!
+//! match result.source {
+//!     CacheSource::PositiveCache => println!("Cache hit!"),
+//!     CacheSource::LoaderCacheMiss => println!("Cache miss, loaded from source"),
+//!     CacheSource::NegativeCache => println!("Known to not exist"),
+//!     _ => println!("Other source: {:?}", result.source),
+//! }
+//!
+//! if let Some(value) = result.value {
+//!     // Use the value
+//! } else {
+//!     // Item doesn't exist
+//! }
+//! ```
+
+pub mod negative_cache;
+pub mod read_through;
+pub mod types;
+
+pub use negative_cache::NegativeCache;
+pub use read_through::ReadThroughCache;
+pub use types::{CacheConfig, CacheResult, CacheSource};

--- a/rust/common/cache/src/negative_cache.rs
+++ b/rust/common/cache/src/negative_cache.rs
@@ -1,0 +1,177 @@
+//! In-memory negative caching to prevent repeated loader calls for missing keys
+//!
+//! This module provides [`NegativeCache`], an in-memory cache that tracks keys known
+//! to not exist. This prevents repeated expensive loader invocations for
+//! non-existent keys.
+//!
+//! Uses Moka for efficient LRU eviction and TTL support, avoiding Redis to prevent
+//! cache poisoning when Redis is struggling.
+
+use moka::sync::Cache;
+use std::time::Duration;
+
+/// In-memory negative cache using Moka to prevent repeated loader calls
+/// for non-existent keys. We use this instead of a Redis-based negative cache
+/// to avoid cache poisoning vulnerabilities. Improved performance is a side-benefit.
+///
+/// Features:
+/// - TTL: Entries automatically expire after configured time
+/// - LRU eviction: Bounded memory usage with automatic cleanup
+/// - Thread-safe: Can be safely shared across async tasks
+/// - Pod isolation: Each service instance has its own cache
+#[derive(Clone)]
+pub struct NegativeCache {
+    cache: Cache<String, ()>,
+}
+
+impl NegativeCache {
+    /// Create a new negative cache with specified capacity and TTL
+    ///
+    /// # Arguments
+    /// * `max_capacity` - Maximum number of entries to store
+    /// * `ttl_seconds` - Time-to-live for entries in seconds
+    ///
+    /// # Example
+    /// ```rust
+    /// use common_cache::NegativeCache;
+    ///
+    /// let cache = NegativeCache::new(1000, 300); // 1000 entries, 5 minute TTL
+    /// ```
+    pub fn new(max_capacity: u64, ttl_seconds: u64) -> Self {
+        let cache = Cache::builder()
+            .max_capacity(max_capacity)
+            .time_to_live(Duration::from_secs(ttl_seconds))
+            .build();
+
+        Self { cache }
+    }
+
+    /// Check if a key is in the negative cache (was not found in database)
+    ///
+    /// # Arguments
+    /// * `key` - The key to check
+    ///
+    /// # Returns
+    /// `true` if the key is in the negative cache, `false` otherwise
+    pub fn contains(&self, key: &str) -> bool {
+        self.cache.contains_key(key)
+    }
+
+    /// Add a key to the negative cache (marking it as not found in database)
+    ///
+    /// # Arguments
+    /// * `key` - The key to mark as not found
+    pub fn insert(&self, key: String) {
+        self.cache.insert(key, ());
+    }
+
+    /// Remove a key from the negative cache (e.g., when positive data is found)
+    ///
+    /// # Arguments
+    /// * `key` - The key to remove from negative cache
+    pub fn invalidate(&self, key: &str) {
+        self.cache.invalidate(key);
+    }
+
+    /// Get cache statistics (entry count and weighted size)
+    ///
+    /// # Returns
+    /// A tuple of (entry_count, weighted_size)
+    pub fn stats(&self) -> (u64, u64) {
+        (self.cache.entry_count(), self.cache.weighted_size())
+    }
+
+    /// Clear all entries from the negative cache
+    pub fn clear(&self) {
+        self.cache.invalidate_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{sleep, Duration as TokioDuration};
+
+    #[tokio::test]
+    async fn test_negative_cache_basic_functionality() {
+        // Test basic Moka negative cache functionality
+        let negative_cache = NegativeCache::new(100, 300); // 100 entries, 5 min TTL
+
+        let key = "test_key_123";
+
+        // Initially, cache should not contain the key
+        assert!(!negative_cache.contains(key));
+
+        // Insert the key into negative cache
+        negative_cache.insert(key.to_string());
+
+        // Now cache should contain the key
+        assert!(negative_cache.contains(key));
+
+        // Test stats - Moka cache stats might not be immediately consistent
+        // So we'll test the functionality instead of exact counts
+        assert!(negative_cache.contains(key));
+
+        // Test invalidation
+        negative_cache.invalidate(key);
+        assert!(!negative_cache.contains(key));
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_ttl_expiration() {
+        // Test that entries expire after TTL
+        let negative_cache = NegativeCache::new(100, 1); // 1 second TTL
+
+        let key = "test_expiry_key";
+        negative_cache.insert(key.to_string());
+
+        // Should be present initially
+        assert!(negative_cache.contains(key));
+
+        // Wait for TTL to expire
+        sleep(TokioDuration::from_secs(2)).await;
+
+        // Should be expired now
+        assert!(!negative_cache.contains(key));
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_capacity_limits() {
+        // Test LRU eviction when capacity is reached
+        let negative_cache = NegativeCache::new(2, 300); // Only 2 entries max
+
+        // Add first two entries
+        negative_cache.insert("key1".to_string());
+        negative_cache.insert("key2".to_string());
+
+        assert!(negative_cache.contains("key1"));
+        assert!(negative_cache.contains("key2"));
+
+        // Add third entry - should evict least recently used
+        negative_cache.insert("key3".to_string());
+
+        // key3 should be present, and one of the others should be evicted
+        assert!(negative_cache.contains("key3"));
+
+        let (entry_count, _) = negative_cache.stats();
+        assert!(entry_count <= 2, "Cache should not exceed capacity");
+    }
+
+    #[test]
+    fn test_negative_cache_clear() {
+        let negative_cache = NegativeCache::new(100, 300);
+
+        negative_cache.insert("key1".to_string());
+        negative_cache.insert("key2".to_string());
+
+        // Verify keys are present
+        assert!(negative_cache.contains("key1"));
+        assert!(negative_cache.contains("key2"));
+
+        negative_cache.clear();
+
+        // Verify keys are no longer present after clear
+        assert!(!negative_cache.contains("key1"));
+        assert!(!negative_cache.contains("key2"));
+    }
+}

--- a/rust/common/cache/src/read_through.rs
+++ b/rust/common/cache/src/read_through.rs
@@ -1,0 +1,740 @@
+//! Read-through cache implementation with Redis backing
+//!
+//! This module provides the main [`ReadThroughCache`] type that implements the read-through
+//! caching pattern with support for:
+//! - Redis-based positive caching
+//! - Optional in-memory negative caching
+//! - Cache corruption handling
+//! - Graceful Redis degradation
+
+use crate::{CacheConfig, CacheResult, CacheSource, NegativeCache};
+use common_redis::{Client as RedisClient, CustomRedisError};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::future::Future;
+use std::sync::Arc;
+
+/// A generic read-through cache that supports:
+/// - Redis-based positive caching with configurable TTL
+/// - Optional in-memory negative caching to prevent repeated loader invocations for missing keys
+/// - Function-based loader API (no trait implementations required)
+/// - User-defined error types
+/// - Rich return types for observability
+/// - Cache corruption handling
+///
+/// The cache follows the "cache-aside" pattern:
+/// 1. Check negative cache first (if enabled)
+/// 2. Try to get data from Redis cache
+/// 3. On cache miss, call the loader function
+/// 4. If loader succeeds, update positive cache and invalidate negative cache
+/// 5. If loader returns None, add to negative cache
+///
+/// # Example
+/// ```rust,ignore
+/// use common_cache::{ReadThroughCache, CacheConfig, CacheSource};
+///
+/// let cache = ReadThroughCache::new(
+///     redis_reader,
+///     redis_writer,
+///     CacheConfig::with_ttl("my_data:", 300),
+///     None, // no negative cache
+/// );
+///
+/// let result = cache
+///     .get_or_load(&key, |key| async {
+///         load_from_source(key).await
+///     })
+///     .await?;
+///
+/// match result.source {
+///     CacheSource::PositiveCache => println!("Cache hit!"),
+///     CacheSource::LoaderCacheMiss => println!("Loaded from source"),
+///     _ => {}
+/// }
+/// ```
+pub struct ReadThroughCache {
+    redis_reader: Arc<dyn RedisClient + Send + Sync>,
+    redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    config: CacheConfig,
+    negative_cache: Option<Arc<NegativeCache>>,
+}
+
+impl ReadThroughCache {
+    /// Create a new read-through cache instance
+    ///
+    /// # Arguments
+    /// * `redis_reader` - Redis client for reading cached data
+    /// * `redis_writer` - Redis client for writing cached data
+    /// * `config` - Cache configuration (prefix, TTL)
+    /// * `negative_cache` - Optional negative cache to prevent repeated loader invocations for missing keys
+    pub fn new(
+        redis_reader: Arc<dyn RedisClient + Send + Sync>,
+        redis_writer: Arc<dyn RedisClient + Send + Sync>,
+        config: CacheConfig,
+        negative_cache: Option<Arc<NegativeCache>>,
+    ) -> Self {
+        Self {
+            redis_reader,
+            redis_writer,
+            config,
+            negative_cache,
+        }
+    }
+
+    /// Get a value from cache or load it using the loader function
+    ///
+    /// This is the main API for the cache. It:
+    /// 1. Checks negative cache first (if enabled)
+    /// 2. Tries Redis cache
+    /// 3. On miss, calls loader function with the key
+    /// 4. Updates caches based on the result
+    ///
+    /// The loader function should return `Option<V>` where:
+    /// - `Some(value)` indicates the item was found
+    /// - `None` indicates the item doesn't exist (will be negative cached)
+    ///
+    /// # Type Parameters
+    /// * `K` - Key type (must be displayable for logging)
+    /// * `V` - Value type (must be serializable)
+    /// * `E` - Error type (user-defined, for loader errors)
+    /// * `F` - Loader function type
+    /// * `Fut` - Future returned by loader function
+    ///
+    /// # Arguments
+    /// * `key` - The key to look up
+    /// * `loader` - Function to call on cache miss, receives the key as parameter
+    ///
+    /// # Returns
+    /// * `Ok(CacheResult)` - Contains the value (if found) and source information
+    /// * `Err(error)` - Error from loader function
+    pub async fn get_or_load<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Serialize + Display + Send + Sync,
+        V: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        let cache_key = self.build_cache_key(key);
+
+        // Check negative cache first
+        if let Some(neg_cache) = &self.negative_cache {
+            if neg_cache.contains(&cache_key) {
+                tracing::debug!("Negative cache hit for key: {}", key);
+                return Ok(CacheResult::not_found(CacheSource::NegativeCache));
+            }
+        }
+
+        // Try to get from Redis cache
+        match self.get_from_redis(&cache_key).await {
+            Ok(cached_value) => {
+                // Positive cache hit
+                tracing::debug!("Positive cache hit for key: {}", key);
+                Ok(CacheResult::found(cached_value, CacheSource::PositiveCache))
+            }
+            Err(cache_error) => {
+                // Cache miss or error - need to fetch from loader
+                self.handle_cache_miss(key, &cache_key, cache_error, loader)
+                    .await
+            }
+        }
+    }
+
+    /// Build the full Redis cache key from the user key
+    fn build_cache_key<K>(&self, key: &K) -> String
+    where
+        K: Display,
+    {
+        format!("{}{}", self.config.cache_prefix, key)
+    }
+
+    /// Get a value from Redis cache
+    async fn get_from_redis<V>(&self, cache_key: &str) -> Result<V, CustomRedisError>
+    where
+        V: for<'de> Deserialize<'de>,
+    {
+        let serialized_value = self.redis_reader.get(cache_key.to_string()).await?;
+        let value = serde_json::from_str(&serialized_value).map_err(|e| {
+            CustomRedisError::ParseError(format!("Failed to deserialize cached value: {e}"))
+        })?;
+        Ok(value)
+    }
+
+    /// Handle cache miss by calling loader and updating caches
+    async fn handle_cache_miss<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        cache_key: &str,
+        cache_error: CustomRedisError,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        match cache_error {
+            CustomRedisError::NotFound => {
+                // True cache miss - key doesn't exist in cache
+                self.handle_true_cache_miss(key, cache_key, loader).await
+            }
+            CustomRedisError::ParseError(ref err) => {
+                // Corrupted cache data - try loader and refresh cache if successful
+                tracing::warn!(
+                    "Cache corruption detected for key {}: {}. Will refresh from source.",
+                    key,
+                    err
+                );
+                self.handle_corrupted_cache(key, cache_key, loader).await
+            }
+            CustomRedisError::Timeout | CustomRedisError::Other(_) => {
+                // Redis infrastructure issues - use loader without caching
+                tracing::warn!(
+                    "Redis infrastructure issue for key {}: {:?}. Operating without cache.",
+                    key,
+                    cache_error
+                );
+                self.handle_redis_unavailable(key, loader).await
+            }
+        }
+    }
+
+    /// Handle a true cache miss (key not in Redis)
+    async fn handle_true_cache_miss<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        cache_key: &str,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        match loader(key).await? {
+            Some(value) => {
+                // Value found - update positive cache and invalidate negative cache
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.invalidate(cache_key);
+                }
+
+                // Update positive cache
+                if let Err(redis_err) = self.set_in_redis(cache_key, &value).await {
+                    tracing::warn!("Failed to update cache for key {}: {:?}", key, redis_err);
+                }
+
+                Ok(CacheResult::found(value, CacheSource::LoaderCacheMiss))
+            }
+            None => {
+                // Value not found - add to negative cache
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.insert(cache_key.to_string());
+                }
+
+                Ok(CacheResult::not_found(CacheSource::LoaderNotFoundCacheMiss))
+            }
+        }
+    }
+
+    /// Handle corrupted cache data
+    async fn handle_corrupted_cache<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        cache_key: &str,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        match loader(key).await? {
+            Some(value) => {
+                // Loader success - refresh cache with valid data
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.invalidate(cache_key);
+                }
+
+                // Update cache with fresh data
+                if let Err(redis_err) = self.set_in_redis(cache_key, &value).await {
+                    tracing::warn!(
+                        "Failed to refresh corrupted cache for key {}: {:?}",
+                        key,
+                        redis_err
+                    );
+                }
+
+                Ok(CacheResult::found(value, CacheSource::LoaderCacheCorrupted))
+            }
+            None => {
+                // Value not found - add to negative cache
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.insert(cache_key.to_string());
+                }
+
+                Ok(CacheResult::not_found(
+                    CacheSource::LoaderNotFoundCacheCorrupted,
+                ))
+            }
+        }
+    }
+
+    /// Handle Redis being unavailable
+    async fn handle_redis_unavailable<K, V, E, F, Fut>(
+        &self,
+        _key: &K,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        // Don't update any caches when Redis is having issues
+        match loader(_key).await? {
+            Some(value) => Ok(CacheResult::found(
+                value,
+                CacheSource::LoaderRedisUnavailable,
+            )),
+            None => Ok(CacheResult::not_found(
+                CacheSource::LoaderNotFoundRedisUnavailable,
+            )),
+        }
+    }
+
+    /// Write a value to Redis cache
+    async fn set_in_redis<V>(&self, cache_key: &str, value: &V) -> Result<(), CustomRedisError>
+    where
+        V: Serialize,
+    {
+        let serialized_value = serde_json::to_string(value).map_err(|e| {
+            CustomRedisError::ParseError(format!("Failed to serialize value for cache: {e}"))
+        })?;
+
+        match self.config.ttl_seconds {
+            Some(ttl) => {
+                self.redis_writer
+                    .setex(cache_key.to_string(), serialized_value, ttl)
+                    .await
+            }
+            None => {
+                self.redis_writer
+                    .set(cache_key.to_string(), serialized_value)
+                    .await
+            }
+        }
+    }
+
+    /// Invalidate a key from both positive and negative caches
+    ///
+    /// # Arguments
+    /// * `key` - The key to invalidate
+    pub async fn invalidate<K>(&self, key: &K) -> Result<(), CustomRedisError>
+    where
+        K: Display,
+    {
+        let cache_key = self.build_cache_key(key);
+
+        // Remove from Redis
+        if let Err(e) = self.redis_writer.del(cache_key.clone()).await {
+            tracing::warn!("Failed to delete cache key {}: {:?}", cache_key, e);
+        }
+
+        // Remove from negative cache
+        if let Some(neg_cache) = &self.negative_cache {
+            neg_cache.invalidate(&cache_key);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common_redis::MockRedisClient;
+    use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestData {
+        id: i32,
+        name: String,
+    }
+
+    fn setup_cache(
+        reader: MockRedisClient,
+        writer: MockRedisClient,
+        negative_cache: Option<Arc<NegativeCache>>,
+    ) -> ReadThroughCache {
+        let config = CacheConfig::with_ttl("test:", 300);
+        ReadThroughCache::new(Arc::new(reader), Arc::new(writer), config, negative_cache)
+    }
+
+    #[tokio::test]
+    async fn test_positive_cache_hit() {
+        let data = TestData {
+            id: 1,
+            name: "test".to_string(),
+        };
+        let serialized = serde_json::to_string(&data).unwrap();
+
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok(serialized));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::PositiveCache);
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_loads_and_caches() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let mut writer = MockRedisClient::new();
+        writer.set_ret("test:key1", Ok(()));
+
+        let cache = setup_cache(reader, writer.clone(), None);
+
+        let data = TestData {
+            id: 1,
+            name: "loaded".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderCacheMiss);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+
+        // Verify cache was written to
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].op, "setex");
+        assert_eq!(calls[0].key, "test:key1");
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_not_found_returns_none() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheMiss);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+    }
+
+    #[tokio::test]
+    async fn test_cache_corruption_reloads_and_refreshes() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok("invalid json{".to_string()));
+
+        let mut writer = MockRedisClient::new();
+        writer.set_ret("test:key1", Ok(()));
+
+        let cache = setup_cache(reader, writer.clone(), None);
+
+        let data = TestData {
+            id: 1,
+            name: "refreshed".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderCacheCorrupted);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+        assert!(result.had_cache_problem());
+
+        // Verify cache was refreshed
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].op, "setex");
+    }
+
+    #[tokio::test]
+    async fn test_cache_corruption_not_found() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok("invalid json{".to_string()));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheCorrupted);
+        assert!(result.had_cache_problem());
+    }
+
+    async fn test_redis_infrastructure_error_skips_cache_write_impl(redis_error: CustomRedisError) {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(redis_error));
+
+        let writer = MockRedisClient::new();
+
+        let cache = setup_cache(reader, writer.clone(), None);
+
+        let data = TestData {
+            id: 1,
+            name: "from_loader".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderRedisUnavailable);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+
+        // Verify NO cache write occurred
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_redis_timeout_skips_cache_write() {
+        test_redis_infrastructure_error_skips_cache_write_impl(CustomRedisError::Timeout).await;
+    }
+
+    #[tokio::test]
+    async fn test_redis_other_error_skips_cache_write() {
+        test_redis_infrastructure_error_skips_cache_write_impl(CustomRedisError::Other(
+            "connection refused".to_string(),
+        ))
+        .await;
+    }
+
+    async fn test_redis_infrastructure_error_not_found_impl(redis_error: CustomRedisError) {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(redis_error));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        let cache = setup_cache(reader, MockRedisClient::new(), Some(negative_cache.clone()));
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundRedisUnavailable);
+        assert!(result.had_cache_problem());
+
+        // Verify negative cache was NOT updated (don't poison cache when Redis is down)
+        assert!(!negative_cache.contains("test:key1"));
+    }
+
+    #[tokio::test]
+    async fn test_redis_timeout_not_found() {
+        test_redis_infrastructure_error_not_found_impl(CustomRedisError::Timeout).await;
+    }
+
+    #[tokio::test]
+    async fn test_redis_other_error_not_found() {
+        test_redis_infrastructure_error_not_found_impl(CustomRedisError::Other(
+            "network error".to_string(),
+        ))
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_hit() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        let cache = setup_cache(reader, MockRedisClient::new(), Some(negative_cache.clone()));
+
+        // First call - cache miss, loader returns None
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheMiss);
+
+        // Second call - should hit negative cache without invoking loader
+        let result: CacheResult<TestData> = cache
+            .get_or_load(&"key1", |_key| async {
+                panic!("Loader should not be called for negative cache hit");
+                #[allow(unreachable_code)]
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::NegativeCache);
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_invalidated_on_found() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let mut writer = MockRedisClient::new();
+        writer.set_ret("test:key1", Ok(()));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        let cache = setup_cache(reader, writer, Some(negative_cache.clone()));
+
+        // First call - loader returns None, should add to negative cache
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheMiss);
+        assert!(negative_cache.contains("test:key1"));
+
+        // Second call - this time loader would return Some if called
+        // But negative cache will return early
+        let result: CacheResult<TestData> = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(Some(TestData {
+                    id: 1,
+                    name: "found".to_string(),
+                }))
+            })
+            .await
+            .unwrap();
+
+        // Should hit negative cache
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::NegativeCache);
+
+        // Now invalidate the cache entry
+        cache.invalidate(&"key1").await.unwrap();
+        assert!(!negative_cache.contains("test:key1"));
+
+        // Third call - after invalidation, loader should be invoked
+        let data = TestData {
+            id: 1,
+            name: "found".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderCacheMiss);
+
+        // Verify negative cache was NOT re-added (since we found a value)
+        assert!(!negative_cache.contains("test:key1"));
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_clears_both_caches() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok(serde_json::to_string(&"cached").unwrap()));
+
+        let mut writer = MockRedisClient::new();
+        writer.del_ret("test:key1", Ok(()));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        negative_cache.insert("test:key1".to_string());
+
+        let cache = setup_cache(reader, writer.clone(), Some(negative_cache.clone()));
+
+        cache.invalidate(&"key1").await.unwrap();
+
+        // Verify Redis delete was called
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].op, "del");
+        assert_eq!(calls[0].key, "test:key1");
+
+        // Verify negative cache was cleared
+        assert!(!negative_cache.contains("test:key1"));
+    }
+
+    #[tokio::test]
+    async fn test_loader_error_propagates() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Err::<Option<TestData>, String>("loader error".to_string())
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "loader error");
+    }
+}

--- a/rust/common/cache/src/types.rs
+++ b/rust/common/cache/src/types.rs
@@ -1,0 +1,233 @@
+//! Cache configuration types and cache operation results
+//!
+//! This module contains the core types used throughout the cache system:
+//! - [`CacheConfig`]: Configuration for cache instances (prefix, TTL)
+//! - [`CacheSource`]: Enum indicating where a value came from (for observability)
+//! - [`CacheResult`]: Wrapper containing a value and its source
+
+use std::fmt;
+
+/// Configuration for cache instances
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    /// Redis key prefix for this cache instance (e.g., "team_token:", "feature_flags:")
+    pub cache_prefix: String,
+
+    /// Optional TTL in seconds for cached values
+    /// If None, values are cached indefinitely
+    pub ttl_seconds: Option<u64>,
+}
+
+impl CacheConfig {
+    /// Create a new cache configuration
+    pub fn new(cache_prefix: impl Into<String>, ttl_seconds: Option<u64>) -> Self {
+        Self {
+            cache_prefix: cache_prefix.into(),
+            ttl_seconds,
+        }
+    }
+
+    /// Create a cache configuration with no TTL (permanent caching)
+    pub fn permanent(cache_prefix: impl Into<String>) -> Self {
+        Self::new(cache_prefix, None)
+    }
+
+    /// Create a cache configuration with a TTL
+    pub fn with_ttl(cache_prefix: impl Into<String>, ttl_seconds: u64) -> Self {
+        Self::new(cache_prefix, Some(ttl_seconds))
+    }
+}
+
+/// Indicates where a cached value came from and what operations were performed
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheSource {
+    // Value found cases
+    /// Value was found in Redis cache
+    PositiveCache,
+    /// Cache miss - value loaded from loader function
+    LoaderCacheMiss,
+    /// Cache data was corrupted - value loaded from loader function
+    LoaderCacheCorrupted,
+    /// Redis was unavailable - value loaded from loader function
+    LoaderRedisUnavailable,
+
+    // Value not found cases
+    /// Key found in negative cache (known to not exist)
+    NegativeCache,
+    /// Cache miss - loader function indicated value doesn't exist
+    LoaderNotFoundCacheMiss,
+    /// Cache was corrupted - loader function indicated value doesn't exist
+    LoaderNotFoundCacheCorrupted,
+    /// Redis was unavailable - loader function indicated value doesn't exist
+    LoaderNotFoundRedisUnavailable,
+}
+
+impl fmt::Display for CacheSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display implementation for better logging and metrics.
+        // This allows `CacheSource` to be used directly in log messages and metric tags
+        // without needing to format the Debug representation or manually convert.
+        //
+        // Example: tracing::info!("Cache result: {}", result.source);
+        // Example: metrics::counter!("cache.access", "source" => result.source.to_string());
+        match self {
+            CacheSource::PositiveCache => write!(f, "positive_cache"),
+            CacheSource::NegativeCache => write!(f, "negative_cache"),
+            CacheSource::LoaderCacheMiss => write!(f, "loader_cache_miss"),
+            CacheSource::LoaderCacheCorrupted => write!(f, "loader_cache_corrupted"),
+            CacheSource::LoaderRedisUnavailable => write!(f, "loader_redis_unavailable"),
+            CacheSource::LoaderNotFoundCacheMiss => write!(f, "loader_not_found_cache_miss"),
+            CacheSource::LoaderNotFoundCacheCorrupted => {
+                write!(f, "loader_not_found_cache_corrupted")
+            }
+            CacheSource::LoaderNotFoundRedisUnavailable => {
+                write!(f, "loader_not_found_redis_unavailable")
+            }
+        }
+    }
+}
+
+/// Result of a cache operation with detailed source information
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheResult<V> {
+    /// The value, if found. None indicates the item doesn't exist (negative result)
+    pub value: Option<V>,
+
+    /// Where the result came from - provides context for observability
+    pub source: CacheSource,
+}
+
+impl<V> CacheResult<V> {
+    /// Create a cache result with a value
+    pub fn found(value: V, source: CacheSource) -> Self {
+        Self {
+            value: Some(value),
+            source,
+        }
+    }
+
+    /// Create a cache result indicating the value was not found
+    pub fn not_found(source: CacheSource) -> Self {
+        Self {
+            value: None,
+            source,
+        }
+    }
+
+    /// Check if this was a cache hit (from Redis or negative cache)
+    pub fn was_cached(&self) -> bool {
+        matches!(
+            self.source,
+            CacheSource::PositiveCache | CacheSource::NegativeCache
+        )
+    }
+
+    /// Check if the loader function was invoked
+    pub fn invoked_loader(&self) -> bool {
+        matches!(
+            self.source,
+            CacheSource::LoaderCacheMiss
+                | CacheSource::LoaderCacheCorrupted
+                | CacheSource::LoaderRedisUnavailable
+                | CacheSource::LoaderNotFoundCacheMiss
+                | CacheSource::LoaderNotFoundCacheCorrupted
+                | CacheSource::LoaderNotFoundRedisUnavailable
+        )
+    }
+
+    /// Check if there was a cache infrastructure problem
+    pub fn had_cache_problem(&self) -> bool {
+        matches!(
+            self.source,
+            CacheSource::LoaderCacheCorrupted
+                | CacheSource::LoaderRedisUnavailable
+                | CacheSource::LoaderNotFoundCacheCorrupted
+                | CacheSource::LoaderNotFoundRedisUnavailable
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_result_helpers() {
+        let result: CacheResult<i32> = CacheResult::found(42, CacheSource::PositiveCache);
+        assert_eq!(result.value, Some(42));
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+        assert!(!result.had_cache_problem());
+
+        let result: CacheResult<i32> = CacheResult::not_found(CacheSource::LoaderNotFoundCacheMiss);
+        assert_eq!(result.value, None);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+        assert!(!result.had_cache_problem());
+
+        let result: CacheResult<i32> = CacheResult::found(42, CacheSource::LoaderCacheCorrupted);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+        assert!(!result.was_cached());
+    }
+
+    #[test]
+    fn test_negative_cache_helper() {
+        let result: CacheResult<String> = CacheResult::not_found(CacheSource::NegativeCache);
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+        assert!(!result.had_cache_problem());
+    }
+
+    #[test]
+    fn test_redis_unavailable_helper() {
+        let result: CacheResult<i32> = CacheResult::found(42, CacheSource::LoaderRedisUnavailable);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+        assert!(!result.was_cached());
+
+        let result: CacheResult<i32> =
+            CacheResult::not_found(CacheSource::LoaderNotFoundRedisUnavailable);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+        assert!(!result.was_cached());
+    }
+
+    #[test]
+    fn test_cache_source_display() {
+        // Test Display implementation for use in logging and metrics
+        assert_eq!(CacheSource::PositiveCache.to_string(), "positive_cache");
+        assert_eq!(CacheSource::NegativeCache.to_string(), "negative_cache");
+        assert_eq!(
+            CacheSource::LoaderCacheMiss.to_string(),
+            "loader_cache_miss"
+        );
+        assert_eq!(
+            CacheSource::LoaderCacheCorrupted.to_string(),
+            "loader_cache_corrupted"
+        );
+        assert_eq!(
+            CacheSource::LoaderRedisUnavailable.to_string(),
+            "loader_redis_unavailable"
+        );
+        assert_eq!(
+            CacheSource::LoaderNotFoundCacheMiss.to_string(),
+            "loader_not_found_cache_miss"
+        );
+        assert_eq!(
+            CacheSource::LoaderNotFoundCacheCorrupted.to_string(),
+            "loader_not_found_cache_corrupted"
+        );
+        assert_eq!(
+            CacheSource::LoaderNotFoundRedisUnavailable.to_string(),
+            "loader_not_found_redis_unavailable"
+        );
+
+        // Test that it works in format strings (useful for logging)
+        let source = CacheSource::PositiveCache;
+        assert_eq!(
+            format!("Cache hit from: {source}"),
+            "Cache hit from: positive_cache"
+        );
+    }
+}

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -12,5 +12,6 @@ redis = { workspace = true }
 serde-pickle = { version = "1.1.1" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 zstd = "0.13"
 

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -12,4 +12,5 @@ redis = { workspace = true }
 serde-pickle = { version = "1.1.1" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+zstd = "0.13"
 

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -535,7 +535,7 @@ impl MockRedisClient {
     }
 
     // Helper method to safely lock the calls mutex
-    fn lock_calls(&self) -> std::sync::MutexGuard<Vec<MockRedisCall>> {
+    fn lock_calls(&self) -> std::sync::MutexGuard<'_, Vec<MockRedisCall>> {
         match self.calls.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 axum = { workspace = true }
 axum-client-ip = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+common-cache = { path = "../common/cache" }
 common-cookieless = { path = "../common/cookieless" }
 common-database = { path = "../common/database" }
 common-redis = { path = "../common/redis" }

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -342,6 +342,9 @@ impl IntoResponse for FlagError {
 impl From<CustomRedisError> for FlagError {
     fn from(e: CustomRedisError) -> Self {
         match e {
+            // NOTE: This mapping is used by legacy team_operations::fetch_team_from_redis_with_fallback
+            // In that context, NotFound means the team token doesn't exist in cache, which is treated
+            // as a token validation error. New code using ReadThroughCache should not rely on this.
             CustomRedisError::NotFound => FlagError::TokenValidationError,
             CustomRedisError::ParseError(_) => FlagError::RedisDataParsingError,
             CustomRedisError::Timeout => FlagError::TimeoutError(Some("redis_timeout".to_string())),

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -231,7 +231,8 @@ fn evaluate_cohort_values(
             for filter in &values.values {
                 if filter.is_cohort() {
                     // Handle cohort membership check
-                    if apply_cohort_membership_logic(&[filter.clone()], cohort_matches)? {
+                    if apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)?
+                    {
                         return Ok(true);
                     }
                 } else {
@@ -247,8 +248,10 @@ fn evaluate_cohort_values(
             for filter in &values.values {
                 if filter.is_cohort() {
                     // Handle cohort membership check with negation
-                    let cohort_result =
-                        apply_cohort_membership_logic(&[filter.clone()], cohort_matches)?;
+                    let cohort_result = apply_cohort_membership_logic(
+                        std::slice::from_ref(filter),
+                        cohort_matches,
+                    )?;
                     // Apply negation if specified
                     if cohort_result == filter.negation.unwrap_or(false) {
                         return Ok(false);

--- a/rust/feature-flags/src/flags/cache_metrics.rs
+++ b/rust/feature-flags/src/flags/cache_metrics.rs
@@ -1,0 +1,63 @@
+use common_cache::CacheSource;
+use common_metrics::inc;
+
+/// Generic cache metrics tracker that works with any cache type
+///
+/// Tracks cache hits, misses, database reads, and cache errors based on the CacheSource
+/// returned by ReadThroughCache operations.
+pub fn track_cache_metrics(
+    source: CacheSource,
+    cache_hit_counter: &'static str,
+    db_reads_counter: &'static str,
+    cache_errors_counter: &'static str,
+) {
+    match source {
+        CacheSource::PositiveCache => {
+            inc(
+                cache_hit_counter,
+                &[
+                    ("cache_hit".to_string(), "true".to_string()),
+                    ("result_type".to_string(), "positive".to_string()),
+                ],
+                1,
+            );
+        }
+        CacheSource::NegativeCache => {
+            inc(
+                cache_hit_counter,
+                &[
+                    ("cache_hit".to_string(), "true".to_string()),
+                    ("result_type".to_string(), "negative".to_string()),
+                ],
+                1,
+            );
+        }
+        CacheSource::LoaderCacheMiss
+        | CacheSource::LoaderCacheCorrupted
+        | CacheSource::LoaderRedisUnavailable
+        | CacheSource::LoaderNotFoundCacheMiss
+        | CacheSource::LoaderNotFoundCacheCorrupted
+        | CacheSource::LoaderNotFoundRedisUnavailable => {
+            // Cache miss
+            inc(
+                cache_hit_counter,
+                &[("cache_hit".to_string(), "false".to_string())],
+                1,
+            );
+
+            // Track database reads
+            inc(db_reads_counter, &[], 1);
+
+            // Track cache errors if there was a problem
+            if matches!(
+                source,
+                CacheSource::LoaderCacheCorrupted
+                    | CacheSource::LoaderRedisUnavailable
+                    | CacheSource::LoaderNotFoundCacheCorrupted
+                    | CacheSource::LoaderNotFoundRedisUnavailable
+            ) {
+                inc(cache_errors_counter, &[], 1);
+            }
+        }
+    }
+}

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -1,15 +1,11 @@
 use crate::{
     api::errors::FlagError,
-    flags::flag_models::FeatureFlagList,
-    metrics::consts::{
-        DB_FLAG_READS_COUNTER, DB_TEAM_READS_COUNTER, FLAG_CACHE_ERRORS_COUNTER,
-        FLAG_CACHE_HIT_COUNTER, TEAM_CACHE_ERRORS_COUNTER, TEAM_CACHE_HIT_COUNTER,
-        TOKEN_VALIDATION_ERRORS_COUNTER,
+    flags::{
+        flag_models::FeatureFlagList, flags_cache::flags_get_or_load, team_cache::team_get_or_load,
     },
     team::team_models::Team,
 };
 use common_database::PostgresReader;
-use common_metrics::inc;
 use common_redis::Client as RedisClient;
 use std::sync::Arc;
 
@@ -26,7 +22,7 @@ pub struct FlagService {
     redis_reader: Arc<dyn RedisClient + Send + Sync>,
     redis_writer: Arc<dyn RedisClient + Send + Sync>,
     pg_client: PostgresReader,
-    team_cache_ttl_seconds: u64,
+    team_token_cache: Arc<common_cache::ReadThroughCache>,
     flags_cache_ttl_seconds: u64,
 }
 
@@ -35,106 +31,30 @@ impl FlagService {
         redis_reader: Arc<dyn RedisClient + Send + Sync>,
         redis_writer: Arc<dyn RedisClient + Send + Sync>,
         pg_client: PostgresReader,
-        team_cache_ttl_seconds: u64,
+        team_token_cache: Arc<common_cache::ReadThroughCache>,
         flags_cache_ttl_seconds: u64,
     ) -> Self {
         Self {
             redis_reader,
             redis_writer,
             pg_client,
-            team_cache_ttl_seconds,
+            team_token_cache,
             flags_cache_ttl_seconds,
         }
     }
 
-    /// Verifies the Project API token against the cache or the database.
-    /// If the token is not found in the cache, it will be verified against the database,
-    /// and the result will be cached in redis.
-    pub async fn verify_token(&self, token: &str) -> Result<String, FlagError> {
-        let (result, cache_hit) = match Team::from_redis(self.redis_reader.clone(), token).await {
-            Ok(_) => (Ok(token.to_string()), true),
-            Err(_) => {
-                match Team::from_pg(self.pg_client.clone(), token).await {
-                    Ok(team) => {
-                        inc(DB_TEAM_READS_COUNTER, &[], 1);
-                        // Token found in PostgreSQL, update Redis cache so that we can verify it from Redis next time
-                        if let Err(e) = Team::update_redis_cache(
-                            self.redis_writer.clone(),
-                            &team,
-                            Some(self.team_cache_ttl_seconds),
-                        )
-                        .await
-                        {
-                            tracing::warn!("Failed to update Redis cache: {}", e);
-                            inc(
-                                TEAM_CACHE_ERRORS_COUNTER,
-                                &[("reason".to_string(), "redis_update_failed".to_string())],
-                                1,
-                            );
-                        }
-                        (Ok(token.to_string()), false)
-                    }
-                    Err(e) => {
-                        tracing::warn!("Token validation failed for token '{}': {:?}", token, e);
-                        inc(
-                            TOKEN_VALIDATION_ERRORS_COUNTER,
-                            &[("reason".to_string(), "token_not_found".to_string())],
-                            1,
-                        );
-                        (Err(FlagError::TokenValidationError), false)
-                    }
-                }
-            }
-        };
-
-        inc(
-            TEAM_CACHE_HIT_COUNTER,
-            &[("cache_hit".to_string(), cache_hit.to_string())],
-            1,
-        );
-
-        result
-    }
-
     /// Fetches the team from the cache or the database.
-    /// If the team is not found in the cache, it will be fetched from the database and stored in the cache.
+    /// If the team is not found in the cache, it will be fetched from the database and stored in the cache (only on true cache misses).
     /// Returns the team if found, otherwise an error.
+    ///
+    /// # Cache Write Behavior
+    /// Only writes to cache when the Redis error is TokenValidationError (NotFound).
+    /// Skips cache writes for Redis timeouts or unavailability to avoid overloading Redis.
     pub async fn get_team_from_cache_or_pg(&self, token: &str) -> Result<Team, FlagError> {
-        let (team_result, cache_hit) =
-            match Team::from_redis(self.redis_reader.clone(), token).await {
-                Ok(team) => (Ok(team), true),
-                Err(_) => match Team::from_pg(self.pg_client.clone(), token).await {
-                    Ok(team) => {
-                        inc(DB_TEAM_READS_COUNTER, &[], 1);
-                        // If we have the team in postgres, but not redis, update redis so we're faster next time
-                        if Team::update_redis_cache(
-                            self.redis_writer.clone(),
-                            &team,
-                            Some(self.team_cache_ttl_seconds),
-                        )
-                        .await
-                        .is_err()
-                        {
-                            inc(
-                                TEAM_CACHE_ERRORS_COUNTER,
-                                &[("reason".to_string(), "redis_update_failed".to_string())],
-                                1,
-                            );
-                        }
-                        (Ok(team), false)
-                    }
-                    // TODO what kind of error should we return here?
-                    Err(e) => (Err(e), false),
-                },
-            };
+        let (team, _cache_hit) =
+            team_get_or_load(self.team_token_cache.clone(), self.pg_client.clone(), token).await?;
 
-        inc(
-            TEAM_CACHE_HIT_COUNTER,
-            &[("cache_hit".to_string(), cache_hit.to_string())],
-            1,
-        );
-
-        team_result
+        Ok(team)
     }
 
     /// Fetches the flags from the cache or the database. Returns a tuple containing
@@ -144,52 +64,23 @@ impl FlagService {
         &self,
         project_id: i64,
     ) -> Result<FlagResult, FlagError> {
-        let flag_result = match FeatureFlagList::from_redis(self.redis_reader.clone(), project_id)
-            .await
-        {
-            Ok(flags_from_redis) => Ok(FlagResult {
-                flag_list: flags_from_redis,
-                was_cache_hit: true,
-                had_deserialization_errors: false,
-            }),
-            Err(_) => match FeatureFlagList::from_pg(self.pg_client.clone(), project_id).await {
-                Ok((flags_from_pg, had_deserialization_errors)) => {
-                    inc(DB_FLAG_READS_COUNTER, &[], 1);
-                    if (FeatureFlagList::update_flags_in_redis(
-                        self.redis_writer.clone(),
-                        project_id,
-                        &flags_from_pg,
-                        Some(self.flags_cache_ttl_seconds),
-                    )
-                    .await)
-                        .is_err()
-                    {
-                        inc(
-                            FLAG_CACHE_ERRORS_COUNTER,
-                            &[("reason".to_string(), "redis_update_failed".to_string())],
-                            1,
-                        );
-                    }
-                    Ok(FlagResult {
-                        flag_list: flags_from_pg,
-                        was_cache_hit: false,
-                        had_deserialization_errors,
-                    })
-                }
-                Err(database_error) => Err(database_error),
-            },
+        let (flag_list, was_cache_hit, had_deserialization_errors) = flags_get_or_load(
+            self.redis_reader.clone(),
+            self.redis_writer.clone(),
+            self.pg_client.clone(),
+            project_id,
+            Some(self.flags_cache_ttl_seconds),
+            None, // TODO: Add negative cache to prevent repeated DB queries for non-existent projects. Should be passed from State/router.
+        )
+        .await?;
+
+        let flag_result = FlagResult {
+            flag_list,
+            was_cache_hit,
+            had_deserialization_errors,
         };
 
-        // Track cache hits and misses
-        if let Ok(ref result) = flag_result {
-            inc(
-                FLAG_CACHE_HIT_COUNTER,
-                &[("cache_hit".to_string(), result.was_cache_hit.to_string())],
-                1,
-            );
-        }
-
-        flag_result
+        Ok(flag_result)
     }
 }
 
@@ -202,67 +93,49 @@ mod tests {
             FeatureFlag, FlagFilters, FlagPropertyGroup, TEAM_FLAGS_CACHE_PREFIX,
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
+        team::team_models::TEAM_TOKEN_CACHE_PREFIX,
         utils::test_utils::{
             insert_new_team_in_redis, setup_pg_reader_client, setup_redis_client, TestContext,
         },
     };
+    use common_cache::{CacheConfig, ReadThroughCache};
 
     use super::*;
 
-    #[tokio::test]
-    async fn test_verify_token() {
-        let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_redis(redis_client.clone())
-            .await
-            .expect("Failed to insert new team in Redis");
-
-        let flag_service = FlagService::new(
+    /// Helper function to create a team token cache for testing
+    fn create_team_token_cache(
+        redis_client: Arc<dyn RedisClient + Send + Sync>,
+        ttl_seconds: Option<u64>,
+    ) -> Arc<ReadThroughCache> {
+        let cache_config = CacheConfig::new("posthog:1:team_token:", ttl_seconds);
+        Arc::new(ReadThroughCache::new(
             redis_client.clone(),
             redis_client.clone(),
-            pg_client.clone(),
-            432000, // team_cache_ttl_seconds
-            432000, // flags_cache_ttl_seconds
-        );
-
-        // Test valid token in Redis
-        let result = flag_service.verify_token(&team.api_token).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), team.api_token);
-
-        // Test valid token in PostgreSQL (simulate Redis miss)
-        // First, remove the team from Redis
-        redis_client
-            .del(format!("team:{}", team.api_token))
-            .await
-            .expect("Failed to remove team from Redis");
-
-        let result = flag_service.verify_token(&team.api_token).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), team.api_token);
-
-        // Test invalid token
-        let result = flag_service.verify_token("invalid_token").await;
-        assert!(matches!(result, Err(FlagError::TokenValidationError)));
-
-        // Verify that the team was re-added to Redis after PostgreSQL hit
-        let redis_team = Team::from_redis(redis_client.clone(), &team.api_token).await;
-        assert!(redis_team.is_ok());
+            cache_config,
+            None, // no negative cache for tests
+        ))
     }
 
     #[tokio::test]
     async fn test_get_team_from_cache_or_pg() {
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
-        let team = insert_new_team_in_redis(redis_client.clone())
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
             .await
-            .expect("Failed to insert new team in Redis");
+            .expect("Failed to insert team in database");
 
+        // Also insert the team in Redis cache
+        Team::update_redis_cache(redis_client.clone(), &team, None)
+            .await
+            .expect("Failed to insert team in Redis cache");
+
+        let team_token_cache = create_team_token_cache(redis_client.clone(), Some(432000));
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
-            pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            context.non_persons_reader.clone(),
+            team_token_cache,
             432000, // flags_cache_ttl_seconds
         );
 
@@ -276,15 +149,16 @@ mod tests {
         // Test fetching from PostgreSQL (simulate Redis miss)
         // First, remove the team from Redis
         redis_client
-            .del(format!("team:{}", team.api_token))
+            .del(format!("{TEAM_TOKEN_CACHE_PREFIX}{}", team.api_token))
             .await
             .expect("Failed to remove team from Redis");
 
+        let team_token_cache = create_team_token_cache(redis_client.clone(), Some(432000));
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
-            pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            context.non_persons_reader.clone(),
+            team_token_cache,
             432000, // flags_cache_ttl_seconds
         );
 
@@ -404,11 +278,12 @@ mod tests {
         .await
         .expect("Failed to insert mock flags in Redis");
 
+        let team_token_cache = create_team_token_cache(redis_client.clone(), Some(432000));
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            team_token_cache,
             432000, // flags_cache_ttl_seconds
         );
 
@@ -506,11 +381,12 @@ mod tests {
         let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
         let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
 
+        let team_token_cache = create_team_token_cache(reader.clone(), Some(432000));
         let flag_service = FlagService::new(
             reader,
             writer,
             context.non_persons_reader.clone(),
-            432000, // team_cache_ttl_seconds
+            team_token_cache,
             432000, // flags_cache_ttl_seconds
         );
 
@@ -554,11 +430,12 @@ mod tests {
         let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
         let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
 
+        let team_token_cache = create_team_token_cache(reader.clone(), Some(432000));
         let flag_service = FlagService::new(
             reader,
             writer,
             context.non_persons_reader.clone(),
-            432000, // team_cache_ttl_seconds
+            team_token_cache,
             432000, // flags_cache_ttl_seconds
         );
 
@@ -579,65 +456,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_config_ttl_values_are_used() {
-        use common_redis::{CustomRedisError, MockRedisClient, MockRedisValue};
-
-        let context = TestContext::new(None).await;
-        let team = context
-            .insert_new_team(None)
-            .await
-            .expect("Failed to insert team");
-
-        // Set up mock redis_reader to return NotFound (cache miss)
-        let mut mock_reader = MockRedisClient::new();
-        mock_reader.get_ret(&team.api_token, Err(CustomRedisError::NotFound));
-
-        // Set up mock redis_writer to track setex calls
-        let mock_writer = MockRedisClient::new();
-
-        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
-        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
-
-        // Test with custom TTL values (different from default 432000)
-        let custom_team_ttl = 7200u64; // 2 hours
-        let custom_flags_ttl = 1800u64; // 30 minutes
-
-        let flag_service = FlagService::new(
-            reader,
-            writer,
-            context.non_persons_reader.clone(),
-            custom_team_ttl,
-            custom_flags_ttl,
-        );
-
-        // Trigger team cache operation
-        let _result = flag_service
-            .get_team_from_cache_or_pg(&team.api_token)
-            .await;
-
-        // Verify setex was called with the custom team TTL
-        let writer_calls = mock_writer.get_calls();
-        let setex_calls: Vec<_> = writer_calls
-            .iter()
-            .filter(|call| call.op == "setex")
-            .collect();
-
-        assert!(!setex_calls.is_empty(), "Expected setex to be called");
-
-        // Verify the TTL value used matches our custom config
-        let team_setex_call = setex_calls
-            .iter()
-            .find(|call| call.key.contains(&team.api_token))
-            .expect("Expected setex call for team token");
-
-        if let MockRedisValue::StringWithTTL(_, ttl) = &team_setex_call.value {
-            assert_eq!(
-                *ttl, custom_team_ttl,
-                "Expected team cache TTL to be {custom_team_ttl} but got {ttl}",
-            );
-        } else {
-            panic!("Expected setex call to have TTL value");
-        }
-    }
+    // Note: The test_config_ttl_values_are_used test was removed because
+    // it tested implementation details that changed when we moved cache creation
+    // outside of FlagService. TTL values are now configured when creating the
+    // ReadThroughCache instances in State.
 }

--- a/rust/feature-flags/src/flags/flags_cache.rs
+++ b/rust/feature-flags/src/flags/flags_cache.rs
@@ -1,0 +1,119 @@
+use crate::api::errors::FlagError;
+use crate::flags::cache_metrics::track_cache_metrics;
+use crate::flags::flag_models::{FeatureFlag, FeatureFlagList};
+use crate::metrics::consts::{
+    DB_FLAG_READS_COUNTER, FLAG_CACHE_ERRORS_COUNTER, FLAG_CACHE_HIT_COUNTER,
+};
+use common_cache::{CacheConfig, CacheResult, NegativeCache, ReadThroughCache};
+use common_database::PostgresReader;
+use common_redis::Client as RedisClient;
+use std::sync::Arc;
+
+// Prefix for team flags cache keys in Redis
+const TEAM_FLAGS_CACHE_PREFIX: &str = "posthog:1:team_feature_flags_";
+
+/// Flags-specific get-or-load helper
+pub async fn flags_get_or_load(
+    redis_reader: Arc<dyn RedisClient + Send + Sync>,
+    redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    pg_client: PostgresReader,
+    project_id: i64,
+    ttl_seconds: Option<u64>,
+    negative_cache: Option<Arc<NegativeCache>>,
+) -> Result<(FeatureFlagList, bool, bool), FlagError> {
+    let cache_config = CacheConfig::new(TEAM_FLAGS_CACHE_PREFIX, ttl_seconds);
+
+    let cache = ReadThroughCache::new(redis_reader, redis_writer, cache_config, negative_cache);
+
+    // We cache Vec<FeatureFlag> to maintain compatibility with update_flags_in_redis
+    // which serializes just the Vec, not the whole FeatureFlagList struct
+    let result: CacheResult<Vec<FeatureFlag>> = cache
+        .get_or_load(&project_id, |project_id| {
+            let project_id = *project_id;
+            async move {
+                // FeatureFlagList::from_pg returns (FeatureFlagList, bool)
+                // We only cache the Vec, not the deserialization errors indicator
+                match FeatureFlagList::from_pg(pg_client.clone(), project_id).await {
+                    Ok((flags, _had_errors)) => Ok(Some(flags.flags)),
+                    Err(FlagError::RowNotFound) => Ok(None), // Not found = negative cache
+                    Err(e) => Err(e),                        // Other errors propagate
+                }
+            }
+        })
+        .await?;
+
+    // Track metrics based on source
+    track_cache_metrics(
+        result.source,
+        FLAG_CACHE_HIT_COUNTER,
+        DB_FLAG_READS_COUNTER,
+        FLAG_CACHE_ERRORS_COUNTER,
+    );
+
+    // Extract value or return error if not found
+    let was_cached = result.was_cached();
+    match result.value {
+        Some(flags_vec) => {
+            // Wrap the Vec in FeatureFlagList
+            let flags = FeatureFlagList { flags: flags_vec };
+            // When loaded from cache, we don't have deserialization error info
+            // This is acceptable as errors only occur during DB load
+            let had_deserialization_errors = false;
+            Ok((flags, was_cached, had_deserialization_errors))
+        }
+        None => Err(FlagError::RowNotFound),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::TestContext;
+    use common_redis::MockRedisClient;
+
+    #[tokio::test]
+    async fn test_flags_cache_basic_functionality() {
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        // Create negative cache for testing
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+
+        // Set up mock redis_reader to return NotFound (cache miss)
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(
+            &format!("{}{}", TEAM_FLAGS_CACHE_PREFIX, team.project_id),
+            Err(common_redis::CustomRedisError::NotFound),
+        );
+
+        // Set up mock redis_writer to succeed
+        let mut mock_writer = MockRedisClient::new();
+        mock_writer.set_ret(
+            &format!("{}{}", TEAM_FLAGS_CACHE_PREFIX, team.project_id),
+            Ok(()),
+        );
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        // Call flags_get_or_load
+        let result = flags_get_or_load(
+            reader,
+            writer,
+            context.non_persons_reader.clone(),
+            team.project_id,
+            None,
+            Some(negative_cache.clone()),
+        )
+        .await;
+
+        // Should succeed and return flags
+        assert!(result.is_ok());
+        let (_flags, was_cache_hit, _had_deserialization_errors) = result.unwrap();
+        assert!(!was_cache_hit); // First call should be a cache miss
+                                 // The flags list might be empty for a new team, but that's valid
+    }
+}

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache_metrics;
 pub mod feature_flag_list;
 pub mod flag_analytics;
 pub mod flag_filters;
@@ -10,7 +11,9 @@ pub mod flag_operations;
 pub mod flag_property_group;
 pub mod flag_request;
 pub mod flag_service;
+pub mod flags_cache;
 pub mod property_filter;
+pub mod team_cache;
 
 #[cfg(test)]
 mod test_flag_matching;

--- a/rust/feature-flags/src/flags/team_cache.rs
+++ b/rust/feature-flags/src/flags/team_cache.rs
@@ -1,0 +1,135 @@
+use crate::api::errors::FlagError;
+use crate::flags::cache_metrics::track_cache_metrics;
+use crate::metrics::consts::{
+    DB_TEAM_READS_COUNTER, TEAM_CACHE_ERRORS_COUNTER, TEAM_CACHE_HIT_COUNTER,
+};
+use crate::team::team_models::Team;
+use common_cache::{CacheResult, ReadThroughCache};
+use common_database::PostgresReader;
+use std::sync::Arc;
+
+/// Team-specific get-or-load helper
+pub async fn team_get_or_load(
+    cache: Arc<ReadThroughCache>,
+    pg_client: PostgresReader,
+    token: &str,
+) -> Result<(Team, bool), FlagError> {
+    let result: CacheResult<Team> = cache
+        .get_or_load(&token.to_string(), |token| {
+            let token = token.clone();
+            async move {
+                match Team::from_pg(pg_client.clone(), &token).await {
+                    Ok(team) => Ok(Some(team)),
+                    Err(FlagError::RowNotFound) => Ok(None), // Not found = negative cache
+                    Err(e) => Err(e),                        // Other errors propagate
+                }
+            }
+        })
+        .await?;
+
+    // Track metrics based on source
+    track_cache_metrics(
+        result.source,
+        TEAM_CACHE_HIT_COUNTER,
+        DB_TEAM_READS_COUNTER,
+        TEAM_CACHE_ERRORS_COUNTER,
+    );
+
+    // Extract value or return error if not found
+    let was_cached = result.was_cached();
+    match result.value {
+        Some(team) => Ok((team, was_cached)),
+        None => Err(FlagError::RowNotFound),
+    }
+}
+
+/// Secret token get-or-load helper
+///
+/// Loads teams by their secret API token (used for authentication endpoints).
+/// Uses a separate cache namespace from regular API tokens.
+pub async fn secret_token_get_or_load(
+    cache: Arc<ReadThroughCache>,
+    pg_client: PostgresReader,
+    secret_token: &str,
+) -> Result<(Team, bool), FlagError> {
+    let result: CacheResult<Team> = cache
+        .get_or_load(&secret_token.to_string(), |secret_token| {
+            let secret_token = secret_token.clone();
+            async move {
+                match Team::from_pg_by_secret_token(pg_client.clone(), &secret_token).await {
+                    Ok(team) => Ok(Some(team)),
+                    Err(FlagError::RowNotFound) => Ok(None), // Not found = negative cache
+                    Err(e) => Err(e),                        // Other errors propagate
+                }
+            }
+        })
+        .await?;
+
+    // Track metrics based on source
+    track_cache_metrics(
+        result.source,
+        TEAM_CACHE_HIT_COUNTER,
+        DB_TEAM_READS_COUNTER,
+        TEAM_CACHE_ERRORS_COUNTER,
+    );
+
+    // Extract value or return error if not found
+    let was_cached = result.was_cached();
+    match result.value {
+        Some(team) => Ok((team, was_cached)),
+        None => Err(FlagError::TokenValidationError),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::TestContext;
+    use common_cache::{CacheConfig, NegativeCache};
+    use common_redis::{Client as RedisClient, MockRedisClient};
+
+    #[tokio::test]
+    async fn test_team_cache_basic_functionality() {
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        // Create negative cache for testing
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+
+        // Set up mock redis_reader to return NotFound (cache miss)
+        let mut mock_reader = MockRedisClient::new();
+        mock_reader.get_ret(
+            &format!("posthog:1:team_token:{}", team.api_token),
+            Err(common_redis::CustomRedisError::NotFound),
+        );
+
+        // Set up mock redis_writer to succeed
+        let mut mock_writer = MockRedisClient::new();
+        mock_writer.set_ret(&format!("posthog:1:team_token:{}", team.api_token), Ok(()));
+
+        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
+        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+
+        // Create cache
+        let cache_config = CacheConfig::new("posthog:1:team_token:", None);
+        let cache = Arc::new(ReadThroughCache::new(
+            reader,
+            writer,
+            cache_config,
+            Some(negative_cache.clone()),
+        ));
+
+        // Call team_get_or_load
+        let result =
+            team_get_or_load(cache, context.non_persons_reader.clone(), &team.api_token).await;
+
+        // Should succeed and return the team
+        assert!(result.is_ok());
+        let (returned_team, was_cache_hit) = result.unwrap();
+        assert_eq!(returned_team.id, team.id);
+        assert!(!was_cache_hit); // First call should be a cache miss
+    }
+}

--- a/rust/feature-flags/src/handler/authentication.rs
+++ b/rust/feature-flags/src/handler/authentication.rs
@@ -1,17 +1,30 @@
 use crate::{
     api::errors::FlagError,
     flags::{flag_request::FlagRequest, flag_service::FlagService},
+    team::team_models::Team,
 };
+use tracing::debug;
 
 use super::{decoding, types::RequestContext};
 
 pub async fn parse_and_authenticate(
     context: &RequestContext,
     flag_service: &FlagService,
-) -> Result<(Option<String>, String, FlagRequest), FlagError> {
+) -> Result<(Option<String>, Team, FlagRequest), FlagError> {
     let request = decoding::decode_request(&context.headers, context.body.clone(), &context.meta)?;
     let token = request.extract_token()?;
-    let verified_token = flag_service.verify_token(&token).await?;
+
+    // Fetch the team (with caching) and validate the token exists
+    let team = flag_service
+        .get_team_from_cache_or_pg(&token)
+        .await
+        .map_err(|e| match e {
+            FlagError::RowNotFound => {
+                debug!(token = %token, "Token not found in database during authentication");
+                FlagError::TokenValidationError
+            }
+            other => other,
+        })?;
 
     // Only validate distinct_id if flags are NOT disabled
     let distinct_id = if request.is_flags_disabled() {
@@ -20,5 +33,5 @@ pub async fn parse_and_authenticate(
         Some(request.extract_distinct_id()?)
     };
 
-    Ok((distinct_id, verified_token, request))
+    Ok((distinct_id, team, request))
 }


### PR DESCRIPTION
## Problem

When Redis is under load, it can start to error out with `TimeoutError` or `Other` (Network errors, etc). Currently, we treat these as a cache miss and try to write to the cache while Redis is under load, potentially contributing to the load.
When we get those errors, we don't want to treat them exactly the same as a cache miss. We should not attempt a write.

However, `NotFound` and `ParseError` errors indicate that the data is not there or that we can't parse it. So we should treat those errors as cache misses. On a cache miss, we query the db and then write the result to the cache. In the case of a `ParseError`, we still want to log the error and increment an error counter so we can investigate the source of the `ParseError`.

In a recent outage, we learned that we were getting a LOT of `ParseError`s because of a lot of "zombie" cache entries for teams that no longer exist. These cache entries have no `TTL` (_the `/flags` service writes to the cache without a TTL [addressed in this PR](https://github.com/PostHog/posthog/pull/40608)_) and are missing a property our `Team` type expects (`project_id`). 

When we have a cache miss AND the entry doesn't exist in the database, we don't evict the entry from the cache. This means these zombie cache entries never get cleaned up. Also, when a team doesn't exist, the request always hits the database because we don't have a negative cache entry.

## Changes

* Refactored cache strategy into new `common-cache` library that separates cache infrastructure from application observability
* Added `CacheSource` enum with 8 distinct cases for detailed observability:
  - *Value found:* `PositiveCache`, `DatabaseCacheMiss`, `DatabaseCacheCorrupted`, `DatabaseRedisUnavailable`
  - *Not found:* `NegativeCache`, `DatabaseNotFoundCacheMiss`, `DatabaseNotFoundCacheCorrupted`, `DatabaseNotFoundRedisUnavailable`
* Added `CacheResult<V>` struct with helper methods for easy metrics tracking by callers
* When we receive a `ParseError`, we log it, but treat it as a cache miss so we can replace the corrupted data with good data from the database
* When we have a cache miss (`ParseError` or `NotFound`) and the database returns nothing, we add the key to an in-memory negative cache (using `Moka` which we use elsewhere) with `TTL` and `LRU` eviction. This prevents repeated database queries for non-existent keys without risking Redis-based cache poisoning.
* In the case of a `ParseError` and we query the database and get a result, we'll cache that result in Redis
* In the case of a `ParseError` and we have a database timeout, we skip the cache write to avoid adding load to Redis
* Cache now provides rich result types allowing callers to implement their own observability strategy
* When Redis is unavailable (timeout, network errors), the cache doesn't write to Redis to avoid contributing to the load

## How did you test this code?

__Unit Tests__
* `cargo test -p common-cache`
* `cargo test -p feature-flags`

__Manual Tests__

1. **Verify cache behavior under Redis load:**
   - Start the feature-flags service locally
   - Make requests with valid tokens → should cache in Redis
   - Simulate Redis timeout (or disconnect Redis): `brew services stop redis`
   - Make requests → should fallback to database without writing to cache
   - Verify logs show `Redis infrastructure issue` warnings
   - Restart Redis: `brew services start redis`

2. **Verify negative cache behavior:**
   - Make requests with invalid tokens
   - First request should hit database (cache miss)
   - Subsequent requests with same invalid token should hit negative cache (no DB query)
   - Verify metrics show `result_type=negative` for cache hits

3. **Verify parse error handling:**
   - Manually corrupt a Redis cache entry: `redis-cli SET "posthog:1:team_feature_flags_123" "invalid json"`
   - Make request for that team
   - Should log parse error warning, fetch from DB, and replace corrupted entry
   - Verify metrics show `result_type=positive` but with cache corruption tracking

## Changelog: (features only) Is this feature complete?

n/a