### PR TITLE
fix(hypercache): Add success and duration metrics to cache sync

### DIFF
--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -1,4 +1,5 @@
 import json
+import time
 from collections.abc import Callable
 from typing import Optional
 
@@ -6,7 +7,7 @@ from django.core.cache import cache
 
 import structlog
 from posthoganalytics import capture_exception
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram
 
 from posthog.models.team.team import Team
 from posthog.storage import object_storage
@@ -23,6 +24,13 @@ CACHE_SYNC_COUNTER = Counter(
     "posthog_hypercache_sync",
     "Number of times the hypercache cache sync task has been run",
     labelnames=["result", "namespace", "value"],
+)
+
+CACHE_SYNC_DURATION_HISTOGRAM = Histogram(
+    "posthog_hypercache_sync_duration_seconds",
+    "Time taken to sync hypercache in seconds",
+    labelnames=["namespace", "value"],
+    buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, float("inf")),
 )
 
 HYPERCACHE_CACHE_COUNTER = Counter(
@@ -126,11 +134,20 @@ class HyperCache:
     def update_cache(self, key: KeyType) -> bool:
         logger.info(f"Syncing {self.namespace} cache for team {key}")
 
+        start_time = time.time()
         try:
             data = self.load_fn(key)
             self.set_cache_value(key, data)
+
+            duration = time.time() - start_time
+            CACHE_SYNC_DURATION_HISTOGRAM.labels(namespace=self.namespace, value=self.value).observe(duration)
+            CACHE_SYNC_COUNTER.labels(result="success", namespace=self.namespace, value=self.value).inc()
+
             return True
         except Exception as e:
+            duration = time.time() - start_time
+            CACHE_SYNC_DURATION_HISTOGRAM.labels(namespace=self.namespace, value=self.value).observe(duration)
+
             capture_exception(e)
             logger.exception(f"Failed to sync {self.namespace} cache for team {key}", exception=str(e))
             CACHE_SYNC_COUNTER.labels(result="failure", namespace=self.namespace, value=self.value).inc()


### PR DESCRIPTION

## Problem

HyperCache updates record failures, but not successes. We also don't record durations for cache rebuilds which could be useful when trying to determine whether a cache rebuild should be on its own Celery queue or not.

## Changes

Track both successful cache syncs and their duration to help determine if cache rebuilds need dedicated queue isolation.

Adds:
- posthog_hypercache_sync{result="success"} counter for successful syncs
- posthog_hypercache_sync_duration_seconds histogram with percentiles

Previously only failures were tracked. With these metrics we can measure:
- P95/P99 cache rebuild duration
- Success vs failure rates
- Whether rebuilds justify dedicated Celery queue

## How did you test this code?

Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
