### PR TITLE
Open in new tab from command bar

### DIFF
--- a/frontend/src/lib/components/CommandBar/SearchResultPreview.tsx
+++ b/frontend/src/lib/components/CommandBar/SearchResultPreview.tsx
@@ -11,7 +11,7 @@ import { searchBarLogic, urlForResult } from './searchBarLogic'
 
 export const SearchResultPreview = (): JSX.Element | null => {
     const { activeResultIndex, combinedSearchResults, combinedSearchLoading } = useValues(searchBarLogic)
-    const { openResult } = useActions(searchBarLogic)
+    const { openResult, openResultInNewTab } = useActions(searchBarLogic)
 
     if (combinedSearchLoading) {
         return (
@@ -49,7 +49,7 @@ export const SearchResultPreview = (): JSX.Element | null => {
                         <ResultDescription result={result} />
                     </div>
                 </div>
-                <div className="grid grid-cols-[auto_1fr] items-center gap-2">
+                <div className="flex items-center gap-2">
                     <LemonButton
                         type="secondary"
                         size="small"
@@ -59,6 +59,16 @@ export const SearchResultPreview = (): JSX.Element | null => {
                         aria-label="Open search result"
                     >
                         <span className="mr-1">Open</span> <KeyboardShortcut enter />
+                    </LemonButton>
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={() => {
+                            openResultInNewTab(activeResultIndex)
+                        }}
+                        aria-label="Open search result in new tab"
+                    >
+                        <span className="mr-1">Open in new tab</span> <KeyboardShortcut command enter />
                     </LemonButton>
                 </div>
             </div>


### PR DESCRIPTION
## Problem

Users currently have no way to open command-bar search results in a new tab. This slows down workflows for power users who want to browse multiple resources side-by-side, or keep context while exploring other stuff.

## Changes
* Added a new action `openResultInNewTab` to `searchBarLogic`.
* Implemented keyboard support (`⌘/Ctrl + Enter`) to open in a new tab from the command bar.
* Added a new “Open in new tab” button in the command bar search result preview.

https://github.com/user-attachments/assets/e23b0f1e-380d-4878-904c-d9f49f9903c3

## How did you test this code?
1. Press `⌘ / Ctrl + K` to open the Command bar.
2. Search for something.
3. Press `⌘ / Ctrl + Enter` to open in a new tab.
4. Or, click the "Open in new tab" button.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

