### PR TITLE
chore(flags): Add dedicated Redis database for feature flags

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -212,6 +212,7 @@ services:
             PGPASSWORD: posthog
             DEPLOYMENT: hobby
             CDP_API_URL: 'http://plugins:6738'
+            FLAGS_REDIS_ENABLED: false
 
     web:
         <<: *worker
@@ -293,12 +294,18 @@ services:
             WRITE_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             READ_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             MAXMIND_DB_PATH: '/share/GeoLite2-City.mmdb'
+            # Shared Redis for non-critical path (analytics, billing, cookieless)
             REDIS_URL: 'redis://redis:6379/'
             # Optional: Use separate Redis URLs for read/write separation
             # REDIS_READER_URL: 'redis://redis-replica:6379/'
             # REDIS_WRITER_URL: 'redis://redis-primary:6379/'
             # Optional: Increase Redis timeout (default is 100ms)
             # REDIS_TIMEOUT_MS: 200
+            # Dedicated Redis database for critical path (team cache + flags cache)
+            FLAGS_REDIS_URL: 'redis://redis:6379/1'
+            # Optional: Use separate Flags Redis URLs for read/write separation
+            # FLAGS_REDIS_READER_URL: 'redis://redis-replica:6379/1'
+            # FLAGS_REDIS_WRITER_URL: 'redis://redis-primary:6379/1'
             ADDRESS: '0.0.0.0:3001'
             RUST_LOG: 'info'
             COOKIELESS_REDIS_HOST: redis7

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -302,9 +302,8 @@ services:
             # Optional: Increase Redis timeout (default is 100ms)
             # REDIS_TIMEOUT_MS: 200
             # Dedicated Redis database for critical path (team cache + flags cache)
-            # NOTE: FLAGS_REDIS_URL is set, but FLAGS_REDIS_ENABLED is false.
-            # This is intentional for the dual-write warming phase: Redis will be warmed but not used as the source of truth.
-            FLAGS_REDIS_URL: 'redis://redis:6379/1'
+            # Hobby deployments start in Mode 1 (shared-only). Developers override in docker-compose.dev.yml for Mode 2.
+            # FLAGS_REDIS_URL: 'redis://redis:6379/1'
             # Optional: Use separate Flags Redis URLs for read/write separation
             # FLAGS_REDIS_READER_URL: 'redis://redis-replica:6379/1'
             # FLAGS_REDIS_WRITER_URL: 'redis://redis-primary:6379/1'

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -302,6 +302,8 @@ services:
             # Optional: Increase Redis timeout (default is 100ms)
             # REDIS_TIMEOUT_MS: 200
             # Dedicated Redis database for critical path (team cache + flags cache)
+            # NOTE: FLAGS_REDIS_URL is set, but FLAGS_REDIS_ENABLED is false.
+            # This is intentional for the dual-write warming phase: Redis will be warmed but not used as the source of truth.
             FLAGS_REDIS_URL: 'redis://redis:6379/1'
             # Optional: Use separate Flags Redis URLs for read/write separation
             # FLAGS_REDIS_READER_URL: 'redis://redis-replica:6379/1'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -201,6 +201,10 @@ services:
         depends_on:
             - redis
             - db
