### PR TITLE
chore(flags): Encapsulate caching patterns with a `ReadThroughCache`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1791,6 +1791,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-cache"
+version = "0.1.0"
+dependencies = [
+ "common-redis",
+ "moka",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "common-compression"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "batch-import-worker",
     "capture",
     "common/alloc",
+    "common/cache",
     "common/cookieless",
     "common/database",
     "common/dns",

--- a/rust/common/cache/Cargo.toml
+++ b/rust/common/cache/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "common-cache"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+common-redis = { path = "../redis" }
+moka = { version = "0.12", features = ["sync"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }

--- a/rust/common/cache/src/lib.rs
+++ b/rust/common/cache/src/lib.rs
@@ -1,0 +1,51 @@
+//! Generic cache system for PostHog services
+//!
+//! This crate provides a generic read-through cache implementation that can be used
+//! across all PostHog services. It supports:
+//!
+//! - Generic key-value caching with Redis
+//! - Configurable TTL and cache prefixes
+//! - Optional negative caching with Moka
+//! - Rich return types indicating cache source for observability
+//! - Function-based fallback API (no trait implementations required)
+//! - User-defined error types
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use common_cache::{ReadThroughCache, CacheConfig, CacheSource};
+//!
+//! let cache = ReadThroughCache::new(
+//!     redis_reader,
+//!     redis_writer,
+//!     CacheConfig::with_ttl("my_data:", 300),
+//!     None, // negative_cache
+//! );
+//!
+//! let result = cache
+//!     .get_or_load(&key, |key| async {
+//!         load_from_source(key).await
+//!     })
+//!     .await?;
+//!
+//! match result.source {
+//!     CacheSource::PositiveCache => println!("Cache hit!"),
+//!     CacheSource::LoaderCacheMiss => println!("Cache miss, loaded from source"),
+//!     CacheSource::NegativeCache => println!("Known to not exist"),
+//!     _ => println!("Other source: {:?}", result.source),
+//! }
+//!
+//! if let Some(value) = result.value {
+//!     // Use the value
+//! } else {
+//!     // Item doesn't exist
+//! }
+//! ```
+
+pub mod negative_cache;
+pub mod read_through;
+pub mod types;
+
+pub use negative_cache::NegativeCache;
+pub use read_through::ReadThroughCache;
+pub use types::{CacheConfig, CacheResult, CacheSource};

--- a/rust/common/cache/src/negative_cache.rs
+++ b/rust/common/cache/src/negative_cache.rs
@@ -1,0 +1,177 @@
+//! In-memory negative caching to prevent repeated loader calls for missing keys
+//!
+//! This module provides [`NegativeCache`], an in-memory cache that tracks keys known
+//! to not exist. This prevents repeated expensive loader invocations for
+//! non-existent keys.
+//!
+//! Uses Moka for efficient LRU eviction and TTL support, avoiding Redis to prevent
+//! cache poisoning when Redis is struggling.
+
+use moka::sync::Cache;
+use std::time::Duration;
+
+/// In-memory negative cache using Moka to prevent repeated loader calls
+/// for non-existent keys. We use this instead of a Redis-based negative cache
+/// to avoid cache poisoning vulnerabilities. Improved performance is a side-benefit.
+///
+/// Features:
+/// - TTL: Entries automatically expire after configured time
+/// - LRU eviction: Bounded memory usage with automatic cleanup
+/// - Thread-safe: Can be safely shared across async tasks
+/// - Pod isolation: Each service instance has its own cache
+#[derive(Clone)]
+pub struct NegativeCache {
+    cache: Cache<String, ()>,
+}
+
+impl NegativeCache {
+    /// Create a new negative cache with specified capacity and TTL
+    ///
+    /// # Arguments
+    /// * `max_capacity` - Maximum number of entries to store
+    /// * `ttl_seconds` - Time-to-live for entries in seconds
+    ///
+    /// # Example
+    /// ```rust
+    /// use common_cache::NegativeCache;
+    ///
+    /// let cache = NegativeCache::new(1000, 300); // 1000 entries, 5 minute TTL
+    /// ```
+    pub fn new(max_capacity: u64, ttl_seconds: u64) -> Self {
+        let cache = Cache::builder()
+            .max_capacity(max_capacity)
+            .time_to_live(Duration::from_secs(ttl_seconds))
+            .build();
+
+        Self { cache }
+    }
+
+    /// Check if a key is in the negative cache (was not found in database)
+    ///
+    /// # Arguments
+    /// * `key` - The key to check
+    ///
+    /// # Returns
+    /// `true` if the key is in the negative cache, `false` otherwise
+    pub fn contains(&self, key: &str) -> bool {
+        self.cache.contains_key(key)
+    }
+
+    /// Add a key to the negative cache (marking it as not found in database)
+    ///
+    /// # Arguments
+    /// * `key` - The key to mark as not found
+    pub fn insert(&self, key: String) {
+        self.cache.insert(key, ());
+    }
+
+    /// Remove a key from the negative cache (e.g., when positive data is found)
+    ///
+    /// # Arguments
+    /// * `key` - The key to remove from negative cache
+    pub fn invalidate(&self, key: &str) {
+        self.cache.invalidate(key);
+    }
+
+    /// Get cache statistics (entry count and weighted size)
+    ///
+    /// # Returns
+    /// A tuple of (entry_count, weighted_size)
+    pub fn stats(&self) -> (u64, u64) {
+        (self.cache.entry_count(), self.cache.weighted_size())
+    }
+
+    /// Clear all entries from the negative cache
+    pub fn clear(&self) {
+        self.cache.invalidate_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{sleep, Duration as TokioDuration};
+
+    #[tokio::test]
+    async fn test_negative_cache_basic_functionality() {
+        // Test basic Moka negative cache functionality
+        let negative_cache = NegativeCache::new(100, 300); // 100 entries, 5 min TTL
+
+        let key = "test_key_123";
+
+        // Initially, cache should not contain the key
+        assert!(!negative_cache.contains(key));
+
+        // Insert the key into negative cache
+        negative_cache.insert(key.to_string());
+
+        // Now cache should contain the key
+        assert!(negative_cache.contains(key));
+
+        // Test stats - Moka cache stats might not be immediately consistent
+        // So we'll test the functionality instead of exact counts
+        assert!(negative_cache.contains(key));
+
+        // Test invalidation
+        negative_cache.invalidate(key);
+        assert!(!negative_cache.contains(key));
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_ttl_expiration() {
+        // Test that entries expire after TTL
+        let negative_cache = NegativeCache::new(100, 1); // 1 second TTL
+
+        let key = "test_expiry_key";
+        negative_cache.insert(key.to_string());
+
+        // Should be present initially
+        assert!(negative_cache.contains(key));
+
+        // Wait for TTL to expire
+        sleep(TokioDuration::from_secs(2)).await;
+
+        // Should be expired now
+        assert!(!negative_cache.contains(key));
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_capacity_limits() {
+        // Test LRU eviction when capacity is reached
+        let negative_cache = NegativeCache::new(2, 300); // Only 2 entries max
+
+        // Add first two entries
+        negative_cache.insert("key1".to_string());
+        negative_cache.insert("key2".to_string());
+
+        assert!(negative_cache.contains("key1"));
+        assert!(negative_cache.contains("key2"));
+
+        // Add third entry - should evict least recently used
+        negative_cache.insert("key3".to_string());
+
+        // key3 should be present, and one of the others should be evicted
+        assert!(negative_cache.contains("key3"));
+
+        let (entry_count, _) = negative_cache.stats();
+        assert!(entry_count <= 2, "Cache should not exceed capacity");
+    }
+
+    #[test]
+    fn test_negative_cache_clear() {
+        let negative_cache = NegativeCache::new(100, 300);
+
+        negative_cache.insert("key1".to_string());
+        negative_cache.insert("key2".to_string());
+
+        // Verify keys are present
+        assert!(negative_cache.contains("key1"));
+        assert!(negative_cache.contains("key2"));
+
+        negative_cache.clear();
+
+        // Verify keys are no longer present after clear
+        assert!(!negative_cache.contains("key1"));
+        assert!(!negative_cache.contains("key2"));
+    }
+}

--- a/rust/common/cache/src/read_through.rs
+++ b/rust/common/cache/src/read_through.rs
@@ -338,7 +338,8 @@ impl ReadThroughCache {
     }
 
     /// Invalidate a key from both positive and negative caches
-    ///
+    /// Errors from Redis deletion are logged but not returned, as invalidation
+    /// is best-effort and shouldn't block the calling operation.
     /// # Arguments
     /// * `key` - The key to invalidate
     pub async fn invalidate<K>(&self, key: &K) -> Result<(), CustomRedisError>

--- a/rust/common/cache/src/read_through.rs
+++ b/rust/common/cache/src/read_through.rs
@@ -1,0 +1,740 @@
+//! Read-through cache implementation with Redis backing
+//!
+//! This module provides the main [`ReadThroughCache`] type that implements the read-through
+//! caching pattern with support for:
+//! - Redis-based positive caching
+//! - Optional in-memory negative caching
+//! - Cache corruption handling
+//! - Graceful Redis degradation
+
+use crate::{CacheConfig, CacheResult, CacheSource, NegativeCache};
+use common_redis::{Client as RedisClient, CustomRedisError};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::future::Future;
+use std::sync::Arc;
+
+/// A generic read-through cache that supports:
+/// - Redis-based positive caching with configurable TTL
+/// - Optional in-memory negative caching to prevent repeated loader invocations for missing keys
+/// - Function-based loader API (no trait implementations required)
+/// - User-defined error types
+/// - Rich return types for observability
+/// - Cache corruption handling
+///
+/// The cache follows the "cache-aside" pattern:
+/// 1. Check negative cache first (if enabled)
+/// 2. Try to get data from Redis cache
+/// 3. On cache miss, call the loader function
+/// 4. If loader succeeds, update positive cache and invalidate negative cache
+/// 5. If loader returns None, add to negative cache
+///
+/// # Example
+/// ```rust,ignore
+/// use common_cache::{ReadThroughCache, CacheConfig, CacheSource};
+///
+/// let cache = ReadThroughCache::new(
+///     redis_reader,
+///     redis_writer,
+///     CacheConfig::with_ttl("my_data:", 300),
+///     None, // no negative cache
+/// );
+///
+/// let result = cache
+///     .get_or_load(&key, |key| async {
+///         load_from_source(key).await
+///     })
+///     .await?;
+///
+/// match result.source {
+///     CacheSource::PositiveCache => println!("Cache hit!"),
+///     CacheSource::LoaderCacheMiss => println!("Loaded from source"),
+///     _ => {}
+/// }
+/// ```
+pub struct ReadThroughCache {
+    redis_reader: Arc<dyn RedisClient + Send + Sync>,
+    redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    config: CacheConfig,
+    negative_cache: Option<Arc<NegativeCache>>,
+}
+
+impl ReadThroughCache {
+    /// Create a new read-through cache instance
+    ///
+    /// # Arguments
+    /// * `redis_reader` - Redis client for reading cached data
+    /// * `redis_writer` - Redis client for writing cached data
+    /// * `config` - Cache configuration (prefix, TTL)
+    /// * `negative_cache` - Optional negative cache to prevent repeated loader invocations for missing keys
+    pub fn new(
+        redis_reader: Arc<dyn RedisClient + Send + Sync>,
+        redis_writer: Arc<dyn RedisClient + Send + Sync>,
+        config: CacheConfig,
+        negative_cache: Option<Arc<NegativeCache>>,
+    ) -> Self {
+        Self {
+            redis_reader,
+            redis_writer,
+            config,
+            negative_cache,
+        }
+    }
+
+    /// Get a value from cache or load it using the loader function
+    ///
+    /// This is the main API for the cache. It:
+    /// 1. Checks negative cache first (if enabled)
+    /// 2. Tries Redis cache
+    /// 3. On miss, calls loader function with the key
+    /// 4. Updates caches based on the result
+    ///
+    /// The loader function should return `Option<V>` where:
+    /// - `Some(value)` indicates the item was found
+    /// - `None` indicates the item doesn't exist (will be negative cached)
+    ///
+    /// # Type Parameters
+    /// * `K` - Key type (must be displayable for logging)
+    /// * `V` - Value type (must be serializable)
+    /// * `E` - Error type (user-defined, for loader errors)
+    /// * `F` - Loader function type
+    /// * `Fut` - Future returned by loader function
+    ///
+    /// # Arguments
+    /// * `key` - The key to look up
+    /// * `loader` - Function to call on cache miss, receives the key as parameter
+    ///
+    /// # Returns
+    /// * `Ok(CacheResult)` - Contains the value (if found) and source information
+    /// * `Err(error)` - Error from loader function
+    pub async fn get_or_load<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Serialize + Display + Send + Sync,
+        V: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        let cache_key = self.build_cache_key(key);
+
+        // Check negative cache first
+        if let Some(neg_cache) = &self.negative_cache {
+            if neg_cache.contains(&cache_key) {
+                tracing::debug!("Negative cache hit for key: {}", key);
+                return Ok(CacheResult::not_found(CacheSource::NegativeCache));
+            }
+        }
+
+        // Try to get from Redis cache
+        match self.get_from_redis(&cache_key).await {
+            Ok(cached_value) => {
+                // Positive cache hit
+                tracing::debug!("Positive cache hit for key: {}", key);
+                Ok(CacheResult::found(cached_value, CacheSource::PositiveCache))
+            }
+            Err(cache_error) => {
+                // Cache miss or error - need to fetch from loader
+                self.handle_cache_miss(key, &cache_key, cache_error, loader)
+                    .await
+            }
+        }
+    }
+
+    /// Build the full Redis cache key from the user key
+    fn build_cache_key<K>(&self, key: &K) -> String
+    where
+        K: Display,
+    {
+        format!("{}{}", self.config.cache_prefix, key)
+    }
+
+    /// Get a value from Redis cache
+    async fn get_from_redis<V>(&self, cache_key: &str) -> Result<V, CustomRedisError>
+    where
+        V: for<'de> Deserialize<'de>,
+    {
+        let serialized_value = self.redis_reader.get(cache_key.to_string()).await?;
+        let value = serde_json::from_str(&serialized_value).map_err(|e| {
+            CustomRedisError::ParseError(format!("Failed to deserialize cached value: {e}"))
+        })?;
+        Ok(value)
+    }
+
+    /// Handle cache miss by calling loader and updating caches
+    async fn handle_cache_miss<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        cache_key: &str,
+        cache_error: CustomRedisError,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        match cache_error {
+            CustomRedisError::NotFound => {
+                // True cache miss - key doesn't exist in cache
+                self.handle_true_cache_miss(key, cache_key, loader).await
+            }
+            CustomRedisError::ParseError(ref err) => {
+                // Corrupted cache data - try loader and refresh cache if successful
+                tracing::warn!(
+                    "Cache corruption detected for key {}: {}. Will refresh from source.",
+                    key,
+                    err
+                );
+                self.handle_corrupted_cache(key, cache_key, loader).await
+            }
+            CustomRedisError::Timeout | CustomRedisError::Other(_) => {
+                // Redis infrastructure issues - use loader without caching
+                tracing::warn!(
+                    "Redis infrastructure issue for key {}: {:?}. Operating without cache.",
+                    key,
+                    cache_error
+                );
+                self.handle_redis_unavailable(key, loader).await
+            }
+        }
+    }
+
+    /// Handle a true cache miss (key not in Redis)
+    async fn handle_true_cache_miss<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        cache_key: &str,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        match loader(key).await? {
+            Some(value) => {
+                // Value found - update positive cache and invalidate negative cache
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.invalidate(cache_key);
+                }
+
+                // Update positive cache
+                if let Err(redis_err) = self.set_in_redis(cache_key, &value).await {
+                    tracing::warn!("Failed to update cache for key {}: {:?}", key, redis_err);
+                }
+
+                Ok(CacheResult::found(value, CacheSource::LoaderCacheMiss))
+            }
+            None => {
+                // Value not found - add to negative cache
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.insert(cache_key.to_string());
+                }
+
+                Ok(CacheResult::not_found(CacheSource::LoaderNotFoundCacheMiss))
+            }
+        }
+    }
+
+    /// Handle corrupted cache data
+    async fn handle_corrupted_cache<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        cache_key: &str,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        match loader(key).await? {
+            Some(value) => {
+                // Loader success - refresh cache with valid data
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.invalidate(cache_key);
+                }
+
+                // Update cache with fresh data
+                if let Err(redis_err) = self.set_in_redis(cache_key, &value).await {
+                    tracing::warn!(
+                        "Failed to refresh corrupted cache for key {}: {:?}",
+                        key,
+                        redis_err
+                    );
+                }
+
+                Ok(CacheResult::found(value, CacheSource::LoaderCacheCorrupted))
+            }
+            None => {
+                // Value not found - add to negative cache
+                if let Some(neg_cache) = &self.negative_cache {
+                    neg_cache.insert(cache_key.to_string());
+                }
+
+                Ok(CacheResult::not_found(
+                    CacheSource::LoaderNotFoundCacheCorrupted,
+                ))
+            }
+        }
+    }
+
+    /// Handle Redis being unavailable
+    async fn handle_redis_unavailable<K, V, E, F, Fut>(
+        &self,
+        _key: &K,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Display + Send + Sync,
+        V: Serialize + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        // Don't update any caches when Redis is having issues
+        match loader(_key).await? {
+            Some(value) => Ok(CacheResult::found(
+                value,
+                CacheSource::LoaderRedisUnavailable,
+            )),
+            None => Ok(CacheResult::not_found(
+                CacheSource::LoaderNotFoundRedisUnavailable,
+            )),
+        }
+    }
+
+    /// Write a value to Redis cache
+    async fn set_in_redis<V>(&self, cache_key: &str, value: &V) -> Result<(), CustomRedisError>
+    where
+        V: Serialize,
+    {
+        let serialized_value = serde_json::to_string(value).map_err(|e| {
+            CustomRedisError::ParseError(format!("Failed to serialize value for cache: {e}"))
+        })?;
+
+        match self.config.ttl_seconds {
+            Some(ttl) => {
+                self.redis_writer
+                    .setex(cache_key.to_string(), serialized_value, ttl)
+                    .await
+            }
+            None => {
+                self.redis_writer
+                    .set(cache_key.to_string(), serialized_value)
+                    .await
+            }
+        }
+    }
+
+    /// Invalidate a key from both positive and negative caches
+    ///
+    /// # Arguments
+    /// * `key` - The key to invalidate
+    pub async fn invalidate<K>(&self, key: &K) -> Result<(), CustomRedisError>
+    where
+        K: Display,
+    {
+        let cache_key = self.build_cache_key(key);
+
+        // Remove from Redis
+        if let Err(e) = self.redis_writer.del(cache_key.clone()).await {
+            tracing::warn!("Failed to delete cache key {}: {:?}", cache_key, e);
+        }
+
+        // Remove from negative cache
+        if let Some(neg_cache) = &self.negative_cache {
+            neg_cache.invalidate(&cache_key);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common_redis::MockRedisClient;
+    use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestData {
+        id: i32,
+        name: String,
+    }
+
+    fn setup_cache(
+        reader: MockRedisClient,
+        writer: MockRedisClient,
+        negative_cache: Option<Arc<NegativeCache>>,
+    ) -> ReadThroughCache {
+        let config = CacheConfig::with_ttl("test:", 300);
+        ReadThroughCache::new(Arc::new(reader), Arc::new(writer), config, negative_cache)
+    }
+
+    #[tokio::test]
+    async fn test_positive_cache_hit() {
+        let data = TestData {
+            id: 1,
+            name: "test".to_string(),
+        };
+        let serialized = serde_json::to_string(&data).unwrap();
+
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok(serialized));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::PositiveCache);
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_loads_and_caches() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let mut writer = MockRedisClient::new();
+        writer.set_ret("test:key1", Ok(()));
+
+        let cache = setup_cache(reader, writer.clone(), None);
+
+        let data = TestData {
+            id: 1,
+            name: "loaded".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderCacheMiss);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+
+        // Verify cache was written to
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].op, "setex");
+        assert_eq!(calls[0].key, "test:key1");
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_not_found_returns_none() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheMiss);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+    }
+
+    #[tokio::test]
+    async fn test_cache_corruption_reloads_and_refreshes() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok("invalid json{".to_string()));
+
+        let mut writer = MockRedisClient::new();
+        writer.set_ret("test:key1", Ok(()));
+
+        let cache = setup_cache(reader, writer.clone(), None);
+
+        let data = TestData {
+            id: 1,
+            name: "refreshed".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderCacheCorrupted);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+        assert!(result.had_cache_problem());
+
+        // Verify cache was refreshed
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].op, "setex");
+    }
+
+    #[tokio::test]
+    async fn test_cache_corruption_not_found() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok("invalid json{".to_string()));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheCorrupted);
+        assert!(result.had_cache_problem());
+    }
+
+    async fn test_redis_infrastructure_error_skips_cache_write_impl(redis_error: CustomRedisError) {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(redis_error));
+
+        let writer = MockRedisClient::new();
+
+        let cache = setup_cache(reader, writer.clone(), None);
+
+        let data = TestData {
+            id: 1,
+            name: "from_loader".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderRedisUnavailable);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+
+        // Verify NO cache write occurred
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_redis_timeout_skips_cache_write() {
+        test_redis_infrastructure_error_skips_cache_write_impl(CustomRedisError::Timeout).await;
+    }
+
+    #[tokio::test]
+    async fn test_redis_other_error_skips_cache_write() {
+        test_redis_infrastructure_error_skips_cache_write_impl(CustomRedisError::Other(
+            "connection refused".to_string(),
+        ))
+        .await;
+    }
+
+    async fn test_redis_infrastructure_error_not_found_impl(redis_error: CustomRedisError) {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(redis_error));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        let cache = setup_cache(reader, MockRedisClient::new(), Some(negative_cache.clone()));
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundRedisUnavailable);
+        assert!(result.had_cache_problem());
+
+        // Verify negative cache was NOT updated (don't poison cache when Redis is down)
+        assert!(!negative_cache.contains("test:key1"));
+    }
+
+    #[tokio::test]
+    async fn test_redis_timeout_not_found() {
+        test_redis_infrastructure_error_not_found_impl(CustomRedisError::Timeout).await;
+    }
+
+    #[tokio::test]
+    async fn test_redis_other_error_not_found() {
+        test_redis_infrastructure_error_not_found_impl(CustomRedisError::Other(
+            "network error".to_string(),
+        ))
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_hit() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        let cache = setup_cache(reader, MockRedisClient::new(), Some(negative_cache.clone()));
+
+        // First call - cache miss, loader returns None
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheMiss);
+
+        // Second call - should hit negative cache without invoking loader
+        let result: CacheResult<TestData> = cache
+            .get_or_load(&"key1", |_key| async {
+                panic!("Loader should not be called for negative cache hit");
+                #[allow(unreachable_code)]
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::NegativeCache);
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_invalidated_on_found() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let mut writer = MockRedisClient::new();
+        writer.set_ret("test:key1", Ok(()));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        let cache = setup_cache(reader, writer, Some(negative_cache.clone()));
+
+        // First call - loader returns None, should add to negative cache
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(None)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::LoaderNotFoundCacheMiss);
+        assert!(negative_cache.contains("test:key1"));
+
+        // Second call - this time loader would return Some if called
+        // But negative cache will return early
+        let result: CacheResult<TestData> = cache
+            .get_or_load(&"key1", |_key| async {
+                Ok::<Option<TestData>, String>(Some(TestData {
+                    id: 1,
+                    name: "found".to_string(),
+                }))
+            })
+            .await
+            .unwrap();
+
+        // Should hit negative cache
+        assert_eq!(result.value, None);
+        assert_eq!(result.source, CacheSource::NegativeCache);
+
+        // Now invalidate the cache entry
+        cache.invalidate(&"key1").await.unwrap();
+        assert!(!negative_cache.contains("test:key1"));
+
+        // Third call - after invalidation, loader should be invoked
+        let data = TestData {
+            id: 1,
+            name: "found".to_string(),
+        };
+        let expected_data = data.clone();
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async move {
+                Ok::<Option<TestData>, String>(Some(expected_data))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some(data));
+        assert_eq!(result.source, CacheSource::LoaderCacheMiss);
+
+        // Verify negative cache was NOT re-added (since we found a value)
+        assert!(!negative_cache.contains("test:key1"));
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_clears_both_caches() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Ok(serde_json::to_string(&"cached").unwrap()));
+
+        let mut writer = MockRedisClient::new();
+        writer.del_ret("test:key1", Ok(()));
+
+        let negative_cache = Arc::new(NegativeCache::new(100, 300));
+        negative_cache.insert("test:key1".to_string());
+
+        let cache = setup_cache(reader, writer.clone(), Some(negative_cache.clone()));
+
+        cache.invalidate(&"key1").await.unwrap();
+
+        // Verify Redis delete was called
+        let calls = writer.get_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].op, "del");
+        assert_eq!(calls[0].key, "test:key1");
+
+        // Verify negative cache was cleared
+        assert!(!negative_cache.contains("test:key1"));
+    }
+
+    #[tokio::test]
+    async fn test_loader_error_propagates() {
+        let mut reader = MockRedisClient::new();
+        reader.get_ret("test:key1", Err(CustomRedisError::NotFound));
+
+        let cache = setup_cache(reader, MockRedisClient::new(), None);
+
+        let result = cache
+            .get_or_load(&"key1", |_key| async {
+                Err::<Option<TestData>, String>("loader error".to_string())
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "loader error");
+    }
+}

