### PR TITLE
fix(cohorts): dont generate bytecode for cohorts referencing non realtime cohorts

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -141,6 +141,9 @@ def generate_cohort_filter_bytecode(filter_data: dict, team: Team) -> tuple[list
         # Check if it's a cohort filter referencing another cohort
         if filter_data.get("type") == "cohort":
             cohort_id = filter_data.get("value")
+            if cohort_id is None:
+                # If cohort_id is missing, don't generate bytecode
+                return None, None, None
             try:
                 referenced_cohort = Cohort.objects.get(team__project_id=team.project_id, id=cohort_id)
                 # Check if the referenced cohort is realtime

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -141,9 +141,6 @@ def generate_cohort_filter_bytecode(filter_data: dict, team: Team) -> tuple[list
         # Check if it's a cohort filter referencing another cohort
         if filter_data.get("type") == "cohort":
             cohort_id = filter_data.get("value")
-            if cohort_id is None:
-                # If cohort_id is missing, don't generate bytecode
-                return None, None, None
             try:
                 referenced_cohort = Cohort.objects.get(team__project_id=team.project_id, id=cohort_id)
                 # Check if the referenced cohort is realtime

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -141,8 +141,16 @@ def generate_cohort_filter_bytecode(filter_data: dict, team: Team) -> tuple[list
         # Check if it's a cohort filter referencing another cohort
         if filter_data.get("type") == "cohort":
             cohort_id = filter_data.get("value")
+            if cohort_id is None:
+                # If cohort_id is missing, don't generate bytecode
+                return None, None, None
+            # Type narrowing: cohort_id is not None at this point, and should be int
             try:
-                referenced_cohort = Cohort.objects.get(team__project_id=team.project_id, id=cohort_id)
+                cohort_id_int = int(cohort_id)
+            except (ValueError, TypeError):
+                return None, None, None
+            try:
+                referenced_cohort = Cohort.objects.get(team__project_id=team.project_id, id=cohort_id_int)
                 # Check if the referenced cohort is realtime
                 if referenced_cohort.cohort_type != CohortType.REALTIME:
                     # Don't generate bytecode for non-realtime cohort references

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -67,6 +67,7 @@ from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.cohort import DEFAULT_COHORT_INSERT_BATCH_SIZE, CohortOrEmpty
 from posthog.models.cohort.calculation_history import CohortCalculationHistory
+from posthog.models.cohort.cohort import CohortPeople, CohortType
 from posthog.models.cohort.util import get_all_cohort_dependencies, print_cohort_hogql_query
 from posthog.models.cohort.validation import CohortTypeValidationSerializer
 from posthog.models.feature_flag.flag_matching import (
@@ -96,8 +97,6 @@ from posthog.utils import format_query_params_absolute_url
 def validate_filters_and_compute_realtime_support(
     filters_dict: dict, team: Team, current_cohort_type: str | None = None
 ) -> tuple[dict, str | None, list | None]:
-    from posthog.models.cohort.cohort import CohortType
-
     try:
         if not filters_dict:
             return filters_dict, current_cohort_type, None
@@ -145,8 +144,6 @@ def generate_cohort_filter_bytecode(filter_data: dict, team: Team) -> tuple[list
             try:
                 referenced_cohort = Cohort.objects.get(team__project_id=team.project_id, id=cohort_id)
                 # Check if the referenced cohort is realtime
-                from posthog.models.cohort.cohort import CohortType
-
                 if referenced_cohort.cohort_type != CohortType.REALTIME:
                     # Don't generate bytecode for non-realtime cohort references
                     return None, None, None
@@ -974,8 +971,6 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         # For static cohorts, copy people directly instead of using the insight filter path
         if cohort.is_static:
-            from posthog.models.cohort.cohort import CohortPeople
-
             person_uuids = CohortPeople.objects.filter(cohort_id=cohort.pk).values_list("person__uuid", flat=True)
             serializer_data["_create_static_person_ids"] = [str(uuid) for uuid in person_uuids]
         else:

--- a/posthog/api/test/test_cohort_bytecode.py
+++ b/posthog/api/test/test_cohort_bytecode.py
@@ -346,3 +346,121 @@ class TestCohortBytecodeScenarios(APIBaseTest):
         self.assertEqual(cohort2.cohort_type, "realtime")
         node2 = cohort2.filters["properties"]["values"][0]["values"][0]
         self.assertEqual(node2["conditionHash"], "827d18e80726ed84")
+
+    def test_cohort_referencing_non_realtime_cohort(self):
+        # 5. Cohort referencing a non-realtime cohort should not generate bytecode
+
+        # Create a non-realtime cohort first
+        base_cohort_filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "OR",
+                        "values": [
+                            {
+                                "key": "$groupidentify",
+                                "type": "behavioral",
+                                "value": "performed_event_regularly",
+                                "negation": False,
+                                "operator": "exact",
+                                "event_type": "events",
+                                "time_value": 1,
+                                "min_periods": 3,
+                                "time_interval": "day",
+                                "total_periods": 5,
+                                "operator_value": 5,
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+        base_cohort = self._create_and_fetch("Non-realtime base cohort", base_cohort_filters)
+        self.assertIsNone(base_cohort.cohort_type)  # Should not be realtime
+
+        # Create a cohort that references the non-realtime cohort
+        referencing_filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {"type": "cohort", "key": "id", "value": base_cohort.id, "negation": False},
+                            {"key": "$browser", "type": "person", "negation": False, "operator": "is_set"},
+                        ],
+                    }
+                ],
+            }
+        }
+
+        referencing_cohort = self._create_and_fetch("Cohort referencing non-realtime", referencing_filters)
+        # The cohort itself might be marked as realtime based on other filters
+        # but the cohort filter should not have bytecode
+        and_group = referencing_cohort.filters["properties"]["values"][0]["values"]
+
+        # The cohort filter should not have bytecode
+        cohort_filter = and_group[0]
+        self.assertEqual(cohort_filter["type"], "cohort")
+        self.assertIsNone(cohort_filter.get("bytecode"))
+        self.assertIsNone(cohort_filter.get("conditionHash"))
+
+        # The person property filter should still have bytecode
+        person_filter = and_group[1]
+        self.assertEqual(person_filter["type"], "person")
+        self.assertIsNotNone(person_filter.get("bytecode"))
+        self.assertIsNotNone(person_filter.get("conditionHash"))
+
+    def test_cohort_referencing_realtime_cohort(self):
+        # 6. Cohort referencing a realtime cohort should generate bytecode
+
+        # Create a realtime cohort first
+        base_cohort_filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {"key": "$browser", "type": "person", "negation": False, "operator": "is_set"},
+                        ],
+                    }
+                ],
+            }
+        }
+        base_cohort = self._create_and_fetch("Realtime base cohort", base_cohort_filters)
+        self.assertEqual(base_cohort.cohort_type, "realtime")  # Should be realtime
+
+        # Create a cohort that references the realtime cohort
+        referencing_filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {"type": "cohort", "key": "id", "value": base_cohort.id, "negation": False},
+                            {"key": "$country", "type": "person", "value": "US", "operator": "exact"},
+                        ],
+                    }
+                ],
+            }
+        }
+
+        referencing_cohort = self._create_and_fetch("Cohort referencing realtime", referencing_filters)
+        and_group = referencing_cohort.filters["properties"]["values"][0]["values"]
+
+        # The cohort filter should have bytecode (in_cohort operation)
+        cohort_filter = and_group[0]
+        self.assertEqual(cohort_filter["type"], "cohort")
+        self.assertIsNotNone(cohort_filter.get("bytecode"))
+        # Should contain IN_COHORT operation
+        self.assertIn(33, cohort_filter["bytecode"])  # 33 is the IN_COHORT operation
+        self.assertIsNotNone(cohort_filter.get("conditionHash"))
+
+        # The person property filter should also have bytecode
+        person_filter = and_group[1]
+        self.assertEqual(person_filter["type"], "person")
+        self.assertIsNotNone(person_filter.get("bytecode"))
+        self.assertIsNotNone(person_filter.get("conditionHash"))

