### PR TITLE
fix: change logs limit from 99 to 100

### DIFF
--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -218,7 +218,7 @@ export const logsLogic = kea<logsLogicType>([
 
                     const response = await api.logs.query({
                         query: {
-                            limit: 99,
+                            limit: 100,
                             offset: values.logs.length,
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,


### PR DESCRIPTION
## Problem

Logs were originally fetching a default limit of 99, instead of 100

## Changes

Switch the default query limit from 99 to 100.

n.b. this will be followed up by dynamic filterable pagination

## How did you test this code?

Tested locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._