### PR TITLE
fix(experiments): use correct logic in release condtions and distributions modal

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -16,7 +16,7 @@ import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authoriz
 import { IconOpenInApp } from 'lib/lemon-ui/icons'
 import { FeatureFlagLogicProps, featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 
-import { Experiment, MultivariateFlagVariant } from '~/types'
+import { MultivariateFlagVariant } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
@@ -24,9 +24,9 @@ import { HoldoutSelector } from './HoldoutSelector'
 import { VariantScreenshot } from './VariantScreenshot'
 import { VariantTag } from './components'
 
-export function DistributionModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
-    const { experiment, experimentLoading } = useValues(experimentLogic({ experimentId }))
-    const { updateDistribution } = useActions(experimentLogic({ experimentId }))
+export function DistributionModal(): JSX.Element {
+    const { experiment, experimentLoading } = useValues(experimentLogic)
+    const { updateDistribution } = useActions(experimentLogic)
     const { closeDistributionModal } = useActions(modalsLogic)
     const { isDistributionModalOpen } = useValues(modalsLogic)
 

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -394,8 +394,8 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                         </>
                     )}
 
-                    <DistributionModal experimentId={experimentId} />
-                    <ReleaseConditionsModal experimentId={experimentId} />
+                    <DistributionModal />
+                    <ReleaseConditionsModal />
 
                     <StopExperimentModal experimentId={experimentId} />
                     <EditConclusionModal experimentId={experimentId} />

--- a/frontend/src/scenes/experiments/ExperimentView/ReleaseConditionsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ReleaseConditionsTable.tsx
@@ -7,13 +7,14 @@ import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagRe
 import { FeatureFlagLogicProps, featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 
 import { groupsModel } from '~/models/groupsModel'
-import { Experiment, FeatureFlagGroupType } from '~/types'
+import { FeatureFlagGroupType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 
-export function ReleaseConditionsModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
-    const { experiment } = useValues(experimentLogic({ experimentId }))
+export function ReleaseConditionsModal(): JSX.Element {
+    const { experiment } = useValues(experimentLogic)
+    const { setExperiment } = useActions(experimentLogic)
     const { closeReleaseConditionsModal } = useActions(modalsLogic)
     const { isReleaseConditionsModalOpen } = useValues(modalsLogic)
 
@@ -33,8 +34,21 @@ export function ReleaseConditionsModal({ experimentId }: { experimentId: Experim
                         Cancel
                     </LemonButton>
                     <LemonButton
-                        onClick={() => {
-                            saveSidebarExperimentFeatureFlag(featureFlag)
+                        onClick={async () => {
+                            await saveSidebarExperimentFeatureFlag(featureFlag)
+
+                            const currentFlag = experiment.feature_flag
+                            if (currentFlag && featureFlag) {
+                                setExperiment({
+                                    feature_flag: {
+                                        ...currentFlag,
+                                        ...featureFlag,
+                                        id: currentFlag.id, // keep existing non-null id
+                                        team_id: currentFlag.team_id,
+                                    },
+                                })
+                            }
+
                             closeReleaseConditionsModal()
                         }}
                         type="primary"


### PR DESCRIPTION
## Problem

These modals are mounting the wrong logic, and does not get the right data.

## Changes

Remove the props passed to the logic, such that they inherit the props from the parent ExperimentView.

Also, noticed that the relase conditions where not reflected in the experiment UI. So update the experiment data when saving such that it's reflected in the UI

## How did you test this code?

Tested locally and confirmed that it's now working. Also checked the corresponding feature flag to make sure updates where reflected there.
