### PR TITLE
refactor(types): add all `Team` struct columns to `common-types` for parity

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1962,6 +1962,7 @@ dependencies = [
  "jiff",
  "rdkafka",
  "regex",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sqlx",

--- a/rust/common/types/.sqlx/query-0075dc262b54e2c4b0139e12a298169e4825500508e9a3a25971813a18fac983.json
+++ b/rust/common/types/.sqlx/query-0075dc262b54e2c4b0139e12a298169e4825500508e9a3a25971813a18fac983.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT pp.id, pp.created_at, pp.team_id, pp.uuid, '{}'::jsonb as properties, pp.is_identified, pp.is_user_id, pp.version\n                FROM posthog_person pp\n                INNER JOIN posthog_persondistinctid\n                    ON pp.id = posthog_persondistinctid.person_id\n                WHERE\n                    posthog_persondistinctid.distinct_id = $1\n                    AND posthog_persondistinctid.team_id = $2\n                    AND pp.team_id = $2\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "team_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "properties",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_identified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_user_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "version",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      null,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "0075dc262b54e2c4b0139e12a298169e4825500508e9a3a25971813a18fac983"
+}

--- a/rust/common/types/.sqlx/query-07d46ca7a583e07c0fe87bd5d2f5e92f968e28d057c1c19d8d18d850d828bcee.json
+++ b/rust/common/types/.sqlx/query-07d46ca7a583e07c0fe87bd5d2f5e92f968e28d057c1c19d8d18d850d828bcee.json
@@ -1,0 +1,238 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out,\n                    autocapture_opt_out,\n                    autocapture_exceptions_opt_in,\n                    autocapture_web_vitals_opt_in,\n                    capture_performance_opt_in,\n                    capture_console_log_opt_in,\n                    session_recording_opt_in,\n                    inject_web_apps,\n                    surveys_opt_in,\n                    heatmaps_opt_in,\n                    capture_dead_clicks,\n                    flags_persistence_default,\n                    session_recording_sample_rate,\n                    session_recording_minimum_duration_milliseconds,\n                    autocapture_web_vitals_allowed_metrics as \"autocapture_web_vitals_allowed_metrics: _\",\n                    autocapture_exceptions_errors_to_ignore as \"autocapture_exceptions_errors_to_ignore: _\",\n                    session_recording_linked_flag as \"session_recording_linked_flag: _\",\n                    session_recording_network_payload_capture_config as \"session_recording_network_payload_capture_config: _\",\n                    session_recording_masking_config as \"session_recording_masking_config: _\",\n                    session_replay_config as \"session_replay_config: _\",\n                    survey_config as \"survey_config: _\",\n                    session_recording_url_trigger_config as \"session_recording_url_trigger_config: _\",\n                    session_recording_url_blocklist_config as \"session_recording_url_blocklist_config: _\",\n                    session_recording_event_trigger_config as \"session_recording_event_trigger_config: _\",\n                    session_recording_trigger_match_type_config,\n                    recording_domains,\n                    cookieless_server_hash_mode,\n                    timezone\n                FROM posthog_team\n                WHERE api_token = $1\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "project_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "api_token",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "anonymize_ips",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "person_processing_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "autocapture_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "autocapture_exceptions_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "autocapture_web_vitals_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "capture_performance_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "capture_console_log_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 15,
+        "name": "session_recording_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "inject_web_apps",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "surveys_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "heatmaps_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "capture_dead_clicks",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "flags_persistence_default",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 21,
+        "name": "session_recording_sample_rate",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 22,
+        "name": "session_recording_minimum_duration_milliseconds",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "autocapture_web_vitals_allowed_metrics: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 24,
+        "name": "autocapture_exceptions_errors_to_ignore: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 25,
+        "name": "session_recording_linked_flag: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 26,
+        "name": "session_recording_network_payload_capture_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 27,
+        "name": "session_recording_masking_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 28,
+        "name": "session_replay_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 29,
+        "name": "survey_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 30,
+        "name": "session_recording_url_trigger_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 31,
+        "name": "session_recording_url_blocklist_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 32,
+        "name": "session_recording_event_trigger_config: _",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 33,
+        "name": "session_recording_trigger_match_type_config",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 34,
+        "name": "recording_domains",
+        "type_info": "VarcharArray"
+      },
+      {
+        "ordinal": 35,
+        "name": "cookieless_server_hash_mode",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 36,
+        "name": "timezone",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "07d46ca7a583e07c0fe87bd5d2f5e92f968e28d057c1c19d8d18d850d828bcee"
+}

