### PR TITLE
fix(cohorts): Block realtime oor cohorts referencing non-leaf cohorts

### DIFF
--- a/posthog/management/commands/resave_cohorts.py
+++ b/posthog/management/commands/resave_cohorts.py
@@ -6,6 +6,8 @@ from django.core.management.base import BaseCommand, CommandParser
 
 from posthog.api.cohort import validate_filters_and_compute_realtime_support
 from posthog.models.cohort.cohort import Cohort
+from posthog.models.cohort.util import get_all_cohort_dependencies
+from posthog.models.team.team import Team
 
 
 class Command(BaseCommand):
@@ -42,16 +44,6 @@ class Command(BaseCommand):
         dry_run: bool = bool(options.get("dry_run"))
         batch_size: int = int(options.get("batch_size") or 500)
 
-        # Establish base queryset and ordering for deterministic keyset pagination
-        base_qs = Cohort.objects.all().order_by("id")
-        if team_id:
-            base_qs = base_qs.filter(team__id=team_id)
-
-        total = 0
-        changed = 0
-        errors = 0
-        prospective_realtime = 0  # how many would be realtime after processing
-
         # Announce run scope and options for operator visibility
         scope_desc = f"team={team_id}" if team_id else "all teams"
         self.stdout.write(
@@ -60,58 +52,214 @@ class Command(BaseCommand):
             )
         )
 
-        # Keyset pagination: iterate by increasing id, limited by batch_size
-        last_id = 0
-        while True:
-            batch = list(base_qs.filter(id__gt=last_id)[:batch_size])
-            if not batch:
-                break
-            for cohort in batch:
-                total += 1
-                try:
-                    # Skip cohorts without filters (nothing to recompute)
-                    if not cohort.filters:
-                        continue
+        # Get teams to process
+        teams_qs = Team.objects.all().order_by("id")
+        if team_id:
+            teams_qs = teams_qs.filter(id=team_id)
 
-                    # Compute the new filters with inline bytecode and cohort_type
-                    clean_filters, computed_type, _ = validate_filters_and_compute_realtime_support(
-                        cohort.filters, cohort.team, current_cohort_type=cohort.cohort_type
-                    )
+        # Track global stats
+        global_total = 0
+        global_changed = 0
+        global_errors = 0
+        global_prospective_realtime = 0
+        teams_processed = 0
+        total_teams = teams_qs.count()
 
-                    # Decide if there is any change worth persisting/reporting
-                    # Bytecode is now inline in filters
-                    will_change = clean_filters != cohort.filters or computed_type != cohort.cohort_type
+        # Process each team separately
+        for team in teams_qs:
+            teams_processed += 1
+            self.stdout.write(self.style.MIGRATE_LABEL(f"Processing team {team.id} ({teams_processed}/{total_teams})"))
 
-                    # Track summary stats for dry-run (no per-cohort logging)
-                    if computed_type == "realtime":
-                        prospective_realtime += 1
-                    if dry_run:
-                        if will_change:
-                            changed += 1
-                        continue
+            stats = self._process_team_cohorts(team, batch_size, dry_run)
 
-                    # Persist changes without triggering recalculation jobs
-                    if will_change:
-                        cohort.filters = clean_filters
-                        cohort.cohort_type = computed_type
-                        cohort.save(update_fields=["filters", "cohort_type"])
-                        changed += 1
-                except Exception as err:
-                    errors += 1
-                    self.stderr.write(self.style.ERROR(f"Cohort {getattr(cohort, 'id', '?')}: {err}"))
+            # Accumulate stats
+            global_total += stats["total"]
+            global_changed += stats["changed"]
+            global_errors += stats["errors"]
+            global_prospective_realtime += stats["prospective_realtime"]
 
-            # Advance the keyset cursor
-            last_id = batch[-1].id
+            # Report team stats
+            if stats["total"] > 0:
+                self.stdout.write(
+                    f"  Team {team.id}: processed={stats['total']} changed={stats['changed']} "
+                    f"realtime={stats['prospective_realtime']} errors={stats['errors']}"
+                )
 