--- a/posthog/api/test/test_cohort_bytecode.py
+++ b/posthog/api/test/test_cohort_bytecode.py
@@ -456,7 +456,7 @@ class TestCohortBytecodeScenarios(APIBaseTest):
         self.assertEqual(cohort_filter["type"], "cohort")
         self.assertIsNotNone(cohort_filter.get("bytecode"))
         # Should contain IN_COHORT operation
-        self.assertIn(33, cohort_filter["bytecode"])  # 33 is the IN_COHORT operation
+        self.assertIn("inCohort", cohort_filter["bytecode"])
         self.assertIsNotNone(cohort_filter.get("conditionHash"))
 
         # The person property filter should also have bytecode

--- a/posthog/management/commands/test/test_resave_cohorts.py
+++ b/posthog/management/commands/test/test_resave_cohorts.py
@@ -66,7 +66,8 @@ class TestResaveCohortsCommandSingleTeam(BaseTest):
     def test_resave_single_team_five_types(self):
         team: Team = self.team
 
-        ref = Cohort.objects.create(team=team, name="ref")
+        # Create a realtime cohort to reference
+        ref = Cohort.objects.create(team=team, name="ref", filters=_make_person_only_filters())
 
         cohorts = [
             Cohort.objects.create(team=team, name="realtime1", filters=_make_realtime_filters()),
@@ -150,9 +151,12 @@ class TestResaveCohortsCommandSingleTeam(BaseTest):
         assert person_filter_2["bytecode"] is not None
         assert person_filter_2["conditionHash"] is not None
 
-        # cohort filter cannot be realtime if it references a non-realtime cohort
-        assert updated[cohorts[3].id].cohort_type is None
-        # The ref cohort has no filters, so it's not realtime, which blocks cohort_filter1 from being realtime
+        # cohort filter is realtime-capable when it references a realtime cohort
+        assert updated[cohorts[3].id].cohort_type == "realtime"
+        assert _has_condition_hash(updated[cohorts[3].id].filters)
+        # The ref cohort is realtime (person-only filters), so cohort_filter1 can also be realtime
+        ref.refresh_from_db()
+        assert ref.cohort_type == "realtime"
 
         # simple behavioral realtime
         assert updated[cohorts[4].id].cohort_type == "realtime"

--- a/posthog/management/commands/test/test_resave_cohorts.py
+++ b/posthog/management/commands/test/test_resave_cohorts.py
@@ -103,7 +103,7 @@ class TestResaveCohortsCommandSingleTeam(BaseTest):
             ),
         ]
 