--- a/rust/common/types/.sqlx/query-0a5daf41fe9185ee691c87aa6e009100999e6ec1c85bf2ab9bdacb933b4a7c50.json
+++ b/rust/common/types/.sqlx/query-0a5daf41fe9185ee691c87aa6e009100999e6ec1c85bf2ab9bdacb933b4a7c50.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, group_type, group_type_index, team_id FROM posthog_grouptypemapping WHERE team_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "group_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "group_type_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "team_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0a5daf41fe9185ee691c87aa6e009100999e6ec1c85bf2ab9bdacb933b4a7c50"
+}

--- a/rust/common/types/.sqlx/query-4122d9f532c4eb09667b5d665f947708e778b99c6ec471f72079af5149ac878f.json
+++ b/rust/common/types/.sqlx/query-4122d9f532c4eb09667b5d665f947708e778b99c6ec471f72079af5149ac878f.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, group_type, group_type_index, team_id FROM posthog_grouptypemapping WHERE team_id = $1 AND group_type = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "group_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "group_type_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "team_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4122d9f532c4eb09667b5d665f947708e778b99c6ec471f72079af5149ac878f"
+}

--- a/rust/common/types/.sqlx/query-9797599a9be923f86da25f824e6992763239554455e0fc17ab6fc9c6797a1520.json
+++ b/rust/common/types/.sqlx/query-9797599a9be923f86da25f824e6992763239554455e0fc17ab6fc9c6797a1520.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, group_type, group_type_index, team_id FROM posthog_grouptypemapping WHERE team_id = $1 AND group_type_index = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "group_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "group_type_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "team_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9797599a9be923f86da25f824e6992763239554455e0fc17ab6fc9c6797a1520"
+}

