### PR TITLE
feat(llma): Add summary view frontend with AI summary [4/4]

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -200,7 +200,6 @@ export const FEATURE_FLAGS = {
     DASHBOARD_THREADS: 'dashboard-threads', // owner: @aspicer #team-product-analytics
     BATCH_EXPORTS_POSTHOG_HTTP: 'posthog-http-batch-exports',
     LLM_ANALYTICS_CUSTOMIZABLE_DASHBOARD: 'llm-analytics-customizable-dashboard', // owner: #team-llm-analytics
-    LLM_ANALYTICS_DISCUSSIONS: 'llm-analytics-discussions', // owner: #team-llm-analytics
     BATCH_EXPORTS_DATABRICKS: 'databricks-batch-exports', // owner: @rossgray #team-batch-exports
     HEDGEHOG_SKIN_SPIDERHOG: 'hedgehog-skin-spiderhog', // owner: @benjackwhite
     WEB_EXPERIMENTS: 'web-experiments', // owner: @team-feature-success
@@ -307,6 +306,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_SESSIONS_VIEW: 'llm-analytics-sessions-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_ERRORS_TAB: 'llm-analytics-errors-tab', // owner: #team-llm-analytics
     LLM_ANALYTICS_TEXT_VIEW: 'llm-analytics-text-view', // owner: #team-llm-analytics
+    LLM_ANALYTICS_SUMMARIZATION: 'llm-analytics-summarization', // owner: #team-llm-analytics
     POSTHOG_AI_BILLING_DISPLAY: 'posthog-ai-billing-display', // owner: #team-posthog-ai
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai
@@ -336,7 +336,6 @@ export const FEATURE_FLAGS = {
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
     REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate
     EXPERIMENTS_USE_NEW_CREATE_FORM: 'experiments-use-new-create-form', // owner: @rodrigoi #team-experiments
-    APP_SHORTCUTS: 'app-shortcuts', // owner: @adamleithp #team-platform-ux
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -200,6 +200,7 @@ export const FEATURE_FLAGS = {
     DASHBOARD_THREADS: 'dashboard-threads', // owner: @aspicer #team-product-analytics
     BATCH_EXPORTS_POSTHOG_HTTP: 'posthog-http-batch-exports',
     LLM_ANALYTICS_CUSTOMIZABLE_DASHBOARD: 'llm-analytics-customizable-dashboard', // owner: #team-llm-analytics
+    LLM_ANALYTICS_DISCUSSIONS: 'llm-analytics-discussions', // owner: #team-llm-analytics
     BATCH_EXPORTS_DATABRICKS: 'databricks-batch-exports', // owner: @rossgray #team-batch-exports
     HEDGEHOG_SKIN_SPIDERHOG: 'hedgehog-skin-spiderhog', // owner: @benjackwhite
     WEB_EXPERIMENTS: 'web-experiments', // owner: @team-feature-success
@@ -336,6 +337,7 @@ export const FEATURE_FLAGS = {
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
     REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate
     EXPERIMENTS_USE_NEW_CREATE_FORM: 'experiments-use-new-create-form', // owner: @rodrigoi #team-experiments
+    APP_SHORTCUTS: 'app-shortcuts', // owner: @adamleithp #team-platform-ux
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -366,7 +366,8 @@ The response includes the summary text and optional metadata.
                 team_id=self.team_id,
                 error=str(e),
             )
+            error_detail = str(e) if settings.DEBUG else "An error occurred while generating the summary"
             return Response(
-                {"error": "Failed to generate summary", "detail": str(e)},
+                {"error": "Failed to generate summary", "detail": error_detail},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -366,8 +366,7 @@ The response includes the summary text and optional metadata.
                 team_id=self.team_id,
                 error=str(e),
             )
-            error_detail = str(e) if settings.DEBUG else "An error occurred while generating the summary"
             return Response(
-                {"error": "Failed to generate summary", "detail": error_detail},
+                {"error": "Failed to generate summary", "detail": "An error occurred while generating the summary"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/products/llm_analytics/backend/summarization/llm/call.py
+++ b/products/llm_analytics/backend/summarization/llm/call.py
@@ -142,5 +142,4 @@ async def summarize(
         return SummarizationResponse.model_validate_json(content)
     except Exception as e:
         logger.exception("OpenAI API call failed", error=str(e), team_id=team_id)
-        error_msg = f"Failed to generate summary: {str(e)}" if settings.DEBUG else "Failed to generate summary"
-        raise exceptions.APIException(error_msg)
+        raise exceptions.APIException("Failed to generate summary")

--- a/products/llm_analytics/backend/summarization/llm/call.py
+++ b/products/llm_analytics/backend/summarization/llm/call.py
@@ -142,4 +142,5 @@ async def summarize(
         return SummarizationResponse.model_validate_json(content)
     except Exception as e:
         logger.exception("OpenAI API call failed", error=str(e), team_id=team_id)
-        raise exceptions.APIException(f"Failed to generate summary: {str(e)}")
+        error_msg = f"Failed to generate summary: {str(e)}" if settings.DEBUG else "Failed to generate summary"
+        raise exceptions.APIException(error_msg)

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -4,7 +4,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import React, { useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
-import { IconAIText, IconChat, IconCopy, IconMessage, IconReceipt, IconSearch } from '@posthog/icons'
+import { IconAIText, IconChat, IconComment, IconCopy, IconMessage, IconReceipt, IconSearch } from '@posthog/icons'
 import {
     LemonButton,
     LemonCheckbox,
@@ -26,6 +26,7 @@ import { NotFound } from 'lib/components/NotFound'
 import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
+import { IconWithCount } from 'lib/lemon-ui/icons/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { identifierToHuman, isObject, pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
@@ -34,8 +35,10 @@ import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBreadcrumbs'
 import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+import { SidePanelTab } from '~/types'
 
 import { ConversationMessagesDisplay } from './ConversationDisplay/ConversationMessagesDisplay'
 import { MetadataHeader } from './ConversationDisplay/MetadataHeader'
@@ -82,25 +85,18 @@ export function LLMAnalyticsTraceScene(): JSX.Element {
     const { traceId, query } = useValues(llmAnalyticsTraceLogic)
 
     return (
-        <BindLogic logic={llmAnalyticsTraceDataLogic} props={{ traceId, query }}>
+        <BindLogic logic={llmAnalyticsTraceDataLogic} props={{ traceId, query, cachedResults: null }}>
             <TraceSceneWrapper />
         </BindLogic>
     )
 }
 
 function TraceSceneWrapper(): JSX.Element {
-    const { eventId } = useValues(llmAnalyticsTraceLogic)
-    const {
-        enrichedTree,
-        trace,
-        event,
-        responseLoading,
-        responseError,
-        feedbackEvents,
-        metricEvents,
-        searchQuery,
-        eventMetadata,
-    } = useValues(llmAnalyticsTraceDataLogic)
+    const { eventId, searchQuery, commentCount } = useValues(llmAnalyticsTraceLogic)
+    const { enrichedTree, trace, event, responseLoading, responseError, feedbackEvents, metricEvents, eventMetadata } =
+        useValues(llmAnalyticsTraceDataLogic)
+    const { openSidePanel } = useActions(sidePanelStateLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const { showBillingInfo, markupUsd, billedTotalUsd, billedCredits } = usePosthogAIBillingCalculations(enrichedTree)
 
@@ -127,6 +123,22 @@ function TraceSceneWrapper(): JSX.Element {
                         />
                         <div className="flex flex-wrap justify-end items-center gap-x-2 gap-y-1">
                             <DisplayOptionsSelect />
+                            {featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_DISCUSSIONS] && (
+                                <LemonButton
+                                    type="secondary"
+                                    size="xsmall"
+                                    icon={
+                                        <IconWithCount count={commentCount} showZero={false}>
+                                            <IconComment />
+                                        </IconWithCount>
+                                    }
+                                    onClick={() => openSidePanel(SidePanelTab.Discussion)}
+                                    tooltip="Add comments on this trace"
+                                    data-attr="open-trace-discussion"
+                                >
+                                    Discussion
+                                </LemonButton>
+                            )}
                             <CopyTraceButton trace={trace} tree={enrichedTree} />
                         </div>
                     </div>

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -924,6 +924,8 @@ const EventContent = React.memo(
                                                   <EvalsTabContent
                                                       generationEventId={event.id}
                                                       timestamp={event.createdAt}
+                                                      event={event.event}
+                                                      distinctId={trace.person.distinct_id}
                                                   />
                                               ),
                                           },

--- a/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
+++ b/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
@@ -23,6 +23,13 @@ export interface SummaryViewDisplayProps {
     tree?: any[]
 }
 
+interface SummaryViewLogicValues {
+    summaryData: { summary: any; text_repr: string } | null
+    summaryDataLoading: boolean
+    summaryMode: 'minimal' | 'detailed'
+    summaryDataFailure?: Error | string | unknown
+}
+
 export function SummaryViewDisplay({ trace, event, tree }: SummaryViewDisplayProps): JSX.Element {
     const logic = summaryViewLogic({ trace, event, tree })
     const { summaryData, summaryDataLoading, summaryMode } = useValues(logic)
@@ -56,11 +63,12 @@ export function SummaryViewDisplay({ trace, event, tree }: SummaryViewDisplayPro
     }
 
     // Extract error message from loader failure if any
-    const errorMessage = (logic.values as any).summaryDataFailure
-        ? (logic.values as any).summaryDataFailure instanceof Error
-            ? (logic.values as any).summaryDataFailure.message
-            : typeof (logic.values as any).summaryDataFailure === 'string'
-              ? (logic.values as any).summaryDataFailure
+    const logicValues = logic.values as SummaryViewLogicValues
+    const errorMessage = logicValues.summaryDataFailure
+        ? logicValues.summaryDataFailure instanceof Error
+            ? logicValues.summaryDataFailure.message
+            : typeof logicValues.summaryDataFailure === 'string'
+              ? logicValues.summaryDataFailure
               : 'An unexpected error occurred'
         : null
 

--- a/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
+++ b/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
@@ -1,0 +1,229 @@
+/**
+ * Summary View Display Component
+ *
+ * Provides AI-powered summarization of LLM traces and events with line references.
+ */
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonSegmentedButton } from '@posthog/lemon-ui'
+
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
+
+import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+
+import { SummaryRenderer } from './components/SummaryRenderer'
+import { TextReprDisplay } from './components/TextReprDisplay'
+import { summaryViewLogic } from './summaryViewLogic'
+
+export interface SummaryViewDisplayProps {
+    trace?: LLMTrace
+    event?: LLMTraceEvent
+    tree?: any[]
+}
+
+export function SummaryViewDisplay({ trace, event, tree }: SummaryViewDisplayProps): JSX.Element {
+    const logic = summaryViewLogic({ trace, event, tree })
+    const { summaryData, summaryDataLoading, summaryMode } = useValues(logic)
+    const { generateSummary, setSummaryMode, regenerateSummary } = useActions(logic)
+    const { dataProcessingAccepted } = useValues(maxGlobalLogic)
+
+    // Compute derived values from props
+    const isSummarizable = !!trace || !!(event && (event.event === '$ai_generation' || event.event === '$ai_span'))
+
+    const eventTypeName = (() => {
+        if (trace) {
+            return 'trace'
+        }
+        if (event) {
+            switch (event.event) {
+                case '$ai_generation':
+                    return 'generation'
+                case '$ai_span':
+                    return 'span'
+                case '$ai_embedding':
+                    return 'embedding'
+                default:
+                    return 'event'
+            }
+        }
+        return 'event'
+    })()
+
+    if (!isSummarizable) {
+        return <div className="p-4 text-muted">Summary is only available for traces, generations, and spans.</div>
+    }
+
+    // Extract error message from loader failure if any
+    const errorMessage = (logic.values as any).summaryDataFailure
+        ? (logic.values as any).summaryDataFailure instanceof Error
+            ? (logic.values as any).summaryDataFailure.message
+            : typeof (logic.values as any).summaryDataFailure === 'string'
+              ? (logic.values as any).summaryDataFailure
+              : 'An unexpected error occurred'
+        : null
+
+    return (
+        <div className="p-4 flex flex-col gap-4 h-full overflow-hidden">
+            {!summaryData && !summaryDataLoading && !errorMessage && (
+                <div className="flex flex-col items-center gap-4 py-8">
+                    <div className="text-muted text-center">
+                        <p>Generate an AI-powered summary of this {eventTypeName}.</p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <LemonSegmentedButton
+                            value={summaryMode}
+                            onChange={setSummaryMode}
+                            options={[
+                                {
+                                    value: 'minimal',
+                                    label: 'Minimal',
+                                    tooltip: 'Quick 3-5 bullet point summary with key highlights',
+                                },
+                                {
+                                    value: 'detailed',
+                                    label: 'Detailed',
+                                    tooltip: 'Comprehensive 5-10 point summary with full context',
+                                },
+                            ]}
+                            size="small"
+                            data-attr="summary-mode-selector"
+                        />
+                        {!dataProcessingAccepted ? (
+                            <AIConsentPopoverWrapper
+                                showArrow
+                                onApprove={() => generateSummary({ mode: summaryMode })}
+                                hidden={summaryDataLoading}
+                            >
+                                <LemonButton
+                                    type="primary"
+                                    data-attr="llm-analytics-generate-summary"
+                                    loading={summaryDataLoading}
+                                    disabledReason="AI data processing must be approved to generate summaries"
+                                >
+                                    Generate Summary
+                                </LemonButton>
+                            </AIConsentPopoverWrapper>
+                        ) : (
+                            <LemonButton
+                                type="primary"
+                                onClick={() => generateSummary({ mode: summaryMode })}
+                                data-attr="llm-analytics-generate-summary"
+                                loading={summaryDataLoading}
+                            >
+                                Generate Summary
+                            </LemonButton>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {summaryDataLoading && (
+                <div className="flex flex-col items-center gap-4 py-8">
+                    <Spinner />
+                    <div className="text-muted">Generating summary...</div>
+                </div>
+            )}
+
+            {errorMessage && (
+                <div className="bg-danger-highlight border border-danger rounded p-4">
+                    <div className="font-semibold text-danger">Failed to generate summary</div>
+                    <div className="text-sm mt-2">{errorMessage}</div>
+                    {!dataProcessingAccepted ? (
+                        <AIConsentPopoverWrapper
+                            showArrow
+                            onApprove={() => generateSummary({ mode: summaryMode })}
+                            hidden={summaryDataLoading}
+                        >
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                className="mt-4"
+                                loading={summaryDataLoading}
+                                disabledReason="AI data processing must be approved to generate summaries"
+                            >
+                                Try Again
+                            </LemonButton>
+                        </AIConsentPopoverWrapper>
+                    ) : (
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            onClick={() => generateSummary({ mode: summaryMode })}
+                            className="mt-4"
+                            loading={summaryDataLoading}
+                        >
+                            Try Again
+                        </LemonButton>
+                    )}
+                </div>
+            )}
+
+            {summaryData && !summaryDataLoading && (
+                <>
+                    <div className="flex items-center gap-2 flex-none">
+                        {!dataProcessingAccepted ? (
+                            <AIConsentPopoverWrapper
+                                showArrow
+                                onApprove={() => regenerateSummary()}
+                                hidden={summaryDataLoading}
+                            >
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    data-attr="llm-analytics-regenerate-summary"
+                                    loading={summaryDataLoading}
+                                    disabledReason="AI data processing must be approved to generate summaries"
+                                >
+                                    Regenerate
+                                </LemonButton>
+                            </AIConsentPopoverWrapper>
+                        ) : (
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                onClick={() => regenerateSummary()}
+                                data-attr="llm-analytics-regenerate-summary"
+                                loading={summaryDataLoading}
+                            >
+                                Regenerate
+                            </LemonButton>
+                        )}
+                        <LemonSegmentedButton
+                            value={summaryMode}
+                            onChange={setSummaryMode}
+                            options={[
+                                {
+                                    value: 'minimal',
+                                    label: 'Minimal',
+                                    tooltip: 'Quick 3-5 bullet point summary with key highlights',
+                                },
+                                {
+                                    value: 'detailed',
+                                    label: 'Detailed',
+                                    tooltip: 'Comprehensive 5-10 point summary with full context',
+                                },
+                            ]}
+                            size="xsmall"
+                            data-attr="summary-mode-selector"
+                        />
+                    </div>
+
+                    <div className="flex-none">
+                        <div className="prose prose-sm max-w-none border rounded p-4 bg-bg-light overflow-x-auto">
+                            <SummaryRenderer summary={summaryData.summary} />
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col min-h-0 max-h-[800px]">
+                        <h4 className="font-semibold mb-2">Text Representation</h4>
+                        <div className="border rounded flex-1 overflow-hidden">
+                            <TextReprDisplay textRepr={summaryData.text_repr} />
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
+++ b/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
@@ -220,7 +220,7 @@ export function SummaryViewDisplay({ trace, event, tree }: SummaryViewDisplayPro
 
                     <div className="flex-none">
                         <div className="prose prose-sm max-w-none border rounded p-4 bg-bg-light overflow-x-auto">
-                            <SummaryRenderer summary={summaryData.summary} />
+                            <SummaryRenderer summary={summaryData.summary} trace={trace} event={event} tree={tree} />
                         </div>
                     </div>
 

--- a/products/llm_analytics/frontend/summary-view/components/SummaryRenderer.tsx
+++ b/products/llm_analytics/frontend/summary-view/components/SummaryRenderer.tsx
@@ -1,21 +1,26 @@
 /**
  * Renders structured summary with collapsible sections
  */
-import { useState } from 'react'
+import { useActions, useValues } from 'kea'
 
 import { Tooltip } from '@posthog/lemon-ui'
 
-import { StructuredSummary } from '../summaryViewLogic'
+import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+
+import { StructuredSummary, summaryViewLogic } from '../summaryViewLogic'
 import { parseLineReferences } from '../utils/lineReferenceUtils'
 
 export interface SummaryRendererProps {
     summary: StructuredSummary
+    trace?: LLMTrace
+    event?: LLMTraceEvent
+    tree?: any[]
 }
 
-export function SummaryRenderer({ summary }: SummaryRendererProps): JSX.Element {
-    const [isFlowExpanded, setIsFlowExpanded] = useState(false)
-    const [isSummaryExpanded, setIsSummaryExpanded] = useState(true)
-    const [isNotesExpanded, setIsNotesExpanded] = useState(true)
+export function SummaryRenderer({ summary, trace, event, tree }: SummaryRendererProps): JSX.Element {
+    const logic = summaryViewLogic({ trace, event, tree })
+    const { isFlowExpanded, isSummaryExpanded, isNotesExpanded } = useValues(logic)
+    const { toggleFlowExpanded, toggleSummaryExpanded, toggleNotesExpanded } = useActions(logic)
 
     const renderLineRefs = (lineRefs: string): JSX.Element | null => {
         if (!lineRefs || lineRefs.trim() === '') {
@@ -35,7 +40,7 @@ export function SummaryRenderer({ summary }: SummaryRendererProps): JSX.Element 
                     <button
                         type="button"
                         className="w-full text-left px-3 py-2 font-medium flex items-center gap-2 hover:bg-accent text-sm"
-                        onClick={() => setIsFlowExpanded(!isFlowExpanded)}
+                        onClick={toggleFlowExpanded}
                         data-attr="summary-toggle-flow-diagram"
                     >
                         <span className="text-xs">{isFlowExpanded ? '▼' : '▶'}</span>
@@ -57,7 +62,7 @@ export function SummaryRenderer({ summary }: SummaryRendererProps): JSX.Element 
                     <button
                         type="button"
                         className="w-full text-left px-3 py-2 font-medium flex items-center gap-2 hover:bg-accent text-sm"
-                        onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
+                        onClick={toggleSummaryExpanded}
                         data-attr="summary-toggle-points"
                     >
                         <span className="text-xs">{isSummaryExpanded ? '▼' : '▶'}</span>
@@ -85,7 +90,7 @@ export function SummaryRenderer({ summary }: SummaryRendererProps): JSX.Element 
                         <button
                             type="button"
                             className="w-full text-left px-3 py-2 font-medium flex items-center gap-2 hover:bg-accent text-sm"
-                            onClick={() => setIsNotesExpanded(!isNotesExpanded)}
+                            onClick={toggleNotesExpanded}
                             data-attr="summary-toggle-notes"
                         >
                             <span className="text-xs">{isNotesExpanded ? '▼' : '▶'}</span>

--- a/products/llm_analytics/frontend/summary-view/components/SummaryRenderer.tsx
+++ b/products/llm_analytics/frontend/summary-view/components/SummaryRenderer.tsx
@@ -1,0 +1,111 @@
+/**
+ * Renders structured summary with collapsible sections
+ */
+import { useState } from 'react'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { StructuredSummary } from '../summaryViewLogic'
+import { parseLineReferences } from '../utils/lineReferenceUtils'
+
+export interface SummaryRendererProps {
+    summary: StructuredSummary
+}
+
+export function SummaryRenderer({ summary }: SummaryRendererProps): JSX.Element {
+    const [isFlowExpanded, setIsFlowExpanded] = useState(false)
+    const [isSummaryExpanded, setIsSummaryExpanded] = useState(true)
+    const [isNotesExpanded, setIsNotesExpanded] = useState(true)
+
+    const renderLineRefs = (lineRefs: string): JSX.Element | null => {
+        if (!lineRefs || lineRefs.trim() === '') {
+            return null
+        }
+        return <span className="ml-2">{parseLineReferences(lineRefs)}</span>
+    }
+
+    return (
+        <div className="space-y-4">
+            {/* Title */}
+            <h3 className="text-lg font-semibold">{summary.title}</h3>
+
+            {/* Flow Diagram - Collapsible ASCII */}
+            <div className="border border-border rounded">
+                <Tooltip title="ASCII diagram showing the main steps and flow of execution">
+                    <button
+                        type="button"
+                        className="w-full text-left px-3 py-2 font-medium flex items-center gap-2 hover:bg-accent text-sm"
+                        onClick={() => setIsFlowExpanded(!isFlowExpanded)}
+                        data-attr="summary-toggle-flow-diagram"
+                    >
+                        <span className="text-xs">{isFlowExpanded ? '▼' : '▶'}</span>
+                        Flow Diagram
+                    </button>
+                </Tooltip>
+                {isFlowExpanded && (
+                    <div className="px-3 py-2 border-t border-border bg-bg-light">
+                        <pre className="font-mono text-sm whitespace-pre overflow-x-auto m-0">
+                            {summary.flow_diagram}
+                        </pre>
+                    </div>
+                )}
+            </div>
+
+            {/* Summary Bullets - Collapsible */}
+            <div className="border border-border rounded">
+                <Tooltip title="Key highlights and main actions from this trace or event">
+                    <button
+                        type="button"
+                        className="w-full text-left px-3 py-2 font-medium flex items-center gap-2 hover:bg-accent text-sm"
+                        onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
+                        data-attr="summary-toggle-points"
+                    >
+                        <span className="text-xs">{isSummaryExpanded ? '▼' : '▶'}</span>
+                        Summary Points
+                    </button>
+                </Tooltip>
+                {isSummaryExpanded && (
+                    <div className="px-3 py-2 border-t border-border bg-bg-light">
+                        <ul className="list-disc list-inside space-y-1">
+                            {summary.summary_bullets.map((bullet, idx) => (
+                                <li key={idx} className="text-sm">
+                                    {bullet.text}
+                                    {renderLineRefs(bullet.line_refs)}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </div>
+
+            {/* Interesting Notes - Collapsible (if present) */}
+            {summary.interesting_notes.length > 0 && (
+                <div className="border border-border rounded">
+                    <Tooltip title="Notable observations like errors, unusual patterns, or important details">
+                        <button
+                            type="button"
+                            className="w-full text-left px-3 py-2 font-medium flex items-center gap-2 hover:bg-accent text-sm"
+                            onClick={() => setIsNotesExpanded(!isNotesExpanded)}
+                            data-attr="summary-toggle-notes"
+                        >
+                            <span className="text-xs">{isNotesExpanded ? '▼' : '▶'}</span>
+                            Interesting Notes
+                        </button>
+                    </Tooltip>
+                    {isNotesExpanded && (
+                        <div className="px-3 py-2 border-t border-border bg-bg-light">
+                            <ul className="list-disc list-inside space-y-1">
+                                {summary.interesting_notes.map((note, idx) => (
+                                    <li key={idx} className="text-sm">
+                                        {note.text}
+                                        {renderLineRefs(note.line_refs)}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/summary-view/components/TextReprDisplay.tsx
+++ b/products/llm_analytics/frontend/summary-view/components/TextReprDisplay.tsx
@@ -1,0 +1,34 @@
+/**
+ * Displays line-numbered text representation
+ */
+export interface TextReprDisplayProps {
+    textRepr: string
+}
+
+export function TextReprDisplay({ textRepr }: TextReprDisplayProps): JSX.Element {
+    const lines = textRepr.split('\n')
+
+    return (
+        <div className="p-4 overflow-auto h-full font-mono text-xs whitespace-pre bg-bg-light">
+            {lines.map((line, index) => {
+                // Extract line number from zero-padded format "L001:", "L010:", "L100:"
+                const match = line.match(/^(L\d+:)(.*)$/)
+                // Parse to int to remove leading zeros so ID matches what click handlers expect
+                const lineNumber = match ? parseInt(match[1].slice(1, -1), 10) : null
+                const linePrefix = match ? match[1] : ''
+                const lineContent = match ? match[2] : line
+
+                return (
+                    <div
+                        key={index}
+                        id={lineNumber ? `summary-line-${lineNumber}` : undefined}
+                        className="transition-all duration-300 ease-in-out"
+                    >
+                        {linePrefix && <span className="text-muted">{linePrefix}</span>}
+                        {lineContent}
+                    </div>
+                )
+            })}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/summary-view/summaryViewLogic.ts
+++ b/products/llm_analytics/frontend/summary-view/summaryViewLogic.ts
@@ -1,0 +1,159 @@
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { getCookie } from 'lib/api'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+
+import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+
+import type { summaryViewLogicType } from './summaryViewLogicType'
+
+export type SummaryMode = 'minimal' | 'detailed'
+
+export interface SummaryBullet {
+    text: string
+    line_refs: string
+}
+
+export interface InterestingNote {
+    text: string
+    line_refs: string // Can be empty string if no line refs
+}
+
+export interface StructuredSummary {
+    title: string
+    flow_diagram: string
+    summary_bullets: SummaryBullet[]
+    interesting_notes: InterestingNote[] // Empty array if none
+}
+
+export interface SummaryViewLogicProps {
+    trace?: LLMTrace
+    event?: LLMTraceEvent
+    tree?: any[]
+}
+
+export const summaryViewLogic = kea<summaryViewLogicType>([
+    path(['products', 'llm_analytics', 'frontend', 'summary-view', 'summaryViewLogic']),
+    props({} as SummaryViewLogicProps),
+    connect({
+        values: [maxGlobalLogic, ['dataProcessingAccepted']],
+    }),
+    key((props) => {
+        // Use trace ID or event ID as the key
+        if (props.trace) {
+            return `trace-${props.trace.id}`
+        }
+        if (props.event) {
+            return `event-${props.event.id}`
+        }
+        return 'unknown'
+    }),
+    actions({
+        setSummaryMode: (mode: SummaryMode) => ({ mode }),
+        regenerateSummary: true,
+        toggleFlowExpanded: true,
+        toggleSummaryExpanded: true,
+        toggleNotesExpanded: true,
+    }),
+    reducers({
+        summaryMode: [
+            'minimal' as SummaryMode,
+            {
+                setSummaryMode: (_, { mode }) => mode,
+            },
+        ],
+        isFlowExpanded: [
+            false,
+            {
+                toggleFlowExpanded: (state) => !state,
+            },
+        ],
+        isSummaryExpanded: [
+            true,
+            {
+                toggleSummaryExpanded: (state) => !state,
+            },
+        ],
+        isNotesExpanded: [
+            true,
+            {
+                toggleNotesExpanded: (state) => !state,
+            },
+        ],
+    }),
+    loaders(({ props, values }) => ({
+        summaryData: {
+            __default: null as { summary: StructuredSummary; text_repr: string } | null,
+            generateSummary: async ({ mode, forceRefresh = false }: { mode: SummaryMode; forceRefresh?: boolean }) => {
+                // Check data processing consent before making API call
+                if (!values.dataProcessingAccepted) {
+                    throw new Error('AI data processing must be approved before generating summaries')
+                }
+
+                // Determine if we're summarizing a trace or an event
+                const isTrace = !!props.trace
+
+                // Build request payload
+                const payload = isTrace
+                    ? {
+                          summarize_type: 'trace',
+                          mode,
+                          force_refresh: forceRefresh,
+                          data: {
+                              trace: props.trace,
+                              hierarchy: props.tree || [],
+                          },
+                      }
+                    : {
+                          summarize_type: 'event',
+                          mode,
+                          force_refresh: forceRefresh,
+                          data: {
+                              event: props.event,
+                          },
+                      }
+
+                // Call the summarization API endpoint
+                const teamId = (window as any).POSTHOG_APP_CONTEXT?.current_team?.id
+                if (!teamId) {
+                    throw new Error('Team ID not available')
+                }
+
+                const url = `/api/environments/${teamId}/llm_analytics/summarization/`
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': getCookie('posthog_csrftoken') || '',
+                    },
+                    body: JSON.stringify(payload),
+                    credentials: 'include',
+                })
+
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}))
+                    throw new Error(errorData.detail || errorData.error || 'Failed to generate summary')
+                }
+
+                const data = await response.json()
+                return {
+                    summary: data.summary,
+                    text_repr: data.text_repr,
+                }
+            },
+        },
+    })),
+    listeners(({ actions, values }) => ({
+        regenerateSummary: () => {
+            // Regenerate with current mode but force refresh to bust cache
+            actions.generateSummary({ mode: values.summaryMode, forceRefresh: true })
+        },
+        setSummaryMode: ({ mode }) => {
+            // Generate summary for new mode if we don't have data yet
+            if (values.summaryData) {
+                actions.generateSummary({ mode, forceRefresh: false })
+            }
+        },
+    })),
+])

--- a/products/llm_analytics/frontend/summary-view/utils/lineReferenceUtils.tsx
+++ b/products/llm_analytics/frontend/summary-view/utils/lineReferenceUtils.tsx
@@ -1,0 +1,70 @@
+/**
+ * Utilities for parsing and handling line references in summaries
+ */
+
+/**
+ * Parse line references like L45 in text and make them clickable
+ * Schema enforces single line references only
+ */
+export function parseLineReferences(text: string): (string | JSX.Element)[] {
+    const parts: (string | JSX.Element)[] = []
+    // Match simple line references: L45 or [L45]
+    const regex = /L\d+/g
+    let lastIndex = 0
+    let match
+
+    while ((match = regex.exec(text)) !== null) {
+        // Add text before the match
+        if (match.index > lastIndex) {
+            parts.push(text.slice(lastIndex, match.index))
+        }
+
+        // Extract line number
+        const lineNumber = parseInt(match[0].slice(1)) // Remove 'L' and parse
+        const displayText = `[${match[0]}]` // Always show with brackets for consistency
+
+        parts.push(
+            <button
+                key={match.index}
+                type="button"
+                className="text-link hover:underline font-semibold cursor-pointer"
+                data-attr="summary-line-reference-link"
+                onClick={(e) => {
+                    e.preventDefault()
+
+                    // Scroll to the line
+                    const element = document.getElementById(`summary-line-${lineNumber}`)
+                    if (element) {
+                        element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+
+                        // Highlight the line
+                        element.classList.add('bg-warning-highlight')
+                        element.classList.add('border-l-4')
+                        element.classList.add('border-warning')
+                    }
+
+                    // Remove highlight after 3 seconds
+                    setTimeout(() => {
+                        const element = document.getElementById(`summary-line-${lineNumber}`)
+                        if (element) {
+                            element.classList.remove('bg-warning-highlight')
+                            element.classList.remove('border-l-4')
+                            element.classList.remove('border-warning')
+                        }
+                    }, 3000)
+                }}
+            >
+                {displayText}
+            </button>
+        )
+
+        lastIndex = regex.lastIndex
+    }
+
+    // Add remaining text
+    if (lastIndex < text.length) {
+        parts.push(text.slice(lastIndex))
+    }
+
+    return parts
+}


### PR DESCRIPTION
## Problem

Users need to quickly understand complex LLM trace behavior without reading through entire text representations. AI-powered summaries provide actionable insights at a glance.

Part of https://github.com/PostHog/posthog/issues/41010

## Changes

Adds summary view frontend with AI-powered trace and event summarization.

**Frontend Components:**
- Summary view display with collapsible sections
- Kea logic for state management (mode switching, summary generation)
- Line reference utilities for clickable navigation to text view
- Integration with LLMAnalyticsTraceScene as new Summary tab

**Features:**
- Minimal mode: 3-5 bullet points for quick overview
- Detailed mode: 5-10 comprehensive points with deeper analysis
- ASCII flow diagrams showing trace execution flow
- Clickable line references (L45) that scroll to specific lines in text view
- Interesting notes highlighting patterns, errors, or unusual behavior
- Collapsible sections for managing information density

**Integration:**
- New Summary tab in trace scene
- Feature flag gated: LLM_ANALYTICS_SUMMARIZATION
- Works for traces, generations, and spans
- Seamless navigation to text view via line references

**Security:**
- Fixed CodeQL warnings by preventing exception details from being exposed to users in production
- DEBUG mode includes full errors for development
- Full error details always logged for debugging

## How it works

1. User clicks Generate Summary button
2. Frontend calls summarization API with trace/event data
3. Backend generates line-numbered text representation
4. OpenAI structured output returns summary with line references
5. Frontend renders collapsible summary sections
6. User can click line references to jump to text view
7. User can toggle between minimal/detailed modes

## Testing

Manual testing:
- Summary generation for traces, generations, spans
- Mode switching (minimal/detailed)
- Line reference navigation to text view
- Error handling and retry logic
- Loading states and UI feedback
- Feature flag behavior

## Stack Context

Part 4 of 4 in stacked PR series:
1. Text representation backend #41004 (merged)
2. Text view frontend #41005 (merged)
3. Summarization backend #41006 (merged)
4. [This PR] Summary view frontend

All dependencies merged. This PR now builds directly on master.

## Changelog

- Add interactive summary view with AI-powered insights
- Add line reference navigation from summaries to text view
- Add minimal/detailed summary modes
- Fix CodeQL security warnings for exception exposure