### PR TITLE
chore(plugin-server): Don't update immutable person attributes

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1008,6 +1008,15 @@ export interface InternalPerson extends BasePerson {
     version: number
 }
 
+/** Mutable fields that can be updated on a Person via updatePerson. */
+export interface PersonUpdateFields {
+    properties?: Properties
+    properties_last_updated_at?: PropertiesLastUpdatedAt
+    properties_last_operation?: PropertiesLastOperation | null
+    is_identified?: boolean
+    version?: number // Optional: allows forcing a specific version (used for dual-write sync)
+}
+
 /** Person model exposed outside of person-specific DB logic. */
 export interface Person {
     team_id: number

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1010,10 +1010,11 @@ export interface InternalPerson extends BasePerson {
 
 /** Mutable fields that can be updated on a Person via updatePerson. */
 export interface PersonUpdateFields {
-    properties?: Properties
-    properties_last_updated_at?: PropertiesLastUpdatedAt
-    properties_last_operation?: PropertiesLastOperation | null
-    is_identified?: boolean
+    properties: Properties
+    properties_last_updated_at: PropertiesLastUpdatedAt
+    properties_last_operation: PropertiesLastOperation | null
+    is_identified: boolean
+    created_at: DateTime
     version?: number // Optional: allows forcing a specific version (used for dual-write sync)
 }
 

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -942,13 +942,14 @@ describe('BatchWritingPersonStore', () => {
                     prop_from_distinctId2: 'value2',
                 },
             }),
+            // Only mutable fields should be in the update object
             expect.objectContaining({
-                id: sharedPerson.id,
                 properties: {
                     initial_prop: 'initial_value',
                     prop_from_distinctId1: 'value1',
                     prop_from_distinctId2: 'value2',
                 },
+                is_identified: expect.any(Boolean),
             }),
             'updatePersonNoAssert'
         )

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -1045,12 +1045,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         this.incrementDatabaseOperation(operation as MethodName, personUpdate.distinct_id)
         // Convert PersonUpdate back to InternalPerson for database call
         const person = toInternalPerson(personUpdate)
-        // Only update mutable fields - exclude immutable fields like id, team_id, uuid, created_at
+        // Always pass all mutable fields for consistent query plans
         const updateFields = {
             properties: person.properties,
             properties_last_updated_at: person.properties_last_updated_at,
             properties_last_operation: person.properties_last_operation,
             is_identified: person.is_identified,
+            created_at: person.created_at,
         }
 
         this.incrementCount('updatePersonNoAssert', personUpdate.distinct_id)

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -1045,8 +1045,13 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
         this.incrementDatabaseOperation(operation as MethodName, personUpdate.distinct_id)
         // Convert PersonUpdate back to InternalPerson for database call
         const person = toInternalPerson(personUpdate)
-        // Create update object without version field (updatePerson handles version internally)
-        const { version, ...updateFields } = person
+        // Only update mutable fields - exclude immutable fields like id, team_id, uuid, created_at
+        const updateFields = {
+            properties: person.properties,
+            properties_last_updated_at: person.properties_last_updated_at,
+            properties_last_operation: person.properties_last_operation,
+            is_identified: person.is_identified,
+        }
 
         this.incrementCount('updatePersonNoAssert', personUpdate.distinct_id)
         this.incrementDatabaseOperation('updatePersonNoAssert', personUpdate.distinct_id)

