### PR TITLE
feat(replay): add entrypoint from cohort page

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -83,6 +83,7 @@ import { EventType, InsightLogicProps } from '~/types'
 import { GroupPropertyFilters } from '../GroupsQuery/GroupPropertyFilters'
 import { GroupsSearch } from '../GroupsQuery/GroupsSearch'
 import { DataTableOpenEditor } from './DataTableOpenEditor'
+import { DataTableViewReplays } from './DataTableViewReplays'
 
 export enum ColumnFeature {
     canSort = 'canSort',
@@ -695,6 +696,7 @@ export function DataTable({
         sourceFeatures.has(QueryFeature.columnConfigurator) ? (
             <ColumnConfigurator key="column-configurator" query={query} setQuery={setQuery} />
         ) : null,
+        <DataTableViewReplays key="data-table-view-replays" />,
         showExport ? (
             <DataTableExport
                 key="data-table-export"

--- a/frontend/src/queries/nodes/DataTable/DataTableOpenEditor.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableOpenEditor.tsx
@@ -44,7 +44,7 @@ export function DataTableOpenEditor({ query }: DataTableOpenEditorProps): JSX.El
             }
             data-attr="open-json-editor-button"
         >
-            Open as new insight
+            Open as new insighttt
         </LemonButton>
     )
 }

--- a/frontend/src/queries/nodes/DataTable/DataTableOpenEditor.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableOpenEditor.tsx
@@ -44,7 +44,7 @@ export function DataTableOpenEditor({ query }: DataTableOpenEditorProps): JSX.El
             }
             data-attr="open-json-editor-button"
         >
-            Open as new insighttt
+            Open as new insight
         </LemonButton>
     )
 }

--- a/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
@@ -42,7 +42,7 @@ export function DataTableViewReplays(): JSX.Element | null {
             type="secondary"
             icon={<IconRewindPlay />}
             to={urls.replay(ReplayTabs.Home, filters)}
-            data-attr="view-replays-button"
+            data-attr="view-replays-from-cohort-button"
         >
             View session recordings
         </LemonButton>

--- a/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
@@ -1,0 +1,50 @@
+import { useValues } from 'kea'
+
+import { IconRewindPlay } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { PropertyFilterType, PropertyOperator, ReplayTabs } from '~/types'
+
+import { dataTableLogic } from './dataTableLogic'
+
+export function DataTableViewReplays(): JSX.Element | null {
+    const { context } = useValues(dataTableLogic)
+    const cohortId = context?.cohortId
+
+    if (!cohortId) {
+        return null
+    }
+
+    const filters = {
+        duration: [],
+        filter_group: {
+            type: 'AND' as const,
+            values: [
+                {
+                    type: 'AND' as const,
+                    values: [
+                        {
+                            type: PropertyFilterType.Cohort,
+                            key: 'id',
+                            operator: PropertyOperator.In,
+                            value: cohortId,
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+    return (
+        <LemonButton
+            type="secondary"
+            icon={<IconRewindPlay />}
+            to={urls.replay(ReplayTabs.Home, filters)}
+            data-attr="view-replays-button"
+        >
+            View replays
+        </LemonButton>
+    )
+}

--- a/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
@@ -5,7 +5,13 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
-import { PropertyFilterType, PropertyOperator, ReplayTabs } from '~/types'
+import {
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    RecordingUniversalFilters,
+    ReplayTabs,
+} from '~/types'
 
 import { dataTableLogic } from './dataTableLogic'
 
@@ -17,13 +23,13 @@ export function DataTableViewReplays(): JSX.Element | null {
         return null
     }
 
-    const filters = {
+    const filters: Partial<RecordingUniversalFilters> = {
         duration: [],
         filter_group: {
-            type: 'AND' as const,
+            type: FilterLogicalOperator.And,
             values: [
                 {
-                    type: 'AND' as const,
+                    type: FilterLogicalOperator.And,
                     values: [
                         {
                             type: PropertyFilterType.Cohort,

--- a/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableViewReplays.tsx
@@ -44,7 +44,7 @@ export function DataTableViewReplays(): JSX.Element | null {
             to={urls.replay(ReplayTabs.Home, filters)}
             data-attr="view-replays-button"
         >
-            View replays
+            View session recordings
         </LemonButton>
     )
 }

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -76,6 +76,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
         ],
     })),
     selectors({
+        context: [() => [(_, props) => props.context], (context) => context],
         sourceKind: [(_, p) => [p.query], (query): NodeKind | null => query.source?.kind],
         sourceFeatures: [
             (_, p) => [p.query, (_, props) => props.context],

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -42,6 +42,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     extraDataTableQueryFeatures?: QueryFeature[]
     /** Allow customization of file name when exporting */
     fileNameForExport?: string
+    /** Cohort ID to enable cohort-specific features like View Replays button */
+    cohortId?: number | null
     /** Custom column features to pass down to the DataTable */
     columnFeatures?: ColumnFeature[]
     /** Key to be used in dataNodeLogic so that we can find the dataNodeLogic */

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -545,6 +545,7 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
                                                 context={{
                                                     refresh: 'force_blocking',
                                                     fileNameForExport: cohort.name,
+                                                    cohortId: cohortId,
                                                     dataNodeLogicKey: dataNodeLogicKey,
                                                     columns: canRemovePersonFromCohort
                                                         ? {


### PR DESCRIPTION
## Problem

Got feedback in a survey that a user wanted a replay an entrypoint on cohort page

## Changes

add that entrypoint

## How did you test this code?

![Screenshot 2025-11-06 at 10.41.41 AM.png](https://app.graphite.com/user-attachments/assets/531309bd-ac58-4283-8ca8-73bcb5016887.png)

[Screen Recording 2025-11-06 at 10.38.43 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f7081bc4-af0e-4409-8936-a5f2271df880.mov" />](https://app.graphite.com/user-attachments/video/f7081bc4-af0e-4409-8936-a5f2271df880.mov)

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
