### PR TITLE
fix: infinite spinner in experiment release conditions modal

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ReleaseConditionsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ReleaseConditionsTable.tsx
@@ -98,7 +98,7 @@ export function ReleaseConditionsTable(): JSX.Element {
                         ? aggregationLabel(experiment.filters.aggregation_group_type_index).plural
                         : 'users'
 
-                const releaseText = `${item.rollout_percentage}% of ${aggregationTargetName}`
+                const releaseText = `${item.rollout_percentage ?? 0}% of ${aggregationTargetName}`
 
                 return (
                     <div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -115,6 +115,7 @@ export function FeatureFlagReleaseConditions({
         filtersTaxonomicOptions,
         aggregationTargetName,
         properties,
+        filterGroups,
     } = useValues(releaseConditionsLogic)
 
     const {
@@ -135,7 +136,6 @@ export function FeatureFlagReleaseConditions({
 
     const featureFlagVariants = nonEmptyFeatureFlagVariants || nonEmptyVariants
 
-    const filterGroups: FeatureFlagGroupType[] = (isSuper ? filters?.super_groups : filters?.groups) || []
     // :KLUDGE: Match by select only allows Select.Option as children, so render groups option directly rather than as a child
     const matchByGroupsIntroductionOption = GroupsIntroductionOption()
 

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -112,16 +112,18 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
     })),
     reducers(() => ({
         filters: {
-            setFilters: (_, { filters }) => {
-                // Only assign sort_keys to groups that don't have one
+            setFilters: (state, { filters }) => {
+                // Preserve sort_keys from previous state when possible
                 const groupsWithKeys = filters.groups.map(
-                    (group: FeatureFlagGroupType): FeatureFlagGroupTypeWithSortKey => {
+                    (group: FeatureFlagGroupType, index: number): FeatureFlagGroupTypeWithSortKey => {
                         if (group.sort_key) {
                             return group as FeatureFlagGroupTypeWithSortKey
                         }
+                        // Try to preserve sort_key from same index in previous state
+                        const previousSortKey = state?.groups?.[index]?.sort_key
                         return {
                             ...group,
-                            sort_key: uuidv4(),
+                            sort_key: previousSortKey ?? uuidv4(),
                         }
                     }
                 )


### PR DESCRIPTION
## Problem

When opening the modal or changing release conditions from inside an experiment, the spinner would load indefinitely after calling the `/user_blast_radius` endpoint. This made it impossible to see the blast radius calculations, leaving users unable to understand the impact of their targeting changes.

The issue occurred because:
1. The `featureFlagReleaseConditionsLogic` assigns sort_keys (UUIDs) to groups for tracking blast radius results
2. When props changed (via `propsChanged` hook), new sort_keys were generated
3. The component rendered with the new sort_keys, but `affectedUsers` still had data keyed by the old sort_keys
4. Result: `affectedUsers[newSortKey]` was always `undefined`, causing the spinner to show forever

## Changes

- Modified `setFilters` reducer to preserve sort_keys from previous state when props update (instead of generating new UUIDs)
- Use `filterGroups` from logic's `useValues` (which have stable sort_keys) instead of computing from props
- This ensures the component renders with the same sort_keys the logic uses to store blast radius data

## How did you test this code?

- Manually tested opening the experiment release conditions modal