+        # Final summary
         if dry_run:
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Done (dry-run). total={total} would_change={changed} would_be_realtime={prospective_realtime} errors={errors}"
+                    f"\nDone (dry-run). teams={teams_processed} total_cohorts={global_total} "
+                    f"would_change={global_changed} would_be_realtime={global_prospective_realtime} "
+                    f"errors={global_errors}"
                 )
             )
         else:
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Done. total={total} changed={changed} realtime_now={prospective_realtime} errors={errors}"
+                    f"\nDone. teams={teams_processed} total_cohorts={global_total} "
+                    f"changed={global_changed} realtime_now={global_prospective_realtime} "
+                    f"errors={global_errors}"
                 )
             )
+
+    def _process_team_cohorts(self, team: Team, batch_size: int, dry_run: bool) -> dict[str, int]:
+        """Process all cohorts for a single team."""
+        # Initialize stats for this team
+        total = 0
+        changed = 0
+        errors = 0
+        prospective_realtime = 0
+
+        # Get all cohorts for this team using pagination
+        base_qs = Cohort.objects.filter(team=team).order_by("id")
+        all_cohorts = []
+        last_id = 0
+
+        while True:
+            batch = list(base_qs.filter(id__gt=last_id)[:batch_size])
+            if not batch:
+                break
+            all_cohorts.extend(batch)
+            last_id = batch[-1].id
+
+        # Build dependency information for all cohorts
+        seen_cohorts_cache = {c.id: c for c in all_cohorts}
+        cohort_dependencies = {}  # cohort_id -> set of all cohort ids it depends on
+        referenced_cohort_ids = set()
+
+        for cohort in all_cohorts:
+            if not cohort.filters:
+                continue
+            # Get ALL dependencies recursively (A->B->C means A depends on both B and C)
+            dependencies = get_all_cohort_dependencies(cohort, seen_cohorts_cache=seen_cohorts_cache)
+            dependency_ids = {dep.id for dep in dependencies}
+            cohort_dependencies[cohort.id] = dependency_ids
+            referenced_cohort_ids.update(dependency_ids)
+
+        # Filter to only include references within this team
+        team_cohort_ids = {c.id for c in all_cohorts}
+        referenced_cohort_ids = referenced_cohort_ids.intersection(team_cohort_ids)
+
+        # Create a map for quick cohort lookups
+        cohort_map = {c.id: c for c in all_cohorts}
+
+        # Step 1: Process all referenced cohorts first
+        for cohort in all_cohorts:
+            if cohort.id not in referenced_cohort_ids:
+                continue
+
+            total += 1
+            try:
+                # Skip cohorts without filters (nothing to recompute)
+                if not cohort.filters:
+                    continue
+
+                # Compute the new filters with inline bytecode and cohort_type
+                clean_filters, computed_type, _ = validate_filters_and_compute_realtime_support(
+                    cohort.filters, cohort.team, current_cohort_type=cohort.cohort_type
+                )
+
+                # Decide if there is any change worth persisting/reporting
+                will_change = clean_filters != cohort.filters or computed_type != cohort.cohort_type
+
+                # Track summary stats
+                if computed_type == "realtime":
+                    prospective_realtime += 1
+                if dry_run:
+                    if will_change:
+                        changed += 1
+                    # Update in-memory for dependency checking even in dry-run
+                    cohort.filters = clean_filters
+                    cohort.cohort_type = computed_type
+                    continue
+
+                # Persist changes without triggering recalculation jobs
+                if will_change:
+                    cohort.filters = clean_filters
+                    cohort.cohort_type = computed_type
+                    cohort.save(update_fields=["filters", "cohort_type"])
+                    changed += 1
+            except Exception as err:
+                errors += 1
+                self.stderr.write(self.style.ERROR(f"Cohort {cohort.id} (team {team.id}): {err}"))
+
+        # Step 2: Process all other cohorts (those that depend on others)
+        for cohort in all_cohorts:
+            if cohort.id in referenced_cohort_ids:
+                continue  # Already processed
+
+            total += 1
+            try:
+                # Skip cohorts without filters (nothing to recompute)
+                if not cohort.filters:
+                    continue
+
+                # Compute the new filters with inline bytecode and cohort_type
+                clean_filters, computed_type, _ = validate_filters_and_compute_realtime_support(
+                    cohort.filters, cohort.team, current_cohort_type=cohort.cohort_type
+                )
+
+                # Check if any directly referenced cohorts have dependencies
+                if computed_type == "realtime" and cohort.filters:
+                    direct_refs = self._get_direct_cohort_references(cohort.filters)
+                    for ref_id in direct_refs:
+                        # If any directly referenced cohort has dependencies, this cannot be realtime
+                        if ref_id in cohort_dependencies and len(cohort_dependencies[ref_id]) > 0:
+                            computed_type = None
+                            break
+                        # Also check if the referenced cohort is not realtime
+                        ref_cohort = cohort_map.get(ref_id)
+                        if ref_cohort and ref_cohort.cohort_type != "realtime":
+                            computed_type = None
+                            break
+
+                # Decide if there is any change worth persisting/reporting
+                will_change = clean_filters != cohort.filters or computed_type != cohort.cohort_type
+
+                # Track summary stats
+                if computed_type == "realtime":
+                    prospective_realtime += 1
+                if dry_run:
+                    if will_change:
+                        changed += 1
+                    continue
+
+                # Persist changes without triggering recalculation jobs
+                if will_change:
+                    cohort.filters = clean_filters
+                    cohort.cohort_type = computed_type
+                    cohort.save(update_fields=["filters", "cohort_type"])
+                    changed += 1
+            except Exception as err:
+                errors += 1
+                self.stderr.write(self.style.ERROR(f"Cohort {cohort.id} (team {team.id}): {err}"))
+
+        return {
+            "total": total,
+            "changed": changed,
+            "errors": errors,
+            "prospective_realtime": prospective_realtime,
+        }
+
+    def _get_direct_cohort_references(self, filters: dict[str, Any]) -> set[int]:
+        """Get only the direct cohort references from filters (not transitive)."""
+        referenced_ids = set()
+        if not isinstance(filters, dict):
+            return referenced_ids
+
+        properties = filters.get("properties", {})
+        if isinstance(properties, dict):
+            values = properties.get("values", [])
+            if isinstance(values, list):
+                for value in values:
+                    if isinstance(value, dict):
+                        if value.get("type") == "cohort" and value.get("value"):
+                            try:
+                                referenced_ids.add(int(value["value"]))
+                            except (ValueError, TypeError):
+                                pass
+                        # Recursively check nested groups
+                        if "values" in value:
+                            referenced_ids.update(self._get_direct_cohort_references({"properties": value}))
+        return referenced_ids

