### PR TITLE
fix(shortcuts): a bit of a cleanup

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -11,6 +11,7 @@ import {
     IconShortcut,
 } from '@posthog/icons'
 
+import { itemSelectModalLogic } from 'lib/components/FileSystem/ItemSelectModal/itemSelectModalLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
 import { dayjs } from 'lib/dayjs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
@@ -103,6 +104,7 @@ export function ProjectTree({
     const treeRef = useRef<LemonTreeRef>(null)
     const { projectTreeMode } = useValues(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { setProjectTreeMode } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
+    const { openItemSelectModal } = useActions(itemSelectModalLogic)
 
     const showFilterDropdown = root === 'project://'
     const showSortDropdown = root === 'project://'
@@ -623,6 +625,24 @@ export function ProjectTree({
                                         })}
                                     />
                                     {selectMode === 'default' ? 'Enable multi-select' : 'Disable multi-select'}
+                                </>
+                            ),
+                        }),
+                },
+                {
+                    ...(root === 'shortcuts://' &&
+                        sortMethod !== 'recent' && {
+                            'data-attr': 'shortcuts-panel-add-button',
+                            onClick: openItemSelectModal,
+                            children: (
+                                <>
+                                    <IconPlusSmall
+                                        className={cn('size-3', {
+                                            'text-tertiary': selectMode === 'default',
+                                            'text-primary': selectMode === 'multi',
+                                        })}
+                                    />
+                                    Add shortcut
                                 </>
                             ),
                         }),

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -259,15 +259,17 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                     return response.results
                 },
                 addShortcutItem: async ({ item }) => {
+                    const shortcutPath = joinPath([splitPath(item.path).pop() ?? 'Unnamed'])
+
                     const shortcutItem =
                         item.type === 'folder'
                             ? {
-                                  path: joinPath([splitPath(item.path).pop() ?? 'Unnamed']),
+                                  path: shortcutPath,
                                   type: 'folder',
                                   ref: item.path,
                               }
                             : {
-                                  path: joinPath([splitPath(item.path).pop() ?? 'Unnamed']),
+                                  path: shortcutPath,
                                   type: item.type,
                                   ref: item.ref,
                                   href: item.href,
@@ -282,7 +284,9 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                             },
                         },
                     })
-                    return [...values.shortcutData, response]
+                    return [...values.shortcutData, response].sort((a, b) =>
+                        a.path.toLowerCase().localeCompare(b.path.toLowerCase())
+                    )
                 },
                 deleteShortcut: async ({ id }) => {
                     await api.fileSystemShortcuts.delete(id)

--- a/frontend/src/lib/components/FileSystem/ItemSelectModal/ItemSelectModal.tsx
+++ b/frontend/src/lib/components/FileSystem/ItemSelectModal/ItemSelectModal.tsx
@@ -105,7 +105,12 @@ export function ItemSelectModal({ className, includeProtocol, includeRoot }: Ite
     return (
         <>
             <LemonModal
-                onClose={closeItemSelectModal}
+                onClose={() => {
+                    closeItemSelectModal()
+                    setSelectedItem(null)
+                    setSearchTerm('')
+                    setTreeRoot('project://')
+                }}
                 isOpen={isOpen}
                 title="Choose an item"
                 // This is a bit of a hack. Without it, the flow "insight" -> "add to dashboard button" ->
@@ -121,9 +126,16 @@ export function ItemSelectModal({ className, includeProtocol, includeRoot }: Ite
                             type="primary"
                             onClick={submitForm}
                             data-attr="item-select-modal-add-button"
-                            disabledReason={!selectedItem ? 'Please select an item' : undefined}
+                            disabledReason={
+                                !selectedItem
+                                    ? 'Please select an item'
+                                    : selectedItem.record?.type === 'folder' &&
+                                        selectedItem.record?.protocol === 'new://'
+                                      ? 'Please select an item inside the folder'
+                                      : undefined
+                            }
                         >
-                            Add {selectedItem?.displayName || selectedItem?.name}
+                            Add {selectedItem?.name || selectedItem?.displayName}
                         </LemonButton>
                     </>
                 }
@@ -165,29 +177,27 @@ export function ItemSelectModal({ className, includeProtocol, includeRoot }: Ite
                                     </RootFolderButton>
                                 </div>
 
-                                {treeRoot === 'project://' && (
-                                    <LemonInput
-                                        type="search"
-                                        placeholder="Search project"
-                                        fullWidth
-                                        size="small"
-                                        onChange={(search) => setSearchTerm(search)}
-                                        value={searchTerm}
-                                        data-attr="folder-select-search-input"
-                                        autoFocus
-                                        inputRef={inputRef}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'ArrowDown') {
-                                                e.preventDefault() // Prevent scrolling
-                                                const visibleItems = treeRef?.current?.getVisibleItems()
-                                                if (visibleItems && visibleItems.length > 0) {
-                                                    e.currentTarget.blur() // Remove focus from input
-                                                    treeRef?.current?.focusItem(visibleItems[0].id)
-                                                }
+                                <LemonInput
+                                    type="search"
+                                    placeholder="Search"
+                                    fullWidth
+                                    size="small"
+                                    onChange={(search) => setSearchTerm(search)}
+                                    value={searchTerm}
+                                    data-attr="folder-select-search-input"
+                                    autoFocus
+                                    inputRef={inputRef}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'ArrowDown') {
+                                            e.preventDefault() // Prevent scrolling
+                                            const visibleItems = treeRef?.current?.getVisibleItems()
+                                            if (visibleItems && visibleItems.length > 0) {
+                                                e.currentTarget.blur() // Remove focus from input
+                                                treeRef?.current?.focusItem(visibleItems[0].id)
                                             }
-                                        }}
-                                    />
-                                )}
+                                        }
+                                    }}
+                                />
 
                                 <ScrollableShadows
                                     direction="vertical"

