### PR TITLE
fix: added missing fields to event payload for weekly-digest

### DIFF
--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -524,7 +524,7 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
                         if input.dry_run:
                             logger.info(
                                 "DRY RUN - would send digest",
-                                digest=user_specific_digest.render_payload(),
+                                digest=user_specific_digest.render_payload(input.digest),
                                 user_email=user.email,
                             )
                         else:
@@ -535,7 +535,7 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
                                 ph_client.capture(
                                     distinct_id=user.distinct_id,
                                     event="transactional email",
-                                    properties=user_specific_digest.render_payload(),
+                                    properties=user_specific_digest.render_payload(input.digest),
                                     groups={
                                         "organization": str(organization.id),
                                         "instance": settings.SITE_URL,


### PR DESCRIPTION
Customer.io will only send out digests if `total_digest_items_with_data` field is present in the event payload and has a value greater than 0. Add the missing field to the new digest implementation.