### PR TITLE
feat(flags): Add database fallback support to HyperCacheReader

### DIFF
--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -159,7 +159,7 @@ async fn get_from_cache(
     let source_name = match source {
         CacheSource::Redis => "Redis",
         CacheSource::S3 => "S3",
-        CacheSource::DatabaseFallback => "DatabaseFallback",
+        CacheSource::Fallback => "Fallback",
     };
     info!(
         team_id = team.id,

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -159,6 +159,7 @@ async fn get_from_cache(
     let source_name = match source {
         CacheSource::Redis => "Redis",
         CacheSource::S3 => "S3",
+        CacheSource::DatabaseFallback => "DatabaseFallback",
     };
     info!(
         team_id = team.id,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -173,7 +173,7 @@ impl FeatureFlagList {
                             "flag_key" => row.key.clone(),
                         )
                         .increment(1);
-                        
+
                         // Also track as a tombstone - invalid data in postgres should never happen
                         counter!(
                             TOMBSTONE_COUNTER,
@@ -182,7 +182,7 @@ impl FeatureFlagList {
                             "flag_key" => row.key.clone(),
                         )
                         .increment(1);
-                        
+
                         None // Skip this flag, continue with others
                     }
                 }

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,4 +1,4 @@
-use crate::metrics::consts::FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER;
+use crate::metrics::consts::{FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER, TOMBSTONE_COUNTER};
 use metrics::counter;
 use std::sync::Arc;
 use tracing;
@@ -173,6 +173,16 @@ impl FeatureFlagList {
                             "flag_key" => row.key.clone(),
                         )
                         .increment(1);
+                        
+                        // Also track as a tombstone - invalid data in postgres should never happen
+                        counter!(
+                            TOMBSTONE_COUNTER,
+                            "failure_type" => "flag_filter_deserialization_error",
+                            "team_id" => row.team_id.to_string(),
+                            "flag_key" => row.key.clone(),
+                        )
+                        .increment(1);
+                        
                         None // Skip this flag, continue with others
                     }
                 }

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -66,3 +66,7 @@ pub const FLAG_ACQUIRE_TIMEOUT_COUNTER: &str = "flags_acquire_timeout_total";
 pub const FLAG_DATABASE_ERROR_COUNTER: &str = "flags_database_error_total";
 pub const FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER: &str =
     "flags_filter_deserialization_error_total";
+
+// Tombstone metric for tracking "impossible" failures that should never happen in production
+// Different failure types are tracked via the "failure_type" label
+pub const TOMBSTONE_COUNTER: &str = "posthog_tombstone_total";


### PR DESCRIPTION
add a `get_with_source_or_fallback` method to the HyperCacheReader that provides database fallback functionality when both cache tiers (Redis and S3) miss.

## Key Changes:

  - Added `CacheSource::DatabaseFallback` variant to track when data comes from the fallback source
  - Implemented `get_with_source_or_fallback` method that:
    - Tries cache layers first (Redis → S3)
    - On complete cache miss, calls a user-provided fallback function (typically database query)
    - Does NOT write fallback data back to cache - this is intentional to avoid cache corruption in catastrophic scenarios
    - Returns `(Value, CacheSource)` tuple to indicate data source
  - Added metrics tracking for fallback hits (`hit_fallback`) and complete misses (`missing_with_fallback`)
  - Implemented `Display` trait for `KeyType` for better logging

## Why this is needed:

  Handles catastrophic cache miss scenarios where both Redis and S3 are empty or unavailable, providing a way to query the database directly without polluting the cache with potentially stale or malformed data.

## Testing:

  - Added comprehensive unit tests covering all scenarios (cache hits, fallback usage, error handling)
  - Verified fallback data is never written to cache
  - All existing tests pass