### PR TITLE
fix(batch-exports): Handle issues with Snowflake warehouse names

### DIFF
--- a/products/batch_exports/backend/api/destination_tests/snowflake.py
+++ b/products/batch_exports/backend/api/destination_tests/snowflake.py
@@ -88,7 +88,7 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
                 password=self.password,
                 account=self.account,
                 private_key=private_key,
-                role=self.role,
+                role=f'"{self.role}"' if self.role is not None else None,
             )
         except (OperationalError, InterfaceError, DatabaseError) as err:
             if err.msg is not None and "404 Not Found" in err.msg:
@@ -170,7 +170,7 @@ class SnowflakeWarehouseTestStep(DestinationTestStep):
             password=self.password,
             account=self.account,
             private_key=private_key,
-            role=self.role,
+            role=f'"{self.role}"' if self.role is not None else None,
         )
 
         with connection.cursor() as cursor:
@@ -258,8 +258,8 @@ class SnowflakeDatabaseTestStep(DestinationTestStep):
             password=self.password,
             account=self.account,
             private_key=private_key,
-            role=self.role,
-            warehouse=self.warehouse,
+            role=f'"{self.role}"' if self.role is not None else None,
+            warehouse=f'"{self.warehouse}"',
         )
 
         with connection:
@@ -352,8 +352,8 @@ class SnowflakeSchemaTestStep(DestinationTestStep):
             password=self.password,
             account=self.account,
             private_key=private_key,
-            role=self.role,
-            warehouse=self.warehouse,
+            role=f'"{self.role}"' if self.role is not None else None,
+            warehouse=f'"{self.warehouse}"',
         )
 
         with connection:

--- a/products/batch_exports/backend/api/destination_tests/snowflake.py
+++ b/products/batch_exports/backend/api/destination_tests/snowflake.py
@@ -88,6 +88,7 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
                 password=self.password,
                 account=self.account,
                 private_key=private_key,
+                # wrap role in quotes in case it contains lowercase or special characters
                 role=f'"{self.role}"' if self.role is not None else None,
             )
         except (OperationalError, InterfaceError, DatabaseError) as err:
@@ -259,7 +260,7 @@ class SnowflakeDatabaseTestStep(DestinationTestStep):
             account=self.account,
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
-            warehouse=f'"{self.warehouse}"',
+            warehouse=self.warehouse,
         )
 
         with connection:
@@ -353,7 +354,7 @@ class SnowflakeSchemaTestStep(DestinationTestStep):
             account=self.account,
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
-            warehouse=f'"{self.warehouse}"',
+            warehouse=self.warehouse,
         )
 
         with connection:

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -365,13 +365,13 @@ class SnowflakeClient:
 
         try:
             async with CONNECTION_SEMAPHORE:
-                # Snowflake expects identifiers to be wrapped in quotes to preserve case sensitivity and
-                # special characters
                 connection = await asyncio.to_thread(
                     snowflake.connector.connect,
-                    user=f'"{self.user}"',
+                    user=self.user,
                     password=self.password,
                     account=self.account,
+                    # Snowflake expects identifiers to be wrapped in quotes to preserve case sensitivity and
+                    # special characters
                     warehouse=f'"{self.warehouse}"',
                     database=f'"{self.database}"',
                     schema=f'"{self.schema}"',

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -97,6 +97,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     # We don't want to continually retry as it could consume a lot of compute resources in the user's account and can
     # lead to a lot of queries queuing up for a given warehouse.
     "SnowflakeQueryTimeoutError",
+    # Raised when either the warehouse does not exist or we are missing 'USAGE' permissions on it
+    "SnowflakeWarehouseUsageError",
 )
 
 
@@ -134,6 +136,13 @@ class SnowflakeWarehouseSuspendedError(Exception):
     """Raised when a Warehouse is suspended."""
 
     pass
+
+
+class SnowflakeWarehouseUsageError(Exception):
+    """Raised when either the warehouse does not exist or we are missing 'USAGE' permissions on it"""
+
+    def __init__(self, warehouse: str):
+        super().__init__(f"Warehouse '{warehouse}' does not exist or we are missing 'USAGE' permissions on it")
 
 
 class SnowflakeTableNotFoundError(Exception):
@@ -356,15 +365,17 @@ class SnowflakeClient:
 
         try:
             async with CONNECTION_SEMAPHORE:
