### PR TITLE
feat(replay): add frontend filter for new URL collections

### DIFF
--- a/frontend/src/scenes/session-recordings/collections/SessionRecordingCollections.tsx
+++ b/frontend/src/scenes/session-recordings/collections/SessionRecordingCollections.tsx
@@ -17,9 +17,11 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { TZLabel } from 'lib/components/TZLabel'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isObject } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
@@ -131,6 +133,7 @@ export function SessionRecordingCollections(): JSX.Element {
     const { setSavedPlaylistsFilters, updatePlaylist, duplicatePlaylist, deletePlaylist } = useActions(
         sessionRecordingCollectionsLogic
     )
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const columns: LemonTableColumns<SessionRecordingPlaylistType> = [
         {
@@ -273,10 +276,14 @@ export function SessionRecordingCollections(): JSX.Element {
                                         label: 'Automatic',
                                         value: 'synthetic',
                                     },
-                                    {
-                                        label: 'New URLs',
-                                        value: 'new-urls',
-                                    },
+                                    ...(featureFlags[FEATURE_FLAGS.REPLAY_NEW_DETECTED_URL_COLLECTIONS] === 'test'
+                                        ? [
+                                              {
+                                                  label: 'New URLs',
+                                                  value: 'new-urls',
+                                              },
+                                          ]
+                                        : []),
                                 ]}
                             />
                         </div>

--- a/frontend/src/scenes/session-recordings/collections/SessionRecordingCollections.tsx
+++ b/frontend/src/scenes/session-recordings/collections/SessionRecordingCollections.tsx
@@ -273,6 +273,10 @@ export function SessionRecordingCollections(): JSX.Element {
                                         label: 'Automatic',
                                         value: 'synthetic',
                                     },
+                                    {
+                                        label: 'New URLs',
+                                        value: 'new-urls',
+                                    },
                                 ]}
                             />
                         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1639,7 +1639,7 @@ export interface SavedSessionRecordingPlaylistsFilters {
     page: number
     pinned: boolean
     type?: 'collection' | 'saved_filters'
-    collectionType: 'custom' | 'synthetic' | null
+    collectionType: 'custom' | 'synthetic' | 'new-urls' | null
 }
 
 export interface SavedSessionRecordingPlaylistsResult extends PaginatedResponse<SessionRecordingPlaylistType> {

--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -453,7 +453,8 @@ class SessionRecordingPlaylistViewSet(
                 elif request_value == SessionRecordingPlaylist.PlaylistType.FILTERS:
                     queryset = queryset.filter(type=SessionRecordingPlaylist.PlaylistType.FILTERS)
             elif key == "collection_type":
-                if request_value == "synthetic":
+                if request_value in ("synthetic", "new-urls"):
+                    # Exclude all DB playlists when filtering for synthetic or new-urls
                     queryset = queryset.none()
             elif key == "pinned":
                 queryset = queryset.filter(pinned=True)
@@ -494,7 +495,11 @@ class SessionRecordingPlaylistViewSet(
                     pass
             elif key == "collection_type":
                 if request_value == "custom":
+                    # Custom means user-created only, exclude all synthetic playlists
                     return []
+                elif request_value == "new-urls":
+                    # Filter for only new-urls synthetic playlists
+                    filtered = [p for p in filtered if p.short_id.startswith("synthetic-new-url-")]
             elif key == "pinned":
                 # Synthetic playlists are never pinned, so exclude them
                 return []


### PR DESCRIPTION
## Problem

Suggestion from Paul, teams might have a LOT of new urls and want to ignore them / filter them out or filter JUST to them

## Changes

add new filter type in dropdown and check in backend
for now i assumed "automatic" was inclusive of URL but happy to change it so that "automatic" = the hardcoded 7 or so only

## How did you test this code?

![Screenshot 2025-11-05 at 12.17.37 PM.png](https://app.graphite.com/user-attachments/assets/e0989dcd-5899-4613-8a61-4bfdaf45bf4d.png)

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
