### PR TITLE
feat: New batch export abstractions

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -1126,6 +1126,7 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                         consumer=consumer,
                         producer_task=producer_task,
                         transformer=transformer,
+                        json_columns=() if can_perform_merge else table_schemas.json_columns,
                     )
 
                     if can_perform_merge:

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -50,14 +50,13 @@ from products.batch_exports.backend.temporal.batch_exports import (
 from products.batch_exports.backend.temporal.pipeline.consumer import Consumer, run_consumer_from_stage
 from products.batch_exports.backend.temporal.pipeline.entrypoint import execute_batch_export_using_internal_stage
 from products.batch_exports.backend.temporal.pipeline.producer import Producer
-from products.batch_exports.backend.temporal.pipeline.transformer import ParquetStreamTransformer, TransformerProtocol
+from products.batch_exports.backend.temporal.pipeline.transformer import (
+    ChunkTransformerProtocol,
+    ParquetStreamTransformer,
+)
 from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_for_schema_or_producer
-from products.batch_exports.backend.temporal.utils import (
-    JsonType,
-    cast_record_batch_schema_json_columns,
-    handle_non_retryable_errors,
-)
+from products.batch_exports.backend.temporal.utils import JsonType, handle_non_retryable_errors
 
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
@@ -1074,22 +1073,17 @@ async def insert_into_databricks_activity_from_stage(inputs: DatabricksInsertInp
                     volume_path=volume_path,
                 )
 
-                transformer: TransformerProtocol = ParquetStreamTransformer(
-                    schema=cast_record_batch_schema_json_columns(
-                        record_batch_schema, json_columns=known_variant_columns
-                    ),
+                transformer: ChunkTransformerProtocol = ParquetStreamTransformer(
                     compression="zstd",
                     include_inserted_at=False,
+                    max_file_size_bytes=settings.BATCH_EXPORT_DATABRICKS_UPLOAD_CHUNK_SIZE_BYTES,
                 )
 
                 result = await run_consumer_from_stage(
                     queue=queue,
                     consumer=consumer,
                     producer_task=producer_task,
-                    schema=record_batch_schema,
                     transformer=transformer,
-                    max_file_size_bytes=settings.BATCH_EXPORT_DATABRICKS_UPLOAD_CHUNK_SIZE_BYTES,
-                    json_columns=known_variant_columns,
                 )
 
                 # TODO - maybe move this into the consumer finalize method?

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -1206,6 +1206,7 @@ async def insert_into_postgres_activity_from_stage(inputs: PostgresInsertInputs)
                         consumer=consumer,
                         producer_task=producer_task,
                         transformer=transformer,
+                        json_columns=(),
                     )
                 finally:
                     if merge_settings.requires_merge:

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -1197,6 +1197,7 @@ async def insert_into_postgres_activity_from_stage(inputs: PostgresInsertInputs)
                     line_terminator="\n",
                     quoting=csv.QUOTE_MINIMAL,
                     include_inserted_at=False,
+                    max_file_size_bytes=settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES,
                 )
 
                 try:
@@ -1205,9 +1206,6 @@ async def insert_into_postgres_activity_from_stage(inputs: PostgresInsertInputs)
                         consumer=consumer,
                         producer_task=producer_task,
                         transformer=transformer,
-                        schema=record_batch_schema,
-                        max_file_size_bytes=settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES,
-                        json_columns=(),
                     )
                 finally:
                     if merge_settings.requires_merge:

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1491,7 +1491,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
 
                     await redshift_client.acopy_from_s3_bucket(
                         table_name=redshift_stage_table,
-                        parquet_fields=[field.name for field in record_batch_schema],
+                        parquet_fields=[field.name for field in transformer.schema],
                         schema_name=inputs.table.schema_name,
                         s3_bucket=inputs.copy.s3_bucket.name,
                         manifest_key=manifest_key,

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1421,6 +1421,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             consumer=consumer,
             producer_task=producer_task,
             transformer=transformer,
+            json_columns=table_schemas.super_columns,
         )
 
         if result.error is not None:

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -445,6 +445,7 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> BatchExp
             max_concurrent_uploads=settings.BATCH_EXPORT_S3_MAX_CONCURRENT_UPLOADS,
         )
 
+        json_columns = ("properties", "person_properties", "set", "set_once")
         if inputs.file_format.lower() == "jsonlines":
             transformer = get_json_stream_transformer(
                 compression=inputs.compression,
@@ -463,6 +464,7 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> BatchExp
             consumer=consumer,
             producer_task=producer_task,
             transformer=transformer,
+            json_columns=json_columns,
         )
 
 

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -1169,6 +1169,7 @@ async def insert_into_snowflake_activity_from_stage(inputs: SnowflakeInsertInput
                     consumer=consumer,
                     producer_task=producer_task,
                     transformer=transformer,
+                    json_columns=known_variant_columns,
                 )
 
                 # TODO - maybe move this into the consumer finalize method?

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -54,7 +54,6 @@ from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_
 from products.batch_exports.backend.temporal.temporary_file import BatchExportTemporaryFile
 from products.batch_exports.backend.temporal.utils import (
     JsonType,
-    cast_record_batch_schema_json_columns,
     handle_non_retryable_errors,
     make_retryable_with_exponential_backoff,
 )
@@ -1162,19 +1161,14 @@ async def insert_into_snowflake_activity_from_stage(inputs: SnowflakeInsertInput
                 )
 
                 transformer = ParquetStreamTransformer(
-                    schema=cast_record_batch_schema_json_columns(
-                        record_batch_schema, json_columns=known_variant_columns
-                    ),
                     compression="zstd",
+                    max_file_size_bytes=settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES,
                 )
                 result = await run_consumer_from_stage(
                     queue=queue,
                     consumer=consumer,
                     producer_task=producer_task,
                     transformer=transformer,
-                    schema=record_batch_schema,
-                    max_file_size_bytes=settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES,
-                    json_columns=known_variant_columns,
                 )
 
                 # TODO - maybe move this into the consumer finalize method?

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -1,20 +1,14 @@
 import abc
 import asyncio
-import collections.abc
 
-import pyarrow as pa
 import temporalio.common
 
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
 
 from products.batch_exports.backend.temporal.metrics import get_bytes_exported_metric, get_rows_exported_metric
-from products.batch_exports.backend.temporal.pipeline.transformer import TransformerProtocol
+from products.batch_exports.backend.temporal.pipeline.transformer import ChunkTransformerProtocol
 from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, raise_on_task_failure
-from products.batch_exports.backend.temporal.utils import (
-    cast_record_batch_json_columns,
-    cast_record_batch_schema_json_columns,
-)
 
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
@@ -31,6 +25,12 @@ class Consumer:
         self.logger = LOGGER.bind()
         self.external_logger = EXTERNAL_LOGGER.bind()
 