+                # Snowflake expects identifiers to be wrapped in quotes to preserve case sensitivity and
+                # special characters
                 connection = await asyncio.to_thread(
                     snowflake.connector.connect,
-                    user=self.user,
+                    user=f'"{self.user}"',
                     password=self.password,
                     account=self.account,
-                    warehouse=self.warehouse,
-                    database=self.database,
-                    schema=self.schema,
-                    role=self.role,
+                    warehouse=f'"{self.warehouse}"',
+                    database=f'"{self.database}"',
+                    schema=f'"{self.schema}"',
+                    role=f'"{self.role}"',
                     private_key=self.private_key,
                     login_timeout=5,
                 )
@@ -406,12 +417,19 @@ class SnowflakeClient:
         logger.setLevel(level)
 
     async def use_namespace(self) -> None:
-        """Switch to a namespace given by database and schema.
+        """Switch to a namespace given by database, schema, and warehouse.
 
         This allows all queries that follow to ignore database and schema.
+        It also ensures that we have permissions to use the warehouse.
         """
         await self.execute_async_query(f'USE DATABASE "{self.database}"', fetch_results=False)
         await self.execute_async_query(f'USE SCHEMA "{self.schema}"', fetch_results=False)
+        try:
+            await self.execute_async_query(f'USE WAREHOUSE "{self.warehouse}"', fetch_results=False)
+        except snowflake.connector.errors.ProgrammingError as exc:
+            if exc.msg is not None and "Object does not exist" in exc.msg:
+                raise SnowflakeWarehouseUsageError(self.warehouse)
+            raise
 
     async def get_query_status(self, query_id: str, throw_if_error: bool = True) -> QueryStatus:
         """Get the status of a query.

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -370,11 +370,10 @@ class SnowflakeClient:
                     user=self.user,
                     password=self.password,
                     account=self.account,
-                    # Snowflake expects identifiers to be wrapped in quotes to preserve case sensitivity and
-                    # special characters
-                    warehouse=f'"{self.warehouse}"',
-                    database=f'"{self.database}"',
-                    schema=f'"{self.schema}"',
+                    warehouse=self.warehouse,
+                    database=self.database,
+                    schema=self.schema,
+                    # wrap role in quotes in case it contains lowercase or special characters
                     role=f'"{self.role}"' if self.role is not None else None,
                     private_key=self.private_key,
                     login_timeout=5,

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -375,7 +375,7 @@ class SnowflakeClient:
                     warehouse=f'"{self.warehouse}"',
                     database=f'"{self.database}"',
                     schema=f'"{self.schema}"',
-                    role=f'"{self.role}"',
+                    role=f'"{self.role}"' if self.role is not None else None,
                     private_key=self.private_key,
                     login_timeout=5,
                 )

