### PR TITLE
fix(react): add type assertion to options in sdk-install-instructions

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -35,15 +35,15 @@ import { PostHogProvider } from 'posthog-js/react'
 const options = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
   defaults: '${SDK_DEFAULTS_DATE}',
-}
+} as const
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY} options={options}>
       <App />
     </PostHogProvider>
-  </StrictMode>,
-);`}
+  </StrictMode>
+)`}
         </CodeSnippet>
     )
 }


### PR DESCRIPTION
Surfaced by https://x.com/MurdockLukas/status/1985105439206564165

Without this, Typescript will complain that our `defaults` option is not valid (because it's a string and not a `ConfigDefaults`-branded string)
