### PR TITLE
fix(redshift-batch-export): Handle copy being over string limit

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -426,7 +426,7 @@ class RedshiftClient(PostgreSQLClient):
                         )
                     ):
                         try:
-                            column = msg_detail.split("length of data column ", 1)[1].split(" ")[0]
+                            column = msg_detail.split("length of the data column ", 1)[1].split(" ")[0]
                         except Exception:
                             column = "unknown"
 

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -94,6 +94,7 @@ NON_RETRYABLE_ERROR_TYPES = (
     # A column, usually properties, exceeds the limit for a VARCHAR field,
     # usually the max of 65535 bytes
     "StringDataRightTruncation",
+    "StringLimitExceededError",
     # Raised by our PostgreSQL client when failing to connect after several attempts.
     "PostgreSQLConnectionError",
     # Column missing in Redshift, likely the schema was altered.
@@ -113,6 +114,16 @@ NON_RETRYABLE_ERROR_TYPES = (
     # compared.
     "UndefinedFunction",
 )
+
+
+class StringLimitExceededError(Exception):
+    """Error raised when exceeding Redshift VARCHAR limit."""
+
+    def __init__(self, column: str, table: str, schema: str):
+        msg = f"Column '{column}' in '{schema}.{table}' exceeds Redshift's 'VARCHAR' limit and cannot be exported"
+        if column in {"properties", "set", "set_once", "person_properties"}:
+            msg += ". Consider switching this column to 'SUPER' type which can support longer documents compared to 'VARCHAR'"
+        super().__init__(msg)
 
 
 class ClientErrorGroup(ExceptionGroup):
@@ -400,7 +411,27 @@ class RedshiftClient(PostgreSQLClient):
 
         async with self.connection.transaction():
             async with self.connection.cursor() as cursor:
-                await cursor.execute(copy_query)
+                try:
+                    await cursor.execute(copy_query)
+                except psycopg.errors.InternalError_ as err:
+                    msg_detail = err.diag.message_detail
+                    # This error is generic, and not well parsed by psycopg
+                    # so we have to do some awkward substring check.
+                    if all(
+                        s in msg_detail
+                        for s in (
+                            "Spectrum Scan Error",
+                            "length of the data column",
+                            "longer than the length defined in the table",
+                        )
+                    ):
+                        try:
+                            column = msg_detail.split("length of data column ", 1)[1].split(" ")[0]
+                        except Exception:
+                            column = "unknown"
+
+                        raise StringLimitExceededError(column, table_name, schema_name)
+                    raise
 
 
 def redshift_default_fields() -> list[BatchExportField]:

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -417,7 +417,7 @@ class RedshiftClient(PostgreSQLClient):
                     msg_detail = err.diag.message_detail
                     # This error is generic, and not well parsed by psycopg
                     # so we have to do some awkward substring check.
-                    if all(
+                    if msg_detail is not None and all(
                         s in msg_detail
                         for s in (
                             "Spectrum Scan Error",

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -677,7 +677,7 @@ async def test_copy_into_redshift_activity_handles_data_over_string_limit(
     bucket_name,
     bucket_region,
     exclude_events,
-    model: BatchExportSchema,
+    model: BatchExportModel,
     data_interval_start,
     data_interval_end,
     properties_data_type,

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -77,6 +77,7 @@ async def _run_activity(
     expected_fields=None,
     expect_duplicates: bool = False,
     extra_fields=None,
+    assert_records: bool = True,
 ):
     """Helper function to run Redshift main COPY activity and assert records exported.
 
@@ -144,6 +145,9 @@ async def _run_activity(
         ),
     )
     result = await activity_environment.run(copy_into_redshift_activity_from_stage, copy_inputs)
+
+    if not assert_records:
+        return result
 
     await assert_clickhouse_records_in_redshift(
         redshift_connection=redshift_connection,
@@ -660,3 +664,68 @@ async def test_copy_into_redshift_activity_inserts_data_with_extra_columns(
         sort_key=sort_key,
         extra_fields=["test"],
     )
+
+
+@pytest.mark.parametrize("exclude_events", [None], indirect=True)
+@pytest.mark.parametrize("properties_data_type", ["varchar"], indirect=True)
+@pytest.mark.parametrize("model", [TEST_MODELS[1]])
+async def test_copy_into_redshift_activity_handles_data_over_string_limit(
+    clickhouse_client,
+    activity_environment,
+    psycopg_connection,
+    redshift_config,
+    bucket_name,
+    bucket_region,
+    exclude_events,
+    model: BatchExportSchema,
+    data_interval_start,
+    data_interval_end,
+    properties_data_type,
+    aws_credentials,
+    key_prefix,
+    ateam,
+):
+    """Test that the copy_into_redshift_activity raises a non-retryable error on varchar limit exceeded."""
+
+    await generate_test_events_in_clickhouse(
+        client=clickhouse_client,
+        team_id=ateam.pk,
+        event_name="test-funny-props-{i}",
+        start_time=data_interval_start,
+        end_time=data_interval_end,
+        count_outside_range=0,
+        count_other_team=0,
+        count=1,
+        properties={
+            "$that_is_a_long_property": "wow" * 64 * 1024,
+        },
+    )
+
+    batch_export_model = model
+    table_name = f"test_copy_activity_table_handles_string_limit__{ateam.pk}"
+
+    sort_key = "event"
+
+    result = await _run_activity(
+        activity_environment,
+        redshift_connection=psycopg_connection,
+        clickhouse_client=clickhouse_client,
+        team=ateam,
+        table_name=table_name,
+        bucket_name=bucket_name,
+        bucket_region=bucket_region,
+        key_prefix=key_prefix,
+        credentials=aws_credentials,
+        properties_data_type=properties_data_type,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        exclude_events=exclude_events,
+        batch_export_model=batch_export_model,
+        redshift_config=redshift_config,
+        sort_key=sort_key,
+        assert_records=False,
+    )
+
+    assert result.error is not None
+    assert result.error.type == "StringLimitExceededError"
+    assert "Consider switching this column to 'SUPER' type" in result.error.message


### PR DESCRIPTION
## Problem

Redshift copy activity raises a different error when the data is over Redshift's VARCHAR limit. This error is a awkward to capture as it's not properly parsed by psycopg, but still we should do our best to not retry forever and inform users on what to do.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Raise a non-retryable error on varchar limit exceeded.
Recommend users switch to SUPER if the column can be parsed and if it is in known json columns.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

New unit test, ran all Redshift tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