+        environment:
+            # Mode 2: Dual-write warming phase for developers
+            FLAGS_REDIS_URL: 'redis://redis:6379/1'
+            FLAGS_REDIS_ENABLED: 'false' # Warming but not reading yet
 
     livestream:
         extends:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1828,6 +1828,7 @@ dependencies = [
 name = "common-cache"
 version = "0.1.0"
 dependencies = [
+ "common-metrics",
  "common-redis",
  "moka",
  "serde",

--- a/rust/common/cache/Cargo.toml
+++ b/rust/common/cache/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+common-metrics = { path = "../metrics" }
 common-redis = { path = "../redis" }
 moka = { version = "0.12", features = ["sync"] }
 serde = { workspace = true, features = ["derive"] }

--- a/rust/common/cache/src/lib.rs
+++ b/rust/common/cache/src/lib.rs
@@ -42,10 +42,12 @@
 //! }
 //! ```
 
+pub mod metrics;
 pub mod negative_cache;
 pub mod read_through;
 pub mod types;
 
+pub use metrics::ReadThroughCacheWithMetrics;
 pub use negative_cache::NegativeCache;
 pub use read_through::ReadThroughCache;
 pub use types::{CacheConfig, CacheResult, CacheSource};

--- a/rust/common/cache/src/metrics.rs
+++ b/rust/common/cache/src/metrics.rs
@@ -1,0 +1,216 @@
+//! Metrics wrapper for ReadThroughCache
+//!
+//! This module provides a wrapper around [`ReadThroughCache`] that automatically
+//! emits Prometheus metrics for cache operations, enabling observability without
+//! coupling the core cache implementation to metrics.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use common_cache::{ReadThroughCache, ReadThroughCacheWithMetrics, CacheConfig};
+//!
+//! let cache = ReadThroughCache::new(
+//!     redis_reader,
+//!     redis_writer,
+//!     CacheConfig::with_ttl("flags:", 300),
+//!     None,
+//! );
+//!
+//! // Wrap with metrics
+//! let cache_with_metrics = ReadThroughCacheWithMetrics::new(
+//!     cache,
+//!     "flags",      // namespace for metrics (e.g., "flags", "surveys")
+//!     "flag",       // cache_name for metrics (e.g., "flag", "team")
+//!     &[("cache_type".to_string(), "dedicated".to_string())],  // additional labels
+//! );
+//!
+//! // Use like regular cache - metrics are emitted automatically
+//! let result = cache_with_metrics.get_or_load(&key, loader).await?;
+//! ```
+
+use crate::{CacheResult, ReadThroughCache};
+use common_metrics::inc;
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::future::Future;
+use std::sync::Arc;
+
+/// Wrapper around [`ReadThroughCache`] that emits Prometheus metrics
+///
+/// This wrapper adds observability to cache operations by emitting metrics
+/// for cache hits, misses, and errors. It maintains separation of concerns by
+/// keeping the core cache logic independent of metrics implementation.
+///
+/// # Metrics Emitted
+///
+/// All metrics use the pattern: `read_through_cache_{metric_name}_total`
+/// with labels: `namespace`, `cache_name`, plus any additional labels
+///
+/// - `read_through_cache_reads_total` - Total cache read attempts
+/// - `read_through_cache_hit_total{cache_hit="true|false"}` - Cache hit/miss tracking
+/// - `read_through_cache_loader_invoked_total` - Times the loader function was called
+/// - `read_through_cache_errors_total{reason="..."}` - Cache operation errors
+pub struct ReadThroughCacheWithMetrics {
+    inner: Arc<ReadThroughCache>,
+    namespace: &'static str,
+    cache_name: &'static str,
+    additional_labels: Vec<(String, String)>,
+}
+
+impl ReadThroughCacheWithMetrics {
+    /// Create a new metrics-wrapped cache
+    ///
+    /// # Arguments
+    /// * `inner` - The underlying ReadThroughCache to wrap
+    /// * `namespace` - Namespace for metrics (e.g., "flags", "surveys")
+    /// * `cache_name` - Cache name for metrics (e.g., "flag", "team")
+    /// * `additional_labels` - Extra labels to add to all metrics (e.g., cache_type, region)
+    pub fn new(
+        inner: Arc<ReadThroughCache>,
+        namespace: &'static str,
+        cache_name: &'static str,
+        additional_labels: &[(String, String)],
+    ) -> Self {
+        Self {
+            inner,
+            namespace,
+            cache_name,
+            additional_labels: additional_labels.to_vec(),
+        }
+    }
+
+    /// Get a value from cache or load it, emitting metrics
+    ///
+    /// This method wraps the underlying cache's `get_or_load` and automatically
+    /// emits appropriate metrics based on the result.
+    ///
+    /// # Type Parameters
+    /// * `K` - Key type (must be serializable and displayable)
+    /// * `V` - Value type (must be serializable)
+    /// * `E` - Error type from loader function
+    /// * `F` - Loader function type
+    /// * `Fut` - Future returned by loader
+    pub async fn get_or_load<K, V, E, F, Fut>(
+        &self,
+        key: &K,
+        loader: F,
+    ) -> Result<CacheResult<V>, E>
+    where
+        K: Serialize + Display + Send + Sync,
+        V: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+        F: FnOnce(&K) -> Fut,
+        Fut: Future<Output = Result<Option<V>, E>>,
+        E: Send + Sync,
+    {
+        // Call the underlying cache
+        let result = self.inner.get_or_load(key, loader).await?;
+
+        // Emit metrics based on result
+        self.emit_metrics(&result);
+
+        Ok(result)
+    }
+
+    /// Emit metrics based on cache result
+    fn emit_metrics<V>(&self, result: &CacheResult<V>) {
+        // Build base labels for all metrics
+        let mut base_labels = vec![
+            ("namespace".to_string(), self.namespace.to_string()),
+            ("cache_name".to_string(), self.cache_name.to_string()),
+        ];
+        base_labels.extend(self.additional_labels.clone());
+
+        // Track total reads
+        inc("read_through_cache_reads_total", &base_labels, 1);
+
+        // Track cache hits and misses
+        let mut hit_labels = base_labels.clone();
+        hit_labels.push(("cache_hit".to_string(), result.was_cached().to_string()));
+        inc("read_through_cache_hit_total", &hit_labels, 1);
+
+        // Track loader invocations
+        if result.invoked_loader() {
+            inc("read_through_cache_loader_invoked_total", &base_labels, 1);
+        }
+
+        // Track cache problems
+        if result.had_cache_problem() {
+            let mut error_labels = base_labels;
+            error_labels.push(("reason".to_string(), result.source.to_string()));
+            inc("read_through_cache_errors_total", &error_labels, 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CacheConfig, CacheSource};
+    use common_redis::MockRedisClient;
+
+    #[tokio::test]
+    async fn test_metrics_wrapper_passes_through_result() {
+        let redis_reader = Arc::new(MockRedisClient::new());
+        let redis_writer = Arc::new(MockRedisClient::new());
+
+        let cache = Arc::new(ReadThroughCache::new(
+            redis_reader,
+            redis_writer,
+            CacheConfig::with_ttl("test:", 60),
+            None,
+        ));
+
+        let cache_with_metrics = ReadThroughCacheWithMetrics::new(
+            cache,
+            "test_namespace",
+            "test_cache",
+            &[("cache_type".to_string(), "shared".to_string())],
+        );
+
+        // Test that the wrapper passes through results correctly
+        let result = cache_with_metrics
+            .get_or_load(&"key", |_| async {
+                Ok::<Option<String>, ()>(Some("value".to_string()))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some("value".to_string()));
+        // Should be cache miss on first access
+        assert!(result.invoked_loader());
+    }
+
+    #[tokio::test]
+    async fn test_metrics_wrapper_with_cache_hit() {
+        let redis_reader = Arc::new(
+            MockRedisClient::new().get_ret("test:key", Ok("\"cached_value\"".to_string())),
+        );
+        let redis_writer = Arc::new(MockRedisClient::new());
+
+        let cache = Arc::new(ReadThroughCache::new(
+            redis_reader,
+            redis_writer,
+            CacheConfig::with_ttl("test:", 60),
+            None,
+        ));
+
+        let cache_with_metrics = ReadThroughCacheWithMetrics::new(
+            cache,
+            "test_namespace",
+            "test_cache",
+            &[("cache_type".to_string(), "dedicated".to_string())],
+        );
+
+        let result = cache_with_metrics
+            .get_or_load(&"key", |_| async {
+                Ok::<Option<String>, ()>(Some("fallback".to_string()))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, Some("cached_value".to_string()));
+        assert_eq!(result.source, CacheSource::PositiveCache);
+        assert!(result.was_cached());
+        assert!(!result.invoked_loader());
+    }
+}

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -207,8 +207,9 @@ pub struct Config {
     #[envconfig(default = "")]
     pub flags_redis_writer_url: String,
 
-    // Enable dual-write mode: write to both shared and dedicated Redis
-    // Used during transition to warm up dedicated cache before cutover
+    // Controls whether to read from dedicated Redis cache
+    // false = Mode 2: dual-write to both caches, read from shared (warming phase)
+    // true = Mode 3: read and write dedicated Redis only (cutover complete)
     #[envconfig(default = "false")]
     pub flags_redis_enabled: FlexBool,
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -193,6 +193,25 @@ pub struct Config {
     #[envconfig(default = "")]
     pub redis_reader_url: String,
 
+    #[envconfig(default = "")]
+    pub redis_writer_url: String,
+
+    // Dedicated Redis for feature flags (critical path: team cache + flags cache)
+    // When empty, falls back to shared Redis URLs above
+    #[envconfig(default = "")]
+    pub flags_redis_url: String,
+
+    #[envconfig(default = "")]
+    pub flags_redis_reader_url: String,
+
+    #[envconfig(default = "")]
+    pub flags_redis_writer_url: String,
+
+    // Enable dual-write mode: write to both shared and dedicated Redis
+    // Used during transition to warm up dedicated cache before cutover
+    #[envconfig(default = "false")]
+    pub flags_redis_enabled: FlexBool,
+
     // S3 configuration for HyperCache fallback
     #[envconfig(default = "posthog")]
     pub object_storage_bucket: String,
@@ -202,9 +221,6 @@ pub struct Config {
 
     #[envconfig(default = "")]
     pub object_storage_endpoint: String,
-
-    #[envconfig(default = "")]
-    pub redis_writer_url: String,
 
     // How long to wait for a connection from the pool before timing out
     // - Increase if seeing "pool timed out" errors under load (e.g., 5-10s)
@@ -443,6 +459,10 @@ impl Config {
             redis_url: "redis://localhost:6379/".to_string(),
             redis_reader_url: "".to_string(),
             redis_writer_url: "".to_string(),
+            flags_redis_url: "".to_string(),
+            flags_redis_reader_url: "".to_string(),
+            flags_redis_writer_url: "".to_string(),
+            flags_redis_enabled: FlexBool(false),
             write_database_url: "postgres://posthog:posthog@localhost:5432/test_posthog"
                 .to_string(),
             read_database_url: "postgres://posthog:posthog@localhost:5432/test_posthog".to_string(),
@@ -534,6 +554,30 @@ impl Config {
             &self.redis_url
         } else {
             &self.redis_writer_url
+        }
+    }
+
+    /// Get the Redis URL for flags cache reads (critical path: team cache + flags cache)
+    /// Falls back to shared Redis reader URL if dedicated flags Redis is not configured
+    pub fn get_flags_redis_reader_url(&self) -> &str {
+        if !self.flags_redis_reader_url.is_empty() {
+            &self.flags_redis_reader_url
+        } else if !self.flags_redis_url.is_empty() {
+            &self.flags_redis_url
+        } else {
+            self.get_redis_reader_url()
+        }
+    }
+
+    /// Get the Redis URL for flags cache writes (critical path: team cache + flags cache)
+    /// Falls back to shared Redis writer URL if dedicated flags Redis is not configured
+    pub fn get_flags_redis_writer_url(&self) -> &str {
+        if !self.flags_redis_writer_url.is_empty() {
+            &self.flags_redis_writer_url
+        } else if !self.flags_redis_url.is_empty() {
+            &self.flags_redis_url
+        } else {
+            self.get_redis_writer_url()
         }
     }
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -558,26 +558,26 @@ impl Config {
     }
 
     /// Get the Redis URL for flags cache reads (critical path: team cache + flags cache)
-    /// Falls back to shared Redis reader URL if dedicated flags Redis is not configured
-    pub fn get_flags_redis_reader_url(&self) -> &str {
+    /// Returns None if dedicated flags Redis is not configured
+    pub fn get_flags_redis_reader_url(&self) -> Option<&str> {
         if !self.flags_redis_reader_url.is_empty() {
-            &self.flags_redis_reader_url
+            Some(&self.flags_redis_reader_url)
         } else if !self.flags_redis_url.is_empty() {
-            &self.flags_redis_url
+            Some(&self.flags_redis_url)
         } else {
-            self.get_redis_reader_url()
+            None
         }
     }
 
     /// Get the Redis URL for flags cache writes (critical path: team cache + flags cache)
-    /// Falls back to shared Redis writer URL if dedicated flags Redis is not configured
-    pub fn get_flags_redis_writer_url(&self) -> &str {
+    /// Returns None if dedicated flags Redis is not configured
+    pub fn get_flags_redis_writer_url(&self) -> Option<&str> {
         if !self.flags_redis_writer_url.is_empty() {
-            &self.flags_redis_writer_url
+            Some(&self.flags_redis_writer_url)
         } else if !self.flags_redis_url.is_empty() {
-            &self.flags_redis_url
+            Some(&self.flags_redis_url)
         } else {
-            self.get_redis_writer_url()
+            None
         }
     }
 

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -481,9 +481,12 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
+            None, // No dedicated flags Redis in tests
+            None,
             pg_client.clone(),
             DEFAULT_CACHE_TTL_SECONDS,
             DEFAULT_CACHE_TTL_SECONDS,
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         match flag_service.verify_token(&token).await {
@@ -510,9 +513,12 @@ mod tests {
         let flag_service = FlagService::new(
             redis_reader_client.clone(),
             redis_writer_client.clone(),
+            None, // No dedicated flags Redis in tests
+            None,
             pg_client.clone(),
             DEFAULT_CACHE_TTL_SECONDS,
             DEFAULT_CACHE_TTL_SECONDS,
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
         assert!(matches!(
             flag_service.verify_token(&result).await,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -24,9 +24,8 @@ pub struct FlagResult {
 
 /// Service layer for handling feature flag operations
 pub struct FlagService {
-    // Flags Redis clients (critical path: team cache + flags cache)
-    flags_redis_reader: Arc<dyn RedisClient + Send + Sync>,
-    flags_redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    team_redis_reader: Arc<dyn RedisClient + Send + Sync>,
+    team_redis_writer: Arc<dyn RedisClient + Send + Sync>,
     pg_client: PostgresReader,
     team_cache_ttl_seconds: u64,
     flags_cache: FlagsReadThroughCache,
@@ -37,34 +36,27 @@ impl FlagService {
     pub fn new(
         shared_redis_reader: Arc<dyn RedisClient + Send + Sync>,
         shared_redis_writer: Arc<dyn RedisClient + Send + Sync>,
-        flags_redis_reader: Option<Arc<dyn RedisClient + Send + Sync>>,
-        flags_redis_writer: Option<Arc<dyn RedisClient + Send + Sync>>,
+        dedicated_redis_reader: Option<Arc<dyn RedisClient + Send + Sync>>,
+        dedicated_redis_writer: Option<Arc<dyn RedisClient + Send + Sync>>,
         pg_client: PostgresReader,
         team_cache_ttl_seconds: u64,
         flags_cache_ttl_seconds: u64,
         config: Config,
     ) -> Self {
-        // Let FlagsReadThroughCache encapsulate all cache selection logic
+        // Flags cache uses FlagsReadThroughCache which handles migration logic
         let flags_cache = FlagsReadThroughCache::from_redis_clients(
             shared_redis_reader.clone(),
             shared_redis_writer.clone(),
-            flags_redis_reader.clone(),
-            flags_redis_writer.clone(),
+            dedicated_redis_reader,
+            dedicated_redis_writer,
             flags_cache_ttl_seconds,
             config,
         );
 
-        // Determine which Redis to use for team cache (critical path)
-        let (team_redis_reader, team_redis_writer) = FlagsReadThroughCache::get_team_cache_clients(
-            shared_redis_reader,
-            shared_redis_writer,
-            flags_redis_reader,
-            flags_redis_writer,
-        );
-
+        // Team cache always uses shared Redis (not part of the dedicated Redis migration)
         Self {
-            flags_redis_reader: team_redis_reader,
-            flags_redis_writer: team_redis_writer,
+            team_redis_reader: shared_redis_reader,
+            team_redis_writer: shared_redis_writer,
             pg_client,
             team_cache_ttl_seconds,
             flags_cache,
@@ -75,7 +67,7 @@ impl FlagService {
     /// If the token is not found in the cache, it will be verified against the database,
     /// and the result will be cached in redis.
     pub async fn verify_token(&self, token: &str) -> Result<String, FlagError> {
-        let (result, cache_hit) = match Team::from_redis(self.flags_redis_reader.clone(), token)
+        let (result, cache_hit) = match Team::from_redis(self.team_redis_reader.clone(), token)
             .await
         {
             Ok(_) => (Ok(token.to_string()), true),
@@ -85,7 +77,7 @@ impl FlagService {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // Token found in PostgreSQL, update Redis cache so that we can verify it from Redis next time
                         if let Err(e) = Team::update_redis_cache(
-                            self.flags_redis_writer.clone(),
+                            self.team_redis_writer.clone(),
                             &team,
                             Some(self.team_cache_ttl_seconds),
                         )
@@ -127,14 +119,14 @@ impl FlagService {
     /// Returns the team if found, otherwise an error.
     pub async fn get_team_from_cache_or_pg(&self, token: &str) -> Result<Team, FlagError> {
         let (team_result, cache_hit) =
-            match Team::from_redis(self.flags_redis_reader.clone(), token).await {
+            match Team::from_redis(self.team_redis_reader.clone(), token).await {
                 Ok(team) => (Ok(team), true),
                 Err(_) => match Team::from_pg(self.pg_client.clone(), token).await {
                     Ok(team) => {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // If we have the team in postgres, but not redis, update redis so we're faster next time
                         if Team::update_redis_cache(
-                            self.flags_redis_writer.clone(),
+                            self.team_redis_writer.clone(),
                             &team,
                             Some(self.team_cache_ttl_seconds),
                         )
@@ -164,10 +156,10 @@ impl FlagService {
     }
 
     /// Fetches the flags from the cache or the database.
-    /// Tracks cache hits and misses for a given project_id.
-    ///
+    /// 
     /// Uses the FlagsReadThroughCache pattern for automatic cache management
-    /// and dual-write support during migration.
+    /// and dual-write support during migration. FlagsReadThroughCache handles
+    /// tracking cache metrics.
     pub async fn get_flags_from_cache_or_pg(
         &self,
         project_id: ProjectId,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -1,6 +1,8 @@
 use crate::{
     api::errors::FlagError,
+    config::Config,
     flags::flag_models::FeatureFlagList,
+    flags_read_through_cache::FlagsReadThroughCache,
     metrics::consts::{
         DB_FLAG_READS_COUNTER, DB_TEAM_READS_COUNTER, FLAG_CACHE_ERRORS_COUNTER,
         FLAG_CACHE_HIT_COUNTER, TEAM_CACHE_ERRORS_COUNTER, TEAM_CACHE_HIT_COUNTER,
@@ -8,7 +10,6 @@ use crate::{
     },
     team::team_models::Team,
 };
-use common_cache::ReadThroughCache;
 use common_database::PostgresReader;
 use common_metrics::inc;
 use common_redis::Client as RedisClient;
@@ -24,30 +25,47 @@ pub struct FlagResult {
 
 /// Service layer for handling feature flag operations
 pub struct FlagService {
-    redis_reader: Arc<dyn RedisClient + Send + Sync>,
-    redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    // Flags Redis clients (critical path: team cache + flags cache)
+    flags_redis_reader: Arc<dyn RedisClient + Send + Sync>,
+    flags_redis_writer: Arc<dyn RedisClient + Send + Sync>,
     pg_client: PostgresReader,
     team_cache_ttl_seconds: u64,
-    flags_cache: ReadThroughCache,
+    flags_cache: FlagsReadThroughCache,
 }
 
 impl FlagService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        redis_reader: Arc<dyn RedisClient + Send + Sync>,
-        redis_writer: Arc<dyn RedisClient + Send + Sync>,
+        shared_redis_reader: Arc<dyn RedisClient + Send + Sync>,
+        shared_redis_writer: Arc<dyn RedisClient + Send + Sync>,
+        flags_redis_reader: Option<Arc<dyn RedisClient + Send + Sync>>,
+        flags_redis_writer: Option<Arc<dyn RedisClient + Send + Sync>>,
         pg_client: PostgresReader,
         team_cache_ttl_seconds: u64,
         flags_cache_ttl_seconds: u64,
+        config: Config,
     ) -> Self {
-        let flags_cache = FeatureFlagList::create_cache(
-            redis_reader.clone(),
-            redis_writer.clone(),
-            Some(flags_cache_ttl_seconds),
+        // Let FlagsReadThroughCache encapsulate all cache selection logic
+        let flags_cache = FlagsReadThroughCache::from_redis_clients(
+            shared_redis_reader.clone(),
+            shared_redis_writer.clone(),
+            flags_redis_reader.clone(),
+            flags_redis_writer.clone(),
+            flags_cache_ttl_seconds,
+            config,
+        );
+
+        // Determine which Redis to use for team cache (critical path)
+        let (team_redis_reader, team_redis_writer) = FlagsReadThroughCache::get_team_cache_clients(
+            shared_redis_reader,
+            shared_redis_writer,
+            flags_redis_reader,
+            flags_redis_writer,
         );
 
         Self {
-            redis_reader,
-            redis_writer,
+            flags_redis_reader: team_redis_reader,
+            flags_redis_writer: team_redis_writer,
             pg_client,
             team_cache_ttl_seconds,
             flags_cache,
@@ -58,7 +76,9 @@ impl FlagService {
     /// If the token is not found in the cache, it will be verified against the database,
     /// and the result will be cached in redis.
     pub async fn verify_token(&self, token: &str) -> Result<String, FlagError> {
-        let (result, cache_hit) = match Team::from_redis(self.redis_reader.clone(), token).await {
+        let (result, cache_hit) = match Team::from_redis(self.flags_redis_reader.clone(), token)
+            .await
+        {
             Ok(_) => (Ok(token.to_string()), true),
             Err(_) => {
                 match Team::from_pg(self.pg_client.clone(), token).await {
@@ -66,7 +86,7 @@ impl FlagService {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // Token found in PostgreSQL, update Redis cache so that we can verify it from Redis next time
                         if let Err(e) = Team::update_redis_cache(
-                            self.redis_writer.clone(),
+                            self.flags_redis_writer.clone(),
                             &team,
                             Some(self.team_cache_ttl_seconds),
                         )
@@ -108,14 +128,14 @@ impl FlagService {
     /// Returns the team if found, otherwise an error.
     pub async fn get_team_from_cache_or_pg(&self, token: &str) -> Result<Team, FlagError> {
         let (team_result, cache_hit) =
-            match Team::from_redis(self.redis_reader.clone(), token).await {
+            match Team::from_redis(self.flags_redis_reader.clone(), token).await {
                 Ok(team) => (Ok(team), true),
                 Err(_) => match Team::from_pg(self.pg_client.clone(), token).await {
                     Ok(team) => {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // If we have the team in postgres, but not redis, update redis so we're faster next time
                         if Team::update_redis_cache(
-                            self.redis_writer.clone(),
+                            self.flags_redis_writer.clone(),
                             &team,
                             Some(self.team_cache_ttl_seconds),
                         )
@@ -147,14 +167,25 @@ impl FlagService {
     /// Fetches the flags from the cache or the database.
     /// Tracks cache hits and misses for a given project_id.
     ///
-    /// Uses the ReadThroughCache pattern for automatic cache management.
+    /// Uses the FlagsReadThroughCache pattern for automatic cache management
+    /// and dual-write support during migration.
     pub async fn get_flags_from_cache_or_pg(
         &self,
         project_id: ProjectId,
     ) -> Result<FlagResult, FlagError> {
-        let cache_result =
-            FeatureFlagList::get_with_cache(&self.flags_cache, self.pg_client.clone(), project_id)
-                .await?;
+        let pg_client = self.pg_client.clone();
+        let cache_result = self
+            .flags_cache
+            .get_or_load(&project_id, move |&project_id| {
+                let pg_client = pg_client.clone();
+                async move {
+                    // Load from PostgreSQL - always returns Some, even for empty results
+                    // This ensures empty flag lists are cached to prevent repeated DB queries
+                    let flags = FeatureFlagList::from_pg(pg_client, project_id).await?;
+                    Ok::<Option<Vec<_>>, FlagError>(Some(flags))
+                }
+            })
+            .await?;
 
         // Track cache hits and misses
         let was_cache_hit = cache_result.was_cached();
@@ -215,9 +246,12 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
+            None, // No dedicated flags Redis in tests
+            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         // Test valid token in Redis
@@ -256,9 +290,12 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
+            None, // No dedicated flags Redis in tests
+            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         // Test fetching from Redis
@@ -278,9 +315,12 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
+            None, // No dedicated flags Redis in tests
+            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         let result = flag_service
@@ -397,9 +437,12 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             redis_client.clone(),
+            None, // No dedicated flags Redis in tests
+            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         // Test fetching from Redis
@@ -499,9 +542,12 @@ mod tests {
         let flag_service = FlagService::new(
             reader,
             writer,
+            None, // No dedicated flags Redis in tests
+            None,
             context.non_persons_reader.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         let result = flag_service
@@ -547,9 +593,12 @@ mod tests {
         let flag_service = FlagService::new(
             reader,
             writer,
+            None, // No dedicated flags Redis in tests
+            None,
             context.non_persons_reader.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         let result = flag_service
@@ -596,9 +645,12 @@ mod tests {
         let flag_service = FlagService::new(
             reader,
             writer,
+            None, // No dedicated flags Redis in tests
+            None,
             context.non_persons_reader.clone(),
             custom_team_ttl,
             custom_flags_ttl,
+            crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
         // Trigger team cache operation

--- a/rust/feature-flags/src/flags_read_through_cache.rs
+++ b/rust/feature-flags/src/flags_read_through_cache.rs
@@ -1,0 +1,368 @@
+use common_cache::{CacheResult, ReadThroughCache};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use crate::api::errors::FlagError;
+use crate::config::Config;
+
+/// Wrapper around ReadThroughCache that handles dual-write mode for flags migration
+///
+/// Three operational modes:
+/// 1. No dedicated Redis configured (dedicated_cache=None): Uses shared cache only
+/// 2. Dedicated Redis configured, flags_redis_enabled=false: Dual-write mode
+///    - Reads from shared cache (source of truth)
+///    - Fire-and-forget writes to dedicated cache (warming)
+/// 3. Dedicated Redis configured, flags_redis_enabled=true: Uses dedicated cache only
+///
+/// This allows us to:
+/// - Develop locally without dedicated Redis
+/// - Warm up dedicated cache in production before cutover
+/// - Cut over to dedicated cache cleanly
+pub struct FlagsReadThroughCache {
+    shared_cache: Arc<ReadThroughCache>,
+    dedicated_cache: Option<Arc<ReadThroughCache>>,
+    config: Config,
+}
+
+impl FlagsReadThroughCache {
+    /// Creates a new FlagsReadThroughCache with explicit caches (for testing)
+    pub fn new(
+        shared_cache: Arc<ReadThroughCache>,
+        dedicated_cache: Option<Arc<ReadThroughCache>>,
+        config: Config,
+    ) -> Self {
+        Self {
+            shared_cache,
+            dedicated_cache,
+            config,
+        }
+    }
+
+    /// Creates a FlagsReadThroughCache from Redis clients, encapsulating all cache selection logic
+    ///
+    /// # Cache Selection Strategy
+    /// - If dedicated Redis URLs are configured: Creates both shared and dedicated caches
+    /// - If dedicated Redis URLs are empty: Creates only shared cache (Mode 1)
+    ///
+    /// The `flags_redis_enabled` flag determines which cache is used for reads/writes.
+    pub fn from_redis_clients(
+        shared_redis_reader: Arc<dyn common_redis::Client + Send + Sync>,
+        shared_redis_writer: Arc<dyn common_redis::Client + Send + Sync>,
+        flags_redis_reader: Option<Arc<dyn common_redis::Client + Send + Sync>>,
+        flags_redis_writer: Option<Arc<dyn common_redis::Client + Send + Sync>>,
+        flags_cache_ttl_seconds: u64,
+        config: Config,
+    ) -> Self {
+        use crate::flags::flag_models::FeatureFlagList;
+
+        // Always create shared cache
+        let shared_cache = Arc::new(FeatureFlagList::create_cache(
+            shared_redis_reader,
+            shared_redis_writer,
+            Some(flags_cache_ttl_seconds),
+        ));
+
+        // Create dedicated cache only if dedicated Redis is configured
+        let dedicated_cache = match (flags_redis_reader, flags_redis_writer) {
+            (Some(reader), Some(writer)) => Some(Arc::new(FeatureFlagList::create_cache(
+                reader,
+                writer,
+                Some(flags_cache_ttl_seconds),
+            ))),
+            _ => None,
+        };
+
+        Self {
+            shared_cache,
+            dedicated_cache,
+            config,
+        }
+    }
+
+    /// Returns the Redis clients that should be used for the team cache (critical path)
+    ///
+    /// Strategy:
+    /// - If dedicated cache exists: Use dedicated Redis (critical path isolation)
+    /// - Otherwise: Use shared Redis (fallback)
+    pub fn get_team_cache_clients(
+        shared_redis_reader: Arc<dyn common_redis::Client + Send + Sync>,
+        shared_redis_writer: Arc<dyn common_redis::Client + Send + Sync>,
+        flags_redis_reader: Option<Arc<dyn common_redis::Client + Send + Sync>>,
+        flags_redis_writer: Option<Arc<dyn common_redis::Client + Send + Sync>>,
+    ) -> (
+        Arc<dyn common_redis::Client + Send + Sync>,
+        Arc<dyn common_redis::Client + Send + Sync>,
+    ) {
+        match (flags_redis_reader, flags_redis_writer) {
+            (Some(reader), Some(writer)) => (reader, writer),
+            _ => (shared_redis_reader, shared_redis_writer),
+        }
+    }
+
+    /// Get value from cache or load it, handling three operational modes
+    ///
+    /// # Behavior
+    /// 1. No dedicated cache: Uses shared cache only
+    /// 2. Dedicated cache exists, flags_redis_enabled=false: Dual-write mode
+    ///    - Reads from shared cache (source of truth)
+    ///    - Background writes to dedicated cache (warming)
+    /// 3. Dedicated cache exists, flags_redis_enabled=true: Uses dedicated cache only
+    ///
+    /// # Type Parameters
+    /// - `K`: Cache key type (must be Display + Clone + Send + Sync + Hash + Serialize + for<'de> Deserialize<'de> + 'static)
+    /// - `V`: Cache value type (must be Clone + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static)
+    /// - `F`: Async loader function type
+    /// - `Fut`: Future returned by loader
+    pub async fn get_or_load<K, V, F, Fut>(
+        &self,
+        key: &K,
+        load: F,
+    ) -> Result<CacheResult<V>, FlagError>
+    where
+        K: Display + Clone + Send + Sync + Hash + Serialize + for<'de> Deserialize<'de> + 'static,
+        V: Clone + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        F: FnOnce(&K) -> Fut + Clone + Send + 'static,
+        Fut: std::future::Future<Output = Result<Option<V>, FlagError>> + Send + 'static,
+    {
+        match (&self.dedicated_cache, *self.config.flags_redis_enabled) {
+            // Mode 3: Dedicated cache enabled, use it exclusively
+            (Some(dedicated_cache), true) => {
+                let cache_result = dedicated_cache.get_or_load(key, load).await?;
+                Ok(cache_result)
+            }
+            // Mode 2: Dedicated cache exists but not enabled yet - dual-write mode
+            (Some(dedicated_cache), false) => {
+                // Read from shared cache (source of truth)
+                let cache_result = self.shared_cache.get_or_load(key, load).await?;
+
+                // Fire-and-forget: warm up dedicated cache in background
+                let cached_value = cache_result.value.clone();
+                let dedicated_cache = Arc::clone(dedicated_cache);
+                let key_clone = key.clone();
+
+                tokio::spawn(async move {
+                    let _unused = dedicated_cache
+                        .get_or_load(&key_clone, move |_| async move {
+                            // Return the same value we got from the shared cache
+                            Ok::<Option<V>, FlagError>(cached_value)
+                        })
+                        .await;
+                });
+
+                Ok(cache_result)
+            }
+            // Mode 1: No dedicated cache configured - use shared cache only
+            (None, _) => {
+                let cache_result = self.shared_cache.get_or_load(key, load).await?;
+                Ok(cache_result)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DEFAULT_TEST_CONFIG;
+    use crate::flags::flag_models::FeatureFlagList;
+    use common_redis::MockRedisClient;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_mode_1_only_uses_shared_cache() {
+        // Mode 1: No dedicated cache configured - uses shared cache only
+        let shared_reader = Arc::new(MockRedisClient::new());
+        let shared_writer = Arc::new(MockRedisClient::new());
+
+        let shared_cache = Arc::new(FeatureFlagList::create_cache(
+            shared_reader.clone(),
+            shared_writer.clone(),
+            Some(60),
+        ));
+
+        let config = DEFAULT_TEST_CONFIG.clone();
+        let flags_cache = FlagsReadThroughCache::new(shared_cache.clone(), None, config);
+
+        // Make a request that will miss cache and trigger load
+        let result = flags_cache
+            .get_or_load(&123i64, |_| async {
+                Ok::<Option<Vec<String>>, FlagError>(Some(vec!["test".to_string()]))
+            })
+            .await;
+
+        assert!(result.is_ok());
+        let cache_result = result.unwrap();
+        assert_eq!(cache_result.value, Some(vec!["test".to_string()]));
+
+        // Verify only shared cache was accessed
+        let shared_reader_calls = shared_reader.get_calls();
+        let shared_writer_calls = shared_writer.get_calls();
+
+        // Should have attempted to read from shared cache
+        assert!(
+            !shared_reader_calls.is_empty()
+                && shared_reader_calls.iter().any(|call| call.op == "get"),
+            "Expected shared cache read. Calls: {shared_reader_calls:?}"
+        );
+
+        // Should have written to shared cache
+        assert!(
+            !shared_writer_calls.is_empty()
+                && shared_writer_calls.iter().any(|call| call.op == "setex"),
+            "Expected shared cache write. Calls: {shared_writer_calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mode_2_reads_shared_writes_both() {
+        // Mode 2: Dedicated cache configured but not enabled - dual-write mode
+        let shared_reader = Arc::new(MockRedisClient::new());
+        let shared_writer = Arc::new(MockRedisClient::new());
+        let dedicated_reader = Arc::new(MockRedisClient::new());
+        let dedicated_writer = Arc::new(MockRedisClient::new());
+
+        let shared_cache = Arc::new(FeatureFlagList::create_cache(
+            shared_reader.clone(),
+            shared_writer.clone(),
+            Some(60),
+        ));
+
+        let dedicated_cache = Arc::new(FeatureFlagList::create_cache(
+            dedicated_reader.clone(),
+            dedicated_writer.clone(),
+            Some(60),
+        ));
+
+        // flags_redis_enabled = false (dual-write mode)
+        let config = DEFAULT_TEST_CONFIG.clone();
+        // Note: DEFAULT_TEST_CONFIG has flags_redis_enabled=false by default
+
+        let flags_cache =
+            FlagsReadThroughCache::new(shared_cache.clone(), Some(dedicated_cache.clone()), config);
+
+        // Make a request - should read from shared, write to both
+        let result = flags_cache
+            .get_or_load(&456i64, |_| async {
+                Ok::<Option<Vec<String>>, FlagError>(Some(vec!["dual_write_test".to_string()]))
+            })
+            .await;
+
+        assert!(result.is_ok());
+        let cache_result = result.unwrap();
+        assert_eq!(
+            cache_result.value,
+            Some(vec!["dual_write_test".to_string()])
+        );
+
+        // Give background task a moment to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Verify read came from shared cache (source of truth)
+        let shared_reader_calls = shared_reader.get_calls();
+        let dedicated_reader_calls = dedicated_reader.get_calls();
+
+        assert!(
+            !shared_reader_calls.is_empty()
+                && shared_reader_calls.iter().any(|call| call.op == "get"),
+            "Expected read from shared cache. Calls: {shared_reader_calls:?}"
+        );
+
+        // Note: Dedicated cache reader IS accessed in dual-write mode (to check if value exists)
+        // but the result is not used - shared cache is still the source of truth
+        assert!(
+            !dedicated_reader_calls.is_empty()
+                && dedicated_reader_calls.iter().any(|call| call.op == "get"),
+            "Expected read attempt from dedicated cache (background warming). Calls: {dedicated_reader_calls:?}"
+        );
+
+        // Verify writes went to BOTH caches
+        let shared_writer_calls = shared_writer.get_calls();
+        let dedicated_writer_calls = dedicated_writer.get_calls();
+
+        assert!(
+            !shared_writer_calls.is_empty()
+                && shared_writer_calls.iter().any(|call| call.op == "setex"),
+            "Expected write to shared cache. Calls: {shared_writer_calls:?}"
+        );
+
+        assert!(
+            !dedicated_writer_calls.is_empty()
+                && dedicated_writer_calls.iter().any(|call| call.op == "setex"),
+            "Expected write to dedicated cache (background dual-write). Calls: {dedicated_writer_calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mode_3_only_uses_dedicated_cache() {
+        // Mode 3: Dedicated cache configured and enabled - uses dedicated only
+        let shared_reader = Arc::new(MockRedisClient::new());
+        let shared_writer = Arc::new(MockRedisClient::new());
+        let dedicated_reader = Arc::new(MockRedisClient::new());
+        let dedicated_writer = Arc::new(MockRedisClient::new());
+
+        let shared_cache = Arc::new(FeatureFlagList::create_cache(
+            shared_reader.clone(),
+            shared_writer.clone(),
+            Some(60),
+        ));
+
+        let dedicated_cache = Arc::new(FeatureFlagList::create_cache(
+            dedicated_reader.clone(),
+            dedicated_writer.clone(),
+            Some(60),
+        ));
+
+        // flags_redis_enabled = true (dedicated-only mode)
+        let mut config = DEFAULT_TEST_CONFIG.clone();
+        config.flags_redis_enabled = crate::config::FlexBool(true);
+
+        let flags_cache =
+            FlagsReadThroughCache::new(shared_cache.clone(), Some(dedicated_cache.clone()), config);
+
+        // Make a request - should only use dedicated cache
+        let result = flags_cache
+            .get_or_load(&789i64, |_| async {
+                Ok::<Option<Vec<String>>, FlagError>(Some(vec!["dedicated_only_test".to_string()]))
+            })
+            .await;
+
+        assert!(result.is_ok());
+        let cache_result = result.unwrap();
+        assert_eq!(
+            cache_result.value,
+            Some(vec!["dedicated_only_test".to_string()])
+        );
+
+        // Verify shared cache was NOT accessed at all
+        let shared_reader_calls = shared_reader.get_calls();
+        let shared_writer_calls = shared_writer.get_calls();
+
+        assert!(
+            shared_reader_calls.is_empty(),
+            "Expected NO reads from shared cache in dedicated-only mode. Calls: {shared_reader_calls:?}"
+        );
+
+        assert!(
+            shared_writer_calls.is_empty(),
+            "Expected NO writes to shared cache in dedicated-only mode. Calls: {shared_writer_calls:?}"
+        );
+
+        // Verify only dedicated cache was accessed
+        let dedicated_reader_calls = dedicated_reader.get_calls();
+        let dedicated_writer_calls = dedicated_writer.get_calls();
+
+        assert!(
+            !dedicated_reader_calls.is_empty()
+                && dedicated_reader_calls.iter().any(|call| call.op == "get"),
+            "Expected read from dedicated cache. Calls: {dedicated_reader_calls:?}"
+        );
+
+        assert!(
+            !dedicated_writer_calls.is_empty()
+                && dedicated_writer_calls.iter().any(|call| call.op == "setex"),
+            "Expected write to dedicated cache. Calls: {dedicated_writer_calls:?}"
+        );
+    }
+}

--- a/rust/feature-flags/src/flags_read_through_cache.rs
+++ b/rust/feature-flags/src/flags_read_through_cache.rs
@@ -109,12 +109,6 @@ impl FlagsReadThroughCache {
     ///    - Reads from shared cache (source of truth)
     ///    - Background writes to dedicated cache (warming)
     /// 3. Dedicated cache exists, flags_redis_enabled=true: Uses dedicated cache only
-    ///
-    /// # Type Parameters
-    /// - `K`: Cache key type (must be Display + Clone + Send + Sync + Hash + Serialize + for<'de> Deserialize<'de> + 'static)
-    /// - `V`: Cache value type (must be Clone + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static)
-    /// - `F`: Async loader function type
-    /// - `Fut`: Future returned by loader
     pub async fn get_or_load<K, V, F, Fut>(
         &self,
         key: &K,

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -95,9 +95,12 @@ async fn process_request_inner(
         let flag_service = FlagService::new(
             context.state.redis_reader.clone(),
             context.state.redis_writer.clone(),
+            context.state.flags_redis_reader.clone(),
+            context.state.flags_redis_writer.clone(),
             context.state.database_pools.non_persons_reader.clone(),
             context.state.config.team_cache_ttl_seconds,
             context.state.config.flags_cache_ttl_seconds,
+            context.state.config.clone(),
         );
 
         let (original_distinct_id, verified_token, request) =

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -95,8 +95,8 @@ async fn process_request_inner(
         let flag_service = FlagService::new(
             context.state.redis_reader.clone(),
             context.state.redis_writer.clone(),
-            context.state.flags_redis_reader.clone(),
-            context.state.flags_redis_writer.clone(),
+            context.state.dedicated_redis_reader.clone(),
+            context.state.dedicated_redis_writer.clone(),
             context.state.database_pools.non_persons_reader.clone(),
             context.state.config.team_cache_ttl_seconds,
             context.state.config.flags_cache_ttl_seconds,

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1151,9 +1151,12 @@ async fn test_fetch_and_filter_flags() {
     let flag_service = FlagService::new(
         redis_reader_client.clone(),
         redis_writer_client.clone(),
+        None, // No dedicated flags Redis in tests
+        None,
         reader.clone(),
         432000, // team_cache_ttl_seconds
         432000, // flags_cache_ttl_seconds
+        crate::config::DEFAULT_TEST_CONFIG.clone(),
     );
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await.unwrap();

--- a/rust/feature-flags/src/lib.rs
+++ b/rust/feature-flags/src/lib.rs
@@ -6,6 +6,7 @@ pub mod database;
 pub mod database_pools;
 pub mod db_monitor;
 pub mod flags;
+pub mod flags_read_through_cache;
 pub mod handler;
 pub mod metrics;
 pub mod properties;

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -1,14 +1,11 @@
 // Flag evaluation counters
 pub const FLAG_EVALUATION_ERROR_COUNTER: &str = "flags_flag_evaluation_error_total";
-pub const FLAG_CACHE_HIT_COUNTER: &str = "flags_flag_cache_hit_total";
-pub const FLAG_CACHE_ERRORS_COUNTER: &str = "flags_flag_cache_errors_total";
 pub const FLAG_HASH_KEY_WRITES_COUNTER: &str = "flags_flag_hash_key_writes_total";
 pub const FLAG_HASH_KEY_RETRIES_COUNTER: &str = "flags_hash_key_retries_total";
 pub const TEAM_CACHE_HIT_COUNTER: &str = "flags_team_cache_hit_total";
 pub const TEAM_CACHE_ERRORS_COUNTER: &str = "flags_team_cache_errors_total";
 pub const DB_TEAM_READS_COUNTER: &str = "flags_db_team_reads_total";
 pub const TOKEN_VALIDATION_ERRORS_COUNTER: &str = "flags_token_validation_errors_total";
-pub const DB_FLAG_READS_COUNTER: &str = "flags_db_flag_reads_total";
 pub const DB_COHORT_READS_COUNTER: &str = "flags_db_cohort_reads_total";
 pub const DB_COHORT_ERRORS_COUNTER: &str = "flags_db_cohort_errors_total";
 pub const COHORT_CACHE_HIT_COUNTER: &str = "flags_cohort_cache_hit_total";

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -37,10 +37,10 @@ pub struct State {
     // Shared Redis for non-critical path (analytics counters, billing limits)
     pub redis_reader: Arc<dyn RedisClient + Send + Sync>,
     pub redis_writer: Arc<dyn RedisClient + Send + Sync>,
-    // Dedicated Redis for critical path (team cache + flags cache)
+    // Dedicated Redis for flags cache (critical path isolation)
     // None if not configured (falls back to shared Redis)
-    pub flags_redis_reader: Option<Arc<dyn RedisClient + Send + Sync>>,
-    pub flags_redis_writer: Option<Arc<dyn RedisClient + Send + Sync>>,
+    pub dedicated_redis_reader: Option<Arc<dyn RedisClient + Send + Sync>>,
+    pub dedicated_redis_writer: Option<Arc<dyn RedisClient + Send + Sync>>,
     pub database_pools: Arc<DatabasePools>,
     pub cohort_cache_manager: Arc<CohortCacheManager>,
     pub geoip: Arc<GeoIpClient>,
@@ -55,11 +55,11 @@ pub struct State {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn router<RR, RW, FRR, FRW>(
+pub fn router<RR, RW, DRR, DRW>(
     redis_reader: Arc<RR>,
     redis_writer: Arc<RW>,
-    flags_redis_reader: Option<Arc<FRR>>,
-    flags_redis_writer: Option<Arc<FRW>>,
+    dedicated_redis_reader: Option<Arc<DRR>>,
+    dedicated_redis_writer: Option<Arc<DRW>>,
     database_pools: Arc<DatabasePools>,
     cohort_cache: Arc<CohortCacheManager>,
     geoip: Arc<GeoIpClient>,
@@ -72,8 +72,8 @@ pub fn router<RR, RW, FRR, FRW>(
 where
     RR: RedisClient + Send + Sync + 'static,
     RW: RedisClient + Send + Sync + 'static,
-    FRR: RedisClient + Send + Sync + 'static,
-    FRW: RedisClient + Send + Sync + 'static,
+    DRR: RedisClient + Send + Sync + 'static,
+    DRW: RedisClient + Send + Sync + 'static,
 {
     // Initialize flag definitions rate limiter with default and custom team rates
     let flag_definitions_limiter = FlagDefinitionsRateLimiter::new(
@@ -116,16 +116,16 @@ where
     let db_pools_for_readiness = database_pools.clone();
 
     // Convert generic Arc types to trait objects for State
-    let flags_redis_reader_trait: Option<Arc<dyn RedisClient + Send + Sync>> =
-        flags_redis_reader.map(|arc| -> Arc<dyn RedisClient + Send + Sync> { arc });
-    let flags_redis_writer_trait: Option<Arc<dyn RedisClient + Send + Sync>> =
-        flags_redis_writer.map(|arc| -> Arc<dyn RedisClient + Send + Sync> { arc });
+    let dedicated_redis_reader_trait: Option<Arc<dyn RedisClient + Send + Sync>> =
+        dedicated_redis_reader.map(|arc| -> Arc<dyn RedisClient + Send + Sync> { arc });
+    let dedicated_redis_writer_trait: Option<Arc<dyn RedisClient + Send + Sync>> =
+        dedicated_redis_writer.map(|arc| -> Arc<dyn RedisClient + Send + Sync> { arc });
 
     let state = State {
         redis_reader,
         redis_writer,
-        flags_redis_reader: flags_redis_reader_trait,
-        flags_redis_writer: flags_redis_writer_trait,
+        dedicated_redis_reader: dedicated_redis_reader_trait,
+        dedicated_redis_writer: dedicated_redis_writer_trait,
         database_pools,
         cohort_cache_manager: cohort_cache,
         geoip,

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -59,11 +59,13 @@ where
     ) {
         (Some(reader_url), Some(writer_url)) => {
             // Dedicated flags Redis is configured
-            let Some(reader) = create_redis_client(reader_url, "dedicated flags reader").await else {
+            let Some(reader) = create_redis_client(reader_url, "dedicated flags reader").await
+            else {
                 return;
             };
 
-            let Some(writer) = create_redis_client(writer_url, "dedicated flags writer").await else {
+            let Some(writer) = create_redis_client(writer_url, "dedicated flags writer").await
+            else {
                 return;
             };
 

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -17,63 +17,79 @@ use crate::db_monitor::DatabasePoolMonitor;
 use crate::router;
 use common_cookieless::CookielessManager;
 
+/// Helper to create a Redis client with error logging
+/// Returns None and logs an error if client creation fails
+async fn create_redis_client(url: &str, client_type: &str) -> Option<Arc<RedisClient>> {
+    match RedisClient::new(url.to_string()).await {
+        Ok(client) => Some(Arc::new(client)),
+        Err(e) => {
+            tracing::error!(
+                "Failed to create {} Redis client for URL {}: {}",
+                client_type,
+                url,
+                e
+            );
+            None
+        }
+    }
+}
+
 pub async fn serve<F>(config: Config, listener: TcpListener, shutdown: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
     // Create separate Redis clients for shared Redis (non-critical path: analytics, billing)
-    let redis_reader_client =
-        match RedisClient::new(config.get_redis_reader_url().to_string()).await {
-            Ok(client) => Arc::new(client),
-            Err(e) => {
-                tracing::error!(
-                    "Failed to create Redis reader client for URL {}: {}",
-                    config.get_redis_reader_url(),
-                    e
-                );
-                return;
-            }
-        };
+    let Some(redis_reader_client) =
+        create_redis_client(config.get_redis_reader_url(), "shared reader").await
+    else {
+        return;
+    };
 
-    let redis_writer_client =
-        match RedisClient::new(config.get_redis_writer_url().to_string()).await {
-            Ok(client) => Arc::new(client),
-            Err(e) => {
-                tracing::error!(
-                    "Failed to create Redis writer client for URL {}: {}",
-                    config.get_redis_writer_url(),
-                    e
-                );
-                return;
-            }
-        };
+    let Some(redis_writer_client) =
+        create_redis_client(config.get_redis_writer_url(), "shared writer").await
+    else {
+        return;
+    };
 
     // Create dedicated Redis clients for flags (critical path: team cache + flags cache)
-    let flags_redis_reader_client =
-        match RedisClient::new(config.get_flags_redis_reader_url().to_string()).await {
-            Ok(client) => Arc::new(client),
-            Err(e) => {
-                tracing::error!(
-                    "Failed to create flags Redis reader client for URL {}: {}",
-                    config.get_flags_redis_reader_url(),
-                    e
-                );
+    // Only create separate clients if dedicated flags Redis URLs are configured
+    let (flags_redis_reader_client, flags_redis_writer_client) = match (
+        config.get_flags_redis_reader_url(),
+        config.get_flags_redis_writer_url(),
+    ) {
+        (Some(reader_url), Some(writer_url)) => {
+            // Dedicated flags Redis is configured
+            let Some(reader) = create_redis_client(reader_url, "flags reader").await else {
                 return;
-            }
-        };
+            };
 
-    let flags_redis_writer_client =
-        match RedisClient::new(config.get_flags_redis_writer_url().to_string()).await {
-            Ok(client) => Arc::new(client),
-            Err(e) => {
-                tracing::error!(
-                    "Failed to create flags Redis writer client for URL {}: {}",
-                    config.get_flags_redis_writer_url(),
-                    e
-                );
+            let Some(writer) = create_redis_client(writer_url, "flags writer").await else {
                 return;
-            }
-        };
+            };
+
+            tracing::info!("Dedicated flags Redis configured");
+            (Some(reader), Some(writer))
+        }
+        _ => {
+            tracing::info!(
+                "Using shared Redis for flags cache (no dedicated flags Redis configured)"
+            );
+            (None, None)
+        }
+    };
+
+    // Log the cache migration mode based on configuration
+    let cache_mode = match (
+        flags_redis_reader_client.is_some(),
+        *config.flags_redis_enabled,
+    ) {
+        (false, _) => "Mode 1 (Shared-only): All caches use shared Redis",
+        (true, false) => {
+            "Mode 2 (Dual-write): Reading from shared Redis, warming dedicated Redis in background"
+        }
+        (true, true) => "Mode 3 (Dedicated-only): All flags caches use dedicated Redis",
+    };
+    tracing::info!("Feature flags cache migration mode: {}", cache_mode);
 
     // Create database pools with persons routing support
     let database_pools = match DatabasePools::from_config(&config).await {

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -38,7 +38,7 @@ pub async fn serve<F>(config: Config, listener: TcpListener, shutdown: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    // Create separate Redis clients for shared Redis (non-critical path: analytics, billing)
+    // Create separate Redis clients for shared Redis (non-critical path: analytics, billing, cookieless)
     let Some(redis_reader_client) =
         create_redis_client(config.get_redis_reader_url(), "shared reader").await
     else {

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -70,6 +70,12 @@ where
             tracing::info!("Dedicated flags Redis configured");
             (Some(reader), Some(writer))
         }
+        (Some(_), None) | (None, Some(_)) => {
+            tracing::warn!(
+                "Incomplete flags Redis configuration: both reader and writer URLs must be set. Falling back to shared Redis (Mode 1)."
+            );
+            (None, None)
+        }
         _ => {
             tracing::info!(
                 "Using shared Redis for flags cache (no dedicated flags Redis configured)"

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -213,8 +213,10 @@ impl ServerHandle {
             });
 
             let app = feature_flags::router::router(
-                redis_reader_client,
-                redis_writer_client,
+                redis_reader_client.clone(),
+                redis_writer_client.clone(),
+                None::<Arc<MockRedisClient>>, // No dedicated flags Redis in tests
+                None::<Arc<MockRedisClient>>,
                 database_pools,
                 cohort_cache,
                 geoip_service,


### PR DESCRIPTION
## Problem

See [this RFC](https://github.com/PostHog/requests-for-comments-internal/pull/909). In short, we want a dedicated Redis cache for feature flags. We want to introduce it in a safe manner.

## Changes

This introduces the concept of a Feature Flags Dedicated Redis Cache. Initially, this cache is only used for flags data currently cached in Redis. The dedicated cache is configured using the following env vars:

| Environment Variable | Description |
|-----------------------|-------------|
| `FLAGS_REDIS_ENABLED` | _If `true`, this cuts us over to only read/write to the dedicated Redis_ |
| `FLAGS_REDIS_URL` | _The dedicated Redis URL_ |
| `FLAGS_REDIS_READER_URL` | _The dedicated Redis reader replica. If not set, defaults to `FLAGS_REDIS_URL`_ |
| `FLAGS_REDIS_WRITER_URL` | _The dedicated Redis writer URL. Defaults to `FLAGS_REDIS_URL`_ |

In order to give us the ability to make this transition step-by-step, there are three modes we can run in:

| Mode | Condition | Behavior |
|------|------------|-----------|
| **Mode 1: Shared Cache Only** | `flags_redis_url` is `None` | Only read/write to the shared cache (AKA our current state). |
| **Mode 2: Dual Write** | `flags_redis_enabled` is `false` AND `flags_redis_url` is not `None` | Read/write to shared cache and use that value, while also reading/writing to the dedicated cache in the background to warm it up. (Transitional state) |
| **Mode 3: Dedicated Cache** | `flags_redis_enabled` is `true` AND `flags_redis_url` is not `None` | Only read/write to the dedicated cache. (Our final state) |

To keep changes as localized as possible, the `FlagsReadThroughCache` wrapper class encapsulates these three modes. Once mode 3 is fully deployed for a while and we trust it, we can remove the multi-modal approach.

> [!NOTE]  
> The plan is to create this cache from the Django side as a HyperCache (working on that in parallel). This is a transition step.

## How did you test this code?

Unit Tests
Manual Testing:

### Useful testing commands:

| Command | Description |
|----------|-------------|
| `redis-cli FLUSHALL` | _Clear all caches_ |
| `redis-cli -n 0 FLUSHDB` | _Clear shared cache_ |
| `redis-cli -n 1 FLUSHDB` | _Clear dedicated cache_ |
| `redis-cli -n 0 KEYS posthog:1:team_feature_flags_*` | _View shared cache flags keys_ |
| `redis-cli -n 1 KEYS posthog:1:team_feature_flags_*` | _View dedicated cache flags keys_ |
| `redis-cli -n 0 GET posthog:1:team_feature_flags_{your_team_id}` | _Get cached flags in shared cache_ |
| `redis-cli -n 1 GET posthog:1:team_feature_flags_{your_team_id}` | _Get cached flags in dedicated cache_ |
| `redis-cli -n 0 SET posthog:1:team_feature_flags_{your_team_id} "myvalue"` | _Set cached flags in shared cache_ |
| `redis-cli -n 1 SET posthog:1:team_feature_flags_{your_team_id} "myvalue"` | _Set cached flags in dedicated cache_ |
| `diff <(redis-cli -n 0 GET posthog:1:team_feature_flags_1) <(redis-cli -n 1 GET posthog:1:team_feature_flags_1)` | Compare two values

### Modes Test Plan: 

Look at the logs for a message like:

```text
2025-11-06T21:14:04.709886Z  INFO ThreadId(01) feature_flags::server: Feature flags cache migration mode: Mode 3 (Dedicated-only): All flags caches use dedicated Redis
```

- [x] Mode 1: `RUST_LOG=debug cargo run -p feature-flags`
  - [x] Make sure read/writes only happen to shared cache
- [x] Mode 2: `RUST_LOG=debug FLAGS_REDIS_URL=redis://localhost:6379/1 cargo run -p feature-flags`
  - [x] Reads/Writes should happen to both caches.
  - [x] Verify only the shared cache returns value though
      - a. Make /flags request
      - b. Verify data is the same
      - c. Write any value to the dedicated cache key
      - d. Make another request.
      - e. Verify response matches shared cache.
      - f. Also check that neither cache values (shared/dedicated) have changed.
- [x] Mode 3: `RUST_LOG=debug FLAGS_REDIS_ENABLED=true FLAGS_REDIS_URL=redis://localhost:6379/1 cargo run -p feature-flags`
  - [x] Reads/Writes should only happen to dedicated cache.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
