### PR TITLE
feat: save dashboard on exiting edit mode using "E"

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1662,8 +1662,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 })
             } else if (
                 mode === null &&
-                (source === DashboardEventSource.DashboardHeaderSaveDashboard ||
-                    (source === DashboardEventSource.Hotkey && values.dashboardMode === DashboardMode.Edit))
+                (source === DashboardEventSource.DashboardHeaderSaveDashboard || source === DashboardEventSource.Hotkey)
             ) {
                 // save edit mode changes
                 actions.saveEditModeChanges()

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1660,7 +1660,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     action: RefreshDashboardItemsAction.Refresh,
                     forceRefresh: false,
                 })
-            } else if (mode === null && source === DashboardEventSource.DashboardHeaderSaveDashboard) {
+            } else if (
+                mode === null &&
+                (source === DashboardEventSource.DashboardHeaderSaveDashboard ||
+                    (source === DashboardEventSource.Hotkey && values.dashboardMode === DashboardMode.Edit))
+            ) {
                 // save edit mode changes
                 actions.saveEditModeChanges()
             }

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -456,7 +456,6 @@ class DashboardSerializer(DashboardMetadataSerializer):
         duplicate_tiles = initial_data.pop("duplicate_tiles", [])
         for tile_data in duplicate_tiles:
             existing_tile = DashboardTile.objects.get(dashboard=instance, id=tile_data["id"])
-            existing_tile.layouts = {}
             self._deep_duplicate_tiles(instance, existing_tile)
 
         if "request" in self.context:


### PR DESCRIPTION
## Problem

1. Right now you can enter edit mode using `E`. You can then press `E` again and you exit edit mode. Save button disappears and dashboard looks like it's saved - but it is not. Refreshing the page brings back the pre edit layout.
2. When pressing `Duplicate` on the dashboard tile, new tile does not inherit the size.

## Changes

1.  Made it so that exiting edit mode using `E` saves the dashboard.
2. Removed `existing_tile.layouts = {}` so now duplicated tile inherits original size - seems that it is working and I wasn't able to break dashboards in any way after this change but I am not super sure about it.

## How did you test this code?

Tested this locally

## Auto saving on pressing `E` to exit edit mode
https://github.com/user-attachments/assets/a42c556a-14cd-4476-b257-c83f37e62a5a

## Inheriting original size on`Duplicate`
https://github.com/user-attachments/assets/4cd3d73a-59b7-4b4c-8a45-577752cc4ade







