### PR TITLE
fix(temporal): delete persons workflow wrong db connection

### DIFF
--- a/posthog/person_db_router.py
+++ b/posthog/person_db_router.py
@@ -21,14 +21,14 @@ PERSONS_DB_MODELS = {
 }
 
 
-def get_persons_db_url() -> str:
+def get_persons_writer_db_url() -> str:
     """Get the database URL for person data writes.
 
     Uses PERSONS_DB_WRITER_URL if available, otherwise falls back to DATABASE_URL.
     This is useful for direct database connections (e.g., psycopg) outside of Django ORM.
 
     Returns:
-        str: The database URL to use for person data operations
+        str: The database URL to use for person write operations
     """
     return os.getenv("PERSONS_DB_WRITER_URL") or settings.DATABASE_URL
 

--- a/posthog/person_db_router.py
+++ b/posthog/person_db_router.py
@@ -1,5 +1,9 @@
 # posthog/person_db_router.py
 
+import os
+
+from django.conf import settings
+
 # Set of models (lowercase) that should live in the persons_db
 # Add other models from the plan here as needed.
 PERSONS_DB_MODELS = {
@@ -15,6 +19,18 @@ PERSONS_DB_MODELS = {
     "group",
     "grouptypemapping",
 }
+
+
+def get_persons_db_url() -> str:
+    """Get the database URL for person data writes.
+
+    Uses PERSONS_DB_WRITER_URL if available, otherwise falls back to DATABASE_URL.
+    This is useful for direct database connections (e.g., psycopg) outside of Django ORM.
+
+    Returns:
+        str: The database URL to use for person data operations
+    """
+    return os.getenv("PERSONS_DB_WRITER_URL") or settings.DATABASE_URL
 
 
 class PersonDBRouter:

--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -11,7 +11,7 @@ import temporalio.workflow
 from structlog import get_logger
 
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.person_db_router import get_persons_db_url
+from posthog.person_db_router import get_persons_writer_db_url
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 
@@ -81,7 +81,7 @@ async def mogrify_delete_queries_activity(inputs: MogrifyDeleteQueriesActivityIn
         delete_query_cohort_people = DELETE_QUERY_COHORT_PEOPLE.format(select_query=select_query)
         delete_query_person = DELETE_QUERY_PERSON.format(select_query=select_query)
 
-        conn = await psycopg.AsyncConnection.connect(get_persons_db_url())
+        conn = await psycopg.AsyncConnection.connect(get_persons_writer_db_url())
         conn.cursor_factory = psycopg.AsyncClientCursor
         async with conn:
             async with conn.cursor() as cursor:
@@ -144,7 +144,7 @@ async def delete_persons_activity(inputs: DeletePersonsActivityInputs) -> tuple[
         delete_query_cohort_people = DELETE_QUERY_COHORT_PEOPLE.format(select_query=select_query)
         delete_query_person = DELETE_QUERY_PERSON.format(select_query=select_query)
 
-        conn = await psycopg.AsyncConnection.connect(get_persons_db_url())
+        conn = await psycopg.AsyncConnection.connect(get_persons_writer_db_url())
         async with conn:
             async with conn.cursor() as cursor:
                 logger.info("Deleting batch %d of %d (%d rows)", inputs.batch_number, inputs.batches, inputs.batch_size)


### PR DESCRIPTION
## Problem

The delete persons temporal workflow connects to the default database for all activity. We should use some persons db router logic for the delete persons queries to connect to the correct one.

## Changes

Changes persons queries in temporal workflows to access the persons db rather than the default db

## How did you test this code?

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