--- a/posthog/management/commands/resave_cohorts.py
+++ b/posthog/management/commands/resave_cohorts.py
@@ -163,21 +163,20 @@ class Command(BaseCommand):
                 # Decide if there is any change worth persisting/reporting
                 will_change = clean_filters != cohort.filters or computed_type != cohort.cohort_type
 
+                # ALWAYS update in-memory for dependency checking
+                cohort.filters = clean_filters
+                cohort.cohort_type = computed_type
+
                 # Track summary stats
                 if computed_type == "realtime":
                     prospective_realtime += 1
                 if dry_run:
                     if will_change:
                         changed += 1
-                    # Update in-memory for dependency checking even in dry-run
-                    cohort.filters = clean_filters
-                    cohort.cohort_type = computed_type
                     continue
 
-                # Persist changes without triggering recalculation jobs
+                # Persist changes to database if needed
                 if will_change:
-                    cohort.filters = clean_filters
-                    cohort.cohort_type = computed_type
                     cohort.save(update_fields=["filters", "cohort_type"])
                     changed += 1
             except Exception as err:
@@ -217,6 +216,10 @@ class Command(BaseCommand):
                 # Decide if there is any change worth persisting/reporting
                 will_change = clean_filters != cohort.filters or computed_type != cohort.cohort_type
 
+                # ALWAYS update in-memory for consistency
+                cohort.filters = clean_filters
+                cohort.cohort_type = computed_type
+
                 # Track summary stats
                 if computed_type == "realtime":
                     prospective_realtime += 1
@@ -225,10 +228,8 @@ class Command(BaseCommand):
                         changed += 1
                     continue
 
-                # Persist changes without triggering recalculation jobs
+                # Persist changes to database if needed
                 if will_change:
-                    cohort.filters = clean_filters
-                    cohort.cohort_type = computed_type
                     cohort.save(update_fields=["filters", "cohort_type"])
                     changed += 1
             except Exception as err:

--- a/posthog/management/commands/test/test_resave_cohorts.py
+++ b/posthog/management/commands/test/test_resave_cohorts.py
@@ -167,6 +167,197 @@ class TestResaveCohortsCommandSingleTeam(BaseTest):
         assert behavioral_filter_4["conditionHash"] is not None
 
 
