### PR TITLE
feat(sessions): Add migration to split count of autocaptures out of screen/pageview count

### DIFF
--- a/posthog/clickhouse/migrations/0167_sessions_v3_split_bounce_rate.py
+++ b/posthog/clickhouse/migrations/0167_sessions_v3_split_bounce_rate.py
@@ -1,0 +1,23 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.migrations_v3 import SPLIT_BOUNCE_RATE
+from posthog.models.raw_sessions.sessions_v3 import (
+    DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
+    SHARDED_RAW_SESSIONS_TABLE_V3,
+    WRITABLE_RAW_SESSIONS_TABLE_V3,
+)
+
+operations = [
+    run_sql_with_exceptions(
+        SPLIT_BOUNCE_RATE.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        SPLIT_BOUNCE_RATE.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()), node_roles=[NodeRole.DATA]
+    ),
+    run_sql_with_exceptions(
+        SPLIT_BOUNCE_RATE.format(table_name=DISTRIBUTED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0166_custom_metrics_refresh
+0167_sessions_v3_split_bounce_rate

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2801,7 +2801,8 @@
   
       -- As a performance optimisation, also keep track of the uniq events for all of these combined.
       -- This is a much more efficient way of calculating the bounce rate, as >2 means not a bounce
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      page_screen_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      has_autocapture SimpleAggregateFunction(max, Boolean),
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
@@ -2998,7 +2999,8 @@
       initializeAggregation('uniqExactState', if(event='$screen', uuid, NULL)) as screen_uniq,
   
       -- perf
-      initializeAggregation('uniqUpToState(1)', if(event='$pageview' OR event='$screen' OR event='$autocapture', uuid, NULL)) as page_screen_autocapture_uniq_up_to,
+      initializeAggregation('uniqUpToState(1)', if(event='$pageview' OR event='$screen', uuid, NULL)) as page_screen_uniq_up_to,
+      event = '$autocapture' as has_autocapture,
   
       -- flags
       initializeAggregation('groupUniqArrayMapState', properties_group_feature_flags) as flag_values,
@@ -3086,7 +3088,8 @@
       initializeAggregation('uniqExactState', null_uuid) as screen_uniq,
   
       -- perf
-      initializeAggregation('uniqUpToState(1)', null_uuid) as page_screen_autocapture_uniq_up_to,
+      initializeAggregation('uniqUpToState(1)', null_uuid) as page_screen_uniq_up_to,
+      false as has_autocapture,
   
       -- flags
       initializeAggregation('groupUniqArrayMapState', CAST(map(), 'Map(String, String)')) as flag_values,
@@ -3940,7 +3943,8 @@
   
       -- As a performance optimisation, also keep track of the uniq events for all of these combined.
       -- This is a much more efficient way of calculating the bounce rate, as >2 means not a bounce
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      page_screen_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      has_autocapture SimpleAggregateFunction(max, Boolean),
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
@@ -5097,7 +5101,8 @@
   
       -- As a performance optimisation, also keep track of the uniq events for all of these combined.
       -- This is a much more efficient way of calculating the bounce rate, as >2 means not a bounce
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      page_screen_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      has_autocapture SimpleAggregateFunction(max, Boolean),
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
@@ -6407,7 +6412,8 @@
   
       -- As a performance optimisation, also keep track of the uniq events for all of these combined.
       -- This is a much more efficient way of calculating the bounce rate, as >2 means not a bounce
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      page_screen_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
+      has_autocapture SimpleAggregateFunction(max, Boolean),
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),

--- a/posthog/hogql/database/schema/sessions_v3.py
+++ b/posthog/hogql/database/schema/sessions_v3.py
@@ -418,6 +418,7 @@ class SessionsTableV3(LazyTable):
                 "$exit_current_url",
                 "$exit_pathname",
                 "$has_autocapture",
+                "$entry_channel_type_properties",
             }
         )
 
@@ -467,7 +468,8 @@ def get_lazy_session_table_properties_v3(search: Optional[str]):
         "$num_uniq_urls",
         "$page_screen_autocapture_count_up_to",
         "$page_screen_count_up_to",
-        "$has_autocapture" "$entry_channel_type_properties",
+        "$has_autocapture",
+        "$entry_channel_type_properties",
         "session_timestamp",  # really people should be using $start_timestamp for most queries
         # aliases for people upgrading from v1 to v2/v3
         "$exit_current_url",

