### PR TITLE
fix: replay filter nested groups was wonky

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -518,27 +518,44 @@ export const RecordingsUniversalFiltersEmbed = ({
                                     filters={filters}
                                     setFilters={setFilters}
                                 />
-                                <Popover
-                                    overlay={
-                                        <UniversalFilters.PureTaxonomicFilter
-                                            fullWidth={false}
-                                            onChange={() => setIsPopoverVisible(false)}
-                                        />
-                                    }
-                                    placement="bottom"
-                                    visible={isPopoverVisible}
-                                    onClickOutside={() => setIsPopoverVisible(false)}
-                                >
-                                    <LemonButton
-                                        type="secondary"
-                                        size="small"
-                                        data-attr="replay-filters-add-filter-button"
-                                        icon={<IconPlus />}
-                                        onClick={() => setIsPopoverVisible(!isPopoverVisible)}
-                                    >
-                                        Add filter
-                                    </LemonButton>
-                                </Popover>
+                                {/* Add filter button scoped to the first nested group */}
+                                {filters.filter_group.values.length > 0 &&
+                                    isUniversalGroupFilterLike(filters.filter_group.values[0]) && (
+                                        <UniversalFilters
+                                            rootKey="session-recordings.nested"
+                                            group={filters.filter_group.values[0]}
+                                            taxonomicGroupTypes={taxonomicGroupTypes}
+                                            onChange={(nestedGroup) => {
+                                                const newFilterGroup = {
+                                                    ...filters.filter_group,
+                                                    values: [nestedGroup, ...filters.filter_group.values.slice(1)],
+                                                }
+                                                setFilters({ filter_group: newFilterGroup })
+                                            }}
+                                        >
+                                            <Popover
+                                                overlay={
+                                                    <UniversalFilters.PureTaxonomicFilter
+                                                        fullWidth={false}
+                                                        onChange={() => setIsPopoverVisible(false)}
+                                                    />
+                                                }
+                                                placement="bottom"
+                                                visible={isPopoverVisible}
+                                                onClickOutside={() => setIsPopoverVisible(false)}
+                                            >
+                                                <LemonButton
+                                                    type="secondary"
+                                                    size="small"
+                                                    data-attr="replay-filters-add-filter-button"
+                                                    icon={<IconPlus />}
+                                                    onClick={() => setIsPopoverVisible(!isPopoverVisible)}
+                                                >
+                                                    Add filter
+                                                </LemonButton>
+                                            </Popover>
+                                        </UniversalFilters>
+                                    )}
                             </div>
                         )}
 


### PR DESCRIPTION
## Problem

I wasnt wrapping this in a `<UniversalFilters />` which meant it was adding filters like: 
`  filters.filter_group.values = [newFilter, ...]` <-- WRONG
however, by wrapping like so: 
``` 
<UniversalFilters
      group={filters.filter_group.values[0]}  // Scoped to NESTED group
      onChange={...}
  >
```
which adds filters like: `filters.filter_group.values[0].values = [newFilter, ...] ` <-- RIGHT level


This wasnt an issue for quick-add filter buttons because I was manually calling` setFilters()` on the correct nested filter group


## Changes

wrap in a universal filters component to call actions on correct nested layer/context/filter

## How did you test this code?

:x: before: (bad, returns all events though there should be 0)

![before_filters_not_applied.png](https://app.graphite.dev/user-attachments/assets/1e74c108-25f7-4d54-a52f-399e4da1e7bb.png)

:white_check_mark:  after (Control group):  (expected: 0 matches)
![after_control.png](https://app.graphite.dev/user-attachments/assets/335108ea-bdaf-47c7-84dc-8596d41f20be.png)

:white_check_mark:  after (test group):  (expected 0 matches)

[after_test_group.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/c3951cf5-3ebe-4c1d-b184-1c7d5a577082.mov" />](https://app.graphite.dev/user-attachments/video/c3951cf5-3ebe-4c1d-b184-1c7d5a577082.mov)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
