### PR TITLE
fix: fix error tracking taxonomy filters dropdown width

### DIFF
--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -79,14 +79,15 @@ const UniversalSearch = (): JSX.Element => {
         <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>
             <LemonDropdown
                 overlay={
-                    <InfiniteSelectResults
-                        focusInput={() => searchInputRef.current?.focus()}
-                        taxonomicFilterLogicProps={taxonomicFilterLogicProps}
-                        popupAnchorElement={floatingRef.current}
-                        useVerticalLayout={true}
-                    />
+                    <div className="w-[400px] md:w-[600px]">
+                        <InfiniteSelectResults
+                            focusInput={() => searchInputRef.current?.focus()}
+                            taxonomicFilterLogicProps={taxonomicFilterLogicProps}
+                            popupAnchorElement={floatingRef.current}
+                            useVerticalLayout={true}
+                        />
+                    </div>
                 }
-                matchWidth
                 visible={visible}
                 closeOnClickInside={false}
                 floatingRef={floatingRef}


### PR DESCRIPTION
## Problem

Right now taxonomy menu dropdown takes full width which makes tooltips very narrow.

| Issues scene | Single issue scene |
|--------|--------|
| <img width="1665" height="499" alt="image" src="https://github.com/user-attachments/assets/3fbae6a6-cfc7-4b74-a933-9a1eb5dc00c6" /> | <img width="1167" height="413" alt="image" src="https://github.com/user-attachments/assets/e2f713ab-5815-418e-ad67-17c8ae37f61c" /> | 

## Changes

Changed it so it looks more natural and there is space for tooltip

| Issues scene | Single issue scene |
|--------|--------|
| <img width="1673" height="605" alt="image" src="https://github.com/user-attachments/assets/7b091baf-ccea-446d-80cf-5c2ed797b4f6" /> | <img width="1140" height="493" alt="image" src="https://github.com/user-attachments/assets/1f23283f-a85a-4481-9c25-7f1c5e160342" /> | 