--- a/posthog/hogql/database/schema/sessions_v3.py
+++ b/posthog/hogql/database/schema/sessions_v3.py
@@ -417,6 +417,7 @@ class SessionsTableV3(LazyTable):
                 # aliases for people upgrading from v1 to v2
                 "$exit_current_url",
                 "$exit_pathname",
+                "$has_autocapture",
             }
         )
 
@@ -465,7 +466,8 @@ def get_lazy_session_table_properties_v3(search: Optional[str]):
         "duration",
         "$num_uniq_urls",
         "$page_screen_autocapture_count_up_to",
-        "$entry_channel_type_properties",
+        "$page_screen_count_up_to",
+        "$has_autocapture" "$entry_channel_type_properties",
         "session_timestamp",  # really people should be using $start_timestamp for most queries
         # aliases for people upgrading from v1 to v2/v3
         "$exit_current_url",

--- a/posthog/hogql/database/schema/sessions_v3.py
+++ b/posthog/hogql/database/schema/sessions_v3.py
@@ -325,7 +325,7 @@ def select_from_sessions_table_v3(
                         name="or",
                         args=[
                             # if >= 2 pageviews/screens, not a bounce
-                            ast.Call(name="greater", args=[bounce_pageview_count, ast.Constant(value=1)]),
+                            ast.Call(name="greaterOrEquals", args=[bounce_pageview_count, ast.Constant(value=2)]),
                             # if there was an autocapture, not a bounce
                             aggregate_fields["$has_autocapture"],
                             # if session duration >= bounce_rate_duration_seconds, not a bounce

--- a/posthog/hogql/database/schema/test/__snapshots__/test_sessions_v3.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_sessions_v3.ambr
@@ -4,7 +4,7 @@
   SELECT sessions.`$is_bounce` AS `$is_bounce`,
          sessions.session_id AS session_id
   FROM
-    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 0), 0), NULL, not(or(ifNull(greater(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 1), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 0), 0), NULL, not(or(ifNull(greaterOrEquals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 2), 0), max(raw_sessions_v3.has_autocapture), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
             toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
             raw_sessions_v3.session_id_v7 AS session_id_v7
      FROM raw_sessions_v3
@@ -111,7 +111,7 @@
   SELECT sessions.`$is_bounce` AS `$is_bounce`,
          sessions.session_id AS session_id
   FROM
-    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 0), 0), NULL, not(or(ifNull(greater(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 1), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 0), 0), NULL, not(or(ifNull(greaterOrEquals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 2), 0), max(raw_sessions_v3.has_autocapture), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
             toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
             raw_sessions_v3.session_id_v7 AS session_id_v7
      FROM raw_sessions_v3
@@ -135,7 +135,7 @@
   SELECT sessions.`$is_bounce` AS `$is_bounce`,
          sessions.session_id AS session_id
   FROM
-    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 0), 0), NULL, not(or(ifNull(greater(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 1), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10.0)))) AS `$is_bounce`,
+    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 0), 0), NULL, not(or(ifNull(greaterOrEquals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 2), 0), max(raw_sessions_v3.has_autocapture), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10.0)))) AS `$is_bounce`,
             toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
             raw_sessions_v3.session_id_v7 AS session_id_v7
      FROM raw_sessions_v3
@@ -159,7 +159,7 @@
   SELECT sessions.`$is_bounce` AS `$is_bounce`,
          sessions.session_id AS session_id
   FROM
-    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 0), 0), NULL, not(or(ifNull(greater(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 1), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 30.0)))) AS `$is_bounce`,
+    (SELECT if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 0), 0), NULL, not(or(ifNull(greaterOrEquals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 2), 0), max(raw_sessions_v3.has_autocapture), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 30.0)))) AS `$is_bounce`,
             toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
             raw_sessions_v3.session_id_v7 AS session_id_v7
      FROM raw_sessions_v3
