### PR TITLE
feat(plugin-server): Add WARPSTREAM_PRODUCER kafka config target

### DIFF
--- a/plugin-server/src/kafka/config.ts
+++ b/plugin-server/src/kafka/config.ts
@@ -10,7 +10,7 @@ export const RDKAFKA_LOG_LEVEL_MAPPING = {
     ERROR: 3,
 }
 
-export type KafkaConfigTarget = 'PRODUCER' | 'CONSUMER' | 'CDP_PRODUCER'
+export type KafkaConfigTarget = 'PRODUCER' | 'CONSUMER' | 'CDP_PRODUCER' | 'WARPSTREAM_PRODUCER'
 
 export const getKafkaConfigFromEnv = (prefix: KafkaConfigTarget): GlobalConfig => {
     // NOTE: We have learnt that having as much exposed config to the env as possible is really useful

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -299,7 +299,7 @@ export class SessionRecordingIngester {
 
         // Initialize overflow producer if not consuming from overflow
         if (!this.consumeOverflow) {
-            this.kafkaOverflowProducer = await KafkaProducerWrapper.create(this.hub, 'CONSUMER')
+            this.kafkaOverflowProducer = await KafkaProducerWrapper.create(this.hub, 'WARPSTREAM_PRODUCER')
         }
 
         // Initialize restriction handler with the overflow producer


### PR DESCRIPTION
## Problem

Currently for overflow in recordings-blob-ingestion-v2 we use the `CONSUMER` settings for the kafka producer config. This is wrong as it does not implement the env variables required by Warpstream. 

This PR fixes that by adding a specific configurable kafka config target for Warpstream

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
