### PR TITLE
feat(experiments): create retention metric.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -330,6 +330,7 @@ export const FEATURE_FLAGS = {
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
     REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate
     EXPERIMENTS_USE_NEW_CREATE_FORM: 'experiments-use-new-create-form', // owner: @rodrigoi #team-experiments
+    EXPERIMENTS_RETENTION_METRICS: 'experiments-retention-metrics', // owner: @rodrigoi #team-experiments
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13069,6 +13069,9 @@
                 },
                 {
                     "$ref": "#/definitions/ExperimentRatioMetricTypeProps"
+                },
+                {
+                    "$ref": "#/definitions/ExperimentRetentionMetricTypeProps"
                 }
             ]
         },
@@ -13328,6 +13331,44 @@
                 "retention_window_start",
                 "retention_window_unit",
                 "start_event",
+                "start_handling"
+            ],
+            "type": "object"
+        },
+        "ExperimentRetentionMetricTypeProps": {
+            "additionalProperties": false,
+            "properties": {
+                "completion_event": {
+                    "$ref": "#/definitions/ExperimentMetricSource"
+                },
+                "metric_type": {
+                    "const": "retention",
+                    "type": "string"
+                },
+                "retention_window_end": {
+                    "$ref": "#/definitions/integer"
+                },
+                "retention_window_start": {
+                    "$ref": "#/definitions/integer"
+                },
+                "retention_window_unit": {
+                    "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
+                },
+                "start_event": {
+                    "$ref": "#/definitions/ExperimentMetricSource"
+                },
+                "start_handling": {
+                    "enum": ["first_seen", "last_seen"],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "metric_type",
+                "start_event",
+                "completion_event",
+                "retention_window_start",
+                "retention_window_end",
+                "retention_window_unit",
                 "start_handling"
             ],
             "type": "object"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12904,6 +12904,9 @@
                 },
                 {
                     "$ref": "#/definitions/ExperimentRatioMetric"
+                },
+                {
+                    "$ref": "#/definitions/ExperimentRetentionMetric"
                 }
             ]
         },
@@ -13053,7 +13056,7 @@
             "type": "object"
         },
         "ExperimentMetricType": {
-            "enum": ["funnel", "mean", "ratio"],
+            "enum": ["funnel", "mean", "ratio", "retention"],
             "type": "string"
         },
         "ExperimentMetricTypeProps": {
@@ -13253,6 +13256,85 @@
                 }
             },
             "required": ["metric_type", "numerator", "denominator"],