--- a/rust/common/cache/src/types.rs
+++ b/rust/common/cache/src/types.rs
@@ -39,6 +39,13 @@ impl CacheConfig {
 }
 
 /// Indicates where a cached value came from and what operations were performed
+///
+/// This type implements `Display` for use in logging and metrics:
+/// ```
+/// # use common_cache::CacheSource;
+/// let source = CacheSource::PositiveCache;
+/// println!("Cache result: {}", source); // "positive_cache"
+/// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheSource {

--- a/rust/common/cache/src/types.rs
+++ b/rust/common/cache/src/types.rs
@@ -39,6 +39,7 @@ impl CacheConfig {
 }
 
 /// Indicates where a cached value came from and what operations were performed
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheSource {
     // Value found cases

--- a/rust/common/cache/src/types.rs
+++ b/rust/common/cache/src/types.rs
@@ -1,0 +1,233 @@
+//! Cache configuration types and cache operation results
+//!
+//! This module contains the core types used throughout the cache system:
+//! - [`CacheConfig`]: Configuration for cache instances (prefix, TTL)
+//! - [`CacheSource`]: Enum indicating where a value came from (for observability)
+//! - [`CacheResult`]: Wrapper containing a value and its source
+
+use std::fmt;
+
+/// Configuration for cache instances
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    /// Redis key prefix for this cache instance (e.g., "team_token:", "feature_flags:")
+    pub cache_prefix: String,
+
+    /// Optional TTL in seconds for cached values
+    /// If None, values are cached indefinitely
+    pub ttl_seconds: Option<u64>,
+}
+
+impl CacheConfig {
+    /// Create a new cache configuration
+    pub fn new(cache_prefix: impl Into<String>, ttl_seconds: Option<u64>) -> Self {
+        Self {
+            cache_prefix: cache_prefix.into(),
+            ttl_seconds,
+        }
+    }
+
+    /// Create a cache configuration with no TTL (permanent caching)
+    pub fn permanent(cache_prefix: impl Into<String>) -> Self {
+        Self::new(cache_prefix, None)
+    }
+
+    /// Create a cache configuration with a TTL
+    pub fn with_ttl(cache_prefix: impl Into<String>, ttl_seconds: u64) -> Self {
+        Self::new(cache_prefix, Some(ttl_seconds))
+    }
+}
+
+/// Indicates where a cached value came from and what operations were performed
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheSource {
+    // Value found cases
+    /// Value was found in Redis cache
+    PositiveCache,
+    /// Cache miss - value loaded from loader function
+    LoaderCacheMiss,
+    /// Cache data was corrupted - value loaded from loader function
+    LoaderCacheCorrupted,
+    /// Redis was unavailable - value loaded from loader function
+    LoaderRedisUnavailable,
+
+    // Value not found cases
+    /// Key found in negative cache (known to not exist)
+    NegativeCache,
+    /// Cache miss - loader function indicated value doesn't exist
+    LoaderNotFoundCacheMiss,
+    /// Cache was corrupted - loader function indicated value doesn't exist
+    LoaderNotFoundCacheCorrupted,
+    /// Redis was unavailable - loader function indicated value doesn't exist
+    LoaderNotFoundRedisUnavailable,
+}
+
+impl fmt::Display for CacheSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display implementation for better logging and metrics.
+        // This allows `CacheSource` to be used directly in log messages and metric tags
+        // without needing to format the Debug representation or manually convert.
+        //
+        // Example: tracing::info!("Cache result: {}", result.source);
+        // Example: metrics::counter!("cache.access", "source" => result.source.to_string());
+        match self {
+            CacheSource::PositiveCache => write!(f, "positive_cache"),
+            CacheSource::NegativeCache => write!(f, "negative_cache"),
+            CacheSource::LoaderCacheMiss => write!(f, "loader_cache_miss"),
+            CacheSource::LoaderCacheCorrupted => write!(f, "loader_cache_corrupted"),
+            CacheSource::LoaderRedisUnavailable => write!(f, "loader_redis_unavailable"),
+            CacheSource::LoaderNotFoundCacheMiss => write!(f, "loader_not_found_cache_miss"),
+            CacheSource::LoaderNotFoundCacheCorrupted => {
+                write!(f, "loader_not_found_cache_corrupted")
+            }
+            CacheSource::LoaderNotFoundRedisUnavailable => {
+                write!(f, "loader_not_found_redis_unavailable")
+            }
+        }
+    }
+}
+
+/// Result of a cache operation with detailed source information
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheResult<V> {
+    /// The value, if found. None indicates the item doesn't exist (negative result)
+    pub value: Option<V>,
+
+    /// Where the result came from - provides context for observability
+    pub source: CacheSource,
+}
+
+impl<V> CacheResult<V> {
+    /// Create a cache result with a value
+    pub fn found(value: V, source: CacheSource) -> Self {
+        Self {
+            value: Some(value),
+            source,
+        }
+    }
+
+    /// Create a cache result indicating the value was not found
+    pub fn not_found(source: CacheSource) -> Self {
+        Self {
+            value: None,
+            source,
+        }
+    }
+
+    /// Check if this was a cache hit (from Redis or negative cache)
+    pub fn was_cached(&self) -> bool {
+        matches!(
+            self.source,
+            CacheSource::PositiveCache | CacheSource::NegativeCache
+        )
+    }
+
+    /// Check if the loader function was invoked
+    pub fn invoked_loader(&self) -> bool {
+        matches!(
+            self.source,
+            CacheSource::LoaderCacheMiss
+                | CacheSource::LoaderCacheCorrupted
+                | CacheSource::LoaderRedisUnavailable
+                | CacheSource::LoaderNotFoundCacheMiss
+                | CacheSource::LoaderNotFoundCacheCorrupted
+                | CacheSource::LoaderNotFoundRedisUnavailable
+        )
+    }
+
+    /// Check if there was a cache infrastructure problem
+    pub fn had_cache_problem(&self) -> bool {
+        matches!(
+            self.source,
+            CacheSource::LoaderCacheCorrupted
+                | CacheSource::LoaderRedisUnavailable
+                | CacheSource::LoaderNotFoundCacheCorrupted
+                | CacheSource::LoaderNotFoundRedisUnavailable
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_result_helpers() {
+        let result: CacheResult<i32> = CacheResult::found(42, CacheSource::PositiveCache);
+        assert_eq!(result.value, Some(42));
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+        assert!(!result.had_cache_problem());
+
+        let result: CacheResult<i32> = CacheResult::not_found(CacheSource::LoaderNotFoundCacheMiss);
+        assert_eq!(result.value, None);
+        assert!(!result.was_cached());
+        assert!(result.invoked_loader());
+        assert!(!result.had_cache_problem());
+
+        let result: CacheResult<i32> = CacheResult::found(42, CacheSource::LoaderCacheCorrupted);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+        assert!(!result.was_cached());
+    }
+
+    #[test]
+    fn test_negative_cache_helper() {
+        let result: CacheResult<String> = CacheResult::not_found(CacheSource::NegativeCache);
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+        assert!(!result.had_cache_problem());
+    }
+
+    #[test]
+    fn test_redis_unavailable_helper() {
+        let result: CacheResult<i32> = CacheResult::found(42, CacheSource::LoaderRedisUnavailable);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+        assert!(!result.was_cached());
+
+        let result: CacheResult<i32> =
+            CacheResult::not_found(CacheSource::LoaderNotFoundRedisUnavailable);
+        assert!(result.had_cache_problem());
+        assert!(result.invoked_loader());
+        assert!(!result.was_cached());
+    }
+
+    #[test]
+    fn test_cache_source_display() {
+        // Test Display implementation for use in logging and metrics
+        assert_eq!(CacheSource::PositiveCache.to_string(), "positive_cache");
+        assert_eq!(CacheSource::NegativeCache.to_string(), "negative_cache");
+        assert_eq!(
+            CacheSource::LoaderCacheMiss.to_string(),
+            "loader_cache_miss"
+        );
+        assert_eq!(
+            CacheSource::LoaderCacheCorrupted.to_string(),
+            "loader_cache_corrupted"
+        );
+        assert_eq!(
+            CacheSource::LoaderRedisUnavailable.to_string(),
+            "loader_redis_unavailable"
+        );
+        assert_eq!(
+            CacheSource::LoaderNotFoundCacheMiss.to_string(),
+            "loader_not_found_cache_miss"
+        );
+        assert_eq!(
+            CacheSource::LoaderNotFoundCacheCorrupted.to_string(),
+            "loader_not_found_cache_corrupted"
+        );
+        assert_eq!(
+            CacheSource::LoaderNotFoundRedisUnavailable.to_string(),
+            "loader_not_found_redis_unavailable"
+        );
+
+        // Test that it works in format strings (useful for logging)
+        let source = CacheSource::PositiveCache;
+        assert_eq!(
+            format!("Cache hit from: {source}"),
+            "Cache hit from: positive_cache"
+        );
+    }
+}

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -535,7 +535,7 @@ impl MockRedisClient {
     }
 
     // Helper method to safely lock the calls mutex
-    fn lock_calls(&self) -> std::sync::MutexGuard<Vec<MockRedisCall>> {
+    fn lock_calls(&self) -> std::sync::MutexGuard<'_, Vec<MockRedisCall>> {
         match self.calls.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),


### PR DESCRIPTION
~This PR targets the [`haacked/redis-client-ztsd` branch](https://github.com/PostHog/posthog/pull/40764) as it needs those changes to be merged first.~

The branch `haacked/redis-client-ztsd` has been merged!

## Problem

Feature flags has a lot of places where it reads from cache, and in case of cache miss, writes to cache. But it isn't consistent in how it does it and the current approach has some problems such as trying to write when Redis is timing out.

We need a consistent approach for caching that:

1. **Handles Redis degradation gracefully** - When Redis is under load and returns timeouts/network errors, we shouldn't treat these the same as cache misses or attempt writes that add to the load
2. **Supports good observability** - Distinguish between different cache scenarios (hit, miss, corruption, Redis unavailable) for better metrics and debugging
3. **Prevents cache poisoning** - Handle corrupted cache entries by replacing them with fresh data
4. **Reduces data source load** - Implement negative caching for non-existent keys to prevent repeated queries to databases, APIs, or other data sources

Currently, our cache handling is scattered across services with inconsistent error handling and limited observability.

## Solution: `ReadThroughCache` in `common-cache`

A new **generic** read-through cache abstraction that encapsulates cache patterns and provides rich metadata for observability. The cache works with any async loader function (databases, HTTP APIs, file systems, computations, etc.), making it reusable across all PostHog services. I separated this out into its own thing to make it easier to review.

### Key Components

```rust
pub enum CacheSource {
    // Value found scenarios
    PositiveCache,                      // Redis hit (valid data)
    NegativeCache,                      // In-memory hit (key doesn't exist)
    LoaderCacheMiss,                    // Loaded from source (Redis miss)
    LoaderCacheCorrupted,               // Loaded from source (Redis had bad data)
    LoaderRedisUnavailable,             // Loaded from source (Redis timeout/error)

    // Not found scenarios
    LoaderNotFoundCacheMiss,            // Not found in source or Redis
    LoaderNotFoundCacheCorrupted,       // Not found in source (Redis had bad data)
    LoaderNotFoundRedisUnavailable,     // Not found in source (Redis timeout/error)
}

pub struct CacheResult<V> {
    pub value: Option<V>,
    pub source: CacheSource,
}

impl<V> CacheResult<V> {
    pub fn was_cached(&self) -> bool;
    pub fn invoked_loader(&self) -> bool;
    pub fn had_cache_problem(&self) -> bool;
}
```

### Usage Examples

#### Basic Usage

```rust
use common_cache::{CacheConfig, ReadThroughCache, CacheResult, CacheSource};
use std::sync::Arc;

// 1. Create cache configuration
let cache_config = CacheConfig::new(
    "posthog:1:team_token:",  // Redis key prefix
    Some(3600)                // TTL in seconds
);

// 2. Create cache instance
let cache = Arc::new(ReadThroughCache::new(
    redis_reader,
    redis_writer,
    cache_config,
    None,  // Optional negative cache
));

// 3. Use with get_or_load
let result: CacheResult<Team> = cache
    .get_or_load(&token, |token| async move {
        match Team::from_pg(pg_client, token).await {
            Ok(team) => Ok(Some(team)),           // Found
            Err(FlagError::RowNotFound) => Ok(None),  // Not found (triggers negative cache)
            Err(e) => Err(e),                     // Database error
        }
    })
    .await?;

// 4. Use CacheSource for observability
match result.source {
    CacheSource::PositiveCache => {
        // Cache hit with valid data
        tracing::debug!("Team loaded from Redis cache");
    }
    CacheSource::LoaderCacheMiss => {
        // Cache miss, loaded from source (database in this example)
        metrics::inc("db_queries");
    }
    CacheSource::LoaderCacheCorrupted => {
        // Redis had corrupted data, replaced with fresh data from source
        tracing::warn!("Corrupted cache entry replaced");
        metrics::inc("cache_corruption");
    }
    CacheSource::LoaderRedisUnavailable => {
        // Redis timeout/error, loaded from source
        tracing::warn!("Redis unavailable, using database");
        metrics::inc("redis_unavailable");
    }
    // ... handle other sources
}

// 5. Use the value
if let Some(team) = result.value {
    // Use team
}
```

#### With Negative Caching

```rust
use common_cache::NegativeCache;

// Create negative cache with LRU and TTL
let negative_cache = Arc::new(NegativeCache::new(
    1000,  // Max 1000 entries
    300    // 5 minute TTL
));

let cache = Arc::new(ReadThroughCache::new(
    redis_reader,
    redis_writer,
    cache_config,
    Some(negative_cache),  // Enable negative caching
));

// When loader returns Ok(None), key is added to negative cache
let result = cache.get_or_load(&invalid_token, |token| async move {
    match Team::from_pg(pg_client, token).await {
        Ok(team) => Ok(Some(team)),
        Err(FlagError::RowNotFound) => Ok(None),  // Cached in negative cache
        Err(e) => Err(e),
    }
}).await?;

// Subsequent lookups with same invalid_token return instantly
// result.source == CacheSource::NegativeCache
```

#### `CacheResult` Helper Methods

The `CacheResult` provides convenience methods for common checks:

```rust
let result = cache.get_or_load(&key, loader).await?;

// Check if we hit the cache (Redis or negative cache)
if result.was_cached() {
    metrics::inc("cache_hits");
} else {
    metrics::inc("cache_misses");
}

// Check if we had to invoke the loader function
if result.invoked_loader() {
    tracing::debug!("Loader was invoked for key: {}", key);
    metrics::inc("loader_invocations");
}

// Check if there were cache infrastructure problems
if result.had_cache_problem() {
    tracing::warn!("Cache problem detected");
    metrics::inc("cache_problems");
    // This includes: corruption or Redis unavailability
}
```

### Cache Write Behavior

The cache writes to Redis on true cache miss or on parse errors.

| Scenario | Redis Read | Loader Invoked | Redis Write | Negative Cache |
|----------|-----------|----------------|-------------|----------------|
| Redis hit (valid) | Success | No | Skip | Skip |
| Redis miss | NotFound | Yes | If found | If not found |
| Redis corrupted | ParseError | Yes | If found | If not found |
| Redis timeout | Timeout | Yes | Skip | Skip |
| Redis unavailable | Network error | Yes | Skip | Skip |

> [!IMPORTANT]  
> The goal: when Redis is struggling, we don't add to its load with writes.

## Implementation Details

- **Error handling:** Distinguishes between infrastructure issues (timeout, network) vs data issues (not found, corrupted)
- **Negative caching:** In-memory `Moka` cache with `LRU` eviction and `TTL` (doesn't poison Redis)
- **Type safety:** Generic `CacheResult<V>` works with any serializable type
- **Testability:** Rich `CacheSource` enum makes it easy to verify behavior in tests

## How did you test this code?

```bash
cargo test -p common-cache    # Cache library tests
```

## Next Steps

Future PRs will migrate feature-flags service to use `ReadThroughCache` for:
- Team token validation
- Feature flag lookups
- Team secret token validation

This infrastructure can also be adopted by other services (capture, data-stack, etc.) for consistent caching behavior across PostHog.
