### PR TITLE
chore: add hedgebox to bin/start --minimal

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -61,5 +61,9 @@ procs:
         shell: 'pnpm --filter=@posthog/storybook install && pnpm run storybook'
         autostart: false
 
+    hedgebox-dummy:
+        shell: 'bin/check_postgres_up && cd hedgebox-dummy && pnpm install && pnpm run dev'
+        autostart: false
+
 mouse_scroll_speed: 1
 scrollback: 10000


### PR DESCRIPTION
## Changes

Add the hedgebox app to `bin/start --minimal`. Autostart is set to `false`, so you need to manually start it when you need it.

## How did you test this code?

Tested locally and worked as expected.

