### PR TITLE
feat: add prettify JSON option to logs display

### DIFF
--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -91,6 +91,7 @@ export const logsLogic = kea<logsLogicType>([
         setSeverityLevels: (severityLevels: LogsQuery['severityLevels']) => ({ severityLevels }),
         setServiceNames: (serviceNames: LogsQuery['serviceNames']) => ({ serviceNames }),
         setWrapBody: (wrapBody: boolean) => ({ wrapBody }),
+        setPrettifyJson: (prettifyJson: boolean) => ({ prettifyJson }),
         setFilterGroup: (filterGroup: UniversalFiltersGroup, openFilterOnInsert: boolean = true) => ({
             filterGroup,
             openFilterOnInsert,
@@ -149,6 +150,13 @@ export const logsLogic = kea<logsLogicType>([
             true as boolean,
             {
                 setWrapBody: (_, { wrapBody }) => wrapBody,
+            },
+        ],
+        prettifyJson: [
+            true as boolean,
+            { persist: true },
+            {
+                setPrettifyJson: (_, { prettifyJson }) => prettifyJson,
             },
         ],
         timestampFormat: [


### PR DESCRIPTION

## Problem

We already have attributes broken down from JSON messages, but reading JSON logs was a little tricky.

## Changes

- Introduced a new state for prettifying JSON logs in the logsLogic.
- Updated LogsScene to handle prettified JSON rendering.
- Added a checkbox in DisplayOptions to toggle JSON prettification.

This enhances the readability of JSON logs when displayed.

## How did you test this code?

local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._