### PR TITLE
fix: Creating custom group detail dashboard raises fk violation

### DIFF
--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -29,7 +29,9 @@ class GroupTypeMapping(RootTeamMixin, models.Model):
 
     default_columns = ArrayField(models.TextField(), null=True, blank=True)
 
-    detail_dashboard = models.ForeignKey("Dashboard", on_delete=models.SET_NULL, null=True, blank=True)
+    detail_dashboard = models.ForeignKey(
+        "Dashboard", on_delete=models.SET_NULL, null=True, blank=True, db_constraint=False
+    )
     created_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:


### PR DESCRIPTION
## Problem
Creating a custom group detail dashboard fails with a foreign key violation
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Fixes https://github.com/PostHog/posthog/issues/40838
## Changes
- Drop db constraint on `detail_dashboard` foreign key in group type mapping

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
