### PR TITLE
feat: Drop order by from sessions query in batch exports

### DIFF
--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -477,7 +477,6 @@ SELECT_FROM_SESSIONS_HOGQL = ast.SelectQuery(
         parse_expr("$entry_irclid as entry_irclid"),
     ],
     select_from=ast.JoinExpr(table=ast.Field(chain=["sessions"])),
-    order_by=[ast.OrderExpr(expr=ast.Field(chain=["_inserted_at"]), order="ASC")],
     settings=HogQLQueryBatchExportSettings(),
 )
 


### PR DESCRIPTION
## Problem

We use internal stage for sessions query now too, so there isn't any point in ordering as we don't resume.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Drop order by clause from sessions query, hopefully save some memory.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
