### PR TITLE
feat(workflows): add history tab for workflows

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1986,6 +1986,7 @@ const api = {
                 [
                     ActivityScope.PLUGIN,
                     ActivityScope.HOG_FUNCTION,
+                    ActivityScope.HOG_FLOW,
                     ActivityScope.EXPERIMENT,
                     ActivityScope.TAG,
                     ActivityScope.ENDPOINT,

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -42,6 +42,8 @@ import { urls } from 'scenes/urls'
 
 import { ActivityScope } from '~/types'
 
+import { workflowActivityDescriber } from 'products/workflows/frontend/Workflows/misc/workflowActivityDescriber'
+
 import type { activityLogLogicType } from './activityLogLogicType'
 
 // Define which scopes should be expanded to include multiple scopes
@@ -118,6 +120,8 @@ export const describerFor = (logItem?: ActivityLogItem): Describer | undefined =
             return flagActivityDescriber
         case ActivityScope.HOG_FUNCTION:
             return hogFunctionActivityDescriber
+        case ActivityScope.HOG_FLOW:
+            return workflowActivityDescriber
         case ActivityScope.COHORT:
             return cohortActivityDescriber
         case ActivityScope.INSIGHT:

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4687,6 +4687,7 @@ export enum ActivityScope {
     PLUGIN = 'Plugin',
     PLUGIN_CONFIG = 'PluginConfig',
     HOG_FUNCTION = 'HogFunction',
+    HOG_FLOW = 'HogFlow',
     DATA_MANAGEMENT = 'DataManagement',
     EVENT_DEFINITION = 'EventDefinition',
     PROPERTY_DEFINITION = 'PropertyDefinition',

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -3,6 +3,7 @@ import { router } from 'kea-router'
 
 import { SpinnerOverlay } from '@posthog/lemon-ui'
 
+import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { LogsViewer } from 'scenes/hog-functions/logs/LogsViewer'
@@ -10,6 +11,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { ActivityScope } from '~/types'
 
 import { Workflow } from './Workflow'
 import { WorkflowMetrics } from './WorkflowMetrics'
@@ -69,6 +71,15 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
              * defined and not "new" (see return statement below)
              */
             content: <WorkflowMetrics id={props.id!} />,
+        },
+        {
+            label: 'History',
+            key: 'history',
+            /**
+             * If we're rendering tabs, props.id is guaranteed to be
+             * defined and not "new" (see return statement below)
+             */
+            content: <ActivityLog id={props.id!} scope={ActivityScope.HOG_FLOW} />,
         },
     ]
 

--- a/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
+++ b/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
@@ -76,8 +76,67 @@ export function workflowActivityDescriber(logItem: ActivityLogItem, asNotificati
                     })
                     break
                 }
+                case 'actions': {
+                    const actionsBefore = (change.before as any[]) || []
+                    const actionsAfter = (change.after as any[]) || []
+
+                    // Create maps by id for easier comparison
+                    const beforeMap = new Map(actionsBefore.map((a: any) => [a.id, a]))
+                    const afterMap = new Map(actionsAfter.map((a: any) => [a.id, a]))
+
+                    const added: string[] = []
+                    const removed: string[] = []
+                    const modified: string[] = []
+
+                    // Find added actions
+                    for (const action of actionsAfter) {
+                        if (!beforeMap.has(action.id)) {
+                            added.push(action.name || action.id)
+                        }
+                    }
+
+                    // Find removed actions
+                    for (const action of actionsBefore) {
+                        if (!afterMap.has(action.id)) {
+                            removed.push(action.name || action.id)
+                        }
+                    }
+
+                    // Find modified actions (same id but different content)
+                    for (const action of actionsAfter) {
+                        const beforeAction = beforeMap.get(action.id)
+                        if (beforeAction && JSON.stringify(beforeAction) !== JSON.stringify(action)) {
+                            modified.push(action.name || action.id)
+                        }
+                    }
+
+                    const changesList: string[] = []
+                    if (added.length > 0) {
+                        changesList.push(`added ${added.length === 1 ? 'action' : 'actions'}: ${added.join(', ')}`)
+                    }
+                    if (removed.length > 0) {
+                        changesList.push(
+                            `removed ${removed.length === 1 ? 'action' : 'actions'}: ${removed.join(', ')}`
+                        )
+                    }
+                    if (modified.length > 0) {
+                        changesList.push(modified.join(', '))
+                    }
+
+                    if (changesList.length > 0) {
+                        changes.push({
+                            inline: <>updated actions ({changesList.join('; ')})</>,
+                            inlist: <>updated actions ({changesList.join('; ')})</>,
+                        })
+                    } else {
+                        changes.push({
+                            inline: 'updated actions',
+                            inlist: 'updated actions',
+                        })
+                    }
+                    break
+                }
                 case 'trigger':
