### PR TITLE
feat(llma): add data-attr to elements

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay.tsx
@@ -50,6 +50,7 @@ export function ConversationDisplay({ eventProperties }: { eventProperties: Even
                         icon={<IconChat />}
                         onClick={handleTryInPlayground}
                         tooltip="Try this prompt in the playground"
+                        data-attr="try-in-playground-conversation"
                     >
                         Try in Playground
                     </LemonButton>

--- a/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
@@ -419,6 +419,7 @@ function OutputSection(): JSX.Element {
                             size="small"
                             onClick={addCurrentRunToComparison}
                             tooltip="Add this run to comparison table"
+                            data-attr="playground-add-to-compare"
                         >
                             Add to compare
                         </LemonButton>
@@ -485,6 +486,7 @@ function ConfigurationPanel(): JSX.Element {
                         }))}
                         loading={modelOptionsLoading}
                         disabled={modelOptionsLoading || options.length === 0}
+                        data-attr="playground-model-selector"
                     />
                 )}
                 {options.length === 0 && !modelOptionsLoading && (
@@ -708,6 +710,7 @@ function StickyActionBar(): JSX.Element {
                             onClick={submitPrompt}
                             loading={submitting}
                             disabledReason={submitting ? 'Generating...' : runDisabledReason}
+                            data-attr="playground-run"
                         >
                             Run
                         </LemonButton>

--- a/products/llm_analytics/frontend/LLMAnalyticsReloadAction.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsReloadAction.tsx
@@ -26,6 +26,7 @@ export function LLMAnalyticsReloadAction(): JSX.Element {
                 icon={isRefreshing ? <Spinner textColored /> : <IconRefresh />}
                 size="small"
                 disabledReason={isRefreshing ? 'Refreshing...' : undefined}
+                data-attr="llm-analytics-refresh-dashboard"
             >
                 <span className="dashboard-items-action-refresh-text">
                     {isRefreshing ? <>Refreshing...</> : <LastRefreshText />}

--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -75,20 +75,15 @@ const Filters = (): JSX.Element => {
 
     return (
         <div className="flex gap-x-4 gap-y-2 items-center flex-wrap py-4 -mt-4 mb-4 border-b">
-            <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} data-attr="llm-analytics-date-filter" />
+            <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
             <PropertyFilters
                 propertyFilters={propertyFilters}
                 taxonomicGroupTypes={generationsQuery.showPropertyFilter as TaxonomicFilterGroupType[]}
                 onChange={setPropertyFilters}
                 pageKey="llm-analytics"
-                data-attr="llm-analytics-property-filters"
             />
             <div className="flex-1" />
-            <TestAccountFilterSwitch
-                checked={shouldFilterTestAccounts}
-                onChange={setShouldFilterTestAccounts}
-                data-attr="llm-analytics-test-account-filter"
-            />
+            <TestAccountFilterSwitch checked={shouldFilterTestAccounts} onChange={setShouldFilterTestAccounts} />
             <LLMAnalyticsReloadAction />
         </div>
     )

--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -75,15 +75,20 @@ const Filters = (): JSX.Element => {
 
     return (
         <div className="flex gap-x-4 gap-y-2 items-center flex-wrap py-4 -mt-4 mb-4 border-b">
-            <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
+            <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} data-attr="llm-analytics-date-filter" />
             <PropertyFilters
                 propertyFilters={propertyFilters}
                 taxonomicGroupTypes={generationsQuery.showPropertyFilter as TaxonomicFilterGroupType[]}
                 onChange={setPropertyFilters}
                 pageKey="llm-analytics"
+                data-attr="llm-analytics-property-filters"
             />
             <div className="flex-1" />
-            <TestAccountFilterSwitch checked={shouldFilterTestAccounts} onChange={setShouldFilterTestAccounts} />
+            <TestAccountFilterSwitch
+                checked={shouldFilterTestAccounts}
+                onChange={setShouldFilterTestAccounts}
+                data-attr="llm-analytics-test-account-filter"
+            />
             <LLMAnalyticsReloadAction />
         </div>
     )
@@ -216,7 +221,10 @@ function LLMAnalyticsGenerations(): JSX.Element {
                             ) : (
                                 <strong>
                                     <Tooltip title={value}>
-                                        <Link to={`/llm-analytics/traces/${ids.traceId}?event=${value}`}>
+                                        <Link
+                                            to={`/llm-analytics/traces/${ids.traceId}?event=${value}`}
+                                            data-attr="generation-id-link"
+                                        >
                                             {visualValue}
                                         </Link>
                                     </Tooltip>
@@ -348,6 +356,7 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                         checked={evaluation.enabled}
                         onChange={() => toggleEvaluationEnabled(evaluation.id)}
                         size="small"
+                        data-attr="toggle-evaluation-enabled"
                     />
                     <span className={evaluation.enabled ? 'text-success' : 'text-muted'}>
                         {evaluation.enabled ? 'Enabled' : 'Disabled'}
@@ -448,7 +457,12 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                         Configure evaluation prompts and triggers to automatically assess your LLM generations.
                     </p>
                 </div>
-                <LemonButton type="primary" icon={<IconPlus />} to={urls.llmAnalyticsEvaluation('new')}>
+                <LemonButton
+                    type="primary"
+                    icon={<IconPlus />}
+                    to={urls.llmAnalyticsEvaluation('new')}
+                    data-attr="create-evaluation-button"
+                >
                     Create Evaluation
                 </LemonButton>
             </div>
@@ -459,6 +473,7 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                     type="search"
                     placeholder="Search evaluations..."
                     value={evaluationsFilter}
+                    data-attr="evaluations-search-input"
                     onChange={setEvaluationsFilter}
                     prefix={<IconSearch />}
                     className="max-w-sm"
@@ -491,6 +506,7 @@ export function LLMAnalyticsScene(): JSX.Element {
             label: 'Dashboard',
             content: <LLMAnalyticsDashboard />,
             link: combineUrl(urls.llmAnalyticsDashboard(), searchParams).url,
+            'data-attr': 'dashboard-tab',
         },
         {
             key: 'traces',
@@ -501,6 +517,7 @@ export function LLMAnalyticsScene(): JSX.Element {
                 </LLMAnalyticsSetupPrompt>
             ),
             link: combineUrl(urls.llmAnalyticsTraces(), searchParams).url,
+            'data-attr': 'traces-tab',
         },
         {
             key: 'generations',
@@ -511,6 +528,7 @@ export function LLMAnalyticsScene(): JSX.Element {
                 </LLMAnalyticsSetupPrompt>
             ),
             link: combineUrl(urls.llmAnalyticsGenerations(), searchParams).url,
+            'data-attr': 'generations-tab',
         },
         {
             key: 'users',
@@ -521,6 +539,7 @@ export function LLMAnalyticsScene(): JSX.Element {
                 </LLMAnalyticsSetupPrompt>
             ),
             link: combineUrl(urls.llmAnalyticsUsers(), searchParams).url,
+            'data-attr': 'users-tab',
         },
     ]
 
@@ -541,6 +560,7 @@ export function LLMAnalyticsScene(): JSX.Element {
                 </LLMAnalyticsSetupPrompt>
             ),
             link: combineUrl(urls.llmAnalyticsSessions(), searchParams).url,
+            'data-attr': 'sessions-tab',
         })
     }
 
@@ -557,6 +577,7 @@ export function LLMAnalyticsScene(): JSX.Element {
             ),
             content: <LLMAnalyticsPlaygroundScene />,
             link: combineUrl(urls.llmAnalyticsPlayground(), searchParams).url,
+            'data-attr': 'playground-tab',
         })
     }
 

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -297,6 +297,7 @@ function TraceSidebar({
                     value={searchValue}
                     onChange={onSearchChange}
                     size="small"
+                    data-attr="trace-search-input"
                 />
                 {searchValue.trim() && (
                     <div className="text-xs text-muted ml-1 mt-1">
@@ -415,6 +416,7 @@ const TreeNode = React.memo(function TraceNode({
                     isSelected && '!bg-accent-highlight-secondary',
                     isCollapsedDueToFilter && 'min-h-4 min-w-0'
                 )}
+                data-attr="trace-event-link"
             >
                 <div className="flex flex-row items-center gap-1.5">
                     <EventTypeTag event={item} size="small" />
@@ -686,6 +688,7 @@ const EventContent = React.memo(
                                             icon={<IconChat />}
                                             onClick={handleTryInPlayground}
                                             tooltip="Try this prompt in the playground"
+                                            data-attr="try-in-playground-trace"
                                         >
                                             Try in Playground
                                         </LemonButton>
@@ -876,6 +879,7 @@ function CopyTraceButton({ trace, tree }: { trace: LLMTrace; tree: EnrichedTrace
             icon={<IconCopy />}
             onClick={handleCopyTrace}
             tooltip="Copy trace to clipboard"
+            data-attr="copy-trace-json"
         >
             Copy trace JSON
         </LemonButton>

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -103,8 +103,8 @@ const IDColumn: QueryContextColumnComponent = ({ record }) => {
         <strong>
             <Tooltip title={row.id}>
                 <Link
-                    className="ph-no-capture"
                     to={urls.llmAnalyticsTrace(row.id, { timestamp: getTraceTimestamp(row.createdAt) })}
+                    data-attr="trace-id-link"
                 >
                     {row.id.slice(0, 4)}...{row.id.slice(-4)}
                 </Link>
@@ -118,8 +118,8 @@ const TraceNameColumn: QueryContextColumnComponent = ({ record }) => {
     return (
         <strong>
             <Link
-                className="ph-no-capture"
                 to={urls.llmAnalyticsTrace(row.id, { timestamp: getTraceTimestamp(row.createdAt) })}
+                data-attr="trace-name-link"
             >
                 {row.traceName || '–'}
             </Link>

--- a/products/llm_analytics/frontend/components/EvalsTabContent.tsx
+++ b/products/llm_analytics/frontend/components/EvalsTabContent.tsx
@@ -65,6 +65,7 @@ function EvalsTabContentInner({
                         }}
                         loading={evaluationRunLoading}
                         disabledReason={!selectedEvaluationId ? 'Select an evaluation first' : undefined}
+                        data-attr="run-evaluation-manual"
                     >
                         Run Evaluation
                     </LemonButton>

--- a/products/llm_analytics/frontend/datasets/LLMAnalyticsDatasetsScene.tsx
+++ b/products/llm_analytics/frontend/datasets/LLMAnalyticsDatasetsScene.tsx
@@ -105,6 +105,7 @@ export function LLMAnalyticsDatasetsScene(): JSX.Element {
                         type="primary"
                         to={urls.llmAnalyticsDataset('new')}
                         data-testid="create-dataset-button"
+                        data-attr="create-dataset-button"
                         size="small"
                     >
                         New dataset
@@ -117,6 +118,7 @@ export function LLMAnalyticsDatasetsScene(): JSX.Element {
                     type="search"
                     placeholder="Search datasets..."
                     value={filters.search}
+                    data-attr="datasets-search-input"
                     onChange={(value) => setFilters({ search: value })}
                     className="max-w-md"
                     data-testid="search-datasets-input"

--- a/products/llm_analytics/frontend/datasets/SaveToDatasetButton.tsx
+++ b/products/llm_analytics/frontend/datasets/SaveToDatasetButton.tsx
@@ -137,6 +137,7 @@ function OverlayMenu(): JSX.Element {
                                         onClick={() => {
                                             setSearchFormValue('datasetId', dataset.id)
                                         }}
+                                        data-attr="save-to-dataset-select"
                                     >
                                         <span className="line-clamp-1">{dataset.name}</span>
                                     </LemonButton>
@@ -155,6 +156,7 @@ function OverlayMenu(): JSX.Element {
                                 onClick={() => {
                                     setSearchFormValue('datasetId', dataset.id)
                                 }}
+                                data-attr="save-to-dataset-select"
                             >
                                 <span className="line-clamp-1">{dataset.name}</span>
                             </LemonButton>

--- a/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
@@ -83,7 +83,9 @@ export const llmAnalyticsColumnRenderers: Record<string, QueryContextColumn> = {
 
             return (
                 <Tooltip title={value}>
-                    <Link to={`/llm-analytics/traces/${value}`}>{visualValue}</Link>
+                    <Link to={`/llm-analytics/traces/${value}`} data-attr="generation-trace-link">
+                        {visualValue}
+                    </Link>
                 </Tooltip>
             )
         },


### PR DESCRIPTION
## Problem

We can't create good actions for LLMA dashboard usage.

## Changes

This adds `data-attr` to many key buttons and interactive UI elements in the LLMA dashboards, so that we can filter events by them.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
