### PR TITLE
fix(experiments): shared metrics on experiment scene logic

### DIFF
--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -246,6 +246,12 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
     }),
     tabAwareUrlToAction(({ actions, values }) => ({
         '/experiments/:id': ({ id }, query, __, currentLocation, previousLocation) => {
+            // Ignore sub-routes like /experiments/shared-metrics/new
+            // The :id parameter should only be 'new' or a number, not strings like 'shared-metrics'
+            if (!id || (id !== 'new' && isNaN(parseInt(id, 10)))) {
+                return
+            }
+
             const didPathChange = currentLocation.initial || currentLocation.pathname !== previousLocation?.pathname
 
             actions.setEditMode(false)
@@ -284,6 +290,12 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
             }
         },
         '/experiments/:id/:formMode': ({ id, formMode }, _, __, currentLocation, previousLocation) => {
+            // Ignore routes where id is not a valid experiment identifier (number or 'new')
+            // This prevents matching routes like /experiments/shared-metrics/new
+            if (!id || (id !== 'new' && isNaN(parseInt(id, 10)))) {
+                return
+            }
+
             const didPathChange = currentLocation.initial || currentLocation.pathname !== previousLocation?.pathname
 
             if (id && didPathChange) {


### PR DESCRIPTION
## Problem

Once the `experimentSceneLogic` is mounted, navigating to any other path will display the experiment view instead. This happens because of Kea's pattern matching, which calls all URL handlers of mounted logics.

The `experimentSceneLogic` will call `setSceneState`, that returns a new `/experiments/NaN` url.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We just added a small check to verify the `id` param. If it's not a number or `new`, we skip (what would be done by `next` on a regular routing middleware).

Making `sharedMetricLogic` _tab aware_ won't fix the problem because `experimentSceneLogic` won't unmount. We have two logics sharins a scene, so we should look into other patterns for this.

| Before | After |
| - | - |
| ![url-to-action-before](https://github.com/user-attachments/assets/026a3cbf-b0c6-4488-9818-d76943182cf6) | ![url-to-action-after](https://github.com/user-attachments/assets/ca19678f-d921-43fe-9069-0136ae5aef20) |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/e9f50250-7943-42cd-8258-49e7cfc34212)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
