### PR TITLE
fix(workflows): fix state persistence bug on template editor

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -513,7 +513,7 @@ function SaveTemplateModal({
 }
 
 function EmailTemplaterModal(): JSX.Element {
-    const { isModalOpen, isEmailEditorReady, emailTemplateChanged, isSaveTemplateModalOpen } =
+    const { isModalOpen, isEmailEditorReady, emailTemplateChanged, isSaveTemplateModalOpen, editorModified } =
         useValues(emailTemplaterLogic)
     const { closeWithConfirmation, submitEmailTemplate, saveAsTemplate, setIsSaveTemplateModalOpen } =
         useActions(emailTemplaterLogic)
@@ -524,7 +524,7 @@ function EmailTemplaterModal(): JSX.Element {
                 isOpen={isModalOpen}
                 width="90vw"
                 onClose={() => closeWithConfirmation()}
-                hasUnsavedInput={emailTemplateChanged}
+                hasUnsavedInput={emailTemplateChanged || editorModified}
             >
                 <div className="h-[80vh] flex">
                     <div className="flex flex-col flex-1">


### PR DESCRIPTION
## Problem

The email templater had several state management issues that caused unwanted persistence of changes after discarding:

  1. State persistence after discard: When opening the email templater, making edits, and clicking "Discard changes" or closing without saving, the changes would persist when reopening the modal
  2. Template selection persistence: Selecting a template and discarding would still show the template as selected when reopening
  3.  Missing change detection: Visual editor changes (adding/removing elements) weren't triggering the unsaved changes warning

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Use defaultValue instead of value for resetting to ensure original state is restored
- Capture initialState once on mount to prevent intermediate changes from becoming the reset state
- Clear appliedTemplate when modal closes to reset template selection

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
