### PR TITLE
fix(experiments): Fix running time calculator logic

### DIFF
--- a/frontend/src/scenes/experiments/RunningTimeCalculator/FunnelMetricDataPanel.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/FunnelMetricDataPanel.tsx
@@ -16,12 +16,12 @@ export const FunnelMetricDataPanel = ({
 }: {
     onChangeType: (type: ConversionRateInputType) => void
 }): JSX.Element => {
-    const { experimentId } = useValues(experimentLogic)
+    const { experiment } = useValues(experimentLogic)
     const { conversionRateInputType, uniqueUsers, automaticConversionRateDecimal, manualConversionRate } = useValues(
-        runningTimeCalculatorLogic({ experimentId })
+        runningTimeCalculatorLogic({ experiment })
     )
     const { setConversionRateInputType, setManualConversionRate } = useActions(
-        runningTimeCalculatorLogic({ experimentId })
+        runningTimeCalculatorLogic({ experiment })
     )
 
     return (

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/MeanMetricDataPanel.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/MeanMetricDataPanel.tsx
@@ -10,9 +10,9 @@ import {
 import { runningTimeCalculatorLogic } from './runningTimeCalculatorLogic'
 
 export const MeanMetricDataPanel = (): JSX.Element => {
-    const { experimentId } = useValues(experimentLogic)
+    const { experiment } = useValues(experimentLogic)
     const { uniqueUsers, averageEventsPerUser, averagePropertyValuePerUser, standardDeviation } = useValues(
-        runningTimeCalculatorLogic({ experimentId })
+        runningTimeCalculatorLogic({ experiment })
     )
 
     return (

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/MetricSelectorStep.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/MetricSelectorStep.tsx
@@ -30,12 +30,10 @@ export const MetricSelectorStep = ({
     onChangeMetric: (metric: ExperimentMetric) => void
     onChangeFunnelConversionRateType: (type: ConversionRateInputType) => void
 }): JSX.Element => {
-    const { experimentId } = useValues(experimentLogic)
+    const { experiment } = useValues(experimentLogic)
 
-    const { experiment, metric, metricUuid, metricResultLoading } = useValues(
-        runningTimeCalculatorLogic({ experimentId })
-    )
-    const { setMetricUuid } = useActions(runningTimeCalculatorLogic({ experimentId }))
+    const { metric, metricUuid, metricResultLoading } = useValues(runningTimeCalculatorLogic({ experiment }))
+    const { setMetricUuid } = useActions(runningTimeCalculatorLogic({ experiment }))
 
     // Create combined array of metrics and saved metrics
     const metricOptions: MetricOption[] = [

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
@@ -18,11 +18,9 @@ export function RunningTimeCalculatorModal(): JSX.Element {
      * Modal open/close is controlled from parent component.
      * This is a candidate for props (onClose, onSave)
      */
-    const { experimentId } = useValues(experimentLogic)
+    const { experiment } = useValues(experimentLogic)
     const { isCalculateRunningTimeModalOpen } = useValues(modalsLogic)
     const {
-        // Experiment Object
-        experiment,
         // Running Time Calculator Object. Saved inside the experiment parameters.
         minimumDetectableEffect,
         recommendedSampleSize,
@@ -32,11 +30,11 @@ export function RunningTimeCalculatorModal(): JSX.Element {
         metricResultLoading,
         // Queried value depending on the exposureEstimateConfig
         uniqueUsers,
-    } = useValues(runningTimeCalculatorLogic({ experimentId }))
+    } = useValues(runningTimeCalculatorLogic({ experiment }))
 
     const { updateExperiment } = useActions(experimentLogic)
     const { setMinimumDetectableEffect, setExposureEstimateConfig } = useActions(
-        runningTimeCalculatorLogic({ experimentId })
+        runningTimeCalculatorLogic({ experiment })
     )
     const { closeCalculateRunningTimeModal } = useActions(modalsLogic)
 

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.test.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.test.ts
@@ -4,7 +4,7 @@ import { uuid } from 'lib/utils'
 
 import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { ExperimentMetricMathType, FeatureFlagBasicType } from '~/types'
+import { Experiment, ExperimentMetricMathType, FeatureFlagBasicType } from '~/types'
 
 import { ConversionRateInputType, runningTimeCalculatorLogic } from './runningTimeCalculatorLogic'
 
@@ -48,9 +48,9 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                }
+                } as Partial<Experiment> as Experiment
 
-                logic = runningTimeCalculatorLogic({ experiment })
+                logic = runningTimeCalculatorLogic.build({ experiment })
                 logic.mount()
                 logic.actions.setMetricIndex(0)
             })
@@ -104,9 +104,9 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                }
+                } as Partial<Experiment> as Experiment
 
-                logic = runningTimeCalculatorLogic({ experiment })
+                logic = runningTimeCalculatorLogic.build({ experiment })
                 logic.mount()
                 logic.actions.setMetricIndex(0)
             })
@@ -163,9 +163,9 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                }
+                } as Partial<Experiment> as Experiment
 
-                logic = runningTimeCalculatorLogic({ experiment })
+                logic = runningTimeCalculatorLogic.build({ experiment })
                 logic.mount()
                 logic.actions.setMetricIndex(0)
             })
@@ -220,9 +220,9 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                }
+                } as Partial<Experiment> as Experiment
 
-                logic = runningTimeCalculatorLogic({ experiment })
+                logic = runningTimeCalculatorLogic.build({ experiment })
                 logic.mount()
                 logic.actions.setMetricIndex(0)
             })
@@ -283,9 +283,9 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                }
+                } as Partial<Experiment> as Experiment
 
-                logic = runningTimeCalculatorLogic({ experiment })
+                logic = runningTimeCalculatorLogic.build({ experiment })
                 logic.mount()
                 logic.actions.setMetricIndex(0)
             })
@@ -348,9 +348,9 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                }
+                } as Partial<Experiment> as Experiment
 
-                logic = runningTimeCalculatorLogic({ experiment })
+                logic = runningTimeCalculatorLogic.build({ experiment })
                 logic.mount()
                 logic.actions.setMetricIndex(0)
             })

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.test.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.test.ts
@@ -1,7 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
 import { uuid } from 'lib/utils'
-import { experimentLogic } from 'scenes/experiments/experimentLogic'
 
 import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -14,17 +13,13 @@ describe('runningTimeCalculatorLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        experimentLogic.mount()
-
-        logic = runningTimeCalculatorLogic()
-        logic.mount()
     })
 
     // Should match https://docs.google.com/spreadsheets/d/11alyC8n7uqewZFLKfV4UAbW-0zH__EdV_Hrk2OQ4140/edit?gid=777532876#gid=777532876
     describe('calculations for MEAN total count', () => {
         describe('with EventsNode', () => {
             beforeEach(() => {
-                experimentLogic.actions.setExperiment({
+                const experiment = {
                     metrics: [
                         {
                             uuid: uuid(),
@@ -53,8 +48,10 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                })
+                }
 
+                logic = runningTimeCalculatorLogic({ experiment })
+                logic.mount()
                 logic.actions.setMetricIndex(0)
             })
 
@@ -78,7 +75,7 @@ describe('runningTimeCalculatorLogic', () => {
 
         describe('with ActionsNode', () => {
             beforeEach(() => {
-                experimentLogic.actions.setExperiment({
+                const experiment = {
                     metrics: [
                         {
                             uuid: uuid(),
@@ -107,8 +104,10 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                })
+                }
 
+                logic = runningTimeCalculatorLogic({ experiment })
+                logic.mount()
                 logic.actions.setMetricIndex(0)
             })
 
@@ -135,7 +134,7 @@ describe('runningTimeCalculatorLogic', () => {
     describe('calculations for MEAN sum', () => {
         describe('with EventsNode', () => {
             beforeEach(() => {
-                experimentLogic.actions.setExperiment({
+                const experiment = {
                     metrics: [
                         {
                             uuid: uuid(),
@@ -164,8 +163,10 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                })
+                }
 
+                logic = runningTimeCalculatorLogic({ experiment })
+                logic.mount()
                 logic.actions.setMetricIndex(0)
             })
 
@@ -189,7 +190,7 @@ describe('runningTimeCalculatorLogic', () => {
 
         describe('with ActionsNode', () => {
             beforeEach(() => {
-                experimentLogic.actions.setExperiment({
+                const experiment = {
                     metrics: [
                         {
                             uuid: uuid(),
@@ -219,8 +220,10 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                })
+                }
 
+                logic = runningTimeCalculatorLogic({ experiment })
+                logic.mount()
                 logic.actions.setMetricIndex(0)
             })
 
@@ -247,7 +250,7 @@ describe('runningTimeCalculatorLogic', () => {
     describe('calculations for FUNNEL', () => {
         describe('with EventsNode', () => {
             beforeEach(() => {
-                experimentLogic.actions.setExperiment({
+                const experiment = {
                     metrics: [
                         {
                             uuid: uuid(),
@@ -280,8 +283,10 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                })
+                }
 
+                logic = runningTimeCalculatorLogic({ experiment })
+                logic.mount()
                 logic.actions.setMetricIndex(0)
             })
 
@@ -310,7 +315,7 @@ describe('runningTimeCalculatorLogic', () => {
 
         describe('with ActionsNode', () => {
             beforeEach(() => {
-                experimentLogic.actions.setExperiment({
+                const experiment = {
                     metrics: [
                         {
                             uuid: uuid(),
@@ -343,8 +348,10 @@ describe('runningTimeCalculatorLogic', () => {
                             },
                         },
                     } as unknown as FeatureFlagBasicType,
-                })
+                }
 
+                logic = runningTimeCalculatorLogic({ experiment })
+                logic.mount()
                 logic.actions.setMetricIndex(0)
             })
 

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -299,7 +299,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
 
                 // If we don't have a "local" state, use the exposure estimate config saved in the experiment parameters
                 // In case of not having all of the fields, we use the default exposure estimate config
-                if (experiment.parameters.exposure_estimate_config) {
+                if (experiment.parameters?.exposure_estimate_config) {
                     return {
                         ...defaultExposureEstimateConfig,
                         ...experiment.parameters.exposure_estimate_config,


### PR DESCRIPTION
## Changes
Fix running time calculator broken by tab-aware refactor where passing `experimentId` no longer connects to the correct logic instance. Changed to retrieve the experiment object from the mounted `experimentLogic` and passing it as props to the `runningTimeCalculatorLogic`.

## How did you test this code?
Tested that metric selection in the running time calculator now works correctly.