### PR TITLE
chore: add two new debug properties to taxonomy

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1259,6 +1259,12 @@
             "examples": ["https://sentry.io/..."],
             "label": "Sentry URL"
         },
+        "$sess_rec_flush_size": {
+            "description": "Estimated size in bytes of flushed recording data so far in this session. Added to events as a debug property.",
+            "label": "Estimated bytes flushed",
+            "type": "Numeric",
+            "used_for_debug": true
+        },
         "$session_entry__kx": {
             "description": "Klaviyo Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
             "ignored_in_assistant": true,
@@ -1453,6 +1459,11 @@
             "ignored_in_assistant": true,
             "label": "Session recording recorder version server-side",
             "system": true,
+            "used_for_debug": true
+        },
+        "$session_recording_remote_config": {
+            "description": "The remote config for session recording received from the server (or loaded from storage).",
+            "label": "Session recording remote config received",
             "used_for_debug": true
         },
         "$session_recording_start_reason": {
@@ -3491,6 +3502,12 @@
             "examples": ["https://sentry.io/..."],
             "label": "Sentry URL"
         },
+        "$sess_rec_flush_size": {
+            "description": "Estimated size in bytes of flushed recording data so far in this session. Added to events as a debug property.",
+            "label": "Estimated bytes flushed",
+            "type": "Numeric",
+            "used_for_debug": true
+        },
         "$session_entry__kx": {
             "description": "Klaviyo Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
             "ignored_in_assistant": true,
@@ -3685,6 +3702,11 @@
             "ignored_in_assistant": true,
             "label": "Session recording recorder version server-side",
             "system": true,
+            "used_for_debug": true
+        },
+        "$session_recording_remote_config": {
+            "description": "The remote config for session recording received from the server (or loaded from storage).",
+            "label": "Session recording remote config received",
             "used_for_debug": true
         },
         "$session_recording_start_reason": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -376,6 +376,17 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "type": "String",
             "used_for_debug": True,
         },
+        "$sess_rec_flush_size": {
+            "label": "Estimated bytes flushed",
+            "description": "Estimated size in bytes of flushed recording data so far in this session. Added to events as a debug property.",
+            "type": "Numeric",
+            "used_for_debug": True,
+        },
+        "$session_recording_remote_config": {
+            "label": "Session recording remote config received",
+            "description": "The remote config for session recording received from the server (or loaded from storage).",
+            "used_for_debug": True,
+        },
         "$initialization_time": {
             "label": "initialization time",
             "description": "The iso formatted timestamp of SDK initialization.",


### PR DESCRIPTION
added event properties, didn't add them to the taxonomy, had a breakdown

![image.png](https://app.graphite.com/user-attachments/assets/43be47f7-5bfd-47d2-ae39-be1791e05c13.png)

