### PR TITLE
fix: disable auto save on new feature

### DIFF
--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -90,6 +90,7 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
         toggleImplementOptInInstructionsModal,
         showGAPromotionConfirmation,
         saveEarlyAccessFeature,
+        setEarlyAccessFeatureValue,
     } = useActions(earlyAccessFeatureLogic)
     const { currentTeamId } = useValues(teamLogic)
 
@@ -149,12 +150,20 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
                         type: 'early_access_feature',
                     }}
                     canEdit
-                    renameDebounceMs={1000}
+                    renameDebounceMs={isNewEarlyAccessFeature ? undefined : 1000}
                     onNameChange={(name) => {
-                        saveEarlyAccessFeature({ ...earlyAccessFeature, name })
+                        if (isNewEarlyAccessFeature) {
+                            setEarlyAccessFeatureValue('name', name)
+                        } else {
+                            saveEarlyAccessFeature({ ...earlyAccessFeature, name })
+                        }
                     }}
                     onDescriptionChange={(description) => {
-                        saveEarlyAccessFeature({ ...earlyAccessFeature, description })
+                        if (isNewEarlyAccessFeature) {
+                            setEarlyAccessFeatureValue('description', description)
+                        } else {
+                            saveEarlyAccessFeature({ ...earlyAccessFeature, description })
+                        }
                     }}
                     forceEdit={isEditingFeature || isNewEarlyAccessFeature}
                     actions={


### PR DESCRIPTION
## Problem

Playwright tests are failing because when creating a new early access feature and typing the name we expect button `Save as draft` to be visible.

In this PR https://github.com/PostHog/posthog/pull/39830/files we made it so that it auto saves (so that button disappears as the feature gets created)

In my opinion auto saving a new feature does not seem natural.

## Changes

Made it so changes are auto persisted only when editing existing feature
## How did you test this code?

Tested this locally
