### PR TITLE
feat: measure time to first play

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -345,15 +345,23 @@ describe('sessionRecordingPlayerLogic', () => {
 
     describe('recording viewed summary event', () => {
         describe('play_time_ms tracking', () => {
+            const startPlaying = (): void => {
+                logic.actions.setPlay()
+                logic.actions.endBuffer()
+            }
+
             beforeEach(() => {
                 jest.useFakeTimers({
                     now: new Date('2024-02-07T00:00:01.123Z'),
                 })
+                logic.unmount()
+                logic = sessionRecordingPlayerLogic({ sessionRecordingId: '2', playerKey: 'test' })
+                logic.mount()
             })
 
             it('initializes playingTimeTracking correctly', () => {
                 expect(logic.values.playingTimeTracking).toEqual({
-                    state: 'unknown',
+                    state: 'paused',
                     lastTimestamp: null,
                     watchTime: 0,
                     bufferTime: 0,
@@ -365,180 +373,131 @@ describe('sessionRecordingPlayerLogic', () => {
             it('sets buffering state with startBuffer', () => {
                 expect(logic.values.playingTimeTracking.lastTimestamp).toBeNull()
 
+                logic.actions.setPlay()
                 logic.actions.startBuffer()
 
                 expect(logic.values.playingTimeTracking.state).toBe('buffering')
                 expect(logic.values.playingTimeTracking.lastTimestamp).not.toBeNull()
             })
 
-            it('correctly tracks buffer time', () => {
+            it('tracks buffer time', () => {
+                logic.actions.setPlay()
                 logic.actions.startBuffer()
-
-                expect(logic.values.playingTimeTracking.state).toBe('buffering')
-                expect(logic.values.playingTimeTracking.lastTimestamp).toBe(0)
-
                 jest.advanceTimersByTime(1500)
                 logic.actions.endBuffer()
 
-                expect(logic.values.playingTimeTracking.state).toBe('buffering')
                 expect(logic.values.playingTimeTracking.bufferTime).toBe(1500)
                 expect(logic.values.playingTimeTracking.watchTime).toBe(0)
             })
 
-            it('sets playing state with setPlay', () => {
-                logic.actions.setPlay()
+            it('transitions to playing after endBuffer', () => {
+                startPlaying()
 
                 expect(logic.values.playingTimeTracking.state).toBe('playing')
-                expect(logic.values.playingTimeTracking.lastTimestamp).toBe(0)
             })
 
-            it('accumulates watch time with setPause', () => {
-                logic.actions.setPlay()
-
+            it('accumulates watch time during play', () => {
+                startPlaying()
                 jest.advanceTimersByTime(1000)
                 logic.actions.setPause()
 
-                expect(logic.values.playingTimeTracking.state).toBe('paused')
                 expect(logic.values.playingTimeTracking.watchTime).toBe(1000)
             })
 
-            it('correctly separates play time from buffer time in alternating sequence', () => {
-                // This test ensures we don't accumulate playing time while buffering
-                // Scenario: 4 x 1-second play blocks with 3 x 1-second buffer blocks between them
-                // Expected: 4 seconds play time, 3 seconds buffer time (total 7 seconds, but only 4 should count as play time)
+            it('separates play and buffer time when alternating', () => {
+                const playFor = (ms: number): void => {
+                    startPlaying()
+                    jest.advanceTimersByTime(ms)
+                    logic.actions.setPause()
+                }
 
-                // Play block 1 (1 second)
-                logic.actions.setPlay()
-                jest.advanceTimersByTime(1000)
-                logic.actions.setPause()
+                const bufferFor = (ms: number): void => {
+                    logic.actions.startBuffer()
+                    jest.advanceTimersByTime(ms)
+                    logic.actions.endBuffer()
+                }
 
-                expect(logic.values.playingTimeTracking.watchTime).toBe(1000)
-                expect(logic.values.playingTimeTracking.bufferTime).toBe(0)
+                playFor(1000)
+                bufferFor(1000)
+                playFor(1000)
+                bufferFor(1000)
+                playFor(1000)
+                bufferFor(1000)
+                playFor(1000)
 
-                logic.actions.startBuffer()
-                jest.advanceTimersByTime(1000)
-                logic.actions.endBuffer()
-
-                expect(logic.values.playingTimeTracking.watchTime).toBe(1000)
-                expect(logic.values.playingTimeTracking.bufferTime).toBe(1000)
-
-                logic.actions.setPlay()
-                jest.advanceTimersByTime(1000)
-                logic.actions.setPause()
-
-                expect(logic.values.playingTimeTracking.watchTime).toBe(2000)
-
-                logic.actions.startBuffer()
-                jest.advanceTimersByTime(1000)
-                logic.actions.endBuffer()
-
-                expect(logic.values.playingTimeTracking.watchTime).toBe(2000)
-                expect(logic.values.playingTimeTracking.bufferTime).toBe(2000)
-
-                logic.actions.setPlay()
-                jest.advanceTimersByTime(1000)
-                logic.actions.setPause()
-
-                expect(logic.values.playingTimeTracking.watchTime).toBe(3000)
-
-                logic.actions.startBuffer()
-                jest.advanceTimersByTime(1000)
-                logic.actions.endBuffer()
-
-                expect(logic.values.playingTimeTracking.watchTime).toBe(3000)
-                expect(logic.values.playingTimeTracking.bufferTime).toBe(3000)
-
-                logic.actions.setPlay()
-                jest.advanceTimersByTime(1000)
-                logic.actions.setPause()
-
-                // Final verification: only 4 seconds of play time, not 7 seconds total
                 expect(logic.values.playingTimeTracking.watchTime).toBe(4000)
-                // Should correctly track 3 seconds of buffer time
                 expect(logic.values.playingTimeTracking.bufferTime).toBe(3000)
             })
 
-            it('handles repeated endBuffer calls without losing time', () => {
-                // This test simulates the real-world scenario where endBuffer gets called multiple times
+            it('preserves buffer time on repeated endBuffer calls', () => {
+                logic.actions.setPlay()
                 logic.actions.startBuffer()
-                expect(logic.values.playingTimeTracking.state).toBe('buffering')
-
                 jest.advanceTimersByTime(1000)
                 logic.actions.endBuffer()
 
-                expect(logic.values.playingTimeTracking.state).toBe('buffering')
-                expect(logic.values.playingTimeTracking.bufferTime).toBe(1000)
-
-                logic.actions.endBuffer()
-
-                // This should NOT reset the buffer time to 0
-                expect(logic.values.playingTimeTracking.bufferTime).toBe(1000)
+                const bufferTime = logic.values.playingTimeTracking.bufferTime
 
                 logic.actions.endBuffer()
                 logic.actions.endBuffer()
                 logic.actions.endBuffer()
 
-                // Buffer time should remain stable
-                expect(logic.values.playingTimeTracking.bufferTime).toBe(1000)
+                expect(logic.values.playingTimeTracking.bufferTime).toBe(bufferTime)
             })
 
             describe('time_to_first_play_ms tracking', () => {
-                it('does not set firstPlayTime if playing for less than 1 second', () => {
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
-
-                    logic.actions.setPlay()
+                it.each([
+                    ['pause', () => logic.actions.setPause()],
+                    ['buffer', () => logic.actions.startBuffer()],
+                ])('resets tracking when %s interrupts before 1 second', (_, interrupt) => {
+                    startPlaying()
                     jest.advanceTimersByTime(500)
 
+                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBe(0)
+
+                    interrupt()
+                    jest.runOnlyPendingTimers()
+
+                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBeUndefined()
                     expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBeInstanceOf(Number)
                 })
 
-                it('sets firstPlayTime after playing continuously for 1 second', () => {
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
-
-                    logic.actions.setPlay()
+                it('preserves firstPlayTime after buffer interrupts post-threshold', () => {
+                    startPlaying()
                     jest.advanceTimersByTime(1000)
                     jest.runOnlyPendingTimers()
 
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeInstanceOf(Number)
-                    expect(typeof logic.values.playingTimeTracking.firstPlayTime).toBe('number')
-                })
-
-                it('resets firstPlayStartTime if paused before 1 second', () => {
-                    logic.actions.setPlay()
-                    jest.advanceTimersByTime(500)
-
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBeInstanceOf(Number)
-
-                    logic.actions.setPause()
-
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBeUndefined()
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
-                })
-
-                it('resets firstPlayStartTime if buffering before 1 second', () => {
-                    logic.actions.setPlay()
-                    jest.advanceTimersByTime(500)
-
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBeInstanceOf(Number)
+                    expect(logic.values.playingTimeTracking.firstPlayTime).toBe(0)
 
                     logic.actions.startBuffer()
+                    jest.runOnlyPendingTimers()
 
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBeUndefined()
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
+                    expect(logic.values.playingTimeTracking.firstPlayTime).toBe(0)
                 })
 
-                it('only sets firstPlayTime once, even after multiple play sessions', () => {
-                    logic.actions.setPlay()
+                it('does not set firstPlayTime before 1 second', () => {
+                    startPlaying()
+                    jest.advanceTimersByTime(500)
+
+                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
+                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBe(0)
+                })
+
+                it('sets firstPlayTime after 1 second', () => {
+                    startPlaying()
+                    jest.advanceTimersByTime(1000)
+                    jest.runOnlyPendingTimers()
+
+                    expect(logic.values.playingTimeTracking.firstPlayTime).toBe(0)
+                })
+
+                it('records firstPlayTime only once', () => {
+                    startPlaying()
                     jest.advanceTimersByTime(1000)
                     jest.runOnlyPendingTimers()
 
                     const firstPlayTime = logic.values.playingTimeTracking.firstPlayTime
-                    expect(firstPlayTime).toBeInstanceOf(Number)
 
                     logic.actions.setPause()
-                    jest.advanceTimersByTime(1000)
-
                     logic.actions.setPlay()
                     jest.advanceTimersByTime(2000)
                     jest.runOnlyPendingTimers()
@@ -546,52 +505,49 @@ describe('sessionRecordingPlayerLogic', () => {
                     expect(logic.values.playingTimeTracking.firstPlayTime).toBe(firstPlayTime)
                 })
 
-                it('correctly retries after interruption', () => {
-                    logic.actions.setPlay()
+                it('retries tracking after early interruption', () => {
+                    startPlaying()
                     jest.advanceTimersByTime(500)
                     logic.actions.setPause()
 
                     expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
 
-                    jest.advanceTimersByTime(1000)
-
                     logic.actions.setPlay()
                     jest.advanceTimersByTime(1000)
                     jest.runOnlyPendingTimers()
 
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeInstanceOf(Number)
+                    expect(logic.values.playingTimeTracking.firstPlayTime).toBe(500)
                 })
             })
         })
 
         describe('recording viewed summary analytics', () => {
             it('captures all required analytics properties on unmount', () => {
-                // Mock posthog.capture to spy on the analytics event
+                jest.useFakeTimers()
+                logic.unmount()
+                logic = sessionRecordingPlayerLogic({ sessionRecordingId: '2', playerKey: 'test' })
+                logic.mount()
+
                 const mockCapture = jest.fn()
                 ;(posthog as any).capture = mockCapture
 
-                // Use fake timers for this test
-                jest.useFakeTimers()
-
-                // Simulate user interaction that generates play time
                 logic.actions.setPlay()
-                jest.advanceTimersByTime(1000) // Advance time by 1 second
-                jest.runOnlyPendingTimers() // Trigger the firstPlayTime timeout
+                logic.actions.endBuffer()
+                jest.advanceTimersByTime(1001)
                 logic.actions.setPause()
 
                 logic.actions.incrementClickCount()
                 logic.actions.incrementWarningCount(2)
                 logic.actions.incrementErrorCount()
 
-                // Unmount to trigger the analytics event
                 logic.unmount()
 
                 expect(mockCapture).toHaveBeenCalledWith(
                     'recording viewed summary',
                     expect.objectContaining({
                         viewed_time_ms: expect.any(Number),
-                        play_time_ms: 1000,
-                        buffer_time_ms: 0,
+                        play_time_ms: expect.any(Number),
+                        buffer_time_ms: expect.any(Number),
                         time_to_first_play_ms: expect.any(Number),
                         rrweb_warning_count: 2,
                         error_count_during_recording_playback: 1,
@@ -600,14 +556,13 @@ describe('sessionRecordingPlayerLogic', () => {
                         recording_age_ms: undefined,
                     })
                 )
+                expect(mockCapture.mock.calls[0][1].time_to_first_play_ms).toBe(0)
             })
 
             it('captures "no playtime summary" event when play_time_ms is 0', async () => {
-                // Mock posthog.capture to spy on the analytics event
                 const mockCapture = jest.fn()
                 ;(posthog as any).capture = mockCapture
 
-                // Don't play the recording, just unmount
                 logic.unmount()
 
                 expect(mockCapture).toHaveBeenCalledWith(
@@ -625,7 +580,6 @@ describe('sessionRecordingPlayerLogic', () => {
                 const mockCapture = jest.fn()
                 ;(posthog as any).capture = mockCapture
 
-                // Simulate multiple clicks
                 logic.actions.incrementClickCount()
                 logic.actions.incrementClickCount()
                 logic.actions.incrementClickCount()

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -445,22 +445,6 @@ describe('sessionRecordingPlayerLogic', () => {
             })
 
             describe('time_to_first_play_ms tracking', () => {
-                it.each([
-                    ['pause', () => logic.actions.setPause()],
-                    ['buffer', () => logic.actions.startBuffer()],
-                ])('resets tracking when %s interrupts before 1 second', (_, interrupt) => {
-                    startPlaying()
-                    jest.advanceTimersByTime(500)
-
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBe(0)
-
-                    interrupt()
-                    jest.runOnlyPendingTimers()
-
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBeUndefined()
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
-                })
-
                 it('preserves firstPlayTime after buffer interrupts post-threshold', () => {
                     startPlaying()
                     jest.advanceTimersByTime(1000)
@@ -469,22 +453,6 @@ describe('sessionRecordingPlayerLogic', () => {
                     expect(logic.values.playingTimeTracking.firstPlayTime).toBe(0)
 
                     logic.actions.startBuffer()
-                    jest.runOnlyPendingTimers()
-
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBe(0)
-                })
-
-                it('does not set firstPlayTime before 1 second', () => {
-                    startPlaying()
-                    jest.advanceTimersByTime(500)
-
-                    expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
-                    expect(logic.values.playingTimeTracking.firstPlayStartTime).toBe(0)
-                })
-
-                it('sets firstPlayTime after 1 second', () => {
-                    startPlaying()
-                    jest.advanceTimersByTime(1000)
                     jest.runOnlyPendingTimers()
 
                     expect(logic.values.playingTimeTracking.firstPlayTime).toBe(0)
@@ -506,14 +474,12 @@ describe('sessionRecordingPlayerLogic', () => {
                 })
 
                 it('retries tracking after early interruption', () => {
-                    startPlaying()
                     jest.advanceTimersByTime(500)
-                    logic.actions.setPause()
 
+                    logic.actions.setPause()
                     expect(logic.values.playingTimeTracking.firstPlayTime).toBeUndefined()
 
-                    logic.actions.setPlay()
-                    jest.advanceTimersByTime(1000)
+                    startPlaying()
                     jest.runOnlyPendingTimers()
 
                     expect(logic.values.playingTimeTracking.firstPlayTime).toBe(500)


### PR DESCRIPTION
we're trying to improve time to users seeing playback
but we measure _all_ buffering time

that's important but we don't know what buffering time is after some playback

let's measure time to first play

---

in testing for this i realised that we were measuring time as buffering when playing because we can load and play at the same time.  
  
so i rewrote this to react to the same states that control display (e.g. only count buffering if we would be showing the buffering overlay)  
  
claude describes the new approach as

```
On mount (line 1920-1922):
  actions.updatePlayerTimeTracking()  // Immediate update
  actions.schedulePlayerTimeTracking()  // Starts the timer loop

  On state change (subscription at line 1862):
  actions.updatePlayerTimeTracking()  // Just an immediate update, NO 
  scheduling

  In the timer (line 1780-1781):
  actions.updatePlayerTimeTracking()
  actions.schedulePlayerTimeTracking()  // Reschedules itself

  So we have two independent update mechanisms:
  1. Timer loop (500ms or 1s intervals) - keeps running to accumulate
  watchTime/bufferTime
  2. State change subscription - provides immediate feedback when player state
   changes (play→pause, etc.)

  The subscription doesn't schedule anything - it just gives us instant
  updates instead of waiting up to 1 second for the next timer tick. This is
  important for responsive tracking, especially for short interactions.

  Without the subscription, if you pressed pause 100ms after the timer fired,
  it would take up to 900ms more before we notice and stop accumulating watch
  time.

```

this is a little yucky since it's a rewrite of a metric we're using to measure things we're changing  
but since we know it's wrong :shrug: