### PR TITLE
fix(flags): backwards compatibility for $groups

### DIFF
--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -51,11 +51,11 @@ pub struct FlagRequest {
     // It's mostly used for folks who want to save money on flag evaluations while still using
     // `/flags` to load the rest of their PostHog configuration.
     pub disable_flags: Option<bool>,
-    #[serde(default)]
+    #[serde(default, alias = "$properties")]
     pub person_properties: Option<HashMap<String, Value>>,
-    #[serde(default)]
+    #[serde(default, alias = "$groups")]
     pub groups: Option<HashMap<String, Value>>,
-    #[serde(default)]
+    #[serde(default, alias = "$group_properties")]
     pub group_properties: Option<HashMap<String, HashMap<String, Value>>>,
     #[serde(alias = "$anon_distinct_id", skip_serializing_if = "Option::is_none")]
     pub anon_distinct_id: Option<String>,
@@ -650,5 +650,92 @@ mod tests {
             flag_payload.evaluation_runtime,
             Some(EvaluationRuntime::Client)
         );
+    }
+
+    #[test]
+    fn test_groups_field_accepts_groups() {
+        let json = json!({
+            "distinct_id": "user123",
+            "token": "my_token1",
+            "groups": {
+                "organization": "org_123",
+                "company": "company_456"
+            }
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        assert!(flag_payload.groups.is_some());
+        let groups = flag_payload.groups.unwrap();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups.get("organization").unwrap(), &json!("org_123"));
+        assert_eq!(groups.get("company").unwrap(), &json!("company_456"));
+    }
+
+    #[test]
+    fn test_groups_field_accepts_dollar_groups_for_backwards_compatibility() {
+        let json = json!({
+            "distinct_id": "user123",
+            "token": "my_token1",
+            "$groups": {
+                "organization": "org_123",
+                "company": "company_456"
+            }
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        assert!(flag_payload.groups.is_some());
+        let groups = flag_payload.groups.unwrap();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups.get("organization").unwrap(), &json!("org_123"));
+        assert_eq!(groups.get("company").unwrap(), &json!("company_456"));
+    }
+
+    #[test]
+    fn test_person_properties_field_accepts_dollar_properties_for_backwards_compatibility() {
+        let json = json!({
+            "distinct_id": "user123",
+            "token": "my_token1",
+            "$properties": {
+                "email": "user@example.com",
+                "age": 25
+            }
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        assert!(flag_payload.person_properties.is_some());
+        let props = flag_payload.person_properties.unwrap();
+        assert_eq!(props.len(), 2);
+        assert_eq!(props.get("email").unwrap(), &json!("user@example.com"));
+        assert_eq!(props.get("age").unwrap(), &json!(25));
+    }
+
+    #[test]
+    fn test_group_properties_field_accepts_dollar_group_properties_for_backwards_compatibility() {
+        let json = json!({
+            "distinct_id": "user123",
+            "token": "my_token1",
+            "$group_properties": {
+                "organization": {
+                    "name": "ACME Corp",
+                    "size": 100
+                }
+            }
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        assert!(flag_payload.group_properties.is_some());
+        let group_props = flag_payload.group_properties.unwrap();
+        assert_eq!(group_props.len(), 1);
+        let org_props = group_props.get("organization").unwrap();
+        assert_eq!(org_props.get("name").unwrap(), &json!("ACME Corp"));
+        assert_eq!(org_props.get("size").unwrap(), &json!(100));
     }
 }


### PR DESCRIPTION
## Problem

Old SDKs send request parameters with `$` prefixes (`$groups`, `$properties`, `$group_properties`) but the Rust `/flags` endpoint only accepted the non-prefixed versions, breaking compatibility with older SDK versions.

Ticket: https://posthoghelp.zendesk.com/agent/tickets/41149 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47675)

## Changes

Added serde aliases to `FlagRequest` fields to accept both formats:
  - `groups` accepts both `"groups"` and `"$groups"`
  - `person_properties` accepts both `"person_properties"` and `"$properties"`
  - `group_properties` accepts both `"group_properties"` and `"$group_properties"`

Added tests for all three backwards compatibility aliases.

## How did you test this code?

- Added unit tests verifying each alias works correctly
- All existing tests pass (`cargo test flags::flag_request::tests`)