### PR TITLE
fix(insight-variables): Return auth error when accessing insight variables via a share token

### DIFF
--- a/posthog/api/insight_variable.py
+++ b/posthog/api/insight_variable.py
@@ -1,8 +1,9 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import pagination, serializers, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.auth import SharingAccessTokenAuthentication, SharingPasswordProtectedAuthentication
 from posthog.models.insight_variable import InsightVariable
 
 
@@ -43,6 +44,15 @@ class InsightVariableViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     pagination_class = InsightVariablePagination
     serializer_class = InsightVariableSerializer
     filter_backends = [DjangoFilterBackend]
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+
+        if isinstance(
+            request.successful_authenticator,
+            SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication,
+        ):
+            raise PermissionDenied("Insight variables cannot be accessed via sharing authentication")
 
 
 def map_stale_to_latest(stale_variables: dict, latest_variables: list[InsightVariable]) -> dict:


### PR DESCRIPTION
## Problem
- If you open a shared insight (e.g. a public link to an insight), then the app will request insight variables if any are being used. If the user is logged in, then it'll return a successful response and show insight variables, even though using them will result in an error thrown - causing confusion for users sharing links and seeing the insight variables
- https://posthog.slack.com/archives/C07KZK0SBFW/p1762802935482929

## Changes
- Make sure insight variables are not shown on the public insight URL