--- a/products/batch_exports/backend/tests/api/destination_tests/test_snowflake_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_snowflake_destination_tests.py
@@ -100,7 +100,7 @@ def snowflake_cursor(snowflake_config):
     with snowflake.connector.connect(
         user=snowflake_config["user"],
         password=password,
-        role=snowflake_config["role"],
+        role=f'"{snowflake_config["role"]}"' if snowflake_config["role"] is not None else None,
         account=snowflake_config["account"],
         warehouse=snowflake_config["warehouse"],
         private_key=private_key,

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
@@ -39,7 +39,7 @@ def snowflake_config(database, schema) -> dict[str, str]:
     """
     warehouse = os.getenv("SNOWFLAKE_WAREHOUSE", "warehouse")
     account = os.getenv("SNOWFLAKE_ACCOUNT", "account")
-    role = os.getenv("SNOWFLAKE_ROLE", "role")
+    role = os.getenv("SNOWFLAKE_ROLE", None)
     username = os.getenv("SNOWFLAKE_USERNAME", "username")
     password = os.getenv("SNOWFLAKE_PASSWORD", "password")
     private_key = os.getenv("SNOWFLAKE_PRIVATE_KEY")
@@ -106,11 +106,11 @@ def snowflake_cursor(snowflake_config: dict[str, str]):
         password = snowflake_config["password"]
 
     with snowflake.connector.connect(
-        user=snowflake_config["user"],
+        user=f'"{snowflake_config["user"]}"',
         password=password,
-        role=snowflake_config["role"],
         account=snowflake_config["account"],
-        warehouse=snowflake_config["warehouse"],
+        role=f'"{snowflake_config["role"]}"',
+        warehouse=f'"{snowflake_config["warehouse"]}"',
         private_key=private_key,
     ) as connection:
         connection.telemetry_enabled = False

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
@@ -110,7 +110,7 @@ def snowflake_cursor(snowflake_config: dict[str, str]):
         password=password,
         account=snowflake_config["account"],
         role=f'"{snowflake_config["role"]}"' if snowflake_config["role"] is not None else None,
-        warehouse=f'"{snowflake_config["warehouse"]}"',
+        warehouse=snowflake_config["warehouse"],
         private_key=private_key,
     ) as connection:
         connection.telemetry_enabled = False

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
@@ -106,7 +106,7 @@ def snowflake_cursor(snowflake_config: dict[str, str]):
         password = snowflake_config["password"]
 
     with snowflake.connector.connect(
-        user=f'"{snowflake_config["user"]}"',
+        user=snowflake_config["user"],
         password=password,
         account=snowflake_config["account"],
         role=f'"{snowflake_config["role"]}"',

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
@@ -109,7 +109,7 @@ def snowflake_cursor(snowflake_config: dict[str, str]):
         user=snowflake_config["user"],
         password=password,
         account=snowflake_config["account"],
-        role=f'"{snowflake_config["role"]}"',
+        role=f'"{snowflake_config["role"]}"' if snowflake_config["role"] is not None else None,
         warehouse=f'"{snowflake_config["warehouse"]}"',
         private_key=private_key,
     ) as connection:

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
@@ -110,7 +110,7 @@ def snowflake_cursor(snowflake_config: dict[str, str]):
         password=password,
         account=snowflake_config["account"],
         role=f'"{snowflake_config["role"]}"' if snowflake_config["role"] is not None else None,
-        warehouse=snowflake_config["warehouse"],
+        warehouse=f'"{snowflake_config["warehouse"]}"',
         private_key=private_key,
     ) as connection:
         connection.telemetry_enabled = False

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
@@ -13,6 +13,7 @@ from products.batch_exports.backend.temporal.destinations.snowflake_batch_export
     SnowflakeClient,
     SnowflakeInsertInputs,
     SnowflakeQueryTimeoutError,
+    SnowflakeWarehouseUsageError,
 )
 from products.batch_exports.backend.tests.temporal.destinations.snowflake.utils import SKIP_IF_MISSING_REQUIRED_ENV_VARS
 
@@ -121,3 +122,10 @@ async def test_execute_async_query_completes_within_timeout(snowflake_client):
     results, _description = result
     assert len(results) == 1
     assert results[0][0] == 1
+
+
+async def test_use_namespace_raises_error_if_warehouse_not_found_or_missing_usage_permissions(snowflake_client):
+    """Test that use_namespace raises an error if the warehouse is not found or we are missing 'USAGE' permissions on it."""
+    snowflake_client.warehouse = "garbage"
+    with pytest.raises(SnowflakeWarehouseUsageError):
+        await snowflake_client.use_namespace()

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -163,9 +163,11 @@ async def test_snowflake_export_workflow_exports_events(
         for call in cursor._execute_async_calls:
             execute_async_calls.append(call["query"].strip())
 
+    warehouse = snowflake_batch_export.destination.config["warehouse"]
     assert execute_async_calls[0:3] == [
         f'USE DATABASE "{database}"',
         f'USE SCHEMA "{schema}"',
+        f'USE WAREHOUSE "{warehouse}"',
         "SET ABORT_DETACHED_QUERY = FALSE",
     ]
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -164,7 +164,7 @@ async def test_snowflake_export_workflow_exports_events(
             execute_async_calls.append(call["query"].strip())
 
     warehouse = snowflake_batch_export.destination.config["warehouse"]
-    assert execute_async_calls[0:3] == [
+    assert execute_async_calls[0:4] == [
         f'USE DATABASE "{database}"',
         f'USE SCHEMA "{schema}"',
         f'USE WAREHOUSE "{warehouse}"',
@@ -173,9 +173,9 @@ async def test_snowflake_export_workflow_exports_events(
 
     assert all(query.startswith("PUT") for query in execute_calls[0:9])
 
-    assert execute_async_calls[3].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
-    assert execute_async_calls[4].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
-    assert execute_async_calls[5].startswith(f'COPY INTO "{table_name}"')
+    assert execute_async_calls[4].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
+    assert execute_async_calls[5].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[6].startswith(f'COPY INTO "{table_name}"')
 
 
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)


### PR DESCRIPTION
## Problem

If a provided Snowflake warehouse name contains special characters or lowercase letters then batch exports may fail with a warehouse error.

## Changes

Wrap identifiers in double-quotes when passing them to the Snowflake connector.

Also explicitly check for permission issues by issuing a `use warehouse` command before starting the batch export.

## How did you test this code?

Extensive local testing.

Added a unit test for checking permissions.
