### PR TITLE
chore: Add validation for request path and query params.

### DIFF
--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -43,7 +43,6 @@ def validated_request(
     request_serializer: type[serializers.Serializer] | None = None,
     *,
     query_serializer: type[serializers.Serializer] | None = None,
-    path_serializer: type[serializers.Serializer] | None = None,
     responses: dict[int, OpenApiResponse | None] | None = None,
     summary: str | None = None,
     description: str | None = None,
@@ -60,7 +59,6 @@ def validated_request(
         @validated_request(
             request_serializer=RequestBodySerializer,
             query_serializer=QuerySerializer,
-            path_serializer=PathSerializer,
             responses={
                 200: Response(response=SuccessResponseSerializer, ...),
             },
@@ -68,15 +66,13 @@ def validated_request(
         )
         def my_action(self, request: Request, **kwargs):
             # request.validated_data contains validated body data (if request_serializer provided)
-            # Query and path params are validated but not mutated
+            # Query params are validated but not mutated
     """
 
     def decorator(view_func: Callable) -> Callable:
         parameters = []
         if query_serializer is not None:
             parameters.append(query_serializer)
-        if path_serializer is not None:
-            parameters.append(path_serializer)
 
         @extend_schema(
             request=request_serializer,
@@ -93,10 +89,6 @@ def validated_request(
             if query_serializer is not None:
                 query_serializer_instance = query_serializer(data=request.query_params)
                 query_serializer_instance.is_valid(raise_exception=True)
-
-            if path_serializer is not None:
-                path_serializer_instance = path_serializer(data=kwargs)
-                path_serializer_instance.is_valid(raise_exception=True)
 
             if request_serializer is not None:
                 serializer = request_serializer(data=request.data)

--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -20,15 +20,6 @@ logger = structlog.get_logger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
-class ValidatedRequest(Request):
-    """
-    Request with validated_data attribute.
-    This is set by the @validated_request decorator when request_serializer is provided.
-    """
-
-    validated_data: dict[str, Any]
-
-
 # Generic Pydantic model mixin for validating the response data
 class PydanticModelMixin:
     def get_model(self, data: dict, model: type[T]) -> T:
@@ -42,6 +33,8 @@ class PydanticModelMixin:
 def validated_request(
     request_serializer: type[serializers.Serializer] | None = None,
     *,
+    query_serializer: type[serializers.Serializer] | None = None,
+    path_serializer: type[serializers.Serializer] | None = None,
     responses: dict[int, OpenApiResponse | None] | None = None,
     summary: str | None = None,
     description: str | None = None,
@@ -49,62 +42,77 @@ def validated_request(
     deprecated: bool = False,
     strict_request_validation: bool = True,
     strict_response_validation: bool = False,
-    **extend_schema_kwargs,
 ) -> Callable:
     """
     Takes req/res serializers and validates against them.
 
     Usage:
         @validated_request(
-            request_serializer=RequestSerializer,
+            request_serializer=RequestBodySerializer,
+            query_serializer=QuerySerializer,
+            path_serializer=PathSerializer,
             responses={
                 200: Response(response=SuccessResponseSerializer, ...),
-                400: Response(response=InvalidRequestResponseSerializer, ...),
             },
             summary="Do something"
         )
-        def my_action(self, request: ValidatedRequest, **kwargs):
-            # When request_serializer is provided, request.validated_data is available
-            request_data = request.validated_data.get("next_stage_id")
-
-            if not request_data:
-                return Response(
-                    ErrorResponseSerializer({"error": "Invalid request"}).data,
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            return Response(SuccessResponseSerializer(request_data, context=self.get_serializer_context()).data)
-
-    Note: Use ValidatedRequest type hint when you need to access request.validated_data.
-    The decorator will set validated_data on the request when request_serializer is provided.
+        def my_action(self, request: Request, **kwargs):
+            # request.data contains validated body data (mutated)
+            # request.query_params contains validated query params (mutated)
+            # kwargs contains validated path params (mutated)
+            # DRF mixins automatically use validated data
     """
 
     def decorator(view_func: Callable) -> Callable:
+        parameters = []
+        if query_serializer is not None:
+            parameters.append(query_serializer)
+        if path_serializer is not None:
+            parameters.append(path_serializer)
+
         @extend_schema(
             request=request_serializer,
+            parameters=parameters if parameters else None,
             responses=responses,
             summary=summary,
             description=description,
             tags=tags,
             deprecated=deprecated,
-            **extend_schema_kwargs,
         )
         @wraps(view_func)
         def wrapper(self, request: Request, *args, **kwargs) -> Response:
+            if query_serializer is not None:
+                query_serializer_instance = query_serializer(data=request.query_params)
+                query_serializer_instance.is_valid(raise_exception=strict_request_validation)
+
+                validated_query_data = query_serializer_instance.validated_data
+                from django.http import QueryDict
+
+                validated_query_dict = QueryDict("", mutable=True)
+                validated_query_dict.update(validated_query_data)
+                request._request.GET = validated_query_dict
+
+            if path_serializer is not None:
+                path_serializer_instance = path_serializer(data=kwargs)
+                path_serializer_instance.is_valid(raise_exception=strict_request_validation)
+
+                # Mutate kwargs directly
+                kwargs.update(path_serializer_instance.validated_data)
+
             if request_serializer is not None:
                 serializer = request_serializer(data=request.data)
                 req_validation_result = serializer.is_valid(raise_exception=strict_request_validation)
 
                 if not req_validation_result and settings.DEBUG:
                     logger.warning(
-                        "Request data does not match declared serializer in @validated_request decorator. Please update the provided API schema to ensure API docs remain up to date",
+                        "Request body does not match declared serializer in @validated_request decorator. Please update the provided API schema to ensure API docs remain up to date",
                         view_func=view_func.__name__,
                         serializer_class=request_serializer.__name__,
                         validation_errors=serializer.errors,
                     )
 
-                # Cast to ValidatedRequest and set validated_data attribute
-                validated_request = cast(ValidatedRequest, request)
-                validated_request.validated_data = serializer.validated_data
+                # Mutate request.data so DRF mixins consume validated data
+                request._full_data = serializer.validated_data
 
             result = view_func(self, request, *args, **kwargs)
 

--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -51,6 +51,7 @@ def validated_request(
     deprecated: bool = False,
     strict_request_validation: bool = True,
     strict_response_validation: bool = False,
+    **extend_schema_kwargs,
 ) -> Callable:
     """
     Takes req/res serializers and validates against them.
@@ -85,6 +86,7 @@ def validated_request(
             description=description,
             tags=tags,
             deprecated=deprecated,
+            **extend_schema_kwargs,
         )
         @wraps(view_func)
         def wrapper(self, request: Request, *args, **kwargs) -> Response:

--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -110,7 +110,8 @@ def validated_request(
                         validation_errors=serializer.errors,
                     )
 
-                request.validated_data = serializer.validated_data
+                validated_request = cast(ValidatedRequest, request)
+                validated_request.validated_data = serializer.validated_data
 
             result = view_func(self, request, *args, **kwargs)
 

--- a/posthog/api/test/test_mixins.py
+++ b/posthog/api/test/test_mixins.py
@@ -41,7 +41,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
             },
         )
         def mock_endpoint(view_self, request):
-            distinct_id = request.validated_data["distinct_id"]
+            distinct_id = request.data["distinct_id"]
             return Response(
                 {
                     "status": "ok",
@@ -55,6 +55,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance.get_serializer_context = Mock(return_value={})
 
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {
             "event": "$pageview",
             "distinct_id": "user_123",
@@ -66,7 +67,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.data["status"] == "ok"
         assert response.data["distinct_id"] == "user_123"
-        assert mock_request.validated_data["event"] == "$pageview"
+        assert mock_request.data["event"] == "$pageview"
 
     def test_request_validation_with_missing_required_field(self):
         """Missing required field, should raise validation error"""
@@ -82,6 +83,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         view_instance = Mock()
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview"}  # Missing 'distinct_id'
 
         with pytest.raises(Exception) as exc_info:
@@ -108,6 +110,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         response = mock_endpoint(view_instance, mock_request)
@@ -134,6 +137,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         # Should log a warning and return the response
@@ -172,6 +176,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         # Should log a warning and return the response
@@ -207,6 +212,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         view_instance = Mock()
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         response = mock_endpoint(view_instance, mock_request)
@@ -230,6 +236,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         # Should log a warning and return the result
@@ -269,6 +276,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         # Test with DEBUG=False (production mode)
@@ -310,6 +318,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         # Should raise ValidationError regardless of DEBUG setting
@@ -336,6 +345,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         # Should raise ValidationError with serializer errors
@@ -361,7 +371,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
                 {
                     "status": "ok",
                     "event_id": str(uuid.uuid4()),
-                    "distinct_id": request.validated_data["distinct_id"],
+                    "distinct_id": request.data["distinct_id"],
                 },
                 status=status.HTTP_200_OK,
             )
@@ -369,6 +379,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
 
         # Should work normally with valid data
@@ -402,6 +413,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview"}  # Missing required 'distinct_id'
 
         # Should log a warning but not raise
@@ -414,7 +426,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
                 mock_logger.warning.assert_called_once()
                 call_args = mock_logger.warning.call_args
                 assert (
-                    "Request data does not match declared serializer in @validated_request decorator. Please update the provided API schema to ensure API docs remain up to date"
+                    "Request body does not match declared serializer in @validated_request decorator. Please update the provided API schema to ensure API docs remain up to date"
                     in call_args[0][0]
                 )
                 assert call_args[1]["view_func"] == "mock_endpoint"
@@ -439,7 +451,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
                 {
                     "status": "ok",
                     "event_id": str(uuid.uuid4()),
-                    "distinct_id": request.validated_data.get("distinct_id", "unknown"),
+                    "distinct_id": request.data.get("distinct_id", "unknown"),
                 },
                 status=status.HTTP_200_OK,
             )
@@ -447,6 +459,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {"event": "$pageview"}  # Missing required 'distinct_id'
 
         # Should not log warning when DEBUG=False
@@ -472,7 +485,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
             strict_request_validation=False,
         )
         def mock_endpoint(view_self, request):
-            distinct_id = request.validated_data["distinct_id"]
+            distinct_id = request.data["distinct_id"]
             return Response(
                 {
                     "status": "ok",
@@ -485,6 +498,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         view_instance = Mock()
         view_instance.get_serializer_context = Mock(return_value={})
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {
             "event": "$pageview",
             "distinct_id": "user_123",
@@ -497,7 +511,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.data["status"] == "ok"
         assert response.data["distinct_id"] == "user_123"
-        assert mock_request.validated_data["event"] == "$pageview"
+        assert mock_request.data["event"] == "$pageview"
 
     def test_no_body_response_declared_as_none_succeeds(self):
         """When status code is declared as None (no body), response with no body should succeed"""
@@ -512,6 +526,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         view_instance = Mock()
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {}
 
         response = mock_endpoint(view_instance, mock_request)
@@ -532,6 +547,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         view_instance = Mock()
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {}
 
         with patch("posthog.api.mixins.settings") as mock_settings:
@@ -563,9 +579,214 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         view_instance = Mock()
         mock_request = Mock()
+        mock_request._full_data = {}
         mock_request.data = {}
 
         with pytest.raises(serializers.ValidationError) as exc_info:
             mock_endpoint(view_instance, mock_request)
 
         assert "Response status code 204 is declared with no body, but response contains data" in str(exc_info.value)
+
+    def test_query_parameter_validation_with_valid_data(self):
+        """Query parameter validation: valid query params should work"""
+
+        class QueryParamSerializer(serializers.Serializer):
+            page = serializers.IntegerField(required=False, default=1)
+            limit = serializers.IntegerField(required=False, default=10, max_value=100)
+
+        @validated_request(
+            query_serializer=QueryParamSerializer,
+            responses={
+                200: OpenApiResponse(response=EventCaptureResponseSerializer),
+            },
+        )
+        def mock_endpoint(view_self, request, **kwargs):
+            page = request.query_params.get("page", 1)
+            limit = request.query_params.get("limit", 10)
+            return Response(
+                {
+                    "status": "ok",
+                    "event_id": str(uuid.uuid4()),
+                    "distinct_id": "test",
+                    "page": int(page),
+                    "limit": int(limit),
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {}
+        from django.http import QueryDict
+
+        mock_get = QueryDict("page=2&limit=20")
+        mock_request._request = Mock()
+        mock_request._request.GET = mock_get
+        mock_request.query_params = mock_get
+
+        response = mock_endpoint(view_instance, mock_request)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["page"] == 2
+        assert response.data["limit"] == 20
+
+    def test_query_parameter_validation_with_invalid_data_raises(self):
+        """Query parameter validation: invalid query params should raise exception"""
+
+        class QueryParamSerializer(serializers.Serializer):
+            limit = serializers.IntegerField(required=True, max_value=100)
+
+        @validated_request(
+            query_serializer=QueryParamSerializer,
+            responses={
+                200: OpenApiResponse(response=EventCaptureResponseSerializer),
+            },
+        )
+        def mock_endpoint(view_self, request, **kwargs):
+            return Response(
+                {
+                    "status": "ok",
+                    "event_id": str(uuid.uuid4()),
+                    "distinct_id": "test",
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {}
+        from django.http import QueryDict
+
+        mock_get = QueryDict("limit=200")  # Exceeds max_value
+        mock_request._request = Mock()
+        mock_request._request.GET = mock_get
+        mock_request.query_params = mock_get
+
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            mock_endpoint(view_instance, mock_request)
+
+        assert "limit" in str(exc_info.value)
+
+    def test_path_parameter_validation_with_valid_data(self):
+        """Path parameter validation: valid path params should work"""
+
+        class PathParamSerializer(serializers.Serializer):
+            pk = serializers.IntegerField(required=True)
+            action = serializers.ChoiceField(choices=["view", "edit"], required=False)
+
+        @validated_request(
+            path_serializer=PathParamSerializer,
+            responses={
+                200: OpenApiResponse(response=EventCaptureResponseSerializer),
+            },
+        )
+        def mock_endpoint(view_self, request, **kwargs):
+            pk = kwargs["pk"]
+            action = kwargs.get("action", "view")
+            return Response(
+                {
+                    "status": "ok",
+                    "event_id": str(uuid.uuid4()),
+                    "distinct_id": "test",
+                    "pk": pk,
+                    "action": action,
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {}
+
+        response = mock_endpoint(view_instance, mock_request, pk=42, action="edit")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["pk"] == 42
+        assert response.data["action"] == "edit"
+
+    def test_path_parameter_validation_with_invalid_data_raises(self):
+        """Path parameter validation: invalid path params should raise exception"""
+
+        class PathParamSerializer(serializers.Serializer):
+            pk = serializers.IntegerField(required=True)
+
+        @validated_request(
+            path_serializer=PathParamSerializer,
+            responses={
+                200: OpenApiResponse(response=EventCaptureResponseSerializer),
+            },
+        )
+        def mock_endpoint(view_self, request, **kwargs):
+            return Response(
+                {
+                    "status": "ok",
+                    "event_id": str(uuid.uuid4()),
+                    "distinct_id": "test",
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {}
+
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            mock_endpoint(view_instance, mock_request, pk="not_an_int")
+
+        assert "pk" in str(exc_info.value)
+
+    def test_query_and_path_parameter_validation_together(self):
+        """Query and path parameter validation: both should work together"""
+
+        class QueryParamSerializer(serializers.Serializer):
+            page = serializers.IntegerField(required=False, default=1)
+
+        class PathParamSerializer(serializers.Serializer):
+            pk = serializers.IntegerField(required=True)
+
+        @validated_request(
+            query_serializer=QueryParamSerializer,
+            path_serializer=PathParamSerializer,
+            responses={
+                200: OpenApiResponse(response=EventCaptureResponseSerializer),
+            },
+        )
+        def mock_endpoint(view_self, request, **kwargs):
+            page = request.query_params.get("page", 1)
+            pk = kwargs["pk"]
+            return Response(
+                {
+                    "status": "ok",
+                    "event_id": str(uuid.uuid4()),
+                    "distinct_id": "test",
+                    "page": int(page),
+                    "pk": pk,
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {}
+        from django.http import QueryDict
+
+        mock_get = QueryDict("page=3")
+        mock_request._request = Mock()
+        mock_request._request.GET = mock_get
+        mock_request.query_params = mock_get
+
+        response = mock_endpoint(view_instance, mock_request, pk=99)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["page"] == 3
+        assert response.data["pk"] == 99

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -156,7 +156,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def update_position(self, request, pk=None, **kwargs):
         task = self.get_object()
 
-        new_position = request.data.get("position")
+        new_position = request.validated_data.get("position")
 
         if new_position is None:
             return Response(
@@ -301,7 +301,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def append_log(self, request, pk=None, **kwargs):
         task_run = cast(TaskRun, self.get_object())
 
-        entries = request.data["entries"]
+        entries = request.validated_data["entries"]
         task_run.append_log(entries)
 
         return Response(TaskRunDetailSerializer(task_run, context=self.get_serializer_context()).data)

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -24,7 +24,6 @@ from .serializers import (
     TaskListQuerySerializer,
     TaskRunAppendLogRequestSerializer,
     TaskRunDetailSerializer,
-    TaskRunPathSerializer,
     TaskSerializer,
     TaskUpdatePositionRequestSerializer,
 )
@@ -215,7 +214,6 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     filter_rewrite_rules = {"team_id": "team_id"}
 
     @validated_request(
-        path_serializer=TaskRunPathSerializer,
         responses={
             200: OpenApiResponse(response=TaskRunDetailSerializer, description="List of task runs"),
         },
@@ -226,7 +224,6 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     @validated_request(
-        path_serializer=TaskRunPathSerializer,
         responses={
             201: OpenApiResponse(response=TaskRunDetailSerializer, description="Created task run"),
         },
@@ -260,7 +257,6 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @validated_request(
         request_serializer=None,
-        path_serializer=TaskRunPathSerializer,
         responses={
             200: OpenApiResponse(response=TaskRunDetailSerializer, description="Run with updated output"),
             404: OpenApiResponse(description="Run not found"),
@@ -287,7 +283,6 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @validated_request(
         request_serializer=TaskRunAppendLogRequestSerializer,
-        path_serializer=TaskRunPathSerializer,
         responses={
             200: OpenApiResponse(response=TaskRunDetailSerializer, description="Run with updated log"),
             400: OpenApiResponse(response=ErrorResponseSerializer, description="Invalid log entries"),

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -282,3 +282,20 @@ class TaskRunAppendLogRequestSerializer(serializers.Serializer):
         if not value:
             raise serializers.ValidationError("At least one log entry is required")
         return value
+
+
+class TaskListQuerySerializer(serializers.Serializer):
+    """Query parameters for listing tasks"""
+
+    origin_product = serializers.CharField(required=False, help_text="Filter by origin product")
+    stage = serializers.CharField(required=False, help_text="Filter by task run stage")
+    organization = serializers.CharField(required=False, help_text="Filter by repository organization")
+    repository = serializers.CharField(
+        required=False, help_text="Filter by repository name (can include org/repo format)"
+    )
+
+
+class TaskRunPathSerializer(serializers.Serializer):
+    """Path parameters for task run endpoints"""
+
+    parent_lookup_task_id = serializers.UUIDField(required=True, help_text="The task ID this run belongs to")

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -293,9 +293,3 @@ class TaskListQuerySerializer(serializers.Serializer):
     repository = serializers.CharField(
         required=False, help_text="Filter by repository name (can include org/repo format)"
     )
-
-
-class TaskRunPathSerializer(serializers.Serializer):
-    """Path parameters for task run endpoints"""
-
-    parent_lookup_task_id = serializers.UUIDField(required=True, help_text="The task ID this run belongs to")


### PR DESCRIPTION
## Problem

We covered payload in the first PR, this one addresses the fact that we dont validate request path and query params

## Changes

- validated_request now validate request path and query params
- Use them on task list and create endpoints
- `validated_data` is now just mutated into req. directly. This is needed for good support for DRF CRUD

## How did you test this code?

- New tests for the mixin
- Ran tests for tasks endpoints

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
