### PR TITLE
fix(logs-ingestion): preserve existing headers in log ingestion

### DIFF
--- a/plugin-server/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
@@ -66,11 +66,10 @@ exports[`LogsIngestionConsumer general should process multiple log messages 1`] 
 ]
 `;
 
-exports[`LogsIngestionConsumer message parsing and validation should preserve kafka message headers 1`] = `
+exports[`LogsIngestionConsumer message parsing and validation should overwrite existing headers 1`] = `
 [
   {
     "headers": {
-      "myHeader": "hello",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },
@@ -86,10 +85,11 @@ exports[`LogsIngestionConsumer message parsing and validation should preserve ka
 ]
 `;
 
-exports[`LogsIngestionConsumer message parsing and validation should overwrite existing headers 1`] = `
+exports[`LogsIngestionConsumer message parsing and validation should preserve kafka message headers 1`] = `
 [
   {
     "headers": {
+      "myHeader": "hello",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },

--- a/plugin-server/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
@@ -65,3 +65,42 @@ exports[`LogsIngestionConsumer general should process multiple log messages 1`] 
   },
 ]
 `;
+
+exports[`LogsIngestionConsumer message parsing and validation should preserve kafka message headers 1`] = `
+[
+  {
+    "headers": {
+      "myHeader": "hello",
+      "team_id": "2",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+    },
+    "key": null,
+    "topic": "clickhouse_logs_test",
+    "value": {
+      "level": "info",
+      "message": "Test log message",
+      "service": "test-service",
+      "timestamp": "2025-01-01T00:00:00.000Z",
+    },
+  },
+]
+`;
+
+exports[`LogsIngestionConsumer message parsing and validation should overwrite existing headers 1`] = `
+[
+  {
+    "headers": {
+      "team_id": "2",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+    },
+    "key": null,
+    "topic": "clickhouse_logs_test",
+    "value": {
+      "level": "info",
+      "message": "Test log message",
+      "service": "test-service",
+      "timestamp": "2025-01-01T00:00:00.000Z",
+    },
+  },
+]
+`;

--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -180,12 +180,12 @@ describe('LogsIngestionConsumer', () => {
             const logData = createLogMessage()
             const messages = createKafkaMessages([logData], {
                 myHeader: 'hello',
+                token: team.api_token,
             })
 
             await consumer.processKafkaBatch(messages)
 
             const producedMessages = mockProducerObserver.getProducedKafkaMessages()
-            expect(producedMessages).toHaveLength(1)
             expect(forSnapshot(producedMessages)).toMatchSnapshot()
         })
 
@@ -197,7 +197,6 @@ describe('LogsIngestionConsumer', () => {
             })
 
             await consumer.processKafkaBatch(messages)
-
             expect(forSnapshot(mockProducerObserver.getProducedKafkaMessages())).toMatchSnapshot()
         })
 

--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -189,7 +189,7 @@ describe('LogsIngestionConsumer', () => {
             expect(forSnapshot(producedMessages)).toMatchSnapshot()
         })
 
-        it('should preserve overwrite existing headers', async () => {
+        it('should overwrite existing headers', async () => {
             const logData = createLogMessage()
             const messages = createKafkaMessages([logData], {
                 token: team.api_token,

--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -176,6 +176,31 @@ describe('LogsIngestionConsumer', () => {
             expect(mockProducerObserver.getProducedKafkaMessages()).toHaveLength(0)
         })
 
+        it('should preserve kafka message headers', async () => {
+            const logData = createLogMessage()
+            const messages = createKafkaMessages([logData], {
+                myHeader: 'hello',
+            })
+
+            await consumer.processKafkaBatch(messages)
+
+            const producedMessages = mockProducerObserver.getProducedKafkaMessages()
+            expect(producedMessages).toHaveLength(1)
+            expect(forSnapshot(producedMessages)).toMatchSnapshot()
+        })
+
+        it('should preserve overwrite existing headers', async () => {
+            const logData = createLogMessage()
+            const messages = createKafkaMessages([logData], {
+                token: team.api_token,
+                team_id: '999',
+            })
+
+            await consumer.processKafkaBatch(messages)
+
+            expect(forSnapshot(mockProducerObserver.getProducedKafkaMessages())).toMatchSnapshot()
+        })
+
         it('should handle parse errors gracefully', async () => {
             const messages = [
                 {

--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -80,6 +80,7 @@ export class LogsIngestionConsumer {
                     value: message.message.value,
                     key: null,
                     headers: {
+                        ...(message.message.headers || []).reduce((a, v) => ({ ...a, [v.key]: v.value }), {}),
                         token: message.token,
                         team_id: message.teamId.toString(),
                     },

--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -80,7 +80,7 @@ export class LogsIngestionConsumer {
                     value: message.message.value,
                     key: null,
                     headers: {
-                        ...(message.message.headers || []).reduce((a, v) => ({ ...a, [v.key]: v.value }), {}),
+                        ...parseKafkaHeaders(message.message.headers),
                         token: message.token,
                         team_id: message.teamId.toString(),
                     },


### PR DESCRIPTION
## Problem

we added bytes headers to log capture but they dropped in ingestion stage so we can't query them in clickhouse

## Changes

preserve existing headers

## How did you test this code?

locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
