### PR TITLE
fix(err): add content column to the embeddings table

### DIFF
--- a/posthog/clickhouse/migrations/0169_add_content_column_to_document_embeddings.py
+++ b/posthog/clickhouse/migrations/0169_add_content_column_to_document_embeddings.py
@@ -16,32 +16,26 @@ ADD COLUMN IF NOT EXISTS content String DEFAULT ''
 """
 
 operations = [
-    # 1. Drop materialized view
     run_sql_with_exceptions(
         f"DROP TABLE IF EXISTS {DOCUMENT_EMBEDDINGS_MV}",
         node_roles=[NodeRole.INGESTION_SMALL],
     ),
-    # 2. Drop kafka table
     run_sql_with_exceptions(
         f"DROP TABLE IF EXISTS {KAFKA_DOCUMENT_EMBEDDINGS}",
         node_roles=[NodeRole.INGESTION_SMALL],
     ),
-    # 3. Add column to main table
     run_sql_with_exceptions(
         ADD_CONTENT_COLUMN_SQL.format(table_name=DOCUMENT_EMBEDDINGS),
         node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
     ),
-    # 4. Add column to writable table
     run_sql_with_exceptions(
         ADD_CONTENT_COLUMN_SQL.format(table_name=DOCUMENT_EMBEDDING_WRITABLE),
         node_roles=[NodeRole.INGESTION_SMALL],
     ),
-    # 5. Recreate kafka table
     run_sql_with_exceptions(
         KAFKA_DOCUMENT_EMBEDDINGS_TABLE_SQL(),
         node_roles=[NodeRole.INGESTION_SMALL],
     ),
-    # 6. Recreate materialized view
     run_sql_with_exceptions(
         DOCUMENT_EMBEDDINGS_MV_SQL(),
         node_roles=[NodeRole.INGESTION_SMALL],

--- a/posthog/clickhouse/migrations/0169_add_content_column_to_document_embeddings.py
+++ b/posthog/clickhouse/migrations/0169_add_content_column_to_document_embeddings.py
@@ -1,0 +1,49 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+from products.error_tracking.backend.embedding import (
+    DOCUMENT_EMBEDDING_WRITABLE,
+    DOCUMENT_EMBEDDINGS,
+    DOCUMENT_EMBEDDINGS_MV,
+    DOCUMENT_EMBEDDINGS_MV_SQL,
+    KAFKA_DOCUMENT_EMBEDDINGS,
+    KAFKA_DOCUMENT_EMBEDDINGS_TABLE_SQL,
+)
+
+ADD_CONTENT_COLUMN_SQL = """
+ALTER TABLE {table_name}
+ADD COLUMN IF NOT EXISTS content String DEFAULT ''
+"""
+
+operations = [
+    # 1. Drop materialized view
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {DOCUMENT_EMBEDDINGS_MV}",
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # 2. Drop kafka table
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {KAFKA_DOCUMENT_EMBEDDINGS}",
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # 3. Add column to main table
+    run_sql_with_exceptions(
+        ADD_CONTENT_COLUMN_SQL.format(table_name=DOCUMENT_EMBEDDINGS),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+    ),
+    # 4. Add column to writable table
+    run_sql_with_exceptions(
+        ADD_CONTENT_COLUMN_SQL.format(table_name=DOCUMENT_EMBEDDING_WRITABLE),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # 5. Recreate kafka table
+    run_sql_with_exceptions(
+        KAFKA_DOCUMENT_EMBEDDINGS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # 6. Recreate materialized view
+    run_sql_with_exceptions(
+        DOCUMENT_EMBEDDINGS_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+]

--- a/posthog/clickhouse/migrations/0174_add_content_column_to_document_embeddings.py
+++ b/posthog/clickhouse/migrations/0174_add_content_column_to_document_embeddings.py
@@ -27,10 +27,14 @@ operations = [
     run_sql_with_exceptions(
         ADD_CONTENT_COLUMN_SQL.format(table_name=DOCUMENT_EMBEDDINGS),
         node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+        sharded=False,
+        is_alter_on_replicated_table=True,
     ),
     run_sql_with_exceptions(
         ADD_CONTENT_COLUMN_SQL.format(table_name=DOCUMENT_EMBEDDING_WRITABLE),
         node_roles=[NodeRole.INGESTION_SMALL],
+        sharded=False,
+        is_alter_on_replicated_table=False,
     ),
     run_sql_with_exceptions(
         KAFKA_DOCUMENT_EMBEDDINGS_TABLE_SQL(),

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0173_sessions_v3_mv
+0174_add_content_column_to_document_embeddings

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -485,6 +485,7 @@
       document_id String, -- A uuid, a path like "issue/<chunk_id>", whatever you like really
       timestamp DateTime64(3, 'UTC'), -- This is a user defined timestamp, meant to be the /documents/ creation time (or similar), rather than the time the embedding was created
       inserted_at DateTime64(3, 'UTC'), -- When was this embedding inserted (if a duplicate-key row was inserted, for example, this is what we use to choose the winner)
+      content String, -- The actual text content that was embedded
       embedding Array(Float64) -- The embedding itself
       
   ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_document_embeddings_test', kafka_group_name = 'clickhouse_document_embeddings', kafka_format = 'JSONEachRow')
@@ -1702,6 +1703,7 @@
       document_id String, -- A uuid, a path like "issue/<chunk_id>", whatever you like really
       timestamp DateTime64(3, 'UTC'), -- This is a user defined timestamp, meant to be the /documents/ creation time (or similar), rather than the time the embedding was created
       inserted_at DateTime64(3, 'UTC'), -- When was this embedding inserted (if a duplicate-key row was inserted, for example, this is what we use to choose the winner)
+      content String, -- The actual text content that was embedded
       embedding Array(Float64) -- The embedding itself
       
   ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_document_embeddings_test', kafka_group_name = 'clickhouse_document_embeddings', kafka_format = 'JSONEachRow')
@@ -2263,6 +2265,7 @@
       document_id String, -- A uuid, a path like "issue/<chunk_id>", whatever you like really
       timestamp DateTime64(3, 'UTC'), -- This is a user defined timestamp, meant to be the /documents/ creation time (or similar), rather than the time the embedding was created
       inserted_at DateTime64(3, 'UTC'), -- When was this embedding inserted (if a duplicate-key row was inserted, for example, this is what we use to choose the winner)
+      content String DEFAULT '', -- The actual text content that was embedded
       embedding Array(Float64) -- The embedding itself
       
       
@@ -2297,6 +2300,7 @@
   document_id,
   timestamp,
   _timestamp as inserted_at,
+  coalesce(content, '') as content,
   embedding,
   _timestamp,
   _offset,
@@ -5798,6 +5802,7 @@
       document_id String, -- A uuid, a path like "issue/<chunk_id>", whatever you like really
       timestamp DateTime64(3, 'UTC'), -- This is a user defined timestamp, meant to be the /documents/ creation time (or similar), rather than the time the embedding was created
       inserted_at DateTime64(3, 'UTC'), -- When was this embedding inserted (if a duplicate-key row was inserted, for example, this is what we use to choose the winner)
+      content String DEFAULT '', -- The actual text content that was embedded
       embedding Array(Float64) -- The embedding itself
       
       

--- a/posthog/hogql/database/schema/document_embeddings.py
+++ b/posthog/hogql/database/schema/document_embeddings.py
@@ -24,6 +24,7 @@ DOCUMENT_EMBEDDINGS_FIELDS: dict[str, FieldOrTable] = {
     "document_id": StringDatabaseField(name="document_id", nullable=False),
     "timestamp": DateTimeDatabaseField(name="timestamp", nullable=False),
     "inserted_at": DateTimeDatabaseField(name="inserted_at", nullable=False),
+    "content": StringDatabaseField(name="content", nullable=False),
     "embedding": FloatArrayDatabaseField(name="embedding", nullable=False),
 }
 

--- a/products/error_tracking/backend/embedding.py
+++ b/products/error_tracking/backend/embedding.py
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     document_id String, -- A uuid, a path like "issue/<chunk_id>", whatever you like really
     timestamp DateTime64(3, 'UTC'), -- This is a user defined timestamp, meant to be the /documents/ creation time (or similar), rather than the time the embedding was created
     inserted_at DateTime64(3, 'UTC'), -- When was this embedding inserted (if a duplicate-key row was inserted, for example, this is what we use to choose the winner)
-    content String DEFAULT '', -- The actual text content that was embedded
+    content String{default_clause}, -- The actual text content that was embedded
     embedding Array(Float64) -- The embedding itself
     {extra_fields}
 ) ENGINE = {engine}
@@ -46,6 +46,7 @@ def DOCUMENT_EMBEDDINGS_TABLE_SQL():
     ).format(
         table_name=DOCUMENT_EMBEDDINGS,
         engine=DOCUMENT_EMBEDDINGS_TABLE_ENGINE(),
+        default_clause=" DEFAULT ''",
         extra_fields=f"""
     {KAFKA_COLUMNS_WITH_PARTITION}
     , {index_by_kafka_timestamp(DOCUMENT_EMBEDDINGS)}
