### PR TITLE
feat(sessions): Add dagster log coments and retries to session dags

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -1,12 +1,23 @@
-from dagster import AssetExecutionContext, BackfillPolicy, DailyPartitionsDefinition, asset
+from dagster import (
+    AssetExecutionContext,
+    BackfillPolicy,
+    Backoff,
+    DailyPartitionsDefinition,
+    Jitter,
+    RetryPolicy,
+    asset,
+)
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.query_tagging import tags_context
 from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import (
     RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3,
     RAW_SESSION_TABLE_BACKFILL_SQL_V3,
 )
+
+from dags.common import dagster_tags
 
 # This is the number of days to backfill in one SQL operation
 MAX_PARTITIONS_PER_RUN = 30
@@ -15,6 +26,13 @@ daily_partitions = DailyPartitionsDefinition(
     start_date="2019-01-01",  # this is a year before posthog was founded, so should be early enough even including data imports
     timezone="UTC",
     end_offset=1,  # include today's partition (note that will create a partition with incomplete data, but all our backfills are idempotent so this is ok providing we re-run later)
+)
+
+retry_policy = RetryPolicy(
+    max_retries=3,
+    delay=60,
+    backoff=Backoff.EXPONENTIAL,
+    jitter=Jitter.PLUS_MINUS,
 )
 
 
@@ -31,6 +49,7 @@ def get_partition_where_clause(context: AssetExecutionContext, timestamp_field: 
     partitions_def=daily_partitions,
     name="sessions_v3_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
+    retry_policy=retry_policy,
 )
 def sessions_v3_backfill(context: AssetExecutionContext) -> None:
     where_clause = get_partition_where_clause(context, timestamp_field="timestamp")
@@ -46,7 +65,8 @@ def sessions_v3_backfill(context: AssetExecutionContext) -> None:
     )
     context.log.info(backfill_sql)
 
-    sync_execute(backfill_sql, workload=Workload.OFFLINE)
+    with tags_context(kind="dagster", dagster=dagster_tags(context)):
+        sync_execute(backfill_sql, workload=Workload.OFFLINE)
 
     context.log.info(f"Successfully backfilled sessions_v3 for {partition_range_str}")
 
@@ -55,6 +75,7 @@ def sessions_v3_backfill(context: AssetExecutionContext) -> None:
     partitions_def=daily_partitions,
     name="sessions_v3_replay_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
+    retry_policy=retry_policy,
 )
 def sessions_v3_backfill_replay(context: AssetExecutionContext) -> None:
     where_clause = get_partition_where_clause(context, timestamp_field="min_first_timestamp")
@@ -70,6 +91,7 @@ def sessions_v3_backfill_replay(context: AssetExecutionContext) -> None:
     )
     context.log.info(backfill_sql)
 
-    sync_execute(backfill_sql, workload=Workload.OFFLINE)
+    with tags_context(kind="dagster", dagster=dagster_tags(context)):
+        sync_execute(backfill_sql, workload=Workload.OFFLINE)
 
     context.log.info(f"Successfully backfilled sessions_v3 for {partition_range_str}")


### PR DESCRIPTION
## Problem

A session dag failed, and I didn't have much visibility into it

## Changes

This PR adds various bits of Dagster information (such as run ID) to the query log comment, making it easier to search for it in Metabase.

It also adds a very basic retry config

## How did you test this code?

n/a (I'm just running the dag manually)

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
