### PR TITLE
feat(migration-analyzer): flag DROP CONSTRAINT for deployment safety review

### DIFF
--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -438,9 +438,23 @@ class RunSQLAnalyzer(OperationAnalyzer):
                 )
             return OperationRisk(
                 type=self.operation_type,
-                score=1,
-                reason="DROP CONSTRAINT is fast (just removes metadata)",
+                score=2,
+                reason="DROP CONSTRAINT is fast but needs deployment safety review",
                 details={"sql": sql},
+                guidance=f"""⚠️ **Deployment Safety:** While `DROP CONSTRAINT` is instant (no table lock), dropping constraints can break running code during rolling deployments.
+
+**Safe pattern:**
+1. Ensure no running code relies on the constraint (uniqueness checks, foreign key validation, etc.)
+2. If replacing with a new constraint, deploy the new one first
+3. Wait at least one full deployment cycle before dropping the old constraint
+4. Consider keeping unused constraints if removal risk outweighs benefits
+
+**Common scenarios:**
+- Dropping UNIQUE constraints: Ensure code handles potential duplicates
+- Dropping FOREIGN KEY constraints: Ensure code doesn't assume referential integrity
+- Replacing constraints: Add new → deploy → wait → drop old
+
+[See the migration safety guide]({SAFE_MIGRATIONS_DOCS_URL})""",
             )
 
         # Check for metadata-only operations (safe and instant)

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -409,7 +409,7 @@ class TestRunSQLOperations:
         assert "validate" in risk.reason.lower()
 
     def test_run_sql_drop_constraint(self):
-        """Test DROP CONSTRAINT - fast metadata operation (score 1)."""
+        """Test DROP CONSTRAINT - fast but needs deployment safety review (score 2)."""
         op = create_mock_operation(
             migrations.RunSQL,
             sql="ALTER TABLE users DROP CONSTRAINT check_age;",
@@ -417,9 +417,10 @@ class TestRunSQLOperations:
 
         risk = self.analyzer.analyze_operation(op)
 
-        assert risk.score == 1
-        assert risk.level == RiskLevel.SAFE
-        assert "fast" in risk.reason.lower() or "metadata" in risk.reason.lower()
+        assert risk.score == 2
+        assert risk.level == RiskLevel.NEEDS_REVIEW
+        assert "fast" in risk.reason.lower()
+        assert "deployment safety" in risk.reason.lower() or "deployment" in risk.guidance.lower()
 
     def test_run_sql_drop_constraint_cascade(self):
         """Test DROP CONSTRAINT CASCADE - may be slow (score 3)."""

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -420,7 +420,7 @@ class TestRunSQLOperations:
         assert risk.score == 2
         assert risk.level == RiskLevel.NEEDS_REVIEW
         assert "fast" in risk.reason.lower()
-        assert "deployment safety" in risk.reason.lower() or "deployment" in risk.guidance.lower()
+        assert "deployment safety" in risk.reason.lower() or (risk.guidance and "deployment" in risk.guidance.lower())
 
     def test_run_sql_drop_constraint_cascade(self):
         """Test DROP CONSTRAINT CASCADE - may be slow (score 3)."""


### PR DESCRIPTION
## Changes

Update migration analyzer to flag `DROP CONSTRAINT` operations as score 2 (needs review) instead of score 1 (safe).

While `DROP CONSTRAINT` is technically instant (no table lock), it can break running code during rolling deployments. The analyzer should flag these for human review rather than auto-approving them.

## What changed

- `operations.py`: Changed DROP CONSTRAINT from score 1 → 2
- Added deployment safety guidance with common scenarios:
  - Dropping UNIQUE constraints: ensure code handles duplicates
  - Dropping FOREIGN KEY constraints: ensure code doesn't assume referential integrity
  - Replacing constraints: add new → deploy → wait → drop old
- Updated test expectations (score 1 → 2, SAFE → NEEDS_REVIEW)

## Test plan

- [x] All 65 tests pass
- [x] Updated `test_run_sql_drop_constraint` to expect score 2