### PR TITLE
fix: slack description max length

### DIFF
--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -296,7 +296,10 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     value: [
                         { type: 'header', text: { type: 'plain_text', text: '🔴 {event.properties.name}' } },
                         { type: 'section', text: { type: 'plain_text', text: 'New issue created' } },
-                        { type: 'section', text: { type: 'mrkdwn', text: '```{event.properties.description}```' } },
+                        {
+                            type: 'section',
+                            text: { type: 'mrkdwn', text: '```{substring(event.properties.description, 1, 150)}```' },
+                        },
                         {
                             type: 'context',
                             elements: [
@@ -414,7 +417,10 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     value: [
                         { type: 'header', text: { type: 'plain_text', text: '🔄 {event.properties.name}' } },
                         { type: 'section', text: { type: 'plain_text', text: 'Issue reopened' } },
-                        { type: 'section', text: { type: 'mrkdwn', text: '```{event.properties.description}```' } },
+                        {
+                            type: 'section',
+                            text: { type: 'mrkdwn', text: '```{substring(event.properties.description, 1, 150)}```' },
+                        },
                         {
                             type: 'context',
                             elements: [

--- a/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
+++ b/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
@@ -26,7 +26,10 @@ const DEFAULT_SLACK_INPUTS: Record<string, any> = {
         value: [
             { type: 'header', text: { type: 'plain_text', text: '🔴 {event.properties.name}' } },
             { type: 'section', text: { type: 'plain_text', text: 'New issue created' } },
-            { type: 'section', text: { type: 'mrkdwn', text: '```{event.properties.description}```' } },
+            {
+                type: 'section',
+                text: { type: 'mrkdwn', text: '```{substring(event.properties.description, 1, 150)}```' },
+            },
             {
                 type: 'context',
                 elements: [


### PR DESCRIPTION
## Problem

Reported in https://posthoghelp.zendesk.com/agent/tickets/41650 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/43491)

## Changes

Slack has a max limit on the number of characters that can be included in a text block