--- a/rust/common/types/.sqlx/query-db11804fee44f3b21df676148637cf002d87f2961df08b47ec9a0ffb2d20deee.json
+++ b/rust/common/types/.sqlx/query-db11804fee44f3b21df676148637cf002d87f2961df08b47ec9a0ffb2d20deee.json
@@ -1,0 +1,238 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out,\n                    autocapture_opt_out,\n                    autocapture_exceptions_opt_in,\n                    autocapture_web_vitals_opt_in,\n                    capture_performance_opt_in,\n                    capture_console_log_opt_in,\n                    session_recording_opt_in,\n                    inject_web_apps,\n                    surveys_opt_in,\n                    heatmaps_opt_in,\n                    capture_dead_clicks,\n                    flags_persistence_default,\n                    session_recording_sample_rate,\n                    session_recording_minimum_duration_milliseconds,\n                    autocapture_web_vitals_allowed_metrics as \"autocapture_web_vitals_allowed_metrics: _\",\n                    autocapture_exceptions_errors_to_ignore as \"autocapture_exceptions_errors_to_ignore: _\",\n                    session_recording_linked_flag as \"session_recording_linked_flag: _\",\n                    session_recording_network_payload_capture_config as \"session_recording_network_payload_capture_config: _\",\n                    session_recording_masking_config as \"session_recording_masking_config: _\",\n                    session_replay_config as \"session_replay_config: _\",\n                    survey_config as \"survey_config: _\",\n                    session_recording_url_trigger_config as \"session_recording_url_trigger_config: _\",\n                    session_recording_url_blocklist_config as \"session_recording_url_blocklist_config: _\",\n                    session_recording_event_trigger_config as \"session_recording_event_trigger_config: _\",\n                    session_recording_trigger_match_type_config,\n                    recording_domains,\n                    cookieless_server_hash_mode,\n                    timezone\n                FROM posthog_team\n                WHERE id = $1\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "project_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "api_token",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "anonymize_ips",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "person_processing_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "autocapture_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "autocapture_exceptions_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "autocapture_web_vitals_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "capture_performance_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "capture_console_log_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 15,
+        "name": "session_recording_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "inject_web_apps",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "surveys_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "heatmaps_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "capture_dead_clicks",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "flags_persistence_default",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 21,
+        "name": "session_recording_sample_rate",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 22,
+        "name": "session_recording_minimum_duration_milliseconds",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 23,
+        "name": "autocapture_web_vitals_allowed_metrics: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 24,
+        "name": "autocapture_exceptions_errors_to_ignore: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 25,
+        "name": "session_recording_linked_flag: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 26,
+        "name": "session_recording_network_payload_capture_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 27,
+        "name": "session_recording_masking_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 28,
+        "name": "session_replay_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 29,
+        "name": "survey_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 30,
+        "name": "session_recording_url_trigger_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 31,
+        "name": "session_recording_url_blocklist_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 32,
+        "name": "session_recording_event_trigger_config: _",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 33,
+        "name": "session_recording_trigger_match_type_config",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 34,
+        "name": "recording_domains",
+        "type_info": "VarcharArray"
+      },
+      {
+        "ordinal": 35,
+        "name": "cookieless_server_hash_mode",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 36,
+        "name": "timezone",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "db11804fee44f3b21df676148637cf002d87f2961df08b47ec9a0ffb2d20deee"
+}

--- a/rust/common/types/.sqlx/query-f73889687c0d58e9800b6df9c8faa1e85e7696dc5cabaa30e4490e558afa93b8.json
+++ b/rust/common/types/.sqlx/query-f73889687c0d58e9800b6df9c8faa1e85e7696dc5cabaa30e4490e558afa93b8.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT pp.id, pp.created_at, pp.team_id, pp.uuid, pp.properties, pp.is_identified, pp.is_user_id, pp.version\n                FROM posthog_person pp\n                INNER JOIN posthog_persondistinctid\n                    ON pp.id = posthog_persondistinctid.person_id\n                WHERE\n                    posthog_persondistinctid.distinct_id = $1\n                    AND posthog_persondistinctid.team_id = $2\n                    AND pp.team_id = $2\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "team_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "properties",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_identified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_user_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "version",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "f73889687c0d58e9800b6df9c8faa1e85e7696dc5cabaa30e4490e558afa93b8"
+}

--- a/rust/common/types/Cargo.toml
+++ b/rust/common/types/Cargo.toml
@@ -11,7 +11,8 @@ chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rdkafka = { workspace = true }
-sqlx = { workspace = true }
+rust_decimal = "1.37.1"
+sqlx = { workspace = true, features = ["rust_decimal"] }
 uuid = { workspace = true }
 time = { workspace = true }
 dateparser = "0.2"

--- a/rust/common/types/src/team.rs
+++ b/rust/common/types/src/team.rs
@@ -28,6 +28,7 @@ pub struct Team {
     pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default)]
     pub anonymize_ips: bool,
     pub person_processing_opt_out: Option<bool>,
     pub autocapture_opt_out: Option<bool>,