+        # Progress tracking
+        self.total_record_batches_count = 0
+        self.total_records_count = 0
+        self.total_record_batch_bytes_count = 0
+        self.total_file_bytes_count = 0
+
     @property
     def rows_exported_counter(self) -> temporalio.common.MetricCounter:
         """Access the rows exported metric counter."""
@@ -41,85 +41,48 @@ class Consumer:
         """Access the bytes exported metric counter."""
         return get_bytes_exported_metric()
 
+    def reset_tracking(self) -> None:
+        self.total_record_batches_count = 0
+        self.total_records_count = 0
+        self.total_record_batch_bytes_count = 0
+        self.total_file_bytes_count = 0
+
     async def start(
         self,
         queue: RecordBatchQueue,
         producer_task: asyncio.Task,
-        schema: pa.Schema,
-        transformer: TransformerProtocol,
-        max_file_size_bytes: int = 0,
-        json_columns: collections.abc.Iterable[str] = ("properties", "person_properties", "set", "set_once"),
+        transformer: ChunkTransformerProtocol,
     ) -> BatchExportResult:
         """Start consuming record batches from queue.
 
-        Record batches will be processed by the `transformer`, which transforms the record batch into chunks of bytes,
-        depending on the `file_format` and `compression`.
+        Record batches will be processed by the `transformer`, which transforms the
+        record batch into chunks of bytes, depending on the `file_format` and
+        `compression`.
 
-        Each of these chunks will be consumed by the `consume_chunk` method, which is implemented by subclasses.
-
-        If `max_file_size_bytes` is set, we split the file into multiples if the file size exceeds this value.
-
-        # TODO - we may need to support `multiple_files` here in future.
-        Callers can control whether a new file is created for each flush or whether we
-        continue flushing to the same file by setting `multiple_files`. File data is
-        reset regardless, so this is not meant to impact total file size, but rather
-        to control whether we are exporting a single large file in multiple parts, or
-        multiple files that must each individually be valid.
+        Each of these chunks will be consumed by the `consume_chunk` method, which is
+        implemented by subclasses.
 
         Returns:
             BatchExportResult:
-                - The total number of records in all consumed record batches. If an error occurs, this will be None.
-                - The total number of bytes exported (this is the size of the actual data exported, which takes into
-                    account the file type and compression). If an error occurs, this will be None.
-                - The error that occurred, if any. If no error occurred, this will be None. If an error occurs, this
-                    will be a string representation of the error.
+                - The total number of records in all consumed record batches. If an
+                  error occurs, this will be None.
+                - The total number of bytes exported (this is the size of the actual
+                  exported, which takes into account the file type and compression). If
+                  an error occurs, this will be None.
+                - The error that occurred, if any. If no error occurred, this will be
+                  None. If an error occurs, this will be a string representation of the
+                  error.
         """
-
-        schema = cast_record_batch_schema_json_columns(schema, json_columns=json_columns)
-        num_records_in_batch = 0
-        num_bytes_in_batch = 0
-        total_record_batches_count = 0
-        total_records_count = 0
-        total_record_batch_bytes_count = 0
-        total_file_bytes_count = 0
-
-        async def track_iteration_of_record_batches():
-            """Wrap generator of record batches to track execution."""
-            nonlocal num_records_in_batch
-            nonlocal num_bytes_in_batch
-            nonlocal total_record_batches_count
-            nonlocal total_records_count
-            nonlocal total_record_batch_bytes_count
-
-            async for record_batch in self.generate_record_batches_from_queue(queue, producer_task):
-                record_batch = cast_record_batch_json_columns(record_batch, json_columns=json_columns)
-
-                total_record_batches_count += 1
-                num_records_in_batch = record_batch.num_rows
-                total_records_count += num_records_in_batch
-                num_bytes_in_batch = record_batch.nbytes
-                total_record_batch_bytes_count += num_bytes_in_batch
-
-                self.rows_exported_counter.add(num_records_in_batch)
-
-                self.logger.info(
-                    f"Consuming {num_records_in_batch:,} records, {num_bytes_in_batch / 1024**2:.2f} MiB from record "
-                    f"batch {total_record_batches_count}. Total records so far: {total_records_count:,}, "
-                    f"total MiB so far: {total_record_batch_bytes_count / 1024**2:.2f}, "
-                    f"total file MiB so far: {total_file_bytes_count / 1024**2:.2f}"
-                )
-
-                yield record_batch
+        self.reset_tracking()
 
         self.logger.info("Starting consumer from internal S3 stage")
 
         try:
             async for chunk, is_eof in transformer.iter(
-                track_iteration_of_record_batches(),
-                max_file_size_bytes,
+                self.generate_record_batches_from_queue(queue, producer_task),
             ):
                 chunk_size = len(chunk)
-                total_file_bytes_count += chunk_size
+                self.total_file_bytes_count += chunk_size
 
                 await self.consume_chunk(data=chunk)
                 self.bytes_exported_counter.add(chunk_size)
@@ -134,11 +97,11 @@ class Consumer:
             raise
 
         self.logger.info(
-            f"Finished consuming {total_records_count:,} records, {total_record_batch_bytes_count / 1024**2:.2f} MiB "
-            f"from {total_record_batches_count:,} record batches. "
-            f"Total file MiB: {total_file_bytes_count / 1024**2:.2f}"
+            f"Finished consuming {self.total_records_count:,} records, {self.total_record_batch_bytes_count / 1024**2:.2f} MiB "
+            f"from {self.total_record_batches_count:,} record batches. "
+            f"Total file MiB: {self.total_file_bytes_count / 1024**2:.2f}"
         )
-        return BatchExportResult(total_records_count, total_file_bytes_count)
+        return BatchExportResult(self.total_records_count, self.total_file_bytes_count)
 
     async def generate_record_batches_from_queue(
         self,
@@ -146,6 +109,7 @@ class Consumer:
         producer_task: asyncio.Task,
     ):
         """Yield record batches from provided `queue` until `producer_task` is done."""
+
         while True:
             try:
                 record_batch = queue.get_nowait()
@@ -159,7 +123,25 @@ class Consumer:
                     await asyncio.sleep(0)
                     continue
 
+            self.logger.info(f"Consuming batch number {self.total_record_batches_count}")
+
             yield record_batch
+
+            num_records_in_batch = record_batch.num_rows
+            self.total_records_count += num_records_in_batch
+            num_bytes_in_batch = record_batch.nbytes
+            self.total_record_batch_bytes_count += num_bytes_in_batch
+            self.rows_exported_counter.add(num_records_in_batch)
+
+            self.logger.info(
+                f"Consumed batch number {self.total_record_batches_count} with "
+                f"{num_records_in_batch:,} records, {num_bytes_in_batch / 1024**2:.2f} "
+                f"MiB. Total records consumed so far: {self.total_records_count:,}, "
+                f"total MiB consumed so far: {self.total_record_batch_bytes_count / 1024**2:.2f}, "
+                f"total file MiB consumed so far: {self.total_file_bytes_count / 1024**2:.2f}"
+            )
+
+            self.total_record_batches_count += 1
 
     @abc.abstractmethod
     async def consume_chunk(self, data: bytes):
