### PR TITLE
fix(persons): show display name on person profile view

### DIFF
--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -40,6 +40,7 @@ import { MergeSplitPerson } from './MergeSplitPerson'
 import { PersonCohorts } from './PersonCohorts'
 import PersonFeedCanvas from './PersonFeedCanvas'
 import { RelatedFeatureFlags } from './RelatedFeatureFlags'
+import { asDisplay } from './person-utils'
 import { PersonsLogicProps, personsLogic } from './personsLogic'
 
 export const scene: SceneExport<PersonsLogicProps> = {
@@ -139,7 +140,7 @@ export function PersonScene(): JSX.Element | null {
     return (
         <SceneContent>
             <SceneTitleSection
-                name="Person"
+                name={asDisplay(person)}
                 resourceType={{
                     type: sceneConfigurations[Scene.Person].iconType || 'default_icon_type',
                 }}


### PR DESCRIPTION
## Problem

Display name not appearing correctly on person profiles. Always show "Person".
https://posthog.slack.com/archives/C0862M4NJHG/p1761856007007509

## Changes

<img width="589" height="118" alt="Screenshot 2025-10-31 at 12 29 49" src="https://github.com/user-attachments/assets/df099b6b-8198-43dd-a662-b057bf9e2c29" />

<img width="704" height="125" alt="Screenshot 2025-10-31 at 12 30 03" src="https://github.com/user-attachments/assets/df4921be-1230-4ef4-a838-0e55ff6fc89b" />

## How did you test this code?

 Manually