### PR TITLE
fix: Include legends in Slack subscriptions when enabled in insights

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -103,7 +103,16 @@ def _export_to_png(exported_asset: ExportedAsset, max_height_pixels: Optional[in
         wait_for_css_selector: CSSSelector
         screenshot_height: int = 600
         if exported_asset.insight is not None:
-            url_to_render = absolute_uri(f"/exporter?token={access_token}&legend")
+            # Check if the insight has legend enabled
+            legend_enabled = False
+            if exported_asset.insight.query and isinstance(exported_asset.insight.query, dict):
+                source = exported_asset.insight.query.get("source", {})
+                if isinstance(source, dict):
+                    trends_filter = source.get("trendsFilter", {})
+                    if isinstance(trends_filter, dict):
+                        legend_enabled = trends_filter.get("showLegend", False)
+
+            url_to_render = absolute_uri(f"/exporter?token={access_token}{'&legend' if legend_enabled else ''}")
             wait_for_css_selector = ".ExportedInsight"
             screenshot_width = 800
         elif exported_asset.dashboard is not None:

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -103,14 +103,26 @@ def _export_to_png(exported_asset: ExportedAsset, max_height_pixels: Optional[in
         wait_for_css_selector: CSSSelector
         screenshot_height: int = 600
         if exported_asset.insight is not None:
-            # Check if the insight has legend enabled
+            # Check if the insight has legend enabled (matches frontend getShowLegend logic)
             legend_enabled = False
             if exported_asset.insight.query and isinstance(exported_asset.insight.query, dict):
                 source = exported_asset.insight.query.get("source", {})
                 if isinstance(source, dict):
-                    trends_filter = source.get("trendsFilter", {})
-                    if isinstance(trends_filter, dict):
-                        legend_enabled = trends_filter.get("showLegend", False)
+                    query_kind = source.get("kind")
+
+                    # Check legend based on query type (matches frontend getShowLegend function)
+                    if query_kind == "TrendsQuery":
+                        trends_filter = source.get("trendsFilter", {})
+                        if isinstance(trends_filter, dict):
+                            legend_enabled = trends_filter.get("showLegend", False)
+                    elif query_kind == "LifecycleQuery":
+                        lifecycle_filter = source.get("lifecycleFilter", {})
+                        if isinstance(lifecycle_filter, dict):
+                            legend_enabled = lifecycle_filter.get("showLegend", False)
+                    elif query_kind == "StickinessQuery":
+                        stickiness_filter = source.get("stickinessFilter", {})
+                        if isinstance(stickiness_filter, dict):
+                            legend_enabled = stickiness_filter.get("showLegend", False)
 
             url_to_render = absolute_uri(f"/exporter?token={access_token}{'&legend' if legend_enabled else ''}")
             wait_for_css_selector = ".ExportedInsight"


### PR DESCRIPTION
### Problem

- Slack subscriptions don't show legends for insights even when legends are enabled in the insight settings.

fix: #40630

### Changes  

- Modified image exporter to conditionally include legends based on insight's `showLegend` setting.

### How did you test this code?

- Tested edge cases for legend detection logic and verified backward compatibility.

### Changelog: (features only) Is this feature complete?

- Yes