@@ -184,39 +166,30 @@ async def run_consumer_from_stage(
     queue: RecordBatchQueue,
     consumer: Consumer,
     producer_task: asyncio.Task[None],
-    transformer: TransformerProtocol,
-    schema: pa.Schema,
-    max_file_size_bytes: int = 0,
-    json_columns: collections.abc.Iterable[str] = ("properties", "person_properties", "set", "set_once"),
+    transformer: ChunkTransformerProtocol,
 ) -> BatchExportResult:
-    """Run a consumer that takes record batches from a queue and writes them to a destination.
+    """Run a record batch consumer to batch export to a destination.
 
-    This uses a newer version of the consumer that works with the internal S3 stage activities.
+    The consumer reads record from a queue populated by a producer that fetches them
+    from an the internal S3 bucket.
 
     Arguments:
         queue: The queue to consume record batches from.
         consumer: The consumer to run.
         producer_task: The task that produces record batches.
-        schema: The schema of the record batches.
-        file_format: The format of the file to write to.
-        compression: The compression to use for the file.
-        include_inserted_at: Whether to include the inserted_at column in the file.
-        max_file_size_bytes: The maximum size of the file to write to (if 0, no file splitting is done)
-        json_columns: The columns which contain JSON data.
+        transformer: The transformer used to convert record batches into their desired
+            export format.
 
     Returns:
         BatchExportResult (A tuple containing):
             - The total number of records in all consumed record batches.
