### PR TITLE
chore(temporal): Add nodemon for restarting temporal worker on changes locally

### DIFF
--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -16,7 +16,15 @@ procs:
         autorestart: true
 
     temporal-worker:
-        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && bin/check_video_deps &&  python manage.py start_temporal_worker --task-queue development-task-queue 2>&1 | tee /tmp/posthog-temporal-worker.log'
+        shell: |-
+            bin/check_kafka_clickhouse_up && \
+            bin/check_temporal_up && \
+            bin/check_video_deps && \
+            if [ -n "$TEMPORAL_WATCH" ]; then \
+                nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue" 2>&1 | tee /tmp/posthog-temporal-worker.log; \
+            else \
+                python manage.py start_temporal_worker --task-queue development-task-queue 2>&1 | tee /tmp/posthog-temporal-worker.log; \
+            fi
 
     dagster:
         shell: |-

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -20,7 +20,11 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/check_temporal_up && \
             bin/check_video_deps && \
-            nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue" 2>&1 | tee /tmp/posthog-temporal-worker.log
+            if [ -n "$TEMPORAL_WATCH" ]; then \
+                nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue"; \
+            else \
+                python manage.py start_temporal_worker --task-queue development-task-queue; \
+            fi
 
     dagster:
         shell: |-

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -16,7 +16,11 @@ procs:
         autorestart: true
 
     temporal-worker:
-        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && bin/check_video_deps && python manage.py start_temporal_worker --task-queue development-task-queue'
+        shell: |-
+            bin/check_kafka_clickhouse_up && \
+            bin/check_temporal_up && \
+            bin/check_video_deps && \
+            nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue" 2>&1 | tee /tmp/posthog-temporal-worker.log
 
     dagster:
         shell: |-


### PR DESCRIPTION
## Problem

In a [previous PR](https://github.com/PostHog/posthog/pull/40684/files#diff-249572b667bd69fa0feceff67b17712628983981a9a9a7125cf6723ff4d54d49L35) I consolidated all the Temporal workers into one when running locally. However I removed `nodemon` which was used when running the PostHog AI worker. This allowed the worker to be restarted automatically when any changes were made to source files in certain directories.

## Changes

Use `nodemon` for running the Temporal worker locally if the `TEMPORAL_WATCH` env var is set

## How did you test this code?

Tested that setting `TEMPORAL_WATCH=1` in my `.env` causes workers to be run under `nodemon`. If I comment out the env var, then the workers run without `nodemon`.
