### PR TITLE
fix: show Endpoint's code examples for insight queries too

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -49,7 +49,7 @@ export function ErrorTrackingScene(): JSX.Element {
 
     useEffect(() => {
         posthog.capture('error_tracking_issues_list_viewed', { active_tab: activeTab })
-    }, [])
+    }, [activeTab])
 
     return (
         <SceneContent>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

code examples were gone fishing when the Endpoint is an InsightQuery

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

bringing sexy back

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
locally

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
no pls