### PR TITLE
feat: use deferred posthogjs loading

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -15,6 +15,7 @@ export function loadPostHogJS(): void {
             opt_in_site_apps: true,
             api_transport: 'fetch',
             disable_surveys: window.IMPERSONATED_SESSION,
+            __preview_deferred_init_extensions: true,
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,7 +1,13 @@
 import posthog from 'posthog-js'
+import { sampleOnProperty } from 'posthog-js/lib/src/extensions/sampling'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils'
+
+const shouldDefer = (): boolean => {
+    const sessionId = posthog.get_session_id()
+    return sampleOnProperty(sessionId, 0.5)
+}
 
 export function loadPostHogJS(): void {
     if (window.JS_POSTHOG_API_KEY) {
@@ -15,7 +21,7 @@ export function loadPostHogJS(): void {
             opt_in_site_apps: true,
             api_transport: 'fetch',
             disable_surveys: window.IMPERSONATED_SESSION,
-            __preview_deferred_init_extensions: true,
+            __preview_deferred_init_extensions: shouldDefer(),
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1178,6 +1178,12 @@
             "type": "String",
             "used_for_debug": true
         },
+        "$sdk_debug_replay_flushed_size": {
+            "description": "Estimated size in bytes of flushed recording data so far in this session. Added to events as a debug property.",
+            "label": "Estimated bytes flushed",
+            "type": "Numeric",
+            "used_for_debug": true
+        },
         "$sdk_debug_replay_internal_buffer_length": {
             "description": "Useful for debugging. The internal buffer length for replay.",
             "examples": ["100"],
@@ -1733,6 +1739,18 @@
         "sccid": {
             "description": "Snapchat Click ID",
             "label": "sccid"
+        },
+        "sdk_debug_extensions_init_method": {
+            "description": "The method used to initialize PostHog.js extensions.",
+            "examples": ["deferred", "synchronous"],
+            "label": "PostHog.js extensions init method",
+            "used_for_debug": true
+        },
+        "sdk_debug_extensions_init_time_ms": {
+            "description": "The time taken to initialize PostHog.js extensions in milliseconds.",
+            "examples": ["150"],
+            "label": "PostHog.js extensions init time (ms)",
+            "used_for_debug": true
         },
         "token": {
             "description": "Token used for authentication.",
@@ -3417,6 +3435,12 @@
             "type": "String",
             "used_for_debug": true
         },
+        "$sdk_debug_replay_flushed_size": {
+            "description": "Estimated size in bytes of flushed recording data so far in this session. Added to events as a debug property.",
+            "label": "Estimated bytes flushed",
+            "type": "Numeric",
+            "used_for_debug": true
+        },
         "$sdk_debug_replay_internal_buffer_length": {
             "description": "Useful for debugging. The internal buffer length for replay.",
             "examples": ["100"],
@@ -4004,6 +4028,18 @@
         "sccid": {
             "description": "Snapchat Click ID Data from the last time this user was seen.",
             "label": "Latest sccid"
+        },
+        "sdk_debug_extensions_init_method": {
+            "description": "The method used to initialize PostHog.js extensions.",
+            "examples": ["deferred", "synchronous"],
+            "label": "PostHog.js extensions init method",
+            "used_for_debug": true
+        },
+        "sdk_debug_extensions_init_time_ms": {
+            "description": "The time taken to initialize PostHog.js extensions in milliseconds.",
+            "examples": ["150"],
+            "label": "PostHog.js extensions init time (ms)",
+            "used_for_debug": true
         },
         "token": {
             "description": "Token used for authentication.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -382,6 +382,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "type": "Numeric",
             "used_for_debug": True,
         },
+        "$sdk_debug_replay_flushed_size": {
+            "label": "Estimated bytes flushed",
+            "description": "Estimated size in bytes of flushed recording data so far in this session. Added to events as a debug property.",
+            "type": "Numeric",
+            "used_for_debug": True,
+        },
         "$session_recording_remote_config": {
             "label": "Session recording remote config received",
             "description": "The remote config for session recording received from the server (or loaded from storage).",
@@ -437,6 +443,18 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "examples": ["100"],
             "system": True,
             "ignored_in_assistant": True,
+            "used_for_debug": True,
+        },
+        "sdk_debug_extensions_init_method": {
+            "label": "PostHog.js extensions init method",
+            "description": "The method used to initialize PostHog.js extensions.",
+            "examples": ["deferred", "synchronous"],
+            "used_for_debug": True,
+        },
+        "sdk_debug_extensions_init_time_ms": {
+            "label": "PostHog.js extensions init time (ms)",
+            "description": "The time taken to initialize PostHog.js extensions in milliseconds.",
+            "examples": ["150"],
             "used_for_debug": True,
         },
         "$sdk_debug_retry_queue_size": {


### PR DESCRIPTION
we can now defer posthog init loading
this should be a little performance boost
we would hopefully see it in INP

we'll also put the init method as a property on each event for the session, and the timing of the init call, so we can't run a true experiment but we'll be able to compare

i can see this running locally

set to turn this on for 50% of sessions

![Screenshot 2025-11-07 at 20.36.39.png](https://app.graphite.com/user-attachments/assets/17a8e4fb-a44b-41ca-b436-f1a14ca51815.png)

