### PR TITLE
fix(capture): avoid locking in overflow limiter capture

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4541,6 +4541,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "common-redis",
+ "dashmap 6.1.0",
  "governor",
  "metrics",
  "rand 0.8.5",

--- a/rust/common/limiters/Cargo.toml
+++ b/rust/common/limiters/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 common-redis = { path = "../redis" }
+dashmap = "6.1"
 governor = { workspace = true }
 metrics = { workspace = true }
 rand = { workspace = true }

--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -143,10 +143,15 @@ impl RedisLimiter {
                         )
                         .set(set.len() as f64);
 
-                        limited.clear();
-                        for item in set {
-                            limited.insert(item, true);
+                        // Two-phase update to avoid partial cache states during concurrent reads:
+                        // Phase 1: Add all new items first (better to temporarily over-limit than under-limit)
+                        let new_set: std::collections::HashSet<_> = set.into_iter().collect();
+                        for item in &new_set {
+                            limited.insert(item.clone(), true);
                         }
+
+                        // Phase 2: Remove items not in new set
+                        limited.retain(|k, _| new_set.contains(k));
                     }
                     Err(e) => {
                         tracing::warn!("Failed to update cache from Redis: {:?}", e);

--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -1,10 +1,10 @@
 use chrono::Utc;
 use common_redis::{Client, CustomRedisError};
+use dashmap::DashMap;
 use metrics::gauge;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashSet, sync::Arc};
 use strum::Display;
-use tokio::sync::RwLock;
 use tokio::task;
 use tokio::time::interval;
 
@@ -83,7 +83,7 @@ impl ServiceName {
 
 #[derive(Clone)]
 pub struct RedisLimiter {
-    limited: Arc<RwLock<HashSet<String>>>,
+    limited: Arc<DashMap<String, bool>>,
     redis: Arc<dyn Client + Send + Sync>,
     key: String,
     interval: Duration,
@@ -107,7 +107,7 @@ impl RedisLimiter {
         resource: QuotaResource,
         service_name: ServiceName,
     ) -> anyhow::Result<RedisLimiter> {
-        let limited = Arc::new(RwLock::new(HashSet::new()));
+        let limited = Arc::new(DashMap::new());
         let key_prefix = redis_key_prefix.unwrap_or_default();
 
         let limiter = RedisLimiter {
@@ -137,15 +137,15 @@ impl RedisLimiter {
             loop {
                 match RedisLimiter::fetch_limited(&redis, &key).await {
                     Ok(set) => {
-                        let set = HashSet::from_iter(set.iter().cloned());
                         gauge!(
                             format!("{}_billing_limits_loaded_tokens", service_name),
                             "cache_key" => key.clone(),
                         )
                         .set(set.len() as f64);
 
-                        let mut limited_lock = limited.write().await;
-                        *limited_lock = set;
+                        for item in set {
+                            limited.insert(item, true);
+                        }
                     }
                     Err(e) => {
                         tracing::warn!("Failed to update cache from Redis: {:?}", e);
@@ -168,8 +168,7 @@ impl RedisLimiter {
     }
 
     pub async fn is_limited(&self, value: &str) -> bool {
-        let limited = self.limited.read().await;
-        limited.contains(value)
+        self.limited.get(value).is_some()
     }
 }
 

--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -143,6 +143,7 @@ impl RedisLimiter {
                         )
                         .set(set.len() as f64);
 
+                        limited.clear();
                         for item in set {
                             limited.insert(item, true);
                         }


### PR DESCRIPTION
## Problem

We currently have for rate limiting a HashSet behind a RWLock, because of this when we read we must hold a lock for the whole Set which can cause contention issues when handling a large number of connections. Switching to a Dashmap alleviates this.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
