### PR TITLE
feat(capture): add connection timeout layer to Axum Router

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -107,6 +107,9 @@ pub struct Config {
     // AI endpoint size limits
     #[envconfig(default = "26214400")] // 25MB in bytes
     pub ai_max_sum_of_parts_bytes: usize,
+
+    #[envconfig(default = "10")]
+    pub request_timeout_seconds: u64,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -108,8 +108,8 @@ pub struct Config {
     #[envconfig(default = "26214400")] // 25MB in bytes
     pub ai_max_sum_of_parts_bytes: usize,
 
-    #[envconfig(default = "10")]
-    pub request_timeout_seconds: u64,
+    // if set in env, will configure a request timeout on the server's Axum router
+    pub request_timeout_seconds: Option<u64>,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -185,6 +185,7 @@ where
         config.is_mirror_deploy,
         config.verbose_sample_percent,
         config.ai_max_sum_of_parts_bytes,
+        config.request_timeout_seconds,
     );
 
     // run our app with hyper

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -136,7 +136,7 @@ pub fn is_likely_base64(payload: &[u8], opt: Base64Option) -> bool {
             || (opt == Base64Option::Loose && *b == b' ')
     });
 
-    let is_b64_aligned = payload.len() % 4 == 0;
+    let is_b64_aligned = payload.len().is_multiple_of(4);
 
     prefix_chars_b64_compatible && is_b64_aligned
 }

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -993,7 +993,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             is_mirror_deploy,
             verbose_sample_percent,
             26_214_400, // 25MB default for AI endpoint
-            10,         // request_timeout_seconds
+            Some(10),   // request_timeout_seconds
         ),
         sink,
     )

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -993,6 +993,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             is_mirror_deploy,
             verbose_sample_percent,
             26_214_400, // 25MB default for AI endpoint
+            10, // request_timeout_seconds
         ),
         sink,
     )

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -993,7 +993,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             is_mirror_deploy,
             verbose_sample_percent,
             26_214_400, // 25MB default for AI endpoint
-            10, // request_timeout_seconds
+            10,         // request_timeout_seconds
         ),
         sink,
     )

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -80,6 +80,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     s3_fallback_prefix: String::new(),
     healthcheck_strategy: HealthStrategy::All,
     ai_max_sum_of_parts_bytes: 26_214_400, // 25MB default
+    request_timeout_seconds: 10,
 });
 
 static TRACING_INIT: Once = Once::new();

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -80,7 +80,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     s3_fallback_prefix: String::new(),
     healthcheck_strategy: HealthStrategy::All,
     ai_max_sum_of_parts_bytes: 26_214_400, // 25MB default
-    request_timeout_seconds: 10,
+    request_timeout_seconds: Some(10),
 });
 
 static TRACING_INIT: Once = Once::new();

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -169,7 +169,7 @@ fn setup_ai_test_router() -> Router {
         false,
         0.0_f32,
         26_214_400, // 25MB default for AI endpoint
-        10, // request_timeout_seconds
+        10,         // request_timeout_seconds
     )
 }
 
@@ -1491,6 +1491,7 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         false,
         0.0_f32,
         26_214_400, // 25MB default for AI endpoint
+        10,         // request_timeout_seconds
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -169,7 +169,7 @@ fn setup_ai_test_router() -> Router {
         false,
         0.0_f32,
         26_214_400, // 25MB default for AI endpoint
-        10,         // request_timeout_seconds
+        Some(10),   // request_timeout_seconds
     )
 }
 
@@ -1491,7 +1491,7 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         false,
         0.0_f32,
         26_214_400, // 25MB default for AI endpoint
-        10,         // request_timeout_seconds
+        Some(10),   // request_timeout_seconds
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -169,6 +169,7 @@ fn setup_ai_test_router() -> Router {
         false,
         0.0_f32,
         26_214_400, // 25MB default for AI endpoint
+        10, // request_timeout_seconds
     )
 }
 

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -139,7 +139,7 @@ async fn setup_router_with_limits(
         false,       // is_mirror_deploy
         0.0,         // verbose_sample_percent
         26_214_400,  // ai_max_sum_of_parts_bytes (25MB)
-        10,          // request_timeout_seconds
+        Some(10),    // request_timeout_seconds
     );
 
     (app, sink)
@@ -1183,7 +1183,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         false,
         0.0,
         26_214_400,
-        10, // request_timeout_seconds
+        Some(10), // request_timeout_seconds
     );
 
     let client = TestClient::new(app);
@@ -1259,7 +1259,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         false,
         0.0,
         26_214_400,
-        10, // request_timeout_seconds
+        Some(10), // request_timeout_seconds
     );
 
     let client = TestClient::new(app);
@@ -1339,7 +1339,7 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         false,
         0.0,
         26_214_400,
-        10, // request_timeout_seconds
+        Some(10), // request_timeout_seconds
     );
 
     let client = TestClient::new(app);
@@ -1756,7 +1756,7 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         false,
         0.0,
         26_214_400,
-        10, // request_timeout_seconds
+        Some(10), // request_timeout_seconds
     );
 
     let client = TestClient::new(app);

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -139,6 +139,7 @@ async fn setup_router_with_limits(
         false,       // is_mirror_deploy
         0.0,         // verbose_sample_percent
         26_214_400,  // ai_max_sum_of_parts_bytes (25MB)
+        10,          // request_timeout_seconds
     );
 
     (app, sink)
@@ -1182,6 +1183,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         false,
         0.0,
         26_214_400,
+        10, // request_timeout_seconds
     );
 
     let client = TestClient::new(app);
@@ -1257,6 +1259,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         false,
         0.0,
         26_214_400,
+        10, // request_timeout_seconds
     );
 
     let client = TestClient::new(app);
@@ -1336,6 +1339,7 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         false,
         0.0,
         26_214_400,
+        10, // request_timeout_seconds
     );
 
     let client = TestClient::new(app);
@@ -1752,6 +1756,7 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         false,
         0.0,
         26_214_400,
+        10, // request_timeout_seconds
     );
 
     let client = TestClient::new(app);


### PR DESCRIPTION
## Problem
Recent `capture-relay` incidents involved relay pods piling up new connections from Envoy without timing out or properly closing, leading to the pods bogging down and not completing work (and high rates of 5xx responses after.)

**This PR is risky - observe when deploying!**

The risk here is that without comparable Envoy adjustments this may not remediate the problem, _and_ that `capture` is very liberal with returning 2xx's, so returning `4xx`s more aggressively may cause trouble on the submission side, where behavior differs across the SDKs.

I've updated the PR so that this will roll out as a no-op and we can add the timeout config as an env var to deploy test it ✅ 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add a configurable request handling timeout we can enable/disable in deploy that returns a `408` (we needed to change this to `504` in order to not break SDK contracts) when triggered

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (new test cases included)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required ✅ 
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
