### PR TITLE
fix(plugin-server): Add JsonB sanitization to group sql operations

### DIFF
--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.ts
@@ -3,6 +3,8 @@ import { QueryResult } from 'pg'
 
 import { Properties } from '@posthog/plugin-scaffold'
 
+import { sanitizeJsonbValue } from '~/utils/db/utils'
+
 import {
     Group,
     GroupTypeIndex,
@@ -120,7 +122,7 @@ export class PostgresGroupRepository
                 teamId,
                 groupKey,
                 groupTypeIndex,
-                JSON.stringify(groupProperties),
+                sanitizeJsonbValue(groupProperties),
                 createdAt.toISO(),
                 JSON.stringify(propertiesLastUpdatedAt),
                 JSON.stringify(propertiesLastOperation),
@@ -164,7 +166,7 @@ export class PostgresGroupRepository
                 groupKey,
                 groupTypeIndex,
                 createdAt.toISO(),
-                JSON.stringify(groupProperties),
+                sanitizeJsonbValue(groupProperties),
                 JSON.stringify(propertiesLastUpdatedAt),
                 JSON.stringify(propertiesLastOperation),
             ],
@@ -206,7 +208,7 @@ export class PostgresGroupRepository
                 groupTypeIndex,
                 expectedVersion,
                 createdAt.toISO(),
-                JSON.stringify(groupProperties),
+                sanitizeJsonbValue(groupProperties),
                 JSON.stringify(propertiesLastUpdatedAt),
                 JSON.stringify(propertiesLastOperation),
             ],


### PR DESCRIPTION
## Problem

We're seeing errors due to lack of sanitization of JSONB values, specifically handling `\\u0000` unicode sequences.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
