### PR TITLE
fix: upside down feature flag on SQL editor managed-views

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -1003,8 +1003,8 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                         : []),
                     createTopLevelFolderNode('views', viewsChildren),
                     ...(featureFlags[FEATURE_FLAGS.MANAGED_VIEWSETS]
-                        ? []
-                        : [createTopLevelFolderNode('managed-views', managedViewsChildren)]),
+                        ? [createTopLevelFolderNode('managed-views', managedViewsChildren)]
+                        : []),
                     ...(featureFlags[FEATURE_FLAGS.ENDPOINTS]
                         ? [createTopLevelFolderNode('endpoints', endpointChildren)]
                         : []),


### PR DESCRIPTION
## Problem

The current implementation of the `queryDatabaseLogic` has an inverted condition for displaying managed views in the sidebar. When the `MANAGED_VIEWSETS` feature flag is enabled, managed views are not being shown, which is the opposite of the intended behavior.

## Changes

Fixed the conditional logic for displaying managed views in the sidebar. Now, when the `MANAGED_VIEWSETS` feature flag is enabled, the managed views folder will be shown, and when disabled, it will be hidden.

## How did you test this code?

Tested by toggling the `MANAGED_VIEWSETS` feature flag on and off and verifying that the managed views folder appears in the sidebar only when the flag is enabled.

## Changelog: No

GitHub: Closes #