### PR TITLE
fix: add background box behind scene top right corner to match backgr…

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -146,7 +146,10 @@ export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
             {/* Rounded corner on the left edge of the tabs to curve the line above into the navbar right border */}
             {showRoundedCorner && (
                 <>
-                    <div className="hidden lg:block absolute bottom-[-11px] left-[-1px] w-[11px] h-[11px] z-10 rounded-tl-lg border-l border-t border-primary" />
+                    {/* background to match the navbar  */}
+                    <div className="hidden lg:block absolute bottom-[-11px] left-[-1px] w-[11px] h-[11px] z-11 rounded-tl-lg border-l border-t border-primary bg-[var(--scene-layout-background)]" />
+                    {/* corner to match the main */}
+                    <div className="hidden lg:block absolute bottom-[-11px] left-[-1px] w-[11px] h-[11px] z-10 bg-surface-tertiary" />
                 </>
             )}
 


### PR DESCRIPTION


## Problem
<img width="200" height="160" alt="image" src="https://github.com/user-attachments/assets/7de2c7ae-9803-4e93-b4a3-1bafbe958f70" />

## Changes
And another small box behind the corner radius box to match the background 

![2025-11-11 11 51 15](https://github.com/user-attachments/assets/a0f23014-1833-486c-9024-719812108d73)


## How did you test this code?
manually
