### PR TITLE
fix(experiments): Init kea logic correctly

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -389,16 +389,16 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                             <LegacyMetricSourceModal experimentId={experimentId} isSecondary={false} />
                             <LegacySharedMetricModal experimentId={experimentId} isSecondary={true} />
                             <LegacySharedMetricModal experimentId={experimentId} isSecondary={false} />
-                            <LegacyMetricModal experimentId={experimentId} isSecondary={true} />
-                            <LegacyMetricModal experimentId={experimentId} isSecondary={false} />
+                            <LegacyMetricModal isSecondary={true} />
+                            <LegacyMetricModal isSecondary={false} />
                         </>
                     )}
 
                     <DistributionModal />
                     <ReleaseConditionsModal />
 
-                    <StopExperimentModal experimentId={experimentId} />
-                    <EditConclusionModal experimentId={experimentId} />
+                    <StopExperimentModal />
+                    <EditConclusionModal />
 
                     <VariantDeltaTimeseries />
                 </>

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -385,10 +385,10 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                         </>
                     ) : (
                         <>
-                            <LegacyMetricSourceModal experimentId={experimentId} isSecondary={true} />
-                            <LegacyMetricSourceModal experimentId={experimentId} isSecondary={false} />
-                            <LegacySharedMetricModal experimentId={experimentId} isSecondary={true} />
-                            <LegacySharedMetricModal experimentId={experimentId} isSecondary={false} />
+                            <LegacyMetricSourceModal isSecondary={true} />
+                            <LegacyMetricSourceModal isSecondary={false} />
+                            <LegacySharedMetricModal isSecondary={true} />
+                            <LegacySharedMetricModal isSecondary={false} />
                             <LegacyMetricModal isSecondary={true} />
                             <LegacyMetricModal isSecondary={false} />
                         </>

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -55,7 +55,6 @@ import {
     AnyPropertyFilter,
     Experiment,
     ExperimentConclusion,
-    ExperimentIdType,
     InsightShortId,
     ProductKey,
     ProgressStatus,
@@ -391,7 +390,6 @@ export function ExperimentLoadingAnimation(): JSX.Element {
 
 export function PageHeaderCustom(): JSX.Element {
     const {
-        experimentId,
         experiment,
         isExperimentDraft,
         isExperimentRunning,
@@ -520,7 +518,7 @@ export function PageHeaderCustom(): JSX.Element {
                                         <b>Ship a variant</b>
                                     </LemonButton>
                                 </Tooltip>
-                                <ShipVariantModal experimentId={experimentId} />
+                                <ShipVariantModal />
                             </>
                         )}
                         {experiment && (
@@ -585,7 +583,7 @@ export function PageHeaderCustom(): JSX.Element {
                             </ButtonPrimitive>
                         )}
 
-                        <ResetButton experimentId={experiment.id} />
+                        <ResetButton />
 
                         {!experiment.end_date && (
                             <ButtonPrimitive
@@ -603,9 +601,9 @@ export function PageHeaderCustom(): JSX.Element {
     )
 }
 
-export function ConclusionForm({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
-    const { experiment } = useValues(experimentLogic({ experimentId }))
-    const { setExperiment } = useActions(experimentLogic({ experimentId }))
+export function ConclusionForm(): JSX.Element {
+    const { experiment } = useValues(experimentLogic)
+    const { setExperiment } = useActions(experimentLogic)
 
     return (
         <div className="space-y-4">
@@ -662,9 +660,9 @@ export function ConclusionForm({ experimentId }: { experimentId: Experiment['id'
     )
 }
 
-export function EditConclusionModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
-    const { experiment } = useValues(experimentLogic({ experimentId }))
-    const { updateExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic({ experimentId }))
+export function EditConclusionModal(): JSX.Element {
+    const { experiment } = useValues(experimentLogic)
+    const { updateExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic)
     const { closeEditConclusionModal } = useActions(modalsLogic)
     const { isEditConclusionModalOpen } = useValues(modalsLogic)
 
@@ -701,14 +699,14 @@ export function EditConclusionModal({ experimentId }: { experimentId: Experiment
                 </div>
             }
         >
-            <ConclusionForm experimentId={experimentId} />
+            <ConclusionForm />
         </LemonModal>
     )
 }
 
-export function StopExperimentModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
-    const { experiment } = useValues(experimentLogic({ experimentId }))
-    const { endExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic({ experimentId }))
+export function StopExperimentModal(): JSX.Element {
+    const { experiment } = useValues(experimentLogic)
+    const { endExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic)
     const { closeStopExperimentModal } = useActions(modalsLogic)
     const { isStopExperimentModalOpen } = useValues(modalsLogic)
 
@@ -746,15 +744,15 @@ export function StopExperimentModal({ experimentId }: { experimentId: Experiment
                 <div className="mb-2">
                     Stopping the experiment will end data collection. You can restart it later if needed.
                 </div>
-                <ConclusionForm experimentId={experimentId} />
+                <ConclusionForm />
             </div>
         </LemonModal>
     )
 }
 
-export function ShipVariantModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
-    const { experiment } = useValues(experimentLogic({ experimentId }))
-    const { shipVariant } = useActions(experimentLogic({ experimentId }))
+export function ShipVariantModal(): JSX.Element {
+    const { experiment } = useValues(experimentLogic)
+    const { shipVariant } = useActions(experimentLogic)
     const { closeShipVariantModal } = useActions(modalsLogic)
     const { isShipVariantModalOpen } = useValues(modalsLogic)
     const { aggregationLabel } = useValues(groupsModel)
@@ -838,8 +836,8 @@ export function ShipVariantModal({ experimentId }: { experimentId: Experiment['i
     )
 }
 
-export const ResetButton = ({ experimentId }: { experimentId: ExperimentIdType }): JSX.Element => {
-    const { experiment } = useValues(experimentLogic({ experimentId }))
+export const ResetButton = (): JSX.Element => {
+    const { experiment } = useValues(experimentLogic)
     const { resetRunningExperiment } = useActions(experimentLogic)
 
     const onClickReset = (): void => {

--- a/frontend/src/scenes/experiments/Metrics/LegacyMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/LegacyMetricModal.tsx
@@ -19,7 +19,7 @@ import { TrendsMetricForm } from './TrendsMetricForm'
 export function LegacyMetricModal({ isSecondary }: { isSecondary?: boolean }): JSX.Element {
     const { experiment, experimentLoading, getInsightType, editingPrimaryMetricUuid, editingSecondaryMetricUuid } =
         useValues(experimentLogic)
-    const { updateExperimentMetrics, setExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic())
+    const { updateExperimentMetrics, setExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic)
     const { closePrimaryMetricModal, closeSecondaryMetricModal } = useActions(modalsLogic)
     const { isPrimaryMetricModalOpen, isSecondaryMetricModalOpen } = useValues(modalsLogic)
 

--- a/frontend/src/scenes/experiments/Metrics/LegacyMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/LegacyMetricModal.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { LemonButton, LemonDialog, LemonModal, LemonSelect } from '@posthog/lemon-ui'
 
 import { ExperimentFunnelsQuery, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
-import { Experiment, InsightType } from '~/types'
+import { InsightType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
@@ -16,18 +16,10 @@ import { TrendsMetricForm } from './TrendsMetricForm'
  * This component is deprecated and only supports the legacy query runner.
  * Use the MetricModal component instead.
  */
-export function LegacyMetricModal({
-    experimentId,
-    isSecondary,
-}: {
-    experimentId: Experiment['id']
-    isSecondary?: boolean
-}): JSX.Element {
+export function LegacyMetricModal({ isSecondary }: { isSecondary?: boolean }): JSX.Element {
     const { experiment, experimentLoading, getInsightType, editingPrimaryMetricUuid, editingSecondaryMetricUuid } =
-        useValues(experimentLogic({ experimentId }))
-    const { updateExperimentMetrics, setExperiment, restoreUnmodifiedExperiment } = useActions(
-        experimentLogic({ experimentId })
-    )
+        useValues(experimentLogic)
+    const { updateExperimentMetrics, setExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic())
     const { closePrimaryMetricModal, closeSecondaryMetricModal } = useActions(modalsLogic)
     const { isPrimaryMetricModalOpen, isSecondaryMetricModalOpen } = useValues(modalsLogic)
 

--- a/frontend/src/scenes/experiments/Metrics/LegacyMetricSourceModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/LegacyMetricSourceModal.tsx
@@ -2,8 +2,6 @@ import { useActions, useValues } from 'kea'
 
 import { LemonModal } from '@posthog/lemon-ui'
 
-import { Experiment } from '~/types'
-
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 import { getDefaultFunnelMetric, getDefaultFunnelsMetric } from '../utils'
@@ -14,15 +12,9 @@ import { getDefaultFunnelMetric, getDefaultFunnelsMetric } from '../utils'
  * This component is deprecated and only supports the legacy query runner.
  * Use the MetricSourceModal component instead.
  */
-export function LegacyMetricSourceModal({
-    experimentId,
-    isSecondary,
-}: {
-    experimentId: Experiment['id']
-    isSecondary?: boolean
-}): JSX.Element {
-    const { experiment, usesNewQueryRunner } = useValues(experimentLogic({ experimentId }))
-    const { setExperiment } = useActions(experimentLogic({ experimentId }))
+export function LegacyMetricSourceModal({ isSecondary }: { isSecondary?: boolean }): JSX.Element {
+    const { experiment, usesNewQueryRunner } = useValues(experimentLogic)
+    const { setExperiment } = useActions(experimentLogic)
     const {
         closePrimaryMetricSourceModal,
         closeSecondaryMetricSourceModal,

--- a/frontend/src/scenes/experiments/Metrics/LegacySharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/LegacySharedMetricModal.tsx
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { NodeKind } from '~/queries/schema/schema-general'
-import { AvailableFeature, Experiment } from '~/types'
+import { AvailableFeature } from '~/types'
 
 import { MetricDisplayFunnels, MetricDisplayTrends } from '../ExperimentView/components'
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
@@ -23,20 +23,14 @@ import { appendMetricToOrderingArray, removeMetricFromOrderingArray } from '../u
  * This component is deprecated and only supports the legacy query runner.
  * Use the SharedMetricModal component instead.
  */
-export function LegacySharedMetricModal({
-    experimentId,
-    isSecondary,
-}: {
-    experimentId: Experiment['id']
-    isSecondary?: boolean
-}): JSX.Element {
-    const { experiment, compatibleSharedMetrics, editingSharedMetricId } = useValues(experimentLogic({ experimentId }))
+export function LegacySharedMetricModal({ isSecondary }: { isSecondary?: boolean }): JSX.Element {
+    const { experiment, compatibleSharedMetrics, editingSharedMetricId } = useValues(experimentLogic)
     const {
         addSharedMetricsToExperiment,
         removeSharedMetricFromExperiment,
         restoreUnmodifiedExperiment,
         setExperiment,
-    } = useActions(experimentLogic({ experimentId }))
+    } = useActions(experimentLogic)
     const { closePrimarySharedMetricModal, closeSecondarySharedMetricModal } = useActions(modalsLogic)
     const { isPrimarySharedMetricModalOpen, isSecondarySharedMetricModalOpen } = useValues(modalsLogic)
     const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])


### PR DESCRIPTION
## Changes
Fixed kea logic initialization by removing the `experimentId` prop. After the recent tab-aware refactoring, passing experimentId created a new logic instance instead of connecting to the already-mounted one that has the experiment loaded.

## How did you test this code?
Manually tested that the following work:
- Ship variant
- Stop experiment
- Set conclusion
- Reset experiment