### PR TITLE
fix(experiments): mount the correct experimentLogic in variantTag

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -137,7 +137,7 @@ export function DistributionModal({ experimentId }: { experimentId: Experiment['
 
 export function DistributionTable(): JSX.Element {
     const { openDistributionModal } = useActions(modalsLogic)
-    const { experimentId, experiment } = useValues(experimentLogic)
+    const { experiment } = useValues(experimentLogic)
     const { reportExperimentReleaseConditionsViewed } = useActions(experimentLogic)
 
     const onSelectElement = (variant: string): void => {
@@ -166,7 +166,7 @@ export function DistributionTable(): JSX.Element {
             key: 'key',
             title: 'Variant',
             render: function Key(_, item): JSX.Element {
-                return <VariantTag experimentId={experimentId} variantKey={item.key} />
+                return <VariantTag variantKey={item.key} />
             },
         },
         {

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -158,8 +158,7 @@ function getExposureCriteriaLabel(exposureCriteria: ExperimentExposureCriteria |
 }
 
 export function Exposures(): JSX.Element {
-    const { experimentId, exposures, exposuresLoading, exposureCriteria, isExperimentDraft } =
-        useValues(experimentLogic)
+    const { exposures, exposuresLoading, exposureCriteria, isExperimentDraft } = useValues(experimentLogic)
     const { openExposureCriteriaModal } = useActions(modalsLogic)
     const colors = useChartColors()
 
@@ -354,7 +353,7 @@ export function Exposures(): JSX.Element {
                                         {variants.map(({ variant, percentage }) => (
                                             <div key={variant} className="flex items-center gap-2">
                                                 <div className="metric-cell">
-                                                    <VariantTag experimentId={experimentId} variantKey={variant} />
+                                                    <VariantTag variantKey={variant} />
                                                 </div>
                                                 <span className="metric-cell">{percentage.toFixed(1)}%</span>
                                             </div>
@@ -447,12 +446,7 @@ export function Exposures(): JSX.Element {
                                                             if (series.isTotal) {
                                                                 return <span className="font-semibold">Total</span>
                                                             }
-                                                            return (
-                                                                <VariantTag
-                                                                    experimentId={experimentId}
-                                                                    variantKey={series.variant}
-                                                                />
-                                                            )
+                                                            return <VariantTag variantKey={series.variant} />
                                                         },
                                                     },
                                                     {

--- a/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
@@ -5,7 +5,6 @@ import {
     CachedExperimentTrendsQueryResponse,
     CachedLegacyExperimentQueryResponse,
 } from '~/queries/schema/schema-general'
-import { ExperimentIdType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
 import { getHighestProbabilityVariant, getIndexForVariant } from '../legacyExperimentCalculations'
@@ -13,13 +12,11 @@ import { VariantTag } from './components'
 
 export function WinningVariantText({
     result,
-    experimentId,
 }: {
     result:
         | CachedLegacyExperimentQueryResponse
         | CachedExperimentFunnelsQueryResponse
         | CachedExperimentTrendsQueryResponse
-    experimentId: ExperimentIdType
 }): JSX.Element {
     const { getInsightType, experiment } = useValues(experimentLogic)
 
@@ -30,7 +27,7 @@ export function WinningVariantText({
 
         return (
             <div className="items-center inline-flex flex-wrap">
-                <VariantTag experimentId={experimentId} variantKey={highestProbabilityVariant} />
+                <VariantTag variantKey={highestProbabilityVariant} />
                 <span>&nbsp;is winning with a&nbsp;</span>
                 <span className="font-semibold items-center">
                     {`${(probability[highestProbabilityVariant] * 100).toFixed(2)}% probability`}&nbsp;
@@ -71,7 +68,7 @@ export function SignificanceText({
 }
 
 export function Overview({ metricUuid }: { metricUuid: string }): JSX.Element {
-    const { experimentId, legacyPrimaryMetricsResults, experiment } = useValues(experimentLogic)
+    const { legacyPrimaryMetricsResults, experiment } = useValues(experimentLogic)
 
     // Find metric index by UUID
     const index = experiment.metrics.findIndex((m) => m.uuid === metricUuid)
@@ -83,7 +80,7 @@ export function Overview({ metricUuid }: { metricUuid: string }): JSX.Element {
     return (
         <div>
             <div className="items-center inline-flex flex-wrap">
-                <WinningVariantText result={result} experimentId={experimentId} />
+                <WinningVariantText result={result} />
                 <SignificanceText metricUuid={metricUuid} />
             </div>
         </div>

--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -47,7 +47,6 @@ export function SummaryTable({
     isSecondary?: boolean
 }): JSX.Element {
     const {
-        experimentId,
         experiment,
         legacyPrimaryMetricsResults,
         legacySecondaryMetricsResults,
@@ -72,7 +71,7 @@ export function SummaryTable({
             render: function Key(_, item): JSX.Element {
                 return (
                     <div className="flex items-center">
-                        <VariantTag experimentId={experimentId} variantKey={item.key} />
+                        <VariantTag variantKey={item.key} />
                     </div>
                 )
             },

--- a/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
@@ -156,7 +156,7 @@ export function VariantScreenshot({
                     <div className="flex items-center gap-2">
                         <span>Screenshot {selectedImageIndex !== null ? selectedImageIndex + 1 : ''}</span>
                         <LemonDivider className="my-0 mx-1" vertical />
-                        <VariantTag experimentId={experiment.id} variantKey={variantKey} />
+                        <VariantTag variantKey={variantKey} />
                         {rolloutPercentage !== undefined && (
                             <span className="text-secondary text-sm">({rolloutPercentage}% rollout)</span>
                         )}

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -149,17 +149,15 @@ export function createMaxToolExperimentSurveyConfig(
 }
 
 export function VariantTag({
-    experimentId,
     variantKey,
     fontSize,
     className,
 }: {
-    experimentId: ExperimentIdType
     variantKey: string
     fontSize?: number
     className?: string
 }): JSX.Element {
-    const { experiment, legacyPrimaryMetricsResults, usesNewQueryRunner } = useValues(experimentLogic({ experimentId }))
+    const { experiment, legacyPrimaryMetricsResults, usesNewQueryRunner } = useValues(experimentLogic)
 
     if (variantKey === EXPERIMENT_VARIANT_MULTIPLE) {
         return (
@@ -817,7 +815,7 @@ export function ShipVariantModal({ experimentId }: { experimentId: Experiment['i
                                     value: key,
                                     label: (
                                         <div className="deprecated-space-x-2 inline-flex">
-                                            <VariantTag experimentId={experimentId} variantKey={key} />
+                                            <VariantTag variantKey={key} />
                                         </div>
                                     ),
                                 })) || []

--- a/frontend/src/scenes/experiments/MetricsView/legacy/ChartModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/ChartModal.tsx
@@ -16,7 +16,7 @@ import {
     ResultsInsightInfoBanner,
     ResultsQuery,
 } from '~/scenes/experiments/components/ResultsBreakdown'
-import type { Experiment, ExperimentIdType } from '~/types'
+import type { Experiment } from '~/types'
 
 interface ChartModalProps {
     isOpen: boolean
@@ -25,7 +25,6 @@ interface ChartModalProps {
     displayOrder: number
     isSecondary: boolean
     result: any
-    experimentId: ExperimentIdType
     experiment: Experiment
 }
 
@@ -36,7 +35,6 @@ export function ChartModal({
     displayOrder,
     isSecondary,
     result,
-    experimentId,
     experiment,
 }: ChartModalProps): JSX.Element {
     const isLegacyResult =
@@ -61,7 +59,7 @@ export function ChartModal({
                     </div>
                     <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
                         <div className="items-center inline-flex flex-wrap">
-                            <WinningVariantText result={result} experimentId={experimentId} />
+                            <WinningVariantText result={result} />
                             <SignificanceText metricUuid={metric.uuid || ''} isSecondary={isSecondary} />
                         </div>
                     </LemonBanner>
@@ -90,7 +88,7 @@ export function ChartModal({
                             )}
                             <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
                                 <div className="items-center inline-flex flex-wrap">
-                                    <WinningVariantText result={result} experimentId={experimentId} />
+                                    <WinningVariantText result={result} />
                                     <SignificanceText metricUuid={metric.uuid || ''} isSecondary={isSecondary} />
                                 </div>
                             </LemonBanner>

--- a/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
@@ -7,7 +7,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { modalsLogic } from 'scenes/experiments/modalsLogic'
 
-import { Experiment, ExperimentIdType, FunnelExperimentVariant, InsightType, TrendExperimentVariant } from '~/types'
+import { Experiment, FunnelExperimentVariant, InsightType, TrendExperimentVariant } from '~/types'
 
 import { VariantTag } from '../../ExperimentView/components'
 import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS, EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS } from '../../constants'
@@ -61,7 +61,6 @@ type DeltaChartContextType = {
     chartBound: number
 
     // Experiment data
-    experimentId: ExperimentIdType
     experiment: Experiment
     variants: FunnelExperimentVariant[] | TrendExperimentVariant[]
     hasMinimumExposureForResults: boolean
@@ -151,7 +150,6 @@ function VariantBar({ variant, index }: { variant: any; index: number }): JSX.El
         metric,
         dimensions,
         valueToX,
-        experimentId,
         featureFlags,
         colors,
         tooltip: { setTooltipData },
@@ -233,12 +231,7 @@ function VariantBar({ variant, index }: { variant: any; index: number }): JSX.El
                         height="16"
                         transform="translate(-90, 0)" // Move left to accommodate tag width
                     >
-                        <VariantTag
-                            className="justify-end mt-0.5"
-                            experimentId={experimentId as ExperimentIdType}
-                            variantKey={variant.key}
-                            fontSize={10}
-                        />
+                        <VariantTag className="justify-end mt-0.5" variantKey={variant.key} fontSize={10} />
                     </foreignObject>
                     {variant.key === 'control' ? (
                         <path
@@ -309,12 +302,7 @@ function VariantBar({ variant, index }: { variant: any; index: number }): JSX.El
                 <>
                     {/* Move foreignObject for variant tag to left of 0 point */}
                     <foreignObject x={valueToX(0) - 150} y={y + barHeight / 2 - 10} width="90" height="16">
-                        <VariantTag
-                            className="justify-end mt-0.5"
-                            experimentId={experimentId as ExperimentIdType}
-                            variantKey={variant.key}
-                            fontSize={10}
-                        />
+                        <VariantTag className="justify-end mt-0.5" variantKey={variant.key} fontSize={10} />
                     </foreignObject>
 
                     {/* First draw a solid background to cover grid lines */}
@@ -426,7 +414,6 @@ function ChartControls(): JSX.Element {
 function ChartTooltips(): JSX.Element {
     const {
         tooltip: { tooltipData },
-        experimentId,
         result,
         metricType,
         conversionRateForVariant,
@@ -441,7 +428,6 @@ function ChartTooltips(): JSX.Element {
             {tooltipData && (
                 <VariantTooltip
                     tooltipData={tooltipData}
-                    experimentId={experimentId as ExperimentIdType}
                     result={result}
                     metricType={metricType}
                     conversionRateForVariant={conversionRateForVariant}
@@ -511,7 +497,6 @@ export function DeltaChart({
 }): JSX.Element {
     // Get values from logic
     const {
-        experimentId,
         experiment,
         primaryMetricsResultsLoading,
         secondaryMetricsResultsLoading,
@@ -585,7 +570,6 @@ export function DeltaChart({
         chartBound,
 
         // Experiment data
-        experimentId: experimentId as ExperimentIdType, // Cast to ensure type compatibility
         experiment,
         variants,
         hasMinimumExposureForResults,
@@ -642,7 +626,6 @@ export function DeltaChart({
                 displayOrder={displayOrder}
                 isSecondary={isSecondary}
                 result={result}
-                experimentId={experimentId as ExperimentIdType}
                 experiment={experiment}
             />
         </DeltaChartContext.Provider>

--- a/frontend/src/scenes/experiments/MetricsView/legacy/VariantTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/VariantTooltip.tsx
@@ -2,7 +2,6 @@ import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { humanFriendlyNumber } from 'lib/utils'
 
 import { InsightType, TrendExperimentVariant } from '~/types'
-import { ExperimentIdType } from '~/types'
 
 import { VariantTag } from '../../ExperimentView/components'
 import { calculateDelta } from '../../legacyExperimentCalculations'
@@ -13,7 +12,6 @@ interface VariantTooltipProps {
         y: number
         variant: string
     }
-    experimentId: ExperimentIdType
     result: any
     metricType: InsightType
     conversionRateForVariant: (result: any, variant: string) => any
@@ -24,7 +22,6 @@ interface VariantTooltipProps {
 
 export function VariantTooltip({
     tooltipData,
-    experimentId,
     result,
     metricType,
     conversionRateForVariant,
@@ -42,7 +39,7 @@ export function VariantTooltip({
             }} // Dynamic positioning based on mouse hover position
         >
             <div className="flex flex-col gap-1">
-                <VariantTag experimentId={experimentId} variantKey={tooltipData.variant} />
+                <VariantTag variantKey={tooltipData.variant} />
                 <div className="inline-flex">
                     <span className="text-secondary font-semibold mb-1">Win probability:</span>
                     {result?.probability?.[tooltipData.variant] !== undefined ? (

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -293,7 +293,7 @@ export function MetricRowGroup({
                             visibility: tooltipState.isPositioned ? 'visible' : 'hidden',
                         }}
                     >
-                        {renderTooltipContent(experiment.id, tooltipState.variantResult, metric)}
+                        {renderTooltipContent(tooltipState.variantResult, metric)}
                     </div>,
                     document.body
                 )}
@@ -331,7 +331,7 @@ export function MetricRowGroup({
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
                 >
-                    <VariantTag experimentId={experiment.id} variantKey={baselineResult.key} />
+                    <VariantTag variantKey={baselineResult.key} />
                 </td>
 
                 {/* Value */}
@@ -441,7 +441,7 @@ export function MetricRowGroup({
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
                         >
-                            <VariantTag experimentId={experiment.id} variantKey={variant.key} />
+                            <VariantTag variantKey={variant.key} />
                         </td>
 
                         {/* Value */}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -3,7 +3,6 @@ import { humanFriendlyNumber } from 'lib/utils'
 import { VariantTag } from 'scenes/experiments/ExperimentView/components'
 
 import { ExperimentMetric } from '~/queries/schema/schema-general'
-import { ExperimentIdType } from '~/types'
 
 import {
     type ExperimentVariantResult,
@@ -17,11 +16,7 @@ import {
     isWinning,
 } from '../shared/utils'
 
-export const renderTooltipContent = (
-    experimentId: ExperimentIdType,
-    variantResult: ExperimentVariantResult,
-    metric: ExperimentMetric
-): JSX.Element => {
+export const renderTooltipContent = (variantResult: ExperimentVariantResult, metric: ExperimentMetric): JSX.Element => {
     const intervalPercent = formatIntervalPercent(variantResult)
     const intervalLabel = getIntervalLabel(variantResult)
     const significant = isSignificant(variantResult)
@@ -31,7 +26,7 @@ export const renderTooltipContent = (
     return (
         <div className="flex flex-col gap-1">
             <div className="flex justify-between items-center">
-                <VariantTag experimentId={experimentId} variantKey={variantResult.key} />
+                <VariantTag variantKey={variantResult.key} />
                 {variantResult.key !== 'control' && (
                     <LemonTag type={!significant ? 'muted' : winning ? 'success' : 'danger'} size="medium">
                         {!significant ? 'Not significant' : winning ? 'Won' : 'Lost'}

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -111,7 +111,7 @@ export function ResultDetails({
         {
             key: 'variant',
             title: 'Variant',
-            render: (_, item) => <VariantTag experimentId={experiment.id} variantKey={item.key} />,
+            render: (_, item) => <VariantTag variantKey={item.key} />,
         },
         {
             key: 'total-users',

--- a/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
@@ -84,7 +84,7 @@ export function TimeseriesModal({
                     </div>
                     <LemonDivider vertical className="h-4 self-stretch" />
                     <div className="flex items-center">
-                        <VariantTag experimentId={experiment.id} variantKey={variantResult.key} />
+                        <VariantTag variantKey={variantResult.key} />
                     </div>
                 </div>
             }


### PR DESCRIPTION
## Problem

I noticed that the variant tag was missing on variants with a key != 'test'. It turns out it was mounting the wrong experimentLogic, one that was not mounted yet and thus got the default new experiment parameters rather than the actual parameters. So thus, when looking up the variant key to get the color, it got no match.

## Changes

Fix the `variantTag` component by replacing this

```tsx
useValues(experimentLogic({ experimentId }))
```

with

```tsx
useValues(experimentLogic)
```

With that, we are using the already mounted logic with correct experiment parameters, and not creating a new one with default parameters.

## How did you test this code?

- verified that the variant tag works correctly locally