@@ -303,9 +303,11 @@
 # ---
 # name: TestSessionsV3.test_page_screen_autocapture_count_up_to
   '''
-  SELECT sessions.`$page_screen_autocapture_count_up_to` AS `$page_screen_autocapture_count_up_to`
+  SELECT sessions.`$page_screen_count_up_to` AS `$page_screen_count_up_to`,
+         sessions.`$has_autocapture` AS `$has_autocapture`
   FROM
-    (SELECT uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to) AS `$page_screen_autocapture_count_up_to`,
+    (SELECT uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to) AS `$page_screen_count_up_to`,
+            max(raw_sessions_v3.has_autocapture) AS `$has_autocapture`,
             toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
             raw_sessions_v3.session_id_v7 AS session_id_v7
      FROM raw_sessions_v3
@@ -385,6 +387,7 @@
          toTimeZone(raw_sessions_v3.max_timestamp, 'UTC') AS max_timestamp,
          toTimeZone(raw_sessions_v3.max_inserted_at, 'UTC') AS max_inserted_at,
          raw_sessions_v3.urls AS urls,
+         raw_sessions_v3.has_autocapture AS has_autocapture,
          raw_sessions_v3.has_replay_events AS has_replay_events
   FROM raw_sessions_v3
   WHERE equals(raw_sessions_v3.team_id, 99999)
@@ -493,7 +496,7 @@
             uniqExactMerge(raw_sessions_v3.screen_uniq) AS `$screen_count`,
             multiIf(match(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 3), ''), 'null')), 'cross-network'), 'Cross Network', or(in(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 2), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), startsWith(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 2), ''), 'null')), 'paid'), tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 5), isNotNull(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 7), ''), 'null'))), coalesce(coalesce(dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 1), ''), 'null')), ''), 'source')), dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 1), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 3), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 2), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', (coalesce(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 4), ''), 'source')), dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 4), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 7), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 3), ''), 'null')), '^(.*video.*)$'), 'Paid Video', tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 6), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 4), '$direct'), 0), isNull(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 2), ''), 'null'))), or(isNull(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 1), ''), 'null'))), in(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 1), ''), 'null')), tuple('(direct)', 'direct', '$direct'))), not(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 6))), 'Direct', coalesce(coalesce(dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 1), ''), 'null')), ''), 'source')), dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 1), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 3), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 2), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', (coalesce(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 4), ''), 'source')), dictGetOrNull('posthog_test.channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 4), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 3), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 2), ''), 'null')), 'push$'), 'Push', tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 6), 'Organic Social', ifNull(equals(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 4), '$direct'), 0), 'Direct', isNotNull(tupleElement(argMinMerge(raw_sessions_v3.entry_channel_type_properties), 4)), 'Referral', 'Unknown'))) AS `$channel_type`,
             dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))) AS `$session_duration`,
-            if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 0), 0), NULL, not(or(ifNull(greater(uniqUpToMerge(1)(raw_sessions_v3.page_screen_autocapture_uniq_up_to), 1), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+            if(ifNull(equals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 0), 0), NULL, not(or(ifNull(greaterOrEquals(uniqUpToMerge(1)(raw_sessions_v3.page_screen_uniq_up_to), 2), 0), max(raw_sessions_v3.has_autocapture), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions_v3.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions_v3.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
             max(raw_sessions_v3.has_replay_events) AS `$has_replay_events`,
             arrayElement(argMinMerge(raw_sessions_v3.entry_ad_ids_map), 'gclsrc') AS `$entry_gclsrc`,
             has(argMinMerge(raw_sessions_v3.entry_ad_ids_set), 'gclsrc') AS `$entry_has_gclsrc`,

--- a/posthog/hogql/database/schema/test/test_sessions_v3.py
+++ b/posthog/hogql/database/schema/test/test_sessions_v3.py
@@ -147,32 +147,6 @@ class TestSessionsV3(ClickhouseTestMixin, APIBaseTest):
             "Paid Search",
         )
 
-    # TODO: restore once #session_id_uuid is migrated properly
-    # @parameterized.expand([[SessionsV2JoinMode.STRING], [SessionsV2JoinMode.UUID]])
-    # def test_event_dot_session_dot_channel_type(self, join_mode):
-    #     session_id = str(uuid7())
-
-    #     _create_event(
-    #         event="$pageview",
-    #         team=self.team,
-    #         distinct_id="d1",
-    #         properties={"gad_source": "1", "$session_id": session_id},
-    #     )
-
-    #     response = self.__execute(
-    #         parse_select(
-    #             "select events.session.$channel_type from events where $session_id = {session_id}",
-    #             placeholders={"session_id": ast.Constant(value=session_id)},
-    #         ),
-    #         sessions_v2_join_mode=join_mode,
-    #     )
-
-    #     result = (response.results or [])[0]
-    #     self.assertEqual(
-    #         result[0],
-    #         "Paid Search",
-    #     )
-
     def test_session_dot_channel_type(self):
         session_id = str(uuid7())
 
@@ -366,7 +340,7 @@ class TestSessionsV3(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": s3},
             timestamp="2023-12-02",
         )
-        # three pageviews (should still count as 2)
+        # >2 pageviews (should still count as 2)
         s4 = str(uuid7(time + 4))
         _create_event(
             event="$pageview",
@@ -405,17 +379,26 @@ class TestSessionsV3(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": s5},
             timestamp="2023-12-02",
         )
+        # one autocapture
+        s6 = str(uuid7(time + 6))
+        _create_event(
+            event="$autocapture",
+            team=self.team,
+            distinct_id=s1,
+            properties={"$session_id": s6},
+            timestamp="2023-12-02",
+        )
 
         results = (
             self.__execute(
                 parse_select(
-                    "select $page_screen_autocapture_count_up_to from sessions ORDER BY session_id",
+                    "select $page_screen_count_up_to, $has_autocapture from sessions ORDER BY session_id",
                     placeholders={"session_id": ast.Constant(value=s1)},
                 ),
             ).results
             or []
         )
-        assert results == [(2,), (2,), (1,), (2,), (1,)]
+        assert results == [(2, False), (1, True), (1, False), (2, False), (1, False), (0, True)]
 
     def test_bounce_rate(self):
         time = time_ns() // (10**6)
@@ -426,6 +409,7 @@ class TestSessionsV3(ClickhouseTestMixin, APIBaseTest):
         s3 = str(uuid7(time + 3))
         s4 = str(uuid7(time + 4))
         s5 = str(uuid7(time + 5))
+        s6 = str(uuid7(time + 6))
 
         # person with 2 different sessions
         _create_event(
@@ -502,6 +486,15 @@ class TestSessionsV3(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": s5, "$current_url": "https://example.com/7"},
             timestamp="2023-12-11T12:00:11",
         )
+        # session with 1 autocapture
+        _create_event(
+            event="autocapture",
+            team=self.team,
+            distinct_id="d6",
+            properties={"$session_id": s6, "$current_url": "https://example.com/7"},
+            timestamp="2023-12-11T12:00:00",
+        )
+
         response = self.__execute(
             parse_select(
                 "select $is_bounce, session_id from sessions ORDER BY session_id",
@@ -514,6 +507,7 @@ class TestSessionsV3(ClickhouseTestMixin, APIBaseTest):
             (0, s3),
             (1, s4),
             (0, s5),
+            (None, s6),
         ]
 
     def test_custom_bounce_rate_duration(self):

--- a/posthog/models/raw_sessions/migrations_v3.py
+++ b/posthog/models/raw_sessions/migrations_v3.py
@@ -8,3 +8,12 @@ ADD_HAS_REPLAY_EVENTS = """
 ALTER TABLE {table_name}
 ADD COLUMN IF NOT EXISTS has_replay_events SimpleAggregateFunction(max, Boolean) AFTER flag_values;
 """
+
+SPLIT_BOUNCE_RATE = """
+ALTER TABLE {table_name}
+DROP COLUMN IF EXISTS page_screen_autocapture_uniq_up_to,
+ADD COLUMN IF NOT EXISTS page_screen_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)) AFTER screen_uniq,
+ADD COLUMN IF NOT EXISTS has_autocapture SimpleAggregateFunction(max, Boolean) AFTER page_screen_uniq_up_to
+;
+
+"""


### PR DESCRIPTION
## Problem

The previous way of handling bounce rate meant that there was a slight discrepancy between v2 and v3 sessions. This might lead to customer being confused when we switch. This PR makes it so the calculation will be identical.

In v2, we set $is_bounce to NULL if there were no (pageviews + screens)
In the old code for v3, we were setting it to NULL if there no (pageviews + screen + autocaptures)

This means that we treated events with only autocapture events different (NULL in v2, FALSE in old v3 code, will be NULL again in v3 after this PR)

Note: this table is not used in production anywhere, so it's safe to add and remove columns in the same PR

## Changes

* Split the column into 2 separate columns, one to keep track of pageview/screen events, and one to keep track of autocapture events

## How did you test this code?

The tests still pass, the snapshots will update_

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
