### PR TITLE
chore(flags): Use the new `ReadThroughCache` for the flags cache

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2873,6 +2873,7 @@ dependencies = [
  "bytes",
  "chrono",
  "common-alloc",
+ "common-cache",
  "common-compression",
  "common-cookieless",
  "common-database",

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 axum = { workspace = true }
 axum-client-ip = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+common-cache = { path = "../common/cache" }
 common-cookieless = { path = "../common/cookieless" }
 common-database = { path = "../common/database" }
 common-redis = { path = "../common/redis" }

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -78,6 +78,9 @@ impl FeatureFlagList {
             })
             .await?;
 
+        // Our loader (load_from_pg) always returns Some(metadata), never None.
+        // Even empty flag lists are wrapped in Some. However, we use unwrap_or
+        // defensively to gracefully handle any future loader contract violations.
         let metadata = result.value.take().unwrap_or(FlagsWithMetadata {
             flags: vec![],
             had_deserialization_errors: false,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -6,16 +6,115 @@ use crate::database::get_connection_with_metrics;
 use crate::flags::flag_models::{
     FeatureFlag, FeatureFlagList, FeatureFlagRow, TEAM_FLAGS_CACHE_PREFIX,
 };
+use common_cache::{CacheConfig, CacheResult, ReadThroughCache};
 use common_database::PostgresReader;
 use common_redis::Client as RedisClient;
 use common_types::ProjectId;
+
+// Constants for cache configuration
+/// Default TTL for feature flags cache: 5 days (432,000 seconds)
+/// This matches the TTL used by the Python cache layer
+pub const DEFAULT_FLAGS_CACHE_TTL_SECONDS: u64 = 432_000;
+
+/// Result of loading flags from the database, including deserialization error tracking
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FlagsWithMetadata {
+    pub flags: Vec<FeatureFlag>,
+    pub had_deserialization_errors: bool,
+}
 
 impl FeatureFlagList {
     pub fn new(flags: Vec<FeatureFlag>) -> Self {
         Self { flags }
     }
 
+    /// Creates a ReadThroughCache instance for feature flags
+    ///
+    /// # Arguments
+    /// * `redis_reader` - Redis client for reading cached data
+    /// * `redis_writer` - Redis client for writing cached data
+    /// * `ttl_seconds` - Cache TTL in seconds (defaults to DEFAULT_FLAGS_CACHE_TTL_SECONDS if None)
+    ///
+    /// # Returns
+    /// A configured ReadThroughCache instance for feature flags
+    pub fn create_cache(
+        redis_reader: Arc<dyn RedisClient + Send + Sync>,
+        redis_writer: Arc<dyn RedisClient + Send + Sync>,
+        ttl_seconds: Option<u64>,
+    ) -> ReadThroughCache {
+        let ttl = ttl_seconds.unwrap_or(DEFAULT_FLAGS_CACHE_TTL_SECONDS);
+        ReadThroughCache::new(
+            redis_reader,
+            redis_writer,
+            CacheConfig::with_ttl(TEAM_FLAGS_CACHE_PREFIX, ttl),
+            None, // No negative caching for now
+        )
+    }
+
+    /// Get feature flags from cache or database using the read-through cache pattern
+    ///
+    /// This is the primary method for fetching feature flags. It:
+    /// 1. Checks Redis cache first
+    /// 2. On cache miss, loads from PostgreSQL
+    /// 3. Automatically updates the cache when loading from DB (unless Redis is unavailable)
+    ///
+    /// # Arguments
+    /// * `cache` - ReadThroughCache instance
+    /// * `pg_client` - PostgreSQL client for database fallback
+    /// * `project_id` - Project ID to fetch flags for
+    ///
+    /// # Returns
+    /// * `Ok((FeatureFlagList, bool, CacheResult))` - Flags, deserialization error flag, and cache source information
+    /// * `Err(FlagError)` - Error from database or cache
+    pub async fn get_with_cache(
+        cache: &ReadThroughCache,
+        pg_client: PostgresReader,
+        project_id: ProjectId,
+    ) -> Result<(FeatureFlagList, bool, CacheResult<FlagsWithMetadata>), FlagError> {
+        let pg_client = pg_client.clone();
+        let mut result = cache
+            .get_or_load(&project_id, |&project_id| async move {
+                Self::load_from_pg(pg_client, project_id).await
+            })
+            .await?;
+
+        let metadata = result.value.take().unwrap_or(FlagsWithMetadata {
+            flags: vec![],
+            had_deserialization_errors: false,
+        });
+
+        let flag_list = FeatureFlagList {
+            flags: metadata.flags,
+        };
+
+        Ok((flag_list, metadata.had_deserialization_errors, result))
+    }
+
+    /// Load feature flags from PostgreSQL
+    ///
+    /// This is the loader function used by the cache. It returns:
+    /// - `Ok(Some(metadata))` when loading succeeds (including empty list for projects with no flags)
+    /// - `Ok(None)` is never returned (we always return Some, even for empty results)
+    /// - `Err(FlagError)` when there's a database error
+    ///
+    /// Note: We always return `Some` (even for empty flag lists) because an empty list
+    /// is a valid state that should be cached. This prevents repeated DB queries for
+    /// projects that have no flags.
+    async fn load_from_pg(
+        pg_client: PostgresReader,
+        project_id: ProjectId,
+    ) -> Result<Option<FlagsWithMetadata>, FlagError> {
+        let (flag_list, had_deserialization_errors) = Self::from_pg(pg_client, project_id).await?;
+        Ok(Some(FlagsWithMetadata {
+            flags: flag_list.flags,
+            had_deserialization_errors,
+        }))
+    }
+
     /// Returns feature flags from redis given a project_id
+    ///
+    /// DEPRECATED: Use `get_with_cache()` instead for automatic cache management.
+    /// This method is kept for backward compatibility with existing code.
     pub async fn from_redis(
         client: Arc<dyn RedisClient + Send + Sync>,
         project_id: ProjectId,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -160,7 +160,6 @@ impl FeatureFlagList {
                     }),
                     Err(e) => {
                         // This is highly unlikely to happen, but if it does, we skip the flag.
-                        // I'll create some sort of alert for this.
                         tracing::warn!(
                             "Failed to deserialize filters for flag {} in project {} (team {}): {}",
                             row.key,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -215,61 +215,6 @@ impl FeatureFlagList {
             had_deserialization_errors,
         ))
     }
-
-    pub async fn update_flags_in_redis(
-        client: Arc<dyn RedisClient + Send + Sync>,
-        project_id: ProjectId,
-        flags: &FeatureFlagList,
-        ttl_seconds: Option<u64>,
-    ) -> Result<(), FlagError> {
-        let payload = serde_json::to_string(&flags.flags).map_err(|e| {
-            tracing::error!(
-                "Failed to serialize {} flags for project {}: {}",
-                flags.flags.len(),
-                project_id,
-                e
-            );
-            FlagError::RedisDataParsingError
-        })?;
-
-        let cache_key = format!("{TEAM_FLAGS_CACHE_PREFIX}{project_id}");
-
-        match ttl_seconds {
-            Some(ttl) => {
-                tracing::info!(
-                    "Writing flags to Redis at key '{}' with TTL {} seconds: {} flags",
-                    cache_key,
-                    ttl,
-                    flags.flags.len()
-                );
-                client.setex(cache_key, payload, ttl).await.map_err(|e| {
-                    tracing::error!(
-                        "Failed to update Redis cache with TTL for project {}: {}",
-                        project_id,
-                        e
-                    );
-                    FlagError::CacheUpdateError
-                })?;
-            }
-            None => {
-                tracing::info!(
-                    "Writing flags to Redis at key '{}' without TTL: {} flags",
-                    cache_key,
-                    flags.flags.len()
-                );
-                client.set(cache_key, payload).await.map_err(|e| {
-                    tracing::error!(
-                        "Failed to update Redis cache for project {}: {}",
-                        project_id,
-                        e
-                    );
-                    FlagError::CacheUpdateError
-                })?;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -87,7 +87,9 @@ mod tests {
     use crate::{
         flags::{
             flag_models::*,
-            test_helpers::{create_simple_flag, create_simple_property_filter},
+            test_helpers::{
+                create_simple_flag, create_simple_property_filter, get_flags_from_redis,
+            },
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
     };
@@ -477,7 +479,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -579,7 +581,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -712,7 +714,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -812,7 +814,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -921,7 +923,7 @@ mod tests {
             .expect("Failed to insert inactive flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -961,7 +963,7 @@ mod tests {
             .await
             .expect("Failed to set malformed JSON in Redis");
 
-        let result = FeatureFlagList::from_redis(redis_client, team.project_id()).await;
+        let result = get_flags_from_redis(redis_client, team.project_id()).await;
         assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
 
         // Test database query error (using a non-existent table)
@@ -1026,7 +1028,7 @@ mod tests {
             let project_id = team.project_id();
 
             let handle = task::spawn(async move {
-                let redis_flags = FeatureFlagList::from_redis(redis_client, project_id)
+                let redis_flags = get_flags_from_redis(redis_client, project_id)
                     .await
                     .unwrap();
                 let (pg_flags, _) = FeatureFlagList::from_pg(reader, project_id).await.unwrap();
@@ -1103,7 +1105,7 @@ mod tests {
         }
 
         let start = Instant::now();
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let redis_duration = start.elapsed();
@@ -1196,7 +1198,7 @@ mod tests {
         }
 
         // Fetch and verify edge case flags
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let (pg_flags, _) =
@@ -1284,7 +1286,7 @@ mod tests {
         }
 
         // Fetch flags from both sources
-        let mut redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let mut redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let (mut pg_flags, _) =
@@ -1404,7 +1406,7 @@ mod tests {
         }
 
         // Fetch flags from both sources
-        let redis_flags = FeatureFlagList::from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
         let (pg_flags, _) =

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -489,12 +489,12 @@ mod tests {
         assert_eq!(redis_flag.get_variants().len(), 3);
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) =
+        let pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
-        assert_eq!(pg_flags.flags.len(), 1);
-        let pg_flag = &pg_flags.flags[0];
+        assert_eq!(pg_flags.len(), 1);
+        let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag");
         assert_eq!(pg_flag.get_variants().len(), 3);
     }
@@ -590,12 +590,12 @@ mod tests {
         assert_eq!(redis_flag.key, "multivariate_flag_with_payloads");
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) =
+        let pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
-        assert_eq!(pg_flags.flags.len(), 1);
-        let pg_flag = &pg_flags.flags[0];
+        assert_eq!(pg_flags.len(), 1);
+        let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag_with_payloads");
 
         // Verify flag contents for both Redis and Postgres
@@ -725,12 +725,12 @@ mod tests {
         assert_eq!(redis_flag.filters.super_groups.as_ref().unwrap().len(), 1);
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) =
+        let pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
-        assert_eq!(pg_flags.flags.len(), 1);
-        let pg_flag = &pg_flags.flags[0];
+        assert_eq!(pg_flags.len(), 1);
+        let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "flag_with_super_groups");
         assert!(pg_flag.filters.super_groups.is_some());
         assert_eq!(pg_flag.filters.super_groups.as_ref().unwrap().len(), 1);
@@ -828,12 +828,12 @@ mod tests {
         assert_eq!(redis_properties[2].prop_type, PropertyType::Cohort);
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) =
+        let pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
-        assert_eq!(pg_flags.flags.len(), 1);
-        let pg_flag = &pg_flags.flags[0];
+        assert_eq!(pg_flags.len(), 1);
+        let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "flag_with_different_properties");
         let pg_properties = &pg_flag.filters.groups[0].properties.as_ref().unwrap();
         assert_eq!(pg_properties.len(), 3);
@@ -935,13 +935,13 @@ mod tests {
             .any(|f| f.key == "inactive_flag" && !f.active));
 
         // Fetch and verify from Postgres
-        let (pg_flags, _) =
+        let pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
-        assert_eq!(pg_flags.flags.len(), 0);
-        assert!(!pg_flags.flags.iter().any(|f| f.deleted)); // no deleted flags
-        assert!(!pg_flags.flags.iter().any(|f| f.active)); // no inactive flags
+        assert_eq!(pg_flags.len(), 0);
+        assert!(!pg_flags.iter().any(|f| f.deleted)); // no deleted flags
+        assert!(!pg_flags.iter().any(|f| f.active)); // no inactive flags
     }
 
     #[tokio::test]
@@ -1031,7 +1031,7 @@ mod tests {
                 let redis_flags = get_flags_from_redis(redis_client, project_id)
                     .await
                     .unwrap();
-                let (pg_flags, _) = FeatureFlagList::from_pg(reader, project_id).await.unwrap();
+                let pg_flags = FeatureFlagList::from_pg(reader, project_id).await.unwrap();
                 (redis_flags, pg_flags)
             });
 
@@ -1041,9 +1041,9 @@ mod tests {
         for handle in handles {
             let (redis_flags, pg_flags) = handle.await.unwrap();
             assert_eq!(redis_flags.flags.len(), 1);
-            assert_eq!(pg_flags.flags.len(), 1);
+            assert_eq!(pg_flags.len(), 1);
             assert_eq!(redis_flags.flags[0].key, "concurrent_flag");
-            assert_eq!(pg_flags.flags[0].key, "concurrent_flag");
+            assert_eq!(pg_flags[0].key, "concurrent_flag");
         }
     }
 
@@ -1111,7 +1111,7 @@ mod tests {
         let redis_duration = start.elapsed();
 
         let start = Instant::now();
-        let (pg_flags, _) = FeatureFlagList::from_pg(context.non_persons_reader, team.project_id())
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader, team.project_id())
             .await
             .expect("Failed to fetch flags from Postgres");
         let pg_duration = start.elapsed();
@@ -1120,7 +1120,7 @@ mod tests {
         tracing::info!("Postgres fetch time: {:?}", pg_duration);
 
         assert_eq!(redis_flags.flags.len(), num_flags);
-        assert_eq!(pg_flags.flags.len(), num_flags);
+        assert_eq!(pg_flags.len(), num_flags);
 
         assert!(redis_duration < std::time::Duration::from_millis(100));
         assert!(pg_duration < std::time::Duration::from_millis(1000));
@@ -1201,26 +1201,26 @@ mod tests {
         let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
-        let (pg_flags, _) =
+        let pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
         assert_eq!(redis_flags.flags.len(), 3);
-        assert_eq!(pg_flags.flags.len(), 3);
+        assert_eq!(pg_flags.len(), 3);
 
         // Verify empty properties flag
         assert!(redis_flags.flags.iter().any(|f| f.key == "empty_properties"
             && f.filters.groups[0].properties.as_ref().unwrap().is_empty()));
-        assert!(pg_flags.flags.iter().any(|f| f.key == "empty_properties"
+        assert!(pg_flags.iter().any(|f| f.key == "empty_properties"
             && f.filters.groups[0].properties.as_ref().unwrap().is_empty()));
 
         // Verify very long key flag
         assert!(redis_flags.flags.iter().any(|f| f.key.len() == 400));
-        assert!(pg_flags.flags.iter().any(|f| f.key.len() == 400));
+        assert!(pg_flags.iter().any(|f| f.key.len() == 400));
 
         // Verify unicode flag
         assert!(redis_flags.flags.iter().any(|f| f.key == "unicode_flag_🚀"));
-        assert!(pg_flags.flags.iter().any(|f| f.key == "unicode_flag_🚀"));
+        assert!(pg_flags.iter().any(|f| f.key == "unicode_flag_🚀"));
     }
 
     #[tokio::test]
@@ -1289,23 +1289,23 @@ mod tests {
         let mut redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
-        let (mut pg_flags, _) =
+        let mut pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
 
         // Sort flags by key to ensure consistent order
         redis_flags.flags.sort_by(|a, b| a.key.cmp(&b.key));
-        pg_flags.flags.sort_by(|a, b| a.key.cmp(&b.key));
+        pg_flags.sort_by(|a, b| a.key.cmp(&b.key));
 
         // Compare results
         assert_eq!(
             redis_flags.flags.len(),
-            pg_flags.flags.len(),
+            pg_flags.len(),
             "Number of flags mismatch"
         );
 
-        for (redis_flag, pg_flag) in redis_flags.flags.iter().zip(pg_flags.flags.iter()) {
+        for (redis_flag, pg_flag) in redis_flags.flags.iter().zip(pg_flags.iter()) {
             assert_eq!(redis_flag.key, pg_flag.key, "Flag key mismatch");
             assert_eq!(
                 redis_flag.name, pg_flag.name,
@@ -1409,13 +1409,13 @@ mod tests {
         let redis_flags = get_flags_from_redis(redis_client, team.project_id())
             .await
             .expect("Failed to fetch flags from Redis");
-        let (pg_flags, _) =
+        let pg_flags =
             FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
                 .await
                 .expect("Failed to fetch flags from Postgres");
 
         // Verify rollout percentages
-        for flags in &[redis_flags, pg_flags] {
+        for flags in &[redis_flags, FeatureFlagList { flags: pg_flags }] {
             assert!(flags
                 .flags
                 .iter()

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     team::team_models::Team,
 };
+use common_cache::ReadThroughCache;
 use common_database::PostgresReader;
 use common_metrics::inc;
 use common_redis::Client as RedisClient;
@@ -28,7 +29,7 @@ pub struct FlagService {
     redis_writer: Arc<dyn RedisClient + Send + Sync>,
     pg_client: PostgresReader,
     team_cache_ttl_seconds: u64,
-    flags_cache_ttl_seconds: u64,
+    flags_cache: ReadThroughCache,
 }
 
 impl FlagService {
@@ -39,12 +40,18 @@ impl FlagService {
         team_cache_ttl_seconds: u64,
         flags_cache_ttl_seconds: u64,
     ) -> Self {
+        let flags_cache = FeatureFlagList::create_cache(
+            redis_reader.clone(),
+            redis_writer.clone(),
+            Some(flags_cache_ttl_seconds),
+        );
+
         Self {
             redis_reader,
             redis_writer,
             pg_client,
             team_cache_ttl_seconds,
-            flags_cache_ttl_seconds,
+            flags_cache,
         }
     }
 
@@ -141,56 +148,41 @@ impl FlagService {
     /// Fetches the flags from the cache or the database. Returns a tuple containing
     /// the flags and a boolean indicating whether there were deserialization errors.
     /// Also tracks cache hits and misses for a given project_id.
+    ///
+    /// Uses the ReadThroughCache pattern for automatic cache management.
     pub async fn get_flags_from_cache_or_pg(
         &self,
         project_id: ProjectId,
     ) -> Result<FlagResult, FlagError> {
-        let flag_result = match FeatureFlagList::from_redis(self.redis_reader.clone(), project_id)
-            .await
-        {
-            Ok(flags_from_redis) => Ok(FlagResult {
-                flag_list: flags_from_redis,
-                was_cache_hit: true,
-                had_deserialization_errors: false,
-            }),
-            Err(_) => match FeatureFlagList::from_pg(self.pg_client.clone(), project_id).await {
-                Ok((flags_from_pg, had_deserialization_errors)) => {
-                    inc(DB_FLAG_READS_COUNTER, &[], 1);
-                    if (FeatureFlagList::update_flags_in_redis(
-                        self.redis_writer.clone(),
-                        project_id,
-                        &flags_from_pg,
-                        Some(self.flags_cache_ttl_seconds),
-                    )
-                    .await)
-                        .is_err()
-                    {
-                        inc(
-                            FLAG_CACHE_ERRORS_COUNTER,
-                            &[("reason".to_string(), "redis_update_failed".to_string())],
-                            1,
-                        );
-                    }
-                    Ok(FlagResult {
-                        flag_list: flags_from_pg,
-                        was_cache_hit: false,
-                        had_deserialization_errors,
-                    })
-                }
-                Err(database_error) => Err(database_error),
-            },
-        };
+        let (flag_list, had_deserialization_errors, cache_result) =
+            FeatureFlagList::get_with_cache(&self.flags_cache, self.pg_client.clone(), project_id)
+                .await?;
 
-        // Track cache hits and misses
-        if let Ok(ref result) = flag_result {
+        // Track cache hits
+        let was_cache_hit = cache_result.was_cached();
+        if was_cache_hit {
+            inc(FLAG_CACHE_HIT_COUNTER, &[], 1);
+        }
+
+        // Track database reads (when loader was invoked)
+        if cache_result.invoked_loader() {
+            inc(DB_FLAG_READS_COUNTER, &[], 1);
+        }
+
+        // Track cache problems
+        if cache_result.had_cache_problem() {
             inc(
-                FLAG_CACHE_HIT_COUNTER,
-                &[("cache_hit".to_string(), result.was_cache_hit.to_string())],
+                FLAG_CACHE_ERRORS_COUNTER,
+                &[("reason".to_string(), cache_result.source.to_string())],
                 1,
             );
         }
 
-        flag_result
+        Ok(FlagResult {
+            flag_list,
+            was_cache_hit,
+            had_deserialization_errors,
+        })
     }
 }
 

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -202,7 +202,7 @@ mod tests {
     use crate::{
         flags::{
             flag_models::{FeatureFlag, FlagFilters, FlagPropertyGroup, TEAM_FLAGS_CACHE_PREFIX},
-            test_helpers::get_flags_from_redis,
+            test_helpers::{get_flags_from_redis, update_flags_in_redis},
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
         utils::test_utils::{
@@ -398,14 +398,9 @@ mod tests {
             ],
         };
 
-        FeatureFlagList::update_flags_in_redis(
-            redis_client.clone(),
-            team.project_id(),
-            &mock_flags,
-            None,
-        )
-        .await
-        .expect("Failed to insert mock flags in Redis");
+        update_flags_in_redis(redis_client.clone(), team.project_id(), &mock_flags, None)
+            .await
+            .expect("Failed to insert mock flags in Redis");
 
         let flag_service = FlagService::new(
             redis_client.clone(),

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -178,10 +178,7 @@ impl FlagService {
             );
         }
 
-        // Extract flags from cache result
-        let flags = cache_result
-            .value
-            .expect("cache result always contains a value after get_with_cache");
+        let flags = cache_result.value.unwrap_or_default();
 
         Ok(FlagResult {
             flag_list: FeatureFlagList { flags },

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -158,11 +158,13 @@ impl FlagService {
             FeatureFlagList::get_with_cache(&self.flags_cache, self.pg_client.clone(), project_id)
                 .await?;
 
-        // Track cache hits
+        // Track cache hits and misses
         let was_cache_hit = cache_result.was_cached();
-        if was_cache_hit {
-            inc(FLAG_CACHE_HIT_COUNTER, &[], 1);
-        }
+        inc(
+            FLAG_CACHE_HIT_COUNTER,
+            &[("cache_hit".to_string(), was_cache_hit.to_string())],
+            1,
+        );
 
         // Track database reads (when loader was invoked)
         if cache_result.invoked_loader() {

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -154,7 +154,7 @@ impl FlagService {
         &self,
         project_id: ProjectId,
     ) -> Result<FlagResult, FlagError> {
-        let (flag_list, had_deserialization_errors, cache_result) =
+        let cache_result =
             FeatureFlagList::get_with_cache(&self.flags_cache, self.pg_client.clone(), project_id)
                 .await?;
 
@@ -180,10 +180,17 @@ impl FlagService {
             );
         }
 
+        // Extract metadata from cache result
+        let metadata = cache_result
+            .value
+            .expect("cache result always contains a value after get_with_cache");
+
         Ok(FlagResult {
-            flag_list,
+            flag_list: FeatureFlagList {
+                flags: metadata.flags,
+            },
             was_cache_hit,
-            had_deserialization_errors,
+            had_deserialization_errors: metadata.had_deserialization_errors,
         })
     }
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -15,12 +15,11 @@ use common_redis::Client as RedisClient;
 use common_types::ProjectId;
 use std::sync::Arc;
 
-/// Result of fetching feature flags, including cache hit status and deserialization errors status
+/// Result of fetching feature flags, including cache hit status
 #[derive(Debug, Clone)]
 pub struct FlagResult {
     pub flag_list: FeatureFlagList,
     pub was_cache_hit: bool,
-    pub had_deserialization_errors: bool,
 }
 
 /// Service layer for handling feature flag operations
@@ -145,9 +144,8 @@ impl FlagService {
         team_result
     }
 
-    /// Fetches the flags from the cache or the database. Returns a tuple containing
-    /// the flags and a boolean indicating whether there were deserialization errors.
-    /// Also tracks cache hits and misses for a given project_id.
+    /// Fetches the flags from the cache or the database.
+    /// Tracks cache hits and misses for a given project_id.
     ///
     /// Uses the ReadThroughCache pattern for automatic cache management.
     pub async fn get_flags_from_cache_or_pg(
@@ -180,17 +178,14 @@ impl FlagService {
             );
         }
 
-        // Extract metadata from cache result
-        let metadata = cache_result
+        // Extract flags from cache result
+        let flags = cache_result
             .value
             .expect("cache result always contains a value after get_with_cache");
 
         Ok(FlagResult {
-            flag_list: FeatureFlagList {
-                flags: metadata.flags,
-            },
+            flag_list: FeatureFlagList { flags },
             was_cache_hit,
-            had_deserialization_errors: metadata.had_deserialization_errors,
         })
     }
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -191,8 +191,9 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        flags::flag_models::{
-            FeatureFlag, FlagFilters, FlagPropertyGroup, TEAM_FLAGS_CACHE_PREFIX,
+        flags::{
+            flag_models::{FeatureFlag, FlagFilters, FlagPropertyGroup, TEAM_FLAGS_CACHE_PREFIX},
+            test_helpers::get_flags_from_redis,
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
         utils::test_utils::{
@@ -471,8 +472,7 @@ mod tests {
             .await;
         assert!(result.is_ok());
         // Verify that the flags were re-added to Redis
-        let redis_flags =
-            FeatureFlagList::from_redis(redis_client.clone(), team.project_id()).await;
+        let redis_flags = get_flags_from_redis(redis_client.clone(), team.project_id()).await;
         assert!(redis_flags.is_ok());
         assert_eq!(redis_flags.unwrap().flags.len(), mock_flags.flags.len());
     }

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -69,6 +69,65 @@ pub fn create_simple_flag(properties: Vec<PropertyFilter>, rollout_percentage: f
     }
 }
 
+/// Test-only helper to write feature flags directly to Redis
+///
+/// This bypasses the ReadThroughCache and directly writes to Redis,
+/// useful for setting up test data and verifying cache updates.
+pub async fn update_flags_in_redis(
+    client: Arc<dyn RedisClient + Send + Sync>,
+    project_id: ProjectId,
+    flags: &FeatureFlagList,
+    ttl_seconds: Option<u64>,
+) -> Result<(), FlagError> {
+    let payload = serde_json::to_string(&flags.flags).map_err(|e| {
+        tracing::error!(
+            "Failed to serialize {} flags for project {}: {}",
+            flags.flags.len(),
+            project_id,
+            e
+        );
+        FlagError::RedisDataParsingError
+    })?;
+
+    let cache_key = format!("{TEAM_FLAGS_CACHE_PREFIX}{project_id}");
+
+    match ttl_seconds {
+        Some(ttl) => {
+            tracing::info!(
+                "Writing flags to Redis at key '{}' with TTL {} seconds: {} flags",
+                cache_key,
+                ttl,
+                flags.flags.len()
+            );
+            client.setex(cache_key, payload, ttl).await.map_err(|e| {
+                tracing::error!(
+                    "Failed to update Redis cache with TTL for project {}: {}",
+                    project_id,
+                    e
+                );
+                FlagError::CacheUpdateError
+            })?;
+        }
+        None => {
+            tracing::info!(
+                "Writing flags to Redis at key '{}' without TTL: {} flags",
+                cache_key,
+                flags.flags.len()
+            );
+            client.set(cache_key, payload).await.map_err(|e| {
+                tracing::error!(
+                    "Failed to update Redis cache for project {}: {}",
+                    project_id,
+                    e
+                );
+                FlagError::CacheUpdateError
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Test-only helper to read feature flags directly from Redis
 ///
 /// This bypasses the ReadThroughCache and directly reads from Redis,

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -202,10 +202,7 @@ pub async fn fetch_and_filter(
         flags_after_tag_filter.len()
     );
 
-    Ok((
-        FeatureFlagList::new(flags_after_tag_filter),
-        flag_result.had_deserialization_errors,
-    ))
+    Ok((FeatureFlagList::new(flags_after_tag_filter), false))
 }
 
 /// Filters flags to only include survey flags if requested

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -175,7 +175,7 @@ pub async fn fetch_and_filter(
     headers: &axum::http::HeaderMap,
     explicit_runtime: Option<EvaluationRuntime>,
     environment_tags: Option<&Vec<String>>,
-) -> Result<(FeatureFlagList, bool), FlagError> {
+) -> Result<FeatureFlagList, FlagError> {
     let flag_result = flag_service.get_flags_from_cache_or_pg(project_id).await?;
 
     // First filter by survey flags if requested
@@ -202,7 +202,7 @@ pub async fn fetch_and_filter(
         flags_after_tag_filter.len()
     );
 
-    Ok((FeatureFlagList::new(flags_after_tag_filter), false))
+    Ok(FeatureFlagList::new(flags_after_tag_filter))
 }
 
 /// Filters flags to only include survey flags if requested

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -145,7 +145,7 @@ async fn process_request_inner(
 
             tracing::debug!("Distinct ID resolved: {}", distinct_id);
 
-            let (filtered_flags, had_flag_errors) = flags::fetch_and_filter(
+            let filtered_flags = flags::fetch_and_filter(
                 &flag_service,
                 team.project_id(),
                 &context.meta,
@@ -160,7 +160,7 @@ async fn process_request_inner(
             let property_overrides = properties::prepare_overrides(&context, &request)?;
 
             // Evaluate flags (this will return empty if is_flags_disabled is true)
-            let mut response = flags::evaluate_for_request(
+            let response = flags::evaluate_for_request(
                 &context.state,
                 team.id,
                 team.project_id(),
@@ -175,11 +175,6 @@ async fn process_request_inner(
                 request.flag_keys.clone(),
             )
             .await;
-
-            // Set error flag if there were deserialization errors
-            if had_flag_errors {
-                response.errors_while_computing_flags = true;
-            }
 
             // Only record billing if flags are not disabled
             if !request.is_flags_disabled() {

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1230,7 +1230,7 @@ async fn test_fetch_and_filter_flags() {
         only_evaluate_survey_feature_flags: Some(true),
         ..Default::default()
     };
-    let (result, had_errors) = fetch_and_filter(
+    let result = fetch_and_filter(
         &flag_service,
         team.project_id(),
         &query_params,
@@ -1245,14 +1245,13 @@ async fn test_fetch_and_filter_flags() {
         .flags
         .iter()
         .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
-    assert!(!had_errors);
 
     // Test 2: only_evaluate_survey_feature_flags = false
     let query_params = FlagsQueryParams {
         only_evaluate_survey_feature_flags: Some(false),
         ..Default::default()
     };
-    let (result, had_errors) = fetch_and_filter(
+    let result = fetch_and_filter(
         &flag_service,
         team.project_id(),
         &query_params,
@@ -1263,11 +1262,10 @@ async fn test_fetch_and_filter_flags() {
     .await
     .unwrap();
     assert_eq!(result.flags.len(), 4);
-    assert!(!had_errors);
 
     // Test 3: only_evaluate_survey_feature_flags not set
     let query_params = FlagsQueryParams::default();
-    let (result, had_errors) = fetch_and_filter(
+    let result = fetch_and_filter(
         &flag_service,
         team.project_id(),
         &query_params,
@@ -1278,7 +1276,6 @@ async fn test_fetch_and_filter_flags() {
     .await
     .unwrap();
     assert_eq!(result.flags.len(), 4);
-    assert!(!had_errors);
     assert!(result
         .flags
         .iter()
@@ -1290,7 +1287,7 @@ async fn test_fetch_and_filter_flags() {
         ..Default::default()
     };
 
-    let (result, had_errors) = fetch_and_filter(
+    let result = fetch_and_filter(
         &flag_service,
         team.project_id(),
         &query_params,
@@ -1303,7 +1300,6 @@ async fn test_fetch_and_filter_flags() {
 
     // Should return all survey flags since flag_keys filtering now happens in evaluation logic
     // Survey filter keeps only survey flags, but flag_keys filtering is deferred to evaluation
-    assert!(!had_errors);
     assert_eq!(result.flags.len(), 2);
     assert!(result
         .flags

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -64,3 +64,5 @@ pub const FLAG_ACQUIRE_TIMEOUT_COUNTER: &str = "flags_acquire_timeout_total";
 
 // Error classification
 pub const FLAG_DATABASE_ERROR_COUNTER: &str = "flags_database_error_total";
+pub const FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER: &str =
+    "flags_filter_deserialization_error_total";


### PR DESCRIPTION
## Problem

We have a lot of code for reading/writing to the Redis cache and each code is different. The `ReadThroughCache` introduced in https://github.com/PostHog/posthog/pull/40751 encapsulates a good pattern for doing this.

## Changes

This uses the new `ReadThroughCache` to read and write the flags cache.

The TTL can be configured through the `FLAGS_CACHE_TTL_SECONDS` env var. The default remains `432000` or `5` days.

This also adds a new counter for an exceedingly rare situation (that we believe can no longer happen): 

```rust
counter!(
    FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER, // "flags_filter_deserialization_error_total"
    "team_id" => row.team_id.to_string(),
    "flag_key" => row.key.clone(),
)
.increment(1);
```

## How did you test this code?

Unit Tests

Manually:

- [x] Test cache miss and cache hit
1. `redis-cli FLUSHALL`
2. `RUST_LOG=debug cargo run -p feature-flags` 
3. `curl -L 'http://localhost:8010/flags?v=2'...` (Verify response)
4. `redis-cli KEYS "posthog:1:team_feature_flags_*"` (confirm flags is cached for your team id)
5. `curl -L 'http://localhost:8010/flags?v=2'...` (Verify response, check logs for `Positive cache hit for key:`)

- [x] Test cache eviction at TTL
1. `redis-cli FLUSHALL`
2. `curl -L 'http://localhost:8010/flags?v=2'...` (Verify response)
3. `redis-cli TTL "posthog:1:team_feature_flags_{team_id}` (Verify key exists with TTL)
4. Wait for TTL
5. `curl -L 'http://localhost:8010/flags?v=2'...` (Verify response, check logs to for absence of `Positive cache hit for key:`)

- [x] Test response when Redis down
1. `redis-cli FLUSHALL`
2. `brew services stop redis`
3. `curl -L 'http://localhost:8010/flags?v=2'...` (Verify response)
4. `brew services restart redis`


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
