### PR TITLE
feat(sessions): Run sessions backfill from distributed events / replay tables

### DIFF
--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -515,7 +515,6 @@ INSERT INTO {database}.{writable_table}
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(
             where=where,
-            # use sharded_events for the source table, this means that the backfill MUST run on every shard
             source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
         ),
     )

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -501,7 +501,6 @@ INSERT INTO {database}.{writable_table}
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
             where=where,
-            # use sharded_events for the source table, this means that the backfill MUST run on every shard
             source_table=f"{settings.CLICKHOUSE_DATABASE}.events",
         ),
     )

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -502,7 +502,7 @@ INSERT INTO {database}.{writable_table}
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
             where=where,
             # use sharded_events for the source table, this means that the backfill MUST run on every shard
-            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events",
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.events",
         ),
     )
 
@@ -517,7 +517,7 @@ INSERT INTO {database}.{writable_table}
         select_sql=RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(
             where=where,
             # use sharded_events for the source table, this means that the backfill MUST run on every shard
-            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_session_replay_events",
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
         ),
     )
 


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C09BDQLM8KA/p1762795913663899

## Changes

Change the source tables of these backfill jobs to be the distributed tables rather than the sharded tables

## How did you test this code?

We test that the backfill SQL works, but that doesn't really test on a realistic cluster.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
