### PR TITLE
fix: show loading state when saving or loading the team settings in replay settings

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -74,7 +74,7 @@ function LinkedFlagSelector(): JSX.Element | null {
     const { selectedPlatform } = useValues(replayTriggersLogic)
 
     const { updateCurrentTeam } = useActions(teamLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
 
     const { hasAvailableFeature } = useValues(userLogic)
 
@@ -114,8 +114,12 @@ function LinkedFlagSelector(): JSX.Element | null {
                                         selectFeatureFlag(flag)
                                         updateCurrentTeam({ session_recording_linked_flag: { id, key, variant: null } })
                                     }}
-                                    disabledReason={disabledReason ?? undefined}
-                                    readOnly={!!disabledReason}
+                                    disabledReason={
+                                        (disabledReason ?? (currentTeamLoading || featureFlagLoading))
+                                            ? 'Loading...'
+                                            : undefined
+                                    }
+                                    readOnly={!!disabledReason || currentTeamLoading || featureFlagLoading}
                                 />
                             )}
                         </AccessControlAction>
@@ -131,6 +135,7 @@ function LinkedFlagSelector(): JSX.Element | null {
                                     type="secondary"
                                     onClick={() => updateCurrentTeam({ session_recording_linked_flag: null })}
                                     title="Clear selected flag"
+                                    loading={currentTeamLoading || featureFlagLoading}
                                 />
                             </AccessControlAction>
                         )}
