### PR TITLE
feat(sessions): Let session backfill dags run for the current day

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -14,6 +14,7 @@ MAX_PARTITIONS_PER_RUN = 30
 daily_partitions = DailyPartitionsDefinition(
     start_date="2019-01-01",  # this is a year before posthog was founded, so should be early enough even including data imports
     timezone="UTC",
+    end_offset=1,  # include today's partition (note that will create a partition with incomplete data, but all our backfills are idempotent so this is ok providing we re-run later)
 )
 
 


### PR DESCRIPTION
## Problem

In the session backfill dags, it's not possible to backfill the current day

## Changes
Inspired by https://github.com/dagster-io/dagster/discussions/19040, change the partition so that it is possible to backfill the current day

## How did you test this code?

can now do this in local dagster

<img width="773" height="573" alt="Screenshot 2025-11-10 at 14 35 32" src="https://github.com/user-attachments/assets/8643255a-f369-4e0e-94f6-c594b4545456" />


## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
