### PR TITLE
feat(capture-logs): add graceful shutdown to capture-logs server

### DIFF
--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -129,10 +129,10 @@ async fn main() {
     // Wait for any server to finish
     tokio::select! {
         _ = http_server => {
-            error!("HTTP server stopped unexpectedly");
+            error!("HTTP server stopped");
         }
         _ = mgmt_server => {
-            error!("Management server stopped unexpectedly");
+            error!("Management server stopped");
         }
     }
 }

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -6,16 +6,33 @@ use capture_logs::config::Config;
 use capture_logs::kafka::KafkaSink;
 use capture_logs::service::export_logs_http;
 use capture_logs::service::Service;
-use common_metrics::{serve, setup_metrics_routes};
+use common_metrics::setup_metrics_routes;
 use std::future::ready;
+use std::net::SocketAddr;
 
 use health::HealthRegistry;
+use tokio::signal;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 use limiters::token_dropper::TokenDropper;
 
 common_alloc::used!();
+
+async fn shutdown() {
+    let mut term = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .expect("failed to register SIGTERM handler");
+
+    let mut interrupt = signal::unix::signal(signal::unix::SignalKind::interrupt())
+        .expect("failed to register SIGINT handler");
+
+    tokio::select! {
+        _ = term.recv() => {},
+        _ = interrupt.recv() => {},
+    };
+
+    tracing::info!("Shutting down gracefully...");
+}
 
 fn setup_tracing() {
     let log_layer: tracing_subscriber::filter::Filtered<
@@ -62,6 +79,9 @@ async fn main() {
     let management_router = setup_metrics_routes(management_router);
     let management_bind = format!("{}:{}", config.management_host, config.management_port);
     info!("Healthcheck and metrics listening on {}", management_bind);
+    let management_listener = tokio::net::TcpListener::bind(management_bind)
+        .await
+        .expect("could not bind management port");
 
     let token_dropper = TokenDropper::new(&config.drop_events_by_token.unwrap_or_default());
     let logs_service = match Service::new(kafka_sink, token_dropper).await {
@@ -73,6 +93,9 @@ async fn main() {
     };
     let http_bind = format!("{}:{}", config.host, config.port);
     info!("Listening on {}", http_bind);
+    let http_listener = tokio::net::TcpListener::bind(http_bind)
+        .await
+        .expect("could not bind http port");
 
     let http_router = Router::new()
         .route("/v1/logs", post(export_logs_http))
@@ -81,13 +104,24 @@ async fn main() {
         .layer(axum::middleware::from_fn(track_metrics));
 
     let http_server = tokio::spawn(async move {
-        if let Err(e) = serve(http_router, &http_bind).await {
+        if let Err(e) = axum::serve(
+            http_listener,
+            http_router.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(shutdown())
+        .await
+        {
             error!("HTTP server failed: {}", e);
         }
     });
 
     let mgmt_server = tokio::spawn(async move {
-        if let Err(e) = serve(management_router, &management_bind).await {
+        if let Err(e) = axum::serve(
+            management_listener,
+            management_router.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        {
             error!("Management server failed: {}", e);
         }
     });


### PR DESCRIPTION
## Problem

add graceful shutdown to ensure we don't drop requests on deployments

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
