### PR TITLE
chore: Add better limit information in organization admin

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -1,13 +1,15 @@
-from datetime import timedelta
+from datetime import UTC, timedelta
 
 from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
 from django.core.management import call_command
 from django.shortcuts import redirect, render
+from django.template.loader import render_to_string
 from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 
 from posthog.admin.inlines.organization_domain_inline import OrganizationDomainInline
 from posthog.admin.inlines.organization_invite_inline import OrganizationInviteInline
@@ -39,7 +41,8 @@ class OrganizationAdmin(admin.ModelAdmin):
         "plugins_access_level",
         "billing_link",
         "usage_posthog",
-        "usage",
+        "usage_display",
+        "limited_products_display",
         "customer_trust_scores",
         "is_hipaa",
         "is_platform",
@@ -52,7 +55,8 @@ class OrganizationAdmin(admin.ModelAdmin):
         "updated_at",
         "billing_link",
         "usage_posthog",
-        "usage",
+        "usage_display",
+        "limited_products_display",
         "customer_trust_scores",
     ]
     search_fields = ("name", "members__email", "team__api_token")
@@ -91,11 +95,150 @@ class OrganizationAdmin(admin.ModelAdmin):
             organization.id,
         )
 
+    @admin.display(description="Limited Products")
+    def limited_products_display(self, organization: Organization):
+        from datetime import datetime
+
+        limited = organization.get_limited_products()
+        total_teams = organization.teams.count()
+
+        # Format Unix timestamps to human-readable dates
+        for _resource, info in limited.items():
+            redis_until = info.get("redis_quota_limited_until")
+            if redis_until and redis_until != 0:
+                try:
+                    dt = datetime.fromtimestamp(redis_until, tz=UTC)
+                    info["redis_quota_limited_until_formatted"] = dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+                except (ValueError, OSError, OverflowError):
+                    info["redis_quota_limited_until_formatted"] = str(redis_until)
+            else:
+                info["redis_quota_limited_until_formatted"] = "-"
+
+            usage_until = info.get("usage_quota_limited_until")
+            if usage_until and usage_until != 0:
+                try:
+                    dt = datetime.fromtimestamp(usage_until, tz=UTC)
+                    info["usage_quota_limited_until_formatted"] = dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+                except (ValueError, OSError, OverflowError):
+                    info["usage_quota_limited_until_formatted"] = str(usage_until)
+            else:
+                info["usage_quota_limited_until_formatted"] = "-"
+
+        # Access request stored during change_view
+        request = getattr(self, "_current_request", None)
+        return mark_safe(
+            render_to_string(
+                "admin/organization/limited_products.html",
+                {"limited": limited, "organization_id": organization.id, "total_teams": total_teams},
+                request=request,
+            )
+        )
+
+    @admin.display(description="Usage")
+    def usage_display(self, organization: Organization):
+        import dateutil.parser
+
+        usage_data = organization.usage or {}
+        period_info = None
+
+        # Parse and format billing period
+        if usage_data.get("period"):
+            try:
+                period = usage_data["period"]
+                start_dt = dateutil.parser.isoparse(period[0])
+                end_dt = dateutil.parser.isoparse(period[1])
+
+                # Calculate days remaining
+                now = timezone.now()
+                days_remaining = (end_dt - now).days
+
+                period_info = {
+                    "start": start_dt.strftime("%Y-%m-%d"),
+                    "end": end_dt.strftime("%Y-%m-%d"),
+                    "days_remaining": max(0, days_remaining),
+                }
+            except (ValueError, IndexError, AttributeError):
+                pass
+
+        # Format numbers with thousand separators
+        formatted_data = {}
+        for product, data in usage_data.items():
+            if product == "period":
+                continue
+            formatted_data[product] = {
+                "usage": f"{int(data.get('usage', 0)):,}" if data.get("usage") is not None else "-",
+                "limit": f"{int(data.get('limit')):,}" if data.get("limit") else None,
+                "todays_usage": f"{int(data.get('todays_usage', 0)):,}"
+                if data.get("todays_usage") is not None
+                else "-",
+                "usage_raw": data.get("usage"),
+                "limit_raw": data.get("limit"),
+            }
+
+        # Access request stored during change_view
+        request = getattr(self, "_current_request", None)
+        return mark_safe(
+            render_to_string(
+                "admin/organization/usage_display.html",
+                {"usage_data": formatted_data, "period_info": period_info},
+                request=request,
+            )
+        )
+
+    def limit_product_view(self, request, organization_id):
+        from ee.billing.quota_limiting import QuotaResource
+
+        organization: Organization = Organization.objects.get(id=organization_id)
+        assert organization
+
+        if request.method == "POST":
+            resource_name = request.POST.get("resource")
+            try:
+                resource = QuotaResource(resource_name)
+                organization.limit_product_until_end_of_billing_cycle(resource)
+                messages.success(request, f"Successfully limited {resource_name} for organization {organization.name}")
+            except ValueError:
+                messages.error(request, f"Invalid resource: {resource_name}")
+            except Exception as e:
+                messages.error(request, f"Error limiting {resource_name}: {str(e)}")
+
+        return redirect(reverse("admin:posthog_organization_change", args=[organization_id]))
+
+    def unlimit_product_view(self, request, organization_id):
+        from ee.billing.quota_limiting import QuotaResource
+
+        organization = Organization.objects.get(id=organization_id)
+
+        if request.method == "POST":
+            resource_name = request.POST.get("resource")
+            try:
+                resource = QuotaResource(resource_name)
+                organization.unlimit_product(resource)
+                messages.success(
+                    request, f"Successfully unlimited {resource_name} for organization {organization.name}"
+                )
+            except ValueError:
+                messages.error(request, f"Invalid resource: {resource_name}")
+            except Exception as e:
+                messages.error(request, f"Error unlimiting {resource_name}: {str(e)}")
+
+        return redirect(reverse("admin:posthog_organization_change", args=[organization_id]))
+
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [
             path(
                 "send-usage-report/", self.admin_site.admin_view(self.send_usage_report_view), name="send-usage-report"
+            ),
+            path(
+                "<path:organization_id>/limit-product/",
+                self.admin_site.admin_view(self.limit_product_view),
+                name="limit_product",
+            ),
+            path(
+                "<path:organization_id>/unlimit-product/",
+                self.admin_site.admin_view(self.unlimit_product_view),
+                name="unlimit_product",
             ),
         ]
         return custom_urls + urls
