### PR TITLE
fix(experiments): no New experiment button for holdouts/shared

### DIFF
--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -430,19 +430,21 @@ export function Experiments(): JSX.Element {
                     type: 'experiment',
                 }}
                 actions={
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.Experiment}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
-                        <LemonButton
-                            size="small"
-                            type="primary"
-                            data-attr="create-experiment"
-                            to={urls.experiment('new')}
+                    tab !== ExperimentsTabs.SharedMetrics && tab !== ExperimentsTabs.Holdouts ? (
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.Experiment}
+                            minAccessLevel={AccessControlLevel.Editor}
                         >
-                            New experiment
-                        </LemonButton>
-                    </AccessControlAction>
+                            <LemonButton
+                                size="small"
+                                type="primary"
+                                data-attr="create-experiment"
+                                to={urls.experiment('new')}
+                            >
+                                New experiment
+                            </LemonButton>
+                        </AccessControlAction>
+                    ) : undefined
                 }
             />
             <LemonTabs

--- a/frontend/src/scenes/experiments/Holdouts.tsx
+++ b/frontend/src/scenes/experiments/Holdouts.tsx
@@ -222,6 +222,11 @@ export function Holdouts(): JSX.Element {
                     </div>
                 </div>
             </LemonBanner>
+            <div className="flex justify-end">
+                <LemonButton type="primary" onClick={openCreateModal} data-attr="add-holdout">
+                    New holdout
+                </LemonButton>
+            </div>
 
             <LemonTable
                 emptyState={
@@ -233,9 +238,6 @@ export function Holdouts(): JSX.Element {
                 dataSource={holdouts}
                 columns={columns as LemonTableColumns<ExperimentHoldoutType>}
             />
-            <LemonButton type="primary" onClick={openCreateModal} data-attr="add-holdout">
-                New holdout
-            </LemonButton>
         </div>
     )
 }


### PR DESCRIPTION
## Problem
When going to the Shared Metrics tab and trying to add a new shared metric, I often click on “New Experiment” instead of “New Shared Metric.” We shouldn’t show two prominent actions on the same page.

## Changes
Hide the “New Experiment” button on the Shared Metrics and Holdouts tabs.  
Move the “New Holdout” button to the top right to match the Shared Metrics tab.

|Before|After|
|----|----|
|<img width="1247" height="379" alt="image" src="https://github.com/user-attachments/assets/c6c7aa7a-d1dc-41e5-ab44-fd3cbbac4458" />|<img width="1245" height="380" alt="image" src="https://github.com/user-attachments/assets/ccc46fd9-748f-40ac-a6fd-e3fed4ab79fb" />|

## How did you test this code?
👀 