-        # Ensure initial state has no cohort_type (and no inline bytecode yet)
+        # Ensure initial state has no cohort_type (and no bytecode yet)
         for c in cohorts:
             assert c.cohort_type is None
             assert not _has_condition_hash(c.filters)
@@ -150,9 +150,9 @@ class TestResaveCohortsCommandSingleTeam(BaseTest):
         assert person_filter_2["bytecode"] is not None
         assert person_filter_2["conditionHash"] is not None
 
-        # cohort filter is realtime-capable
-        assert updated[cohorts[3].id].cohort_type == "realtime"
-        assert _has_condition_hash(updated[cohorts[3].id].filters)
+        # cohort filter cannot be realtime if it references a non-realtime cohort
+        assert updated[cohorts[3].id].cohort_type is None
+        # The ref cohort has no filters, so it's not realtime, which blocks cohort_filter1 from being realtime
 
         # simple behavioral realtime
         assert updated[cohorts[4].id].cohort_type == "realtime"


### PR DESCRIPTION
## Problem

When a cohort references another cohort that is not a realtime cohort we would generate the bytecode indicating that this lookup will be possible but it is not as only referencing realtime supported cohorts should be possible to be evaluated later.

We need to make that clear in the UI later on

## Changes

- don't generate bytecode if a cohort references another cohort that is not of type realtime

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added tests
