### PR TITLE
fix(batch-exports): Improve handling of Postgres arrays

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -1195,7 +1195,7 @@ async def insert_into_postgres_activity_from_stage(inputs: PostgresInsertInputs)
                     quote_char='"',
                     escape_char=None,
                     line_terminator="\n",
-                    quoting=csv.QUOTE_MINIMAL,
+                    quoting=csv.QUOTE_STRINGS,
                     include_inserted_at=False,
                     max_file_size_bytes=settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES,
                 )

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/__init__.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+# ensure asserts in the utils module are rewritten by pytest
+# see: https://docs.pytest.org/en/stable/how-to/writing_plugins.html#assertion-rewriting
+pytest.register_assert_rewrite("products.batch_exports.backend.tests.temporal.destinations.postgres.utils")

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/conftest.py
@@ -54,6 +54,8 @@ def test_properties(request, session_id):
             "unicode_null": "\u0000",
             "emoji": "🤣",
             "newline": "\n",
+            # URL with curly braces, which needs to be escaped when converted to a PostgreSQL array.
+            "$current_url": "https://www.posthog.com#link={foo}",
         }
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/test_activity.py
@@ -40,8 +40,8 @@ from products.batch_exports.backend.tests.temporal.utils.persons import (
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.django_db,
-    # While we migrate to the new workflow, we need to test both new and old activities
-    pytest.mark.parametrize("use_internal_stage", [False, True]),
+    # TODO - clean up when we remove the old activity
+    pytest.mark.parametrize("use_internal_stage", [True]),
 ]
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/test_workflow.py
@@ -45,8 +45,8 @@ from products.batch_exports.backend.tests.temporal.utils.workflow import mocked_
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.django_db,
-    # While we migrate to the new workflow, we need to test both new and old activities
-    pytest.mark.parametrize("use_internal_stage", [False, True]),
+    # TODO - clean up when we remove the old activity
+    pytest.mark.parametrize("use_internal_stage", [True]),
 ]
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/utils.py
@@ -168,9 +168,8 @@ async def assert_clickhouse_records_in_postgres(
             expected_record = {}
 
             for k, v in record.items():
-                if k == "_inserted_at" or k == "bq_ingested_timestamp":
+                if k == "_inserted_at":
                     # _inserted_at is not exported, only used for tracking progress.
-                    # bq_ingested_timestamp cannot be compared as it comes from an unstable function.
                     continue
 
                 # Remove \u0000 from strings and bytes (we perform the same operation in the COPY query)


### PR DESCRIPTION
## Problem

Currently our type conversion from Python lists into Postgres arrays is very basic and doesn't handle cases like nested lists or text that includes curly braces.

## Changes

Use `psycopg`'s built-in functions for performing the conversion.

## How did you test this code?

- Added a full end-to-end test case, which uses a `$current_url` with a curly brace in it
- Added some tests to the transformer
