### PR TITLE
fix: Capture invalid input params for org id

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -272,7 +272,7 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
         else:
             try:
                 team = Team.objects.get(id=self.team_id)
-            except Team.DoesNotExist:
+            except (Team.DoesNotExist, ValueError):
                 raise NotFound(
                     detail="Project not found."  # TODO: "Environment" instead of "Project" when project environments are rolled out
                 )
@@ -306,7 +306,7 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
             return team.project
         try:
             return Project.objects.get(id=self.project_id)
-        except Project.DoesNotExist:
+        except (Project.DoesNotExist, ValueError):
             raise NotFound(detail="Project not found.")
 
     @cached_property
@@ -332,7 +332,7 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
     def organization(self) -> Organization:
         try:
             return Organization.objects.get(id=self.organization_id)
-        except Organization.DoesNotExist:
+        except (Organization.DoesNotExist, ValueError):
             raise NotFound(detail="Organization not found.")
 
     def _filter_queryset_by_parents_lookups(self, queryset):


### PR DESCRIPTION
## Problem

- Invalid UUIDs in URL parameters caused unhandled ValueError exceptions when querying the database, resulting in 500 errors instead of proper 404 responses.
- [Exception](https://us.posthog.com/project/2/error_tracking/0199f1e2-8986-7003-9e57-1c404adf446e?timestamp=2025-11-04%2003%3A38%3A00.853000-08%3A00&searchQuery=personal&dateRange=%7B%22date_from%22%3A%22-90d%22%2C%22date_to%22%3Anull%7D)

## Changes

- Added ValueError to the exception handlers alongside DoesNotExist in the organization, project, and team properties to return proper 404 "Not Found" responses.
