### PR TITLE
feat(experiments): enable create experiments testing.

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -23,7 +23,7 @@ export const scene: SceneExport<ExperimentLogicProps> = {
 export function Experiment(): JSX.Element {
     const { formMode, experimentMissing, experimentId } = useValues(experimentLogic)
     const { currentTeamId } = useValues(teamLogic)
-    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM')
+    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM', 'test')
 
     useFileSystemLogView({
         type: 'experiment',

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -222,7 +222,7 @@ export function ExperimentView(): JSX.Element {
      * We show the create form if the experiment is draft + has no primary metrics. Otherwise,
      * we show the experiment view.
      */
-    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM')
+    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM', 'test')
     const allPrimaryMetrics = [
         ...(experiment.metrics || []),
         ...(experiment.saved_metrics || []).filter((sm) => sm.metadata.type === 'primary'),


### PR DESCRIPTION
## Problem

The create experiment form is governed by a boolean flag, and we need to change it to run an experiment.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Update the feature flag evaluation to check for the `test` variant. While the flag is set up a boolean, it should return `false` for everyone.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?


![cat-type-small](https://github.com/user-attachments/assets/3c01bbf9-426f-49d5-9f74-e7b1a0d26141)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
