### PR TITLE
fix(alerts): enable info logging for alerts

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -92,7 +92,7 @@ LOGGING = {
         },  # blackhole Django autoreload logs (this is only needed in DEV)
         "kafka.conn": {"level": "WARN"},  # kafka-python logs are noisy
         "posthog.caching.warming": {"level": "INFO"},
-        "posthog.tasks.alerts": {"level": "INFO"},
+        "posthog.tasks.alerts": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "boto3": {"level": "WARN"},  # boto3 logs are noisy
         "botocore": {"level": "WARN"},  # botocore logs are noisy
     },

--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -92,6 +92,7 @@ LOGGING = {
         },  # blackhole Django autoreload logs (this is only needed in DEV)
         "kafka.conn": {"level": "WARN"},  # kafka-python logs are noisy
         "posthog.caching.warming": {"level": "INFO"},
+        "posthog.tasks.alerts": {"level": "INFO"},
         "boto3": {"level": "WARN"},  # boto3 logs are noisy
         "botocore": {"level": "WARN"},  # botocore logs are noisy
     },

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -128,7 +128,7 @@ def reset_stuck_alerts_task() -> None:
 
     for alert in stuck_alerts:
         # we need to check the alert, reset is_calculating
-        logger.info(f"Alert {alert.id} is stuck in is_calculating for too long, resetting is_calculating")
+        logger.info("check_alert.reset_stuck_alert", alert_id=alert.id)
         alert.is_calculating = False
         alert.save()
 
@@ -236,7 +236,7 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
             alert.state = AlertState.NOT_FIRING
 
     # we will attempt to check alert
-    logger.info(f"Checking alert id = {alert.id}")
+    logger.info("check_alert", alert_id=alert.id)
     alert.last_checked_at = datetime.now(UTC)
     alert.is_calculating = True
     alert.save()

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -182,7 +182,7 @@ def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[st
         for target in email_targets:
             message.add_recipient(email=target)
 
-        logger.info(f"Send notifications about {len(breaches)} anomalies", alert_id=alert.id)
+        logger.info("send_notifications_for_breaches", alert_id=alert.id, anomaly_count=len(breaches))
         message.send()
 
     trigger_alert_hog_functions(alert=alert, properties={"breaches": ", ".join(breaches)})


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Info logs for alerts were not showing up in Grafana.

This is because Celery's [worker_hijack_root_logger](https://docs.celeryq.dev/en/latest/userguide/configuration.html) setting removes root logger handlers in worker processes.


```
kubectl exec -n posthog posthog-worker-django-alerts-5d494dcdf4-4r6tm -- python3 -c "
from celery import current_app
print('worker_hijack_root_logger:', current_app.conf.worker_hijack_root_logger)
"

worker_hijack_root_logger: True
```

## Changes

- Enable INFO logging for alerts by adding explicit handler, since Celery removes root logger handlers in workers
- Use structured logging instead of f-string to make it easier to parse logs. 


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
