### PR TITLE
feat(migration-analyzer): add override for UPDATE/DELETE on small tables

### DIFF
--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -377,8 +377,14 @@ class RunSQLAnalyzer(OperationAnalyzer):
         return None
 
     def analyze(self, op, migration: Optional[Any] = None, loader: Optional[Any] = None) -> OperationRisk:
-        sql = str(op.sql).upper()
+        # Parse override from original SQL (before stripping comments)
         override = self._parse_override_comment(op)
+
+        # Strip comments before detecting SQL keywords to avoid false matches
+        sql_original = str(op.sql)
+        sql_without_comments = re.sub(r"--[^\n]*", "", sql_original)  # Remove -- comments
+        sql_without_comments = re.sub(r"#[^\n]*", "", sql_without_comments)  # Remove # comments
+        sql = sql_without_comments.upper()
 
         # Check for CONCURRENTLY operations first (these are safe)
         # This must come before DROP check to avoid flagging DROP INDEX CONCURRENTLY as dangerous

--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -306,6 +306,41 @@ class TestRunSQLOperations:
         assert "locking" in risk.reason.lower() or "review" in risk.reason.lower()
         assert risk.level == RiskLevel.BLOCKED
 
+    def test_run_sql_with_update_override_for_small_table(self):
+        """Test UPDATE with migration-analyzer override comment reduces severity."""
+        op = create_mock_operation(
+            migrations.RunSQL,
+            sql="""
+            -- migration-analyzer: safe reason=Data warehouse table with limited customer usage
+            UPDATE posthog_externaldataschema SET sync_time_of_day = null WHERE sync_time_of_day = '00:00:00';
+            """,
+        )
+
+        risk = self.analyzer.analyze_operation(op)
+
+        assert risk.score == 2
+        assert risk.level == RiskLevel.NEEDS_REVIEW
+        assert "override" in risk.reason.lower()
+        assert "Data warehouse table" in risk.details.get("override_reason", "")
+        assert "Developer override applied" in (risk.guidance or "")
+
+    def test_run_sql_with_delete_override_for_small_table(self):
+        """Test DELETE with migration-analyzer override comment reduces severity."""
+        op = create_mock_operation(
+            migrations.RunSQL,
+            sql="""
+            # migration-analyzer: safe reason=Cleanup table with minimal rows
+            DELETE FROM temp_table WHERE created_at < NOW() - INTERVAL '30 days';
+            """,
+        )
+
+        risk = self.analyzer.analyze_operation(op)
+
+        assert risk.score == 2
+        assert risk.level == RiskLevel.NEEDS_REVIEW
+        assert "override" in risk.reason.lower()
+        assert "Cleanup table with minimal rows" in risk.details.get("override_reason", "")
+
     def test_run_sql_with_alter(self):
         op = create_mock_operation(
             migrations.RunSQL,


### PR DESCRIPTION
Add override mechanism for migration analyzer to handle legitimate small-table UPDATE/DELETE operations.

**Problem**

Migration analyzer blocks ALL UPDATE/DELETE operations (score 4) since they can cause locks. This is correct for large tables but overly cautious for small tables with few rows.

Example: #40662 updates `posthog_externaldataschema` (data warehouse feature with limited usage) but gets blocked despite being safe.

**Solution**

Add override comment support for RunSQL operations:

```sql
-- migration-analyzer: safe reason=Data warehouse table with limited customer usage
UPDATE posthog_externaldataschema SET ...
```

- Downgrades from Blocked (4) to Needs Review (2)
- Requires explicit justification visible in code review
- Override not documented in error messages to prevent casual misuse
- Only applies to UPDATE/DELETE operations in RunSQL

**Test plan**

- Added tests for UPDATE and DELETE override scenarios
- All tests pass
- Override reduces severity as expected while preserving justification in output