-            - The total number of bytes exported (this is the size of the actual data exported, which takes into
-                account the file type and compression).
+            - The total number of bytes exported (this is the size of the actual data
+                exported, which takes into account the file type and compression).
     """
     result = await consumer.start(
         queue=queue,
         producer_task=producer_task,
-        schema=schema,
         transformer=transformer,
-        max_file_size_bytes=max_file_size_bytes,
-        json_columns=json_columns,
     )
 
     await raise_on_task_failure(producer_task)

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -127,7 +127,7 @@ class Consumer:
                     await asyncio.sleep(0)
                     continue
 
-            self.logger.info(f"Consuming batch number {self.total_record_batches_count}")
+            self.logger.debug(f"Consuming batch number {self.total_record_batches_count}")
 
             record_batch = cast_record_batch_json_columns(record_batch, json_columns=json_columns)
 
@@ -139,7 +139,7 @@ class Consumer:
             self.total_record_batch_bytes_count += num_bytes_in_batch
             self.rows_exported_counter.add(num_records_in_batch)
 
-            self.logger.info(
+            self.logger.debug(
                 f"Consumed batch number {self.total_record_batches_count} with "
                 f"{num_records_in_batch:,} records, {num_bytes_in_batch / 1024**2:.2f} "
                 f"MiB. Total records consumed so far: {self.total_records_count:,}, "

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -69,7 +69,7 @@ class Consumer:
             BatchExportResult:
                 - The total number of records in all consumed record batches. If an
                   error occurs, this will be None.
-                - The total number of bytes exported (this is the size of the actual
+                - The total number of bytes exported (this is the size of the actual data
                   exported, which takes into account the file type and compression). If
                   an error occurs, this will be None.
                 - The error that occurred, if any. If no error occurred, this will be

--- a/products/batch_exports/backend/temporal/pipeline/table.py
+++ b/products/batch_exports/backend/temporal/pipeline/table.py
@@ -1,0 +1,406 @@
+import abc
+import typing
+import datetime as dt
+import functools
+import collections
+import collections.abc
+
+import pyarrow as pa
+
+from products.batch_exports.backend.temporal.utils import JsonType
+
+_T = typing.TypeVar("_T")
+
+EPOCH = dt.datetime(1970, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+EPOCH_SECONDS = pa.scalar(EPOCH, type=pa.timestamp("s", tz="UTC"))
+EPOCH_MILLISECONDS = pa.scalar(EPOCH, type=pa.timestamp("ms", tz="UTC"))
+EPOCH_MICROSECONDS = pa.scalar(EPOCH, type=pa.timestamp("us", tz="UTC"))
+
+
+def _noop_cast(arr: pa.Array) -> pa.Array:
+    return arr
+
+
+def _make_ensure_array(
+    func: collections.abc.Callable[[pa.Array], pa.Array | pa.Scalar],
+) -> collections.abc.Callable[[pa.Array], pa.Array]:
+    """Wrap func with an assertion that returned value is an array.
+
+    Pyarrow compute functions usually return either array values or scalar values.
+    However, we work exclusively with arrays, and can almost always expect that if we
+    pass an array we'll get one back. So, to help mypy understand this, we decorate func
+    with an assertion.
+    """
+
+    @functools.wraps(func)
+    def f(arr: pa.Array) -> pa.Array:
+        result = func(arr)
+        assert isinstance(result, pa.Array)
+        return result
+
+    return f
+
+
+TypeTupleToCastMapping = dict[tuple[pa.DataType, pa.DataType], collections.abc.Callable[[pa.Array], pa.Array]]
+
+# I played around with the idea of making this a proper graph and then using DFS/BFS to
+# find a path between two types. But that seemed too much complexity for our current
+# requirements, so I tabled the idea for the time being. Leaving a comment here in case
+# the higher complexity is warranted in the future.
+COMPATIBLE_TYPES: TypeTupleToCastMapping = {
+    (pa.timestamp("s", tz="UTC"), pa.int64()): _make_ensure_array(
+        functools.partial(pa.compute.seconds_between, EPOCH_SECONDS)
+    ),
+    (pa.timestamp("ms", tz="UTC"), pa.int64()): _make_ensure_array(
+        functools.partial(pa.compute.milliseconds_between, EPOCH_MILLISECONDS)
+    ),
+    (pa.timestamp("us", tz="UTC"), pa.int64()): _make_ensure_array(
+        functools.partial(pa.compute.microseconds_between, EPOCH_MICROSECONDS)
+    ),
+    (pa.string(), JsonType()): _make_ensure_array(functools.partial(pa.compute.cast, target_type=JsonType())),
+}
+
+
+def are_types_compatible(
+    source: pa.DataType,
+    target: pa.DataType,
+    extra_compatible_types: TypeTupleToCastMapping | None = None,
+) -> tuple[bool, collections.abc.Callable[[pa.Array], pa.Array] | None]:
+    """Define whether a pair of Arrow data types are compatible.
+
+    Compatible means we can cast source to target without or with an acceptably low loss
+    of precision.
+
+    These rules can be destination-dependent, so the `extra_compatible_types` argument
+    can be used to pass new compatible types or overwrite existing ones.
+
+    Arguments:
+        source: Arrow data type we want to cast from.
+        target: Arrow data type we want to cast to.
+        extra_compatible_types: Additional casting rules.
+
+    Returns:
+        A tuple in which the first element is whether source can be casted to target,
+        and the second element is a casting function when the first element is `True`,
+        otherwise `None`.
+    """
+    if source == target:
+        # Callers should be checking this, but just in case...
+        return (True, _noop_cast)
+
+    compatible_mapping = {**COMPATIBLE_TYPES, **(extra_compatible_types or {})}
+    try:
+        return (True, compatible_mapping[(source, target)])
+    except KeyError:
+        return (False, None)
+
+
+class Field[T](typing.Protocol):
+    """A protocol for a field in a batch exports destination.
+
+    A `Field`'s responsibility is to handle resolution between a `pyarrow.Field` and
+    a destination-specific field, by converting to and from each one.
+
+    Flexibility inherent to the usage of a protocol instead of a class and with the
+    usage of a generic `T` destination field is intended to allow implementations
+    of this protocol with enough margin to handle any specific types from all
+    destinations.
+    """
+
+    name: str
+    data_type: pa.DataType
+
+    @classmethod
+    def from_arrow_field(cls, field: pa.Field) -> typing.Self: ...
+
+    def to_arrow_field(cls) -> pa.Field: ...
+
+    @classmethod
+    def from_destination_field(cls, field: T) -> typing.Self: ...
+
+    def to_destination_field(cls) -> T: ...
+
+    def with_new_arrow_type(self, new_type: pa.DataType) -> "Field[T]": ...
+
+    def __repr__(self) -> str:
+        return f"<Field '{self.name}': data_type={self.data_type}>"
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __hash__(self) -> int:
+        return self.name.__hash__()
+
+
+FieldType = typing.TypeVar("FieldType", bound=Field)
+
+
+class TableBase:
+    """Base class for `TableReference` and `Table`."""
+
+    def __init__(
+        self,
+        name: str,
+        parents: collections.abc.Iterable[str] = (),
+    ) -> None:
+        self.name = name
+        self.parents = tuple(parents)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: '{self.fully_qualified_name}'>"
+
+    def __str__(self) -> str:
+        return self.fully_qualified_name
+
+    @property
+    def fully_qualified_name(self) -> str:
+        """Return this table's fully qualified name.
+
+        This consists of the parents and name concatenated, separated by a ".".
+        """
+        if self.parents:
+            return f'{".".join(self.parents)}.{self.name}'
+        else:
+            return self.name
+
+
+class TableReference(TableBase):
+    """A reference to a `Table` by its fully qualified name."""
+
+    @classmethod
+    def from_fully_qualified_name(
+        cls: type[typing.Self], fully_qualified_name: str, *, separator: str = "."
+    ) -> typing.Self:
+        """Initialize a `TableReference` from a fully qualified name.
+
+        A fully qualified name is a string of dot separated names. Only the last
+        name is required, all parents can be omitted.
+        """
+        try:
+            all_parents, name = fully_qualified_name.rsplit(sep=separator, maxsplit=1)
+        except ValueError:
+            name = fully_qualified_name
+            parents = None
+        else:
+            parents = (parent for parent in all_parents.split("."))
+
+        return cls(name=name, parents=parents or ())
+
+
+class Table(TableBase, typing.Generic[FieldType]):
+    """A Table abstraction for batch exports.
+
+    The intended use is to wrap the actual target table used in a destination with a
+    common API for all batch exports to use.
+
+    Moreover, this can also be derived from an arrow schema, to allow comparisons with
+    tables derived from destination data.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        fields: collections.abc.Iterable[FieldType],
+        parents: collections.abc.Iterable[str] = (),
+        primary_key: collections.abc.Iterable[str] = (),
+        version_key: collections.abc.Iterable[str] = (),
+    ) -> None:
+        super().__init__(name, parents)
+        self._primary_key = tuple(primary_key)
+        self._version_key = tuple(version_key)
+        self.fields: list[FieldType] = list(fields)
+
+    @classmethod
+    @abc.abstractmethod
+    def from_arrow_schema(cls, schema: pa.Schema, **kwargs) -> typing.Self:
+        """Sub-classes should implement how to create a Table from an arrow schema.
+
+        The body of this method should just be a call to from_arrow_schema_full.
+
+        This method offers a relaxed signature via kwargs to allow sub-classes some
+        flexibility in figuring out how to:
+        * Pass their concrete Field implementation as field_type.
+            * Unfortunately, generic types are not available at runtime, so we need this
+              to be passed as an argument, even if the class definition already displays
+              the concrete Field type.
+        * Obtain name and parents.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def from_arrow_schema_full(
+        cls,
+        schema: pa.Schema,
+        field_type: type[FieldType],
+        name: str,
+        parents: collections.abc.Iterable[str] = (),
+        primary_key: collections.abc.Iterable[str] = (),
+        version_key: collections.abc.Iterable[str] = (),
+    ) -> typing.Self:
+        return cls(
+            name=name,
+            fields=(field_type.from_arrow_field(field) for field in schema),
+            parents=parents,
+            primary_key=primary_key,
+            version_key=version_key,
+        )
+
+    @property
+    def primary_key(self) -> tuple[str, ...]:
+        """A non-empty set of field names representing the primary key for this table.
+
+        This is required for the table to be considered mutable as the primary key is
+        used to match new rows with existing rows.
+        """
+        return self._primary_key
+
+    @primary_key.setter
+    def primary_key(self, value: collections.abc.Iterable[str]) -> None:
+        primary_key = tuple(value)
+
+        self._contains_fields(primary_key, raise_if_missing=True)
+
+        self._primary_key = primary_key
+
+    @property
+    def version_key(self) -> tuple[str, ...]:
+        """A non-empty set of field names representing the version key for this table.
+
+        This is required for the table to be considered mutable as the version key is
+        used to decide whether a matching row needs to be updated or not.
+        """
+        return self._version_key
+
+    @version_key.setter
+    def version_key(self, value: collections.abc.Iterable[str]) -> None:
+        version_key = tuple(value)
+
+        self._contains_fields(version_key, raise_if_missing=True)
+
+        self._version_key = version_key
+
+    def _contains_fields(self, field_names: collections.abc.Iterable[str], *, raise_if_missing: bool = False) -> bool:
+        """Check if this table contains `field_names`."""
+        missing = tuple(name for name in field_names if name not in self)
+
+        if not missing:
+            return True
+
+        if raise_if_missing:
+            if len(missing) == 1:
+                raise ValueError(f"Field is not in this table: '{missing[0]}'")
+            else:
+                raise ValueError(f"Fields are not in this table: '{", ".join(missing)}'")
+
+        return False
+
+    def __iter__(self) -> collections.abc.Iterator[FieldType]:
+        """Iterate through this `Table`'s fields."""
+        yield from self.fields
+
+    def __reversed__(self) -> collections.abc.Iterator[FieldType]:
+        """Iterate through this `Table`'s fields in reverse order."""
+        yield from reversed(self.fields)
+
+    def __len__(self) -> int:
+        """Return the number of fields in this `Table`."""
+        return len(self.fields)
+
+    def __getitem__(self, key: int | str) -> FieldType:
+        """Get a field from this `Table`.
+
+        Raises:
+            TypeError: On an unsupported key type.
+            KeyError: If a `str` key doesn't exist.
+            IndexError: If an `int` key is out of bounds.
+        """
+        if isinstance(key, int):
+            return self.fields[key]
+        elif isinstance(key, str):
+            return self._get_field_by_name(key)
+
+        raise TypeError(f"unsupported key type: '{type(key)}'")
+
+    def __setitem__(self, key: int | str, value: FieldType) -> None:
+        """Set a field in this `Table`.
+
+        Raises:
+            TypeError: On an unsupported key type.
+            IndexError: If an `int` key is out of bounds.
+        """
+        if isinstance(key, int):
+            self.fields[key] = value
+
+        elif isinstance(key, str):
+            if not key == value.name:
+                raise ValueError(f"Cannot update '{key}' with field of name '{value.name}'")
+
+            try:
+                existing = self._get_field_by_name(key)
+                index = self.fields.index(existing)
+            except KeyError:
+                # New field.
+                self.fields.append(value)
+            else:
+                self.fields[index] = value
+
+        else:
+            raise TypeError(f"unsupported key type: '{type(key)}'")
+
+        self._get_field_by_name.cache_clear()
+
+    def __delitem__(self, key: int | str) -> None:
+        """Delete a field from this `Table`.
+
+        Raises:
+            TypeError: On an unsupported key type.
+            KeyError: If a `str` key doesn't exist.
+            IndexError: If an `int` key is out of bounds.
+        """
+        if isinstance(key, int):
+            del self.fields[key]
+
+        elif isinstance(key, str):
+            existing = self._get_field_by_name(key)
+            index = self.fields.index(existing)
+
+            del self.fields[index]
+
+        self._get_field_by_name.cache_clear()
+
+    def __contains__(self, field: FieldType | str) -> bool:
+        """Check if this `Table` contains a field.
+
+        Accepts both an object that implements `Field` and a `str`. The latter
+        case being interpreted as the name of the field.
+        """
+        if not self.fields:
+            return False
+
+        if isinstance(field, str):
+            try:
+                _ = self._get_field_by_name(field)
+            except KeyError:
+                return False
+            else:
+                return True
+        else:
+            return field in self.fields
+
+    @functools.lru_cache
+    def _get_field_by_name(self, key: str) -> FieldType:
+        """Get a field from this `Table` by its name.
+
+        This method uses a LRU cache to avoid iterating more than once per `key`, in case
+        it is in a loop and frequently getting fields by name.
+
+        Raises:
+            KeyError: If a field with the name doesn't exist.
+        """
+        try:
+            return next(field for field in self.fields if field.name == key)
+        except StopIteration:
+            raise KeyError(key)
+
+    def is_mutable(self) -> bool:
+        return len(self.primary_key) > 0 and len(self.version_key) > 0

