### PR TITLE
feat(dagster): add analytics platform slack alerts

### DIFF
--- a/dags/common/common.py
+++ b/dags/common/common.py
@@ -13,14 +13,15 @@ from posthog.redis import get_client, redis
 
 
 class JobOwners(str, Enum):
+    TEAM_ANALYTICS_PLATFORM = "team-analytics-platform"
     TEAM_CLICKHOUSE = "team-clickhouse"
+    TEAM_DATA_WAREHOUSE = "team-data-warehouse"
+    TEAM_ERROR_TRACKING = "team-error-tracking"
+    TEAM_EXPERIMENTS = "team-experiments"
+    TEAM_GROWTH = "team-growth"
+    TEAM_MAX_AI = "team-max-ai"
     TEAM_REVENUE_ANALYTICS = "team-revenue-analytics"
     TEAM_WEB_ANALYTICS = "team-web-analytics"
-    TEAM_ERROR_TRACKING = "team-error-tracking"
-    TEAM_GROWTH = "team-growth"
-    TEAM_EXPERIMENTS = "team-experiments"
-    TEAM_MAX_AI = "team-max-ai"
-    TEAM_DATA_WAREHOUSE = "team-data-warehouse"
 
 
 class ClickhouseClusterResource(dagster.ConfigurableResource):

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -18,6 +18,7 @@ from posthog.models.raw_sessions.sessions_v3 import (
 )
 
 from dags.common import dagster_tags
+from dags.common.common import JobOwners
 
 # This is the number of days to backfill in one SQL operation
 MAX_PARTITIONS_PER_RUN = 10
@@ -56,6 +57,7 @@ def get_partition_where_clause(context: AssetExecutionContext, timestamp_field: 
     name="sessions_v3_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
     retry_policy=retry_policy,
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value},
 )
 def sessions_v3_backfill(context: AssetExecutionContext) -> None:
     where_clause = get_partition_where_clause(context, timestamp_field="timestamp")
@@ -82,6 +84,7 @@ def sessions_v3_backfill(context: AssetExecutionContext) -> None:
     name="sessions_v3_replay_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
     retry_policy=retry_policy,
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value},
 )
 def sessions_v3_backfill_replay(context: AssetExecutionContext) -> None:
     where_clause = get_partition_where_clause(context, timestamp_field="min_first_timestamp")

--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -9,14 +9,15 @@ from dagster import DagsterRunStatus, RunsFilter
 from dags.common import JobOwners
 
 notification_channel_per_team = {
+    JobOwners.TEAM_ANALYTICS_PLATFORM.value: "#alerts-analytics-platform",
     JobOwners.TEAM_CLICKHOUSE.value: "#alerts-clickhouse",
-    JobOwners.TEAM_WEB_ANALYTICS.value: "#alerts-web-analytics",
-    JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-revenue-analytics",
-    JobOwners.TEAM_ERROR_TRACKING.value: "#alerts-error-tracking",
-    JobOwners.TEAM_GROWTH.value: "#alerts-growth",
-    JobOwners.TEAM_EXPERIMENTS.value: "#alerts-experiments",
-    JobOwners.TEAM_MAX_AI.value: "#alerts-max-ai",
     JobOwners.TEAM_DATA_WAREHOUSE.value: "#alerts-data-warehouse",
+    JobOwners.TEAM_ERROR_TRACKING.value: "#alerts-error-tracking",
+    JobOwners.TEAM_EXPERIMENTS.value: "#alerts-experiments",
+    JobOwners.TEAM_GROWTH.value: "#alerts-growth",
+    JobOwners.TEAM_MAX_AI.value: "#alerts-max-ai",
+    JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-revenue-analytics",
+    JobOwners.TEAM_WEB_ANALYTICS.value: "#alerts-web-analytics",
 }
 
 CONSECUTIVE_FAILURE_THRESHOLDS = {


### PR DESCRIPTION
## Problem

There was no JobOwner configured for those assets, so any failures would not be directed to the `notify_slack_on_failure` signal. 

## Changes

Added the JobOwner value. I've already created the #alerts-analytics-platform Slack channel with the AlertManager integration. 

## How did you test this code?

I did not, but it should work by default.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
