### PR TITLE
fix(plugin-server): fixes timing for instrumented queries

### DIFF
--- a/plugin-server/src/common/tracing/tracing-utils.ts
+++ b/plugin-server/src/common/tracing/tracing-utils.ts
@@ -58,7 +58,7 @@ export function withTracingSpan<T>(
 /**
  * Wraps a function in an OpenTelemetry tracing span and logs the execution time as a summary metric.
  */
-export function withSpan<T>(
+export async function withSpan<T>(
     tracer: Tracer | string,
     name: string,
     attrs: Attributes,
@@ -72,7 +72,7 @@ export function withSpan<T>(
         .startTimer()
 
     try {
-        return withTracingSpan(tracer, name, attrs, fn)
+        return await withTracingSpan(tracer, name, attrs, fn)
     } finally {
         stopTimer()
     }


### PR DESCRIPTION
## Problem

withSpan wrapper was not awaiting anything and so the query timer was immediately getting stopped after it was started

this meant our query timing/reporting in dashboards was broken

## Changes

awaits the instrumented query fn before it stops the timer to get more accurate query latencies

## How did you test this code?

Unit tests