--- a/products/batch_exports/backend/temporal/pipeline/table.py
+++ b/products/batch_exports/backend/temporal/pipeline/table.py
@@ -24,12 +24,21 @@ def _noop_cast(arr: pa.Array) -> pa.Array:
 def _make_ensure_array(
     func: collections.abc.Callable[[pa.Array], pa.Array | pa.Scalar],
 ) -> collections.abc.Callable[[pa.Array], pa.Array]:
-    """Wrap func with an assertion that returned value is an array.
+    """Wrap `func` with an assertion that returned value is an `pyarrow.Array`.
 
-    Pyarrow compute functions usually return either array values or scalar values.
-    However, we work exclusively with arrays, and can almost always expect that if we
-    pass an array we'll get one back. So, to help mypy understand this, we decorate func
-    with an assertion.
+    `pyarrow.compute` functions usually return either array values or scalar values.
+    However, we work exclusively with arrays and thus can expect that if we pass an
+    array we'll get one back. But `pyarrow.compute` functions are not properly
+    type-hinted to represent this.
+
+    So, to help mypy understand this, we decorate `func` with an assertion to confirm we
+    got an `pyarrow.Array` back.
+
+    Naturally, this comes with the implicit, hereby made explicit, request that you
+    review the pyarrow documentation to confirm that the used `pyarrow.compute` function
+    actually returns an `pyarrow.Array` when passed one as input. Most of the time, this
+    is the case, but I have not reviewed all of them, and new ones may be added over
+    time.
     """
 
     @functools.wraps(func)

--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -4,6 +4,7 @@ import gzip
 import json
 import typing
 import asyncio
+import functools
 import contextlib
 import collections
 import collections.abc
@@ -21,6 +22,7 @@ from psycopg import sql
 from posthog.temporal.common.logger import get_write_only_logger
 
 from products.batch_exports.backend.temporal.metrics import ExecutionTimeRecorder
+from products.batch_exports.backend.temporal.pipeline.table import Table, TypeTupleToCastMapping, are_types_compatible
 
 logger = get_write_only_logger()
 
@@ -32,30 +34,44 @@ class Chunk(typing.NamedTuple):
     is_eof: bool
 
 
-class TransformerProtocol(typing.Protocol):
+class TransformerProtocol[T](typing.Protocol):
     """Transformer protocol iterating record batches into chunks of bytes."""
 
     async def iter(
-        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
-    ) -> collections.abc.AsyncIterator[Chunk]:
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch]
+    ) -> collections.abc.AsyncIterator[T]:
         if typing.TYPE_CHECKING:
             # We need a yield for mypy to interpret this as Callable[[...], AsyncIterator[int]].
             # Otherwise, it will treat it as Callable[[], Coroutine[Any, Any, AsyncIterator[int]]].
             # See: https://mypy.readthedocs.io/en/stable/more_types.html#asynchronous-iterators
-            yield Chunk(b"", False)
+            # Update: Unfortunately, now that the protocol is generic, we cannot yield a
+            # Chunk as that is a concrete type. But we still need the yield for the
+            # reason above. And if we have a yield, then we must yield something that
+            # fits the type hint for mypy to be happy. But no concrete type fits a
+            # generic. So, the best we can do is to just ignore.
+            yield Chunk(b"", False)  # type: ignore[misc]
         raise NotImplementedError
+
+
+ChunkTransformerProtocol = TransformerProtocol[Chunk]
 
 
 def get_json_stream_transformer(
     include_inserted_at: bool = False,
     compression: str | None = None,
+    max_file_size_bytes: int = 0,
     max_workers: int = settings.BATCH_EXPORT_TRANSFORMER_MAX_WORKERS,
-) -> TransformerProtocol:
+) -> ChunkTransformerProtocol:
     if compression == "brotli":
-        return JSONLBrotliStreamTransformer(include_inserted_at=include_inserted_at, max_workers=max_workers)
+        return JSONLBrotliStreamTransformer(
+            include_inserted_at=include_inserted_at, max_file_size_bytes=max_file_size_bytes, max_workers=max_workers
+        )
 
     return JSONLStreamTransformer(
-        compression=compression, include_inserted_at=include_inserted_at, max_workers=max_workers
+        compression=compression,
+        include_inserted_at=include_inserted_at,
+        max_file_size_bytes=max_file_size_bytes,
+        max_workers=max_workers,
     )
 
 
@@ -69,17 +85,19 @@ class JSONLStreamTransformer:
         self,
         compression: str | None = None,
         include_inserted_at: bool = False,
+        max_file_size_bytes: int = 0,
         max_workers: int = settings.BATCH_EXPORT_TRANSFORMER_MAX_WORKERS,
     ):
         self.include_inserted_at = include_inserted_at
         self.compression = compression
         self.max_workers = max_workers
+        self.max_file_size_bytes = max_file_size_bytes
 
         self._futures_pending: set[asyncio.Future[list[bytes]]] = set()
         self._semaphore = asyncio.Semaphore(max_workers)
 
     async def iter(
-        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch]
     ) -> collections.abc.AsyncIterator[Chunk]:
         """Distribute transformation of record batches into multiple processes.
 
