### PR TITLE
fix(llma): display issues

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -182,13 +182,6 @@
             "examples": ["{\"temperature\": 0.5, \"max_tokens\": 50}"],
             "label": "AI model parameters (LLM)"
         },
-        "$ai_output": {
-            "description": "The output JSON that was received from the LLM API.",
-            "examples": [
-                "{\"choices\": [{\"text\": \"Quantum computing is a type of computing that harnesses the power of quantum mechanics to perform operations on data.\"}]}"
-            ],
-            "label": "AI output (LLM)"
-        },
         "$ai_output_choices": {
             "description": "The output message choices JSON that was received from the LLM API.",
             "examples": [
@@ -2128,13 +2121,6 @@
             "description": "The parameters used to configure the model in the LLM API, in JSON.",
             "examples": ["{\"temperature\": 0.5, \"max_tokens\": 50}"],
             "label": "AI model parameters (LLM)"
-        },
-        "$ai_output": {
-            "description": "The output JSON that was received from the LLM API.",
-            "examples": [
-                "{\"choices\": [{\"text\": \"Quantum computing is a type of computing that harnesses the power of quantum mechanics to perform operations on data.\"}]}"
-            ],
-            "label": "AI output (LLM)"
         },
         "$ai_output_choices": {
             "description": "The output message choices JSON that was received from the LLM API.",

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -2522,13 +2522,6 @@ Here is the taxonomy for event properties:
             "description": "The number of tokens in the input prompt that was sent to the LLM API.",
             "examples": [23],
         },
-        "$ai_output": {
-            "label": "AI output (LLM)",
-            "description": "The output JSON that was received from the LLM API.",
-            "examples": [
-                '{"choices": [{"text": "Quantum computing is a type of computing that harnesses the power of quantum mechanics to perform operations on data."}]}',
-            ],
-        },
         "$ai_output_choices": {
             "label": "AI output (LLM)",
             "description": "The output message choices JSON that was received from the LLM API.",


### PR DESCRIPTION
Fixes a couple of issues raised in a ticket:
- We hadn't properly removed the deprecated `$ai_output` column from every taxonomy
- Expanding the details of an LLM generation in the list would break if the user reordered the columns
