### PR TITLE
chore(flags): Add dual-write support for dedicated Redis cache

### DIFF
--- a/posthog/caching/flags_redis_cache.py
+++ b/posthog/caching/flags_redis_cache.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Any, Optional
+
+from django.conf import settings
+from django.core.cache import cache, caches
+
+from posthog.exceptions_capture import capture_exception
+
+logger = logging.getLogger(__name__)
+
+FLAGS_DEDICATED_CACHE_ALIAS = "flags_dedicated"
+
+
+def write_flags_to_cache(key: str, value: Any, timeout: Optional[int] = None) -> None:
+    """Write feature flags to the appropriate cache(s).
+
+    - FLAGS_REDIS_URL not set: writes to shared cache only
+    - FLAGS_REDIS_URL set: dual-writes to both shared and dedicated
+      (Django reads from shared, Rust service reads from dedicated)
+    """
+    has_dedicated_cache = FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES
+
+    try:
+        # Always write to shared cache. If it fails, let the caller handle the error.
+        cache.set(key, value, timeout)
+
+        if has_dedicated_cache:
+            try:
+                dedicated_cache = caches[FLAGS_DEDICATED_CACHE_ALIAS]
+                dedicated_cache.set(key, value, timeout)
+            except Exception as e:
+                logger.warning(
+                    "Dedicated cache write failed",
+                    extra={"key": key},
+                    exc_info=True,
+                )
+                capture_exception(e)
+    except Exception as e:
+        logger.exception("Failed to write to cache", extra={"key": key})
+        capture_exception(e)

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 import structlog
 
+from posthog.caching.flags_redis_cache import write_flags_to_cache
 from posthog.constants import ENRICHED_DASHBOARD_INSIGHT_IDENTIFIER, PropertyOperatorType
 from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
@@ -567,12 +568,7 @@ def set_feature_flags_for_team_in_cache(
 
     serialized_flags = MinimalFeatureFlagSerializer(all_feature_flags, many=True).data
 
-    try:
-        cache.set(f"team_feature_flags_{project_id}", json.dumps(serialized_flags), FIVE_DAYS)
-    except Exception:
-        # redis is unavailable
-        logger.exception("Redis is unavailable")
-        capture_exception()
+    write_flags_to_cache(f"team_feature_flags_{project_id}", json.dumps(serialized_flags), FIVE_DAYS)
 
     return all_feature_flags
 
@@ -581,7 +577,6 @@ def get_feature_flags_for_team_in_cache(project_id: int) -> Optional[list[Featur
     try:
         flag_data = cache.get(f"team_feature_flags_{project_id}")
     except Exception:
-        # redis is unavailable
         logger.exception("Redis is unavailable")
         return None
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -401,6 +401,10 @@ EMBEDDING_API_URL = get_from_env("EMBEDDING_API_URL", "")
 if not EMBEDDING_API_URL:
     EMBEDDING_API_URL = "http://localhost:3305" if DEBUG else "http://embedding-api.posthog.svc.cluster.local"
 
+# Dedicated Redis for feature flags
+# This allows feature-flags service to have dedicated Redis for better resource isolation
+FLAGS_REDIS_URL = os.getenv("FLAGS_REDIS_URL", None)
+
 
 CACHES = {
     "default": {
@@ -418,6 +422,21 @@ CACHES = {
         "KEY_PREFIX": "posthog",
     }
 }
+
+# Dedicated cache for the feature flags service (if configured)
+# Django only writes to this cache (never reads), so no reader URL needed
+if FLAGS_REDIS_URL:
+    from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
+
+    CACHES[FLAGS_DEDICATED_CACHE_ALIAS] = {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": FLAGS_REDIS_URL,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "COMPRESSOR": "posthog.caching.zstd_compressor.ZstdCompressor",
+        },
+        "KEY_PREFIX": "posthog",
+    }
 
 if TEST:
     CACHES["default"] = {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}

--- a/posthog/test/test_flags_redis_cache.py
+++ b/posthog/test/test_flags_redis_cache.py
@@ -1,0 +1,154 @@
+"""
+Tests for flags Redis cache dual-write functionality.
+
+Tests the write_flags_to_cache() function which handles writing feature flags
+to both shared and dedicated Redis caches when configured.
+"""
+
+import json
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import override_settings
+
+from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS, write_flags_to_cache
+from posthog.models import FeatureFlag
+from posthog.models.feature_flag import set_feature_flags_for_team_in_cache
+
+
+class TestFlagsRedisCache(BaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def test_writes_to_shared_cache_only_when_no_dedicated(self):
+        """No dedicated cache configured - writes to shared cache only"""
+        test_data = {"test": "data"}
+
+        write_flags_to_cache("test-key", test_data, timeout=300)
+
+        # Verify data was written to shared cache
+        cached_value = cache.get("test-key")
+        self.assertEqual(cached_value, test_data)
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+            FLAGS_DEDICATED_CACHE_ALIAS: {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+        }
+    )
+    def test_dual_writes_when_dedicated_configured(self):
+        """Dedicated cache configured - dual-writes to both shared and dedicated"""
+        from django.core.cache import caches
+
+        caches["default"].clear()
+        caches[FLAGS_DEDICATED_CACHE_ALIAS].clear()
+
+        test_data = {"test": "data"}
+
+        write_flags_to_cache("test-key", test_data, timeout=300)
+
+        # Verify data was written to both caches
+        shared_value = caches["default"].get("test-key")
+        dedicated_value = caches[FLAGS_DEDICATED_CACHE_ALIAS].get("test-key")
+
+        self.assertEqual(shared_value, test_data)
+        self.assertEqual(dedicated_value, test_data)
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+            FLAGS_DEDICATED_CACHE_ALIAS: {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+        }
+    )
+    def test_continues_on_dedicated_cache_failure(self):
+        """Dedicated cache write failure - continues successfully, writes to shared"""
+        from django.core.cache import caches
+
+        test_data = {"test": "data"}
+
+        # Create a mock for the dedicated cache that fails on set
+        mock_dedicated_cache = MagicMock()
+        mock_dedicated_cache.set.side_effect = Exception("Redis connection failed")
+
+        shared_cache = caches["default"]
+        shared_cache.clear()
+
+        # Patch cache, caches, and settings to return our mocks
+        with (
+            patch("posthog.caching.flags_redis_cache.cache", shared_cache),
+            patch("posthog.caching.flags_redis_cache.caches") as mock_caches,
+            patch("posthog.caching.flags_redis_cache.settings") as mock_settings,
+        ):
+
+            def get_cache(name):
+                if name == "default":
+                    return shared_cache
+                elif name == FLAGS_DEDICATED_CACHE_ALIAS:
+                    return mock_dedicated_cache
+                raise KeyError(f"Unknown cache: {name}")
+
+            mock_caches.__getitem__.side_effect = get_cache
+            mock_settings.CACHES = {"default": {}, FLAGS_DEDICATED_CACHE_ALIAS: {}}
+
+            write_flags_to_cache("test-key", test_data, timeout=300)
+
+            # Shared cache should still have the data
+            shared_value = shared_cache.get("test-key")
+            self.assertEqual(shared_value, test_data)
+
+            # Dedicated cache set should have been attempted
+            mock_dedicated_cache.set.assert_called_once_with("test-key", test_data, 300)
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+            FLAGS_DEDICATED_CACHE_ALIAS: {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+        }
+    )
+    def test_integration_with_set_feature_flags_for_team(self):
+        """Integration test: set_feature_flags_for_team_in_cache uses write_flags_to_cache"""
+        from django.core.cache import caches
+
+        caches["default"].clear()
+        caches[FLAGS_DEDICATED_CACHE_ALIAS].clear()
+
+        # Create a feature flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag",
+            active=True,
+            filters={"groups": [{"rollout_percentage": 100}]},
+        )
+
+        # Call the integration point
+        set_feature_flags_for_team_in_cache(self.team.project_id)
+
+        # Verify both caches received the data
+        shared_data = caches["default"].get(f"team_feature_flags_{self.team.project_id}")
+        dedicated_data = caches[FLAGS_DEDICATED_CACHE_ALIAS].get(f"team_feature_flags_{self.team.project_id}")
+
+        self.assertIsNotNone(shared_data)
+        self.assertIsNotNone(dedicated_data)
+
+        # Verify the data is identical and correct
+        self.assertEqual(shared_data, dedicated_data)
+        flags = json.loads(shared_data)
+        self.assertEqual(len(flags), 1)
+        self.assertEqual(flags[0]["key"], "test-flag")
+        self.assertTrue(flags[0]["active"])


