### PR TITLE
feat(session): Switch back to sharded -> distributed approach but don't ignore errors

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -1,3 +1,4 @@
+from clickhouse_driver import Client
 from dagster import (
     AssetExecutionContext,
     BackfillPolicy,
@@ -10,6 +11,7 @@ from dagster import (
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import (
@@ -31,7 +33,7 @@ daily_partitions = DailyPartitionsDefinition(
 
 retry_policy = RetryPolicy(
     max_retries=3,
-    delay=60,
+    delay=10 * 60,  # 10 minutes
     backoff=Backoff.EXPONENTIAL,
     jitter=Jitter.PLUS_MINUS,
 )
@@ -64,7 +66,7 @@ def sessions_v3_backfill(context: AssetExecutionContext) -> None:
 
     # note that this is idempotent, so we don't need to worry about running it multiple times for the same partition
     # as long as the backfill has run at least once for each partition, the data will be correct
-    backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause)
+    backfill_sql = RAW_SESSION_TABLE_BACKFILL_SQL_V3(where=where_clause, use_sharded_source=True)
 
     partition_range = context.partition_key_range
     partition_range_str = f"{partition_range.start} to {partition_range.end}"
@@ -74,7 +76,12 @@ def sessions_v3_backfill(context: AssetExecutionContext) -> None:
     context.log.info(backfill_sql)
 
     with tags_context(kind="dagster", dagster=dagster_tags(context)):
-        sync_execute(backfill_sql, workload=Workload.OFFLINE, settings=settings)
+        cluster = get_cluster()
+
+        def backfill_per_shard(client: Client):
+            sync_execute(backfill_sql, settings=settings, sync_client=client)
+
+        cluster.map_one_host_per_shard(backfill_per_shard).result()
 
     context.log.info(f"Successfully backfilled sessions_v3 for {partition_range_str}")
 
@@ -91,7 +98,7 @@ def sessions_v3_backfill_replay(context: AssetExecutionContext) -> None:
 
     # note that this is idempotent, so we don't need to worry about running it multiple times for the same partition
     # as long as the backfill has run at least once for each partition, the data will be correct
-    backfill_sql = RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where=where_clause)
+    backfill_sql = RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where=where_clause, use_sharded_source=True)
 
     partition_range = context.partition_key_range
     partition_range_str = f"{partition_range.start} to {partition_range.end}"
@@ -101,6 +108,11 @@ def sessions_v3_backfill_replay(context: AssetExecutionContext) -> None:
     context.log.info(backfill_sql)
 
     with tags_context(kind="dagster", dagster=dagster_tags(context)):
-        sync_execute(backfill_sql, workload=Workload.OFFLINE, settings=settings)
+        cluster = get_cluster()
+
+        def backfill_per_shard(client: Client):
+            sync_execute(backfill_sql, workload=Workload.OFFLINE, settings=settings, sync_client=client)
+
+        cluster.map_one_host_per_shard(backfill_per_shard).result()
 
     context.log.info(f"Successfully backfilled sessions_v3 for {partition_range_str}")

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -517,7 +517,7 @@ INSERT INTO {database}.{writable_table}
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(
             where=where,
-            source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events"
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_session_replay_events"
             if use_sharded_source
             else f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
         ),

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -492,7 +492,7 @@ AS
     )
 
 
-def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where="TRUE"):
+def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where="TRUE", use_sharded_source=True):
     return """
 INSERT INTO {database}.{writable_table}
 {select_sql}
@@ -501,12 +501,14 @@ INSERT INTO {database}.{writable_table}
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
             where=where,
-            source_table=f"{settings.CLICKHOUSE_DATABASE}.events",
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events"
+            if use_sharded_source
+            else f"{settings.CLICKHOUSE_DATABASE}.events",
         ),
     )
 
 
-def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where="TRUE"):
+def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where="TRUE", use_sharded_source=True):
     return """
 INSERT INTO {database}.{writable_table}
 {select_sql}
@@ -515,7 +517,9 @@ INSERT INTO {database}.{writable_table}
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(
             where=where,
-            source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events"
+            if use_sharded_source
+            else f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
         ),
     )
 


### PR DESCRIPTION
## Problem
See https://posthog.slack.com/archives/C09BDQLM8KA/p1762795913663899

## Changes

Revert back to using map_one_host_per_shard, but now actually check if there were errors 🤦 

I've kept some of the other improvements I've made today, like query tagging and memory limits and such

## How did you test this code?

Running this dagster in local dev

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
