### PR TITLE
chore(batch-exports): Remove support for beginning of time backfills for sessions model

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfillModal.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfillModal.tsx
@@ -117,7 +117,7 @@ export function BatchExportBackfillModal({ id }: BatchExportBackfillModalLogicPr
                     }
                 </LemonField>
 
-                {batchExportConfig?.model == 'persons' || batchExportConfig?.model == 'sessions' ? (
+                {batchExportConfig?.model == 'persons' ? (
                     <LemonField name="earliest_backfill">
                         {({ onChange }) => (
                             <LemonCheckbox


### PR DESCRIPTION
## Problem

Backfills from the beginning of time for the sessions model can regularly result in queries that exceed our ClickHouse memory limits, causing them to fail.

## Changes

Remove support for beginning of time backfills for the sessions model.

## How did you test this code?

Using local stack.