### PR TITLE
fix: add sticky top 0 to new tab categories

### DIFF
--- a/frontend/src/scenes/new-tab/components/Results.tsx
+++ b/frontend/src/scenes/new-tab/components/Results.tsx
@@ -172,7 +172,7 @@ function Category({
                 key={category}
             >
                 <div className="mb-2 @xl/main-content:min-w-[200px]">
-                    <div className="flex items-baseline gap-0">
+                    <div className="flex items-baseline gap-0 sticky top-0">
                         <Label intent="menu" className="px-2">
                             {getCategoryDisplayName(category)}
                         </Label>


### PR DESCRIPTION

## Problem
when scrolling, context on the visible items can be forgotten

![2025-11-11 12 02 36](https://github.com/user-attachments/assets/f0705b0c-1b01-43dc-9df9-82c72cb26b09)


## Changes
Add position sticky to new tab scene categories

## How did you test this code?
Manually