### PR TITLE
chore(flags): make feature flags team a hard codeowner for modules that would trigger `posthog-feature-flag` deployments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,25 @@
-# If a file is set here, then PRs will require that team's approval to get that code merged.
+# If a file is set here, then PRs will require that team's approval to get that code merged
 
 # ClickHouse team owns Clickhouse migrations
 
 posthog/clickhouse/migrations/** @PostHog/clickhouse
 
-# HogQL team owns HogQL changes 
+# HogQL team owns HogQL changes
 
 posthog/hogql/** @PostHog/hogql
+
+# Platform (the `/flags` and `/decide` endpoints + associated utils)
+
+rust/feature-flags/ @PostHog/team-feature-flags
+posthog/api/decide.py @PostHog/team-feature-flags
+posthog/models/feature_flag/flag_matching.py @PostHog/team-feature-flags
+
+# Common Rust crates used by the `/flags` service (the flags team wants to know about changes to these modules since they affect flag deployments)
+
+rust/common/types @PostHog/team-feature-flags
+rust/common/database @PostHog/team-feature-flags
+rust/common/redis @PostHog/team-feature-flags
+rust/common/cookieless @PostHog/team-feature-flags
+rust/common/compression @PostHog/team-feature-flags
+rust/common/geoip @PostHog/team-feature-flags
+rust/common/hypercache @PostHog/team-feature-flags

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -53,12 +53,6 @@ products/revenue_analytics/** @PostHog/team-revenue-analytics
 
 # Feature Flags team
 
-# Platform (the `/flags` and `/decide` endpoints + associated utils)
-
-rust/feature-flags/ @PostHog/team-feature-flags
-posthog/api/decide.py @PostHog/team-feature-flags
-posthog/models/flag_matching.py @PostHog/team-feature-flags
-
 # Feature Flags CRUD operations
 
 posthog/models/feature_flag/ @PostHog/team-feature-flags


### PR DESCRIPTION
## Problem

We've been burned by deployments going out in the past for which we weren't provisioned, and recently that caused an incident. Let's add a bit more overhead to make that less likely to happen.