@@ -35,6 +36,7 @@ pub struct Team {
     pub autocapture_web_vitals_opt_in: Option<bool>,
     pub capture_performance_opt_in: Option<bool>,
     pub capture_console_log_opt_in: Option<bool>,
+    #[serde(default)]
     pub session_recording_opt_in: bool,
     pub inject_web_apps: Option<bool>,
     pub surveys_opt_in: Option<bool>,

--- a/rust/common/types/src/team.rs
+++ b/rust/common/types/src/team.rs
@@ -1,4 +1,7 @@
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde_json::Value as JsonValue;
+use sqlx::types::Json;
 use sqlx::Postgres;
 use uuid::Uuid;
 
@@ -26,6 +29,33 @@ pub struct Team {
     pub updated_at: DateTime<Utc>,
     pub anonymize_ips: bool,
     pub person_processing_opt_out: Option<bool>,
+    pub autocapture_opt_out: Option<bool>,
+    pub autocapture_exceptions_opt_in: Option<bool>,
+    pub autocapture_web_vitals_opt_in: Option<bool>,
+    pub capture_performance_opt_in: Option<bool>,
+    pub capture_console_log_opt_in: Option<bool>,
+    pub session_recording_opt_in: bool,
+    pub inject_web_apps: Option<bool>,
+    pub surveys_opt_in: Option<bool>,
+    pub heatmaps_opt_in: Option<bool>,
+    pub capture_dead_clicks: Option<bool>,
+    pub flags_persistence_default: Option<bool>,
+    pub session_recording_sample_rate: Option<Decimal>,
+    pub session_recording_minimum_duration_milliseconds: Option<i32>,
+    pub autocapture_web_vitals_allowed_metrics: Option<Json<JsonValue>>,
+    pub autocapture_exceptions_errors_to_ignore: Option<Json<JsonValue>>,
+    pub session_recording_linked_flag: Option<Json<JsonValue>>,
+    pub session_recording_network_payload_capture_config: Option<Json<JsonValue>>,
+    pub session_recording_masking_config: Option<Json<JsonValue>>,
+    pub session_replay_config: Option<Json<JsonValue>>,
+    pub survey_config: Option<Json<JsonValue>>,
+    pub session_recording_url_trigger_config: Option<Vec<Json<JsonValue>>>,
+    pub session_recording_url_blocklist_config: Option<Vec<Json<JsonValue>>>,
+    pub session_recording_event_trigger_config: Option<Vec<Option<String>>>,
+    pub session_recording_trigger_match_type_config: Option<String>,
+    pub recording_domains: Option<Vec<String>>,
+    pub cookieless_server_hash_mode: Option<i16>,
+    pub timezone: String,
 }
 
 impl Team {
@@ -46,7 +76,34 @@ impl Team {
                     created_at,
                     updated_at,
                     anonymize_ips,
-                    person_processing_opt_out
+                    person_processing_opt_out,
+                    autocapture_opt_out,
+                    autocapture_exceptions_opt_in,
+                    autocapture_web_vitals_opt_in,
+                    capture_performance_opt_in,
+                    capture_console_log_opt_in,
+                    session_recording_opt_in,
+                    inject_web_apps,
+                    surveys_opt_in,
+                    heatmaps_opt_in,
+                    capture_dead_clicks,
+                    flags_persistence_default,
+                    session_recording_sample_rate,
+                    session_recording_minimum_duration_milliseconds,
+                    autocapture_web_vitals_allowed_metrics as "autocapture_web_vitals_allowed_metrics: _",
+                    autocapture_exceptions_errors_to_ignore as "autocapture_exceptions_errors_to_ignore: _",
+                    session_recording_linked_flag as "session_recording_linked_flag: _",
+                    session_recording_network_payload_capture_config as "session_recording_network_payload_capture_config: _",
+                    session_recording_masking_config as "session_recording_masking_config: _",
+                    session_replay_config as "session_replay_config: _",
+                    survey_config as "survey_config: _",
+                    session_recording_url_trigger_config as "session_recording_url_trigger_config: _",
+                    session_recording_url_blocklist_config as "session_recording_url_blocklist_config: _",
+                    session_recording_event_trigger_config as "session_recording_event_trigger_config: _",
+                    session_recording_trigger_match_type_config,
+                    recording_domains,
+                    cookieless_server_hash_mode,
+                    timezone
                 FROM posthog_team
                 WHERE id = $1
                 LIMIT 1
@@ -74,7 +131,34 @@ impl Team {
                     created_at,
                     updated_at,
                     anonymize_ips,
-                    person_processing_opt_out
+                    person_processing_opt_out,
+                    autocapture_opt_out,
+                    autocapture_exceptions_opt_in,
+                    autocapture_web_vitals_opt_in,
+                    capture_performance_opt_in,
+                    capture_console_log_opt_in,
+                    session_recording_opt_in,
+                    inject_web_apps,
+                    surveys_opt_in,
+                    heatmaps_opt_in,
+                    capture_dead_clicks,
+                    flags_persistence_default,
+                    session_recording_sample_rate,
+                    session_recording_minimum_duration_milliseconds,
+                    autocapture_web_vitals_allowed_metrics as "autocapture_web_vitals_allowed_metrics: _",
+                    autocapture_exceptions_errors_to_ignore as "autocapture_exceptions_errors_to_ignore: _",
+                    session_recording_linked_flag as "session_recording_linked_flag: _",
+                    session_recording_network_payload_capture_config as "session_recording_network_payload_capture_config: _",
+                    session_recording_masking_config as "session_recording_masking_config: _",
+                    session_replay_config as "session_replay_config: _",
+                    survey_config as "survey_config: _",
+                    session_recording_url_trigger_config as "session_recording_url_trigger_config: _",
+                    session_recording_url_blocklist_config as "session_recording_url_blocklist_config: _",
+                    session_recording_event_trigger_config as "session_recording_event_trigger_config: _",
+                    session_recording_trigger_match_type_config,
+                    recording_domains,
+                    cookieless_server_hash_mode,
+                    timezone
                 FROM posthog_team
                 WHERE api_token = $1
                 LIMIT 1

--- a/rust/common/types/src/team.rs
+++ b/rust/common/types/src/team.rs
@@ -57,7 +57,6 @@ pub struct Team {
     pub session_recording_event_trigger_config: Option<Vec<Option<String>>>,
     pub session_recording_trigger_match_type_config: Option<String>,
     pub recording_domains: Option<Vec<String>>,
-    #[serde(with = "option_i16_as_i16")]
     pub cookieless_server_hash_mode: Option<i16>,
     #[serde(default = "default_timezone")]
     pub timezone: String,
@@ -65,24 +64,6 @@ pub struct Team {
 
 fn default_timezone() -> String {
     "UTC".to_string()
-}
-
-mod option_i16_as_i16 {
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(value: &Option<i16>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_i16(value.unwrap_or(0))
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<i16>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Option::<i16>::deserialize(deserializer)
-    }
 }
 
 impl Team {


### PR DESCRIPTION
This is a follow-up to https://github.com/PostHog/posthog/pull/40891

Add all columns from `feature-flags` `Team` struct to `common-types` `Team` struct to achieve parity. This is preparation for eventually merging the two structs.

> [!IMPORTANT]  
> AFAIK, Cymbal is the only consumer currently using `Team` from `common-types` and it ignores fields it doesn't need, making this a safe change. This change does not affect `/flags` at all.

The `feature-flags` crate is still missing some properties from `common-types` which I'll handle next.

## Problem

Our `Team` struct has diverged a bit from the `Team` model in Django and the `Team` struct in `common-types`.

In the long run, we want to have some sort of automation to help warn us when these things diverge. For now, I want to take baby steps toward that goal by getting our model more in-line with the one in `common-types`.

Eventually we want to use the `Team` in `common-types` and then add our automation to ensure *that* type matches Django.

## Changes

Changes:
- Add 27 new fields to Team struct (feature flags, session recording config, etc.)
- Add `rust_decimal` dependency for `session_recording_sample_rate` field
- Update both `load()` and `load_by_token()` SQL queries to include new columns
- Update `sqlx` query cache with new column definitions

## How did you test this code?

All tests pass (`common-types`, `feature-flags`, `cymbal`).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