+            "type": "object"
+        },
+        "ExperimentRetentionMetric": {
+            "additionalProperties": false,
+            "properties": {
+                "completion_event": {
+                    "$ref": "#/definitions/ExperimentMetricSource"
+                },
+                "conversion_window": {
+                    "$ref": "#/definitions/integer"
+                },
+                "conversion_window_unit": {
+                    "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
+                },
+                "fingerprint": {
+                    "type": "string"
+                },
+                "goal": {
+                    "$ref": "#/definitions/ExperimentMetricGoal"
+                },
+                "incomplete_retention_handling": {
+                    "enum": ["exclude", "include"],
+                    "type": "string"
+                },
+                "isSharedMetric": {
+                    "type": "boolean"
+                },
+                "kind": {
+                    "const": "ExperimentMetric",
+                    "type": "string"
+                },
+                "metric_type": {
+                    "const": "retention",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "response": {
+                    "type": "object"
+                },
+                "retention_window_end": {
+                    "$ref": "#/definitions/integer"
+                },
+                "retention_window_start": {
+                    "$ref": "#/definitions/integer"
+                },
+                "retention_window_unit": {
+                    "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
+                },
+                "sharedMetricId": {
+                    "type": "number"
+                },
+                "start_event": {
+                    "$ref": "#/definitions/ExperimentMetricSource"
+                },
+                "start_handling": {
+                    "enum": ["first_seen", "last_seen"],
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "completion_event",
+                "incomplete_retention_handling",
+                "kind",
+                "metric_type",
+                "retention_window_end",
+                "retention_window_start",
+                "retention_window_unit",
+                "start_event",
+                "start_handling"
+            ],
             "type": "object"
         },
         "ExperimentSignificanceCode": {
@@ -29446,6 +29528,22 @@
         },
         "isExperimentRatioMetric": {
             "$comment": "(metric: ExperimentMetric) => metric is ExperimentRatioMetric",
+            "properties": {
+                "namedArgs": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "metric": {
+                            "$ref": "#/definitions/ExperimentMetric"
+                        }
+                    },
+                    "required": ["metric"],
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "isExperimentRetentionMetric": {
+            "$comment": "(metric: ExperimentMetric) => metric is ExperimentRetentionMetric",
             "properties": {
                 "namedArgs": {
                     "additionalProperties": false,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13276,10 +13276,6 @@
                 "goal": {
                     "$ref": "#/definitions/ExperimentMetricGoal"
                 },
-                "incomplete_retention_handling": {
-                    "enum": ["exclude", "include"],
-                    "type": "string"
-                },
                 "isSharedMetric": {
                     "type": "boolean"
                 },
@@ -13326,7 +13322,6 @@
             },
             "required": [
                 "completion_event",
-                "incomplete_retention_handling",
                 "kind",
                 "metric_type",
                 "retention_window_end",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2879,8 +2879,6 @@ export type ExperimentRetentionMetric = ExperimentMetricBaseProperties & {
 
     // How to handle the start of the retention window
     start_handling: 'first_seen' | 'last_seen'
-    // How to handle incomplete retention windows
-    incomplete_retention_handling: 'exclude' | 'include'
 }
 
 export const isExperimentRetentionMetric = (metric: ExperimentMetric): metric is ExperimentRetentionMetric =>

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2887,10 +2887,13 @@ export const isExperimentRetentionMetric = (metric: ExperimentMetric): metric is
 export type ExperimentMeanMetricTypeProps = Omit<ExperimentMeanMetric, keyof ExperimentMetricBaseProperties>
 export type ExperimentFunnelMetricTypeProps = Omit<ExperimentFunnelMetric, keyof ExperimentMetricBaseProperties>
 export type ExperimentRatioMetricTypeProps = Omit<ExperimentRatioMetric, keyof ExperimentMetricBaseProperties>
+export type ExperimentRetentionMetricTypeProps = Omit<ExperimentRetentionMetric, keyof ExperimentMetricBaseProperties>
+
 export type ExperimentMetricTypeProps =
     | ExperimentMeanMetricTypeProps
     | ExperimentFunnelMetricTypeProps
     | ExperimentRatioMetricTypeProps
+    | ExperimentRetentionMetricTypeProps
 
 export type ExperimentMetric =
     | ExperimentMeanMetric

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2804,6 +2804,7 @@ export const enum ExperimentMetricType {
     FUNNEL = 'funnel',
     MEAN = 'mean',
     RATIO = 'ratio',
+    RETENTION = 'retention',
 }
 
 export interface ExperimentMetricBaseProperties extends Node {
@@ -2863,6 +2864,28 @@ export type ExperimentRatioMetric = ExperimentMetricBaseProperties & {
 export const isExperimentRatioMetric = (metric: ExperimentMetric): metric is ExperimentRatioMetric =>
     metric.metric_type === ExperimentMetricType.RATIO
 
+export type ExperimentRetentionMetric = ExperimentMetricBaseProperties & {
+    metric_type: ExperimentMetricType.RETENTION
+    // Event that defines the start of the retention window
+    start_event: ExperimentMetricSource
+    // Event that defines the completion of the retention window
+    completion_event: ExperimentMetricSource
+
+    // Start of the retention window
+    retention_window_start: integer
+    // End of the retention window
+    retention_window_end: integer
+    retention_window_unit: FunnelConversionWindowTimeUnit
+
+    // How to handle the start of the retention window
+    start_handling: 'first_seen' | 'last_seen'
+    // How to handle incomplete retention windows
+    incomplete_retention_handling: 'exclude' | 'include'
+}
+
+export const isExperimentRetentionMetric = (metric: ExperimentMetric): metric is ExperimentRetentionMetric =>
+    metric.metric_type === ExperimentMetricType.RETENTION
+
 export type ExperimentMeanMetricTypeProps = Omit<ExperimentMeanMetric, keyof ExperimentMetricBaseProperties>
 export type ExperimentFunnelMetricTypeProps = Omit<ExperimentFunnelMetric, keyof ExperimentMetricBaseProperties>
 export type ExperimentRatioMetricTypeProps = Omit<ExperimentRatioMetric, keyof ExperimentMetricBaseProperties>
@@ -2871,7 +2894,11 @@ export type ExperimentMetricTypeProps =
     | ExperimentFunnelMetricTypeProps
     | ExperimentRatioMetricTypeProps
 
-export type ExperimentMetric = ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric
+export type ExperimentMetric =
+    | ExperimentMeanMetric
+    | ExperimentFunnelMetric
+    | ExperimentRatioMetric
+    | ExperimentRetentionMetric
 
 export interface ExperimentQuery extends DataNode<ExperimentQueryResponse> {
     kind: NodeKind.ExperimentQuery

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -4,6 +4,7 @@ import { IconInfo, IconPencil } from '@posthog/icons'
 import { LemonBanner, LemonInput } from '@posthog/lemon-ui'
 
 import { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
@@ -130,6 +131,8 @@ export function ExperimentMetricForm({
     const [eventCount, setEventCount] = useState<number | null>(null)
     const [isLoading, setIsLoading] = useState(false)
 
+    const isRetentionMetricEnabled = useFeatureFlag('EXPERIMENTS_RETENTION_METRICS')
+
     const getEventTypeLabel = (): string => {
         if (isExperimentMeanMetric(metric)) {
             return metric.source.kind === NodeKind.ActionsNode ? 'actions' : 'events'
@@ -221,12 +224,16 @@ export function ExperimentMetricForm({
             description:
                 'Calculates the ratio between two metrics. Useful when you want to use a different denominator than users exposed to the experiment.',
         },
-        {
-            value: ExperimentMetricType.RETENTION,
-            label: 'Retention',
-            description:
-                'Calculates the retention rate of users exposed to the experiment. Useful for measuring the percentage of users who return to the app after a certain period of time.',
-        },
+        ...(isRetentionMetricEnabled
+            ? [
+                  {
+                      value: ExperimentMetricType.RETENTION,
+                      label: 'Retention',
+                      description:
+                          'Calculates the retention rate of users exposed to the experiment. Useful for measuring the percentage of users who return to the app after a certain period of time.',
+                  },
+              ]
+            : []),
     ]
 
     const metricFilter = getFilter(metric)
@@ -425,7 +432,7 @@ export function ExperimentMetricForm({
                     </div>
                 )}
 
-                {isExperimentRetentionMetric(metric) && (
+                {isRetentionMetricEnabled && isExperimentRetentionMetric(metric) && (
                     <div className="space-y-4">
                         <div>
                             <LemonLabel className="mb-1">

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -487,8 +487,8 @@ export function ExperimentMetricForm({
                                         handleSetMetric({ ...metric, completion_event: source })
                                     }
                                 }}
-                                typeKey="experiment-metric-start-event"
-                                buttonCopy="Add start event"
+                                typeKey="experiment-metric-completion-event"
+                                buttonCopy="Add completion event"
                                 showSeriesIndicator={false}
                                 hideRename={true}
                                 entitiesLimit={1}

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -53,6 +53,10 @@ export const getDefaultMetricTitle = (metric: ExperimentMetric): string => {
             const numeratorName = getDefaultName(metric.numerator)
             const denominatorName = getDefaultName(metric.denominator)
             return `${numeratorName || 'Numerator'} / ${denominatorName || 'Denominator'}`
+        case ExperimentMetricType.RETENTION:
+            const startEventName = getDefaultName(metric.start_event)
+            const completionEventName = getDefaultName(metric.completion_event)
+            return `${startEventName || 'Start event'} / ${completionEventName || 'Completion event'}`
         default:
             return 'Untitled metric'
     }

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -459,12 +459,40 @@ export function getDefaultRatioMetric(): ExperimentMetric {
     }
 }
 
+export function getDefaultRetentionMetric(): ExperimentMetric {
+    return {
+        kind: NodeKind.ExperimentMetric,
+        uuid: uuid(),
+        metric_type: ExperimentMetricType.RETENTION,
+        goal: ExperimentMetricGoal.Increase,
+        start_event: {
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+            name: '$pageview',
+            math: ExperimentMetricMathType.TotalCount,
+        },
+        completion_event: {
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+            name: '$pageview',
+            math: ExperimentMetricMathType.TotalCount,
+        },
+        retention_window_start: 1,
+        retention_window_end: 1,
+        retention_window_unit: FunnelConversionWindowTimeUnit.Day,
+        start_handling: 'first_seen',
+        incomplete_retention_handling: 'exclude',
+    }
+}
+
 export function getDefaultExperimentMetric(metricType: ExperimentMetricType): ExperimentMetric {
     switch (metricType) {
         case ExperimentMetricType.FUNNEL:
             return getDefaultFunnelMetric()
         case ExperimentMetricType.RATIO:
             return getDefaultRatioMetric()
+        case ExperimentMetricType.RETENTION:
+            return getDefaultRetentionMetric()
         default:
             return getDefaultCountMetric()
     }

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -481,7 +481,6 @@ export function getDefaultRetentionMetric(): ExperimentMetric {
         retention_window_end: 1,
         retention_window_unit: FunnelConversionWindowTimeUnit.Day,
         start_handling: 'first_seen',
-        incomplete_retention_handling: 'exclude',
     }
 }
 

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -15,6 +15,7 @@ from posthog.schema import (
     ExperimentMeanMetric,
     ExperimentMetricMathType,
     ExperimentRatioMetric,
+    ExperimentRetentionMetric,
     FunnelConversionWindowTimeUnit,
     FunnelMathType,
     MultipleVariantHandling,
@@ -289,7 +290,7 @@ def get_metric_time_window(
 
 
 def get_exposure_time_window_constraints(
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric],
     timestamp_field: ast.Field,
     exposure_time_field: ast.Field,
 ) -> list[ast.CompareOperation]:
@@ -355,7 +356,7 @@ def get_experiment_exposure_query(
     date_range_query: QueryDateRange,
     team: Team,
     entity_key: str,
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric],
     multiple_variant_handling: MultipleVariantHandling,
 ) -> ast.SelectQuery:
     """
@@ -508,7 +509,7 @@ def get_source_events_query(
 
 
 def get_metric_events_query(
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric],
     team: Team,
     entity_key: str,
     experiment: Experiment,
@@ -634,7 +635,7 @@ def get_source_aggregation_expr(
 
 def get_metric_aggregation_expr(
     experiment: Experiment,
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric],
     team: Team,
     source_type: Literal["numerator", "denominator"] | None = None,
 ) -> ast.Expr:

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -40,7 +40,7 @@ from posthog.models.team.team import Team
 
 
 def get_data_warehouse_metric_source(
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric],
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric],
 ) -> ExperimentDataWarehouseNode | None:
     if isinstance(metric, ExperimentMeanMetric) and isinstance(metric.source, ExperimentDataWarehouseNode):
         return metric.source
@@ -525,6 +525,9 @@ def get_metric_events_query(
     if isinstance(metric, ExperimentFunnelMetric):
         assert source_type is None
         return _get_metric_events_for_funnel_metric(metric, team, entity_key, experiment, date_range_query)
+
+    if isinstance(metric, ExperimentRetentionMetric):
+        raise NotImplementedError("Retention metrics are not yet supported in get_metric_events_query")
 
     # For ratio metrics, determine which source to use and delegate to source-based function
     if isinstance(metric, ExperimentRatioMetric):

--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -5,6 +5,7 @@ from posthog.schema import (
     ExperimentMeanMetric,
     ExperimentQueryResponse,
     ExperimentRatioMetric,
+    ExperimentRetentionMetric,
     ExperimentStatsBase,
     ExperimentStatsBaseValidated,
     ExperimentStatsValidationFailure,
@@ -89,7 +90,7 @@ def get_new_variant_results(sorted_results: list[tuple]) -> list[ExperimentStats
 
 def validate_variant_result(
     variant_result: ExperimentStatsBase,
-    metric: ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRatioMetric,
+    metric: ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRatioMetric | ExperimentRetentionMetric,
     is_baseline=False,
 ) -> ExperimentStatsBaseValidated:
     validation_failures = []
@@ -127,7 +128,8 @@ def validate_variant_result(
 
 
 def metric_variant_to_statistic(
-    metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric, variant: ExperimentStatsBaseValidated
+    metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric,
+    variant: ExperimentStatsBaseValidated,
 ) -> SampleMeanStatistic | ProportionStatistic | RatioStatistic:
     if isinstance(metric, ExperimentMeanMetric):
         return SampleMeanStatistic(
@@ -163,7 +165,7 @@ def metric_variant_to_statistic(
 
 
 def get_frequentist_experiment_result(
-    metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric,
+    metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric,
     control_variant: ExperimentStatsBase,
     test_variants: list[ExperimentStatsBase],
 ) -> ExperimentQueryResponse:
@@ -222,7 +224,7 @@ def get_frequentist_experiment_result(
 
 
 def get_bayesian_experiment_result(
-    metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric,
+    metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric,
     control_variant: ExperimentStatsBase,
     test_variants: list[ExperimentStatsBase],
 ) -> ExperimentQueryResponse:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1356,6 +1356,17 @@ class ExperimentMetricType(StrEnum):
     FUNNEL = "funnel"
     MEAN = "mean"
     RATIO = "ratio"
+    RETENTION = "retention"
+
+
+class IncompleteRetentionHandling(StrEnum):
+    EXCLUDE = "exclude"
+    INCLUDE = "include"
+
+
+class StartHandling(StrEnum):
+    FIRST_SEEN = "first_seen"
+    LAST_SEEN = "last_seen"
 
 
 class ExperimentSignificanceCode(StrEnum):
@@ -12772,6 +12783,31 @@ class ExperimentRatioMetricTypeProps(BaseModel):
     numerator: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
 
 
+class ExperimentRetentionMetric(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    completion_event: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
+    conversion_window: Optional[int] = None
+    conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
+    fingerprint: Optional[str] = None
+    goal: Optional[ExperimentMetricGoal] = None
+    incomplete_retention_handling: IncompleteRetentionHandling
+    isSharedMetric: Optional[bool] = None
+    kind: Literal["ExperimentMetric"] = "ExperimentMetric"
+    metric_type: Literal["retention"] = "retention"
+    name: Optional[str] = None
+    response: Optional[dict[str, Any]] = None
+    retention_window_end: int
+    retention_window_start: int
+    retention_window_unit: FunnelConversionWindowTimeUnit
+    sharedMetricId: Optional[float] = None
+    start_event: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
+    start_handling: StartHandling
+    uuid: Optional[str] = None
+    version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
+
+
 class FunnelsFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -13742,8 +13778,10 @@ class ExperimentMeanMetricTypeProps(BaseModel):
     upper_bound_percentile: Optional[float] = None
 
 
-class ExperimentMetric(RootModel[Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]]):
-    root: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
+class ExperimentMetric(
+    RootModel[Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]]
+):
+    root: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
 
 
 class ExperimentMetricTypeProps(
@@ -13760,7 +13798,9 @@ class ExperimentQueryResponse(BaseModel):
     credible_intervals: Optional[dict[str, list[float]]] = None
     insight: Optional[list[dict[str, Any]]] = None
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    metric: Optional[Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]] = None
+    metric: Optional[
+        Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
+    ] = None
     p_value: Optional[float] = None
     probability: Optional[dict[str, float]] = None
     significance_code: Optional[ExperimentSignificanceCode] = None
@@ -14135,7 +14175,7 @@ class LegacyExperimentQueryResponse(BaseModel):
     credible_intervals: dict[str, list[float]]
     insight: list[dict[str, Any]]
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
     p_value: float
     probability: dict[str, float]
     significance_code: ExperimentSignificanceCode
@@ -14263,7 +14303,9 @@ class QueryResponseAlternative19(BaseModel):
     credible_intervals: Optional[dict[str, list[float]]] = None
     insight: Optional[list[dict[str, Any]]] = None
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    metric: Optional[Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]] = None
+    metric: Optional[
+        Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
+    ] = None
     p_value: Optional[float] = None
     probability: Optional[dict[str, float]] = None
     significance_code: Optional[ExperimentSignificanceCode] = None
@@ -14380,7 +14422,7 @@ class NamedArgs(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
 
 
 class IsExperimentFunnelMetric(BaseModel):
@@ -14392,6 +14434,10 @@ class IsExperimentMeanMetric(BaseModel):
 
 
 class IsExperimentRatioMetric(BaseModel):
+    namedArgs: Optional[NamedArgs] = None
+
+
+class IsExperimentRetentionMetric(BaseModel):
     namedArgs: Optional[NamedArgs] = None
 
 
@@ -14439,7 +14485,9 @@ class CachedExperimentQueryResponse(BaseModel):
     is_cached: bool
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
     last_refresh: datetime
-    metric: Optional[Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]] = None
+    metric: Optional[
+        Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
+    ] = None
     next_allowed_client_refresh: datetime
     p_value: Optional[float] = None
     probability: Optional[dict[str, float]] = None
@@ -14471,7 +14519,7 @@ class CachedLegacyExperimentQueryResponse(BaseModel):
     is_cached: bool
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
     last_refresh: datetime
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
     next_allowed_client_refresh: datetime
     p_value: float
     probability: dict[str, float]
@@ -14540,7 +14588,7 @@ class ExperimentQuery(BaseModel):
     )
     experiment_id: Optional[int] = None
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
+    metric: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric, ExperimentRetentionMetric]
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1359,11 +1359,6 @@ class ExperimentMetricType(StrEnum):
     RETENTION = "retention"
 
 
-class IncompleteRetentionHandling(StrEnum):
-    EXCLUDE = "exclude"
-    INCLUDE = "include"
-
-
 class StartHandling(StrEnum):
     FIRST_SEEN = "first_seen"
     LAST_SEEN = "last_seen"
@@ -12792,7 +12787,6 @@ class ExperimentRetentionMetric(BaseModel):
     conversion_window_unit: Optional[FunnelConversionWindowTimeUnit] = None
     fingerprint: Optional[str] = None
     goal: Optional[ExperimentMetricGoal] = None
-    incomplete_retention_handling: IncompleteRetentionHandling
     isSharedMetric: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["retention"] = "retention"

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -12802,6 +12802,19 @@ class ExperimentRetentionMetric(BaseModel):
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class ExperimentRetentionMetricTypeProps(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    completion_event: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
+    metric_type: Literal["retention"] = "retention"
+    retention_window_end: int
+    retention_window_start: int
+    retention_window_unit: FunnelConversionWindowTimeUnit
+    start_event: Union[EventsNode, ActionsNode, ExperimentDataWarehouseNode]
+    start_handling: StartHandling
+
+
 class FunnelsFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -13779,9 +13792,21 @@ class ExperimentMetric(
 
 
 class ExperimentMetricTypeProps(
-    RootModel[Union[ExperimentMeanMetricTypeProps, ExperimentFunnelMetricTypeProps, ExperimentRatioMetricTypeProps]]
+    RootModel[
+        Union[
+            ExperimentMeanMetricTypeProps,
+            ExperimentFunnelMetricTypeProps,
+            ExperimentRatioMetricTypeProps,
+            ExperimentRetentionMetricTypeProps,
+        ]
+    ]
 ):
-    root: Union[ExperimentMeanMetricTypeProps, ExperimentFunnelMetricTypeProps, ExperimentRatioMetricTypeProps]
+    root: Union[
+        ExperimentMeanMetricTypeProps,
+        ExperimentFunnelMetricTypeProps,
+        ExperimentRatioMetricTypeProps,
+        ExperimentRetentionMetricTypeProps,
+    ]
 
 
 class ExperimentQueryResponse(BaseModel):


### PR DESCRIPTION
## Problem

> [!IMPORTANT]
> this is hidden behind the `experiments-retention-metrics` feature flag.

We currently don't offer a retention metric, which is derived from the ratio metric itself.

### What is a _rentention metric_

> A _retention metric_ measures the percentage of users who perform a "completion event" within a specified time window after performing a "start event." It answers the question: "Of the users who did X, how many came back to do Y within N days?"
> - Found on the Internet somewhere

### Metric Properties

- **Start Event**: The initial action that triggers retention tracking (e.g., "signed up", "made first purchase", "completed onboarding")
- **Completion Event**: The action that indicates the user "returned" or was "retained" (e.g., "logged in", "created content", "made purchase")
- **Retention Window**: The time period after the start event during which we check for the completion event
	- **Window Start**: How many days after start event to begin looking (e.g., day 7)
	- **Window End**: How many days after start event to stop looking (e.g., day 14)

### Modifiers

- **Handle Start Events**:  Users can configure how to handle entities with multiple start events.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've added the necessary types to support retention metrics as described in the problem statement. The `ExperimentMetricForm` correctly saves the _ratio metric_ informato as part of the experiment, and the `MetricView` shows a default title if the metric name is not provided.

| Retention metric on the metric dialog |
| - |
| <img width="1644" height="1234" alt="image" src="https://github.com/user-attachments/assets/e2bdd4f2-2e18-4be3-a5cc-f6b0bd6cc01d" /> |

| Metric view with retention metric |
| - |
| <img width="1048" height="78" alt="image" src="https://github.com/user-attachments/assets/8561204c-f44c-49b4-8742-0846ba53422e" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/9cbeb957-aa1d-438e-9cd0-054054a75712)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
