### PR TITLE
chore(ci): optimize sqlx-cli installation with caching

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -143,7 +143,7 @@ jobs:
                   components: cargo
 
             - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@v2
+              uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
 
             - name: Install sqlx-cli
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -142,6 +142,9 @@ jobs:
                   toolchain: 1.88.0
                   components: cargo
 
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@v2
+
             - name: Install sqlx-cli
               run: |
                   cargo install sqlx-cli --version 0.8.0 --features postgres --no-default-features --locked

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -107,6 +107,9 @@ jobs:
                   toolchain: stable
                   components: cargo
 
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@v2
+
             - name: Install sqlx-cli
               run: |
                   cargo install sqlx-cli --version 0.8.0 --features postgres --no-default-features --locked

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -108,7 +108,7 @@ jobs:
                   components: cargo
 
             - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@v2
+              uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
 
             - name: Install sqlx-cli
               run: |

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -158,7 +158,7 @@ jobs:
               uses: dtolnay/rust-toolchain@6691ebadcb18182cc1391d07c9f295f657c593cd # 1.88
 
             - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@v2
+              uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
 
             - name: Install sqlx-cli
               working-directory: rust

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -157,13 +157,8 @@ jobs:
             - name: Install rust
               uses: dtolnay/rust-toolchain@6691ebadcb18182cc1391d07c9f295f657c593cd # 1.88
 
-            - uses: actions/cache@v4
-              with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                      rust/target
-                  key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@v2
 
             - name: Install sqlx-cli
               working-directory: rust

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -177,6 +177,10 @@ jobs:
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev --directory ..
 
+            - name: Cache Rust dependencies
+              if: needs.changes.outputs.rust == 'true'
+              uses: Swatinem/rust-cache@v2
+
             - name: Install sqlx-cli
               if: needs.changes.outputs.rust == 'true'
               run: |

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -179,7 +179,7 @@ jobs:
 
             - name: Cache Rust dependencies
               if: needs.changes.outputs.rust == 'true'
-              uses: Swatinem/rust-cache@v2
+              uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
 
             - name: Install sqlx-cli
               if: needs.changes.outputs.rust == 'true'


### PR DESCRIPTION
## Summary

Add Swatinem/rust-cache to speed up sqlx-cli installation in CI workflows. Uses the same battle-tested caching action that the official sqlx project uses.

## Changes

- Add Swatinem/rust-cache@v2 to ci-rust.yml, ci-backend.yml, ci-dagster.yml
- Replace manual cache implementation with Swatinem/rust-cache@v2 in ci-nodejs.yml

## Impact

sqlx-cli installation currently takes several minutes to compile from source on every CI run. With caching, first run still compiles but subsequent runs restore from cache in seconds.

Cache is automatically shared across branches.