### PR TITLE
chore(plugin-server): Install jemalloc in prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -226,6 +226,7 @@ RUN apt-get update && \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
     "libssl-dev=3.0.17-1~deb12u2" \
     "libssl3=3.0.17-1~deb12u2" \
+    "libjemalloc2" \
     && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The plugin-server service shows consistent RSS memory growth over time despite having a stable workload and low Node heap usage. Investigation confirmed that the growth originates from native allocations (very likely to be primarily in librdkafka) retained by glibc’s default allocator. Over time it seems that pages are not being returned to the OS, causing inflated memory usage and slower workloads.

## Changes

- Add `libjemalloc` to installed libraries in the production image to test this allocator

This shouldn't impact any other workload as the allocator needs to be explicitly set