### PR TITLE
feat(llma): Add text view frontend with line permalinks [2/4]

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -303,6 +303,7 @@ export const FEATURE_FLAGS = {
     SWITCH_SUBSCRIPTION_PLAN: 'switch-subscription-plan', // owner: @a-lider #team-platform-features
     LLM_ANALYTICS_DATASETS: 'llm-analytics-datasets', // owner: #team-llm-analytics #team-posthog-ai
     LLM_ANALYTICS_SESSIONS_VIEW: 'llm-analytics-sessions-view', // owner: #team-llm-analytics
+    LLM_ANALYTICS_TEXT_VIEW: 'llm-analytics-text-view', // owner: #team-llm-analytics
     POSTHOG_AI_BILLING_DISPLAY: 'posthog-ai-billing-display', // owner: #team-posthog-ai
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -49,6 +49,7 @@ import { SaveToDatasetButton } from './datasets/SaveToDatasetButton'
 import { llmAnalyticsPlaygroundLogic } from './llmAnalyticsPlaygroundLogic'
 import { EnrichedTraceTreeNode, llmAnalyticsTraceDataLogic } from './llmAnalyticsTraceDataLogic'
 import { DisplayOption, llmAnalyticsTraceLogic } from './llmAnalyticsTraceLogic'
+import { TextViewDisplay } from './text-view/TextViewDisplay'
 import { exportTraceToClipboard } from './traceExportUtils'
 import { usePosthogAIBillingCalculations } from './usePosthogAIBillingCalculations'
 import {
@@ -650,6 +651,8 @@ const EventContent = React.memo(
     }): JSX.Element => {
         const { setupPlaygroundFromEvent } = useActions(llmAnalyticsPlaygroundLogic)
         const { featureFlags } = useValues(featureFlagLogic)
+        const { displayOption, lineNumber } = useValues(llmAnalyticsTraceLogic)
+        const { setDisplayOption } = useActions(llmAnalyticsTraceLogic)
 
         const [viewMode, setViewMode] = useState(TraceViewMode.Conversation)
 
@@ -807,46 +810,69 @@ const EventContent = React.memo(
                                     label: 'Conversation',
                                     content: (
                                         <>
-                                            {isLLMEvent(event) ? (
-                                                event.event === '$ai_generation' ? (
-                                                    <ConversationMessagesDisplay
-                                                        inputNormalized={normalizeMessages(
-                                                            event.properties.$ai_input,
-                                                            'user',
-                                                            event.properties.$ai_tools
-                                                        )}
-                                                        outputNormalized={normalizeMessages(
-                                                            event.properties.$ai_output_choices ??
-                                                                event.properties.$ai_output,
-                                                            'assistant'
-                                                        )}
-                                                        errorData={event.properties.$ai_error}
-                                                        httpStatus={event.properties.$ai_http_status}
-                                                        raisedError={event.properties.$ai_is_error}
-                                                        searchQuery={searchQuery}
+                                            {displayOption === DisplayOption.TextView &&
+                                            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TEXT_VIEW] ? (
+                                                isLLMEvent(event) &&
+                                                (event.event === '$ai_generation' ||
+                                                    event.event === '$ai_span' ||
+                                                    event.event === '$ai_embedding') ? (
+                                                    <TextViewDisplay
+                                                        event={event}
+                                                        lineNumber={lineNumber}
+                                                        onFallback={() => setDisplayOption(DisplayOption.ExpandAll)}
                                                     />
-                                                ) : event.event === '$ai_embedding' ? (
-                                                    <EventContentDisplay
-                                                        input={event.properties.$ai_input}
-                                                        output="Embedding vector generated"
+                                                ) : !isLLMEvent(event) ? (
+                                                    <TextViewDisplay
+                                                        trace={event}
+                                                        tree={tree}
+                                                        lineNumber={lineNumber}
+                                                        onFallback={() => setDisplayOption(DisplayOption.ExpandAll)}
                                                     />
-                                                ) : (
-                                                    <EventContentDisplay
-                                                        input={event.properties.$ai_input_state}
-                                                        output={
-                                                            event.properties.$ai_output_state ??
-                                                            event.properties.$ai_error
-                                                        }
-                                                        raisedError={event.properties.$ai_is_error}
-                                                    />
-                                                )
+                                                ) : null
                                             ) : (
                                                 <>
-                                                    <TraceMetricsTable />
-                                                    <EventContentDisplay
-                                                        input={event.inputState}
-                                                        output={event.outputState}
-                                                    />
+                                                    {isLLMEvent(event) ? (
+                                                        event.event === '$ai_generation' ? (
+                                                            <ConversationMessagesDisplay
+                                                                inputNormalized={normalizeMessages(
+                                                                    event.properties.$ai_input,
+                                                                    'user',
+                                                                    event.properties.$ai_tools
+                                                                )}
+                                                                outputNormalized={normalizeMessages(
+                                                                    event.properties.$ai_output_choices ??
+                                                                        event.properties.$ai_output,
+                                                                    'assistant'
+                                                                )}
+                                                                errorData={event.properties.$ai_error}
+                                                                httpStatus={event.properties.$ai_http_status}
+                                                                raisedError={event.properties.$ai_is_error}
+                                                                searchQuery={searchQuery}
+                                                            />
+                                                        ) : event.event === '$ai_embedding' ? (
+                                                            <EventContentDisplay
+                                                                input={event.properties.$ai_input}
+                                                                output="Embedding vector generated"
+                                                            />
+                                                        ) : (
+                                                            <EventContentDisplay
+                                                                input={event.properties.$ai_input_state}
+                                                                output={
+                                                                    event.properties.$ai_output_state ??
+                                                                    event.properties.$ai_error
+                                                                }
+                                                                raisedError={event.properties.$ai_is_error}
+                                                            />
+                                                        )
+                                                    ) : (
+                                                        <>
+                                                            <TraceMetricsTable />
+                                                            <EventContentDisplay
+                                                                input={event.inputState}
+                                                                output={event.outputState}
+                                                            />
+                                                        </>
+                                                    )}
                                                 </>
                                             )}
                                         </>
@@ -960,16 +986,28 @@ function CopyTraceButton({ trace, tree }: { trace: LLMTrace; tree: EnrichedTrace
 function DisplayOptionsSelect(): JSX.Element {
     const { displayOption } = useValues(llmAnalyticsTraceLogic)
     const { setDisplayOption } = useActions(llmAnalyticsTraceLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const displayOptions = [
         {
             value: DisplayOption.ExpandAll,
             label: 'Expand all',
+            tooltip: 'Show all messages and full conversation history',
         },
         {
             value: DisplayOption.CollapseExceptOutputAndLastInput,
             label: 'Collapse except output and last input',
+            tooltip: 'Focus on the most recent input and final output',
         },
+        ...(featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TEXT_VIEW]
+            ? [
+                  {
+                      value: DisplayOption.TextView,
+                      label: 'Text view',
+                      tooltip: 'Simple human readable text view, for humans',
+                  },
+              ]
+            : []),
     ]
 
     return (

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -652,7 +652,7 @@ const EventContent = React.memo(
         const { setupPlaygroundFromEvent } = useActions(llmAnalyticsPlaygroundLogic)
         const { featureFlags } = useValues(featureFlagLogic)
         const { displayOption, lineNumber } = useValues(llmAnalyticsTraceLogic)
-        const { setDisplayOption } = useActions(llmAnalyticsTraceLogic)
+        const { handleTextViewFallback, copyLinePermalink } = useActions(llmAnalyticsTraceLogic)
 
         const [viewMode, setViewMode] = useState(TraceViewMode.Conversation)
 
@@ -819,14 +819,16 @@ const EventContent = React.memo(
                                                     <TextViewDisplay
                                                         event={event}
                                                         lineNumber={lineNumber}
-                                                        onFallback={() => setDisplayOption(DisplayOption.ExpandAll)}
+                                                        onFallback={handleTextViewFallback}
+                                                        onCopyPermalink={copyLinePermalink}
                                                     />
                                                 ) : !isLLMEvent(event) ? (
                                                     <TextViewDisplay
                                                         trace={event}
                                                         tree={tree}
                                                         lineNumber={lineNumber}
-                                                        onFallback={() => setDisplayOption(DisplayOption.ExpandAll)}
+                                                        onFallback={handleTextViewFallback}
+                                                        onCopyPermalink={copyLinePermalink}
                                                     />
                                                 ) : null
                                             ) : (

--- a/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
@@ -2,6 +2,7 @@ import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
 import { dayjs } from 'lib/dayjs'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { urls } from 'scenes/urls'
 
 import { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -66,6 +67,8 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
         hideAllMessages: (type: 'input' | 'output') => ({ type }),
         applySearchResults: (inputMatches: boolean[], outputMatches: boolean[]) => ({ inputMatches, outputMatches }),
         setDisplayOption: (displayOption: DisplayOption) => ({ displayOption }),
+        handleTextViewFallback: true,
+        copyLinePermalink: (lineNumber: number) => ({ lineNumber }),
         toggleEventTypeExpanded: (eventType: string) => ({ eventType }),
     }),
 
@@ -143,6 +146,7 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
             persistConfig,
             {
                 setDisplayOption: (_, { displayOption }) => displayOption,
+                handleTextViewFallback: () => DisplayOption.ExpandAll,
             },
         ],
         eventTypeExpandedMap: [
@@ -266,6 +270,12 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
                     router.actions.replace(urls.llmAnalyticsTrace(traceId, params))
                 }
             }
+        },
+        copyLinePermalink: ({ lineNumber }) => {
+            // Copy permalink to clipboard with line number in URL
+            const url = new URL(window.location.href)
+            url.searchParams.set('line', lineNumber.toString())
+            copyToClipboard(url.toString(), 'permalink')
         },
     })),
 

--- a/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
@@ -17,6 +17,7 @@ const persistConfig = { persist: true, prefix: `${teamId}__` }
 export enum DisplayOption {
     ExpandAll = 'expand_all',
     CollapseExceptOutputAndLastInput = 'collapse_except_output_and_last_input',
+    TextView = 'text_view',
 }
 
 export interface LLMAnalyticsTraceDataNodeLogicParams {
@@ -52,6 +53,7 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
     actions({
         setTraceId: (traceId: string) => ({ traceId }),
         setEventId: (eventId: string | null) => ({ eventId }),
+        setLineNumber: (lineNumber: number | null) => ({ lineNumber }),
         setDateRange: (dateFrom: string | null, dateTo?: string | null) => ({ dateFrom, dateTo }),
         setIsRenderingMarkdown: (isRenderingMarkdown: boolean) => ({ isRenderingMarkdown }),
         toggleMarkdownRendering: true,
@@ -70,6 +72,7 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
     reducers({
         traceId: ['' as string, { setTraceId: (_, { traceId }) => traceId }],
         eventId: [null as string | null, { setEventId: (_, { eventId }) => eventId }],
+        lineNumber: [null as number | null, { setLineNumber: (_, { lineNumber }) => lineNumber }],
         dateRange: [
             null as { dateFrom: string | null; dateTo: string | null } | null,
             {
@@ -267,9 +270,10 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
     })),
 
     urlToAction(({ actions }) => ({
-        [urls.llmAnalyticsTrace(':id')]: ({ id }, { event, timestamp, exception_ts, search }) => {
+        [urls.llmAnalyticsTrace(':id')]: ({ id }, { event, timestamp, exception_ts, search, line }) => {
             actions.setTraceId(id ?? '')
             actions.setEventId(event || null)
+            actions.setLineNumber(line ? parseInt(line, 10) : null)
             if (timestamp) {
                 actions.setDateRange(timestamp || null)
             } else if (exception_ts) {

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -28,12 +28,14 @@ export function TextViewDisplay({
     tree,
     onFallback,
     lineNumber,
+    onCopyPermalink,
 }: {
     event?: LLMTraceEvent
     trace?: LLMTrace
     tree?: TraceTreeNode[]
     onFallback?: () => void
     lineNumber?: number | null
+    onCopyPermalink?: (lineNumber: number) => void
 }): JSX.Element {
     const { currentTeamId } = useValues(teamLogic)
 
@@ -159,6 +161,7 @@ export function TextViewDisplay({
                                     traceId={traceId}
                                     activeLineNumber={lineNumber}
                                     lineNumberPadding={lineNumberPadding}
+                                    onCopyPermalink={onCopyPermalink}
                                 />
                             </span>
                         )

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -9,7 +9,6 @@ import { IconCopy, IconExternal } from '@posthog/icons'
 import { LemonButton, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -426,8 +425,7 @@ function renderTextWithLinks(text: string, traceId?: string): JSX.Element[] {
                                     onClick={() => {
                                         const url = new URL(window.location.href)
                                         url.searchParams.set('line', lineNumber.toString())
-                                        copyToClipboard(url.toString(), 'line')
-                                        lemonToast.success('Permalink copied to clipboard')
+                                        copyToClipboard(url.toString(), 'permalink')
                                     }}
                                 >
                                     {linePrefix}

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -18,7 +18,7 @@ import { calculateLineNumberPadding, getExpandedTreeText, getPlainText, parseTex
 import { textViewLogic } from './textViewLogic'
 
 interface TraceTreeNode {
-    event: any
+    event: LLMTraceEvent
     children?: TraceTreeNode[]
 }
 

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -3,7 +3,7 @@
  * Shows a formatted text representation with copy functionality and expandable truncated sections
  */
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { IconCopy } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
@@ -74,8 +74,8 @@ export function TextViewDisplay({
         }
     }, [popoutSegment])
 
-    const segments = parseTextSegments(textRepr || '')
-    const lineNumberPadding = calculateLineNumberPadding(textRepr || '')
+    const segments = useMemo(() => parseTextSegments(textRepr || ''), [textRepr])
+    const lineNumberPadding = useMemo(() => calculateLineNumberPadding(textRepr || ''), [textRepr])
 
     // Get indices of all expandable segments
     const allExpandableIndices = segments

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -1,0 +1,1070 @@
+/**
+ * Text view display component for generation events
+ * Shows a formatted text representation with copy functionality and expandable truncated sections
+ */
+import { useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { IconCopy, IconExternal } from '@posthog/icons'
+import { LemonButton, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+
+interface TextSegment {
+    type: 'text' | 'truncated' | 'gen_expandable' | 'tools_expandable'
+    content: string
+    fullContent?: string
+    charCount?: number
+    eventId?: string
+}
+
+/**
+ * Parse text for TRUNCATED and TOOLS_EXPANDABLE markers (used for nested content)
+ */
+function parseTruncatedSegments(text: string): TextSegment[] {
+    const segments: TextSegment[] = []
+    const truncatedRegex = /<<<TRUNCATED\|([^|]+)\|(\d+)>>>/g
+    const toolsExpandableRegex = /<<<TOOLS_EXPANDABLE\|([^|]+)\|([^>]+)>>>/g
+
+    const allMatches: Array<{
+        index: number
+        length: number
+        type: 'truncated' | 'tools_expandable'
+        data: any
+    }> = []
+
+    // Find all truncated markers
+    let truncMatch: RegExpExecArray | null
+    while ((truncMatch = truncatedRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: truncMatch.index,
+            length: truncMatch[0].length,
+            type: 'truncated',
+            data: { encodedContent: truncMatch[1], charCount: parseInt(truncMatch[2], 10) },
+        })
+    }
+
+    // Find all tools expandable markers
+    let toolsMatch: RegExpExecArray | null
+    while ((toolsMatch = toolsExpandableRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: toolsMatch.index,
+            length: toolsMatch[0].length,
+            type: 'tools_expandable',
+            data: { displayText: toolsMatch[1], encodedContent: toolsMatch[2] },
+        })
+    }
+
+    // Sort by index
+    allMatches.sort((a, b) => a.index - b.index)
+
+    let lastIndex = 0
+
+    for (const match of allMatches) {
+        // Add text before the marker
+        if (match.index > lastIndex) {
+            segments.push({
+                type: 'text',
+                content: text.slice(lastIndex, match.index),
+            })
+        }
+
+        if (match.type === 'truncated') {
+            // Add truncated segment
+            try {
+                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                segments.push({
+                    type: 'truncated',
+                    content: `... (${match.data.charCount} chars truncated)`,
+                    fullContent,
+                    charCount: match.data.charCount,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        } else if (match.type === 'tools_expandable') {
+            // Add tools expandable segment
+            try {
+                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                segments.push({
+                    type: 'tools_expandable',
+                    content: match.data.displayText,
+                    fullContent,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        }
+
+        lastIndex = match.index + match.length
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+        segments.push({
+            type: 'text',
+            content: text.slice(lastIndex),
+        })
+    }
+
+    return segments
+}
+
+/**
+ * Parse text to find truncation, generation expandable, and tools expandable markers and split into segments
+ */
+function parseTextSegments(text: string): TextSegment[] {
+    const segments: TextSegment[] = []
+
+    // Combined regex to match TRUNCATED, GEN_EXPANDABLE, and TOOLS_EXPANDABLE markers
+    const truncatedRegex = /<<<TRUNCATED\|([^|]+)\|(\d+)>>>/g
+    const genExpandableRegex = /<<<GEN_EXPANDABLE\|([^|]+)\|([^|]+)\|([^>]+)>>>/g
+    const toolsExpandableRegex = /<<<TOOLS_EXPANDABLE\|([^|]+)\|([^>]+)>>>/g
+
+    const allMatches: Array<{
+        index: number
+        length: number
+        type: 'truncated' | 'gen_expandable' | 'tools_expandable'
+        data: any
+    }> = []
+
+    // Find all truncated markers
+    let truncMatch: RegExpExecArray | null
+    while ((truncMatch = truncatedRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: truncMatch.index,
+            length: truncMatch[0].length,
+            type: 'truncated',
+            data: { encodedContent: truncMatch[1], charCount: parseInt(truncMatch[2], 10) },
+        })
+    }
+
+    // Find all gen expandable markers
+    let genMatch: RegExpExecArray | null
+    while ((genMatch = genExpandableRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: genMatch.index,
+            length: genMatch[0].length,
+            type: 'gen_expandable',
+            data: { eventId: genMatch[1], displayText: genMatch[2], encodedContent: genMatch[3] },
+        })
+    }
+
+    // Find all tools expandable markers
+    let toolsMatch: RegExpExecArray | null
+    while ((toolsMatch = toolsExpandableRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: toolsMatch.index,
+            length: toolsMatch[0].length,
+            type: 'tools_expandable',
+            data: { displayText: toolsMatch[1], encodedContent: toolsMatch[2] },
+        })
+    }
+
+    // Sort by index
+    allMatches.sort((a, b) => a.index - b.index)
+
+    let lastIndex = 0
+
+    for (const match of allMatches) {
+        // Add text before the marker
+        if (match.index > lastIndex) {
+            segments.push({
+                type: 'text',
+                content: text.slice(lastIndex, match.index),
+            })
+        }
+
+        if (match.type === 'truncated') {
+            // Add truncated segment
+            try {
+                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                segments.push({
+                    type: 'truncated',
+                    content: `... (${match.data.charCount} chars truncated)`,
+                    fullContent,
+                    charCount: match.data.charCount,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        } else if (match.type === 'gen_expandable') {
+            // Add gen expandable segment
+            try {
+                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                segments.push({
+                    type: 'gen_expandable',
+                    content: match.data.displayText,
+                    fullContent,
+                    eventId: match.data.eventId,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        } else if (match.type === 'tools_expandable') {
+            // Add tools expandable segment
+            try {
+                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                segments.push({
+                    type: 'tools_expandable',
+                    content: match.data.displayText,
+                    fullContent,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        }
+
+        lastIndex = match.index + match.length
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+        segments.push({
+            type: 'text',
+            content: text.slice(lastIndex),
+        })
+    }
+
+    return segments
+}
+
+/**
+ * Get plain text representation for copying (with all truncated sections collapsed)
+ */
+function getPlainText(segments: TextSegment[]): string {
+    return segments.map((seg) => (seg.type === 'truncated' ? seg.content : seg.content)).join('')
+}
+
+/**
+ * Get expanded tree text for copying trace views
+ * Expands all gen_expandable nodes but keeps truncation markers collapsed
+ */
+function getExpandedTreeText(segments: TextSegment[]): string {
+    return segments
+        .map((seg) => {
+            if (seg.type === 'gen_expandable' && seg.fullContent) {
+                // Expand this node but keep any nested truncation markers collapsed
+                const nestedSegments = parseTruncatedSegments(seg.fullContent)
+                return nestedSegments.map((nestedSeg) => nestedSeg.content).join('')
+            }
+            // For truncated and text segments, use content as-is
+            return seg.content
+        })
+        .join('')
+}
+
+interface TextPart {
+    type: 'text' | 'url'
+    content: string
+}
+
+interface EventLinkPart {
+    type: 'event_link'
+    eventId: string
+    displayText: string
+}
+
+/**
+ * Parse text to find URLs and event links, split into parts
+ */
+function parseUrls(text: string, traceId?: string): Array<TextPart | EventLinkPart> {
+    const parts: Array<TextPart | EventLinkPart> = []
+
+    // Process event links first, then URLs
+    const eventLinkRegex = /<<<EVENT_LINK\|([^|]+)\|([^>]+)>>>/g
+    const urlRegex = /(https?:\/\/[^\s]+)/g
+
+    let lastIndex = 0
+    const matches: Array<{ index: number; length: number; type: 'url' | 'event_link'; data: any }> = []
+
+    // Find all event links
+    let eventMatch: RegExpExecArray | null
+    while ((eventMatch = eventLinkRegex.exec(text)) !== null) {
+        matches.push({
+            index: eventMatch.index,
+            length: eventMatch[0].length,
+            type: 'event_link',
+            data: { eventId: eventMatch[1], displayText: eventMatch[2] },
+        })
+    }
+
+    // Find all URLs
+    let urlMatch: RegExpExecArray | null
+    while ((urlMatch = urlRegex.exec(text)) !== null) {
+        matches.push({
+            index: urlMatch.index,
+            length: urlMatch[0].length,
+            type: 'url',
+            data: { content: urlMatch[1] },
+        })
+    }
+
+    // Sort by index
+    matches.sort((a, b) => a.index - b.index)
+
+    // Build parts
+    for (const match of matches) {
+        // Add text before match
+        if (match.index > lastIndex) {
+            parts.push({
+                type: 'text',
+                content: text.slice(lastIndex, match.index),
+            })
+        }
+
+        // Add the match
+        if (match.type === 'url') {
+            parts.push({
+                type: 'url',
+                content: match.data.content,
+            })
+        } else if (match.type === 'event_link' && traceId) {
+            parts.push({
+                type: 'event_link',
+                eventId: match.data.eventId,
+                displayText: match.data.displayText,
+            })
+        } else {
+            // Fallback to text if no traceId
+            parts.push({
+                type: 'text',
+                content: match.data.displayText || '',
+            })
+        }
+
+        lastIndex = match.index + match.length
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+        parts.push({
+            type: 'text',
+            content: text.slice(lastIndex),
+        })
+    }
+
+    // If no matches found, return the whole text as one part
+    if (parts.length === 0) {
+        parts.push({
+            type: 'text',
+            content: text,
+        })
+    }
+
+    return parts
+}
+
+/**
+ * Render text with muted line numbers, clickable URLs and event links
+ */
+function renderTextWithLinks(text: string, traceId?: string): JSX.Element[] {
+    const parts = parseUrls(text, traceId)
+    const result: JSX.Element[] = []
+
+    parts.forEach((part, i) => {
+        if (part.type === 'url') {
+            result.push(
+                <Link key={`url-${i}`} to={part.content} target="_blank" targetBlankIcon>
+                    {part.content}
+                </Link>
+            )
+        } else if (part.type === 'event_link' && traceId) {
+            result.push(
+                <Link key={`event-${i}`} to={urls.llmAnalyticsTrace(traceId, { event: part.eventId })}>
+                    {part.displayText}
+                </Link>
+            )
+        } else {
+            // Must be TextPart - process line by line to handle line numbers
+            const content = (part as TextPart).content
+            const lines = content.split('\n')
+
+            lines.forEach((line, lineIdx) => {
+                if (lineIdx > 0) {
+                    // Add newline between lines (except before first line)
+                    result.push(<span key={`nl-${i}-${lineIdx}`}>{'\n'}</span>)
+                }
+
+                const lineMatch = line.match(/^(L\d+:)(.*)$/)
+                if (lineMatch) {
+                    const linePrefix = lineMatch[1]
+                    const lineContent = lineMatch[2]
+                    const lineNumber = parseInt(linePrefix.slice(1, -1), 10)
+                    result.push(
+                        <span key={`line-${i}-${lineIdx}`} id={`line-${lineNumber}`}>
+                            <Tooltip title="Click to copy permalink to this line">
+                                <button
+                                    type="button"
+                                    className="text-muted hover:text-link cursor-pointer"
+                                    onClick={() => {
+                                        const url = new URL(window.location.href)
+                                        url.searchParams.set('line', lineNumber.toString())
+                                        copyToClipboard(url.toString(), 'line')
+                                        lemonToast.success('Permalink copied to clipboard')
+                                    }}
+                                >
+                                    {linePrefix}
+                                </button>
+                            </Tooltip>
+                            {lineContent}
+                        </span>
+                    )
+                } else {
+                    result.push(<span key={`text-${i}-${lineIdx}`}>{line}</span>)
+                }
+            })
+        }
+    })
+
+    return result
+}
+
+interface TraceTreeNode {
+    event: any
+    children?: TraceTreeNode[]
+}
+
+/**
+ * Render content that may contain truncated segments (used for nested content)
+ */
+function NestedContentRenderer({
+    content,
+    traceId,
+    parentKey,
+    expandedSegments,
+    setExpandedSegments,
+    popoutSegment,
+    setPopoutSegment,
+}: {
+    content: string
+    traceId?: string
+    parentKey: string
+    expandedSegments: Set<number | string>
+    setExpandedSegments: React.Dispatch<React.SetStateAction<Set<number | string>>>
+    popoutSegment: number | string | null
+    setPopoutSegment: React.Dispatch<React.SetStateAction<number | string | null>>
+}): JSX.Element {
+    const nestedSegments = parseTruncatedSegments(content)
+
+    const toggleNestedSegment = (nestedIndex: number): void => {
+        const key = `${parentKey}-${nestedIndex}`
+        setExpandedSegments((prev) => {
+            const next = new Set(prev)
+            if (next.has(key)) {
+                next.delete(key)
+            } else {
+                next.add(key)
+            }
+            return next
+        })
+    }
+
+    const toggleNestedPopout = (nestedIndex: number): void => {
+        const key = `${parentKey}-${nestedIndex}`
+        setPopoutSegment((prev) => (prev === key ? null : key))
+    }
+
+    return (
+        <>
+            {nestedSegments.map((nestedSeg, nestedIdx) => {
+                const nestedKey = `${parentKey}-${nestedIdx}`
+                const isNestedExpanded = expandedSegments.has(nestedKey)
+                const isNestedPopoutOpen = popoutSegment === nestedKey
+
+                if (nestedSeg.type === 'text') {
+                    return <span key={nestedIdx}>{renderTextWithLinks(nestedSeg.content, traceId)}</span>
+                }
+
+                if (nestedSeg.type === 'tools_expandable') {
+                    // Parse full content to split into individual tools
+                    const fullContent = nestedSeg.fullContent || ''
+                    const lines = fullContent.split('\n')
+
+                    // Find header line (e.g., "AVAILABLE TOOLS: 10")
+                    const headerLine = lines[0]
+                    const toolLines = lines.slice(1) // Skip header
+
+                    // Parse individual tool blocks
+                    const toolBlocks: string[] = []
+                    let currentBlock: string[] = []
+
+                    for (const line of toolLines) {
+                        if (line.trim() === '' && currentBlock.length > 0) {
+                            toolBlocks.push(currentBlock.join('\n'))
+                            currentBlock = []
+                        } else if (line.trim() !== '') {
+                            currentBlock.push(line)
+                        }
+                    }
+                    if (currentBlock.length > 0) {
+                        toolBlocks.push(currentBlock.join('\n'))
+                    }
+
+                    // Split into first 5 and remaining
+                    const visibleTools = toolBlocks.slice(0, 5)
+                    const hiddenTools = toolBlocks.slice(5)
+
+                    return (
+                        <span key={nestedIdx}>
+                            {headerLine}
+                            {'\n\n'}
+                            {visibleTools.map((toolBlock, i) => (
+                                <span key={i}>
+                                    {renderTextWithLinks(toolBlock, traceId)}
+                                    {'\n\n'}
+                                </span>
+                            ))}
+                            {hiddenTools.length > 0 && (
+                                <>
+                                    <button
+                                        onClick={() => toggleNestedSegment(nestedIdx)}
+                                        className="text-link hover:underline cursor-pointer"
+                                        title={isNestedExpanded ? 'Collapse' : 'Expand'}
+                                    >
+                                        {isNestedExpanded ? '[−]' : '[+]'} {hiddenTools.length} more tool
+                                        {hiddenTools.length > 1 ? 's' : ''}
+                                    </button>
+                                    {isNestedExpanded && (
+                                        <div className="ml-4 mt-2 mb-2">
+                                            {hiddenTools.map((toolBlock, i) => (
+                                                <span key={i}>
+                                                    {renderTextWithLinks(toolBlock, traceId)}
+                                                    {'\n\n'}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </span>
+                    )
+                }
+
+                // Truncated segment
+                return (
+                    <span key={nestedIdx}>
+                        {isNestedExpanded ? (
+                            <>
+                                {renderTextWithLinks(nestedSeg.fullContent || '', traceId)}
+                                <button
+                                    onClick={() => toggleNestedSegment(nestedIdx)}
+                                    className="text-link hover:underline cursor-pointer ml-1"
+                                >
+                                    [collapse]
+                                </button>
+                            </>
+                        ) : (
+                            <>
+                                <button
+                                    onClick={() => toggleNestedSegment(nestedIdx)}
+                                    className="text-link hover:underline cursor-pointer"
+                                >
+                                    {nestedSeg.content}
+                                </button>
+                                <Tooltip
+                                    title={
+                                        isNestedPopoutOpen ? (
+                                            <div
+                                                data-popout-content
+                                                className="max-h-96 overflow-auto whitespace-pre-wrap font-mono text-xs"
+                                            >
+                                                {nestedSeg.fullContent}
+                                            </div>
+                                        ) : null
+                                    }
+                                    containerClassName="max-w-4xl"
+                                    placement="top"
+                                    visible={isNestedPopoutOpen}
+                                >
+                                    <button
+                                        data-popout-button
+                                        onClick={(e) => {
+                                            e.stopPropagation()
+                                            toggleNestedPopout(nestedIdx)
+                                        }}
+                                        className="inline-flex items-center justify-center w-4 h-4 ml-1 text-muted hover:text-default transition-colors"
+                                        title="Preview truncated content"
+                                    >
+                                        <IconExternal className="w-3 h-3" />
+                                    </button>
+                                </Tooltip>
+                            </>
+                        )}
+                    </span>
+                )
+            })}
+        </>
+    )
+}
+
+export function TextViewDisplay({
+    event,
+    trace,
+    tree,
+    onFallback,
+    lineNumber,
+}: {
+    event?: LLMTraceEvent
+    trace?: LLMTrace
+    tree?: TraceTreeNode[]
+    onFallback?: () => void
+    lineNumber?: number | null
+}): JSX.Element {
+    const { currentTeamId } = useValues(teamLogic)
+    const [copied, setCopied] = useState(false)
+    const [textRepr, setTextRepr] = useState<string>('')
+    const [loading, setLoading] = useState<boolean>(true)
+    const [error, setError] = useState<string | null>(null)
+    const [fallbackTriggered, setFallbackTriggered] = useState<boolean>(false)
+
+    // Get trace ID for event links
+    const traceId = trace?.id
+
+    // Scroll to line when lineNumber changes
+    useEffect(() => {
+        if (lineNumber && !loading) {
+            // Small delay to ensure the content is rendered
+            setTimeout(() => {
+                const element = document.getElementById(`line-${lineNumber}`)
+                if (element) {
+                    element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                    // Highlight temporarily
+                    element.classList.add('bg-warning-highlight', 'border-l-4', 'border-warning')
+                    setTimeout(() => {
+                        element.classList.remove('bg-warning-highlight', 'border-l-4', 'border-warning')
+                    }, 3000)
+                }
+            }, 100)
+        }
+    }, [lineNumber, loading])
+
+    // Fetch text representation from API
+    useEffect(() => {
+        const fetchTextRepr = async (): Promise<void> => {
+            try {
+                setLoading(true)
+                setError(null)
+                setFallbackTriggered(false)
+                // Reset expanded state when switching events
+                setExpandedSegments(new Set())
+                setPopoutSegment(null)
+
+                // Prepare request based on what data we have
+                let requestData: any
+
+                if (trace && tree) {
+                    // Full trace view - need to send tree structure with children
+                    // Recursively convert tree nodes to { event, children } format
+                    const convertTreeNode = (node: TraceTreeNode): any => ({
+                        event: node.event,
+                        children: node.children ? node.children.map(convertTreeNode) : [],
+                    })
+
+                    requestData = {
+                        event_type: '$ai_trace',
+                        data: {
+                            trace: {
+                                ...trace,
+                                trace_id: trace.id,
+                                name: trace.traceName || 'Trace',
+                            },
+                            hierarchy: tree.map(convertTreeNode),
+                        },
+                        options: {
+                            truncated: true,
+                            include_markers: true,
+                            include_line_numbers: true,
+                        },
+                    }
+                } else if (event) {
+                    // Single event view
+                    requestData = {
+                        event_type: event.event,
+                        data: event,
+                        options: {
+                            truncated: true,
+                            include_markers: true,
+                            include_line_numbers: true,
+                        },
+                    }
+                } else {
+                    setTextRepr('')
+                    setLoading(false)
+                    return
+                }
+
+                // Create abort controller for timeout
+                const abortController = new AbortController()
+                const timeoutId = setTimeout(() => abortController.abort(), 10000) // 10 second timeout
+
+                try {
+                    // Call Django API with timeout
+                    const response = await api.create(
+                        `api/environments/${currentTeamId}/llm_analytics/text_repr/`,
+                        requestData,
+                        { signal: abortController.signal }
+                    )
+                    clearTimeout(timeoutId)
+                    setTextRepr(response.text || '')
+                } catch (apiErr) {
+                    clearTimeout(timeoutId)
+                    throw apiErr
+                }
+            } catch (err) {
+                console.error('Error fetching text representation:', err)
+                const isTimeout = err instanceof Error && err.name === 'AbortError'
+                const errorMessage = isTimeout
+                    ? 'Text view generation timed out'
+                    : err instanceof Error
+                      ? err.message
+                      : 'Failed to load text representation'
+
+                setError(errorMessage)
+
+                // Trigger fallback to standard view
+                setFallbackTriggered(true)
+                if (onFallback) {
+                    // Small delay to show the fallback message briefly
+                    setTimeout(() => {
+                        onFallback()
+                    }, 1500)
+                }
+            } finally {
+                setLoading(false)
+            }
+        }
+
+        void fetchTextRepr()
+    }, [event, trace, tree, currentTeamId, onFallback])
+
+    const segments = parseTextSegments(textRepr)
+
+    const [expandedSegments, setExpandedSegments] = useState<Set<number | string>>(new Set())
+    const [popoutSegment, setPopoutSegment] = useState<number | string | null>(null)
+
+    // Get indices of all expandable segments (truncated, gen_expandable, tools_expandable)
+    const truncatedIndices = segments
+        .map((seg, idx) => (seg.type === 'truncated' ? idx : -1))
+        .filter((idx) => idx !== -1)
+
+    const genExpandableIndices = segments
+        .map((seg, idx) => (seg.type === 'gen_expandable' ? idx : -1))
+        .filter((idx) => idx !== -1)
+
+    const toolsExpandableIndices = segments
+        .map((seg, idx) => (seg.type === 'tools_expandable' ? idx : -1))
+        .filter((idx) => idx !== -1)
+
+    const allExpandableIndices = [...truncatedIndices, ...genExpandableIndices, ...toolsExpandableIndices]
+
+    const allExpanded =
+        allExpandableIndices.length > 0 && allExpandableIndices.every((idx) => expandedSegments.has(idx))
+
+    // Close popout when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent): void => {
+            // Close if clicking outside and popout is open
+            if (popoutSegment !== null) {
+                const target = event.target as HTMLElement
+                // Don't close if clicking on the tooltip or the button
+                if (!target.closest('[data-popout-content]') && !target.closest('[data-popout-button]')) {
+                    setPopoutSegment(null)
+                }
+            }
+        }
+
+        if (popoutSegment !== null) {
+            document.addEventListener('mousedown', handleClickOutside)
+            return () => {
+                document.removeEventListener('mousedown', handleClickOutside)
+            }
+        }
+    }, [popoutSegment])
+
+    const handleCopy = (): void => {
+        // Check if we have gen_expandable segments (trace view)
+        const hasGenExpandable = segments.some((seg) => seg.type === 'gen_expandable')
+
+        // For trace views, copy the full expanded tree with truncation markers
+        // For single events, copy the plain text as-is
+        const textToCopy = hasGenExpandable ? getExpandedTreeText(segments) : getPlainText(segments)
+
+        copyToClipboard(textToCopy, 'generation text')
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+    }
+
+    const toggleSegment = (index: number): void => {
+        setExpandedSegments((prev) => {
+            const next = new Set(prev)
+            if (next.has(index)) {
+                next.delete(index)
+            } else {
+                next.add(index)
+            }
+            return next
+        })
+    }
+
+    const toggleExpandAll = (): void => {
+        if (allExpanded) {
+            // Collapse all
+            setExpandedSegments(new Set())
+        } else {
+            // Expand all (truncated, gen_expandable, and tools_expandable segments)
+            setExpandedSegments(new Set(allExpandableIndices))
+        }
+    }
+
+    const togglePopout = (index: number): void => {
+        setPopoutSegment((prev) => (prev === index ? null : index))
+    }
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center p-8 bg-bg-light rounded border border-border">
+                <Spinner className="text-2xl" />
+                <span className="ml-2">Loading text representation...</span>
+            </div>
+        )
+    }
+
+    if (error) {
+        return (
+            <div className="p-4 bg-bg-light rounded border border-border">
+                <div className="flex items-start gap-2">
+                    <div className="flex-1">
+                        <div className="text-warning font-semibold mb-1">{error}</div>
+                        {fallbackTriggered && <div className="text-muted text-xs">Switching to standard view...</div>}
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="relative flex flex-col flex-1 min-h-0">
+            <div className="absolute top-2 right-2 z-10 flex gap-2">
+                {allExpandableIndices.length > 0 && (
+                    <LemonButton
+                        type="secondary"
+                        size="xsmall"
+                        onClick={toggleExpandAll}
+                        tooltip={allExpanded ? 'Collapse all expandable sections' : 'Expand all expandable sections'}
+                    >
+                        {allExpanded ? 'Collapse all' : 'Expand all'}
+                    </LemonButton>
+                )}
+                <LemonButton
+                    type="secondary"
+                    size="xsmall"
+                    icon={<IconCopy />}
+                    onClick={handleCopy}
+                    tooltip={copied ? 'Copied!' : 'Copy text representation'}
+                >
+                    {copied ? 'Copied!' : 'Copy text'}
+                </LemonButton>
+            </div>
+            <pre className="font-mono text-xs whitespace-pre-wrap p-4 bg-bg-light rounded border border-border overflow-auto flex-1 min-h-0 max-h-[200vh]">
+                {segments.map((segment, index) => {
+                    if (segment.type === 'text') {
+                        // Trim trailing whitespace if followed by gen_expandable
+                        const nextSegment = segments[index + 1]
+                        const content =
+                            nextSegment?.type === 'gen_expandable' ? segment.content.trimEnd() : segment.content
+                        return <span key={index}>{renderTextWithLinks(content, traceId)}</span>
+                    }
+                    if (segment.type === 'gen_expandable') {
+                        const isExpanded = expandedSegments.has(index)
+                        // Extract [GEN], [SPAN], or [EMBED] tag and rest of content
+                        const tagMatch = segment.content.match(/^(\[(?:GEN|SPAN|EMBED)\])\s*(.*)$/)
+                        const tag = tagMatch ? tagMatch[1] : segment.content
+                        const restContent = tagMatch ? tagMatch[2] : segment.content
+                        return (
+                            <span key={index}>
+                                <Link
+                                    to={urls.llmAnalyticsTrace(traceId!, { event: segment.eventId })}
+                                    title="Jump to event"
+                                >
+                                    {tag}
+                                </Link>
+                                <button
+                                    onClick={() => toggleSegment(index)}
+                                    className="text-link hover:underline cursor-pointer"
+                                    title={isExpanded ? 'Collapse' : 'Expand'}
+                                >
+                                    {isExpanded ? '[−]' : '[+]'}
+                                </button>{' '}
+                                {restContent.trim()}
+                                {isExpanded && (
+                                    <div className="ml-4 mt-2 mb-2 pl-4 border-l-2 border-border">
+                                        <NestedContentRenderer
+                                            content={segment.fullContent || ''}
+                                            traceId={traceId}
+                                            parentKey={`gen-${index}`}
+                                            expandedSegments={expandedSegments}
+                                            setExpandedSegments={setExpandedSegments}
+                                            popoutSegment={popoutSegment}
+                                            setPopoutSegment={setPopoutSegment}
+                                        />
+                                    </div>
+                                )}
+                            </span>
+                        )
+                    }
+                    if (segment.type === 'tools_expandable') {
+                        const isExpanded = expandedSegments.has(index)
+
+                        // Parse full content to split into individual tools
+                        const fullContent = segment.fullContent || ''
+                        const lines = fullContent.split('\n')
+
+                        // Find header line (e.g., "AVAILABLE TOOLS: 10")
+                        const headerLine = lines[0]
+                        const toolLines = lines.slice(1) // Skip header
+
+                        // Parse individual tool blocks (tool_name(), description, blank line)
+                        const toolBlocks: string[] = []
+                        let currentBlock: string[] = []
+
+                        for (const line of toolLines) {
+                            if (line.trim() === '' && currentBlock.length > 0) {
+                                // End of a tool block
+                                toolBlocks.push(currentBlock.join('\n'))
+                                currentBlock = []
+                            } else if (line.trim() !== '') {
+                                currentBlock.push(line)
+                            }
+                        }
+                        // Add last block if exists
+                        if (currentBlock.length > 0) {
+                            toolBlocks.push(currentBlock.join('\n'))
+                        }
+
+                        // Split into first 5 and remaining
+                        const visibleTools = toolBlocks.slice(0, 5)
+                        const hiddenTools = toolBlocks.slice(5)
+
+                        return (
+                            <span key={index}>
+                                {headerLine}
+                                {'\n\n'}
+                                {/* Show first 5 tools inline */}
+                                {visibleTools.map((toolBlock, i) => (
+                                    <span key={i}>
+                                        {renderTextWithLinks(toolBlock, traceId)}
+                                        {'\n\n'}
+                                    </span>
+                                ))}
+                                {/* Show expandable for remaining tools */}
+                                {hiddenTools.length > 0 && (
+                                    <>
+                                        <button
+                                            onClick={() => toggleSegment(index)}
+                                            className="text-link hover:underline cursor-pointer"
+                                            title={isExpanded ? 'Collapse' : 'Expand'}
+                                        >
+                                            {isExpanded ? '[−]' : '[+]'} {hiddenTools.length} more tool
+                                            {hiddenTools.length > 1 ? 's' : ''}
+                                        </button>
+                                        {isExpanded && (
+                                            <div className="ml-4 mt-2 mb-2">
+                                                {hiddenTools.map((toolBlock, i) => (
+                                                    <span key={i}>
+                                                        {renderTextWithLinks(toolBlock, traceId)}
+                                                        {'\n\n'}
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </>
+                                )}
+                            </span>
+                        )
+                    }
+                    // Truncated segment
+                    const isExpanded = expandedSegments.has(index)
+                    const isPopoutOpen = popoutSegment === index
+                    return (
+                        <span key={index}>
+                            {isExpanded ? (
+                                <>
+                                    {renderTextWithLinks(segment.fullContent || '', traceId)}
+                                    <button
+                                        onClick={() => toggleSegment(index)}
+                                        className="text-link hover:underline cursor-pointer ml-1"
+                                    >
+                                        [collapse]
+                                    </button>
+                                </>
+                            ) : (
+                                <>
+                                    <button
+                                        onClick={() => toggleSegment(index)}
+                                        className="text-link hover:underline cursor-pointer"
+                                    >
+                                        {segment.content}
+                                    </button>
+                                    <Tooltip
+                                        title={
+                                            isPopoutOpen ? (
+                                                <div
+                                                    data-popout-content
+                                                    className="max-h-96 overflow-auto whitespace-pre-wrap font-mono text-xs"
+                                                >
+                                                    {segment.fullContent}
+                                                </div>
+                                            ) : null
+                                        }
+                                        containerClassName="max-w-4xl"
+                                        placement="top"
+                                        visible={isPopoutOpen}
+                                    >
+                                        <button
+                                            data-popout-button
+                                            onClick={(e) => {
+                                                e.stopPropagation()
+                                                togglePopout(index)
+                                            }}
+                                            className="inline-flex items-center justify-center w-4 h-4 ml-1 text-muted hover:text-default transition-colors"
+                                            title="Preview truncated content"
+                                        >
+                                            <IconExternal className="w-3 h-3" />
+                                        </button>
+                                    </Tooltip>
+                                </>
+                            )}
+                        </span>
+                    )
+                })}
+            </pre>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -641,6 +641,8 @@ export function TextViewDisplay({
     const [loading, setLoading] = useState<boolean>(true)
     const [error, setError] = useState<string | null>(null)
     const [fallbackTriggered, setFallbackTriggered] = useState<boolean>(false)
+    const [expandedSegments, setExpandedSegments] = useState<Set<number | string>>(new Set())
+    const [popoutSegment, setPopoutSegment] = useState<number | string | null>(null)
 
     // Get trace ID for event links
     const traceId = trace?.id
@@ -763,9 +765,6 @@ export function TextViewDisplay({
     }, [event, trace, tree, currentTeamId, onFallback])
 
     const segments = parseTextSegments(textRepr)
-
-    const [expandedSegments, setExpandedSegments] = useState<Set<number | string>>(new Set())
-    const [popoutSegment, setPopoutSegment] = useState<number | string | null>(null)
 
     // Get indices of all expandable segments (truncated, gen_expandable, tools_expandable)
     const truncatedIndices = segments

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -16,6 +16,19 @@ import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
 
 import { textViewLogic } from './textViewLogic'
 
+/**
+ * Decode base64-encoded UTF-8 string properly
+ * Using TextDecoder to handle emoji and special characters correctly
+ */
+function decodeBase64Utf8(base64String: string): string {
+    const binaryString = atob(base64String)
+    const bytes = new Uint8Array(binaryString.length)
+    for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i)
+    }
+    return new TextDecoder('utf-8').decode(bytes)
+}
+
 interface TextSegment {
     type: 'text' | 'truncated' | 'gen_expandable' | 'tools_expandable'
     content: string
@@ -78,7 +91,7 @@ function parseTruncatedSegments(text: string): TextSegment[] {
         if (match.type === 'truncated') {
             // Add truncated segment
             try {
-                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
                 segments.push({
                     type: 'truncated',
                     content: `... (${match.data.charCount} chars truncated)`,
@@ -95,7 +108,7 @@ function parseTruncatedSegments(text: string): TextSegment[] {
         } else if (match.type === 'tools_expandable') {
             // Add tools expandable segment
             try {
-                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
                 segments.push({
                     type: 'tools_expandable',
                     content: match.data.displayText,
@@ -192,7 +205,7 @@ function parseTextSegments(text: string): TextSegment[] {
         if (match.type === 'truncated') {
             // Add truncated segment
             try {
-                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
                 segments.push({
                     type: 'truncated',
                     content: `... (${match.data.charCount} chars truncated)`,
@@ -209,7 +222,7 @@ function parseTextSegments(text: string): TextSegment[] {
         } else if (match.type === 'gen_expandable') {
             // Add gen expandable segment
             try {
-                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
                 segments.push({
                     type: 'gen_expandable',
                     content: match.data.displayText,
@@ -226,7 +239,7 @@ function parseTextSegments(text: string): TextSegment[] {
         } else if (match.type === 'tools_expandable') {
             // Add tools expandable segment
             try {
-                const fullContent = decodeURIComponent(atob(match.data.encodedContent))
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
                 segments.push({
                     type: 'tools_expandable',
                     content: match.data.displayText,

--- a/products/llm_analytics/frontend/text-view/components/LineWithNumber.tsx
+++ b/products/llm_analytics/frontend/text-view/components/LineWithNumber.tsx
@@ -6,16 +6,21 @@ import { useEffect, useRef } from 'react'
 
 import { Tooltip } from '@posthog/lemon-ui'
 
-import { copyToClipboard } from 'lib/utils/copyToClipboard'
-
 interface LineWithNumberProps {
     lineNumber: number
     content: string
     isActive: boolean
     padding: number
+    onCopyPermalink?: (lineNumber: number) => void
 }
 
-export function LineWithNumber({ lineNumber, content, isActive, padding }: LineWithNumberProps): JSX.Element {
+export function LineWithNumber({
+    lineNumber,
+    content,
+    isActive,
+    padding,
+    onCopyPermalink,
+}: LineWithNumberProps): JSX.Element {
     const lineRef = useRef<HTMLSpanElement>(null)
 
     useEffect(() => {
@@ -30,9 +35,9 @@ export function LineWithNumber({ lineNumber, content, isActive, padding }: LineW
     }, [isActive])
 
     const handleCopyPermalink = (): void => {
-        const url = new URL(window.location.href)
-        url.searchParams.set('line', lineNumber.toString())
-        copyToClipboard(url.toString(), 'permalink')
+        if (onCopyPermalink) {
+            onCopyPermalink(lineNumber)
+        }
     }
 
     const paddedLineNumber = padding > 0 ? lineNumber.toString().padStart(padding, '0') : lineNumber.toString()

--- a/products/llm_analytics/frontend/text-view/components/LineWithNumber.tsx
+++ b/products/llm_analytics/frontend/text-view/components/LineWithNumber.tsx
@@ -1,0 +1,54 @@
+/**
+ * Line rendering component with line number and permalink functionality
+ * Uses ref for proper scroll handling
+ */
+import { useEffect, useRef } from 'react'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+
+interface LineWithNumberProps {
+    lineNumber: number
+    content: string
+    isActive: boolean
+    padding: number
+}
+
+export function LineWithNumber({ lineNumber, content, isActive, padding }: LineWithNumberProps): JSX.Element {
+    const lineRef = useRef<HTMLSpanElement>(null)
+
+    useEffect(() => {
+        if (isActive && lineRef.current) {
+            lineRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            lineRef.current.classList.add('bg-warning-highlight', 'border-l-4', 'border-warning')
+            const timer = setTimeout(() => {
+                lineRef.current?.classList.remove('bg-warning-highlight', 'border-l-4', 'border-warning')
+            }, 3000)
+            return () => clearTimeout(timer)
+        }
+    }, [isActive])
+
+    const handleCopyPermalink = (): void => {
+        const url = new URL(window.location.href)
+        url.searchParams.set('line', lineNumber.toString())
+        copyToClipboard(url.toString(), 'permalink')
+    }
+
+    const paddedLineNumber = padding > 0 ? lineNumber.toString().padStart(padding, '0') : lineNumber.toString()
+
+    return (
+        <span ref={lineRef}>
+            <Tooltip title="Click to copy permalink to this line">
+                <button
+                    type="button"
+                    className="text-muted hover:text-link cursor-pointer"
+                    onClick={handleCopyPermalink}
+                >
+                    L{paddedLineNumber}:
+                </button>
+            </Tooltip>
+            {content}
+        </span>
+    )
+}

--- a/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
@@ -14,9 +14,9 @@ interface NestedContentRendererProps {
     traceId?: string
     parentKey: string
     expandedSegments: Set<number | string>
-    setExpandedSegments: React.Dispatch<React.SetStateAction<Set<number | string>>>
+    setExpandedSegments: (segments: Set<number | string>) => void
     popoutSegment: number | string | null
-    setPopoutSegment: React.Dispatch<React.SetStateAction<number | string | null>>
+    setPopoutSegment: (index: number | string | null) => void
     activeLineNumber?: number | null
     lineNumberPadding?: number
 }
@@ -36,20 +36,18 @@ export function NestedContentRenderer({
 
     const toggleNestedSegment = (nestedIndex: number): void => {
         const key = `${parentKey}-${nestedIndex}`
-        setExpandedSegments((prev) => {
-            const next = new Set(prev)
-            if (next.has(key)) {
-                next.delete(key)
-            } else {
-                next.add(key)
-            }
-            return next
-        })
+        const next = new Set(expandedSegments)
+        if (next.has(key)) {
+            next.delete(key)
+        } else {
+            next.add(key)
+        }
+        setExpandedSegments(next)
     }
 
     const toggleNestedPopout = (nestedIndex: number): void => {
         const key = `${parentKey}-${nestedIndex}`
-        setPopoutSegment((prev) => (prev === key ? null : key))
+        setPopoutSegment(popoutSegment === key ? null : key)
     }
 
     return (

--- a/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
@@ -19,6 +19,7 @@ interface NestedContentRendererProps {
     setPopoutSegment: (index: number | string | null) => void
     activeLineNumber?: number | null
     lineNumberPadding?: number
+    onCopyPermalink?: (lineNumber: number) => void
 }
 
 export function NestedContentRenderer({
@@ -31,6 +32,7 @@ export function NestedContentRenderer({
     setPopoutSegment,
     activeLineNumber,
     lineNumberPadding,
+    onCopyPermalink,
 }: NestedContentRendererProps): JSX.Element {
     const nestedSegments = parseTruncatedSegments(content)
 
@@ -65,6 +67,7 @@ export function NestedContentRenderer({
                                 traceId={traceId}
                                 activeLineNumber={activeLineNumber}
                                 lineNumberPadding={lineNumberPadding}
+                                onCopyPermalink={onCopyPermalink}
                             />
                         </span>
                     )
@@ -110,6 +113,7 @@ export function NestedContentRenderer({
                                         traceId={traceId}
                                         activeLineNumber={activeLineNumber}
                                         lineNumberPadding={lineNumberPadding}
+                                        onCopyPermalink={onCopyPermalink}
                                     />
                                     {'\n\n'}
                                 </span>
@@ -133,6 +137,7 @@ export function NestedContentRenderer({
                                                         traceId={traceId}
                                                         activeLineNumber={activeLineNumber}
                                                         lineNumberPadding={lineNumberPadding}
+                                                        onCopyPermalink={onCopyPermalink}
                                                     />
                                                     {'\n\n'}
                                                 </span>
@@ -155,6 +160,7 @@ export function NestedContentRenderer({
                                     traceId={traceId}
                                     activeLineNumber={activeLineNumber}
                                     lineNumberPadding={lineNumberPadding}
+                                    onCopyPermalink={onCopyPermalink}
                                 />
                                 <button
                                     onClick={() => toggleNestedSegment(nestedIdx)}

--- a/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
@@ -5,6 +5,7 @@
 import { IconExternal } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
 
+import { VISIBLE_TOOLS_COUNT } from '../constants'
 import { parseTruncatedSegments } from '../parsing'
 import { TextWithLinks } from './TextWithLinks'
 
@@ -96,9 +97,9 @@ export function NestedContentRenderer({
                         toolBlocks.push(currentBlock.join('\n'))
                     }
 
-                    // Split into first 5 and remaining
-                    const visibleTools = toolBlocks.slice(0, 5)
-                    const hiddenTools = toolBlocks.slice(5)
+                    // Split into visible and remaining tools
+                    const visibleTools = toolBlocks.slice(0, VISIBLE_TOOLS_COUNT)
+                    const hiddenTools = toolBlocks.slice(VISIBLE_TOOLS_COUNT)
 
                     return (
                         <span key={nestedIdx}>

--- a/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/NestedContentRenderer.tsx
@@ -1,0 +1,209 @@
+/**
+ * Component for rendering nested content that may contain truncated segments
+ * Used for expandable sections within the main text view
+ */
+import { IconExternal } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { parseTruncatedSegments } from '../parsing'
+import { TextWithLinks } from './TextWithLinks'
+
+interface NestedContentRendererProps {
+    content: string
+    traceId?: string
+    parentKey: string
+    expandedSegments: Set<number | string>
+    setExpandedSegments: React.Dispatch<React.SetStateAction<Set<number | string>>>
+    popoutSegment: number | string | null
+    setPopoutSegment: React.Dispatch<React.SetStateAction<number | string | null>>
+    activeLineNumber?: number | null
+    lineNumberPadding?: number
+}
+
+export function NestedContentRenderer({
+    content,
+    traceId,
+    parentKey,
+    expandedSegments,
+    setExpandedSegments,
+    popoutSegment,
+    setPopoutSegment,
+    activeLineNumber,
+    lineNumberPadding,
+}: NestedContentRendererProps): JSX.Element {
+    const nestedSegments = parseTruncatedSegments(content)
+
+    const toggleNestedSegment = (nestedIndex: number): void => {
+        const key = `${parentKey}-${nestedIndex}`
+        setExpandedSegments((prev) => {
+            const next = new Set(prev)
+            if (next.has(key)) {
+                next.delete(key)
+            } else {
+                next.add(key)
+            }
+            return next
+        })
+    }
+
+    const toggleNestedPopout = (nestedIndex: number): void => {
+        const key = `${parentKey}-${nestedIndex}`
+        setPopoutSegment((prev) => (prev === key ? null : key))
+    }
+
+    return (
+        <>
+            {nestedSegments.map((nestedSeg, nestedIdx) => {
+                const nestedKey = `${parentKey}-${nestedIdx}`
+                const isNestedExpanded = expandedSegments.has(nestedKey)
+                const isNestedPopoutOpen = popoutSegment === nestedKey
+
+                if (nestedSeg.type === 'text') {
+                    return (
+                        <span key={nestedIdx}>
+                            <TextWithLinks
+                                text={nestedSeg.content}
+                                traceId={traceId}
+                                activeLineNumber={activeLineNumber}
+                                lineNumberPadding={lineNumberPadding}
+                            />
+                        </span>
+                    )
+                }
+
+                if (nestedSeg.type === 'tools_expandable') {
+                    // Parse full content to split into individual tools
+                    const fullContent = nestedSeg.fullContent || ''
+                    const lines = fullContent.split('\n')
+
+                    // Find header line (e.g., "AVAILABLE TOOLS: 10")
+                    const headerLine = lines[0]
+                    const toolLines = lines.slice(1) // Skip header
+
+                    // Parse individual tool blocks
+                    const toolBlocks: string[] = []
+                    let currentBlock: string[] = []
+
+                    for (const line of toolLines) {
+                        if (line.trim() === '' && currentBlock.length > 0) {
+                            toolBlocks.push(currentBlock.join('\n'))
+                            currentBlock = []
+                        } else if (line.trim() !== '') {
+                            currentBlock.push(line)
+                        }
+                    }
+                    if (currentBlock.length > 0) {
+                        toolBlocks.push(currentBlock.join('\n'))
+                    }
+
+                    // Split into first 5 and remaining
+                    const visibleTools = toolBlocks.slice(0, 5)
+                    const hiddenTools = toolBlocks.slice(5)
+
+                    return (
+                        <span key={nestedIdx}>
+                            {headerLine}
+                            {'\n\n'}
+                            {visibleTools.map((toolBlock, i) => (
+                                <span key={i}>
+                                    <TextWithLinks
+                                        text={toolBlock}
+                                        traceId={traceId}
+                                        activeLineNumber={activeLineNumber}
+                                        lineNumberPadding={lineNumberPadding}
+                                    />
+                                    {'\n\n'}
+                                </span>
+                            ))}
+                            {hiddenTools.length > 0 && (
+                                <>
+                                    <button
+                                        onClick={() => toggleNestedSegment(nestedIdx)}
+                                        className="text-link hover:underline cursor-pointer"
+                                        title={isNestedExpanded ? 'Collapse' : 'Expand'}
+                                    >
+                                        {isNestedExpanded ? '[−]' : '[+]'} {hiddenTools.length} more tool
+                                        {hiddenTools.length > 1 ? 's' : ''}
+                                    </button>
+                                    {isNestedExpanded && (
+                                        <div className="ml-4 mt-2 mb-2">
+                                            {hiddenTools.map((toolBlock, i) => (
+                                                <span key={i}>
+                                                    <TextWithLinks
+                                                        text={toolBlock}
+                                                        traceId={traceId}
+                                                        activeLineNumber={activeLineNumber}
+                                                        lineNumberPadding={lineNumberPadding}
+                                                    />
+                                                    {'\n\n'}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </span>
+                    )
+                }
+
+                // Truncated segment
+                return (
+                    <span key={nestedIdx}>
+                        {isNestedExpanded ? (
+                            <>
+                                <TextWithLinks
+                                    text={nestedSeg.fullContent || ''}
+                                    traceId={traceId}
+                                    activeLineNumber={activeLineNumber}
+                                    lineNumberPadding={lineNumberPadding}
+                                />
+                                <button
+                                    onClick={() => toggleNestedSegment(nestedIdx)}
+                                    className="text-link hover:underline cursor-pointer ml-1"
+                                >
+                                    [collapse]
+                                </button>
+                            </>
+                        ) : (
+                            <>
+                                <button
+                                    onClick={() => toggleNestedSegment(nestedIdx)}
+                                    className="text-link hover:underline cursor-pointer"
+                                >
+                                    {nestedSeg.content}
+                                </button>
+                                <Tooltip
+                                    title={
+                                        isNestedPopoutOpen ? (
+                                            <div
+                                                data-popout-content
+                                                className="max-h-96 overflow-auto whitespace-pre-wrap font-mono text-xs"
+                                            >
+                                                {nestedSeg.fullContent}
+                                            </div>
+                                        ) : null
+                                    }
+                                    containerClassName="max-w-4xl"
+                                    placement="top"
+                                    visible={isNestedPopoutOpen}
+                                >
+                                    <button
+                                        data-popout-button
+                                        onClick={(e) => {
+                                            e.stopPropagation()
+                                            toggleNestedPopout(nestedIdx)
+                                        }}
+                                        className="inline-flex items-center justify-center w-4 h-4 ml-1 text-muted hover:text-default transition-colors"
+                                        title="Preview truncated content"
+                                    >
+                                        <IconExternal className="w-3 h-3" />
+                                    </button>
+                                </Tooltip>
+                            </>
+                        )}
+                    </span>
+                )
+            })}
+        </>
+    )
+}

--- a/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
@@ -1,0 +1,213 @@
+/**
+ * Component for rendering different segment types (truncated, gen_expandable, tools_expandable)
+ */
+import { IconExternal } from '@posthog/icons'
+import { Link, Tooltip } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { TextSegment } from '../parsing'
+import { NestedContentRenderer } from './NestedContentRenderer'
+import { TextWithLinks } from './TextWithLinks'
+
+interface SegmentRendererProps {
+    segment: TextSegment
+    index: number
+    traceId?: string
+    isExpanded: boolean
+    isPopoutOpen: boolean
+    onToggleExpand: (index: number) => void
+    onTogglePopout: (index: number) => void
+    expandedSegments: Set<number | string>
+    setExpandedSegments: React.Dispatch<React.SetStateAction<Set<number | string>>>
+    popoutSegment: number | string | null
+    setPopoutSegment: React.Dispatch<React.SetStateAction<number | string | null>>
+    activeLineNumber?: number | null
+    lineNumberPadding?: number
+}
+
+export function SegmentRenderer({
+    segment,
+    index,
+    traceId,
+    isExpanded,
+    isPopoutOpen,
+    onToggleExpand,
+    onTogglePopout,
+    expandedSegments,
+    setExpandedSegments,
+    popoutSegment,
+    setPopoutSegment,
+    activeLineNumber,
+    lineNumberPadding,
+}: SegmentRendererProps): JSX.Element {
+    if (segment.type === 'gen_expandable') {
+        // Extract [GEN], [SPAN], or [EMBED] tag and rest of content
+        const tagMatch = segment.content.match(/^(\[(?:GEN|SPAN|EMBED)\])\s*(.*)$/)
+        const tag = tagMatch ? tagMatch[1] : segment.content
+        const restContent = tagMatch ? tagMatch[2] : segment.content
+
+        return (
+            <span>
+                <Link to={urls.llmAnalyticsTrace(traceId!, { event: segment.eventId })} title="Jump to event">
+                    {tag}
+                </Link>
+                <button
+                    onClick={() => onToggleExpand(index)}
+                    className="text-link hover:underline cursor-pointer"
+                    title={isExpanded ? 'Collapse' : 'Expand'}
+                >
+                    {isExpanded ? '[−]' : '[+]'}
+                </button>{' '}
+                {restContent.trim()}
+                {isExpanded && (
+                    <div className="ml-4 mt-2 mb-2 pl-4 border-l-2 border-border">
+                        <NestedContentRenderer
+                            content={segment.fullContent || ''}
+                            traceId={traceId}
+                            parentKey={`gen-${index}`}
+                            expandedSegments={expandedSegments}
+                            setExpandedSegments={setExpandedSegments}
+                            popoutSegment={popoutSegment}
+                            setPopoutSegment={setPopoutSegment}
+                            activeLineNumber={activeLineNumber}
+                            lineNumberPadding={lineNumberPadding}
+                        />
+                    </div>
+                )}
+            </span>
+        )
+    }
+
+    if (segment.type === 'tools_expandable') {
+        // Parse full content to split into individual tools
+        const fullContent = segment.fullContent || ''
+        const lines = fullContent.split('\n')
+
+        // Find header line (e.g., "AVAILABLE TOOLS: 10")
+        const headerLine = lines[0]
+        const toolLines = lines.slice(1) // Skip header
+
+        // Parse individual tool blocks (tool_name(), description, blank line)
+        const toolBlocks: string[] = []
+        let currentBlock: string[] = []
+
+        for (const line of toolLines) {
+            if (line.trim() === '' && currentBlock.length > 0) {
+                // End of a tool block
+                toolBlocks.push(currentBlock.join('\n'))
+                currentBlock = []
+            } else if (line.trim() !== '') {
+                currentBlock.push(line)
+            }
+        }
+        // Add last block if exists
+        if (currentBlock.length > 0) {
+            toolBlocks.push(currentBlock.join('\n'))
+        }
+
+        // Split into first 5 and remaining
+        const visibleTools = toolBlocks.slice(0, 5)
+        const hiddenTools = toolBlocks.slice(5)
+
+        return (
+            <span>
+                {headerLine}
+                {'\n\n'}
+                {visibleTools.map((toolBlock, i) => (
+                    <span key={i}>
+                        <TextWithLinks
+                            text={toolBlock}
+                            traceId={traceId}
+                            activeLineNumber={activeLineNumber}
+                            lineNumberPadding={lineNumberPadding}
+                        />
+                        {'\n\n'}
+                    </span>
+                ))}
+                {hiddenTools.length > 0 && (
+                    <>
+                        <button
+                            onClick={() => onToggleExpand(index)}
+                            className="text-link hover:underline cursor-pointer"
+                            title={isExpanded ? 'Collapse' : 'Expand'}
+                        >
+                            {isExpanded ? '[−]' : '[+]'} {hiddenTools.length} more tool
+                            {hiddenTools.length > 1 ? 's' : ''}
+                        </button>
+                        {isExpanded && (
+                            <div className="ml-4 mt-2 mb-2">
+                                {hiddenTools.map((toolBlock, i) => (
+                                    <span key={i}>
+                                        <TextWithLinks
+                                            text={toolBlock}
+                                            traceId={traceId}
+                                            activeLineNumber={activeLineNumber}
+                                            lineNumberPadding={lineNumberPadding}
+                                        />
+                                        {'\n\n'}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                    </>
+                )}
+            </span>
+        )
+    }
+
+    // Truncated segment
+    return (
+        <span>
+            {isExpanded ? (
+                <>
+                    <TextWithLinks
+                        text={segment.fullContent || ''}
+                        traceId={traceId}
+                        activeLineNumber={activeLineNumber}
+                        lineNumberPadding={lineNumberPadding}
+                    />
+                    <button
+                        onClick={() => onToggleExpand(index)}
+                        className="text-link hover:underline cursor-pointer ml-1"
+                    >
+                        [collapse]
+                    </button>
+                </>
+            ) : (
+                <>
+                    <button onClick={() => onToggleExpand(index)} className="text-link hover:underline cursor-pointer">
+                        {segment.content}
+                    </button>
+                    <Tooltip
+                        title={
+                            isPopoutOpen ? (
+                                <div
+                                    data-popout-content
+                                    className="max-h-96 overflow-auto whitespace-pre-wrap font-mono text-xs"
+                                >
+                                    {segment.fullContent}
+                                </div>
+                            ) : null
+                        }
+                        containerClassName="max-w-4xl"
+                        placement="top"
+                        visible={isPopoutOpen}
+                    >
+                        <button
+                            data-popout-button
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onTogglePopout(index)
+                            }}
+                            className="inline-flex items-center justify-center w-4 h-4 ml-1 text-muted hover:text-default transition-colors"
+                            title="Preview truncated content"
+                        >
+                            <IconExternal className="w-3 h-3" />
+                        </button>
+                    </Tooltip>
+                </>
+            )}
+        </span>
+    )
+}

--- a/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
@@ -6,6 +6,7 @@ import { Link, Tooltip } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
+import { VISIBLE_TOOLS_COUNT } from '../constants'
 import { TextSegment } from '../parsing'
 import { NestedContentRenderer } from './NestedContentRenderer'
 import { TextWithLinks } from './TextWithLinks'
@@ -106,9 +107,9 @@ export function SegmentRenderer({
             toolBlocks.push(currentBlock.join('\n'))
         }
 
-        // Split into first 5 and remaining
-        const visibleTools = toolBlocks.slice(0, 5)
-        const hiddenTools = toolBlocks.slice(5)
+        // Split into visible and remaining tools
+        const visibleTools = toolBlocks.slice(0, VISIBLE_TOOLS_COUNT)
+        const hiddenTools = toolBlocks.slice(VISIBLE_TOOLS_COUNT)
 
         return (
             <span>

--- a/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
@@ -20,9 +20,9 @@ interface SegmentRendererProps {
     onToggleExpand: (index: number) => void
     onTogglePopout: (index: number) => void
     expandedSegments: Set<number | string>
-    setExpandedSegments: React.Dispatch<React.SetStateAction<Set<number | string>>>
+    setExpandedSegments: (segments: Set<number | string>) => void
     popoutSegment: number | string | null
-    setPopoutSegment: React.Dispatch<React.SetStateAction<number | string | null>>
+    setPopoutSegment: (index: number | string | null) => void
     activeLineNumber?: number | null
     lineNumberPadding?: number
 }

--- a/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
+++ b/products/llm_analytics/frontend/text-view/components/SegmentRenderer.tsx
@@ -25,6 +25,7 @@ interface SegmentRendererProps {
     setPopoutSegment: (index: number | string | null) => void
     activeLineNumber?: number | null
     lineNumberPadding?: number
+    onCopyPermalink?: (lineNumber: number) => void
 }
 
 export function SegmentRenderer({
@@ -41,6 +42,7 @@ export function SegmentRenderer({
     setPopoutSegment,
     activeLineNumber,
     lineNumberPadding,
+    onCopyPermalink,
 }: SegmentRendererProps): JSX.Element {
     if (segment.type === 'gen_expandable') {
         // Extract [GEN], [SPAN], or [EMBED] tag and rest of content
@@ -73,6 +75,7 @@ export function SegmentRenderer({
                             setPopoutSegment={setPopoutSegment}
                             activeLineNumber={activeLineNumber}
                             lineNumberPadding={lineNumberPadding}
+                            onCopyPermalink={onCopyPermalink}
                         />
                     </div>
                 )}
@@ -122,6 +125,7 @@ export function SegmentRenderer({
                             traceId={traceId}
                             activeLineNumber={activeLineNumber}
                             lineNumberPadding={lineNumberPadding}
+                            onCopyPermalink={onCopyPermalink}
                         />
                         {'\n\n'}
                     </span>
@@ -145,6 +149,7 @@ export function SegmentRenderer({
                                             traceId={traceId}
                                             activeLineNumber={activeLineNumber}
                                             lineNumberPadding={lineNumberPadding}
+                                            onCopyPermalink={onCopyPermalink}
                                         />
                                         {'\n\n'}
                                     </span>
@@ -167,6 +172,7 @@ export function SegmentRenderer({
                         traceId={traceId}
                         activeLineNumber={activeLineNumber}
                         lineNumberPadding={lineNumberPadding}
+                        onCopyPermalink={onCopyPermalink}
                     />
                     <button
                         onClick={() => onToggleExpand(index)}

--- a/products/llm_analytics/frontend/text-view/components/TextWithLinks.tsx
+++ b/products/llm_analytics/frontend/text-view/components/TextWithLinks.tsx
@@ -13,6 +13,7 @@ interface TextWithLinksProps {
     traceId?: string
     activeLineNumber?: number | null
     lineNumberPadding?: number
+    onCopyPermalink?: (lineNumber: number) => void
 }
 
 export function TextWithLinks({
@@ -20,6 +21,7 @@ export function TextWithLinks({
     traceId,
     activeLineNumber,
     lineNumberPadding = 0,
+    onCopyPermalink,
 }: TextWithLinksProps): JSX.Element {
     const parts = parseUrls(text, traceId)
     const result: JSX.Element[] = []
@@ -59,6 +61,7 @@ export function TextWithLinks({
                             content={lineContent}
                             isActive={activeLineNumber === lineNumber}
                             padding={lineNumberPadding}
+                            onCopyPermalink={onCopyPermalink}
                         />
                     )
                 } else {

--- a/products/llm_analytics/frontend/text-view/components/TextWithLinks.tsx
+++ b/products/llm_analytics/frontend/text-view/components/TextWithLinks.tsx
@@ -1,0 +1,72 @@
+/**
+ * Component for rendering text with clickable URLs, event links, and line numbers
+ */
+import { Link } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { TextPart, parseUrls } from '../parsing'
+import { LineWithNumber } from './LineWithNumber'
+
+interface TextWithLinksProps {
+    text: string
+    traceId?: string
+    activeLineNumber?: number | null
+    lineNumberPadding?: number
+}
+
+export function TextWithLinks({
+    text,
+    traceId,
+    activeLineNumber,
+    lineNumberPadding = 0,
+}: TextWithLinksProps): JSX.Element {
+    const parts = parseUrls(text, traceId)
+    const result: JSX.Element[] = []
+
+    parts.forEach((part, i) => {
+        if (part.type === 'url') {
+            result.push(
+                <Link key={`url-${i}`} to={part.content} target="_blank" targetBlankIcon>
+                    {part.content}
+                </Link>
+            )
+        } else if (part.type === 'event_link' && traceId) {
+            result.push(
+                <Link key={`event-${i}`} to={urls.llmAnalyticsTrace(traceId, { event: part.eventId })}>
+                    {part.displayText}
+                </Link>
+            )
+        } else {
+            // Must be TextPart - process line by line to handle line numbers
+            const content = (part as TextPart).content
+            const lines = content.split('\n')
+
+            lines.forEach((line, lineIdx) => {
+                if (lineIdx > 0) {
+                    // Add newline between lines (except before first line)
+                    result.push(<span key={`nl-${i}-${lineIdx}`}>{'\n'}</span>)
+                }
+
+                const lineMatch = line.match(/^(L\d+:)(.*)$/)
+                if (lineMatch) {
+                    const lineNumber = parseInt(lineMatch[1].slice(1, -1), 10)
+                    const lineContent = lineMatch[2]
+                    result.push(
+                        <LineWithNumber
+                            key={`line-${i}-${lineIdx}`}
+                            lineNumber={lineNumber}
+                            content={lineContent}
+                            isActive={activeLineNumber === lineNumber}
+                            padding={lineNumberPadding}
+                        />
+                    )
+                } else {
+                    result.push(<span key={`text-${i}-${lineIdx}`}>{line}</span>)
+                }
+            })
+        }
+    })
+
+    return <>{result}</>
+}

--- a/products/llm_analytics/frontend/text-view/components/index.ts
+++ b/products/llm_analytics/frontend/text-view/components/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Text view display components
+ */
+
+export { LineWithNumber } from './LineWithNumber'
+export { TextWithLinks } from './TextWithLinks'
+export { NestedContentRenderer } from './NestedContentRenderer'
+export { SegmentRenderer } from './SegmentRenderer'

--- a/products/llm_analytics/frontend/text-view/constants.ts
+++ b/products/llm_analytics/frontend/text-view/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Constants for text view display and behavior
+ */
+
+/** Timeout for text representation API requests in milliseconds */
+export const TEXT_REPR_API_TIMEOUT_MS = 10000 // 10 seconds
+
+/** Delay before triggering fallback to standard view in milliseconds */
+export const FALLBACK_DELAY_MS = 1500 // 1.5 seconds
+
+/** Number of tools to show before hiding the rest behind an expand button */
+export const VISIBLE_TOOLS_COUNT = 5

--- a/products/llm_analytics/frontend/text-view/parsing/index.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Parsing utilities for text view display
+ */
+
+export * from './types'
+export * from './segmentParser'
+export * from './urlParser'
+export * from './textHelpers'

--- a/products/llm_analytics/frontend/text-view/parsing/segmentParser.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/segmentParser.ts
@@ -1,0 +1,237 @@
+/**
+ * Segment parsing utilities for text view display
+ * Handles parsing of TRUNCATED, GEN_EXPANDABLE, and TOOLS_EXPANDABLE markers
+ */
+import { decodeBase64Utf8 } from './textHelpers'
+import { TextSegment } from './types'
+
+/**
+ * Parse text for TRUNCATED and TOOLS_EXPANDABLE markers (used for nested content)
+ */
+export function parseTruncatedSegments(text: string): TextSegment[] {
+    const segments: TextSegment[] = []
+    const truncatedRegex = /<<<TRUNCATED\|([^|]+)\|(\d+)>>>/g
+    const toolsExpandableRegex = /<<<TOOLS_EXPANDABLE\|([^|]+)\|([^>]+)>>>/g
+
+    const allMatches: Array<{
+        index: number
+        length: number
+        type: 'truncated' | 'tools_expandable'
+        data: any
+    }> = []
+
+    // Find all truncated markers
+    let truncMatch: RegExpExecArray | null
+    while ((truncMatch = truncatedRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: truncMatch.index,
+            length: truncMatch[0].length,
+            type: 'truncated',
+            data: { encodedContent: truncMatch[1], charCount: parseInt(truncMatch[2], 10) },
+        })
+    }
+
+    // Find all tools expandable markers
+    let toolsMatch: RegExpExecArray | null
+    while ((toolsMatch = toolsExpandableRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: toolsMatch.index,
+            length: toolsMatch[0].length,
+            type: 'tools_expandable',
+            data: { displayText: toolsMatch[1], encodedContent: toolsMatch[2] },
+        })
+    }
+
+    // Sort by index
+    allMatches.sort((a, b) => a.index - b.index)
+
+    let lastIndex = 0
+
+    for (const match of allMatches) {
+        // Add text before the marker
+        if (match.index > lastIndex) {
+            segments.push({
+                type: 'text',
+                content: text.slice(lastIndex, match.index),
+            })
+        }
+
+        if (match.type === 'truncated') {
+            // Add truncated segment
+            try {
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
+                segments.push({
+                    type: 'truncated',
+                    content: `... (${match.data.charCount} chars truncated)`,
+                    fullContent,
+                    charCount: match.data.charCount,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        } else if (match.type === 'tools_expandable') {
+            // Add tools expandable segment
+            try {
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
+                segments.push({
+                    type: 'tools_expandable',
+                    content: match.data.displayText,
+                    fullContent,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        }
+
+        lastIndex = match.index + match.length
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+        segments.push({
+            type: 'text',
+            content: text.slice(lastIndex),
+        })
+    }
+
+    return segments
+}
+
+/**
+ * Parse text to find truncation, generation expandable, and tools expandable markers and split into segments
+ */
+export function parseTextSegments(text: string): TextSegment[] {
+    const segments: TextSegment[] = []
+
+    // Combined regex to match TRUNCATED, GEN_EXPANDABLE, and TOOLS_EXPANDABLE markers
+    const truncatedRegex = /<<<TRUNCATED\|([^|]+)\|(\d+)>>>/g
+    const genExpandableRegex = /<<<GEN_EXPANDABLE\|([^|]+)\|([^|]+)\|([^>]+)>>>/g
+    const toolsExpandableRegex = /<<<TOOLS_EXPANDABLE\|([^|]+)\|([^>]+)>>>/g
+
+    const allMatches: Array<{
+        index: number
+        length: number
+        type: 'truncated' | 'gen_expandable' | 'tools_expandable'
+        data: any
+    }> = []
+
+    // Find all truncated markers
+    let truncMatch: RegExpExecArray | null
+    while ((truncMatch = truncatedRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: truncMatch.index,
+            length: truncMatch[0].length,
+            type: 'truncated',
+            data: { encodedContent: truncMatch[1], charCount: parseInt(truncMatch[2], 10) },
+        })
+    }
+
+    // Find all gen expandable markers
+    let genMatch: RegExpExecArray | null
+    while ((genMatch = genExpandableRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: genMatch.index,
+            length: genMatch[0].length,
+            type: 'gen_expandable',
+            data: { eventId: genMatch[1], displayText: genMatch[2], encodedContent: genMatch[3] },
+        })
+    }
+
+    // Find all tools expandable markers
+    let toolsMatch: RegExpExecArray | null
+    while ((toolsMatch = toolsExpandableRegex.exec(text)) !== null) {
+        allMatches.push({
+            index: toolsMatch.index,
+            length: toolsMatch[0].length,
+            type: 'tools_expandable',
+            data: { displayText: toolsMatch[1], encodedContent: toolsMatch[2] },
+        })
+    }
+
+    // Sort by index
+    allMatches.sort((a, b) => a.index - b.index)
+
+    let lastIndex = 0
+
+    for (const match of allMatches) {
+        // Add text before the marker
+        if (match.index > lastIndex) {
+            segments.push({
+                type: 'text',
+                content: text.slice(lastIndex, match.index),
+            })
+        }
+
+        if (match.type === 'truncated') {
+            // Add truncated segment
+            try {
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
+                segments.push({
+                    type: 'truncated',
+                    content: `... (${match.data.charCount} chars truncated)`,
+                    fullContent,
+                    charCount: match.data.charCount,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        } else if (match.type === 'gen_expandable') {
+            // Add gen expandable segment
+            try {
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
+                segments.push({
+                    type: 'gen_expandable',
+                    content: match.data.displayText,
+                    fullContent,
+                    eventId: match.data.eventId,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        } else if (match.type === 'tools_expandable') {
+            // Add tools expandable segment
+            try {
+                const fullContent = decodeBase64Utf8(match.data.encodedContent)
+                segments.push({
+                    type: 'tools_expandable',
+                    content: match.data.displayText,
+                    fullContent,
+                })
+            } catch {
+                // If decoding fails, show as regular text
+                segments.push({
+                    type: 'text',
+                    content: text.slice(match.index, match.index + match.length),
+                })
+            }
+        }
+
+        lastIndex = match.index + match.length
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+        segments.push({
+            type: 'text',
+            content: text.slice(lastIndex),
+        })
+    }
+
+    return segments
+}

--- a/products/llm_analytics/frontend/text-view/parsing/segmentParser.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/segmentParser.ts
@@ -3,7 +3,7 @@
  * Handles parsing of TRUNCATED, GEN_EXPANDABLE, and TOOLS_EXPANDABLE markers
  */
 import { decodeBase64Utf8 } from './textHelpers'
-import { TextSegment } from './types'
+import { SegmentMatch, TextSegment } from './types'
 
 /**
  * Parse text for TRUNCATED and TOOLS_EXPANDABLE markers (used for nested content)
@@ -13,12 +13,7 @@ export function parseTruncatedSegments(text: string): TextSegment[] {
     const truncatedRegex = /<<<TRUNCATED\|([^|]+)\|(\d+)>>>/g
     const toolsExpandableRegex = /<<<TOOLS_EXPANDABLE\|([^|]+)\|([^>]+)>>>/g
 
-    const allMatches: Array<{
-        index: number
-        length: number
-        type: 'truncated' | 'tools_expandable'
-        data: any
-    }> = []
+    const allMatches: Array<Extract<SegmentMatch, { type: 'truncated' | 'tools_expandable' }>> = []
 
     // Find all truncated markers
     let truncMatch: RegExpExecArray | null
@@ -116,12 +111,7 @@ export function parseTextSegments(text: string): TextSegment[] {
     const genExpandableRegex = /<<<GEN_EXPANDABLE\|([^|]+)\|([^|]+)\|([^>]+)>>>/g
     const toolsExpandableRegex = /<<<TOOLS_EXPANDABLE\|([^|]+)\|([^>]+)>>>/g
 
-    const allMatches: Array<{
-        index: number
-        length: number
-        type: 'truncated' | 'gen_expandable' | 'tools_expandable'
-        data: any
-    }> = []
+    const allMatches: SegmentMatch[] = []
 
     // Find all truncated markers
     let truncMatch: RegExpExecArray | null

--- a/products/llm_analytics/frontend/text-view/parsing/textHelpers.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/textHelpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Text helper utilities for text view display
+ */
+import { parseTruncatedSegments } from './segmentParser'
+import { TextSegment } from './types'
+
+/**
+ * Decode base64-encoded UTF-8 string properly
+ * Using TextDecoder to handle emoji and special characters correctly
+ */
+export function decodeBase64Utf8(base64String: string): string {
+    const binaryString = atob(base64String)
+    const bytes = new Uint8Array(binaryString.length)
+    for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i)
+    }
+    return new TextDecoder('utf-8').decode(bytes)
+}
+
+/**
+ * Get plain text representation for copying (with all truncated sections collapsed)
+ */
+export function getPlainText(segments: TextSegment[]): string {
+    return segments.map((seg) => (seg.type === 'truncated' ? seg.content : seg.content)).join('')
+}
+
+/**
+ * Get expanded tree text for copying trace views
+ * Expands all gen_expandable nodes but keeps truncation markers collapsed
+ */
+export function getExpandedTreeText(segments: TextSegment[]): string {
+    return segments
+        .map((seg) => {
+            if (seg.type === 'gen_expandable' && seg.fullContent) {
+                // Expand this node but keep any nested truncation markers collapsed
+                const nestedSegments = parseTruncatedSegments(seg.fullContent)
+                return nestedSegments.map((nestedSeg) => nestedSeg.content).join('')
+            }
+            // For truncated and text segments, use content as-is
+            return seg.content
+        })
+        .join('')
+}
+
+/**
+ * Calculate the padding width needed for line numbers based on the maximum line number
+ * Returns the number of digits in the largest line number (e.g., 3 for L100, 4 for L1000)
+ */
+export function calculateLineNumberPadding(text: string): number {
+    let maxLineNumber = 0
+    const lineMatches = text.matchAll(/^L(\d+):/gm)
+    for (const match of lineMatches) {
+        const lineNum = parseInt(match[1], 10)
+        if (lineNum > maxLineNumber) {
+            maxLineNumber = lineNum
+        }
+    }
+    return maxLineNumber > 0 ? maxLineNumber.toString().length : 0
+}

--- a/products/llm_analytics/frontend/text-view/parsing/types.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/types.ts
@@ -20,3 +20,43 @@ export interface EventLinkPart {
     eventId: string
     displayText: string
 }
+
+/**
+ * Internal types for parsing segment markers
+ */
+export type SegmentMatch =
+    | {
+          index: number
+          length: number
+          type: 'truncated'
+          data: { encodedContent: string; charCount: number }
+      }
+    | {
+          index: number
+          length: number
+          type: 'gen_expandable'
+          data: { eventId: string; displayText: string; encodedContent: string }
+      }
+    | {
+          index: number
+          length: number
+          type: 'tools_expandable'
+          data: { displayText: string; encodedContent: string }
+      }
+
+/**
+ * Internal types for parsing URL and event link markers
+ */
+export type UrlMatch =
+    | {
+          index: number
+          length: number
+          type: 'url'
+          data: { content: string }
+      }
+    | {
+          index: number
+          length: number
+          type: 'event_link'
+          data: { eventId: string; displayText: string }
+      }

--- a/products/llm_analytics/frontend/text-view/parsing/types.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Type definitions for text view parsing
+ */
+
+export interface TextSegment {
+    type: 'text' | 'truncated' | 'gen_expandable' | 'tools_expandable'
+    content: string
+    fullContent?: string
+    charCount?: number
+    eventId?: string
+}
+
+export interface TextPart {
+    type: 'text' | 'url'
+    content: string
+}
+
+export interface EventLinkPart {
+    type: 'event_link'
+    eventId: string
+    displayText: string
+}

--- a/products/llm_analytics/frontend/text-view/parsing/urlParser.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/urlParser.ts
@@ -1,7 +1,7 @@
 /**
  * URL and event link parsing utilities
  */
-import { EventLinkPart, TextPart } from './types'
+import { EventLinkPart, TextPart, UrlMatch } from './types'
 
 /**
  * Parse text to find URLs and event links, split into parts
@@ -14,7 +14,7 @@ export function parseUrls(text: string, traceId?: string): Array<TextPart | Even
     const urlRegex = /(https?:\/\/[^\s]+)/g
 
     let lastIndex = 0
-    const matches: Array<{ index: number; length: number; type: 'url' | 'event_link'; data: any }> = []
+    const matches: UrlMatch[] = []
 
     // Find all event links
     let eventMatch: RegExpExecArray | null

--- a/products/llm_analytics/frontend/text-view/parsing/urlParser.ts
+++ b/products/llm_analytics/frontend/text-view/parsing/urlParser.ts
@@ -1,0 +1,94 @@
+/**
+ * URL and event link parsing utilities
+ */
+import { EventLinkPart, TextPart } from './types'
+
+/**
+ * Parse text to find URLs and event links, split into parts
+ */
+export function parseUrls(text: string, traceId?: string): Array<TextPart | EventLinkPart> {
+    const parts: Array<TextPart | EventLinkPart> = []
+
+    // Process event links first, then URLs
+    const eventLinkRegex = /<<<EVENT_LINK\|([^|]+)\|([^>]+)>>>/g
+    const urlRegex = /(https?:\/\/[^\s]+)/g
+
+    let lastIndex = 0
+    const matches: Array<{ index: number; length: number; type: 'url' | 'event_link'; data: any }> = []
+
+    // Find all event links
+    let eventMatch: RegExpExecArray | null
+    while ((eventMatch = eventLinkRegex.exec(text)) !== null) {
+        matches.push({
+            index: eventMatch.index,
+            length: eventMatch[0].length,
+            type: 'event_link',
+            data: { eventId: eventMatch[1], displayText: eventMatch[2] },
+        })
+    }
+
+    // Find all URLs
+    let urlMatch: RegExpExecArray | null
+    while ((urlMatch = urlRegex.exec(text)) !== null) {
+        matches.push({
+            index: urlMatch.index,
+            length: urlMatch[0].length,
+            type: 'url',
+            data: { content: urlMatch[1] },
+        })
+    }
+
+    // Sort by index
+    matches.sort((a, b) => a.index - b.index)
+
+    // Build parts
+    for (const match of matches) {
+        // Add text before match
+        if (match.index > lastIndex) {
+            parts.push({
+                type: 'text',
+                content: text.slice(lastIndex, match.index),
+            })
+        }
+
+        // Add the match
+        if (match.type === 'url') {
+            parts.push({
+                type: 'url',
+                content: match.data.content,
+            })
+        } else if (match.type === 'event_link' && traceId) {
+            parts.push({
+                type: 'event_link',
+                eventId: match.data.eventId,
+                displayText: match.data.displayText,
+            })
+        } else {
+            // Fallback to text if no traceId
+            parts.push({
+                type: 'text',
+                content: match.data.displayText || '',
+            })
+        }
+
+        lastIndex = match.index + match.length
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+        parts.push({
+            type: 'text',
+            content: text.slice(lastIndex),
+        })
+    }
+
+    // If no matches found, return the whole text as one part
+    if (parts.length === 0) {
+        parts.push({
+            type: 'text',
+            content: text,
+        })
+    }
+
+    return parts
+}

--- a/products/llm_analytics/frontend/text-view/textViewLogic.ts
+++ b/products/llm_analytics/frontend/text-view/textViewLogic.ts
@@ -5,10 +5,8 @@ import api from 'lib/api'
 
 import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
 
+import { FALLBACK_DELAY_MS, TEXT_REPR_API_TIMEOUT_MS } from './constants'
 import type { textViewLogicType } from './textViewLogicType'
-
-const TEXT_REPR_API_TIMEOUT_MS = 10000 // 10 seconds
-const FALLBACK_DELAY_MS = 1500 // 1.5 seconds
 
 interface TraceTreeNode {
     event: LLMTraceEvent

--- a/products/llm_analytics/frontend/text-view/textViewLogic.ts
+++ b/products/llm_analytics/frontend/text-view/textViewLogic.ts
@@ -7,6 +7,9 @@ import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
 
 import type { textViewLogicType } from './textViewLogicType'
 
+const TEXT_REPR_API_TIMEOUT_MS = 10000 // 10 seconds
+const FALLBACK_DELAY_MS = 1500 // 1.5 seconds
+
 interface TraceTreeNode {
     event: LLMTraceEvent
     children?: TraceTreeNode[]
@@ -92,7 +95,7 @@ export const textViewLogic = kea<textViewLogicType>([
 
                 // Create abort controller for timeout
                 const abortController = new AbortController()
-                const timeoutId = setTimeout(() => abortController.abort(), 10000) // 10 second timeout
+                const timeoutId = setTimeout(() => abortController.abort(), TEXT_REPR_API_TIMEOUT_MS)
 
                 try {
                     // Call Django API with timeout
@@ -127,7 +130,7 @@ export const textViewLogic = kea<textViewLogicType>([
                 // Small delay to show the fallback message briefly
                 setTimeout(() => {
                     props.onFallback?.()
-                }, 1500)
+                }, FALLBACK_DELAY_MS)
             }
         },
     })),

--- a/products/llm_analytics/frontend/text-view/textViewLogic.ts
+++ b/products/llm_analytics/frontend/text-view/textViewLogic.ts
@@ -1,0 +1,134 @@
+import { actions, kea, key, listeners, path, props } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+
+import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+
+import type { textViewLogicType } from './textViewLogicType'
+
+interface TraceTreeNode {
+    event: LLMTraceEvent
+    children?: TraceTreeNode[]
+}
+
+export interface TextViewLogicProps {
+    trace?: LLMTrace
+    event?: LLMTraceEvent
+    tree?: TraceTreeNode[]
+    teamId: number | null
+    onFallback?: () => void
+}
+
+export const textViewLogic = kea<textViewLogicType>([
+    path(['products', 'llm_analytics', 'frontend', 'text-view', 'textViewLogic']),
+    props({} as TextViewLogicProps),
+    key((props) => {
+        // Use trace ID or event ID as the key
+        if (props.trace) {
+            return `trace-${props.trace.id}`
+        }
+        if (props.event) {
+            return `event-${props.event.id}`
+        }
+        return 'unknown'
+    }),
+    actions({
+        triggerFallback: true,
+    }),
+    loaders(({ props }) => ({
+        textRepr: {
+            __default: null as string | null,
+            fetchTextRepr: async () => {
+                // Return empty if no data or no team ID
+                if (!props.trace && !props.event) {
+                    return ''
+                }
+                if (!props.teamId) {
+                    return ''
+                }
+
+                // Prepare request based on what data we have
+                let requestData: any
+
+                if (props.trace && props.tree) {
+                    // Full trace view - need to send tree structure with children
+                    // Recursively convert tree nodes to { event, children } format
+                    const convertTreeNode = (node: TraceTreeNode): any => ({
+                        event: node.event,
+                        children: node.children ? node.children.map(convertTreeNode) : [],
+                    })
+
+                    requestData = {
+                        event_type: '$ai_trace',
+                        data: {
+                            trace: {
+                                ...props.trace,
+                                trace_id: props.trace.id,
+                                name: props.trace.traceName || 'Trace',
+                            },
+                            hierarchy: props.tree.map(convertTreeNode),
+                        },
+                        options: {
+                            truncated: true,
+                            include_markers: true,
+                            include_line_numbers: true,
+                        },
+                    }
+                } else if (props.event) {
+                    // Single event view
+                    requestData = {
+                        event_type: props.event.event,
+                        data: props.event,
+                        options: {
+                            truncated: true,
+                            include_markers: true,
+                            include_line_numbers: true,
+                        },
+                    }
+                } else {
+                    return ''
+                }
+
+                // Create abort controller for timeout
+                const abortController = new AbortController()
+                const timeoutId = setTimeout(() => abortController.abort(), 10000) // 10 second timeout
+
+                try {
+                    // Call Django API with timeout
+                    const response = await api.create(
+                        `api/environments/${props.teamId}/llm_analytics/text_repr/`,
+                        requestData,
+                        { signal: abortController.signal }
+                    )
+                    clearTimeout(timeoutId)
+                    return response.text || ''
+                } catch (apiErr) {
+                    clearTimeout(timeoutId)
+                    const isTimeout = apiErr instanceof Error && apiErr.name === 'AbortError'
+                    const errorMessage = isTimeout
+                        ? 'Text view generation timed out'
+                        : apiErr instanceof Error
+                          ? apiErr.message
+                          : 'Failed to load text representation'
+                    throw new Error(errorMessage)
+                }
+            },
+        },
+    })),
+    listeners(({ props, actions }) => ({
+        fetchTextReprFailure: async ({ error }) => {
+            console.error('Error fetching text representation:', error)
+            // Trigger fallback to standard view with a small delay
+            actions.triggerFallback()
+        },
+        triggerFallback: async () => {
+            if (props.onFallback) {
+                // Small delay to show the fallback message briefly
+                setTimeout(() => {
+                    props.onFallback?.()
+                }, 1500)
+            }
+        },
+    })),
+])

--- a/products/llm_analytics/frontend/text-view/textViewLogic.ts
+++ b/products/llm_analytics/frontend/text-view/textViewLogic.ts
@@ -13,6 +13,36 @@ interface TraceTreeNode {
     children?: TraceTreeNode[]
 }
 
+interface ConvertedTreeNode {
+    event: LLMTraceEvent
+    children: ConvertedTreeNode[]
+}
+
+interface TextReprOptions {
+    truncated: boolean
+    include_markers: boolean
+    include_line_numbers: boolean
+}
+
+type TextReprRequest =
+    | {
+          event_type: '$ai_trace'
+          data: {
+              trace: {
+                  trace_id: string
+                  name: string
+                  [key: string]: unknown
+              }
+              hierarchy: ConvertedTreeNode[]
+          }
+          options: TextReprOptions
+      }
+    | {
+          event_type: string
+          data: LLMTraceEvent
+          options: TextReprOptions
+      }
+
 export interface TextViewLogicProps {
     trace?: LLMTrace
     event?: LLMTraceEvent
@@ -50,12 +80,12 @@ export const textViewLogic = kea<textViewLogicType>([
                 }
 
                 // Prepare request based on what data we have
-                let requestData: any
+                let requestData: TextReprRequest
 
                 if (props.trace && props.tree) {
                     // Full trace view - need to send tree structure with children
                     // Recursively convert tree nodes to { event, children } format
-                    const convertTreeNode = (node: TraceTreeNode): any => ({
+                    const convertTreeNode = (node: TraceTreeNode): ConvertedTreeNode => ({
                         event: node.event,
                         children: node.children ? node.children.map(convertTreeNode) : [],
                     })


### PR DESCRIPTION
## Problem

Users need an easy way to view and share LLM trace data in a human-readable text format with the ability to reference specific lines.

## Changes

This PR adds the frontend text view component and integration:

**TextViewDisplay Component (~1070 lines):**
- Fetches formatted text from text_repr API endpoint
- Renders syntax-highlighted text with line numbers
- Expandable sections for truncated/collapsed content
- Base64 decoding for compressed content
- Loading and error states

**Line Number Permalinks:**
- Clickable line numbers generate `?line=N` URLs
- Auto-scroll and highlight on page load with line parameter
- Smooth scrolling to target line
- Highlighted line remains visible

**Integration:**
- New 'Text view' display option in trace scene
- Line number state management in `llmAnalyticsTraceLogic`
- URL parameter parsing for `?line=N`
- Feature flag gated (`LLM_ANALYTICS_TEXT_VIEW`)
- Fallback to expand-all view on errors

**User Experience:**
- Copy line reference URLs to share specific parts of traces
- Interactive expansion of truncated content
- Clean, readable text format for long traces
- Works for both individual events and full traces

## Testing

Manual testing:
- Text view rendering for generations, spans, embeddings, traces
- Line number clicking and URL generation
- Permalink navigation and scrolling
- Truncated section expansion
- Error handling and fallback

## Stack Context

**Part 2 of 4** in stacked PR series:
1. Text representation backend PR #41004
2. **[This PR]** Text view frontend (depends on #41004)
3. Summarization backend (depends on #41004)
4. Summary view frontend (depends on #41004, #41005)

## Changelog

- Add interactive text view with line number permalinks for LLM analytics