+class TestResaveCohortsCommandWithDependencies(BaseTest):
+    def test_cohort_dependency_blocks_realtime(self):
+        """Test that a cohort referencing a non-realtime cohort cannot be realtime."""
+        team: Team = self.team
+
+        # Create a cohort with unsupported filters (cannot be realtime)
+        unsupported_cohort = Cohort.objects.create(
+            team=team,
+            name="unsupported_dependency",
+            filters=_make_unsupported_filters(),  # This cannot be realtime
+        )
+
+        # Create a cohort that would be realtime on its own (person-only filter)
+        # but references the unsupported cohort
+        dependent_cohort = Cohort.objects.create(
+            team=team,
+            name="dependent_cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"type": "person", "key": "email", "operator": "exact", "value": "test@example.com"},
+                        {"type": "cohort", "key": "id", "value": unsupported_cohort.id},
+                    ],
+                }
+            },
+        )
+
+        # Create another cohort that only has realtime-capable filters
+        realtime_cohort = Cohort.objects.create(team=team, name="fully_realtime", filters=_make_person_only_filters())
+
+        # Run command
+        call_command("resave_cohorts", team_id=team.id)
+
+        # Reload cohorts
+        unsupported_cohort.refresh_from_db()
+        dependent_cohort.refresh_from_db()
+        realtime_cohort.refresh_from_db()
+
+        # Assertions:
+        # 1. Unsupported cohort should NOT be realtime
+        assert unsupported_cohort.cohort_type is None
+
+        # 2. Dependent cohort should NOT be realtime (blocked by dependency)
+        assert dependent_cohort.cohort_type is None
+
+        # 3. Realtime cohort should be realtime (no problematic dependencies)
+        assert realtime_cohort.cohort_type == "realtime"
+
+    def test_cohort_with_multiple_leaf_dependencies_can_be_realtime(self):
+        """Test that a cohort referencing multiple leaf cohorts (no dependencies) can be realtime."""
+        team: Team = self.team
+
+        # Create two cohorts with realtime-capable filters (no dependencies)
+        leaf_cohort1 = Cohort.objects.create(
+            team=team, name="leaf_cohort_1", filters=_make_person_only_filters(email="user1@example.com")
+        )
+
+        leaf_cohort2 = Cohort.objects.create(
+            team=team, name="leaf_cohort_2", filters=_make_person_only_filters(email="user2@example.com")
+        )
+
+        # Create a cohort that references both leaf cohorts
+        multi_ref_cohort = Cohort.objects.create(
+            team=team,
+            name="multi_ref_cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"type": "cohort", "key": "id", "value": leaf_cohort1.id},
+                        {"type": "cohort", "key": "id", "value": leaf_cohort2.id},
+                    ],
+                }
+            },
+        )
+
+        # Run command
+        call_command("resave_cohorts", team_id=team.id)
+
+        # Reload cohorts
+        leaf_cohort1.refresh_from_db()
+        leaf_cohort2.refresh_from_db()
+        multi_ref_cohort.refresh_from_db()
+
+        # Assertions:
+        # 1. Both leaf cohorts should be realtime
+        assert leaf_cohort1.cohort_type == "realtime"
+        assert leaf_cohort2.cohort_type == "realtime"
+
+        # 2. Multi-reference cohort CAN be realtime (references only leaf cohorts)
+        assert multi_ref_cohort.cohort_type == "realtime"
+
+    def test_cohort_with_realtime_dependency_can_be_realtime(self):
+        """Test that a cohort referencing a realtime cohort can be realtime."""
+        team: Team = self.team
+
+        # Create a cohort with realtime-capable filters
+        realtime_dependency = Cohort.objects.create(
+            team=team,
+            name="realtime_dependency",
+            filters=_make_person_only_filters(),  # This can be realtime
+        )
+
+        # Create a cohort that references the realtime dependency
+        dependent_cohort = Cohort.objects.create(
+            team=team,
+            name="dependent_cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"type": "person", "key": "name", "operator": "exact", "value": "Test User"},
+                        {"type": "cohort", "key": "id", "value": realtime_dependency.id},
+                    ],
+                }
+            },
+        )
+
+        # Run command
+        call_command("resave_cohorts", team_id=team.id)
+
+        # Reload cohorts
+        realtime_dependency.refresh_from_db()
+        dependent_cohort.refresh_from_db()
+
+        # Assertions:
+        # 1. Dependency cohort should be realtime
+        assert realtime_dependency.cohort_type == "realtime"
+
+        # 2. Dependent cohort should also be realtime (dependency is realtime)
+        assert dependent_cohort.cohort_type == "realtime"
+
+    def test_cohort_referencing_non_leaf_cannot_be_realtime(self):
+        """Test that a cohort referencing a non-leaf cohort (B->C) cannot be realtime."""
+        team: Team = self.team
+
+        # Create base cohort C (realtime capable, leaf)
+        cohort_c = Cohort.objects.create(
+            team=team, name="cohort_c", filters=_make_person_only_filters(email="c@example.com")
+        )
+
+        # Create cohort B that references C (non-leaf)
+        cohort_b = Cohort.objects.create(
+            team=team,
+            name="cohort_b",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"type": "cohort", "key": "id", "value": cohort_c.id},
+                        {"type": "person", "key": "name", "operator": "exact", "value": "B User"},
+                    ],
+                }
+            },
+        )
+
+        # Create cohort A that references B (B has dependencies, so A cannot be realtime)
+        cohort_a = Cohort.objects.create(
+            team=team,
+            name="cohort_a",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"type": "cohort", "key": "id", "value": cohort_b.id},
+                        {"type": "person", "key": "name", "operator": "exact", "value": "A User"},
+                    ],
+                }
+            },
+        )
+
+        # Run command
+        call_command("resave_cohorts", team_id=team.id)
+
+        # Reload cohorts
+        cohort_a.refresh_from_db()
+        cohort_b.refresh_from_db()
+        cohort_c.refresh_from_db()
+
+        # Assertions:
+        # 1. Base cohort C can be realtime (no dependencies)
+        assert cohort_c.cohort_type == "realtime"
+
+        # 2. Cohort B can be realtime (references only leaf cohort C)
+        assert cohort_b.cohort_type == "realtime"
+
+        # 3. Cohort A cannot be realtime (references B which has dependencies)
+        assert cohort_a.cohort_type is None
+
+
 class TestResaveCohortsCommandTwoTeams(BaseTest):
     def test_resave_two_teams_each_five_types(self):
         team_a: Team = self.team