--- a/frontend/src/lib/components/FileSystem/ItemSelectModal/itemSelectModalLogic.tsx
+++ b/frontend/src/lib/components/FileSystem/ItemSelectModal/itemSelectModalLogic.tsx
@@ -1,10 +1,13 @@
 import { actions, connect, kea, path, reducers } from 'kea'
 import { forms } from 'kea-forms'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
+import { joinPath, splitPath } from '~/layout/panel-layout/ProjectTree/utils'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 import type { itemSelectModalLogicType } from './itemSelectModalLogicType'
@@ -12,7 +15,7 @@ import type { itemSelectModalLogicType } from './itemSelectModalLogicType'
 export const itemSelectModalLogic = kea<itemSelectModalLogicType>([
     path(['lib', 'components', 'FileSystem', 'ItemSelectModal', 'itemSelectModalLogic']),
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [featureFlagLogic, ['featureFlags'], projectTreeDataLogic, ['shortcutData']],
         actions: [projectTreeDataLogic, ['addShortcutItem']],
     })),
     actions({
@@ -28,16 +31,24 @@ export const itemSelectModalLogic = kea<itemSelectModalLogicType>([
             },
         ],
     }),
-    forms(({ actions }) => ({
+    forms(({ actions, values }) => ({
         form: {
             defaults: {
                 item: null as TreeDataItem | null,
             },
-            submit: (formValues) => {
+            submit: async (formValues) => {
                 if (formValues.item?.record) {
-                    actions.addShortcutItem(formValues.item.record as FileSystemEntry)
+                    const item = formValues.item.record as FileSystemEntry
+                    const shortcutPath = joinPath([splitPath(item.path).pop() ?? 'Unnamed'])
+
+                    if (values.shortcutData.some((s) => s.path === shortcutPath)) {
+                        lemonToast.info('Shortcut already exists')
+                        return
+                    }
+
+                    await actions.addShortcutItem(item)
+                    actions.closeItemSelectModal()
                 }
-                actions.closeItemSelectModal()
             },
         },
     })),


### PR DESCRIPTION
## Problem

some annoying issues

1. it is possible to add duplicate shortcuts.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

![image.png](https://app.graphite.com/user-attachments/assets/22df1918-8b03-43da-809b-eb1944455c4f.png)

1. if you don't have the Shortcuts folder pinned on the left-most sidebar, there's no button to open the Add shortcut modal.

![image.png](https://app.graphite.com/user-attachments/assets/c591cc48-e6d5-4288-bcb6-14251225ab0c.png)

1. when you add a shortcut, it's just added to the bottom without any sorting
2. on the Add shortcut modal - the search bar was only on the projects:// root. May be intentional, but annoying to find that the searchTerm is applied across any root. 
3. on the Add shortcut modal - when an item is selected after search is used, the `Add <>`​ button is missing a space because the `item.displayName`​ is annoying.

![image.png](https://app.graphite.com/user-attachments/assets/31dadda5-ee1f-44d2-b8b7-739750fcba66.png)

1. when root is `new://`​ and the user selects one of the folders (Data or Insight), when this folder is added to the shortcuts, it does not expand. Instead of showing all items in the folder, I now disallow adding that folder to the shortcuts and ask the user to select an item from it.
2. when the add shortcut modal is closed, nothing is reset. this feels like it should remvoe the searchTerm and the selectedItem when closed.

## Changes

[Screen Recording 2025-11-08 at 12.42.29.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/96577a96-1f9c-41d3-8fcf-a8ff2ab275a0.mov" />](https://app.graphite.com/user-attachments/video/96577a96-1f9c-41d3-8fcf-a8ff2ab275a0.mov)



## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

- poking around

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

no

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->