### PR TITLE
fix(commands): delete distinct id command database connection fix

### DIFF
--- a/posthog/management/commands/delete_persons_with_no_distinct_ids.py
+++ b/posthog/management/commands/delete_persons_with_no_distinct_ids.py
@@ -1,7 +1,7 @@
 import time
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
+from django.db import connection, connections
 
 
 class Command(BaseCommand):
@@ -34,7 +34,8 @@ class Command(BaseCommand):
 
 
 def delete_persons_without_distinct_ids_raw_sql(team_id, max_delete):
-    with connection.cursor() as cursor:
+    conn = connections["persons_db_writer"] if "persons_db_writer" in connections else connection
+    with conn.cursor() as cursor:
         cursor.execute(
             """
             WITH persons_to_delete AS (
@@ -59,7 +60,8 @@ def delete_persons_without_distinct_ids_raw_sql(team_id, max_delete):
 
 
 def delete_persons_without_distinct_ids_raw_sql_dry_run(team_id, max_delete):
-    with connection.cursor() as cursor:
+    conn = connections["persons_db_writer"] if "persons_db_writer" in connections else connection
+    with conn.cursor() as cursor:
         cursor.execute(
             """
             WITH persons_to_delete AS (


### PR DESCRIPTION
## Problem

The command for deleting persons with particular distinct ids was not connecting to the correct database

## Changes

Use the persons db if the url exists

## How did you test this code?

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
