### PR TITLE
chore(flags): Enable Redis compression for local development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -205,6 +205,7 @@ services:
             # Mode 2: Dual-write warming phase for developers
             FLAGS_REDIS_URL: 'redis://redis:6379/1'
             FLAGS_REDIS_ENABLED: 'false' # Warming but not reading yet
+            REDIS_COMPRESSION_ENABLED: 'true'
 
     livestream:
         extends:

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -451,6 +451,12 @@ pub struct Config {
     // Log-only mode for IP-based rate limiting (defaults to true for safe rollout)
     #[envconfig(from = "FLAGS_IP_RATE_LIMIT_LOG_ONLY", default = "true")]
     pub flags_ip_rate_limit_log_only: FlexBool,
+
+    // Redis compression configuration
+    // When enabled, uses zstd compression for Redis values above threshold
+    // Defaults to true in local development, false elsewhere for safe rollout
+    #[envconfig(from = "REDIS_COMPRESSION_ENABLED", default = "false")]
+    pub redis_compression_enabled: FlexBool,
 }
 
 impl Config {
@@ -525,6 +531,7 @@ impl Config {
             flags_ip_replenish_rate: 100.0,
             flags_rate_limit_log_only: FlexBool(true),
             flags_ip_rate_limit_log_only: FlexBool(true),
+            redis_compression_enabled: FlexBool(true),
         }
     }
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -454,7 +454,7 @@ pub struct Config {
 
     // Redis compression configuration
     // When enabled, uses zstd compression for Redis values above threshold
-    // Defaults to true in local development, false elsewhere for safe rollout
+    // The `default_test_config()` sets this to true for test/development scenarios.
     #[envconfig(from = "REDIS_COMPRESSION_ENABLED", default = "false")]
     pub redis_compression_enabled: FlexBool,
 }


### PR DESCRIPTION
## Problem

We recently learned that cache entries written by the `/flags` service doesn't use `ztsd` compression for entries in the same way that the Django app does.

I recently deployed a change to enable reading compressed entries. That's working. But we don't have a way to turn on writing compressed entries.

## Changes

Adds `REDIS_COMPRESSION_ENABLED` environment variable to control zstd compression for Redis values. When enabled, uses Django-compatible compression settings (512 byte threshold, level 0).

Also sets this to `true` for local development.

This setting doesn't yet exist in production so this PR will have no effect until we modify charts. I'll be following-up with some posthog/charts PRs to enable it in production after thorough testing in the cloud dev environment.

* https://github.com/PostHog/charts/pull/6860 - enable it in cloud dev

## How did you test this code?

Manually.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
