### PR TITLE
fix(cohortpeople): delete ClickHouse cohortpeople rows when a person …

### DIFF
--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -27,6 +27,7 @@ from posthog.models.signals import mutable_receiver
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
 from posthog.settings import TEST
+from posthog.clickhouse.client import Workload
 
 if TEST:
     # :KLUDGE: Hooks are kept around for tests. All other code goes through plugin-server or the other methods explicitly
@@ -205,6 +206,7 @@ def delete_person(person: Person, sync: bool = False) -> None:
     # This is racy https://github.com/PostHog/posthog/issues/11590
     distinct_ids_to_version = _get_distinct_ids_with_version(person)
     _delete_person(person.team_id, person.uuid, int(person.version or 0), person.created_at, sync)
+    _delete_ch_cohortpeople(person.team_id, person.uuid, sync)
     for distinct_id, version in distinct_ids_to_version.items():
         _delete_ch_distinct_id(person.team_id, person.uuid, distinct_id, version, sync)
 
@@ -229,6 +231,21 @@ def _delete_person(
         sync=sync,
     )
 
+def _delete_ch_cohortpeople(team_id: int, person_uuid, sync: bool = False) -> None:
+    """
+    Delete of cohortpeople rows for this person.
+    """
+    settings = {"lightweight_deletes_sync": 1 if sync else 0}
+
+    sync_execute(
+        """
+        DELETE FROM cohortpeople
+        WHERE team_id = %(team_id)s AND person_id = %(person_id)s
+        """,
+        {"team_id": team_id, "person_id": str(person_uuid)},
+        settings=settings,
+        workload=Workload.OFFLINE,
+    )
 
 def _get_distinct_ids_with_version(person: Person) -> dict[str, int]:
     return {


### PR DESCRIPTION
## Problem
Dynamic cohorts were still counting deleted people.
`cohortpeople` entries in ClickHouse were not being cleaned when a person was deleted, leading to inflated cohort membership counts.

Closes #40840 

## Changes

- Added `_delete_ch_cohortpeople` delete helper
- Called it inside `delete_person()` so cohortpeople rows are removed immediately
- Keeps batch cleanup job disabled to avoid cluster pressure

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