@@ -164,7 +169,12 @@ function LinkedFlagSelector(): JSX.Element | null {
                                 <LemonSegmentedButton
                                     className="min-w-1/3"
                                     value={currentTeam?.session_recording_linked_flag?.variant ?? ANY_VARIANT}
-                                    options={variantOptions(linkedFlag?.filters.multivariate, disabledReason)}
+                                    options={variantOptions(
+                                        linkedFlag?.filters.multivariate,
+                                        (disabledReason ?? (currentTeamLoading || featureFlagLoading))
+                                            ? 'Loading...'
+                                            : undefined
+                                    )}
                                     onChange={(variant) => {
                                         if (!linkedFlag) {
                                             return

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -190,7 +190,7 @@ export function Since(props: {
 
 function LogCaptureSettings(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
 
     return (
         <div>
@@ -229,6 +229,7 @@ function LogCaptureSettings(): JSX.Element {
                     disabledReason={
                         !currentTeam?.session_recording_opt_in ? 'Session replay must be enabled' : undefined
                     }
+                    loading={currentTeamLoading}
                 />
             </AccessControlAction>
         </div>
@@ -237,7 +238,7 @@ function LogCaptureSettings(): JSX.Element {
 
 function CanvasCaptureSettings(): JSX.Element | null {
     const { updateCurrentTeam } = useActions(teamLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
 
     return (
         <div>
@@ -287,6 +288,7 @@ function CanvasCaptureSettings(): JSX.Element | null {
                     disabledReason={
                         !currentTeam?.session_recording_opt_in ? 'Session replay must be enabled' : undefined
                     }
+                    loading={currentTeamLoading}
                 />
             </AccessControlAction>
         </div>
@@ -315,7 +317,7 @@ function PayloadWarning(): JSX.Element {
 
 export function NetworkCaptureSettings(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
 
     return (
         <>
@@ -352,6 +354,7 @@ export function NetworkCaptureSettings(): JSX.Element {
                     disabledReason={
                         !currentTeam?.session_recording_opt_in ? 'Session replay must be enabled' : undefined
                     }
+                    loading={currentTeamLoading}
                 />
             </AccessControlAction>
 
@@ -421,6 +424,7 @@ export function NetworkCaptureSettings(): JSX.Element {
                                     ? 'session and network performance capture must be enabled'
                                     : undefined
                             }
+                            loading={currentTeamLoading}
                         />
                     </AccessControlAction>
                     <AccessControlAction
@@ -469,6 +473,7 @@ export function NetworkCaptureSettings(): JSX.Element {
                                     ? 'session and network performance capture must be enabled'
                                     : undefined
                             }
+                            loading={currentTeamLoading}
                         />
                     </AccessControlAction>
                 </div>
@@ -664,7 +669,7 @@ export function ReplayAISettings(): JSX.Element | null {
 
 export function ReplayMaskingSettings(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
 
     const handleMaskingChange = (level: SessionRecordingMaskingLevel): void => {
         updateCurrentTeam({
@@ -702,6 +707,7 @@ export function ReplayMaskingSettings(): JSX.Element {
                         { value: 'normal', label: 'Normal (mask inputs but not text/images)' },
                         { value: 'free-love', label: 'Free love (mask only passwords)' },
                     ]}
+                    loading={currentTeamLoading}
                 />
             </AccessControlAction>
         </div>
@@ -710,7 +716,7 @@ export function ReplayMaskingSettings(): JSX.Element {
 
 export function ReplayDataRetentionSettings(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const retentionFeature = currentOrganization?.available_product_features?.find(
         (feature) => feature.key === 'session_replay_data_retention'
@@ -722,13 +728,15 @@ export function ReplayDataRetentionSettings(): JSX.Element {
         retentionFeature?.limit >= 60
     const currentRetention = currentTeam?.session_recording_retention_period || '30d'
 
-    const renderOptions = (): LemonSegmentedButtonOption<SessionRecordingRetentionPeriod>[] => {
+    const renderOptions = (loading: boolean): LemonSegmentedButtonOption<SessionRecordingRetentionPeriod>[] => {
+        const disabledReason = loading ? 'Loading...' : undefined
         const options = [
             {
                 value: '30d' as SessionRecordingRetentionPeriod,
                 icon: <IconClock />,
                 label: '30 days',
                 'data-attr': 'session-recording-retention-button-30d',
+                disabledReason,
             },
             {
                 value: '90d' as SessionRecordingRetentionPeriod,
@@ -760,15 +768,15 @@ export function ReplayDataRetentionSettings(): JSX.Element {
             retentionFeature?.limit > 1
         ) {
             if (retentionFeature.limit >= 3) {
-                options[1].disabledReason = ''
+                options[1].disabledReason = disabledReason ?? ''
             }
 
             if (retentionFeature.limit >= 12) {
-                options[2].disabledReason = ''
+                options[2].disabledReason = disabledReason ?? ''
             }
 
             if (retentionFeature.limit >= 60) {
-                options[3].disabledReason = ''
+                options[3].disabledReason = disabledReason ?? ''
             }
         }
 
@@ -798,7 +806,7 @@ export function ReplayDataRetentionSettings(): JSX.Element {
                 <LemonSegmentedButton
                     value={currentRetention}
                     onChange={(val) => val && handleRetentionChange(val)}
-                    options={renderOptions()}
+                    options={renderOptions(currentTeamLoading)}
                 />
             </AccessControlAction>
             {!hasMaxRetentionEntitlement && (
@@ -816,7 +824,7 @@ export function ReplayDataRetentionSettings(): JSX.Element {
 
 export function ReplayGeneral(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const [showSurvey, setShowSurvey] = useState<boolean>(false)
 
     /**
@@ -856,6 +864,7 @@ export function ReplayGeneral(): JSX.Element {
                         label="Record user sessions"
                         bordered
                         checked={!!currentTeam?.session_recording_opt_in}
+                        loading={currentTeamLoading}
                     />
                 </AccessControlAction>
 


### PR DESCRIPTION
i've noticed a few times that i've clicked a settings toggle and got no visual feedback so not been sure that i actually clicked it...

let's feed back visually

![2025-11-04 15.24.06.gif](https://app.graphite.dev/user-attachments/assets/6e914da1-18c7-4514-a6d5-2ffb58cf23ea.gif)

