### PR TITLE
fix: set expiry when saving an exported asset model, not only in the API

### DIFF
--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -113,6 +113,9 @@ class ExportedAsset(models.Model):
             expiry_datetime = now() + expiry_delta
             self.expires_after = expiry_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
 
+            if update_fields is not None and "expires_after" not in update_fields:
+                kwargs["update_fields"] = {*update_fields, "expires_after"}
+
         super().save(*args, **kwargs)
 
     @property

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -113,10 +113,6 @@ class ExportedAsset(models.Model):
             expiry_datetime = now() + expiry_delta
             self.expires_after = expiry_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
 
-            # Add expires_after to update_fields if it's being used
-            if update_fields is not None:
-                kwargs["update_fields"] = set(update_fields) | {"expires_after"}
-
         super().save(*args, **kwargs)
 
     @property


### PR DESCRIPTION
we're still creating >20k exported assets a day that have no expiry date set

which means they stay in the daatabase but the content is deleted

let's move the expiry setting onto the model
now you _really_ have to try hard to avoid setting an expiry date