### PR TITLE
fix: correct typo in SDK doctor warning message

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
@@ -269,7 +269,7 @@ export function SidePanelSdkDoctor(): JSX.Element | null {
                             }}
                         >
                             <p className="font-semibold">
-                                An outdated SDK means you're missing out on bug fixes and enhacements.
+                                An outdated SDK means you're missing out on bug fixes and enhancements.
                             </p>
                             <p className="text-sm mt-1">Check the links below to get caught up.</p>
                         </LemonBanner>


### PR DESCRIPTION
## Problem

Fixed a typo in the SDK Doctor warning message where "enhacements" was misspelled instead of "enhancements".

https://posthoghelp.zendesk.com/agent/tickets/41512 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/43116)

## Changes

- Corrected the spelling of "enhancements" in the SDK doctor warning banner text

## How did you test this code?

Manual review of the text change. This is a simple typo fix in a user-facing string.

## Changelog: (features only) Is this feature complete?

N/A - This is a typo fix, not a feature.