### PR TITLE
fix: make nested union'ed queries run with projection pushdown

### DIFF
--- a/posthog/hogql/transforms/test/__snapshots__/test_projection_pushdown.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_projection_pushdown.ambr
@@ -38,6 +38,9 @@
 # name: TestProjectionPushdown.test_prewhere_clause
   "SELECT event FROM (SELECT event, distinct_id FROM events) AS sub PREWHERE equals(distinct_id, 'test')"
 # ---
+# name: TestProjectionPushdown.test_root_union_with_nested_union_cte
+  'SELECT properties, timestamp FROM (SELECT properties, timestamp FROM (SELECT properties, timestamp FROM events LIMIT 20) AS us UNION ALL SELECT properties, timestamp FROM (SELECT properties, timestamp FROM events LIMIT 20) AS eu) AS all_exports UNION ALL SELECT properties, timestamp FROM (SELECT properties, timestamp FROM (SELECT properties, timestamp FROM events LIMIT 20) AS us UNION ALL SELECT properties, timestamp FROM (SELECT properties, timestamp FROM events LIMIT 20) AS eu) AS all_exports ORDER BY timestamp DESC'
+# ---
 # name: TestProjectionPushdown.test_simple_pushdown
   'SELECT event FROM (SELECT event FROM events) AS sub'
 # ---
@@ -52,4 +55,7 @@
 # ---
 # name: TestProjectionPushdown.test_union_all_without_alias
   'SELECT event FROM (SELECT event FROM events UNION ALL SELECT event FROM events)'
+# ---
+# name: TestProjectionPushdown.test_union_cte_with_select_star_and_order_by
+  'SELECT properties, timestamp FROM (SELECT properties, timestamp FROM (SELECT properties, timestamp FROM events LIMIT 20) AS us UNION ALL SELECT properties, timestamp FROM (SELECT properties, timestamp FROM events LIMIT 20) AS eu) AS all_exports ORDER BY timestamp DESC LIMIT 20'
 # ---


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

A query like this was failing because the column demands were not being propagated from the outer most query.

```
with us as (
   select properties, timestamp from events limit 20
),
eu as (
   select properties, timestamp from events limit 20
),
all_exports as (select * from us union all select * from eu)
select * from all_exports order by timestamp desc
limit 20
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- check if the `node.select` is from the root of the query - if yes, then always propagate those column demands


## How did you test this code?

- tests, added one for this case