### PR TITLE
chore(flags): Align Redis config with Django pattern

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -296,17 +296,15 @@ services:
             MAXMIND_DB_PATH: '/share/GeoLite2-City.mmdb'
             # Shared Redis for non-critical path (analytics, billing, cookieless)
             REDIS_URL: 'redis://redis:6379/'
-            # Optional: Use separate Redis URLs for read/write separation
+            # Optional: Use separate Redis URL for read replicas
             # REDIS_READER_URL: 'redis://redis-replica:6379/'
-            # REDIS_WRITER_URL: 'redis://redis-primary:6379/'
             # Optional: Increase Redis timeout (default is 100ms)
             # REDIS_TIMEOUT_MS: 200
             # Dedicated Redis database for critical path (team cache + flags cache)
             # Hobby deployments start in Mode 1 (shared-only). Developers override in docker-compose.dev.yml for Mode 2.
             # FLAGS_REDIS_URL: 'redis://redis:6379/1'
-            # Optional: Use separate Flags Redis URLs for read/write separation
+            # Optional: Use separate Flags Redis URL for read replicas
             # FLAGS_REDIS_READER_URL: 'redis://redis-replica:6379/1'
-            # FLAGS_REDIS_WRITER_URL: 'redis://redis-primary:6379/1'
             ADDRESS: '0.0.0.0:3001'
             RUST_LOG: 'info'
             COOKIELESS_REDIS_HOST: redis7

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -193,9 +193,6 @@ pub struct Config {
     #[envconfig(default = "")]
     pub redis_reader_url: String,
 
-    #[envconfig(default = "")]
-    pub redis_writer_url: String,
-
     // Dedicated Redis for feature flags (critical path: team cache + flags cache)
     // When empty, falls back to shared Redis URLs above
     #[envconfig(default = "")]
@@ -203,9 +200,6 @@ pub struct Config {
 
     #[envconfig(default = "")]
     pub flags_redis_reader_url: String,
-
-    #[envconfig(default = "")]
-    pub flags_redis_writer_url: String,
 
     // Controls whether to read from dedicated Redis cache
     // false = Mode 2: dual-write to both caches, read from shared (warming phase)
@@ -465,10 +459,8 @@ impl Config {
             address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
             redis_url: "redis://localhost:6379/".to_string(),
             redis_reader_url: "".to_string(),
-            redis_writer_url: "".to_string(),
             flags_redis_url: "".to_string(),
             flags_redis_reader_url: "".to_string(),
-            flags_redis_writer_url: "".to_string(),
             flags_redis_enabled: FlexBool(false),
             write_database_url: "postgres://posthog:posthog@localhost:5432/test_posthog"
                 .to_string(),
@@ -558,11 +550,7 @@ impl Config {
     }
 
     pub fn get_redis_writer_url(&self) -> &str {
-        if self.redis_writer_url.is_empty() {
-            &self.redis_url
-        } else {
-            &self.redis_writer_url
-        }
+        &self.redis_url
     }
 
     /// Get the Redis URL for flags cache reads (critical path: team cache + flags cache)
@@ -580,9 +568,7 @@ impl Config {
     /// Get the Redis URL for flags cache writes (critical path: team cache + flags cache)
     /// Returns None if dedicated flags Redis is not configured
     pub fn get_flags_redis_writer_url(&self) -> Option<&str> {
-        if !self.flags_redis_writer_url.is_empty() {
-            Some(&self.flags_redis_writer_url)
-        } else if !self.flags_redis_url.is_empty() {
+        if !self.flags_redis_url.is_empty() {
             Some(&self.flags_redis_url)
         } else {
             None

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -50,8 +50,12 @@ where
 {
     // Configure compression based on environment variable
     let compression_config = if *config.redis_compression_enabled {
-        tracing::info!("Redis compression enabled");
-        CompressionConfig::default()
+        let config = CompressionConfig::default();
+        tracing::info!(
+            "Redis compression enabled (threshold: {} bytes)",
+            config.threshold
+        );
+        config
     } else {
         tracing::info!("Redis compression disabled");
         CompressionConfig::disabled()


### PR DESCRIPTION
## Problem

The `REDIS_WRITER_URL` (and `FLAGS_REDIS_WRITER_URL`) are redundant with `REDIS_URL` (and `FLAGS_REDIS_URL`). We don't need them and they just lead to confusion. Not to mention they don't exist on the Django side.

The logic should be if only `REDIS_WRITER_URL` is set, then it's both reader/writer. But if `REDIS_READER_URL` is also set, then that is the reader replica (aka read-only) and `REDIS_WRITER_URL` is the writer client.

Same pattern applies to the `FLAGS_REDIS_*` settings.

Discussed in this [Slack thread](https://posthog.slack.com/archives/C07Q2U4BH4L/p1762797101717419).

## Changes

Remove redundant `REDIS_WRITER_URL` and `FLAGS_REDIS_WRITER_URL` config options to match Django's simpler approach using `REDIS_URL` for writes and optional `REDIS_READER_URL` for read replicas.

## How did you test this code?

Existing Unit Tests.

Manual Testing.

### Other Test Notes:

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
