### PR TITLE
chore(flags): Add compression and serialization configuration to Redis clients

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "serde-pickle",
  "thiserror 2.0.16",
  "tokio",
+ "tracing",
  "zstd",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "serde-pickle",
  "thiserror 2.0.16",
  "tokio",
+ "zstd",
 ]
 
 [[package]]

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -12,5 +12,6 @@ redis = { workspace = true }
 serde-pickle = { version = "1.1.1" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 zstd = "0.13"
 

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -12,4 +12,5 @@ redis = { workspace = true }
 serde-pickle = { version = "1.1.1" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+zstd = "0.13"
 


### PR DESCRIPTION
## Problem

The Rust `RedisClient` needs to be compatible with Django's Redis caching behavior for seamless interoperability between Python and Rust services. Currently:

1. **No compression support** - Django uses `Zstd` compression for large values (>512 bytes) to reduce Redis memory usage and network overhead
2. **Limited serialization options** - Only Pickle format is supported, but different use cases need different formats (UTF-8 for simple strings, raw bytes for binary data)
3. **Inconsistent configuration** - No centralized way to configure compression and serialization behavior per client

Without these features, Rust services cannot properly read/write data that Django services cache, and vice versa.

## Changes

Added configurable compression and serialization format support to `RedisClient` with Django-compatible defaults:

### Compression Support (Zstd)

- **`CompressionConfig`** - Configures compression behavior with Django-compatible defaults:
  - `enabled: false` - Compression off by default
  - `threshold: 512` - Matches Django's `ZstdCompressor.min_length`
  - `level: 0` - Matches Django's default preset (equivalent to level 3)
- **Graceful decompression** - `try_decompress()` handles both compressed and uncompressed data, allowing gradual rollout
- **Automatic compression** - Values over threshold are automatically compressed on write

### Serialization Format Support

- **`RedisValueFormat` enum** - Three formats for different use cases:
  - `Pickle` (default) - Django-compatible serialization
  - `Utf8` - Simple string encoding
  - `RawBytes` - Direct binary data (via dedicated methods)
- **Per-client configuration** - Format is set once at client creation
- **Per-call overrides** - `*_with_format()` methods available when needed

### API Design

Simplified constructor API:
```rust
// Default: compression disabled, Pickle format
let client = RedisClient::new(addr).await?;

// Full control over both settings
let client = RedisClient::with_config(
    addr,
    CompressionConfig::new(true, 512, 0),
    RedisValueFormat::Utf8,
).await?;

// Django-compatible: compression enabled, Pickle serialization
let client = RedisClient::with_config(
    addr,
    CompressionConfig::default(),  // 512-byte threshold, level 0
    RedisValueFormat::Pickle,
).await?;
```

## How did you test this code?

```bash
cargo test --package common-redis --lib  # All 20 tests pass
cargo clippy --package common-redis --all-targets --all-features -- -D warnings  # No warnings
```

Tests cover:
- Compression behavior at various thresholds (below, at, above)
- Compression levels (0, custom levels)
- Round-trip serialization for all formats (Pickle, Utf8)
- Format interoperability (ensuring different formats produce different outputs)
- Decompression of both compressed and uncompressed data
- Error handling for invalid formats

## Backwards Compatible

Existing code is not affected as defaults remain the same. Added a new `ctor` for configuring the client.