### PR TITLE
feat(workflows): create template from email templater

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -310,7 +310,7 @@ function NativeEmailTemplaterForm({
                     <>
                         {isWorkflowsProductEnabled && (
                             <div className="flex gap-2 items-center px-2 py-1 border-b">
-                                <span className="flex-1">Templates</span>
+                                <span className="flex-1">Start from a template (optional)</span>
                                 <LemonSelect
                                     size="xsmall"
                                     placeholder="Choose template"

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -420,21 +420,26 @@ function SaveTemplateModal({
     const [templateName, setTemplateName] = useState('')
     const [templateDescription, setTemplateDescription] = useState('')
 
+    const handleClose = (): void => {
+        setTemplateName('')
+        setTemplateDescription('')
+        onClose()
+    }
+
     return (
         <LemonModal
             isOpen={isOpen}
-            onClose={onClose}
+            onClose={handleClose}
             title="Save as template"
             description="Create a reusable template from this email"
             footer={
                 <>
-                    <LemonButton onClick={onClose}>Cancel</LemonButton>
+                    <LemonButton onClick={handleClose}>Cancel</LemonButton>
                     <LemonButton
                         type="primary"
                         onClick={() => {
                             if (templateName) {
                                 onSave(templateName, templateDescription)
-                                onClose()
                                 setTemplateName('')
                                 setTemplateDescription('')
                             }
@@ -471,9 +476,10 @@ function SaveTemplateModal({
 }
 
 function EmailTemplaterModal(): JSX.Element {
-    const { isModalOpen, isEmailEditorReady, emailTemplateChanged } = useValues(emailTemplaterLogic)
-    const { closeWithConfirmation, submitEmailTemplate, saveAsTemplate } = useActions(emailTemplaterLogic)
-    const [isSaveTemplateModalOpen, setIsSaveTemplateModalOpen] = useState(false)
+    const { isModalOpen, isEmailEditorReady, emailTemplateChanged, isSaveTemplateModalOpen } =
+        useValues(emailTemplaterLogic)
+    const { closeWithConfirmation, submitEmailTemplate, saveAsTemplate, setIsSaveTemplateModalOpen } =
+        useActions(emailTemplaterLogic)
 
     return (
         <>

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -242,7 +242,13 @@ function LiquidSupportedText({
     )
 }
 
-function NativeEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX.Element {
+function NativeEmailTemplaterForm({
+    mode,
+    onSaveAsTemplate,
+}: {
+    mode: EmailEditorMode
+    onSaveAsTemplate?: () => void
+}): JSX.Element {
     const { unlayerEditorProjectId, logicProps, appliedTemplate, templates, templatesLoading, mergeTags } =
         useValues(emailTemplaterLogic)
     const { setEmailEditorRef, onEmailEditorReady, setIsModalOpen, applyTemplate } = useActions(emailTemplaterLogic)
@@ -304,24 +310,40 @@ function NativeEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX.Elem
                     <>
                         {isWorkflowsProductEnabled && (
                             <div className="flex gap-2 items-center px-2 py-1 border-b">
-                                <span className="flex-1">Start from a template (optional)</span>
+                                <span className="flex-1">Templates</span>
                                 <LemonSelect
                                     size="xsmall"
                                     placeholder="Choose template"
                                     loading={templatesLoading}
                                     value={appliedTemplate?.id}
-                                    options={templates.map((template) => ({
-                                        label: template.name,
-                                        value: template.id,
-                                    }))}
+                                    options={[
+                                        {
+                                            title: 'Templates',
+                                            options: templates.map((template) => ({
+                                                label: template.name,
+                                                value: template.id,
+                                            })),
+                                        },
+                                        {
+                                            options: [
+                                                {
+                                                    label: 'Save as new template',
+                                                    value: 'save-as-template',
+                                                },
+                                            ],
+                                        },
+                                    ]}
                                     onChange={(id) => {
+                                        if (id === 'save-as-template') {
+                                            onSaveAsTemplate?.()
+                                            return
+                                        }
                                         const template = templates.find((t) => t.id === id)
                                         if (template) {
                                             applyTemplate(template)
                                         }
                                     }}
                                     data-attr="email-template-selector"
-                                    disabledReason={templates.length > 0 ? undefined : 'No templates created yet'}
                                 />
                             </div>
                         )}
@@ -368,7 +390,13 @@ function NativeEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX.Elem
     )
 }
 
-function EmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX.Element {
+function EmailTemplaterForm({
+    mode,
+    onSaveAsTemplate,
+}: {
+    mode: EmailEditorMode
+    onSaveAsTemplate?: () => void
+}): JSX.Element {
     const { logicProps } = useValues(emailTemplaterLogic)
 
     switch (logicProps.type) {
@@ -376,7 +404,7 @@ function EmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX.Element {
             return <DestinationEmailTemplaterForm mode={mode} />
         case 'native_email_template':
         case 'native_email':
-            return <NativeEmailTemplaterForm mode={mode} />
+            return <NativeEmailTemplaterForm mode={mode} onSaveAsTemplate={onSaveAsTemplate} />
     }
 }
 
@@ -443,7 +471,7 @@ function SaveTemplateModal({
 }
 
 function EmailTemplaterModal(): JSX.Element {
-    const { isModalOpen, isEmailEditorReady, emailTemplateChanged, logicProps } = useValues(emailTemplaterLogic)
+    const { isModalOpen, isEmailEditorReady, emailTemplateChanged } = useValues(emailTemplaterLogic)
     const { closeWithConfirmation, submitEmailTemplate, saveAsTemplate } = useActions(emailTemplaterLogic)
     const [isSaveTemplateModalOpen, setIsSaveTemplateModalOpen] = useState(false)
 
@@ -460,17 +488,8 @@ function EmailTemplaterModal(): JSX.Element {
                         <div className="shrink-0">
                             <h2>Editing email template</h2>
                         </div>
-                        <EmailTemplaterForm mode="full" />
+                        <EmailTemplaterForm mode="full" onSaveAsTemplate={() => setIsSaveTemplateModalOpen(true)} />
                         <div className="flex gap-2 items-center mt-2">
-                            {(logicProps.type === 'native_email' || logicProps.type === 'native_email_template') && (
-                                <LemonButton
-                                    type="secondary"
-                                    onClick={() => setIsSaveTemplateModalOpen(true)}
-                                    disabledReason={isEmailEditorReady ? undefined : 'Loading email editor...'}
-                                >
-                                    Save as template
-                                </LemonButton>
-                            )}
                             <div className="flex-1" />
                             <LemonButton onClick={() => closeWithConfirmation()}>Discard changes</LemonButton>
                             <LemonButton

--- a/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
@@ -53,6 +53,7 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
         setEmailEditorRef: (emailEditorRef: EditorRef | null) => ({ emailEditorRef }),
         onEmailEditorReady: true,
         setIsModalOpen: (isModalOpen: boolean) => ({ isModalOpen }),
+        setIsSaveTemplateModalOpen: (isOpen: boolean) => ({ isOpen }),
         applyTemplate: (template: MessageTemplate) => ({ template }),
         closeWithConfirmation: true,
         setTemplatingEngine: (templating: 'hog' | 'liquid') => ({ templating }),
@@ -76,6 +77,12 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
             false,
             {
                 setIsModalOpen: (_, { isModalOpen }) => isModalOpen,
+            },
+        ],
+        isSaveTemplateModalOpen: [
+            false,
+            {
+                setIsSaveTemplateModalOpen: (_, { isOpen }) => isOpen,
             },
         ],
         appliedTemplate: [
@@ -218,6 +225,11 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
         applyTemplate: ({ template }) => {
             const emailTemplateContent = template.content.email
             actions.setEmailTemplateValues(emailTemplateContent)
+
+            // Load the design into the editor if it's ready and has a design
+            if (values.isEmailEditorReady && emailTemplateContent.design) {
+                values.emailEditorRef?.editor?.loadDesign(emailTemplateContent.design)
+            }
         },
 
         closeWithConfirmation: () => {
@@ -274,6 +286,7 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
                 await api.messaging.createTemplate(templateData)
                 lemonToast.success('Template saved successfully')
                 actions.loadTemplates()
+                actions.setIsSaveTemplateModalOpen(false)
             } catch (error) {
                 lemonToast.error('Failed to save template')
                 console.error(error)


### PR DESCRIPTION
## Problem

When you are in the email editor in a hogflow & you create e.g. a new email that you would like to re-use as template .. you have no possibility to do so right now. 

- save just saves it currently 
- you can just pick from an existing template
- weird behaviour when picking a template it does not automatically load the content right away

![2025-11-07 11 51 25](https://github.com/user-attachments/assets/2993acee-2745-4798-9c0a-b7b9da814941)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![2025-11-07 11 54 02](https://github.com/user-attachments/assets/4133cf72-fe7a-40bf-8953-caa882f13919)


- you can now chose a template 
- edit the template and then go back to the dropdown and save it as new template
- fixed the re-loading behaviour

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
