### PR TITLE
feat(workflows): add duplication for templates

### DIFF
--- a/products/workflows/frontend/TemplateLibrary/MessageTemplate.tsx
+++ b/products/workflows/frontend/TemplateLibrary/MessageTemplate.tsx
@@ -48,6 +48,11 @@ export function MessageTemplate({ id }: MessageTemplateLogicProps): JSX.Element 
                                                     data-attr="duplicate-message-template"
                                                     fullWidth
                                                     onClick={duplicateTemplate}
+                                                    disabledReason={
+                                                        templateChanged
+                                                            ? 'Save your changes before duplicating'
+                                                            : undefined
+                                                    }
                                                 >
                                                     Duplicate
                                                 </LemonButton>

--- a/products/workflows/frontend/TemplateLibrary/MessageTemplate.tsx
+++ b/products/workflows/frontend/TemplateLibrary/MessageTemplate.tsx
@@ -2,8 +2,9 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
 import { IconCode } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonTextArea, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonInput, LemonTextArea, Spinner, Tooltip } from '@posthog/lemon-ui'
 
+import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { EmailTemplater } from 'scenes/hog-functions/email-templater/EmailTemplater'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -24,7 +25,8 @@ export const scene: SceneExport<MessageTemplateLogicProps> = {
 }
 
 export function MessageTemplate({ id }: MessageTemplateLogicProps): JSX.Element {
-    const { submitTemplate, resetTemplate, setTemplateValue } = useActions(messageTemplateLogic)
+    const { submitTemplate, resetTemplate, setTemplateValue, duplicateTemplate, deleteTemplate } =
+        useActions(messageTemplateLogic)
     const { template, originalTemplate, isTemplateSubmitting, templateChanged, messageLoading } =
         useValues(messageTemplateLogic)
 
@@ -36,6 +38,34 @@ export function MessageTemplate({ id }: MessageTemplateLogicProps): JSX.Element 
                     resourceType={{ type: 'template' }}
                     actions={
                         <>
+                            {id !== 'new' && (
+                                <>
+                                    <More
+                                        size="small"
+                                        overlay={
+                                            <>
+                                                <LemonButton
+                                                    data-attr="duplicate-message-template"
+                                                    fullWidth
+                                                    onClick={duplicateTemplate}
+                                                >
+                                                    Duplicate
+                                                </LemonButton>
+                                                <LemonDivider />
+                                                <LemonButton
+                                                    data-attr="delete-message-template"
+                                                    status="danger"
+                                                    fullWidth
+                                                    onClick={deleteTemplate}
+                                                >
+                                                    Delete
+                                                </LemonButton>
+                                            </>
+                                        }
+                                    />
+                                    <LemonDivider vertical />
+                                </>
+                            )}
                             {templateChanged && (
                                 <LemonButton
                                     data-attr="cancel-message-template"

--- a/products/workflows/frontend/TemplateLibrary/MessageTemplatesTable.tsx
+++ b/products/workflows/frontend/TemplateLibrary/MessageTemplatesTable.tsx
@@ -13,7 +13,7 @@ import { MessageTemplate, messageTemplatesLogic } from './messageTemplatesLogic'
 export function MessageTemplatesTable(): JSX.Element {
     useMountedLogic(messageTemplatesLogic)
     const { templates, templatesLoading } = useValues(messageTemplatesLogic)
-    const { deleteTemplate, createTemplate } = useActions(messageTemplatesLogic)
+    const { deleteTemplate, createTemplate, duplicateTemplate } = useActions(messageTemplatesLogic)
 
     const columns: LemonTableColumns<MessageTemplate> = [
         {
@@ -37,6 +37,13 @@ export function MessageTemplatesTable(): JSX.Element {
                     <More
                         overlay={
                             <>
+                                <LemonButton
+                                    data-attr="message-template-duplicate"
+                                    fullWidth
+                                    onClick={() => duplicateTemplate(message)}
+                                >
+                                    Duplicate
+                                </LemonButton>
                                 <LemonButton
                                     data-attr="message-template-delete"
                                     fullWidth

--- a/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.ts
+++ b/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.ts
@@ -145,6 +145,10 @@ export const messageTemplateLogic = kea<messageTemplateLogicType>([
             })
         },
         duplicateTemplate: async () => {
+            if (values.templateChanged) {
+                lemonToast.error('Please save your changes before duplicating')
+                return
+            }
             const template = values.template
             try {
                 const duplicatedTemplate = await api.messaging.createTemplate({

--- a/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.ts
+++ b/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.ts
@@ -5,6 +5,7 @@ import { router } from 'kea-router'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -27,6 +28,8 @@ export const messageTemplateLogic = kea<messageTemplateLogicType>([
     actions({
         setTemplate: (template: MessageTemplate) => ({ template }),
         setOriginalTemplate: (template: MessageTemplate) => ({ template }),
+        duplicateTemplate: true,
+        deleteTemplate: true,
     }),
     selectors({
         breadcrumbs: [
@@ -122,7 +125,7 @@ export const messageTemplateLogic = kea<messageTemplateLogicType>([
             },
         },
     })),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         saveTemplateSuccess: async ({ template }) => {
             lemonToast.success('Template saved')
             template.id && router.actions.replace(urls.workflowsLibraryTemplate(template.id))
@@ -138,6 +141,38 @@ export const messageTemplateLogic = kea<messageTemplateLogicType>([
                 description: message.description,
                 content: {
                     email: message.inputs?.email?.value,
+                },
+            })
+        },
+        duplicateTemplate: async () => {
+            const template = values.template
+            try {
+                const duplicatedTemplate = await api.messaging.createTemplate({
+                    name: `${template.name} (copy)`,
+                    description: template.description,
+                    content: template.content,
+                })
+                lemonToast.success('Template duplicated successfully')
+                router.actions.push(urls.workflowsLibraryTemplate(duplicatedTemplate.id))
+            } catch {
+                lemonToast.error('Failed to duplicate template')
+            }
+        },
+        deleteTemplate: async () => {
+            const template = values.template
+            if (!template || template.id === 'new') {
+                return
+            }
+            await deleteWithUndo({
+                endpoint: `environments/@current/messaging_templates`,
+                object: {
+                    id: template.id,
+                    name: template.name,
+                },
+                callback: (undo) => {
+                    if (!undo) {
+                        router.actions.push(urls.workflows('library'))
+                    }
                 },
             })
         },

--- a/products/workflows/frontend/TemplateLibrary/messageTemplatesLogic.ts
+++ b/products/workflows/frontend/TemplateLibrary/messageTemplatesLogic.ts
@@ -74,6 +74,20 @@ export const messageTemplatesLogic = kea<messageTemplatesLogicType>([
                         return values.templates
                     }
                 },
+                duplicateTemplate: async (template: MessageTemplate) => {
+                    try {
+                        const duplicatedTemplate = await api.messaging.createTemplate({
+                            name: `${template.name} (copy)`,
+                            description: template.description,
+                            content: template.content,
+                        })
+                        lemonToast.success('Template duplicated successfully')
+                        return [...values.templates, duplicatedTemplate]
+                    } catch {
+                        lemonToast.error('Failed to duplicate template')
+                        return values.templates
+                    }
+                },
             },
         ],
     })),


### PR DESCRIPTION
## Problem

No duplication for templates was possible and also no deletion on the template detail page

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- added duplication for the tableView
- added duplication for the detailView
- also added deletion

![2025-11-05 09 46 58](https://github.com/user-attachments/assets/a1867449-fc07-460f-bb3a-10a105942c45)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
