### PR TITLE
refactor: remove ts normalization from node

### DIFF
--- a/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
+++ b/plugin-server/src/worker/ingestion/timestamp-comparison.test.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 
-import { EventHeaders } from '../../types'
+import type { EventHeaders } from '../../types'
 import { logger } from '../../utils/logger'
 import { compareTimestamps } from './timestamp-comparison'
 

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -1,116 +1,58 @@
-import { DateTime, Duration } from 'luxon'
+import { DateTime } from 'luxon'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { logger } from '../../utils/logger'
-import { captureException } from '../../utils/posthog'
-
 type IngestionWarningCallback = (type: string, details: Record<string, any>) => void
 
-const FutureEventHoursCutoffMillis = 23 * 3600 * 1000 // 23 hours
-
+/**
+ * Parse event timestamp from plugin-server event data.
+ *
+ * NOTE: Timestamp normalization (clock skew adjustment, future event clamping, offset handling)
+ * is now handled in the Rust capture service. This function only parses the timestamp string
+ * that comes from the event data. The timestamp in event data is already normalized by the Rust
+ * capture service (via parse_event_timestamp in rust/common/types/src/timestamp.rs).
+ *
+ * The Rust capture service handles:
+ * - Clock skew adjustment using sent_at and now
+ * - Future event clamping (to now if >23 hours in future)
+ * - Out-of-bounds validation (year < 0 or > 9999, fallback to epoch)
+ * - Offset handling
+ *
+ * This function only needs to parse the string to a DateTime object.
+ */
 export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarningCallback): DateTime {
-    const now = DateTime.fromISO(data['now']).toUTC() // now is set by the capture endpoint and assumed valid
+    // The timestamp has already been normalized by the Rust capture service
+    // Just parse it from the data
+    if (data['timestamp']) {
+        const parsedTs = parseDate(data['timestamp'])
 
-    let sentAt: DateTime | null = null
-    if (!data.properties?.['$ignore_sent_at'] && data['sent_at']) {
-        sentAt = DateTime.fromISO(data['sent_at']).toUTC()
-        if (!sentAt.isValid) {
+        if (!parsedTs.isValid) {
             callback?.('ignored_invalid_timestamp', {
                 eventUuid: data['uuid'] ?? '',
-                field: 'sent_at',
-                value: data['sent_at'],
-                reason: sentAt.invalidExplanation || 'unknown error',
+                field: 'timestamp',
+                value: data['timestamp'],
+                reason: parsedTs.invalidExplanation || 'unknown error',
             })
-            sentAt = null
-        }
-    }
-
-    let parsedTs = handleTimestamp(data, now, sentAt, data.team_id)
-
-    // Events in the future would indicate an instrumentation bug, lets' ingest them
-    // but publish an integration warning to help diagnose such issues.
-    // We will also 'fix' the date to be now()
-    const nowDiff = parsedTs.toUTC().diff(now).toMillis()
-    if (nowDiff > FutureEventHoursCutoffMillis) {
-        callback?.('event_timestamp_in_future', {
-            timestamp: data['timestamp'] ?? '',
-            sentAt: data['sent_at'] ?? '',
-            offset: data['offset'] ?? '',
-            now: data['now'],
-            result: parsedTs.toISO(),
-            eventUuid: data['uuid'],
-            eventName: data['event'],
-        })
-
-        parsedTs = now
-    }
-
-    const parsedTsOutOfBounds = parsedTs.year < 0 || parsedTs.year > 9999
-    if (!parsedTs.isValid || parsedTsOutOfBounds) {
-        const details: Record<string, any> = {
-            eventUuid: data['uuid'] ?? '',
-            field: 'timestamp',
-            value: data['timestamp'] ?? '',
-            reason: parsedTs.invalidExplanation || (parsedTsOutOfBounds ? 'out of bounds' : 'unknown error'),
+            return DateTime.utc()
         }
 
+        const parsedTsOutOfBounds = parsedTs.year < 0 || parsedTs.year > 9999
         if (parsedTsOutOfBounds) {
-            details['offset'] = data['offset']
-            details['parsed_year'] = parsedTs.year
-        }
-
-        callback?.('ignored_invalid_timestamp', details)
-        return DateTime.utc()
-    }
-
-    return parsedTs
-}
-
-function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | null, teamId: number): DateTime {
-    let parsedTs: DateTime = now
-    let timestamp: DateTime = now
-
-    if (data['timestamp']) {
-        timestamp = parseDate(data['timestamp'])
-
-        if (!sentAt || !timestamp.isValid) {
-            return timestamp
-        }
-
-        // To handle clock skew between the client and server, we attempt
-        // to compute the skew based on the difference between the
-        // client-generated `sent_at` and the server-generated `now`
-        // filled by the capture endpoint.
-        //
-        // We calculate the skew as:
-        //
-        //      skew = sent_at - now
-        //
-        // And adjust the timestamp accordingly.
-
-        // sent_at - timestamp == now - x
-        // x = now + (timestamp - sent_at)
-        try {
-            // timestamp and sent_at must both be in the same format: either both with or both without timezones
-            // otherwise we can't get a diff to add to now
-            parsedTs = now.plus(timestamp.diff(sentAt))
-        } catch (error) {
-            logger.error('⚠️', 'Error when handling timestamp:', { error: error.message })
-            captureException(error, {
-                tags: { team_id: teamId },
-                extra: { data, now, sentAt },
+            callback?.('ignored_invalid_timestamp', {
+                eventUuid: data['uuid'] ?? '',
+                field: 'timestamp',
+                value: data['timestamp'],
+                reason: 'out of bounds',
+                parsed_year: parsedTs.year,
             })
-
-            return timestamp
+            return DateTime.utc()
         }
+
+        return parsedTs
     }
 
-    if (data['offset']) {
-        parsedTs = now.minus(Duration.fromMillis(data['offset']))
-    }
-
-    return parsedTs
+    // Fallback to current time if no timestamp provided
+    return DateTime.utc()
 }
 
 export function parseDate(supposedIsoString: string): DateTime {

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -42,26 +42,11 @@ describe('parseEventTimestamp()', () => {
         jest.useRealTimers()
     })
 
-    it('captures sent_at to adjusts timestamp', () => {
+    it('parses a valid timestamp', () => {
+        // Timestamp normalization is now done in Rust capture service
+        // This test verifies we correctly parse the already-normalized timestamp
         const event = {
             timestamp: '2021-10-30T03:02:00.000Z',
-            sent_at: '2021-10-30T03:12:00.000Z',
-            now: '2021-10-29T01:44:00.000Z',
-        } as any as PluginEvent
-
-        const callbackMock = jest.fn()
-        const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls.length).toEqual(0)
-
-        expect(timestamp.toISO()).toEqual('2021-10-29T01:34:00.000Z')
-    })
-
-    it('Ignores sent_at if $ignore_sent_at set', () => {
-        const event = {
-            properties: { $ignore_sent_at: true },
-            timestamp: '2021-10-30T03:02:00.000Z',
-            sent_at: '2021-10-30T03:12:00.000Z',
-            now: '2021-11-29T01:44:00.000Z',
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
@@ -71,91 +56,24 @@ describe('parseEventTimestamp()', () => {
         expect(timestamp.toISO()).toEqual('2021-10-30T03:02:00.000Z')
     })
 
-    it('ignores and reports invalid sent_at', () => {
-        const event = {
-            timestamp: '2021-10-31T00:44:00.000Z',
-            sent_at: 'invalid',
-            now: '2021-10-30T01:44:00.000Z',
-            uuid: new UUIDT(),
-        } as any as PluginEvent
-
-        const callbackMock = jest.fn()
-        const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls).toEqual([
-            [
-                'ignored_invalid_timestamp',
-                {
-                    field: 'sent_at',
-                    reason: 'the input "invalid" can\'t be parsed as ISO 8601',
-                    value: 'invalid',
-                    eventUuid: event.uuid,
-                },
-            ],
-        ])
-
-        expect(timestamp.toISO()).toEqual('2021-10-31T00:44:00.000Z')
-    })
-
-    it('captures sent_at with timezone info', () => {
+    it('parses timestamp with timezone info', () => {
         const event = {
             timestamp: '2021-10-30T03:02:00.000+04:00',
-            sent_at: '2021-10-30T03:12:00.000+04:00',
-            now: '2021-10-29T01:44:00.000Z',
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
         const timestamp = parseEventTimestamp(event, callbackMock)
         expect(callbackMock.mock.calls.length).toEqual(0)
 
-        expect(timestamp.toISO()).toEqual('2021-10-29T01:34:00.000Z')
+        // Should be converted to UTC
+        expect(timestamp.toISO()).toEqual('2021-10-29T23:02:00.000Z')
     })
 
-    it('captures timestamp with no sent_at', () => {
+    it('handles out of bounds timestamps', () => {
+        // Even though Rust normalizes, we still validate for safety
+        // Year 10000 is out of bounds (> 9999) - luxon can't parse it
         const event = {
-            timestamp: '2021-10-30T03:02:00.000Z',
-            now: '2021-10-30T01:44:00.000Z',
-        } as any as PluginEvent
-
-        const callbackMock = jest.fn()
-        const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls.length).toEqual(0)
-
-        expect(timestamp.toISO()).toEqual(event.timestamp)
-    })
-
-    it('captures with time offset and ignores sent_at', () => {
-        const event = {
-            offset: 6000, // 6 seconds
-            now: '2021-10-29T01:44:00.000Z',
-            sent_at: '2021-10-30T03:12:00.000+04:00', // ignored
-        } as any as PluginEvent
-
-        const callbackMock = jest.fn()
-        const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls.length).toEqual(0)
-
-        expect(timestamp.toUTC().toISO()).toEqual('2021-10-29T01:43:54.000Z')
-    })
-
-    it('captures with time offset', () => {
-        const event = {
-            offset: 6000, // 6 seconds
-            now: '2021-10-29T01:44:00.000Z',
-        } as any as PluginEvent
-
-        const callbackMock = jest.fn()
-        const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls.length).toEqual(0)
-
-        expect(timestamp.toUTC().toISO()).toEqual('2021-10-29T01:43:54.000Z')
-    })
-
-    it('timestamps adjusted way out of bounds are ignored', () => {
-        const event = {
-            offset: 600000000000000,
-            timestamp: '2021-10-28T01:00:00.000Z',
-            sent_at: '2021-10-28T01:05:00.000Z',
-            now: '2021-10-28T01:10:00.000Z',
+            timestamp: '10000-01-01T00:00:00.000Z',
             uuid: new UUIDT(),
         } as any as PluginEvent
 
@@ -167,14 +85,13 @@ describe('parseEventTimestamp()', () => {
                 {
                     field: 'timestamp',
                     eventUuid: event.uuid,
-                    offset: 600000000000000,
-                    parsed_year: -16992,
-                    reason: 'out of bounds',
-                    value: '2021-10-28T01:00:00.000Z',
+                    reason: 'the input "10000-01-01T00:00:00.000Z" can\'t be parsed as ISO 8601',
+                    value: '10000-01-01T00:00:00.000Z',
                 },
             ],
         ])
 
+        // Falls back to current time
         expect(timestamp.toUTC().toISO()).toEqual('2020-08-12T01:02:00.000Z')
     })
 
@@ -182,7 +99,6 @@ describe('parseEventTimestamp()', () => {
         const event = {
             team_id: 123,
             timestamp: 'notISO',
-            now: '2020-01-01T12:00:05.200Z',
             uuid: new UUIDT(),
         } as any as PluginEvent
 
@@ -203,89 +119,17 @@ describe('parseEventTimestamp()', () => {
         expect(timestamp.toUTC().toISO()).toEqual('2020-08-12T01:02:00.000Z')
     })
 
-    it('reports event_timestamp_in_future with sent_at', () => {
+    it('returns current time when no timestamp provided', () => {
         const event = {
-            timestamp: '2021-10-29T02:30:00.000Z',
-            sent_at: '2021-10-28T01:00:00.000Z',
-            now: '2021-10-29T01:00:00.000Z',
-            event: 'test event name',
-            uuid: '12345678-1234-1234-1234-123456789abc',
+            uuid: new UUIDT(),
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
         const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls).toEqual([
-            [
-                'event_timestamp_in_future',
-                {
-                    now: '2021-10-29T01:00:00.000Z',
-                    offset: '',
-                    result: '2021-10-30T02:30:00.000Z',
-                    sentAt: '2021-10-28T01:00:00.000Z',
-                    timestamp: '2021-10-29T02:30:00.000Z',
-                    eventUuid: '12345678-1234-1234-1234-123456789abc',
-                    eventName: 'test event name',
-                },
-            ],
-        ])
+        expect(callbackMock.mock.calls.length).toEqual(0)
 
-        expect(timestamp.toISO()).toEqual('2021-10-29T01:00:00.000Z')
-    })
-
-    it('reports event_timestamp_in_future with $ignore_sent_at', () => {
-        const event = {
-            timestamp: '2021-10-29T02:30:00.000Z',
-            now: '2021-09-29T01:00:00.000Z',
-            event: 'test event name',
-            uuid: '12345678-1234-1234-1234-123456789abc',
-        } as any as PluginEvent
-
-        const callbackMock = jest.fn()
-        const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls).toEqual([
-            [
-                'event_timestamp_in_future',
-                {
-                    now: '2021-09-29T01:00:00.000Z',
-                    offset: '',
-                    result: '2021-10-29T02:30:00.000Z',
-                    sentAt: '',
-                    timestamp: '2021-10-29T02:30:00.000Z',
-                    eventUuid: '12345678-1234-1234-1234-123456789abc',
-                    eventName: 'test event name',
-                },
-            ],
-        ])
-        expect(timestamp.toISO()).toEqual('2021-09-29T01:00:00.000Z')
-    })
-
-    it('reports event_timestamp_in_future with negative offset', () => {
-        const event = {
-            offset: -82860000,
-            now: '2021-10-29T01:00:00.000Z',
-            event: 'test event name',
-            uuid: '12345678-1234-1234-1234-123456789abc',
-        } as any as PluginEvent
-
-        const callbackMock = jest.fn()
-        const timestamp = parseEventTimestamp(event, callbackMock)
-
-        expect(callbackMock.mock.calls).toEqual([
-            [
-                'event_timestamp_in_future',
-                {
-                    now: '2021-10-29T01:00:00.000Z',
-                    offset: -82860000,
-                    result: '2021-10-30T00:01:00.000Z',
-                    sentAt: '',
-                    timestamp: '',
-                    eventUuid: '12345678-1234-1234-1234-123456789abc',
-                    eventName: 'test event name',
-                },
-            ],
-        ])
-
-        expect(timestamp.toISO()).toEqual('2021-10-29T01:00:00.000Z')
+        // Should return current UTC time
+        expect(timestamp.toUTC().toISO()).toEqual('2020-08-12T01:02:00.000Z')
     })
 })
 


### PR DESCRIPTION
## Problem

After deploying https://github.com/PostHog/posthog/pull/40668 we're applying timestamp normalization twice.

## Changes

- Removes timestamp normalization from plugin-server, as it's now done in capture
- Fixes the timestamps test in non-UTC timezones

## How did you test this code?

- Updated the tests
