### PR TITLE
chore: log tokens missing a team

### DIFF
--- a/rust/cymbal/src/pipeline/prep.rs
+++ b/rust/cymbal/src/pipeline/prep.rs
@@ -6,6 +6,7 @@ use common_types::{
     CapturedEvent, ClickHouseEvent, PersonMode, RawEvent, Team,
 };
 use serde_json::Value;
+use tracing::warn;
 
 use crate::{
     error::{EventError, PipelineFailure, PipelineResult},
@@ -32,6 +33,7 @@ pub fn prepare_events(
                     .expect("Team lookup table is fully populated");
 
                 let Some(team) = maybe_team else {
+                    warn!("Received event for unknown team token: {}", outer.token);
                     buffer.push(Err(EventError::NoTeamForToken(outer.token)));
                     continue;
                 };

--- a/rust/cymbal/src/pipeline/prep.rs
+++ b/rust/cymbal/src/pipeline/prep.rs
@@ -6,7 +6,6 @@ use common_types::{
     CapturedEvent, ClickHouseEvent, PersonMode, RawEvent, Team,
 };
 use serde_json::Value;
-use tracing::warn;
 
 use crate::{
     error::{EventError, PipelineFailure, PipelineResult},
@@ -33,7 +32,6 @@ pub fn prepare_events(
                     .expect("Team lookup table is fully populated");
 
                 let Some(team) = maybe_team else {
-                    warn!("Received event for unknown team token: {}", outer.token);
                     buffer.push(Err(EventError::NoTeamForToken(outer.token)));
                     continue;
                 };

--- a/rust/cymbal/src/teams.rs
+++ b/rust/cymbal/src/teams.rs
@@ -188,10 +188,10 @@ pub async fn do_team_lookups(
         let (indices, task) = (lookup.indices, lookup.inner);
         match task.await.expect("Task was not cancelled") {
             Ok(maybe_team) => {
-                results.insert(token, maybe_team);
                 if maybe_team.is_none() {
                     warn!("Received event for unknown team token: {}", token);
                 }
+                results.insert(token, maybe_team);
             }
             Err(err) => return Err((indices[0], err).into()),
         };

--- a/rust/cymbal/src/teams.rs
+++ b/rust/cymbal/src/teams.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use common_types::{GroupType, Team, TeamId};
 use moka::sync::{Cache, CacheBuilder};
+use tracing::warn;
 
 use crate::{
     app_context::AppContext,
@@ -186,7 +187,12 @@ pub async fn do_team_lookups(
     for (token, lookup) in team_lookups {
         let (indices, task) = (lookup.indices, lookup.inner);
         match task.await.expect("Task was not cancelled") {
-            Ok(maybe_team) => results.insert(token, maybe_team),
+            Ok(maybe_team) => {
+                results.insert(token, maybe_team);
+                if maybe_team.is_none() {
+                    warn!("Received event for unknown team token: {}", token);
+                }
+            }
             Err(err) => return Err((indices[0], err).into()),
         };
     }


### PR DESCRIPTION
## Problem

@oliverb123 pointed out that we've seen a large spike in events being sent for a team token that doesn't seem to be legit. Printing it so that we can get a better insight into whether it's an actual token or a mistake someone is making elsewhere