### PR TITLE
fix: Add display names for two missed auth providers.

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -97,6 +97,8 @@ def logout(request):
 
     clear_two_factor_session_flags(request)
 
+    request.session.pop("reauth", None)
+
     if is_impersonated_session(request):
         restore_original_login(request)
         return redirect("/admin/")

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -354,4 +354,6 @@ AUTH_BACKEND_DISPLAY_NAMES = {
     "github": "GitHub",
     "gitlab": "GitLab",
     "saml": "SAML",
+    "ee.api.authentication.CustomGoogleOAuth2": "Google OAuth",
+    "ee.api.authentication.MultitenantSAMLAuth": "SAML",
 }


### PR DESCRIPTION
## Problem

- Saw some `login_method: Unknown` and after some digging, the reauth flow uses two alternative backends.

## Changes

- Adding display names for them.
- Also added a quick cleanup of the `session.reauth` field on logout.