-                case 'actions':
                 case 'edges':
                 case 'variables': {
                     changes.push({

--- a/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
+++ b/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
@@ -1,0 +1,119 @@
+import {
+    ActivityLogItem,
+    HumanizedChange,
+    defaultDescriber,
+    userNameForLogItem,
+} from 'lib/components/ActivityLog/humanizeActivity'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+
+const nameOrLinkToWorkflow = (id?: string | null, name?: string | null): string | JSX.Element => {
+    const displayName = name || '(empty string)'
+    return id ? <Link to={urls.workflow(id, 'workflow')}>{displayName}</Link> : displayName
+}
+
+export function workflowActivityDescriber(logItem: ActivityLogItem, asNotification?: boolean): HumanizedChange {
+    if (logItem.scope != 'HogFlow') {
+        console.error('Workflow describer received a non-HogFlow activity')
+        return { description: null }
+    }
+
+    const objectNoun = 'workflow'
+
+    if (logItem.activity == 'created') {
+        return {
+            description: (
+                <>
+                    <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> created the {objectNoun}:{' '}
+                    {nameOrLinkToWorkflow(logItem?.item_id, logItem?.detail.name)}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'deleted') {
+        return {
+            description: (
+                <>
+                    <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> deleted the {objectNoun}:{' '}
+                    {logItem.detail.name}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'updated') {
+        const changes: { inline: string | JSX.Element; inlist: string | JSX.Element }[] = []
+        for (const change of logItem.detail.changes ?? []) {
+            switch (change.field) {
+                case 'name': {
+                    changes.push({
+                        inline: (
+                            <>
+                                renamed from <strong>{change.before}</strong> to <strong>{change.after}</strong>
+                            </>
+                        ),
+                        inlist: (
+                            <>
+                                renamed from <strong>{change.before}</strong> to <strong>{change.after}</strong>
+                            </>
+                        ),
+                    })
+                    break
+                }
+                case 'description': {
+                    changes.push({
+                        inline: 'updated description',
+                        inlist: 'updated description',
+                    })
+                    break
+                }
+                case 'status': {
+                    const statusChange = change.after === 'active' ? 'enabled' : 'disabled'
+                    changes.push({
+                        inline: statusChange,
+                        inlist: `${statusChange} the ${objectNoun}`,
+                    })
+                    break
+                }
+                case 'trigger':
+                case 'actions':
+                case 'edges':
+                case 'variables': {
+                    changes.push({
+                        inline: `updated ${change.field}`,
+                        inlist: `updated ${change.field}`,
+                    })
+                    break
+                }
+                default:
+                    changes.push({
+                        inline: `updated ${change.field}`,
+                        inlist: `updated ${change.field}`,
+                    })
+            }
+        }
+        const name = userNameForLogItem(logItem)
+        const workflowName = nameOrLinkToWorkflow(logItem?.item_id, logItem?.detail.name)
+
+        return {
+            description:
+                changes.length == 1 ? (
+                    <>
+                        <strong className="ph-no-capture">{name}</strong> {changes[0].inline} the {objectNoun}:{' '}
+                        {workflowName}
+                    </>
+                ) : (
+                    <div>
+                        <strong className="ph-no-capture">{name}</strong> updated the {objectNoun}: {workflowName}
+                        <ul className="ml-5 list-disc">
+                            {changes.map((c, i) => (
+                                <li key={i}>{c.inlist}</li>
+                            ))}
+                        </ul>
+                    </div>
+                ),
+        }
+    }
+    return defaultDescriber(logItem, asNotification, nameOrLinkToWorkflow(logItem?.item_id, logItem?.detail.name))
+}

--- a/products/workflows/frontend/Workflows/workflowSceneLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowSceneLogic.ts
@@ -8,7 +8,7 @@ import { Breadcrumb } from '~/types'
 
 import type { workflowSceneLogicType } from './workflowSceneLogicType'
 
-export const WorkflowTabs = ['workflow', 'logs', 'metrics'] as const
+export const WorkflowTabs = ['workflow', 'logs', 'metrics', 'history'] as const
 export type WorkflowTab = (typeof WorkflowTabs)[number]
 
 export interface WorkflowSceneLogicProps {


### PR DESCRIPTION
## Problem

We did not see who changed anything like in other destinations or transformations.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![2025-11-06 16 52 17](https://github.com/user-attachments/assets/70a0c2a9-2abc-401b-b9ae-84011988491f)

- added history tab to workflows

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
