### PR TITLE
fix(experiments): metric dialog shows wrong metric source

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -111,12 +111,14 @@ const dataWarehousePopoverFields: DataWarehousePopoverField[] = [
 
 export function ExperimentMetricForm({
     metric,
+    isSharedMetric = false,
     handleSetMetric,
     filterTestAccounts,
     exposureCriteria,
     openExposureCriteriaModal,
 }: {
     metric: ExperimentMetric
+    isSharedMetric?: boolean
     handleSetMetric: (newMetric: ExperimentMetric) => void
     filterTestAccounts: boolean
     exposureCriteria?: ExperimentExposureCriteria | undefined
@@ -227,7 +229,7 @@ export function ExperimentMetricForm({
 
     return (
         <SceneContent>
-            <SceneSection title="Shared metric type" className="max-w-prose">
+            <SceneSection title={isSharedMetric ? 'Shared metric type' : 'Metric type'} className="max-w-prose">
                 <div>
                     <LemonRadio
                         data-attr="metrics-selector"

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -192,6 +192,7 @@ export function SharedMetric(): JSX.Element {
             {sharedMetric.query.kind === NodeKind.ExperimentMetric ? (
                 <ExperimentMetricForm
                     metric={sharedMetric.query as ExperimentMetric}
+                    isSharedMetric={true}
                     handleSetMetric={(newMetric) => {
                         setSharedMetric({
                             ...sharedMetric,


### PR DESCRIPTION
## Problem

A regression after the refactor of the metric dialog caused the metric type label to show the wrong metric source.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Setting a new `isSharedMetric` optional prop, defaulting to `false`, so all the uses of the form will show "metric" as the source, while the create metric page will show "shared metric".

| Before | After |
| - | - |
| <img width="656" height="427" alt="image" src="https://github.com/user-attachments/assets/dacde88b-f998-4a85-a5e9-8b2f66b70c91" /> | <img width="646" height="424" alt="image" src="https://github.com/user-attachments/assets/931d5a03-7dda-4a5d-b4b0-bc5166e118ae" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/70f7f415-bc74-4d32-a4b0-d550f2c52816)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