@@ -124,4 +267,6 @@ class OrganizationAdmin(admin.ModelAdmin):
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         extra_context = extra_context or {}
+        # Store request for access in display methods (needed for CSRF tokens in templates)
+        self._current_request = request
         return super().change_view(request, object_id, form_url, extra_context=extra_context)

--- a/posthog/templates/admin/organization/limited_products.html
+++ b/posthog/templates/admin/organization/limited_products.html
@@ -1,0 +1,41 @@
+<table style="border-collapse: collapse; width: 100%;">
+    <thead>
+        <tr>
+            <th style="padding: 8px; text-align: left;">Resource</th>
+            <th style="padding: 8px; text-align: left;">Redis Status</th>
+            <th style="padding: 8px; text-align: left;">Limited Teams</th>
+            <th style="padding: 8px; text-align: left;">Redis Until</th>
+            <th style="padding: 8px; text-align: left;">Usage Until</th>
+            <th style="padding: 8px; text-align: left;">Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for resource, info in limited.items %}
+        <tr style="border-top: 1px solid #ddd;">
+            <td style="padding: 8px;">{{ resource }}</td>
+            <td style="padding: 8px; color: {% if info.is_limited_in_redis %}red{% else %}green{% endif %}; font-weight: bold;">
+                {% if info.is_limited_in_redis %}🔒 Limited{% else %}✓ OK{% endif %}
+            </td>
+            <td style="padding: 8px;">{{ info.limited_teams|length }}<span style="color: #888">/{{ total_teams }}</span></td>
+            <td style="padding: 8px;">{{ info.redis_quota_limited_until_formatted }}</td>
+            <td style="padding: 8px;">{{ info.usage_quota_limited_until_formatted }}</td>
+            <td style="padding: 8px;">
+                <form method="post" action="{% url 'admin:limit_product' organization_id %}" style="display: inline-block; margin-right: 4px;">
+                    {% csrf_token %}
+                    <input type="hidden" name="resource" value="{{ resource }}">
+                    <button type="submit" class="button" style="padding: 2px 8px; font-size: 11px;" {% if info.is_limited_in_redis %}disabled{% endif %}>
+                        Limit
+                    </button>
+                </form>
+                <form method="post" action="{% url 'admin:unlimit_product' organization_id %}" style="display: inline-block;">
+                    {% csrf_token %}
+                    <input type="hidden" name="resource" value="{{ resource }}">
+                    <button type="submit" class="button" style="padding: 2px 8px; font-size: 11px;" {% if not info.is_limited_in_redis %}disabled{% endif %}>
+                        Unlimit
+                    </button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/posthog/templates/admin/organization/usage_display.html
+++ b/posthog/templates/admin/organization/usage_display.html
@@ -1,0 +1,44 @@
+{% if period_info %}
+<div style="margin-bottom: 12px; padding: 8px; border-left: 3px solid #007bff;">
+    <strong>Billing Period:</strong> {{ period_info.start }} to {{ period_info.end }}
+    <span style="margin-left: 12px;">({{ period_info.days_remaining }} days remaining)</span>
+</div>
+{% endif %}
+
+<table style="border-collapse: collapse; width: 100%;">
+    <thead>
+        <tr>
+            <th style="padding: 8px; text-align: left;">Product</th>
+            <th style="padding: 8px; text-align: right;">Usage</th>
+            <th style="padding: 8px; text-align: right;">Limit</th>
+            <th style="padding: 8px; text-align: right;">Today's Usage</th>
+            <th style="padding: 8px; text-align: center;">% Used</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for product, data in usage_data.items %}
+        <tr style="border-top: 1px solid;">
+            <td style="padding: 8px;">{{ product }}</td>
+            <td style="padding: 8px; text-align: right;">{{ data.usage }}</td>
+            <td style="padding: 8px; text-align: right;">
+                {% if data.limit %}
+                    {{ data.limit }}
+                {% else %}
+                    <span style="color: #28a745;">∞ Unlimited</span>
+                {% endif %}
+            </td>
+            <td style="padding: 8px; text-align: right;">{{ data.todays_usage }}</td>
+            <td style="padding: 8px; text-align: center;">
+                {% if data.limit_raw and data.usage_raw is not None %}
+                    {% widthratio data.usage_raw data.limit_raw 100 as percentage %}
+                    <span style="color: {% if percentage >= 90 %}#dc3545{% elif percentage >= 75 %}#fd7e14{% else %}#28a745{% endif %};">
+                        {{ percentage }}%
+                    </span>
+                {% else %}
+                    -
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
Add a couple of custom django admin views in the Organization admin that shows usage and limit information as well as adding the ability to limit/unlimit a product.

![Screenshot 2025-11-10 at 10.27.07.png](https://app.graphite.com/user-attachments/assets/4adf9696-ab2b-4837-b442-8d3509a01e29.png)

