### PR TITLE
chore(cli): add terminal checks

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.10
+
+- Add terminal checks for login and query command
+
 # 0.5.9
 
 - Improve error handling from api

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1521,7 +1521,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.9"
+version = "0.5.10"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/experimental/tui/query.rs
+++ b/cli/src/experimental/tui/query.rs
@@ -1,6 +1,6 @@
 use std::{io::Stdout, thread::JoinHandle, time::Duration};
 
-use anyhow::Error;
+use anyhow::{bail, Error};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -17,6 +17,7 @@ use crate::{
     experimental::query::{
         run_query, HogQLQueryErrorResponse, HogQLQueryResponse, HogQLQueryResult,
     },
+    invocation_context::context,
     utils::homedir::posthog_home_dir,
 };
 
@@ -302,6 +303,9 @@ impl QueryTui {
 }
 
 pub fn start_query_editor(debug: bool) -> Result<String, Error> {
+    if !context().is_terminal {
+        bail!("Failed to start query editor: Terminal not available");
+    }
     let terminal = ratatui::init();
 
     let mut app = QueryTui::new(debug);

--- a/cli/src/invocation_context.rs
+++ b/cli/src/invocation_context.rs
@@ -6,6 +6,7 @@ use inquire::{
 use posthog_rs::Event;
 use reqwest::blocking::Client;
 use std::{
+    io::{self, IsTerminal},
     sync::{Mutex, OnceLock},
     thread::JoinHandle,
 };
@@ -22,6 +23,7 @@ pub static INVOCATION_CONTEXT: OnceLock<InvocationContext> = OnceLock::new();
 pub struct InvocationContext {
     pub config: InvocationConfig,
     pub client: PHClient,
+    pub is_terminal: bool,
 
     handles: Mutex<Vec<JoinHandle<()>>>,
 }
@@ -93,6 +95,7 @@ impl InvocationContext {
         Self {
             config,
             client,
+            is_terminal: io::stdout().is_terminal(),
             handles: Default::default(),
         }
     }

--- a/cli/src/login.rs
+++ b/cli/src/login.rs
@@ -1,8 +1,9 @@
-use anyhow::{Context, Error};
+use anyhow::{bail, Context, Error, Result};
 use inquire::{Select, Text};
 use serde::{Deserialize, Serialize};
-use std::thread;
+use std::io::IsTerminal;
 use std::time::Duration;
+use std::{io, thread};
 use tracing::info;
 
 use crate::{
@@ -34,14 +35,14 @@ struct PollResponse {
     project_id: Option<String>,
 }
 
-pub fn login(host_override: Option<String>) -> Result<(), Error> {
+pub fn login(host_override: Option<String>) -> Result<()> {
+    if !io::stdout().is_terminal() {
+        bail!("Failed to login. If you are running on a CI, skip this step and use POSTHOG_CLI_HOST, POSTHOG_CLI_ENV_ID, POSTHOG_CLI_TOKEN env variables when running commands")
+    }
     login_with_use_cases(host_override, vec!["schema", "error_tracking"])
 }
 
-pub fn login_with_use_cases(
-    host_override: Option<String>,
-    use_cases: Vec<&str>,
-) -> Result<(), Error> {
+pub fn login_with_use_cases(host_override: Option<String>, use_cases: Vec<&str>) -> Result<()> {
     let host = if let Some(override_host) = host_override {
         // Strip trailing slashes to avoid double slashes in URLs
         override_host.trim_end_matches('/').to_string()


### PR DESCRIPTION
## Problem

- Users sometimes invoke the interactive login command on CI

Fix https://posthoghelp.zendesk.com/agent/tickets/41686 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/44007)
Fix https://posthog.com/questions/ci-cd-environment
 
## Changes

- Add clear error message to avoid this situation
