### PR TITLE
feat: Cleanup growth error tracking

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -213,7 +213,6 @@ class SetupWizardViewSet(viewsets.ViewSet):
                     {
                         "model": model,
                         "ai_product": "wizard",
-                        "team": "growth",
                     },
                 )
                 raise error
@@ -251,7 +250,6 @@ class SetupWizardViewSet(viewsets.ViewSet):
                     {
                         "model": model,
                         "ai_product": "wizard",
-                        "team": "growth",
                         "trace_id": trace_id,
                         "distinct_id": distinct_id,
                     },
@@ -302,7 +300,6 @@ class SetupWizardViewSet(viewsets.ViewSet):
                     {
                         "model": model,
                         "ai_product": "wizard",
-                        "team": "growth",
                         "trace_id": trace_id,
                         "distinct_id": distinct_id,
                         "response_content": result.choices[0].message.content[:500]
@@ -358,7 +355,6 @@ class SetupWizardViewSet(viewsets.ViewSet):
                     "user_id": request.user.id if request.user else None,
                     "user_distinct_id": request.user.distinct_id if request.user else None,
                     "ai_product": "wizard",
-                    "team": "growth",
                 },
             )
             raise serializers.ValidationError({"projectId": [ERROR_PROJECT_NOT_FOUND]}, code="not_found")

--- a/products/mcp/typescript/src/integrations/mcp/utils/handleToolError.ts
+++ b/products/mcp/typescript/src/integrations/mcp/utils/handleToolError.ts
@@ -42,6 +42,7 @@ export class MCPToolError extends Error {
  * @param tool - Tool that caused the error.
  * @param distinctId - User's distinct ID for tracking.
  * @param sessionId - Session UUID for tracking.
+ *
  * @returns A structured error message.
  */
 export function handleToolError(
@@ -63,7 +64,7 @@ export function handleToolError(
         team: 'growth',
         tool: mcpError.tool,
         is_mcp_tool_error: error instanceof MCPToolError,
-        $exception_fingerprint: `${mcpError.tool}-${mcpError.message}`,
+        $exception_fingerprint: mcpError.tool,
     }
 
     if (sessionUuid) {

--- a/products/mcp/typescript/src/integrations/mcp/utils/handleToolError.ts
+++ b/products/mcp/typescript/src/integrations/mcp/utils/handleToolError.ts
@@ -62,6 +62,7 @@ export function handleToolError(
     const properties: Record<string, any> = {
         team: 'growth',
         tool: mcpError.tool,
+        is_mcp_tool_error: error instanceof MCPToolError,
         $exception_fingerprint: `${mcpError.tool}-${mcpError.message}`,
     }
 

--- a/products/mcp/typescript/src/lib/utils/SessionManager.ts
+++ b/products/mcp/typescript/src/lib/utils/SessionManager.ts
@@ -10,13 +10,12 @@ export class SessionManager {
         this.cache = cache
     }
 
-    async _getKey(sessionId: string): Promise<PrefixedString<'session'>> {
+    _getKey(sessionId: string): PrefixedString<'session'> {
         return `session:${sessionId}`
     }
 
     async getSessionUuid(sessionId: string): Promise<string> {
-        const key = await this._getKey(sessionId)
-
+        const key = this._getKey(sessionId)
         const existingSession = await this.cache.get(key)
 
         if (existingSession?.uuid) {
@@ -24,7 +23,6 @@ export class SessionManager {
         }
 
         const newSessionUuid = uuidv7()
-
         await this.cache.set(key, { uuid: newSessionUuid })
 
         return newSessionUuid


### PR DESCRIPTION
We're tracking more stuff than we need. See commit by commit.

CC @daniloc I'm removing the `team` key from growth events. These events were going to #alerts-growth in Slack but you'll need to configure a new one if you still wanna see them