### PR TITLE
fix: Fix tabs on the nuxt env vars snippet

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/nuxt.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/nuxt.tsx
@@ -16,14 +16,14 @@ function NuxtEnvVarsSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.JavaScript}>
             {`export default defineNuxtConfig({
-                runtimeConfig: {
-                  public: {
-                    posthogPublicKey: '${currentTeam?.api_token}',
-                    posthogHost: '${apiHostOrigin()}',
-                    posthogDefaults: '${SDK_DEFAULTS_DATE}'
-                  }
-                }
-              })`}
+  runtimeConfig: {
+    public: {
+      posthogPublicKey: '${currentTeam?.api_token}',
+      posthogHost: '${apiHostOrigin()}',
+      posthogDefaults: '${SDK_DEFAULTS_DATE}'
+    }
+  }
+})`}
         </CodeSnippet>
     )
 }


### PR DESCRIPTION
## Problem

Fixed indentation of Nuxt installation code.

## Changes

Before
<img width="1397" height="976" alt="image" src="https://github.com/user-attachments/assets/f8f31006-80db-447a-82cb-073a488a3581" />


After
<img width="1572" height="1001" alt="image" src="https://github.com/user-attachments/assets/8deeaebf-97bc-4f40-a4ea-54019dd84037" />


## How did you test this code?

Loaded the page with the nuxt sdk http://localhost:8010/project/1/onboarding/product_analytics?step=install
