### PR TITLE
feat(sessions): Re-add sessions v3 recordings mv

### DIFF
--- a/posthog/clickhouse/migrations/0172_sessions_v3_recordings_mvs.py
+++ b/posthog/clickhouse/migrations/0172_sessions_v3_recordings_mvs.py
@@ -1,0 +1,7 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sessions_v3 import RAW_SESSIONS_TABLE_MV_RECORDINGS_SQL_V3
+
+operations = [
+    run_sql_with_exceptions(RAW_SESSIONS_TABLE_MV_RECORDINGS_SQL_V3(), node_roles=[NodeRole.DATA], sharded=True),
+]

--- a/posthog/clickhouse/migrations/0172_sessions_v3_recordings_mvs.py
+++ b/posthog/clickhouse/migrations/0172_sessions_v3_recordings_mvs.py
@@ -3,5 +3,5 @@ from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.raw_sessions.sessions_v3 import RAW_SESSIONS_TABLE_MV_RECORDINGS_SQL_V3
 
 operations = [
-    run_sql_with_exceptions(RAW_SESSIONS_TABLE_MV_RECORDINGS_SQL_V3(), node_roles=[NodeRole.DATA], sharded=True),
+    run_sql_with_exceptions(RAW_SESSIONS_TABLE_MV_RECORDINGS_SQL_V3(), node_roles=[NodeRole.DATA], sharded=False),
 ]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0171_sessions_v3_split_bounce_rate
+0172_sessions_v3_recordings_mvs


### PR DESCRIPTION
## Problem

We dropped this mv due to an incident https://posthog.slack.com/archives/C09QZQQRE6B



## Changes

Re-add this MV.