@@ -60,6 +61,7 @@ def DOCUMENT_EMBEDDINGS_WRITABLE_TABLE_SQL():
             data_table=DOCUMENT_EMBEDDINGS,
             cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER,
         ),
+        default_clause=" DEFAULT ''",
         extra_fields=KAFKA_COLUMNS_WITH_PARTITION,
     )
 
@@ -68,6 +70,7 @@ def KAFKA_DOCUMENT_EMBEDDINGS_TABLE_SQL():
     return DOCUMENT_EMBEDDINGS_TABLE_BASE_SQL.format(
         table_name=KAFKA_DOCUMENT_EMBEDDINGS,
         engine=kafka_engine(KAFKA_DOCUMENT_EMBEDDINGS_TOPIC, group="clickhouse_document_embeddings"),
+        default_clause="",
         extra_fields="",
     )
 

--- a/products/error_tracking/backend/embedding.py
+++ b/products/error_tracking/backend/embedding.py
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     document_id String, -- A uuid, a path like "issue/<chunk_id>", whatever you like really
     timestamp DateTime64(3, 'UTC'), -- This is a user defined timestamp, meant to be the /documents/ creation time (or similar), rather than the time the embedding was created
     inserted_at DateTime64(3, 'UTC'), -- When was this embedding inserted (if a duplicate-key row was inserted, for example, this is what we use to choose the winner)
+    content String DEFAULT '', -- The actual text content that was embedded
     embedding Array(Float64) -- The embedding itself
     {extra_fields}
 ) ENGINE = {engine}
@@ -86,6 +87,7 @@ rendering,
 document_id,
 timestamp,
 _timestamp as inserted_at,
+coalesce(content, '') as content,
 embedding,
 _timestamp,
 _offset,


### PR DESCRIPTION
Generally this will be small (8192 tokens, on that order of magnitude of bytes), but it will be duplicate semi-often. I'm not sure what compression modes we're running (or if we even pick them), but text should be fairly compressible so 🤷.