### PR TITLE
refactor(flags): change `Team.project_id` to `Option<ProjectId>`

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
+++ b/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
@@ -123,18 +123,18 @@ mod tests {
             Some(1), // 1-second TTL
         );
 
-        let cohorts = cohort_cache.get_cohorts(team.project_id).await?;
+        let cohorts = cohort_cache.get_cohorts(team.project_id()).await?;
         assert_eq!(cohorts.len(), 1);
         assert_eq!(cohorts[0].team_id, team.id);
 
-        let cached_cohorts = cohort_cache.cache.get(&team.project_id).await;
+        let cached_cohorts = cohort_cache.cache.get(&team.project_id()).await;
         assert!(cached_cohorts.is_some());
 
         // Wait for TTL to expire
         sleep(Duration::from_secs(2)).await;
 
         // Attempt to retrieve from cache again
-        let cached_cohorts = cohort_cache.cache.get(&team.project_id).await;
+        let cached_cohorts = cohort_cache.cache.get(&team.project_id()).await;
         assert!(cached_cohorts.is_none(), "Cache entry should have expired");
 
         Ok(())
@@ -157,7 +157,7 @@ mod tests {
         let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});
         for _ in 0..max_capacity {
             let team = context.insert_new_team(None).await?;
-            let project_id = team.project_id;
+            let project_id = team.project_id();
             inserted_project_ids.push(project_id);
             context
                 .insert_cohort(team.id, None, filters.clone(), false)
@@ -173,7 +173,7 @@ mod tests {
         );
 
         let new_team = context.insert_new_team(None).await?;
-        let new_project_id = new_team.project_id;
+        let new_project_id = new_team.project_id();
         let new_team_id = new_team.id;
         context
             .insert_cohort(new_team_id, None, filters, false)
@@ -207,7 +207,7 @@ mod tests {
     async fn test_get_cohorts() -> Result<(), anyhow::Error> {
         let context = TestContext::new(None).await;
         let team = context.insert_new_team(None).await?;
-        let project_id = team.project_id;
+        let project_id = team.project_id();
         let team_id = team.id;
 
         let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -11,12 +11,13 @@ use crate::properties::property_models::OperatorType;
 use crate::utils::graph_utils::{DependencyGraph, DependencyProvider, DependencyType};
 use crate::{api::errors::FlagError, properties::property_models::PropertyFilter};
 use common_database::PostgresReader;
+use common_types::ProjectId;
 
 impl Cohort {
     /// Returns all cohorts for a given team
     pub async fn list_from_pg(
         client: PostgresReader,
-        project_id: i64,
+        project_id: ProjectId,
     ) -> Result<Vec<Cohort>, FlagError> {
         let mut conn = get_connection_with_metrics(&client, "non_persons_reader", "fetch_cohorts")
             .await
@@ -435,7 +436,7 @@ mod tests {
             .await
             .expect("Failed to insert cohort2");
 
-        let cohorts = Cohort::list_from_pg(context.non_persons_reader, team.project_id)
+        let cohorts = Cohort::list_from_pg(context.non_persons_reader, team.project_id())
             .await
             .expect("Failed to list cohorts");
 
@@ -510,7 +511,7 @@ mod tests {
             .await
             .expect("Failed to insert main_cohort");
 
-        let cohorts = Cohort::list_from_pg(context.non_persons_reader.clone(), team.project_id)
+        let cohorts = Cohort::list_from_pg(context.non_persons_reader.clone(), team.project_id())
             .await
             .expect("Failed to fetch cohorts");
 

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -8,6 +8,7 @@ use crate::flags::flag_models::{
 };
 use common_database::PostgresReader;
 use common_redis::Client as RedisClient;
+use common_types::ProjectId;
 
 impl FeatureFlagList {
     pub fn new(flags: Vec<FeatureFlag>) -> Self {
@@ -17,7 +18,7 @@ impl FeatureFlagList {
     /// Returns feature flags from redis given a project_id
     pub async fn from_redis(
         client: Arc<dyn RedisClient + Send + Sync>,
-        project_id: i64,
+        project_id: ProjectId,
     ) -> Result<FeatureFlagList, FlagError> {
         tracing::debug!(
             "Attempting to read flags from Redis at key '{}{}'",
@@ -52,7 +53,7 @@ impl FeatureFlagList {
     /// Returns feature flags from postgres given a project_id
     pub async fn from_pg(
         client: PostgresReader,
-        project_id: i64,
+        project_id: ProjectId,
     ) -> Result<(FeatureFlagList, bool), FlagError> {
         let mut conn = get_connection_with_metrics(&client, "non_persons_reader", "fetch_flags")
             .await
@@ -155,7 +156,7 @@ impl FeatureFlagList {
 
     pub async fn update_flags_in_redis(
         client: Arc<dyn RedisClient + Send + Sync>,
-        project_id: i64,
+        project_id: ProjectId,
         flags: &FeatureFlagList,
         ttl_seconds: Option<u64>,
     ) -> Result<(), FlagError> {
@@ -226,11 +227,11 @@ mod tests {
             .await
             .expect("Failed to insert team");
 
-        insert_flags_for_team_in_redis(redis_client.clone(), team.id, team.project_id, None)
+        insert_flags_for_team_in_redis(redis_client.clone(), team.id, team.project_id(), None)
             .await
             .expect("Failed to insert flags");
 
-        let flags_from_redis = FeatureFlagList::from_redis(redis_client.clone(), team.project_id)
+        let flags_from_redis = FeatureFlagList::from_redis(redis_client.clone(), team.project_id())
             .await
             .expect("Failed to fetch flags from redis");
         assert_eq!(flags_from_redis.flags.len(), 1);
@@ -277,7 +278,7 @@ mod tests {
             .expect("Failed to insert flag");
 
         let (flags_from_pg, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from pg");
 
@@ -375,7 +376,7 @@ mod tests {
             .expect("Failed to insert flags");
 
         let (flags_from_pg, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from pg");
 
@@ -409,7 +410,7 @@ mod tests {
             .expect("Failed to insert evaluation tags");
 
         let (flags_from_pg, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from pg");
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -1375,7 +1375,7 @@ mod tests {
             &router,
             team.id,
             vec![distinct_id.clone()],
-            team.project_id,
+            team.project_id(),
             "hash_key_2".to_string(),
         )
         .await
@@ -1488,7 +1488,7 @@ mod tests {
             &router,
             team.id,
             distinct_ids.clone(),
-            team.project_id,
+            team.project_id(),
             hash_key.clone(),
         )
         .await
@@ -1624,7 +1624,7 @@ mod tests {
             &router,
             team.id,
             distinct_ids.clone(),
-            team.project_id,
+            team.project_id(),
             new_hash.clone(),
         )
         .await
@@ -1771,7 +1771,7 @@ mod tests {
             &router,
             team.id,
             vec!["filter_test_user".to_string()],
-            team.project_id,
+            team.project_id(),
             "filter_hash".to_string(),
         )
         .await
@@ -1850,7 +1850,7 @@ mod tests {
             &router,
             team.id,
             "should_write_user".to_string(),
-            team.project_id,
+            team.project_id(),
             "hash_key_1".to_string(),
         )
         .await
@@ -1864,7 +1864,7 @@ mod tests {
             &router,
             team.id,
             vec!["should_write_user".to_string()],
-            team.project_id,
+            team.project_id(),
             "hash_key_1".to_string(),
         )
         .await
@@ -1876,7 +1876,7 @@ mod tests {
             &router,
             team.id,
             "should_write_user".to_string(),
-            team.project_id,
+            team.project_id(),
             "hash_key_1".to_string(),
         )
         .await
@@ -1893,7 +1893,7 @@ mod tests {
             &router,
             team.id,
             "non_existent_user".to_string(),
-            team.project_id,
+            team.project_id(),
             "hash_key_2".to_string(),
         )
         .await
@@ -1938,7 +1938,7 @@ mod tests {
                 "nonexistent_user1".to_string(),
                 "nonexistent_user2".to_string(),
             ],
-            team.project_id,
+            team.project_id(),
             "some_hash".to_string(),
         )
         .await

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -449,7 +449,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(json!([multivariate_flag]).to_string()),
         )
         .await
@@ -477,7 +477,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -488,7 +488,7 @@ mod tests {
 
         // Fetch and verify from Postgres
         let (pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
@@ -551,7 +551,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(json!([multivariate_flag_with_payloads]).to_string()),
         )
         .await
@@ -579,7 +579,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -589,7 +589,7 @@ mod tests {
 
         // Fetch and verify from Postgres
         let (pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
@@ -684,7 +684,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(json!([flag_with_super_groups]).to_string()),
         )
         .await
@@ -712,7 +712,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -724,7 +724,7 @@ mod tests {
 
         // Fetch and verify from Postgres
         let (pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
@@ -784,7 +784,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(json!([flag_with_different_properties]).to_string()),
         )
         .await
@@ -812,7 +812,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -827,7 +827,7 @@ mod tests {
 
         // Fetch and verify from Postgres
         let (pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 1);
@@ -873,7 +873,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(json!([deleted_flag, inactive_flag]).to_string()),
         )
         .await
@@ -921,7 +921,7 @@ mod tests {
             .expect("Failed to insert inactive flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -934,7 +934,7 @@ mod tests {
 
         // Fetch and verify from Postgres
         let (pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.flags.len(), 0);
@@ -961,7 +961,7 @@ mod tests {
             .await
             .expect("Failed to set malformed JSON in Redis");
 
-        let result = FeatureFlagList::from_redis(redis_client, team.project_id).await;
+        let result = FeatureFlagList::from_redis(redis_client, team.project_id()).await;
         assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
 
         // Test database query error (using a non-existent table)
@@ -993,7 +993,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(json!([flag]).to_string()),
         )
         .await
@@ -1023,7 +1023,7 @@ mod tests {
         for _ in 0..10 {
             let redis_client = redis_client.clone();
             let reader = context.non_persons_reader.clone();
-            let project_id = team.project_id;
+            let project_id = team.project_id();
 
             let handle = task::spawn(async move {
                 let redis_flags = FeatureFlagList::from_redis(redis_client, project_id)
@@ -1074,7 +1074,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(json!(flags).to_string()),
         )
         .await
@@ -1103,13 +1103,13 @@ mod tests {
         }
 
         let start = Instant::now();
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let redis_duration = start.elapsed();
 
         let start = Instant::now();
-        let (pg_flags, _) = FeatureFlagList::from_pg(context.non_persons_reader, team.project_id)
+        let (pg_flags, _) = FeatureFlagList::from_pg(context.non_persons_reader, team.project_id())
             .await
             .expect("Failed to fetch flags from Postgres");
         let pg_duration = start.elapsed();
@@ -1167,7 +1167,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(edge_case_flags.to_string()),
         )
         .await
@@ -1196,11 +1196,11 @@ mod tests {
         }
 
         // Fetch and verify edge case flags
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let (pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
         assert_eq!(redis_flags.flags.len(), 3);
@@ -1255,7 +1255,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(flags.to_string()),
         )
         .await
@@ -1284,11 +1284,11 @@ mod tests {
         }
 
         // Fetch flags from both sources
-        let mut redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let mut redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let (mut pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
 
@@ -1375,7 +1375,7 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             Some(flags.to_string()),
         )
         .await
@@ -1404,11 +1404,11 @@ mod tests {
         }
 
         // Fetch flags from both sources
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id)
+        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let (pg_flags, _) =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id)
+            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
 

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -84,7 +84,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -105,7 +105,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             not_matching_distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -126,7 +126,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "other_distinct_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router3,
             cohort_cache.clone(),
             None,
@@ -189,7 +189,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -248,7 +248,7 @@ mod tests {
             None,
         );
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -271,7 +271,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             context.create_postgres_router(),
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -354,7 +354,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -512,7 +512,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -668,7 +668,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user_distinct_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -792,7 +792,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -945,7 +945,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -1063,7 +1063,7 @@ mod tests {
 
         let flag = create_test_flag_with_variants(team.id);
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -1073,7 +1073,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -1290,7 +1290,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -1337,6 +1337,8 @@ mod tests {
             None,
         ));
         let team = context.insert_new_team(None).await.unwrap();
+        let team_id = team.id;
+        let project_id = team.project_id();
         let flag = Arc::new(create_test_flag(
             None,
             Some(team.id),
@@ -1367,8 +1369,8 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 let matcher = FeatureFlagMatcher::new(
                     format!("test_user_{i}"),
-                    team.id,
-                    team.project_id,
+                    team_id,
+                    project_id,
                     router,
                     cohort_cache_clone,
                     None,
@@ -1450,7 +1452,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -1679,7 +1681,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -1743,7 +1745,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -1869,7 +1871,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -2102,7 +2104,7 @@ mod tests {
             let mut matcher = FeatureFlagMatcher::new(
                 user_id.to_string(),
                 team.id,
-                team.project_id,
+                team.project_id(),
                 router,
                 cohort_cache.clone(),
                 None,
@@ -2217,7 +2219,7 @@ mod tests {
         let mut matcher_test_id = FeatureFlagMatcher::new(
             "test_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2227,7 +2229,7 @@ mod tests {
         let mut matcher_example_id = FeatureFlagMatcher::new(
             "lil_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2237,7 +2239,7 @@ mod tests {
         let mut matcher_another_id = FeatureFlagMatcher::new(
             "another_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2353,7 +2355,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2464,7 +2466,7 @@ mod tests {
         let mut matcher_test_id = FeatureFlagMatcher::new(
             "test_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2474,7 +2476,7 @@ mod tests {
         let mut matcher_example_id = FeatureFlagMatcher::new(
             "lil_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2484,7 +2486,7 @@ mod tests {
         let mut matcher_another_id = FeatureFlagMatcher::new(
             "another_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2611,7 +2613,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2707,7 +2709,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2803,7 +2805,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2920,7 +2922,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3016,7 +3018,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3112,7 +3114,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3200,7 +3202,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3283,7 +3285,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3381,7 +3383,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3417,7 +3419,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -3459,7 +3461,7 @@ mod tests {
             &router,
             team.id,
             vec![distinct_id.clone()],
-            team.project_id,
+            team.project_id(),
             "hash_key_continuity".to_string(),
         )
         .await
@@ -3473,7 +3475,7 @@ mod tests {
         let result = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -3521,7 +3523,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -3565,7 +3567,7 @@ mod tests {
         let result = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -3608,7 +3610,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -3680,7 +3682,7 @@ mod tests {
             &router2,
             team.id,
             vec![distinct_id.clone()],
-            team.project_id,
+            team.project_id(),
             "hash_key_mixed".to_string(),
         )
         .await
@@ -3694,7 +3696,7 @@ mod tests {
         let result = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -3800,7 +3802,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4031,7 +4033,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "example_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4053,7 +4055,7 @@ mod tests {
         let mut matcher2 = FeatureFlagMatcher::new(
             "example_id2".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -4166,7 +4168,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "11".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4189,7 +4191,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "example_id".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4212,7 +4214,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "3".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4307,7 +4309,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4373,7 +4375,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "nonexistent_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4432,7 +4434,7 @@ mod tests {
         );
 
         // Set up group type mapping cache
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -4444,7 +4446,7 @@ mod tests {
         let mut matcher_numeric = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4464,7 +4466,7 @@ mod tests {
         let mut matcher_string = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router2,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4496,7 +4498,7 @@ mod tests {
         let mut matcher_float = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router3,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4517,7 +4519,7 @@ mod tests {
         let mut matcher_bool = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router4,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4661,7 +4663,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "super_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4686,7 +4688,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "posthog_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -4711,7 +4713,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "regular_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router3,
             cohort_cache.clone(),
             None,
@@ -4783,7 +4785,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4903,7 +4905,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4948,7 +4950,7 @@ mod tests {
         let mut matcher2 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -4982,7 +4984,7 @@ mod tests {
         let mut matcher3 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router3,
             cohort_cache.clone(),
             None,
@@ -5018,7 +5020,7 @@ mod tests {
         let mut matcher4 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router4,
             cohort_cache.clone(),
             None,
@@ -5140,7 +5142,7 @@ mod tests {
         );
 
         // Set up group type mappings
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id);
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -5171,7 +5173,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5215,7 +5217,7 @@ mod tests {
         let mut matcher2 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router2,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5255,7 +5257,7 @@ mod tests {
         let mut matcher3 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router3,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5291,7 +5293,7 @@ mod tests {
         let mut matcher4 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router4,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5331,7 +5333,7 @@ mod tests {
         let mut matcher5 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router5,
             cohort_cache.clone(),
             None,
@@ -5434,7 +5436,7 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "specific_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -5464,7 +5466,7 @@ mod tests {
         let matcher2 = FeatureFlagMatcher::new(
             "other_user".to_string(),
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -5509,7 +5511,7 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id,
             team.id,
-            team.project_id,
+            team.project_id(),
             router,
             cohort_cache,
             None,

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -249,7 +249,7 @@ mod tests {
             id: 1,
             name: "Test Team".to_string(),
             api_token: "test-token".to_string(),
-            project_id: 1,
+            project_id: Some(1),
             uuid: Uuid::new_v4(),
             organization_id: None,
             autocapture_opt_out: None,

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 use axum::extract::State;
+use common_types::ProjectId;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -169,7 +170,7 @@ fn filter_flags_by_runtime(
 
 pub async fn fetch_and_filter(
     flag_service: &FlagService,
-    project_id: i64,
+    project_id: ProjectId,
     query_params: &FlagsQueryParams,
     headers: &axum::http::HeaderMap,
     explicit_runtime: Option<EvaluationRuntime>,
@@ -247,7 +248,7 @@ fn filter_flags_by_evaluation_tags(
 pub async fn evaluate_for_request(
     state: &State<router::State>,
     team_id: i32,
-    project_id: i64,
+    project_id: ProjectId,
     distinct_id: String,
     filtered_flags: FeatureFlagList,
     person_property_overrides: Option<HashMap<String, Value>>,

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -199,7 +199,7 @@ async fn process_request_inner(
             request_id = %context.request_id,
             distinct_id = %distinct_id_for_logging,
             team_id = team.id,
-            project_id = team.project_id,
+            project_id = team.project_id(),
             flags_count = response.flags.len(),
             flags_disabled = request.is_flags_disabled(),
             quota_limited = response.quota_limited.is_some(),

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -122,7 +122,7 @@ async fn process_request_inner(
         tracing::debug!(
             "Team fetched: team_id={}, project_id={}",
             team.id,
-            team.project_id
+            team.project_id()
         );
 
         // Early exit if flags are disabled
@@ -147,7 +147,7 @@ async fn process_request_inner(
 
             let (filtered_flags, had_flag_errors) = flags::fetch_and_filter(
                 &flag_service,
-                team.project_id,
+                team.project_id(),
                 &context.meta,
                 &context.headers,
                 request.evaluation_runtime,
@@ -163,7 +163,7 @@ async fn process_request_inner(
             let mut response = flags::evaluate_for_request(
                 &context.state,
                 team.id,
-                team.project_id,
+                team.project_id(),
                 distinct_id.clone(),
                 filtered_flags.clone(),
                 property_overrides.person_properties,

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -176,7 +176,7 @@ async fn test_evaluate_feature_flags() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id,
+        project_id: team.project_id(),
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
         persons_reader: reader.clone(),
@@ -265,7 +265,7 @@ async fn test_evaluate_feature_flags_with_errors() {
     // Set up evaluation context
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id,
+        project_id: team.project_id(),
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
         persons_reader: context.persons_reader.clone(),
@@ -666,7 +666,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id,
+        project_id: team.project_id(),
         distinct_id: distinct_id.clone(),
         feature_flags: feature_flag_list,
         persons_reader: reader.clone(),
@@ -767,7 +767,7 @@ async fn test_evaluate_feature_flags_details() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id,
+        project_id: team.project_id(),
         distinct_id: distinct_id.clone(),
         feature_flags: feature_flag_list,
         persons_reader: reader.clone(),
@@ -919,7 +919,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id,
+        project_id: team.project_id(),
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
         persons_reader: context.persons_reader.clone(),
@@ -1008,7 +1008,7 @@ async fn test_long_distinct_id() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id,
+        project_id: team.project_id(),
         distinct_id: long_id,
         feature_flags: feature_flag_list,
         persons_reader: context.persons_reader.clone(),
@@ -1219,7 +1219,7 @@ async fn test_fetch_and_filter_flags() {
     insert_flags_for_team_in_redis(
         redis_reader_client.clone(),
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags_json),
     )
     .await
@@ -1232,7 +1232,7 @@ async fn test_fetch_and_filter_flags() {
     };
     let (result, had_errors) = fetch_and_filter(
         &flag_service,
-        team.project_id,
+        team.project_id(),
         &query_params,
         &axum::http::HeaderMap::new(),
         None,
@@ -1254,7 +1254,7 @@ async fn test_fetch_and_filter_flags() {
     };
     let (result, had_errors) = fetch_and_filter(
         &flag_service,
-        team.project_id,
+        team.project_id(),
         &query_params,
         &axum::http::HeaderMap::new(),
         None,
@@ -1269,7 +1269,7 @@ async fn test_fetch_and_filter_flags() {
     let query_params = FlagsQueryParams::default();
     let (result, had_errors) = fetch_and_filter(
         &flag_service,
-        team.project_id,
+        team.project_id(),
         &query_params,
         &axum::http::HeaderMap::new(),
         None,
@@ -1292,7 +1292,7 @@ async fn test_fetch_and_filter_flags() {
 
     let (result, had_errors) = fetch_and_filter(
         &flag_service,
-        team.project_id,
+        team.project_id(),
         &query_params,
         &axum::http::HeaderMap::new(),
         None,

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -1,5 +1,6 @@
 use axum::{extract::State, http::HeaderMap};
 use bytes::Bytes;
+use common_types::ProjectId;
 use serde_json::Value;
 use std::{collections::HashMap, net::IpAddr, sync::Arc};
 use uuid::Uuid;
@@ -42,7 +43,7 @@ pub struct RequestPropertyOverrides {
 /// Represents all context required for evaluating a set of feature flags.
 pub struct FeatureFlagEvaluationContext {
     pub team_id: i32,
-    pub project_id: i64,
+    pub project_id: ProjectId,
     pub distinct_id: String,
     pub feature_flags: FeatureFlagList,
     pub persons_reader: Arc<dyn common_database::Client + Send + Sync>,

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -10,11 +10,9 @@ pub struct Team {
     pub id: TeamId,
     pub name: String,
     pub api_token: String,
-    /// Project ID. This field is not present in Redis cache before Dec 2025, but this is not a problem at all,
-    /// because we know all Teams created before Dec 2025 have `project_id` = `id`. To handle this case gracefully,
-    /// we use 0 as a fallback value in deserialization here, and handle this in `Team::from_redis`.
-    /// Thanks to this default-base approach, we avoid invalidating the whole cache needlessly.
-    pub project_id: ProjectId,
+    /// Project ID. This field may be None in Redis cache for teams created before Dec 2024.
+    /// For such teams, project_id equals the team id. Use Team::project_id() to get the resolved value.
+    pub project_id: Option<ProjectId>,
     pub uuid: Uuid,
     pub organization_id: Option<Uuid>,
     pub autocapture_opt_out: Option<bool>,

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -293,7 +293,7 @@ async fn insert_team_group_mappings(
         .bind(group_type)
         .bind(group_type_index)
         .bind(team.id)
-        .bind(team.project_id)
+        .bind(team.project_id())
         .execute(&mut *persons_conn)
         .await?;
         assert_eq!(res.rows_affected(), 1);
@@ -336,7 +336,7 @@ pub async fn insert_new_team_in_pg(
         (id, organization_id, name, created_at) VALUES
         ($1, $2::uuid, $3, '2024-06-17 14:40:51.332036+00:00')"#,
     )
-    .bind(team.project_id)
+    .bind(team.project_id())
     .bind(org_id)
     .bind(&team.name)
     .execute(&mut *non_persons_conn)
@@ -348,7 +348,7 @@ pub async fn insert_new_team_in_pg(
         r#"INSERT INTO posthog_team
         (id, uuid, organization_id, project_id, api_token, name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical, cookieless_server_hash_mode, base_currency, session_recording_retention_period, web_analytics_pre_aggregated_tables_enabled) VALUES
         ($1, $2, $3::uuid, $4, $5, $6, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]', $7, 'USD', '30d', false)"#
-    ).bind(team.id).bind(uuid).bind(org_id).bind(team.project_id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode.unwrap_or(0)).execute(&mut *non_persons_conn).await?;
+    ).bind(team.id).bind(uuid).bind(org_id).bind(team.project_id()).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode.unwrap_or(0)).execute(&mut *non_persons_conn).await?;
     assert_eq!(res.rows_affected(), 1);
 
     // Insert group type mappings
@@ -1138,7 +1138,7 @@ impl TestContext {
             (id, organization_id, name, created_at) VALUES
             ($1, $2::uuid, $3, '2024-06-17 14:40:51.332036+00:00')"#,
         )
-        .bind(team.project_id)
+        .bind(team.project_id())
         .bind(ORG_ID)
         .bind(&team.name)
         .execute(&mut *conn)
@@ -1169,7 +1169,7 @@ impl TestContext {
             .bind(team.id)
             .bind(uuid)
             .bind(ORG_ID)
-            .bind(team.project_id)
+            .bind(team.project_id())
             .bind(&team.api_token)
             .bind(&secret_token);
 
@@ -1223,7 +1223,7 @@ impl TestContext {
         let mut conn = self.non_persons_reader.get_connection().await?;
         let org_id: uuid::Uuid =
             sqlx::query_scalar("SELECT organization_id FROM posthog_project WHERE id = $1")
-                .bind(team.project_id)
+                .bind(team.project_id())
                 .fetch_one(&mut *conn)
                 .await?;
         Ok(org_id)

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -12,7 +12,7 @@ use anyhow::Error;
 use axum::async_trait;
 use common_database::{get_pool, Client, CustomDatabaseError};
 use common_redis::{Client as RedisClientTrait, RedisClient};
-use common_types::{PersonId, TeamId};
+use common_types::{PersonId, ProjectId, TeamId};
 use rand::{distributions::Alphanumeric, Rng};
 use serde_json::{json, Value};
 use sqlx::{pool::PoolConnection, Error as SqlxError, Postgres, Row};
@@ -35,7 +35,7 @@ pub async fn insert_new_team_in_redis(
     let token = random_string("phc_", 12);
     let team = Team {
         id,
-        project_id: i64::from(id),
+        project_id: Some(i64::from(id)),
         name: "team".to_string(),
         api_token: token,
         cookieless_server_hash_mode: Some(0),
@@ -57,7 +57,7 @@ pub async fn insert_new_team_in_redis(
 pub async fn insert_flags_for_team_in_redis(
     client: Arc<dyn RedisClientTrait + Send + Sync>,
     team_id: i32,
-    project_id: i64,
+    project_id: ProjectId,
     json_value: Option<String>,
 ) -> Result<(), Error> {
     let payload = match json_value {
@@ -318,7 +318,7 @@ pub async fn insert_new_team_in_pg(
     let token = random_string("phc_", 12);
     let team = Team {
         id,
-        project_id: id as i64,
+        project_id: Some(id as i64),
         name: "Test Team".to_string(),
         api_token: token.clone(),
         cookieless_server_hash_mode: Some(0),
@@ -1120,7 +1120,7 @@ impl TestContext {
         let id = rand::thread_rng().gen_range(0..10_000_000);
         let team = Team {
             id,
-            project_id: id as i64,
+            project_id: Some(id as i64),
             name: "Test Team".to_string(),
             api_token: public_token.clone(),
             cookieless_server_hash_mode: Some(0),

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -57,7 +57,7 @@ impl ServerHandle {
             // Create a minimal valid Team object
             let team = Team {
                 id: team_id,
-                project_id: team_id as i64,
+                project_id: Some(team_id as i64),
                 name: "Test Team".to_string(),
                 api_token: token.clone(),
                 cookieless_server_hash_mode: Some(0),

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -25,7 +25,7 @@ async fn it_handles_get_requests_with_minimal_response() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -73,7 +73,7 @@ async fn it_gets_legacy_response_for_v1_or_invalid_version(
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -103,7 +103,7 @@ async fn it_gets_legacy_response_for_v1_or_invalid_version(
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -144,7 +144,7 @@ async fn it_gets_v2_response_by_default_when_no_params() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -175,7 +175,7 @@ async fn it_gets_v2_response_by_default_when_no_params() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -232,7 +232,7 @@ async fn it_get_new_response_when_version_is_2_or_more(#[case] version: &str) ->
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -263,7 +263,7 @@ async fn it_get_new_response_when_version_is_2_or_more(#[case] version: &str) ->
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -316,7 +316,7 @@ async fn it_rejects_invalid_headers_flag_request() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -355,7 +355,7 @@ async fn it_accepts_empty_distinct_id() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
     let distinct_id = "user_distinct_id".to_string();
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -392,7 +392,7 @@ async fn it_rejects_missing_distinct_id() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
     let server = ServerHandle::for_config(config).await;
 
     let payload = json!({
@@ -478,7 +478,7 @@ async fn it_handles_base64_auto_detection_fallback() -> Result<()> {
     // Set up Redis and PostgreSQL clients
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -529,12 +529,12 @@ async fn it_handles_disable_flags_without_distinct_id() -> Result<()> {
     // Set up Redis and PostgreSQL clients
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    insert_flags_for_team_in_redis(client.clone(), team.id, team.project_id, None)
+    insert_flags_for_team_in_redis(client.clone(), team.id, team.project_id(), None)
         .await
         .unwrap();
 
@@ -645,7 +645,7 @@ async fn it_handles_multivariate_flags() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -693,7 +693,7 @@ async fn it_handles_multivariate_flags() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -736,7 +736,7 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
     context
@@ -770,7 +770,7 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -839,7 +839,7 @@ async fn it_matches_flags_to_a_request_with_group_property_overrides() -> Result
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(Some(team.id)).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let flag_json = json!([{
         "id": 1,
@@ -870,7 +870,7 @@ async fn it_matches_flags_to_a_request_with_group_property_overrides() -> Result
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -950,7 +950,7 @@ async fn test_feature_flags_with_json_payloads() -> Result<()> {
     let team = insert_new_team_in_redis(redis_client.clone())
         .await
         .unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -995,7 +995,7 @@ async fn test_feature_flags_with_json_payloads() -> Result<()> {
     insert_flags_for_team_in_redis(
         redis_client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1042,7 +1042,7 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
         .insert_person(team.id, distinct_id.clone(), None)
         .await?;
 
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     // Create a group of type "organization" (group_type_index 1) with group_key "foo" and specific properties
     context
@@ -1104,7 +1104,7 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
     insert_flags_for_team_in_redis(
         redis_client.clone(),
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags_json.to_string()),
     )
     .await?;
@@ -1204,7 +1204,7 @@ async fn it_handles_not_contains_property_filter() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -1240,7 +1240,7 @@ async fn it_handles_not_contains_property_filter() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1279,7 +1279,7 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
     context
@@ -1339,7 +1339,7 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1435,7 +1435,7 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
         .insert_person(team.id, distinct_id.clone(), None)
         .await
         .unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     // Create a group with matching name
     context
@@ -1499,7 +1499,7 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
     insert_flags_for_team_in_redis(
         redis_client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1575,7 +1575,7 @@ async fn test_super_condition_with_complex_request() -> Result<()> {
     let team = insert_new_team_in_redis(redis_client.clone()).await?;
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await?;
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     // Insert person with just their stored properties from the DB
     context
@@ -1626,7 +1626,7 @@ async fn test_super_condition_with_complex_request() -> Result<()> {
     insert_flags_for_team_in_redis(
         redis_client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1682,7 +1682,7 @@ async fn test_flag_matches_with_no_person_profile() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -1719,7 +1719,7 @@ async fn test_flag_matches_with_no_person_profile() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1810,7 +1810,7 @@ async fn it_only_includes_config_fields_when_requested() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -1839,7 +1839,7 @@ async fn it_only_includes_config_fields_when_requested() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1881,7 +1881,7 @@ async fn test_config_basic_fields() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -1905,7 +1905,7 @@ async fn test_config_basic_fields() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -1950,7 +1950,7 @@ async fn test_config_analytics_enabled() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -1989,7 +1989,7 @@ async fn test_config_analytics_enabled_by_default() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -2027,7 +2027,7 @@ async fn test_config_analytics_disabled_debug_mode() -> Result<()> {
     let distinct_id = "user_distinct_id".to_string();
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -2063,7 +2063,7 @@ async fn test_config_capture_performance_combinations() -> Result<()> {
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
 
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -2099,7 +2099,7 @@ async fn test_config_autocapture_exceptions() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -2135,7 +2135,7 @@ async fn test_config_optional_team_features() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -2179,7 +2179,7 @@ async fn test_config_site_apps_empty_by_default() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -2215,7 +2215,7 @@ async fn test_config_included_in_legacy_response() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -2239,7 +2239,7 @@ async fn test_config_included_in_legacy_response() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -3224,7 +3224,7 @@ async fn test_disable_flags_returns_empty_response() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -3255,7 +3255,7 @@ async fn test_disable_flags_returns_empty_response() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -3295,7 +3295,7 @@ async fn test_disable_flags_returns_empty_response_v2() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -3326,7 +3326,7 @@ async fn test_disable_flags_returns_empty_response_v2() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -3365,7 +3365,7 @@ async fn test_disable_flags_false_still_returns_flags() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -3396,7 +3396,7 @@ async fn test_disable_flags_false_still_returns_flags() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -3437,7 +3437,7 @@ async fn test_disable_flags_with_config_still_returns_config_data() -> Result<()
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -3468,7 +3468,7 @@ async fn test_disable_flags_with_config_still_returns_config_data() -> Result<()
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -3525,7 +3525,7 @@ async fn test_disable_flags_with_config_v2_still_returns_config_data() -> Result
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -3556,7 +3556,7 @@ async fn test_disable_flags_with_config_v2_still_returns_config_data() -> Result
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -3612,7 +3612,7 @@ async fn test_disable_flags_without_config_param_has_minimal_response() -> Resul
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -3643,7 +3643,7 @@ async fn test_disable_flags_without_config_param_has_minimal_response() -> Resul
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -3695,7 +3695,7 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
         .insert_person(team.id, distinct_id.clone(), None)
         .await?;
 
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     // Create a group with a numeric group_key (as a string in DB, but represents a number)
     context
@@ -3731,7 +3731,7 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
     insert_flags_for_team_in_redis(
         redis_client.clone(),
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags_json.to_string()),
     )
     .await?;
@@ -3861,7 +3861,7 @@ async fn test_super_condition_property_overrides_bug_fix() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -3909,7 +3909,7 @@ async fn test_super_condition_property_overrides_bug_fix() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -4053,7 +4053,7 @@ async fn test_property_override_bug_real_scenario() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -4127,7 +4127,7 @@ async fn test_property_override_bug_real_scenario() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -4190,7 +4190,7 @@ async fn test_super_condition_with_cohort_filters() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -4245,7 +4245,7 @@ async fn test_super_condition_with_cohort_filters() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -4373,7 +4373,7 @@ async fn test_returns_empty_flags_when_no_active_flags_configured() -> Result<()
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -4438,7 +4438,7 @@ async fn test_returns_empty_flags_when_no_active_flags_configured() -> Result<()
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -4515,7 +4515,7 @@ async fn test_group_key_property_matching() -> Result<()> {
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(Some(team.id)).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     // Create a flag that filters on $group_key property
     let flag_json = json!([{
@@ -4547,7 +4547,7 @@ async fn test_group_key_property_matching() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -4640,7 +4640,7 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -4728,7 +4728,7 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -4854,7 +4854,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -4963,7 +4963,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -5086,7 +5086,7 @@ async fn test_flag_keys_to_evaluate_parameter() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -5151,7 +5151,7 @@ async fn test_flag_keys_to_evaluate_parameter() -> Result<()> {
     insert_flags_for_team_in_redis(
         client.clone(),
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags.to_string()),
     )
     .await
@@ -5212,7 +5212,7 @@ async fn it_handles_empty_query_parameters() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -5262,7 +5262,7 @@ async fn it_handles_boolean_query_params_as_truthy() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -5344,7 +5344,7 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let pg_client = setup_pg_reader_client(None).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -5494,7 +5494,7 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -5756,7 +5756,7 @@ async fn test_empty_distinct_id_flag_matching() -> Result<()> {
     insert_flags_for_team_in_redis(
         client.clone(),
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags_json.to_string()),
     )
     .await?;
@@ -6010,7 +6010,7 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
     insert_flags_for_team_in_redis(
         client.clone(),
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await?;
@@ -6138,7 +6138,7 @@ async fn test_date_string_property_matching_with_is_date_after() -> Result<()> {
     let team = insert_new_team_in_redis(redis_client.clone())
         .await
         .unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
@@ -6214,7 +6214,7 @@ async fn test_date_string_property_matching_with_is_date_after() -> Result<()> {
     insert_flags_for_team_in_redis(
         redis_client.clone(),
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flag_json.to_string()),
     )
     .await

--- a/rust/feature-flags/tests/test_legacy_decide_formats.rs
+++ b/rust/feature-flags/tests/test_legacy_decide_formats.rs
@@ -20,7 +20,7 @@ async fn test_legacy_decide_v1_format() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     // Insert test flags - one enabled, one with variant, one disabled
     let flags_json = json!([
@@ -90,7 +90,7 @@ async fn test_legacy_decide_v1_format() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags_json.to_string()),
     )
     .await?;
@@ -169,7 +169,7 @@ async fn test_legacy_decide_v2_format() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     // Insert test flags
     let flags_json = json!([
@@ -222,7 +222,7 @@ async fn test_legacy_decide_v2_format() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags_json.to_string()),
     )
     .await?;
@@ -291,7 +291,7 @@ async fn test_decide_header_changes_version_interpretation() -> Result<()> {
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
-    let token = team.api_token;
+    let token = team.api_token.clone();
 
     let flags_json = json!([
         {
@@ -316,7 +316,7 @@ async fn test_decide_header_changes_version_interpretation() -> Result<()> {
     insert_flags_for_team_in_redis(
         client,
         team.id,
-        team.project_id,
+        team.project_id(),
         Some(flags_json.to_string()),
     )
     .await?;


### PR DESCRIPTION
## Problem

Our `Team` struct has diverged a bit from the `Team` model in Django and the `Team` struct in `common-types`.

In the long run, we want to have some sort of automation to help warn us when these things diverge. For now, I want to take baby steps toward that goal by getting our model more in-line with the one in `common-types`.

Eventually we want to use the `Team` in `common-types` and then add our automation to ensure *that* type matches Django.

## Changes

Changes `Team.project_id` from `ProjectId` to `Option<ProjectId>` to align with the Django model and the `Team` struct in `common-types`.

## How did you test this code?

Manual test of `/flags`
Unit Tests

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
