### PR TITLE
chore(ph-ai): error tracking prompt improvement

### DIFF
--- a/products/error_tracking/backend/prompts.py
+++ b/products/error_tracking/backend/prompts.py
@@ -26,7 +26,7 @@ Your output schema looks like this:
 ```ts
 export interface ErrorTrackingSceneToolOutput {
     // REQUIRED: REPLACES the existing order key
-    orderBy: 'last_seen' | 'first_seen' | 'occurrences' | 'users' | 'sessions'
+    orderBy: 'last_seen' | 'first_seen' | 'occurrences' | 'users' | 'sessions' | 'revenue'
     // REPLACES the existing order direction
     orderDirection?: 'ASC' | 'DESC'
     // REPLACE the existing status filter

--- a/products/error_tracking/backend/prompts.py
+++ b/products/error_tracking/backend/prompts.py
@@ -25,8 +25,8 @@ following the format below:
 Your output schema looks like this:
 ```ts
 export interface ErrorTrackingSceneToolOutput {
-    // REPLACES the existing order key
-    orderBy?: 'last_seen' | 'first_seen' | 'occurrences' | 'users' | 'sessions'
+    // REQUIRED: REPLACES the existing order key
+    orderBy: 'last_seen' | 'first_seen' | 'occurrences' | 'users' | 'sessions'
     // REPLACES the existing order direction
     orderDirection?: 'ASC' | 'DESC'
     // REPLACE the existing status filter
@@ -89,7 +89,9 @@ export enum PropertyOperator {
 }
 ```
 
-Remember, all items marked optional are optional - only include a new value if:
+**Important**: `orderBy` is REQUIRED and must always be included in your response. If the user doesn't specify a sort order, use the current value from the existing filters.
+
+All other items marked optional are optional - only include a new value if:
 - It's relevant to the user's query.
 - It's not already present in the existing filterGroup
 


### PR DESCRIPTION
## Problem

<img width="1134" height="691" alt="image" src="https://github.com/user-attachments/assets/65e3e0b6-4adc-4196-8816-3b7e748226f2" />

[Error prod link](https://us.posthog.com/project/2/error_tracking/019a57bb-f5b2-7823-adc9-8fddb3595e07?timestamp=2025-11-09T23:16:27.352000-08:00&filterGroup=%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22key%22:%22tag%22,%22value%22:%5B%22max_ai%22%5D,%22operator%22:%22exact%22,%22type%22:%22event%22%7D%5D%7D%5D%7D&dateRange=%7B%22date_from%22:%22-14d%22,%22date_to%22:null%7D)

The error tracking issue filtering tool was failing with a Pydantic validation error:

```
ValidationError: 1 validation error for ErrorTrackingIssueFilteringToolOutput
orderBy
  Field required [type=missing, input_value={'dateRange': {...}, 'explicitDate': True}}, input_type=dict]
```

We had a mismatch between the LLM prompt and the backend schema:
- The prompt defined `orderBy` as optional (`orderBy?:`)
- The backend schema defined `orderBy` as required (`orderBy: OrderBy1`)

When the LLM generated responses without the `orderBy` field, Pydantic validation would fail, causing the tool to crash.

## Changes

* prompt adjustment
	* Changed `orderBy?:` to `orderBy:` to make it required in the TypeScript interface, added explicit instruction that `orderBy` is REQUIRED and must always be included
	* Instructed the LLM to preserve the current value if the user doesn't specify a sort order

## How did you test this code?

- [x] manual tests

**before**:

https://github.com/user-attachments/assets/16e4e9a9-15e4-4c2b-aeb6-c51cfd65b6ab

**after**:

https://github.com/user-attachments/assets/71666aed-70d9-42fd-b6c0-65846c313665
