### PR TITLE
chore: Only allow owners/admins to toggle the new team toggle

### DIFF
--- a/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
+++ b/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
@@ -4,11 +4,12 @@ import { IconInfo } from '@posthog/icons'
 import { LemonButton, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
 
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
+import { useRestrictedArea } from 'lib/components/RestrictedArea'
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
 
@@ -27,10 +28,11 @@ export function ActivityLogSettings(): JSX.Element {
 }
 
 export function ActivityLogOrgLevelSettings(): JSX.Element {
-    const { userLoading } = useValues(userLogic)
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportActivityLogSettingToggled } = useActions(eventUsageLogic)
+
+    const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
 
     const handleToggle = (checked: boolean): void => {
         updateCurrentTeam({ receive_org_level_activity_logs: checked })
@@ -59,7 +61,7 @@ export function ActivityLogOrgLevelSettings(): JSX.Element {
                     id="posthog-activity-log-org-level-switch"
                     onChange={handleToggle}
                     checked={!!currentTeam?.receive_org_level_activity_logs}
-                    disabled={userLoading}
+                    disabledReason={restrictionReason || undefined}
                     label="Receive organization-level activity logs"
                     bordered
                 />

--- a/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
+++ b/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
@@ -43,7 +43,7 @@ export function ActivityLogOrgLevelSettings(): JSX.Element {
         <PayGateMini feature={AvailableFeature.AUDIT_LOGS}>
             <div>
                 <p className="flex items-center gap-1">
-                    Enable organization-level activity logs notifications for this project.
+                    Enable organization-level activity logs for this project.
                     <Tooltip
                         title={
                             <>

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -265,6 +265,9 @@ class ProjectBackwardCompatSerializer(ProjectBackwardCompatBasicSerializer, User
     def validate_session_replay_ai_summary_config(value: dict | None) -> dict | None:
         return TeamSerializer.validate_session_replay_ai_summary_config(value)
 
+    def validate_receive_org_level_activity_logs(self, value: bool | None) -> bool | None:
+        return TeamSerializer.validate_receive_org_level_activity_logs(cast(TeamSerializer, self), value)
+
     def validate(self, attrs: Any) -> Any:
         attrs = validate_team_attrs(attrs, self.context["view"], self.context["request"], self.instance)
         return super().validate(attrs)

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -310,6 +310,9 @@ def team_api_test_factory():
             self.assertEqual(response_data["receive_org_level_activity_logs"], False)
 
         def test_update_receive_org_level_activity_logs(self):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+
             response = self.client.patch("/api/environments/@current/", {"receive_org_level_activity_logs": True})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 


### PR DESCRIPTION
## Problem

- There is a new toggle which enabled teams to receive org-level activity logs. This is now toggable by everyone.
<img width="990" height="436" alt="image" src="https://github.com/user-attachments/assets/7cd32bb3-fa5c-4a7e-84fc-a113a34bb9aa" />


## Changes

- We restrict this to only be editable by admins/owners.

## How did you test this code?

- Unit
