### PR TITLE
chore(dev): Ensure Flox activation in lint-staged

### DIFF
--- a/bin/wrap-in-flox
+++ b/bin/wrap-in-flox
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+if command -v flox &> /dev/null && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
+# If `flox` available, and .flox/cache/ has content, and $FLOX_ENV is empty, activate the environment
+    flox activate -- "$@"
+else
+    # Otherwise, run the command directly
+    "$@"
+fi

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -417,7 +417,11 @@ tools:
         hidden: true
     create:notebook:node:
         bin_script: create-notebook-node.sh
-        description: 'Create a new NotebookNode file and update types and editor references'
+        description: Create a new NotebookNode file and update types and editor references
+        hidden: true
+    wrap:in:flox:
+        bin_script: wrap-in-flox
+        description: 'Runs the provided Bash command with Flox activation guaranteed'
         hidden: true
 utilities:
     utilities:posthog-worktree:

--- a/package.json
+++ b/package.json
@@ -81,16 +81,16 @@
         }
     },
     "lint-staged": {
-        "*.{json,yaml,yml}": "bin/hogli format:yaml",
-        "*.{css,scss}": "bin/hogli format:css",
-        "{playwright,frontend,products,common,ee}/**/*.{js,jsx,mjs,ts,tsx}": "bin/hogli format:js",
-        "plugin-server/**/*.{js,jsx,mjs,ts,tsx}": "bin/hogli format:plugin-server",
-        "funnel-udf/**/*.rs": "bin/hogli format:rust",
+        "*.{json,yaml,yml}": "bin/wrap-in-flox bin/hogli format:yaml",
+        "*.{css,scss}": "bin/wrap-in-flox bin/hogli format:css",
+        "{playwright,frontend,products,common,ee}/**/*.{js,jsx,mjs,ts,tsx}": "bin/wrap-in-flox bin/hogli format:js",
+        "plugin-server/**/*.{js,jsx,mjs,ts,tsx}": "bin/wrap-in-flox bin/hogli format:plugin-server",
+        "funnel-udf/**/*.rs": "bin/wrap-in-flox bin/hogli format:rust",
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
-            "bin/hogli lint:python:fix",
-            "bin/hogli format:python"
+            "bin/wrap-in-flox bin/hogli lint:python:fix",
+            "bin/wrap-in-flox bin/hogli format:python"
         ],
-        "*.{md,mdx}": "bin/hogli format:markdown"
+        "*.{md,mdx}": "bin/wrap-in-flox bin/hogli format:markdown"
     },
     "browserslist": {
         "development": [


### PR DESCRIPTION
## Problem

Since the introduction of `hogli`, I've been unable to use GitHub Desktop to commit, getting an error that my Python venv isn't activated (which is now necessary to lint-staged):

<img width="682" height="135" alt="Screenshot 2025-11-10 at 11 05 28" src="https://github.com/user-attachments/assets/bd801f2c-7c3d-417f-b517-16319a8c8304" />

## Changes

This makes sure that lint-staged runs in a Flox context (which activates the right venv), allowing it to run in GitHub Desktop and other UI clients.

## How did you test this code?

Committed some files.
