### PR TITLE
feat: Support session replay classes on toolbar PII tool

### DIFF
--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -21,6 +21,7 @@ import {
     IconStethoscope,
     IconTestTube,
     IconToggle,
+    IconWarning,
     IconX,
 } from '@posthog/icons'
 import { LemonBadge, Spinner } from '@posthog/lemon-ui'
@@ -145,12 +146,15 @@ function piiMaskingMenuItem(
     piiMaskingEnabled: boolean,
     piiMaskingColor: string,
     togglePiiMasking: () => void,
-    setPiiMaskingColor: (color: string) => void
+    setPiiMaskingColor: (color: string) => void,
+    piiWarning: string[] | null
 ): LemonMenuItem[] {
     return [
         {
             icon: piiMaskingEnabled ? <IconEye /> : <IconHide />,
             label: piiMaskingEnabled ? 'Show PII' : 'Hide PII',
+            sideIcon: piiWarning && piiWarning.length > 0 ? <IconWarning className="text-warning" /> : undefined,
+            tooltip: piiWarning && piiWarning.length > 0 ? piiWarning.join('\n') : undefined,
             onClick: (e: React.MouseEvent) => {
                 e.preventDefault()
                 e.stopPropagation()
@@ -191,7 +195,7 @@ function piiMaskingMenuItem(
 }
 
 function MoreMenu(): JSX.Element {
-    const { hedgehogMode, theme, posthog, piiMaskingEnabled, piiMaskingColor } = useValues(toolbarLogic)
+    const { hedgehogMode, theme, posthog, piiMaskingEnabled, piiMaskingColor, piiWarning } = useValues(toolbarLogic)
     const { setHedgehogMode, toggleTheme, setVisibleMenu, togglePiiMasking, setPiiMaskingColor } =
         useActions(toolbarLogic)
 
@@ -237,7 +241,13 @@ function MoreMenu(): JSX.Element {
                         label: `Switch to ${currentlyLightMode ? 'dark' : 'light'} mode`,
                         onClick: () => toggleTheme(),
                     },
-                    ...piiMaskingMenuItem(piiMaskingEnabled, piiMaskingColor, togglePiiMasking, setPiiMaskingColor),
+                    ...piiMaskingMenuItem(
+                        piiMaskingEnabled,
+                        piiMaskingColor,
+                        togglePiiMasking,
+                        setPiiMaskingColor,
+                        piiWarning
+                    ),
                     postHogDebugInfoMenuItem(posthog, loadingSurveys, surveysCount),
                     {
                         icon: <IconQuestion />,

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -335,14 +335,32 @@ export const toolbarLogic = kea<toolbarLogicType>([
                         warnings.push(
                             "The toolbar's PII masking tool doesn't support non-string `session_recording.blockClass`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
                         )
-                    } else if (
+                if (posthog.sessionRecording?.status === 'active') {
+                    if (
+                        posthog.config.session_recording?.blockClass !== undefined &&
+                        typeof posthog.config.session_recording?.blockClass !== 'string'
+                    ) {
+                        warnings.push(
+                            "The toolbar's PII masking tool doesn't support non-string `session_recording.blockClass`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
+                        )
+                    }
+                    if (
                         posthog.config.session_recording?.maskTextClass !== undefined &&
                         typeof posthog.config.session_recording?.maskTextClass !== 'string'
                     ) {
                         warnings.push(
                             "The toolbar's PII masking tool doesn't support non-string `session_recording.maskTextClass`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
                         )
-                    } else if (
+                    }
+                    if (
+                        posthog.config.session_recording?.maskTextSelector !== undefined &&
+                        typeof posthog.config.session_recording?.maskTextSelector !== 'string'
+                    ) {
+                        warnings.push(
+                            "The toolbar's PII masking tool doesn't support non-string `session_recording.maskTextSelector`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
+                        )
+                    }
+                }
                         posthog.config.session_recording?.maskTextSelector !== undefined &&
                         typeof posthog.config.session_recording?.maskTextSelector !== 'string'
                     ) {

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -1,5 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { windowValues } from 'kea-window-values'
+import { PostHog } from 'posthog-js'
 
 import { HedgehogActor } from 'lib/components/HedgehogBuddy/HedgehogBuddy'
 import { SPRITE_SIZE } from 'lib/components/HedgehogBuddy/sprites/sprites'
@@ -317,6 +318,43 @@ export const toolbarLogic = kea<toolbarLogicType>([
                 }
             },
         ],
+
+        piiWarning: [
+            (s) => [s.posthog, s.piiMaskingEnabled],
+            (posthog: PostHog | null, piiMaskingEnabled: boolean) => {
+                if (!posthog || !piiMaskingEnabled) {
+                    return null
+                }
+
+                const warnings: string[] = []
+                if (posthog.sessionRecording?.status === 'active') {
+                    if (
+                        posthog.config.session_recording?.blockClass !== undefined &&
+                        typeof posthog.config.session_recording?.blockClass !== 'string'
+                    ) {
+                        warnings.push(
+                            "The toolbar's PII masking tool doesn't support non-string `session_recording.blockClass`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
+                        )
+                    } else if (
+                        posthog.config.session_recording?.maskTextClass !== undefined &&
+                        typeof posthog.config.session_recording?.maskTextClass !== 'string'
+                    ) {
+                        warnings.push(
+                            "The toolbar's PII masking tool doesn't support non-string `session_recording.maskTextClass`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
+                        )
+                    } else if (
+                        posthog.config.session_recording?.maskTextSelector !== undefined &&
+                        typeof posthog.config.session_recording?.maskTextSelector !== 'string'
+                    ) {
+                        warnings.push(
+                            "The toolbar's PII masking tool doesn't support non-string `session_recording.maskTextSelector`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
+                        )
+                    }
+                }
+
+                return warnings
+            },
+        ],
     }),
     listeners(({ actions, values }) => ({
         setVisibleMenu: ({ visibleMenu }) => {
@@ -450,13 +488,14 @@ export const toolbarLogic = kea<toolbarLogicType>([
             const styleElement = document.getElementById(PII_MASKING_STYLESHEET_ID) as HTMLStyleElement | null
 
             if (values.piiMaskingEnabled) {
+                const css = generatePiiMaskingCSS(values.piiMaskingColor, values.posthog)
                 if (!styleElement) {
                     const newStyleElement = document.createElement('style')
                     newStyleElement.id = PII_MASKING_STYLESHEET_ID
                     document.head.appendChild(newStyleElement)
-                    newStyleElement.textContent = generatePiiMaskingCSS(values.piiMaskingColor)
+                    newStyleElement.textContent = css
                 } else {
-                    styleElement.textContent = generatePiiMaskingCSS(values.piiMaskingColor)
+                    styleElement.textContent = css
                 }
             } else {
                 if (styleElement) {
@@ -468,7 +507,7 @@ export const toolbarLogic = kea<toolbarLogicType>([
             const styleElement = document.getElementById(PII_MASKING_STYLESHEET_ID) as HTMLStyleElement | null
 
             if (styleElement && values.piiMaskingEnabled) {
-                styleElement.textContent = generatePiiMaskingCSS(color)
+                styleElement.textContent = generatePiiMaskingCSS(color, values.posthog)
             }
         },
     })),
@@ -507,7 +546,7 @@ export const toolbarLogic = kea<toolbarLogicType>([
                     styleElement.id = PII_MASKING_STYLESHEET_ID
                     document.head.appendChild(styleElement)
                 }
-                styleElement.textContent = generatePiiMaskingCSS(values.piiMaskingColor)
+                styleElement.textContent = generatePiiMaskingCSS(values.piiMaskingColor, values.posthog)
             }
 
             return () => {

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -335,14 +335,6 @@ export const toolbarLogic = kea<toolbarLogicType>([
                         warnings.push(
                             "The toolbar's PII masking tool doesn't support non-string `session_recording.blockClass`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
                         )
-                if (posthog.sessionRecording?.status === 'active') {
-                    if (
-                        posthog.config.session_recording?.blockClass !== undefined &&
-                        typeof posthog.config.session_recording?.blockClass !== 'string'
-                    ) {
-                        warnings.push(
-                            "The toolbar's PII masking tool doesn't support non-string `session_recording.blockClass`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
-                        )
                     }
                     if (
                         posthog.config.session_recording?.maskTextClass !== undefined &&
@@ -353,14 +345,6 @@ export const toolbarLogic = kea<toolbarLogicType>([
                         )
                     }
                     if (
-                        posthog.config.session_recording?.maskTextSelector !== undefined &&
-                        typeof posthog.config.session_recording?.maskTextSelector !== 'string'
-                    ) {
-                        warnings.push(
-                            "The toolbar's PII masking tool doesn't support non-string `session_recording.maskTextSelector`. If you want to use PII masking, please set it to a string. Or, reach out to support@posthog.com to file a feature request."
-                        )
-                    }
-                }
                         posthog.config.session_recording?.maskTextSelector !== undefined &&
                         typeof posthog.config.session_recording?.maskTextSelector !== 'string'
                     ) {


### PR DESCRIPTION
Let's support more stuff here not just the basic `ph-no-capture`. It's slightly harder to support RegExp/JavaScript functions since it'd require a MutationObserver which might be a bit painful to set up (and this is just a hackathon project).

In those cases, we simply display a warning telling customers we don't support that in the tool.