### PR TITLE
fix: Add scopes to create/revoke PAT alogs

### DIFF
--- a/posthog/models/activity_logging/personal_api_key_utils.py
+++ b/posthog/models/activity_logging/personal_api_key_utils.py
@@ -25,6 +25,7 @@ class PersonalAPIKeyContext(ActivityContextBase):
     user_name: Optional[str] = None
     organization_name: Optional[str] = None
     team_name: Optional[str] = None
+    scopes: Optional[list[str]] = None
 
 
 def get_personal_api_key_access_locations(api_key: PersonalAPIKey) -> set[LogScope]:
@@ -191,6 +192,7 @@ def log_personal_api_key_scope_change(
                 if log_entry["organization_id"]
                 else None,
                 team_name=get_team_name(team_id) if team_id else None,
+                scopes=after_api_key.scopes or ["*"],
             ),
         )
 
@@ -258,6 +260,7 @@ def log_personal_api_key_activity(api_key: PersonalAPIKey, activity: str, user, 
                         user_name=api_key.user.get_full_name(),
                         organization_name=get_organization_name(location.org_id),
                         team_name=get_team_name(location.team_id),
+                        scopes=api_key.scopes or ["*"],
                     ),
                 ),
             }

--- a/posthog/test/activity_logging/test_personal_api_key_activity_logging.py
+++ b/posthog/test/activity_logging/test_personal_api_key_activity_logging.py
@@ -40,6 +40,7 @@ class TestPersonalAPIKeyActivityLogging(ActivityLogTestHelper):
         self.assertEqual(context["user_email"], self.user.email)
         self.assertEqual(context["organization_name"], self.organization.name)
         self.assertEqual(context["team_name"], "Unknown Project")  # Global keys have no team context
+        self.assertEqual(context["scopes"], ["*"])
 
     def test_personal_api_key_update_activity_logging(self):
         api_key = self.create_personal_api_key(label="Original API Key")
@@ -86,6 +87,10 @@ class TestPersonalAPIKeyActivityLogging(ActivityLogTestHelper):
         self.assertEqual(scopes_change["action"], "changed")
         self.assertEqual(scopes_change["before"], ["*"])
         self.assertEqual(scopes_change["after"], ["insight:read", "insight:write"])
+
+        context = update_log.detail.get("context")
+        assert context is not None
+        self.assertEqual(context["scopes"], ["insight:read", "insight:write"])
 
     def test_personal_api_key_deletion_activity_logging(self):
         api_key = self.create_personal_api_key(label="To Delete API Key")
@@ -269,6 +274,7 @@ class TestPersonalAPIKeyActivityLogging(ActivityLogTestHelper):
         self.assertEqual(context["user_email"], self.user.email)
         self.assertEqual(context["organization_name"], self.organization.name)
         self.assertEqual(context["team_name"], self.team.name)
+        self.assertEqual(context["scopes"], ["*"])
 
 
 class TestPersonalAPIKeyScopeChanges(ActivityLogTestHelper):


### PR DESCRIPTION
## Problem

- PAT alogs miss scopes

## Changes

- Adding them