--- a/posthog/management/commands/test/test_resave_cohorts.py
+++ b/posthog/management/commands/test/test_resave_cohorts.py
@@ -467,7 +467,7 @@ class TestResaveCohortsCommandTwoTeams(BaseTest):
         assert cohorts_a[0].cohort_type == "realtime"
         assert cohorts_a[1].cohort_type is None
         assert cohorts_a[2].cohort_type == "realtime"
-        assert cohorts_a[3].cohort_type == "realtime"
+        assert cohorts_a[3].cohort_type is None  # Cannot be realtime because it references a static cohort
         assert cohorts_a[4].cohort_type == "realtime"
 
         # Team B untouched (no inline bytecode yet)
@@ -485,5 +485,5 @@ class TestResaveCohortsCommandTwoTeams(BaseTest):
         assert cohorts_b[0].cohort_type == "realtime"
         assert cohorts_b[1].cohort_type is None
         assert cohorts_b[2].cohort_type == "realtime"
-        assert cohorts_b[3].cohort_type == "realtime"
+        assert cohorts_b[3].cohort_type is None  # Cannot be realtime because it references a static cohort
         assert cohorts_b[4].cohort_type == "realtime"


### PR DESCRIPTION
## Problem

Cohorts that reference other cohorts with dependencies can't be evaluated in realtime, but the resave command wasn't enforcing this properly. It also wasn't processing cohorts in dependency order. Which would lead to two problems

1. cohort references another cohort with inCohort. The referenced cohort is non realtime but the parent cohort would still evaluate to realtime. 
2. we need to restrict the depth of the dependency graph for now (at least) so if a cohort references another cohort and this cohort then references yet another cohort we automatically render it non realtime

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

  - Process cohorts team-by-team to reduce memory usage & for easier retries & easier in order processing
  - Process referenced cohorts before dependent ones
  - Block realtime for cohorts that reference non-leaf cohorts (cohorts with dependencies)
  - Only allow realtime when all referenced cohorts are leaves AND realtime

 A cohort can only be realtime if all cohorts it references are leaves (have no dependencies
 themselves). This prevents complex dependency chains in realtime evaluation.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests

