### PR TITLE
feat: Add sessions v3 mvs

### DIFF
--- a/posthog/clickhouse/migrations/0168_sessions_v3_mvs.py
+++ b/posthog/clickhouse/migrations/0168_sessions_v3_mvs.py
@@ -1,0 +1,17 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sessions_v3 import (
+    RAW_SESSIONS_TABLE_MV_RECORDINGS_SQL_V3,
+    RAW_SESSIONS_TABLE_MV_SQL_V3,
+)
+
+operations = [
+    run_sql_with_exceptions(
+        RAW_SESSIONS_TABLE_MV_SQL_V3(),
+        node_roles=[NodeRole.DATA],
+    ),
+    run_sql_with_exceptions(
+        RAW_SESSIONS_TABLE_MV_RECORDINGS_SQL_V3(),
+        node_roles=[NodeRole.DATA],
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0167_sessions_v3_split_bounce_rate
+0168_sessions_v3_mvs


### PR DESCRIPTION
Merge https://github.com/PostHog/posthog/pull/41039 first

## Problem

We haven't been ingesting data in the v3 sessions table so far, so that we could run the backfill / measure perf without needing to add to the ingestion load.

That's done now, so let's start ingesting data

## Changes

Add the 2 MVs (one for the events table, one for replay)

## How did you test this code?

These tables already have tests, under `posthog/clickhouse/test/test_raw_sessions_v3_model.py`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
