### PR TITLE
feat: Subscriptions to resource/object activity logs

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -141,55 +141,77 @@ export const SidePanelActivity = (): JSX.Element => {
                                     <LemonMenu
                                         placement="bottom-start"
                                         items={
-                                            HOG_FUNCTION_SUB_TEMPLATES['activity-log'].map((subTemplate) => {
-                                                // Build property filters based on context
-                                                const properties: CyclotronJobFilterPropertyFilter[] = [
-                                                    {
-                                                        key: 'scope',
-                                                        type: PropertyFilterType.Event,
-                                                        value: contextFromPage!.scope!,
-                                                        operator: PropertyOperator.Exact,
-                                                    },
-                                                ]
+                                            [
+                                                {
+                                                    items: HOG_FUNCTION_SUB_TEMPLATES['activity-log'].map(
+                                                        (subTemplate) => {
+                                                            // Build property filters based on context
+                                                            const properties: CyclotronJobFilterPropertyFilter[] = [
+                                                                {
+                                                                    key: 'scope',
+                                                                    type: PropertyFilterType.Event,
+                                                                    value: contextFromPage!.scope!,
+                                                                    operator: PropertyOperator.Exact,
+                                                                },
+                                                            ]
 
-                                                // If we have item_id, add it to filters
-                                                if (hasItemContext) {
-                                                    properties.push({
-                                                        key: 'item_id',
-                                                        type: PropertyFilterType.Event,
-                                                        value: contextFromPage!.item_id,
-                                                        operator: PropertyOperator.Exact,
-                                                    })
-                                                }
+                                                            // If we have item_id, add it to filters
+                                                            if (hasItemContext) {
+                                                                properties.push({
+                                                                    key: 'item_id',
+                                                                    type: PropertyFilterType.Event,
+                                                                    value: contextFromPage!.item_id,
+                                                                    operator: PropertyOperator.Exact,
+                                                                })
+                                                            }
 
-                                                // Create filters with properties at the top level
-                                                // HogFunctionFiltersInternal expects filters.properties, not filters.events[0].properties
-                                                const filters = {
-                                                    events: subTemplate.filters?.events || [],
-                                                    properties,
-                                                }
+                                                            // Create filters with properties at the top level
+                                                            // HogFunctionFiltersInternal expects filters.properties, not filters.events[0].properties
+                                                            const filters = {
+                                                                events: subTemplate.filters?.events || [],
+                                                                properties,
+                                                            }
 
-                                                const configurationOverrides = { filters }
+                                                            const configurationOverrides = { filters }
 
-                                                const configuration: Record<string, any> = {
-                                                    ...subTemplate,
-                                                    ...configurationOverrides,
-                                                }
+                                                            const configuration: Record<string, any> = {
+                                                                ...subTemplate,
+                                                                ...configurationOverrides,
+                                                            }
 
-                                                const url = combineUrl(
-                                                    urls.hogFunctionNew(subTemplate.template_id),
-                                                    {},
-                                                    { configuration }
-                                                ).url
+                                                            const url = combineUrl(
+                                                                urls.hogFunctionNew(subTemplate.template_id),
+                                                                {},
+                                                                { configuration }
+                                                            ).url
 
-                                                return {
-                                                    label: subTemplate.name || 'Subscribe',
-                                                    onClick: () => {
-                                                        closeSidePanel()
-                                                        router.actions.push(url)
-                                                    },
-                                                }
-                                            }) as LemonMenuItems
+                                                            return {
+                                                                label: subTemplate.name || 'Subscribe',
+                                                                onClick: () => {
+                                                                    closeSidePanel()
+                                                                    router.actions.push(url)
+                                                                },
+                                                            }
+                                                        }
+                                                    ),
+                                                },
+                                                {
+                                                    items: [
+                                                        {
+                                                            label: 'View all notifications',
+                                                            onClick: () => {
+                                                                closeSidePanel()
+                                                                router.actions.push(
+                                                                    urls.settings(
+                                                                        'environment-activity-logs',
+                                                                        'activity-log-notifications'
+                                                                    )
+                                                                )
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ] as LemonMenuItems
                                         }
                                     >
                                         <LemonButton size="xsmall" type="secondary" tooltip="Subscribe">

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -25,7 +25,7 @@ import {
 } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic'
 import { sidePanelNotificationsLogic } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
-import { AvailableFeature, PropertyFilterType, PropertyOperator } from '~/types'
+import { AvailableFeature, CyclotronJobFilterPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { SidePanelPaneHeader } from '../../components/SidePanelPaneHeader'
 import { SidePanelActivityMetalytics } from './SidePanelActivityMetalytics'
@@ -143,7 +143,7 @@ export const SidePanelActivity = (): JSX.Element => {
                                         items={
                                             HOG_FUNCTION_SUB_TEMPLATES['activity-log'].map((subTemplate) => {
                                                 // Build property filters based on context
-                                                const properties: any[] = [
+                                                const properties: CyclotronJobFilterPropertyFilter[] = [
                                                     {
                                                         key: 'scope',
                                                         type: PropertyFilterType.Event,
@@ -153,7 +153,7 @@ export const SidePanelActivity = (): JSX.Element => {
                                                 ]
 
                                                 // If we have item_id, add it to filters
-                                                if (hasItemContext && contextFromPage!.item_id) {
+                                                if (hasItemContext) {
                                                     properties.push({
                                                         key: 'item_id',
                                                         type: PropertyFilterType.Event,
@@ -169,7 +169,6 @@ export const SidePanelActivity = (): JSX.Element => {
                                                     properties,
                                                 }
 
-                                                // Configuration overrides to merge with subTemplate (like urlForTemplate does)
                                                 const configurationOverrides = { filters }
 
                                                 const configuration: Record<string, any> = {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -1,8 +1,9 @@
 import { useActions, useValues } from 'kea'
+import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconList, IconNotification } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
+import { IconBell, IconList, IconNotification } from '@posthog/icons'
+import { LemonButton, LemonMenu, LemonSkeleton, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
 
 import { ActivityLogRow } from 'lib/components/ActivityLog/ActivityLog'
 import { humanizeScope } from 'lib/components/ActivityLog/humanizeActivity'
@@ -11,8 +12,10 @@ import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { LemonMenuItems } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { IconWithCount } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { HOG_FUNCTION_SUB_TEMPLATES } from 'scenes/hog-functions/sub-templates/sub-templates'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -22,11 +25,10 @@ import {
 } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic'
 import { sidePanelNotificationsLogic } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
-import { AvailableFeature } from '~/types'
+import { AvailableFeature, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { SidePanelPaneHeader } from '../../components/SidePanelPaneHeader'
 import { SidePanelActivityMetalytics } from './SidePanelActivityMetalytics'
-import { SidePanelActivitySubscriptions } from './SidePanelActivitySubscriptions'
 
 const SCROLL_TRIGGER_OFFSET = 100
 
@@ -111,14 +113,6 @@ export const SidePanelActivity = (): JSX.Element => {
                                           },
                                       ]
                                     : []),
-                                ...(featureFlags[FEATURE_FLAGS.CDP_ACTIVITY_LOG_NOTIFICATIONS]
-                                    ? [
-                                          {
-                                              key: SidePanelActivityTab.Subscriptions,
-                                              label: 'Subscriptions',
-                                          },
-                                      ]
-                                    : []),
                             ]}
                         />
                     </div>
@@ -136,13 +130,74 @@ export const SidePanelActivity = (): JSX.Element => {
                         </div>
                     ) : activeTab === SidePanelActivityTab.All && hasAnyContext ? (
                         <div className="flex items-center justify-between gap-2 px-2 pb-2 deprecated-space-y-2">
-                            <div>
+                            <div className="flex items-center gap-1">
                                 Activity on{' '}
                                 <strong>
                                     {hasItemContext
                                         ? `this ${humanizeScope(contextFromPage!.scope!, true).toLowerCase()}`
                                         : `all ${humanizeScope(contextFromPage!.scope!).toLowerCase()}`}{' '}
                                 </strong>
+                                {featureFlags[FEATURE_FLAGS.CDP_ACTIVITY_LOG_NOTIFICATIONS] && (
+                                    <LemonMenu
+                                        placement="bottom-start"
+                                        items={
+                                            HOG_FUNCTION_SUB_TEMPLATES['activity-log'].map((subTemplate) => {
+                                                // Build property filters based on context
+                                                const properties: any[] = [
+                                                    {
+                                                        key: 'scope',
+                                                        type: PropertyFilterType.Event,
+                                                        value: contextFromPage!.scope!,
+                                                        operator: PropertyOperator.Exact,
+                                                    },
+                                                ]
+
+                                                // If we have item_id, add it to filters
+                                                if (hasItemContext && contextFromPage!.item_id) {
+                                                    properties.push({
+                                                        key: 'item_id',
+                                                        type: PropertyFilterType.Event,
+                                                        value: contextFromPage!.item_id,
+                                                        operator: PropertyOperator.Exact,
+                                                    })
+                                                }
+
+                                                // Create filters with properties at the top level
+                                                // HogFunctionFiltersInternal expects filters.properties, not filters.events[0].properties
+                                                const filters = {
+                                                    events: subTemplate.filters?.events || [],
+                                                    properties,
+                                                }
+
+                                                // Configuration overrides to merge with subTemplate (like urlForTemplate does)
+                                                const configurationOverrides = { filters }
+
+                                                const configuration: Record<string, any> = {
+                                                    ...subTemplate,
+                                                    ...configurationOverrides,
+                                                }
+
+                                                const url = combineUrl(
+                                                    urls.hogFunctionNew(subTemplate.template_id),
+                                                    {},
+                                                    { configuration }
+                                                ).url
+
+                                                return {
+                                                    label: subTemplate.name || 'Subscribe',
+                                                    onClick: () => {
+                                                        closeSidePanel()
+                                                        router.actions.push(url)
+                                                    },
+                                                }
+                                            }) as LemonMenuItems
+                                        }
+                                    >
+                                        <LemonButton size="xsmall" type="secondary" tooltip="Subscribe">
+                                            <IconBell />
+                                        </LemonButton>
+                                    </LemonMenu>
+                                )}
                             </div>
                             <MemberSelect
                                 value={activeFilters?.user ?? null}
@@ -270,8 +325,6 @@ export const SidePanelActivity = (): JSX.Element => {
                                 )
                             ) : activeTab === SidePanelActivityTab.Metalytics ? (
                                 <SidePanelActivityMetalytics />
-                            ) : activeTab === SidePanelActivityTab.Subscriptions ? (
-                                <SidePanelActivitySubscriptions />
                             ) : null}
                         </ScrollableShadows>
                     </div>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -42,7 +42,6 @@ export enum SidePanelActivityTab {
     Unread = 'unread',
     All = 'all',
     Metalytics = 'metalytics',
-    Subscriptions = 'subscriptions',
 }
 
 export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([


### PR DESCRIPTION

## Changes

- Retire Subscriptions tab on the Team Activity sidebar tab. 
- Add a way to subscribe to a resource type alogs or to a specific item alogs via the Activity tab on the sidebar.

Note: To test this you need:
1) To have Scale+ platform addon
2) To have `posthog.featureFlags.override({'cdp-activity-log-notifications': true})` (currently only available to PostHog team).

<img width="494" height="302" alt="image" src="https://github.com/user-attachments/assets/27242050-35c3-4634-8776-11d20bdb2ab3" />

<img width="442" height="302" alt="image" src="https://github.com/user-attachments/assets/5a1689a3-2186-4d96-9710-7979334a8bd7" />


## How did you test this code?

- Manually

## Changelog: (features only) Is this feature complete?

- Users can now subscribe to resource activity logs (e.g. while on the Dashboards, subscribe to ALL dashboard activity log) or to specific items activity logs (e.g. while on the Dashboard ID XXX page, subscribe to that specific dashboards activity logs).
