### PR TITLE
chore: Basic filters validation in batch exports API

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -351,7 +351,6 @@ class BatchExportSerializer(serializers.ModelSerializer):
     latest_runs = BatchExportRunSerializer(many=True, read_only=True)
     interval = serializers.ChoiceField(choices=BATCH_EXPORT_INTERVALS)
     hogql_query = HogQLSelectQueryField(required=False)
-    filters = serializers.JSONField(required=False, allow_null=True)
 
     class Meta:
         model = BatchExport


### PR DESCRIPTION
## Problem

Filters are not validated when using the batch exports API, we assume that the UI is providing valid filters. This is not the case if users use the API directly. Unfortunately, filters are parsed as the generic `JSONField` instead of a proper type, so we have to write some awkward validation.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Validate that filters are at least of the expected type and don't contain `data_interval_*`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
