### PR TITLE
fix(replay): dont scrub player on details clicks in inspector

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -202,14 +202,12 @@ function RowItemMenu({ item }: { item: InspectorListItem }): JSX.Element | null 
 function RowItemDetail({
     item,
     finalTimestamp,
-    onClick,
 }: {
     item: InspectorListItem
     finalTimestamp: Dayjs | null
-    onClick: () => void
 }): JSX.Element | null {
     return (
-        <div onClick={onClick}>
+        <div>
             {item.type === 'network' ? (
                 <ItemPerformanceEventDetail item={item.data} finalTimestamp={finalTimestamp} />
             ) : item.type === 'app-state' ? (
@@ -330,14 +328,9 @@ const ListItemTitle = memo(function ListItemTitle({
 
 const ListItemDetail = memo(function ListItemDetail({ item, index }: { item: InspectorListItem; index: number }) {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
-    const { seekToTime } = useActions(sessionRecordingPlayerLogic)
 
     const { end } = useValues(playerInspectorLogic(logicProps))
     const { setItemExpanded } = useActions(playerInspectorLogic(logicProps))
-
-    // NOTE: We offset by 1 second so that the playback starts just before the event occurs.
-    // Ceiling second is used since this is what's displayed to the user.
-    const seekToEvent = (): void => seekToTime(ceilMsToClosestSecond(item.timeInRecording) - 1000)
 
     return (
         <div
@@ -347,7 +340,7 @@ const ListItemDetail = memo(function ListItemDetail({ item, index }: { item: Ins
             )}
         >
             <div className="text-xs">
-                <RowItemDetail item={item} finalTimestamp={end} onClick={() => seekToEvent()} />
+                <RowItemDetail item={item} finalTimestamp={end} />
                 <LemonDivider dashed />
 
                 <div


### PR DESCRIPTION
## Problem

Got feedback from a user that scrubbing on detail clicks frequently annoyed him, he wasnt trying to navigate

## Changes

stop scrubbing. only scrub on header row click, not expanded details

## How did you test this code?

clicked around

[dont-scrub-on-details-click.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d51fd4fe-87cf-4c71-9da4-6689e02499e9.mov" />](https://app.graphite.com/user-attachments/video/d51fd4fe-87cf-4c71-9da4-6689e02499e9.mov)

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
