### PR TITLE
feat(managed migrations): adding pause / resume to managed migration

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -427,7 +427,7 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     @action(methods=["POST"], detail=True)
-    def pause(self, request: Request, pk=None) -> Response:
+    def pause(self, request: Request, **kwargs) -> Response:
         """Pause a running batch import."""
         batch_import = self.get_object()
 
@@ -444,7 +444,7 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response({"status": "paused"})
 
     @action(methods=["POST"], detail=True)
-    def resume(self, request: Request, pk=None) -> Response:
+    def resume(self, request: Request, **kwargs) -> Response:
         """Resume a paused batch import."""
         batch_import = self.get_object()
 

--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -214,6 +214,7 @@ export function ManagedMigration(): JSX.Element {
 
 export function ManagedMigrations(): JSX.Element {
     const { managedMigrationId, migrations, migrationsLoading } = useValues(managedMigrationLogic)
+    const { pauseMigration, resumeMigration } = useActions(managedMigrationLogic)
 
     const calculateProgress = (migration: ManagedMigration): { progress: number; completed: number; total: number } => {
         if (migration.state?.parts && Array.isArray(migration.state.parts)) {
@@ -398,6 +399,36 @@ export function ManagedMigrations(): JSX.Element {
                                 title: 'Status Message',
                                 dataIndex: 'status_message',
                                 render: (_: any, migration: ManagedMigration) => migration.status_message || '-',
+                            },
+                            {
+                                title: 'Actions',
+                                key: 'actions',
+                                render: (_: any, migration: ManagedMigration) => {
+                                    if (migration.status === 'running') {
+                                        return (
+                                            <LemonButton
+                                                type="secondary"
+                                                size="small"
+                                                onClick={() => pauseMigration(migration.id)}
+                                                loading={migrationsLoading}
+                                            >
+                                                Pause
+                                            </LemonButton>
+                                        )
+                                    } else if (migration.status === 'paused') {
+                                        return (
+                                            <LemonButton
+                                                type="primary"
+                                                size="small"
+                                                onClick={() => resumeMigration(migration.id)}
+                                                loading={migrationsLoading}
+                                            >
+                                                Resume
+                                            </LemonButton>
+                                        )
+                                    }
+                                    return null
+                                },
                             },
                         ]}
                         emptyState="No migrations found. Create a new migration to get started."

--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -57,6 +57,8 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
     }),
     actions({
         editManagedMigration: (id: string | null) => ({ id }),
+        pauseMigration: (id: string) => ({ id }),
+        resumeMigration: (id: string) => ({ id }),
         startPolling: true,
         stopPolling: true,
     }),
@@ -177,6 +179,26 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                 lemonToast.error(error.message)
             } else {
                 lemonToast.error('Failed to create migration. Please try again.')
+            }
+        },
+        pauseMigration: async ({ id }) => {
+            try {
+                const projectId = ApiConfig.getCurrentProjectId()
+                await api.create(`api/projects/${projectId}/managed_migrations/${id}/pause/`)
+                lemonToast.success('Migration paused successfully')
+                actions.loadMigrations()
+            } catch (error: any) {
+                lemonToast.error(error?.message || 'Failed to pause migration')
+            }
+        },
+        resumeMigration: async ({ id }) => {
+            try {
+                const projectId = ApiConfig.getCurrentProjectId()
+                await api.create(`api/projects/${projectId}/managed_migrations/${id}/resume/`)
+                lemonToast.success('Migration resumed successfully')
+                actions.loadMigrations()
+            } catch (error: any) {
+                lemonToast.error(error?.message || 'Failed to resume migration')
             }
         },
         loadMigrationsSuccess: () => {


### PR DESCRIPTION
## Problem
Right now you can't resume a paused migration.

Closes #ISSUE_ID
https://github.com/PostHog/posthog/pull/36003
https://github.com/PostHog/posthog/issues/35994

## Changes

Added a pause/resume button to managed migrations. 
<img width="1269" height="227" alt="image" src="https://github.com/user-attachments/assets/750801e5-15ff-47cb-a5ba-94190ba3e3ec" />


## How did you test this code?
Tested on dev site

## Changelog: (features only) Is this feature complete?

<!-- Optional, but helpful for our content team! -->
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
