### PR TITLE
fix(experiments): alternative experiment exposure

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1,7 +1,6 @@
 import { BindLogic, useValues } from 'kea'
 
 import { NotFound } from 'lib/components/NotFound'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import type { SceneExport } from 'scenes/sceneTypes'
@@ -9,7 +8,6 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { ExperimentForm } from './ExperimentForm'
 import { ExperimentView } from './ExperimentView/ExperimentView'
-import { CreateExperiment } from './create/CreateExperiment'
 import { type ExperimentLogicProps, FORM_MODES, experimentLogic } from './experimentLogic'
 import { type ExperimentSceneLogicProps, experimentSceneLogic } from './experimentSceneLogic'
 
@@ -29,7 +27,6 @@ export function Experiment({ tabId }: ExperimentSceneLogicProps): JSX.Element {
     }
     const { formMode, experimentMissing, experimentId } = useValues(experimentSceneLogic({ tabId }))
     const { currentTeamId } = useValues(teamLogic)
-    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM', 'test')
 
     useFileSystemLogView({
         type: 'experiment',
@@ -43,14 +40,6 @@ export function Experiment({ tabId }: ExperimentSceneLogicProps): JSX.Element {
 
     if (experimentMissing) {
         return <NotFound object="experiment" />
-    }
-
-    if (isCreateFormEnabled && formMode === FORM_MODES.create) {
-        return (
-            <BindLogic logic={experimentLogic} props={logicProps}>
-                <CreateExperiment tabId={tabId} />
-            </BindLogic>
-        )
     }
 
     return (

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -16,7 +16,7 @@ import {
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ExperimentVariantNumber } from 'lib/components/SeriesGlyph'
-import { MAX_EXPERIMENT_VARIANTS } from 'lib/constants'
+import { FEATURE_FLAGS, MAX_EXPERIMENT_VARIANTS } from 'lib/constants'
 import { GroupsAccessStatus, groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -37,6 +37,7 @@ import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { AccessControlLevel, AccessControlResourceType, FeatureFlagType } from '~/types'
 
+import { CreateExperiment } from './create/CreateExperiment'
 import { experimentLogic } from './experimentLogic'
 
 const ExperimentFormFields = (): JSX.Element => {
@@ -428,7 +429,11 @@ export const HoldoutSelector = (): JSX.Element => {
 }
 
 export function ExperimentForm(): JSX.Element {
-    const { props } = useValues(experimentLogic)
+    const { props, featureFlags } = useValues(experimentLogic)
+
+    if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_CREATE_FORM] === 'test') {
+        return <CreateExperiment />
+    }
 
     return (
         <div>

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { LemonTabs } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { WebExperimentImplementationDetails } from 'scenes/experiments/WebExperimentImplementationDetails'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -205,8 +205,15 @@ const VariantsTab = (): JSX.Element => {
 }
 
 export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.Element {
-    const { experimentLoading, experimentId, experiment, usesNewQueryRunner, isExperimentDraft, exposureCriteria } =
-        useValues(experimentLogic)
+    const {
+        experimentLoading,
+        experimentId,
+        experiment,
+        usesNewQueryRunner,
+        isExperimentDraft,
+        exposureCriteria,
+        featureFlags,
+    } = useValues(experimentLogic)
     const { setExperiment, updateExperimentMetrics, addSharedMetricsToExperiment, removeSharedMetricFromExperiment } =
         useActions(experimentLogic)
 
@@ -228,7 +235,6 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
      * We show the create form if the experiment is draft + has no primary metrics. Otherwise,
      * we show the experiment view.
      */
-    const isCreateFormEnabled = useFeatureFlag('EXPERIMENTS_CREATE_FORM', 'test')
     const allPrimaryMetrics = [
         ...(experiment.metrics || []),
         ...(experiment.saved_metrics || []).filter((sm) => sm.metadata.type === 'primary'),
@@ -236,9 +242,9 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
 
     if (
         !experimentLoading &&
-        isCreateFormEnabled &&
         getExperimentStatus(experiment) === ProgressStatus.Draft &&
-        allPrimaryMetrics.length === 0
+        allPrimaryMetrics.length === 0 &&
+        featureFlags[FEATURE_FLAGS.EXPERIMENTS_CREATE_FORM] === 'test'
     ) {
         return <CreateExperiment draftExperiment={experiment} tabId={tabId} />
     }


### PR DESCRIPTION
## Problem

The experiment running on this feature flag is overexposing users.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Instead of using the `useFeatureFlag` hook, we are getting the value via the `Proxy` using the `experimentLogic`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/c8484524-ff7b-4c24-afb3-162fbeeeae0a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
