### PR TITLE
fix(ph-ai): unhandled message type exception

### DIFF
--- a/ee/hogai/utils/stream_processor.py
+++ b/ee/hogai/utils/stream_processor.py
@@ -6,7 +6,6 @@ from langchain_core.messages import AIMessageChunk
 from posthog.schema import (
     AssistantGenerationStatusEvent,
     AssistantGenerationStatusType,
-    AssistantToolCallMessage,
     AssistantUpdateEvent,
     FailureMessage,
     MultiVisualizationMessage,
@@ -224,12 +223,7 @@ class AssistantStreamProcessor(AssistantStreamProcessorProtocol, Generic[StateTy
         ):
             return message
 
-        if isinstance(message, AssistantToolCallMessage):
-            # No need to yield tool call messages not at the root level
-            return None
-
-        # Should not reach here
-        raise ValueError(f"Unhandled special message type: {type(message).__name__}")
+        return None
 
     def _handle_message_stream(
         self, event: AssistantDispatcherEvent, message: AIMessageChunk


### PR DESCRIPTION
## Problem

Fixes [this](https://us.posthog.com/project/2/error_tracking/019a30ee-32a3-7c90-9ba1-d1b73563b728?timestamp=2025-11-09%2001:46:08.308000-08:00) issue. The code was raising an exception for message types other than AssistantMessage, HumanMessage, AssistantToolCallMessage, or VisualizationMessage when messages were dispatched from the node.

## Changes

- Removed the exception and just made returning None since those messages are internal.

## How did you test this code?

Added a new test + manual testing