### PR TITLE
fix(ci): upload storybook snapshot patches even when tests fail

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -373,9 +373,10 @@ jobs:
 
             # Create git patch for aggregation (handles A/M/D including binary files)
             # Only run in UPDATE mode - CHECK mode doesn't update snapshots
+            # Run even if tests failed, as long as snapshots may have been updated
             - name: Create snapshot patch
               id: create-patch
-              if: needs.detect-snapshot-mode.outputs.mode == 'update' && success() && github.event.pull_request.head.repo.full_name == github.repository
+              if: needs.detect-snapshot-mode.outputs.mode == 'update' && (success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository
               run: |
                   # Verify we're in a git repository before running git commands
                   if ! git rev-parse --git-dir > /dev/null 2>&1; then


### PR DESCRIPTION
Fixes snapshot patch upload logic in Storybook workflow to match the Playwright workflow behavior.

**Problem**
When Storybook tests failed due to non-snapshot issues (e.g., timeouts) after successfully updating snapshots on attempt 3, the snapshot patches were never uploaded because the job failed before reaching the patch creation step.

Example: PR #39779 updated snapshots for `StacktraceDisplay.stories.tsx` on attempt 3, but then failed due to unrelated timeout issues. The updated snapshots were lost because patches were only created on `success()`.

**Test plan**
Verify that when Storybook tests fail after updating snapshots, the patches are still uploaded and committed.