### PR TITLE
fix(data_warehouse): correct ContentType app_label to match AppConfig

### DIFF
--- a/posthog/migrations/0897_migrate_data_warehouse_models.py
+++ b/posthog/migrations/0897_migrate_data_warehouse_models.py
@@ -23,7 +23,7 @@ def update_content_type(apps, schema_editor):
     ]:
         try:
             ct = ContentType.objects.get(app_label="posthog", model=model)
-            ct.app_label = "datawarehouse"
+            ct.app_label = "data_warehouse"
             ct.save()
         except ContentType.DoesNotExist:
             pass
@@ -48,7 +48,7 @@ def reverse_content_type(apps, schema_editor):
         "querytabstate",
     ]:
         try:
-            ct = ContentType.objects.get(app_label="datawarehouse", model=model)
+            ct = ContentType.objects.get(app_label="data_warehouse", model=model)
             ct.app_label = "posthog"
             ct.save()
         except ContentType.DoesNotExist:


### PR DESCRIPTION
## Summary

Fix critical bug in migration 0897 where ContentType app_label was set to "datawarehouse" but DataWarehouseConfig declares label as "data_warehouse" (with underscore).

## Problem

The mismatch between ContentType.app_label and AppConfig.label breaks generic relations:
- `ContentType.model_class()` returns `None` when the app_label doesn't match any installed app's label
- Activity logs fail to resolve generic foreign keys to data warehouse models
- Any code using `GenericForeignKey` to reference these models breaks

## Changes

- Changed `ct.app_label = "datawarehouse"` to `ct.app_label = "data_warehouse"` in forward migration
- Changed corresponding line in reverse migration for consistency

## Impact

Without this fix, generic relations to all migrated data warehouse models would be broken in production.