### PR TITLE
fix: upside down feature flag on SQL editor managed-views

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -1003,8 +1003,8 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                         : []),
                     createTopLevelFolderNode('views', viewsChildren),
                     ...(featureFlags[FEATURE_FLAGS.MANAGED_VIEWSETS]
-                        ? []
-                        : [createTopLevelFolderNode('managed-views', managedViewsChildren)]),
+                        ? [createTopLevelFolderNode('managed-views', managedViewsChildren)]
+                        : []),
                     ...(featureFlags[FEATURE_FLAGS.ENDPOINTS]
                         ? [createTopLevelFolderNode('endpoints', endpointChildren)]
                         : []),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
could be wrong, maybe not

i currently see an empty managed views folder on a personal EU account, but don't see it on Team 2 in US.

EU:

![image.png](https://app.graphite.com/user-attachments/assets/e7530bbd-0edd-4688-978d-169e4a637aa6.png)

US Team 2:
![image.png](https://app.graphite.com/user-attachments/assets/30942600-1c3b-4a4d-ac6e-2f64658480ef.png)

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
