### PR TITLE
chore(sql-editor): Remove the SQL tab from product analytics

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -1,8 +1,6 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
 
-import { IconExternal } from '@posthog/icons'
-
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -193,15 +191,6 @@ export const insightNavLogic = kea<insightNavLogicType>([
                         label: 'Lifecycle',
                         type: InsightType.LIFECYCLE,
                         dataAttr: 'insight-lifecycle-tab',
-                    },
-                    {
-                        label: (
-                            <>
-                                SQL <IconExternal />
-                            </>
-                        ),
-                        type: InsightType.SQL,
-                        dataAttr: 'insight-sql-tab',
                     },
                 ]
 


### PR DESCRIPTION
## Problem
- It's a bit confusing to have the SQL tab in product analytics when it redirects users to the SQL editor
- The editor has been out long enough now for people to know where it lives in the sidebar

## Changes
- Removes the SQL tab from new product analytics insights 