--- a/plugin-server/src/worker/ingestion/persons/repositories/dualwrite-person-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/dualwrite-person-repository-transaction.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '~/kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '~/types'
+import { InternalPerson, PersonUpdateFields, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '~/types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '~/utils/db/db'
 import { TransactionClient } from '~/utils/db/postgres'
 
@@ -81,7 +81,7 @@ export class DualWritePersonRepositoryTransaction implements PersonRepositoryTra
 
     async updatePerson(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tag?: string
     ): Promise<[InternalPerson, TopicMessage[], boolean]> {
         // Enforce version parity across primary/secondary: run primary first, then set secondary to primary's new version

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository-transaction.ts
@@ -3,7 +3,13 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../../types'
+import {
+    InternalPerson,
+    PersonUpdateFields,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+} from '../../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../../utils/db/db'
 
 export interface PersonRepositoryTransaction {
@@ -21,7 +27,7 @@ export interface PersonRepositoryTransaction {
 
     updatePerson(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tag?: string
     ): Promise<[InternalPerson, TopicMessage[], boolean]>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -3,7 +3,14 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team, TeamId } from '../../../../types'
+import {
+    InternalPerson,
+    PersonUpdateFields,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+    TeamId,
+} from '../../../../types'
 import { CreatePersonResult } from '../../../../utils/db/db'
 import { PersonUpdate } from '../person-update-batch'
 import { PersonRepositoryTransaction } from './person-repository-transaction'
@@ -50,7 +57,7 @@ export interface PersonRepository {
 
     updatePerson(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tag?: string
     ): Promise<[InternalPerson, TopicMessage[], boolean]>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
@@ -149,11 +149,12 @@ export class PostgresDualWritePersonRepository implements PersonRepository {
             primaryOut = p
 
             const primaryUpdated = p[0]
-            const secondaryUpdate: Partial<InternalPerson> = {
+            const secondaryUpdate: PersonUpdateFields = {
                 properties: primaryUpdated.properties,
                 properties_last_updated_at: primaryUpdated.properties_last_updated_at,
                 properties_last_operation: primaryUpdated.properties_last_operation,
                 is_identified: primaryUpdated.is_identified,
+                created_at: primaryUpdated.created_at,
                 version: primaryUpdated.version,
             }
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
@@ -3,7 +3,14 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team, TeamId } from '../../../../types'
+import {
+    InternalPerson,
+    PersonUpdateFields,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+    TeamId,
+} from '../../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../../utils/db/db'
 import { PostgresRouter, PostgresUse } from '../../../../utils/db/postgres'
 import { TwoPhaseCommitCoordinator } from '../../../../utils/db/two-phase'
@@ -132,7 +139,7 @@ export class PostgresDualWritePersonRepository implements PersonRepository {
 
     async updatePerson(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tag?: string
     ): Promise<[InternalPerson, TopicMessage[], boolean]> {
         // Enforce version parity across primary/secondary: run primary first, then set secondary to primary's new version

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository-transaction.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository-transaction.ts
@@ -3,7 +3,13 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../../../types'
+import {
+    InternalPerson,
+    PersonUpdateFields,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+} from '../../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../../utils/db/db'
 import { TransactionClient } from '../../../../utils/db/postgres'
 import { PersonRepositoryTransaction } from './person-repository-transaction'
@@ -42,7 +48,7 @@ export class PostgresPersonRepositoryTransaction implements PersonRepositoryTran
 
     async updatePerson(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tag?: string
     ): Promise<[InternalPerson, TopicMessage[], boolean]> {
         return await this.repository.updatePerson(person, update, tag, this.transaction)

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -68,7 +68,7 @@ export class PostgresPersonRepository
 
     private async handleOversizedPersonProperties(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[], boolean]> {
         const currentSize = await this.personPropertiesSize(person.id)
@@ -114,7 +114,7 @@ export class PostgresPersonRepository
 
     private async handleExistingOversizedRecord(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[], boolean]> {
         try {
@@ -126,7 +126,7 @@ export class PostgresPersonRepository
                 { teamId: person.team_id, personId: person.id }
             )
 
-            const trimmedUpdate: Partial<InternalPerson> = {
+            const trimmedUpdate: PersonUpdateFields = {
                 ...update,
                 properties: trimmedProperties,
             }

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -8,6 +8,7 @@ import { TopicMessage } from '../../../../kafka/producer'
 import {
     InternalPerson,
     PersonDistinctId,
+    PersonUpdateFields,
     PropertiesLastOperation,
     PropertiesLastUpdatedAt,
     RawPerson,
@@ -769,7 +770,7 @@ export class PostgresPersonRepository
 
     async updatePerson(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tag?: string,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[], boolean]> {

--- a/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
@@ -3,7 +3,14 @@ import { DateTime } from 'luxon'
 import { Properties } from '@posthog/plugin-scaffold'
 
 import { TopicMessage } from '../../../../kafka/producer'
-import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team, TeamId } from '../../../../types'
+import {
+    InternalPerson,
+    PersonUpdateFields,
+    PropertiesLastOperation,
+    PropertiesLastUpdatedAt,
+    Team,
+    TeamId,
+} from '../../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../../utils/db/db'
 import { TransactionClient } from '../../../../utils/db/postgres'
 import { PersonUpdate } from '../person-update-batch'
@@ -36,7 +43,7 @@ export interface RawPostgresPersonRepository {
 
     updatePerson(
         person: InternalPerson,
-        update: Partial<InternalPerson>,
+        update: PersonUpdateFields,
         tag?: string,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[], boolean]>

--- a/plugin-server/src/worker/ingestion/persons/repositories/singlewrite-dualwrite-compat.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/singlewrite-dualwrite-compat.test.ts
@@ -22,6 +22,7 @@ import {
     assertCreatePersonConflictContractParity,
     assertCreatePersonContractParity,
     cleanupPrepared,
+    createPersonUpdateFields,
     getFirstTeam,
     mockDatabaseError,
     setupMigrationDb,
@@ -303,12 +304,12 @@ describe('Postgres Single Write - Postgres Dual Write Compatibility', () => {
 
             const singleUpdateResult = await singleWriteRepository.updatePerson(
                 singleCreatePersonResult.person,
-                { properties: { name: 'B' } },
+                createPersonUpdateFields(singleCreatePersonResult.person, { properties: { name: 'B' } }),
                 'single-update'
             )
             const dualUpdateResult = await dualWriteRepository.updatePerson(
                 dualCreatePersonResult.person,
-                { properties: { name: 'B' } },
+                createPersonUpdateFields(dualCreatePersonResult.person, { properties: { name: 'B' } }),
                 'dual-update'
             )
             assertUpdatePersonContractParity(singleUpdateResult, dualUpdateResult)
@@ -333,13 +334,13 @@ describe('Postgres Single Write - Postgres Dual Write Compatibility', () => {
                 () =>
                     singleWriteRepository.updatePerson(
                         singleCreatePersonResult.person,
-                        { properties: { name: 'B' } },
+                        createPersonUpdateFields(singleCreatePersonResult.person, { properties: { name: 'B' } }),
                         'single-update'
                     ),
                 () =>
                     dualWriteRepository.updatePerson(
                         dualCreatePersonResult.person,
-                        { properties: { name: 'B' } },
+                        createPersonUpdateFields(dualCreatePersonResult.person, { properties: { name: 'B' } }),
                         'dual-update'
                     ),
                 'unhandled database error'
@@ -366,13 +367,13 @@ describe('Postgres Single Write - Postgres Dual Write Compatibility', () => {
                 () =>
                     singleWriteRepository.updatePerson(
                         singleCreatePersonResult.person,
-                        { properties: { name: 'B' } },
+                        createPersonUpdateFields(singleCreatePersonResult.person, { properties: { name: 'B' } }),
                         'single-update'
                     ),
                 () =>
                     dualWriteRepository.updatePerson(
                         dualCreatePersonResult.person,
-                        { properties: { name: 'B' } },
+                        createPersonUpdateFields(dualCreatePersonResult.person, { properties: { name: 'B' } }),
                         'dual-update'
                     ),
                 PersonPropertiesSizeViolationError as any
@@ -428,12 +429,12 @@ describe('Postgres Single Write - Postgres Dual Write Compatibility', () => {
             }
             const singleUpdateResult = await singleWriteRepository.updatePerson(
                 singleCreatePersonResult.person,
-                updateToApply,
+                createPersonUpdateFields(singleCreatePersonResult.person, updateToApply),
                 'single-update'
             )
             const dualUpdateResult = await dualWriteRepository.updatePerson(
                 dualCreatePersonResult.person,
-                updateToApply,
+                createPersonUpdateFields(dualCreatePersonResult.person, updateToApply),
                 'dual-update'
             )
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/test-helpers.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/test-helpers.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import { DateTime } from 'luxon'
 import path from 'path'
 
-import { Hub, InternalPerson, PersonDistinctId, RawPerson, Team } from '~/types'
+import { Hub, InternalPerson, PersonDistinctId, PersonUpdateFields, RawPerson, Team } from '~/types'
 import { PostgresRouter, PostgresUse } from '~/utils/db/postgres'
 
 import { CreatePersonResult } from '../../../../utils/db/db'
@@ -215,5 +215,23 @@ function toPerson(row: RawPerson): InternalPerson {
         id: String(row.id),
         created_at: DateTime.fromISO(row.created_at).toUTC(),
         version: Number(row.version || 0),
+    }
+}
+
+/**
+ * Helper to create PersonUpdateFields for tests with all required fields.
+ * Pass partial updates and it will fill in defaults from the person object.
+ */
+export function createPersonUpdateFields(
+    person: InternalPerson,
+    updates: Partial<PersonUpdateFields>
+): PersonUpdateFields {
+    return {
+        properties: updates.properties ?? person.properties,
+        properties_last_updated_at: updates.properties_last_updated_at ?? person.properties_last_updated_at,
+        properties_last_operation: updates.properties_last_operation ?? person.properties_last_operation,
+        is_identified: updates.is_identified ?? person.is_identified,
+        created_at: updates.created_at ?? person.created_at,
+        ...(updates.version !== undefined && { version: updates.version }),
     }
 }


### PR DESCRIPTION
## Problem

Our current update query for persons prevents HOT updates, since it overrides values that are indexed. However, these values are uuid and team_id and those are immutable. This is a mistake on the query design. 

In production we always have the same query:
```
/* plugin-server:PERSONS_WRITE<updatePerson-updatePersonNoAssert> */ 
UPDATE [posthog_person ](https://app.pganalyze.com/databases/-652541965/tables/53617747922)SET version = COALESCE(version, $11)::numeric + $12, "id" = $1,"uuid" = $2,"team_id" = $3,"properties" = $4,"properties_last_updated_at" = $5,"properties_last_operation" = $6,"created_at" = $7,"is_identified" = $8,"is_user_id" = $9 
 WHERE id = $10 
RETURNING * 
/* operation='updatePerson',purpose='updatePersonNoAssert' */
```



## Changes

- Update query now only updates mutable fields, attempting to increase the chance of HOT updates.
- Tightens the contract of the updatePerson function so that we must send all relevant fields so that all updates use the same query planner

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