You can check that sharded_raw_sessions_v3 is not in the list of tables with schema drift [EU](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiIvKiBSZXR1cm5zIG9ubHkgdGFibGVzIHRoYXQgaGF2ZSDiiaUyIGRpc3RpbmN0IG5vcm1hbGl6ZWQgQ1JFQVRFcyBzb21ld2hlcmUgaW4gdGhlIGNsdXN0ZXIgKi9cbldJVEggc3ViIEFTXG4oXG4gICAgU0VMRUNUXG4gICAgICAgIGRhdGFiYXNlLFxuICAgICAgICBuYW1lIEFTIHRhYmxlX25hbWUsXG4gICAgICAgIGhvc3ROYW1lKCkgQVMgaG9zdCxcbiAgICAgICAgLS0gU3RyaXAgUmVwbGljYXRlZCogZW5naW5lIGFyZ3VtZW50czogUmVwbGljYXRlZFh4eCggLi4uICkgLT4gUmVwbGljYXRlZFh4eCgpXG4gICAgICAgIHJlcGxhY2VSZWdleHBBbGwoXG4gICAgICAgICAgICBjcmVhdGVfdGFibGVfcXVlcnksXG4gICAgICAgICAgICAnKEVOR0lORVxcXFxzKj1cXFxccypSZXBsaWNhdGVkXFxcXHcrKVxcXFxzKlxcXFwoW14pXSpcXFxcKScsXG4gICAgICAgICAgICAnXFxcXDEoKSdcbiAgICAgICAgKSBBUyBzdGVwMVxuICAgIEZST00gY2x1c3RlckFsbFJlcGxpY2FzKCdwb3N0aG9nJywgJ3N5c3RlbScsICd0YWJsZXMnKVxuICAgIFdIRVJFIGRhdGFiYXNlIE5PVCBJTiAoJ3N5c3RlbScpXG4pLFxubm9ybWVkIEFTXG4oXG4gICAgU0VMRUNUXG4gICAgICAgIGRhdGFiYXNlLFxuICAgICAgICB0YWJsZV9uYW1lLFxuICAgICAgICBob3N0LFxuICAgICAgICAtLSBSZW1vdmUgYmFja3RpY2tzOyBjb2xsYXBzZSB3aGl0ZXNwYWNlOyB0cmltXG4gICAgICAgIHRyaW0oQk9USCAnICcgRlJPTSByZXBsYWNlUmVnZXhwQWxsKHJlcGxhY2VSZWdleHBBbGwoc3RlcDEsICdgKFteYF0qKWAnLCdcXFxcMScpLCAnXFxcXHMrJywgJyAnKSkgQVMgbm9ybV9zcWxcbiAgICBGUk9NIHN1YlxuKSxcbnZhcmlhbnRzIEFTXG4oXG4gICAgU0VMRUNUXG4gICAgICAgIGRhdGFiYXNlLFxuICAgICAgICB0YWJsZV9uYW1lLFxuICAgICAgICBjaXR5SGFzaDY0KG5vcm1fc3FsKSBBUyBzY2hlbWFfaGFzaCxcbiAgICAgICAgYW55KG5vcm1fc3FsKSAgICAgICAgQVMgc2FtcGxlX2NyZWF0ZSxcbiAgICAgICAgZ3JvdXBBcnJheShob3N0KSAgICAgQVMgaG9zdHMsXG4gICAgICAgIGNvdW50KCkgICAgICAgICAgICAgIEFTIHJlcGxpY2FzXG4gICAgRlJPTSBub3JtZWRcbiAgICBHUk9VUCBCWSBkYXRhYmFzZSwgdGFibGVfbmFtZSwgc2NoZW1hX2hhc2hcbiksXG5kcmlmdGVkIEFTXG4oXG4gICAgU0VMRUNUIGRhdGFiYXNlLCB0YWJsZV9uYW1lXG4gICAgRlJPTSB2YXJpYW50c1xuICAgIEdST1VQIEJZIGRhdGFiYXNlLCB0YWJsZV9uYW1lXG4gICAgSEFWSU5HIGNvdW50KCkgPiAxXG4pXG5TRUxFQ1RcbiAgICB2LmRhdGFiYXNlLFxuICAgIHYudGFibGVfbmFtZSxcbiAgICB2LnJlcGxpY2FzLFxuICAgIHYuaG9zdHMsXG4gICAgdi5zY2hlbWFfaGFzaCxcbiAgICB2LnNhbXBsZV9jcmVhdGVcbkZST00gdmFyaWFudHMgdlxuSU5ORVIgSk9JTiBkcmlmdGVkIGQgVVNJTkcgKGRhdGFiYXNlLCB0YWJsZV9uYW1lKVxuT1JERVIgQlkgdi5kYXRhYmFzZSwgdi50YWJsZV9uYW1lLCB2LnJlcGxpY2FzIERFU0M7IiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6MzV9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) [US](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiIvKiBSZXR1cm5zIG9ubHkgdGFibGVzIHRoYXQgaGF2ZSDiiaUyIGRpc3RpbmN0IG5vcm1hbGl6ZWQgQ1JFQVRFcyBzb21ld2hlcmUgaW4gdGhlIGNsdXN0ZXIgKi9cbldJVEggc3ViIEFTXG4oXG4gICAgU0VMRUNUXG4gICAgICAgIGRhdGFiYXNlLFxuICAgICAgICBuYW1lIEFTIHRhYmxlX25hbWUsXG4gICAgICAgIGhvc3ROYW1lKCkgQVMgaG9zdCxcbiAgICAgICAgLS0gU3RyaXAgUmVwbGljYXRlZCogZW5naW5lIGFyZ3VtZW50czogUmVwbGljYXRlZFh4eCggLi4uICkgLT4gUmVwbGljYXRlZFh4eCgpXG4gICAgICAgIHJlcGxhY2VSZWdleHBBbGwoXG4gICAgICAgICAgICBjcmVhdGVfdGFibGVfcXVlcnksXG4gICAgICAgICAgICAnKEVOR0lORVxcXFxzKj1cXFxccypSZXBsaWNhdGVkXFxcXHcrKVxcXFxzKlxcXFwoW14pXSpcXFxcKScsXG4gICAgICAgICAgICAnXFxcXDEoKSdcbiAgICAgICAgKSBBUyBzdGVwMVxuICAgIEZST00gY2x1c3RlckFsbFJlcGxpY2FzKCdwb3N0aG9nJywgJ3N5c3RlbScsICd0YWJsZXMnKVxuICAgIFdIRVJFIGRhdGFiYXNlIE5PVCBJTiAoJ3N5c3RlbScpXG4pLFxubm9ybWVkIEFTXG4oXG4gICAgU0VMRUNUXG4gICAgICAgIGRhdGFiYXNlLFxuICAgICAgICB0YWJsZV9uYW1lLFxuICAgICAgICBob3N0LFxuICAgICAgICAtLSBSZW1vdmUgYmFja3RpY2tzOyBjb2xsYXBzZSB3aGl0ZXNwYWNlOyB0cmltXG4gICAgICAgIHRyaW0oQk9USCAnICcgRlJPTSByZXBsYWNlUmVnZXhwQWxsKHJlcGxhY2VSZWdleHBBbGwoc3RlcDEsICdgKFteYF0qKWAnLCdcXFxcMScpLCAnXFxcXHMrJywgJyAnKSkgQVMgbm9ybV9zcWxcbiAgICBGUk9NIHN1YlxuKSxcbnZhcmlhbnRzIEFTXG4oXG4gICAgU0VMRUNUXG4gICAgICAgIGRhdGFiYXNlLFxuICAgICAgICB0YWJsZV9uYW1lLFxuICAgICAgICBjaXR5SGFzaDY0KG5vcm1fc3FsKSBBUyBzY2hlbWFfaGFzaCxcbiAgICAgICAgYW55KG5vcm1fc3FsKSAgICAgICAgQVMgc2FtcGxlX2NyZWF0ZSxcbiAgICAgICAgZ3JvdXBBcnJheShob3N0KSAgICAgQVMgaG9zdHMsXG4gICAgICAgIGNvdW50KCkgICAgICAgICAgICAgIEFTIHJlcGxpY2FzXG4gICAgRlJPTSBub3JtZWRcbiAgICBHUk9VUCBCWSBkYXRhYmFzZSwgdGFibGVfbmFtZSwgc2NoZW1hX2hhc2hcbiksXG5kcmlmdGVkIEFTXG4oXG4gICAgU0VMRUNUIGRhdGFiYXNlLCB0YWJsZV9uYW1lXG4gICAgRlJPTSB2YXJpYW50c1xuICAgIEdST1VQIEJZIGRhdGFiYXNlLCB0YWJsZV9uYW1lXG4gICAgSEFWSU5HIGNvdW50KCkgPiAxXG4pXG5TRUxFQ1RcbiAgICB2LmRhdGFiYXNlLFxuICAgIHYudGFibGVfbmFtZSxcbiAgICB2LnJlcGxpY2FzLFxuICAgIHYuaG9zdHMsXG4gICAgdi5zY2hlbWFfaGFzaCxcbiAgICB2LnNhbXBsZV9jcmVhdGVcbkZST00gdmFyaWFudHMgdlxuSU5ORVIgSk9JTiBkcmlmdGVkIGQgVVNJTkcgKGRhdGFiYXNlLCB0YWJsZV9uYW1lKVxuT1JERVIgQlkgdi5kYXRhYmFzZSwgdi50YWJsZV9uYW1lLCB2LnJlcGxpY2FzIERFU0M7IiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6NDJ9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) 

## How did you test this code?

This MV already has tests, the problem was that the migration was incorrectly rolled out

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
