### PR TITLE
fix: Deleted people are being count in dynamic cohorts calculations

### DIFF
--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -244,21 +244,7 @@ def _delete_person(
         sync=sync,
     )
 
-def _delete_ch_cohortpeople(team_id: int, person_uuid, sync: bool = False) -> None:
-    """
-    Delete of cohortpeople rows for this person.
-    """
-    settings = {"lightweight_deletes_sync": 1 if sync else 0}
-
-    sync_execute(
-        """
-        DELETE FROM cohortpeople
-        WHERE team_id = %(team_id)s AND person_id = %(person_id)s
-        """,
-        {"team_id": team_id, "person_id": str(person_uuid)},
-        settings=settings,
-        workload=Workload.OFFLINE,
-    )
+def _delete_ch_cohortpeople(team_id: int, person_uuid: UUID, sync: bool = False) -> None:
 
 def _get_distinct_ids_with_version(person: Person) -> dict[str, int]:
     return {


### PR DESCRIPTION
## Problem
Dynamic cohorts were still counting deleted people.
`cohortpeople` entries in ClickHouse were not being cleaned when a person was deleted, leading to inflated cohort membership counts.

Closes #40840 

## Changes

- Added `_delete_ch_cohortpeople` delete helper
- Called it inside `delete_person()` so cohortpeople rows are removed immediately
- Keeps batch cleanup job disabled to avoid cluster pressure

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._