### PR TITLE
fix(logs): fix runner slicing logic when sorting by earliest logs

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.schema import DateRange, LogsQuery
+from posthog.schema import DateRange, LogsQuery, OrderBy3
 
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -58,36 +58,58 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             limit = logs_query_params["limit"]
 
             def runner_slice(
-                runner: LogsQueryRunner, slice_length: dt.timedelta
+                runner: LogsQueryRunner, slice_length: dt.timedelta, orderBy: OrderBy3 | None
             ) -> tuple[LogsQueryRunner, LogsQueryRunner]:
                 """
                 Slices a LogsQueryRunner into two query runners
                 The first one returns just the `slice_length` most recent logs
                 The second one returns the rest of the logs
                 """
-                slice_query = LogsQuery(
-                    **{
-                        **query.model_dump(),
-                        "dateRange": DateRange(
-                            date_from=(runner.query_date_range.date_to() - slice_length).isoformat(),
-                            date_to=runner.query_date_range.date_to().isoformat(),
-                        ),
-                    }
-                )
-                remainder_query = LogsQuery(
-                    **{
-                        **query.model_dump(),
-                        "dateRange": DateRange(
-                            date_from=runner.query_date_range.date_from().isoformat(),
-                            date_to=(runner.query_date_range.date_to() - slice_length).isoformat(),
-                        ),
-                    }
-                )
+                if orderBy == OrderBy3.LATEST or orderBy is None:
+                    slice_query = LogsQuery(
+                        **{
+                            **query.model_dump(),
+                            "dateRange": DateRange(
+                                date_from=(runner.query_date_range.date_to() - slice_length).isoformat(),
+                                date_to=runner.query_date_range.date_to().isoformat(),
+                            ),
+                        }
+                    )
+                    remainder_query = LogsQuery(
+                        **{
+                            **query.model_dump(),
+                            "dateRange": DateRange(
+                                date_from=runner.query_date_range.date_from().isoformat(),
+                                date_to=(runner.query_date_range.date_to() - slice_length).isoformat(),
+                            ),
+                        }
+                    )
+                else:
+                    # invert the logic as we're looking at earliest logs not latest
+                    slice_query = LogsQuery(
+                        **{
+                            **query.model_dump(),
+                            "dateRange": DateRange(
+                                date_from=runner.query_date_range.date_from().isoformat(),
+                                date_to=(runner.query_date_range.date_from() + slice_length).isoformat(),
+                            ),
+                        }
+                    )
+                    remainder_query = LogsQuery(
+                        **{
+                            **query.model_dump(),
+                            "dateRange": DateRange(
+                                date_to=runner.query_date_range.date_to().isoformat(),
+                                date_from=(runner.query_date_range.date_from() + slice_length).isoformat(),
+                            ),
+                        }
+                    )
+
                 return LogsQueryRunner(slice_query, self.team), LogsQueryRunner(remainder_query, self.team)
 
-            # if we're searching more than 30 minutes, first fetch the first 3 minutes of logs and see if that hits the limit
-            if date_range_length > dt.timedelta(minutes=30):
-                recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=3))
+            # if we're searching more than 20 minutes, first fetch the first 3 minutes of logs and see if that hits the limit
+            if date_range_length > dt.timedelta(minutes=20):
+                recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=3), query.orderBy)
                 response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
                 limit -= len(response.results)
                 yield from response.results
@@ -97,7 +119,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
 
             # otherwise if we're searching more than 4 hours search the next hour
             if date_range_length > dt.timedelta(hours=4):
-                recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=60))
+                recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=60), query.orderBy)
                 response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
                 limit -= len(response.results)
                 yield from response.results
@@ -107,7 +129,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
 
             # otherwise if we're searching more than 24 hours search the next 6 hours
             if date_range_length > dt.timedelta(hours=24):
-                recent_runner, runner = runner_slice(runner, dt.timedelta(hours=6))
+                recent_runner, runner = runner_slice(runner, dt.timedelta(hours=6), query.orderBy)
                 response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
                 limit -= len(response.results)
                 yield from response.results


### PR DESCRIPTION
## Problem

currently when sorted earliest logs we're still slicing the latest logs first in the query slicing logic, reverse this so it works as expected for sorting by earliest

## Changes

## How did you test this code?
just ran locally
<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