### PR DESCRIPTION
Implements dual-write functionality for feature flags cache to support migration from shared to dedicated Redis for flags.

We always write to both caches if the dedicated cache is configured. This is because the Django app will always read from the shared cache, while the Rust service will read from the dedicated cache if available and enabled.

1. `FLAGS_REDIS_URL` is not set (no dedicated flags cache)  - writes to shared cache only
2. `FLAGS_REDIS_URL` is set (dedicated flags cache) - writes to both shared and dedicated cache.
   - Rust `/flags` service code reads from dedicated cache
   - Django code (`/my_flags` and `/evaluation_reasons` reads from shared cache)

## Problem

We need flag changes to invalidate the flags cache in the Flags Dedicated Redis.

## Changes

Adds a new setting to configure the dedicated flags Redis cache.

* `FLAGS_REDIS_URL` - dedicated flags Redis cache with write access (Django only ever writes to this cache).

## How did you test this code?

Unit Tests
Manual testing

### Test Scenarios:

Each scenario is tested by modifying the `.env` file. Each time I call `redis-cli FLUSHALL` to clear the cache. I then run `bin/start --minimal` and edit a flag in the UI.

1. Current behavior

```yaml
# FLAGS_REDIS_URL=redis://localhost:6379/1
```

```yaml
# Invalid values act as if this wasn't set.
# FLAGS_REDIS_URL=xxxx or redis://localhost:0000/1 or xxxx://localhost:6379/1
```

Expected:
1. `redis-cli -n 0 GET posthog:1:team_feature_flags_1` returns flags
2. `redis-cli -n 1 GET posthog:1:team_feature_flags_1` returns nothing.


2. Dual Write

```yaml
FLAGS_REDIS_URL=redis://localhost:6379/1
```

Expected:
1. `redis-cli -n 0 GET posthog:1:team_feature_flags_1` returns flags.
2. `redis-cli -n 1 GET posthog:1:team_feature_flags_1` returns flags.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
