### PR TITLE
fix(ai): Replace "Max can" with "PostHog AI can"

### DIFF
--- a/ee/hogai/README.md
+++ b/ee/hogai/README.md
@@ -127,7 +127,7 @@ For a _lot_ of great detail on prompting, check out the [GPT-4.1 prompting guide
 
 ## Support new query types
 
-Max can now read from frontend context multiple query types like trends, funnels, retention, and HogQL queries. To add support for new query types, you need to extend both the QueryExecutor and the Root node.
+PostHog AI can now read from frontend context multiple query types like trends, funnels, retention, and HogQL queries. To add support for new query types, you need to extend both the QueryExecutor and the Root node.
 
 NOTE: this won't extend query types generation. For that, talk to the Max AI team.
 

--- a/ee/hogai/README.md
+++ b/ee/hogai/README.md
@@ -129,7 +129,7 @@ For a _lot_ of great detail on prompting, check out the [GPT-4.1 prompting guide
 
 PostHog AI can now read from frontend context multiple query types like trends, funnels, retention, and HogQL queries. To add support for new query types, you need to extend both the QueryExecutor and the Root node.
 
-NOTE: this won't extend query types generation. For that, talk to the Max AI team.
+NOTE: this won't extend query types generation. For that, talk to the PostHog AI team.
 
 ### Adding a new query type
 

--- a/frontend/src/scenes/max/Max.stories.tsx
+++ b/frontend/src/scenes/max/Max.stories.tsx
@@ -655,7 +655,7 @@ export const MaxInstanceWithContextualTools: StoryFn = () => {
         registerTool({
             identifier: 'query_insights' as ToolRegistration['identifier'],
             name: 'Query insights',
-            description: 'Max can query insights and their properties',
+            description: 'PostHog AI can query insights and their properties',
             context: {
                 available_insights: ['pageview_trends', 'user_retention', 'conversion_rates'],
                 active_filters: { date_from: '-7d', properties: [{ key: 'browser', value: 'Chrome' }] },
@@ -669,7 +669,7 @@ export const MaxInstanceWithContextualTools: StoryFn = () => {
         registerTool({
             identifier: 'manage_cohorts' as ToolRegistration['identifier'],
             name: 'Manage cohorts',
-            description: 'Max can manage cohorts and their properties',
+            description: 'PostHog AI can manage cohorts and their properties',
             context: {
                 existing_cohorts: [
                     { id: 1, name: 'Power Users', size: 1250 },
@@ -685,7 +685,7 @@ export const MaxInstanceWithContextualTools: StoryFn = () => {
         registerTool({
             identifier: 'feature_flags' as ToolRegistration['identifier'],
             name: 'Feature flags',
-            description: 'Max can manage feature flags and their properties',
+            description: 'PostHog AI can manage feature flags and their properties',
             context: {
                 active_flags: ['new-dashboard', 'beta-feature', 'experiment-checkout'],
                 flag_stats: { total: 15, active: 8, inactive: 7 },

--- a/frontend/src/scenes/max/components/ToolsDisplay.tsx
+++ b/frontend/src/scenes/max/components/ToolsDisplay.tsx
@@ -164,7 +164,7 @@ function TruncatedHorizontalCollection<Children extends React.ReactElement>({
 function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration[] }): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
-    /** Dynamic list of things Max can do right now, i.e. general capabilities + tools registered. */
+    /** Dynamic list of things PostHog AI can do right now, i.e. general capabilities + tools registered. */
     const maxCanHere = useMemo(
         () =>
             (toolsInReverse as { name?: string; description?: string; identifier?: keyof typeof TOOL_DEFINITIONS }[])
@@ -196,7 +196,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                 )),
         [toolsInReverse.map((t) => t.name).join(';')] // eslint-disable-line react-hooks/exhaustive-deps
     )
-    /** Dynamic list of things Max can do elsewhere in PostHog, by product. */
+    /** Dynamic list of things PostHog AI can do elsewhere in PostHog, by product. */
     const maxCanElsewhereByProduct = useMemo(
         () =>
             Object.entries(TOOL_DEFINITIONS)
@@ -220,7 +220,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                 ),
         [toolsInReverse.map((t) => t.name).join(';'), featureFlags] // eslint-disable-line react-hooks/exhaustive-deps
     )
-    /** Dynamic list of things Max can do elsewhere in PostHog, by product. */
+    /** Dynamic list of things PostHog AI can do elsewhere in PostHog, by product. */
     const maxCanElsewhere = useMemo(
         () =>
             Object.entries(maxCanElsewhereByProduct).map(([product, tools]) => (
@@ -244,7 +244,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
     return (
         <>
             <div className="mb-2">
-                <div className="font-semibold mb-0.5">Max can:</div>
+                <div className="font-semibold mb-0.5">PostHog AI can:</div>
                 <ul className="space-y-0.5 text-sm *:flex *:items-start">
                     {maxCanHere.map((item, index) => (
                         <li key={`here-${index}`}>{item}</li>
@@ -255,7 +255,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                 </ul>
             </div>
             <div>
-                <div className="font-semibold mb-0.5">Max can't (yet):</div>
+                <div className="font-semibold mb-0.5">PostHog AI can't (yet):</div>
                 <ul className="space-y-0.5 text-sm *:flex *:items-start">
                     {MAX_GENERALLY_CANNOT.map((item, index) => (
                         <li key={index}>

--- a/frontend/src/scenes/max/components/ToolsDisplay.tsx
+++ b/frontend/src/scenes/max/components/ToolsDisplay.tsx
@@ -165,7 +165,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
     const { featureFlags } = useValues(featureFlagLogic)
 
     /** Dynamic list of things PostHog AI can do right now, i.e. general capabilities + tools registered. */
-    const maxCanHere = useMemo(
+    const currentCapabilities = useMemo(
         () =>
             (toolsInReverse as { name?: string; description?: string; identifier?: keyof typeof TOOL_DEFINITIONS }[])
                 .reduce(
@@ -197,7 +197,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
         [toolsInReverse.map((t) => t.name).join(';')] // eslint-disable-line react-hooks/exhaustive-deps
     )
     /** Dynamic list of things PostHog AI can do elsewhere in PostHog, by product. */
-    const maxCanElsewhereByProduct = useMemo(
+    const capabilitiesByProduct = useMemo(
         () =>
             Object.entries(TOOL_DEFINITIONS)
                 .filter(
@@ -221,9 +221,9 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
         [toolsInReverse.map((t) => t.name).join(';'), featureFlags] // eslint-disable-line react-hooks/exhaustive-deps
     )
     /** Dynamic list of things PostHog AI can do elsewhere in PostHog, by product. */
-    const maxCanElsewhere = useMemo(
+    const productCapabilities = useMemo(
         () =>
-            Object.entries(maxCanElsewhereByProduct).map(([product, tools]) => (
+            Object.entries(capabilitiesByProduct).map(([product, tools]) => (
                 <>
                     <IconArrowRight className="text-base text-secondary shrink-0 ml-1 mr-2 h-[1.25em]" />
                     <span>
@@ -238,7 +238,7 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                     </span>
                 </>
             )),
-        [maxCanElsewhereByProduct]
+        [capabilitiesByProduct]
     )
 
     return (
@@ -246,10 +246,10 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
             <div className="mb-2">
                 <div className="font-semibold mb-0.5">PostHog AI can:</div>
                 <ul className="space-y-0.5 text-sm *:flex *:items-start">
-                    {maxCanHere.map((item, index) => (
+                    {currentCapabilities.map((item, index) => (
                         <li key={`here-${index}`}>{item}</li>
                     ))}
-                    {maxCanElsewhere.map((item, index) => (
+                    {productCapabilities.map((item, index) => (
                         <li key={`elsewhere-${index}`}>{item}</li>
                     ))}
                 </ul>

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -521,7 +521,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
                 content: 'Calculate a conversion rate for <events or actions>…',
             },
         ],
-        tooltip: 'Max can generate insights from natural language and tweak existing ones.',
+        tooltip: 'PostHog AI can generate insights from natural language and tweak existing ones.',
     },
     {
         label: 'SQL',
@@ -532,7 +532,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
             },
         ],
         url: urls.sqlEditor(),
-        tooltip: 'Max can generate SQL queries for your PostHog data, both analytics and the data warehouse.',
+        tooltip: 'PostHog AI can generate SQL queries for your PostHog data, both analytics and the data warehouse.',
     },
     {
         label: 'Session replay',
@@ -543,7 +543,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
             },
         ],
         url: productUrls.replay(),
-        tooltip: 'Max can find session recordings for you.',
+        tooltip: 'PostHog AI can find session recordings for you.',
     },
     {
         label: 'SDK setup',
@@ -571,7 +571,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
                 content: 'How can I set up the product analytics in…',
             },
         ],
-        tooltip: 'Max can help you set up PostHog SDKs in your stack.',
+        tooltip: 'PostHog AI can help you set up PostHog SDKs in your stack.',
     },
     {
         label: 'Surveys',
@@ -591,7 +591,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
             },
         ],
         url: urls.surveys(),
-        tooltip: 'Max can help you create surveys to collect feedback from your users.',
+        tooltip: 'PostHog AI can help you create surveys to collect feedback from your users.',
     },
     {
         label: 'Docs',


### PR DESCRIPTION
## Problem

We still had some cases of "Max" remaining after rebrand. See @corywatilo's Slack thread: https://posthog.slack.com/archives/C06NZEZ7V3Q/p1762800075627849

## Changes

Updates all cases "Max can" to "PostHog AI can" across:
- Frontend UI elements (tooltips, labels)
- Comments
- Documentation
