### PR TITLE
chore: measure person property sizes on write

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -207,3 +207,10 @@ export const personProfileBatchIgnoredPropertiesCounter = new Counter({
     help: 'Count of specific properties that were ignored during person profile updates at batch level',
     labelNames: ['property'],
 })
+
+export const personJsonFieldSizeHistogram = new Histogram({
+    name: 'person_json_field_size_bytes',
+    help: 'Approximate size in bytes of serialized JSON fields (using string length as proxy for performance)',
+    labelNames: ['operation', 'field'], // operation: createPerson, updatePerson; field: properties, properties_last_updated_at, properties_last_operation
+    buckets: [100, 500, 1024, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576], // 100B, 500B, 1KB, 4KB, 8KB, 16KB, 32KB, 64KB, 128KB, 256KB, 512KB, 1MB
+})

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -349,15 +349,21 @@ export class PostgresPersonRepository
             const sanitizedPropertiesLastOperation = sanitizeJsonbValue(propertiesLastOperation)
 
             // Record JSON field sizes (using string length as approximation)
-            personJsonFieldSizeHistogram
-                .labels({ operation: 'createPerson', field: 'properties' })
-                .observe(sanitizedProperties.length)
-            personJsonFieldSizeHistogram
-                .labels({ operation: 'createPerson', field: 'properties_last_updated_at' })
-                .observe(sanitizedPropertiesLastUpdatedAt.length)
-            personJsonFieldSizeHistogram
-                .labels({ operation: 'createPerson', field: 'properties_last_operation' })
-                .observe(sanitizedPropertiesLastOperation.length)
+            if (typeof sanitizedProperties === 'string') {
+                personJsonFieldSizeHistogram
+                    .labels({ operation: 'createPerson', field: 'properties' })
+                    .observe(sanitizedProperties.length)
+            }
+            if (typeof sanitizedPropertiesLastUpdatedAt === 'string') {
+                personJsonFieldSizeHistogram
+                    .labels({ operation: 'createPerson', field: 'properties_last_updated_at' })
+                    .observe(sanitizedPropertiesLastUpdatedAt.length)
+            }
+            if (typeof sanitizedPropertiesLastOperation === 'string') {
+                personJsonFieldSizeHistogram
+                    .labels({ operation: 'createPerson', field: 'properties_last_operation' })
+                    .observe(sanitizedPropertiesLastOperation.length)
+            }
 
             const baseParams = [
                 createdAt.toISO(),


### PR DESCRIPTION
## Problem

We don't have any instrumentation on property sizes for person inserts and updates.

## Changes

Adds approximate metrics based on the pre-postgres-encoded JSON blobs.

## How did you test this code?

Added unit tests.