### PR TITLE
fix: Set client configuration for GCS in manifest upload

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -878,9 +878,10 @@ class ConcurrentS3Consumer(Consumer):
             Body=json.dumps({"files": files_uploaded}),
         )
 
-        await self._s3_client_ctx.__aexit__(None, None, None)
-        self._s3_client = None
-        self._s3_client_ctx = None
+        if self._s3_client is not None and self._s3_client_ctx is not None:
+            await self._s3_client_ctx.__aexit__(None, None, None)
+            self._s3_client = None
+            self._s3_client_ctx = None
 
     # TODO - maybe we can support upload small files without the need for multipart uploads
     # we just want to ensure we test both versions of the code path

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_gcs_bucket.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_gcs_bucket.py
@@ -12,15 +12,11 @@ from products.batch_exports.backend.temporal.destinations.s3_batch_export import
     FILE_FORMAT_EXTENSIONS,
     SUPPORTED_COMPRESSIONS,
 )
-from products.batch_exports.backend.tests.temporal.destinations.s3.utils import run_s3_batch_export_workflow
+from products.batch_exports.backend.tests.temporal.destinations.s3.utils import (
+    has_valid_gcs_credentials,
+    run_s3_batch_export_workflow,
+)
 from products.batch_exports.backend.tests.temporal.utils.s3 import delete_all_from_s3
-
-
-def has_valid_gcs_credentials() -> bool:
-    return (
-        "GCS_TEST_BUCKET" in os.environ and "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ
-    )
-
 
 pytestmark = [
     pytest.mark.asyncio,


### PR DESCRIPTION
## Problem

Same as #40593, but applied to the client that is spawned to upload a manifest file.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
