### PR TITLE
fix(auth): no reauth when changing org

### DIFF
--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -31,9 +31,10 @@ from posthog.auth import OAuthAccessTokenAuthentication, ProjectSecretAPIKeyAuth
 from posthog.models import User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
-from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal
 
 VALID_TEST_PASSWORD = "mighty-strong-secure-1337!!"
@@ -1031,6 +1032,26 @@ class TestTimeSensitivePermissions(APIBaseTest):
                 {"theme_mode": "system", "first_name": "still protected"},
             )
             assert res.status_code == 403
+
+    def test_user_can_switch_organization_without_recent_authentication(self):
+        new_org = Organization.objects.create(name="Switch Org")
+        Team.objects.create(organization=new_org, name="Switch Team")
+        OrganizationMembership.objects.create(organization=new_org, user=self.user)
+
+        now = datetime.now()
+        with freeze_time(now):
+            res = self.client.patch(
+                "/api/users/@me",
+                {"set_current_organization": str(new_org.id)},
+            )
+            assert res.status_code == 200
+
+        with freeze_time(now + timedelta(seconds=settings.SESSION_SENSITIVE_ACTIONS_AGE + 10)):
+            res = self.client.patch(
+                "/api/users/@me",
+                {"set_current_organization": str(self.organization.id)},
+            )
+            assert res.status_code == 200
 
 
 class TestProjectSecretAPIKeyAuthentication(APIBaseTest):

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -419,7 +419,7 @@ class UserViewSet(
         UserNoOrgMembershipDeletePermission,
         TimeSensitiveActionPermission,
     ]
-    time_sensitive_allow_if_only_fields = ["theme_mode"]
+    time_sensitive_allow_if_only_fields = ["theme_mode", "set_current_organization"]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["is_staff", "email"]
     queryset = User.objects.filter(is_active=True)


### PR DESCRIPTION
## Problem

We get a reauth modal when changing orgs.

https://posthog.slack.com/archives/C08499A7REU/p1762809282125559?thread_ts=1762399856.737619&cid=C08499A7REU

<img width="533" height="266" alt="image" src="https://github.com/user-attachments/assets/e5c6ef20-37dd-4518-82c3-1bfa0056606b" />


## Changes

Makes it so that you don't need to enter a password to change orgs.

## How did you test this code?

Clicked locally with and without the change. Got the dialog and didn't get the dialog.
