### PR TITLE
fix: Remove people from cohort creation activity log

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1198,13 +1198,6 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         serializer.save()
         instance = cast(Cohort, serializer.instance)
 
-        # Although there are no changes when creating a Cohort, we synthesize one here because
-        # it is helpful to show the list of people in the cohort when looking at the activity log.
-        people = instance.to_dict()["people"]
-        changes = dict_changes_between(
-            "Cohort", previous={"people": []}, new={"people": people}, use_field_exclusions=True
-        )
-
         log_activity(
             organization_id=self.organization.id,
             team_id=self.team_id,
@@ -1213,7 +1206,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             item_id=instance.id,
             scope="Cohort",
             activity="created",
-            detail=Detail(changes=changes, name=instance.name),
+            detail=Detail(name=instance.name),
         )
 
     def perform_update(self, serializer):

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1206,7 +1206,12 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             item_id=instance.id,
             scope="Cohort",
             activity="created",
-            detail=Detail(name=instance.name),
+            detail=Detail(
+                changes=[
+                    Change(type="Cohort", action="created", field="people", before=0, after=instance.people.count())
+                ],
+                name=instance.name,
+            ),
         )
 
     def perform_update(self, serializer):

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -1413,7 +1413,15 @@ email@example.org,
                     "activity": "created",
                     "scope": "Cohort",
                     "item_id": str(cohort.pk),
-                    "detail": {"changes": None, "trigger": None, "name": "whatever", "short_id": None, "type": None},
+                    "detail": {
+                        "changes": [
+                            {"type": "Cohort", "action": "created", "field": "people", "before": 0, "after": 0}
+                        ],
+                        "trigger": None,
+                        "name": "whatever",
+                        "short_id": None,
+                        "type": None,
+                    },
                     "created_at": mock.ANY,
                 }
             ],
@@ -1475,7 +1483,15 @@ email@example.org,
                     "activity": "created",
                     "scope": "Cohort",
                     "item_id": str(cohort.pk),
-                    "detail": {"changes": None, "trigger": None, "name": "whatever", "short_id": None, "type": None},
+                    "detail": {
+                        "changes": [
+                            {"type": "Cohort", "action": "created", "field": "people", "before": 0, "after": 0}
+                        ],
+                        "trigger": None,
+                        "name": "whatever",
+                        "short_id": None,
+                        "type": None,
+                    },
                     "created_at": mock.ANY,
                 },
             ],
@@ -1514,7 +1530,15 @@ email@example.org,
                     "item_id": str(cohort_id),
                     "detail": {
                         "trigger": None,
-                        "changes": None,
+                        "changes": [
+                            {
+                                "type": "Cohort",
+                                "action": "created",
+                                "field": "people",
+                                "before": 0,
+                                "after": len(person_uuids),
+                            }
+                        ],
                         "name": "my static cohort",
                         "short_id": None,
                         "type": None,


### PR DESCRIPTION
## Problem

With large static cohorts, this would exceed the maximum size of a message that Kafka allows, causing the cohort creation to fail.

See https://us.posthog.com/project/2/error_tracking/0199ea23-18f0-70c0-b371-aec526a4d832?dcb7217cc6896112706b0b7913984ddbc1dc4cc470aaebb1397ddb25546d411887129478541e250a00cf4db0ca206f5c2db3a1bb7843046e95c6ffc944c4f3e6&timestamp=2025-11-11%2007%3A48%3A19.065000-08%3A00

## How did you test this code?

I've updated unit tests to validate this is working as expected.
