### PR TITLE
chore(dev): Ensure Flox activation in pre-commit hook for lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,8 +3,8 @@
 
 # Activate Flox environment if available and not already active
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
-if [ -x /usr/local/bin/flox ] && [ -z "$FLOX_ENV" ]; then
-    exec /usr/local/bin/flox activate -- bash -c "NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
+if command -v flox &> /dev/null && [ -z "$FLOX_ENV" ]; then
+    exec "$(command -v flox)" activate -- bash -c "NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
 fi
 
 # Fallback: run without Flox (for non-Flox users or if already activated)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
 if command -v flox &> /dev/null && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
     exec "$(command -v flox)" activate -- bash -c "NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
+else
+    # Fallback: run without Flox (for non-Flox users or if already activated)
+    NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged
 fi
-
-# Fallback: run without Flox (for non-Flox users or if already activated)
-NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,7 @@
 
 # Activate Flox environment if available and not already active
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
-if command -v flox &> /dev/null && [ -z "$FLOX_ENV" ]; then
+if command -v flox &> /dev/null && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
     exec "$(command -v flox)" activate -- bash -c "NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
 fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# Activate Flox environment if available and not already active
+# This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
+if [ -x /usr/local/bin/flox ] && [ -z "$FLOX_ENV" ]; then
+    exec /usr/local/bin/flox activate -- bash -c "NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
+fi
+
+# Fallback: run without Flox (for non-Flox users or if already activated)
 NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged


### PR DESCRIPTION
Fixes the same issue as #41181 but with a cleaner approach - activates environment at the hook level instead of wrapping each lint-staged command.

**Problem**

GUI Git clients (GitHub Desktop, etc.) fail to commit because they don't inherit the shell environment, so tools like pnpm and hogli aren't available.

**Solution**

Activate Flox once at the pre-commit hook level, before running lint-staged. This ensures:
- GUI clients work without additional setup
- Correct tool versions used (project-specified pnpm 9.15.5, not global)
- Better performance (one activation, not per file pattern)
- Clean lint-staged config (no wrapper scripts needed)

**Gated for Flox users** - checks if flox exists and isn't already active before activating.

Credits to @Twixes for identifying the issue in #41181.

**Test plan**

Tested with Flox deactivated to simulate GUI client environment - commits succeed and lint-staged runs correctly.