@@ -124,7 +142,7 @@ class JSONLStreamTransformer:
                         for chunk in chunks:
                             yield Chunk(chunk, False)
 
-                            if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+                            if self.max_file_size_bytes and current_file_size + len(chunk) > self.max_file_size_bytes:
                                 yield Chunk(b"", True)
                                 current_file_size = 0
 
@@ -136,9 +154,11 @@ class JSONLBrotliStreamTransformer:
     def __init__(
         self,
         include_inserted_at: bool = False,
+        max_file_size_bytes: int = 0,
         max_workers: int = settings.BATCH_EXPORT_TRANSFORMER_MAX_WORKERS,
     ):
         self.include_inserted_at = include_inserted_at
+        self.max_file_size_bytes = max_file_size_bytes
         self.max_workers = max_workers
 
         self._futures_pending: set[asyncio.Future[list[bytes]]] = set()
@@ -146,7 +166,7 @@ class JSONLBrotliStreamTransformer:
         self._brotli_compressor = None
 
     async def iter(
-        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch]
     ) -> collections.abc.AsyncIterator[Chunk]:
         """Distribute transformation of record batches into multiple processes.
 
@@ -191,7 +211,7 @@ class JSONLBrotliStreamTransformer:
 
                             yield Chunk(chunk, False)
 
-                            if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+                            if self.max_file_size_bytes and current_file_size + len(chunk) > self.max_file_size_bytes:
                                 data = await loop.run_in_executor(None, self._finish_brotli_compressor)
 
                                 yield Chunk(data, True)
@@ -271,7 +291,11 @@ def dump_record_batch(
     """Dump all records in a record batch to JSON lines."""
     column_names = record_batch.column_names
     if not include_inserted_at:
-        _ = column_names.pop(column_names.index("_inserted_at"))
+        try:
+            _ = column_names.pop(column_names.index("_inserted_at"))
+        except ValueError:
+            # Already not included, filtered upstream.
+            pass
 
     def compress(content: bytes):
         match compression:
@@ -355,27 +379,30 @@ class ParquetStreamTransformer:
 
     def __init__(
         self,
-        schema: pa.Schema,
         compression: str | None = None,
         compression_level: int | None = None,
         include_inserted_at: bool = False,
+        max_file_size_bytes: int = 0,
     ):
         self.include_inserted_at = include_inserted_at
-        self.schema = schema
         self.compression = compression
         self.compression_level = compression_level
+        self.max_file_size_bytes = max_file_size_bytes
 
         # For Parquet, we need to handle schema and batching
         self._parquet_writer: pq.ParquetWriter | None = None
         self._parquet_buffer = io.BytesIO()
+        self._schema: pa.Schema | None = None
 
     async def iter(
-        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch]
     ) -> collections.abc.AsyncIterator[Chunk]:
         """Iterate over record batches transforming them into chunks."""
         current_file_size = 0
 
         async for record_batch in record_batches:
+            self.schema = record_batch.schema
+
             with ExecutionTimeRecorder(
                 "parquet_stream_transformer_record_batch_transform_duration",
                 description="Duration to transform a record batch into Parquet bytes.",
@@ -392,7 +419,7 @@ class ParquetStreamTransformer:
 
                 yield Chunk(chunk, False)
 
-                if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+                if self.max_file_size_bytes and current_file_size + len(chunk) > self.max_file_size_bytes:
                     footer = await asyncio.to_thread(self.finish_parquet_file)
 
                     yield Chunk(footer, True)
@@ -416,6 +443,20 @@ class ParquetStreamTransformer:
         assert self._parquet_writer is not None
         return self._parquet_writer
 
+    @property
+    def schema(self) -> pa.Schema:
+        if not self._schema:
+            raise ValueError("Schema not set, is the transformer running?")
+        return self._schema
+
+    @schema.setter
+    def schema(self, schema: pa.Schema) -> None:
+        if not self.include_inserted_at:
+            if (index := schema.get_field_index("_inserted_at")) >= 0:
+                schema.remove(index)
+
+        self._schema = schema
+
     def finish_parquet_file(self) -> bytes:
         """Ensure underlying Parquet writer is closed before flushing buffer."""
         self.parquet_writer.close()
@@ -429,10 +470,7 @@ class ParquetStreamTransformer:
 
     def write_record_batch(self, record_batch: pa.RecordBatch) -> bytes:
         """Write record batch to buffer as Parquet."""
-        column_names = self.parquet_writer.schema.names
-        if not self.include_inserted_at and "_inserted_at" in column_names:
-            column_names.pop(column_names.index("_inserted_at"))
-
+        column_names = self.schema.names
         self.parquet_writer.write_batch(record_batch.select(column_names))
         data = self._parquet_buffer.getvalue()
 
@@ -453,6 +491,7 @@ class RedshiftQueryStreamTransformer:
         table_columns: collections.abc.Sequence[str],
         known_json_columns: collections.abc.Iterable[str],
         redshift_client,
+        max_query_size_bytes: int = 8 * 1024 * 1024,
     ):
         self.schema = schema
         self.redshift_table = redshift_table
@@ -460,6 +499,7 @@ class RedshiftQueryStreamTransformer:
         self.table_columns = list(table_columns)
         self.known_json_columns = known_json_columns
         self.redshift_client = redshift_client
+        self.max_query_size_bytes = max_query_size_bytes
 
         placeholders: list[sql.Composable] = []
         for column in table_columns:
@@ -468,7 +508,8 @@ class RedshiftQueryStreamTransformer:
         self.template = sql.SQL("({})").format(sql.SQL(", ").join(placeholders))
 
     async def iter(
-        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+        self,
+        record_batches: collections.abc.AsyncIterable[pa.RecordBatch],
     ) -> collections.abc.AsyncIterator[Chunk]:
         """Iterate over record batches transforming them into chunks."""
         current_file_size = 0
@@ -497,7 +538,7 @@ class RedshiftQueryStreamTransformer:
 
                 yield Chunk(chunk, False)
 
-                if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+                if current_file_size + len(chunk) > self.max_query_size_bytes:
                     yield Chunk(b"", True)
                     current_file_size = 0
                     is_query_start = True
@@ -586,6 +627,7 @@ class CSVStreamTransformer:
         line_terminator: str = "\n",
         quoting: typing.Literal[0, 1, 2, 3, 4, 5] = csv.QUOTE_NONE,
         include_inserted_at: bool = False,
+        max_file_size_bytes: int = 0,
     ):
         self.field_names = field_names
         self.delimiter = delimiter
@@ -594,9 +636,11 @@ class CSVStreamTransformer:
         self.line_terminator = line_terminator
         self.quoting = quoting
         self.include_inserted_at = include_inserted_at
+        self.max_file_size_bytes = max_file_size_bytes
 
     async def iter(
-        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch], max_file_size_bytes: int = 0
+        self,
+        record_batches: collections.abc.AsyncIterable[pa.RecordBatch],
     ) -> collections.abc.AsyncIterator[Chunk]:
         """Iterate over record batches transforming them into CSV chunks."""
         current_file_size = 0
@@ -606,7 +650,7 @@ class CSVStreamTransformer:
 
             yield Chunk(chunk, False)
 
-            if max_file_size_bytes and current_file_size + len(chunk) > max_file_size_bytes:
+            if self.max_file_size_bytes and current_file_size + len(chunk) > self.max_file_size_bytes:
                 yield Chunk(b"", True)
                 current_file_size = 0
 
@@ -644,3 +688,79 @@ class CSVStreamTransformer:
         text_wrapper.flush()
 
         return buffer.getvalue()
+
+
+class SchemaTransformer:
+    """Transformer to cast record batches into a new schema."""
+
+    def __init__(
+        self,
+        table: Table,
+        extra_compatible_types: TypeTupleToCastMapping | None = None,
+    ):
+        self.table = table
+        self.extra_compatible_types = extra_compatible_types
+
+    async def iter(
+        self,
+        record_batches: collections.abc.AsyncIterable[pa.RecordBatch],
+    ) -> collections.abc.AsyncIterator[pa.RecordBatch]:
+        async for record_batch in record_batches:
+            yield self.cast_record_batch(record_batch)
+
+    def cast_record_batch(self, record_batch: pa.RecordBatch) -> pa.RecordBatch:
+        """Cast a record batch into a new schema that matches `self.table`.
+
+        If the record batch's schema already matches table, then nothing is cast.
+        """
+        field_names = [field.name for field in self.table.fields]
+
+        arrays = []
+        for field_name, array in zip(field_names, record_batch.select(field_names).itercolumns()):
+            field = self.table[field_name]
+
+            if array.type == field.data_type:
+                arrays.append(array)
+                continue
+
+            compatible, cast = are_types_compatible(array.type, field.data_type, self.extra_compatible_types)
+
+            if compatible:
+                assert cast is not None, "If types are compatible cast function should be defined"
+
+                arrays.append(cast(array))
+            else:
+                raise TypeError(
+                    f"'{field_name}' has type '{array.type}' which is not compatible with field's type: '{field.data_type}'"
+                )
+
+        return pa.RecordBatch.from_arrays(
+            arrays,
+            names=field_names,
+        )
+
+
+class PipelineTransformer:
+    """Transformer that pipes multiple transformers together.
+
+    It is expected that the 1..n-1 transformers will yield record batches, and the n
+    transformer will yield a `Chunk`. Thus, the pipeline in its entirety is a
+    `ChunkTransformerProtocol`.
+
+    Unfortunately, we don't really have a way to enforce this.
+    """
+
+    def __init__(self, transformers: collections.abc.Sequence[TransformerProtocol]):
+        self.transformers = transformers
+
+    async def iter(
+        self, record_batches: collections.abc.AsyncIterable[pa.RecordBatch]
+    ) -> collections.abc.AsyncIterator[Chunk]:
+        async def generate(record_batches_iter, transformer):
+            async for chunk in transformer.iter(record_batches_iter):
+                yield chunk
+
+        pipeline = functools.reduce(generate, iter(self.transformers), record_batches)
+
+        async for chunk in pipeline:
+            yield chunk  # type: ignore[misc]

--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -451,6 +451,9 @@ class ParquetStreamTransformer:
 
     @schema.setter
     def schema(self, schema: pa.Schema) -> None:
+        if self._schema:
+            return
+
         if not self.include_inserted_at:
             if (index := schema.get_field_index("_inserted_at")) >= 0:
                 schema = schema.remove(index)

--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -453,7 +453,7 @@ class ParquetStreamTransformer:
     def schema(self, schema: pa.Schema) -> None:
         if not self.include_inserted_at:
             if (index := schema.get_field_index("_inserted_at")) >= 0:
-                schema.remove(index)
+                schema = schema.remove(index)
 
         self._schema = schema
 

--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -451,7 +451,7 @@ class ParquetStreamTransformer:
 
     @schema.setter
     def schema(self, schema: pa.Schema) -> None:
-        if self._schema:
+        if self._schema is not None:
             return
 
         if not self.include_inserted_at:

--- a/products/batch_exports/backend/temporal/utils.py
+++ b/products/batch_exports/backend/temporal/utils.py
@@ -181,6 +181,9 @@ class JsonType(pa.ExtensionType):
     def __arrow_ext_serialize__(self):
         return b""
 
+    def __hash__(self):
+        return pa.DataType.__hash__(self)
+
     @classmethod
     def __arrow_ext_deserialize__(self, storage_type, serialized):
         return JsonType()

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_table.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_table.py
@@ -1,0 +1,204 @@
+import typing
+import datetime as dt
+
+import pytest
+
+import pyarrow as pa
+
+from products.batch_exports.backend.temporal.pipeline.table import (
+    Field,
+    Table,
+    TableBase,
+    TableReference,
+    are_types_compatible,
+)
+from products.batch_exports.backend.temporal.utils import JsonType
+
+
+@pytest.mark.parametrize(
+    "source,target,expected_compatible,value,expected_result",
+    (
+        (
+            pa.timestamp("s", tz="UTC"),
+            pa.int64(),
+            True,
+            pa.array(
+                [dt.datetime(2025, 1, 1, tzinfo=dt.UTC), dt.datetime(2025, 1, 2, tzinfo=dt.UTC)],
+                type=pa.timestamp("s", tz="UTC"),
+            ),
+            pa.array(
+                [
+                    dt.datetime(2025, 1, 1, tzinfo=dt.UTC).timestamp(),
+                    dt.datetime(2025, 1, 2, tzinfo=dt.UTC).timestamp(),
+                ],
+                type=pa.int64(),
+            ),
+        ),
+        (
+            pa.string(),
+            JsonType(),
+            True,
+            pa.array(["{1: 1}", "{2: 2}"], type=pa.string()),
+            pa.array(
+                ["{1: 1}", "{2: 2}"],
+                type=JsonType(),
+            ),
+        ),
+        (
+            pa.int32(),
+            pa.int16(),
+            False,
+            None,
+            None,
+        ),
+    ),
+)
+def test_are_types_compatible(
+    source: pa.DataType,
+    target: pa.DataType,
+    expected_compatible: bool,
+    value: pa.Array | None,
+    expected_result: pa.Array | None,
+):
+    compatible, cast_func = are_types_compatible(source, target)
+
+    assert compatible == expected_compatible
+
+    if not compatible:
+        assert cast_func is None
+
+        return
+
+    assert cast_func is not None
+    assert value is not None
+
+    result = cast_func(value)
+
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "name,parents,expected_fully_qualified_name",
+    (
+        ("test", ("parent",), "parent.test"),
+        ("test", ("grandparent", "parent"), "grandparent.parent.test"),
+        ("test", (), "test"),
+    ),
+)
+def test_table_base_fully_qualified_name(name: str, parents: tuple[str, ...], expected_fully_qualified_name: str):
+    t = TableBase(name, parents)
+    assert t.fully_qualified_name == expected_fully_qualified_name == str(t)
+
+
+def test_table_is_a_sequence_of_fields():
+    """Test `Table` acts like a mutable sequence of `Field`s.
+
+    Although not explicitly inheriting from the `MutableSequence` abc, we still provide
+    all of its dunder methods, and thus we test them.
+    """
+
+    class TestField(Field):
+        def __init__(self, name: str, data_type: pa.DataType):
+            self.name = name
+            self.data_type = data_type
+
+        @classmethod
+        def from_arrow_field(cls, field: pa.Field) -> typing.Self:
+            raise NotImplementedError()
+
+        def to_arrow_field(cls) -> pa.Field:
+            raise NotImplementedError()
+
+        @classmethod
+        def from_destination_field(cls, field: typing.Any) -> typing.Self:
+            raise NotImplementedError()
+
+        def to_destination_field(cls) -> typing.Any:
+            raise NotImplementedError()
+
+        def with_new_arrow_type(self, new_type: pa.DataType) -> "TestField":
+            raise NotImplementedError()
+
+    class TestTable(Table):
+        @classmethod
+        def from_arrow_schema(cls, schema: pa.Schema, **kwargs) -> typing.Self:
+            return cls(name="test", fields=[])
+
+    one = TestField(name="one", data_type=pa.string())
+    two = TestField(name="two", data_type=pa.string())
+    t = TestTable(
+        "test",
+        (
+            one,
+            two,
+        ),
+    )
+
+    # __len__
+    assert len(t) == 2
+
+    # __getitem__
+    assert t["one"] == t[0] == one
+    assert t["two"] == t[1] == two
+
+    # __contains__
+    assert "one" in t
+    assert "two" in t
+    assert one in t
+    assert two in t
+
+    three = TestField(name="three", data_type=pa.string())
+
+    assert "three" not in t
+    assert three not in t
+
+    # __setitem__
+    t["three"] = three
+
+    assert "three" in t
+    assert three in t
+
+    new_three = TestField(name="three", data_type=pa.int64())
+    t["three"] = new_three
+
+    assert t["three"] == t[2] == new_three
+
+    t[2] = three
+
+    assert t["three"] == t[2] == three
+
+    with pytest.raises(ValueError):
+        t["three"] = one
+
+    # __iter__
+    assert list(t) == [one, two, three]
+
+    # __reversed__
+    assert list(reversed(t)) == [three, two, one]
+
+    # __delitem__
+    del t["three"]
+
+    assert "three" not in t
+    assert three not in t
+
+    del t[1]
+
+    assert "two" not in t
+    assert two not in t
+
+
+@pytest.mark.parametrize(
+    "fully_qualified_name,expected_name,expected_parents,",
+    (
+        ("parent.test", "test", ("parent",)),
+        ("grandparent.parent.test", "test", ("grandparent", "parent")),
+        ("test", "test", ()),
+    ),
+)
+def test_table_reference_from_fully_qualified_name(
+    fully_qualified_name: str, expected_name: str, expected_parents: tuple[str, ...]
+):
+    t = TableReference.from_fully_qualified_name(fully_qualified_name)
+    assert t.name == expected_name
+    assert t.parents == expected_parents


### PR DESCRIPTION
## Problem

Batch exports works by exporting data to third party databases and object storage systems. Working with third party systems has a lot of challenges; one of them specific to databases is that we do not control the actual schemas of the tables we export to. Our users may, at any point and without any warning, update the schema of the destination target table.

This can cause issues at runtime as we will likely fail when the destination table types are not what we expect.

Given that we want to be as flexible as possible, some amount of drift should be allowed between our datasets and the destination tables. But this requires handling that drift during the batch export to avoid runtime crashes.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR introduces new abstractions for batch exports:
* A `Field` protocol and `Table` class to wrap destination tables.
* A `SchemaTransformer` and `PipelineTransformer`.

These abstractions work together to identify when there is a difference between the schema of the arrow record batches we iterate through and the destination tables of our users.

A `Table` is like a sequence of `Field`s and it helps us by having a single abstraction with everything we need to know about a destination table. In particular, each `Field` contains the arrow data type expected by that destination for a particular field. So, by comparing that data type with the data type of the corresponding field in the incoming record batches, we can identify a drift.

This is done by the `SchemaTransformer`, which compares with the schema of the record batches as we iterate through them. Once a drift is identified, we can lookup if the drift can be resolved by casting the incoming record batch type to the destination table's type.

At the moment, this drift resolution is quite simple: There is a dictionary of compatible types, and if the type pair is in that dictionary, then there is a function to cast an array from one type to the other. Later on we could expand on this with a more complex type resolution algorithm. We allow each destination to define its own set of compatible types and casting functions.

Finally, `PipelineTransformer` is just there to pipe a `SchemaTransformer` into the "real" transformer that outputs chunks of bytes. This means the transformer protocol is now generalized to be anything that can iterate through record batches and return a generic type. A `ChunkTransformerProtocol` is provided for concrete typing when expecting the transformer to yield instances of `Chunk`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added unit tests for all the abstractions. Moreover, it should be relatively safe to merge this as the changes to the destinations are minimal: Mostly updating them to use the new transformer protocol, and cleaning up some unused parameters from `run_consumer_from_stage`.

Still, will run all tests.

Update: Test progress:
- BigQuery: ✅ All passing
- PostgreSQL: ✅ All passing
- Snowflake: ✅ All passing
- Redshift: ✅ All passing (after a couple bugfixes)
- S3: ✅ All passing
- Databricks: ❌ One failed, but unrelated to this PR (see #40944)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
