### PR TITLE
fix: mongodb directConnection support

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -126,6 +126,9 @@ def mongo_client(connection_string: str, connection_params: dict[str, Any]) -> I
             }
         )
 
+    if connection_params["direct_connection"]:
+        connection_kwargs["directConnection"] = True
+
     if connection_params["tls"]:
         connection_kwargs["tls"] = True
         connection_kwargs["tlsCAFile"] = certifi.where()
@@ -190,6 +193,7 @@ def _parse_connection_string(connection_string: str) -> dict[str, Any]:
 
     # Extract common parameters
     auth_source = query_params.get("authSource", ["admin"])[0]
+    direct_connection = query_params.get("directConnection", ["false"])[0].lower() in ["true", "1"]
     tls = query_params.get("tls", ["false"])[0].lower() in ["true", "1"]
     ssl = query_params.get("ssl", ["false"])[0].lower() in ["true", "1"]
 
@@ -203,6 +207,7 @@ def _parse_connection_string(connection_string: str) -> dict[str, Any]:
         "user": user,
         "password": password,
         "auth_source": auth_source,
+        "direct_connection": direct_connection,
         "tls": use_tls,
         "connection_string": connection_string,
         "is_srv": parsed.scheme == "mongodb+srv",


### PR DESCRIPTION
## Problem

Since directConnection=False by default 
[PyMongo docs](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#pymongo4-migration-direct-connection)

I couldn't connect to a MongoDB instance that is part of a replica set. I discovered this by inspecting the web container logs, where I noticed host ip address being resolved to mongo-1 (mongo container name), and the client attempting to discover all other members of the replica set. 

`mongo-1:27017: [Errno 111] Connection refused (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms),mongo-3:27019: [Errno 111] Connection refused (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms),mongo-2:27018: [Errno 111] Connection refused (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms)`

## Changes

Added directConnect parsing like tls, authSource etc.

## How did you test this code?

Data pipelines => New Source => MongoDB

[Replica] `mongodb://...@<replica-db-ip>:27017/example?authSource=example&directConnection=true` ✅

[Standalone] `mongodb://...@<standalone-db-ip>:27017/example?authSource=example` ✅