### PR TITLE
feat: view and delete team caches in admin

### DIFF
--- a/posthog/admin/inlines/team_inline.py
+++ b/posthog/admin/inlines/team_inline.py
@@ -36,7 +36,7 @@ class TeamInline(TabularInlinePaginated):
         "plugins_opt_in",
         "opt_out_capture",
     )
-    readonly_fields = [*TeamAdmin.readonly_fields[:-1], "displayed_name"]
+    readonly_fields = [*TeamAdmin.readonly_fields[:-2], "displayed_name"]
 
     def displayed_name(self, team: Team):
         return format_html(


### PR DESCRIPTION
particularly locally i want to be able to see what is cached for a team when i am trying to understand behaviour

this adds buttons to the team page in admin to view and delete cached config for the team

![2025-11-09 23.35.29.gif](https://app.graphite.com/user-attachments/assets/1e218094-df56-4186-9f9f-24d0ac070e97.gif)

## Changelog: (features only) Is this feature complete?

no changelog
