### PR TITLE
chore(common-redis): Add RedisError to CustomRedisError.

### DIFF
--- a/rust/common/cache/src/read_through.rs
+++ b/rust/common/cache/src/read_through.rs
@@ -193,7 +193,7 @@ impl ReadThroughCache {
                 );
                 self.handle_corrupted_cache(key, cache_key, loader).await
             }
-            CustomRedisError::Timeout | CustomRedisError::Other(_) => {
+            CustomRedisError::Timeout | CustomRedisError::Redis(_) => {
                 // Redis infrastructure issues - use loader without caching
                 tracing::warn!(
                     "Redis infrastructure issue for key {}: {:?}. Operating without cache.",
@@ -365,7 +365,7 @@ impl ReadThroughCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common_redis::MockRedisClient;
+    use common_redis::{MockRedisClient, RedisErrorKind};
     use serde::{Deserialize, Serialize};
     use std::sync::Arc;
 
@@ -557,10 +557,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_redis_other_error_skips_cache_write() {
-        test_redis_infrastructure_error_skips_cache_write_impl(CustomRedisError::Other(
-            "connection refused".to_string(),
-        ))
-        .await;
+        let error =
+            CustomRedisError::from_redis_kind(RedisErrorKind::IoError, "connection refused");
+        test_redis_infrastructure_error_skips_cache_write_impl(error).await;
     }
 
     async fn test_redis_infrastructure_error_not_found_impl(redis_error: CustomRedisError) {
@@ -592,10 +591,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_redis_other_error_not_found() {
-        test_redis_infrastructure_error_not_found_impl(CustomRedisError::Other(
-            "network error".to_string(),
-        ))
-        .await;
+        let error = CustomRedisError::from_redis_kind(RedisErrorKind::IoError, "network error");
+        test_redis_infrastructure_error_not_found_impl(error).await;
     }
 
     #[tokio::test]

--- a/rust/common/cookieless/src/manager.rs
+++ b/rust/common/cookieless/src/manager.rs
@@ -1097,8 +1097,9 @@ mod tests {
         // Set up the mock to return an error
         mock_redis = mock_redis.scard_ret(
             &redis_key,
-            Err(common_redis::CustomRedisError::Other(
-                "Some Redis error".to_string(),
+            Err(common_redis::CustomRedisError::from_redis_kind(
+                common_redis::RedisErrorKind::IoError,
+                "Some Redis error",
             )),
         );
         let redis_client = Arc::new(mock_redis);

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -345,7 +345,7 @@ impl From<CustomRedisError> for FlagError {
             CustomRedisError::NotFound => FlagError::TokenValidationError,
             CustomRedisError::ParseError(_) => FlagError::RedisDataParsingError,
             CustomRedisError::Timeout => FlagError::TimeoutError(Some("redis_timeout".to_string())),
-            CustomRedisError::Other(_) => FlagError::RedisUnavailable,
+            CustomRedisError::Redis(_) => FlagError::RedisUnavailable,
         }
     }
 }


### PR DESCRIPTION
This preserves full Redis error information by wrapping the underlying `redis::RedisError` instead of converting it to limited custom types.

## Problem

The `common-redis` crate encapsulates our approach to using Redis. Previously, errors from the underlying redis client were converted to `CustomRedisError::Other`, which lost valuable error information and behavior.

The underlying `redis::RedisError` has important methods like `is_unrecoverable_error()` and `retry_method()` that provide battle-tested error handling semantics. By not preserving the original error, we had to manually reimplement this logic, which was error-prone and could diverge from the redis crate's behavior over time.

## Changes

- Added new `retry_method()` method that delegates to `redis::RedisError` and tells us whether a retry is suggested based on the error and what kind of retry to do. This is not yet used, but will be soon.
  - `NoRetry` - Permanent error, don't retry
  - `RetryImmediately` - Temporary issue, retry right away
  - `WaitAndRetry` - Sleep first to avoid overload
  - `Reconnect` - Create fresh connection (current is broken)
  - `MovedRedirect` / `AskRedirect` - Cluster-specific redirections
- Added new `is_unrecoverable_error()` method that delegates to `redis::RedisError` to determine whether the error is a recoverable error.
- Changed `CustomRedisError::Other` to wrap the full error: `Redis(Arc<redis::RedisError>)`
- Renamed the variant from `Other` to `Redis` for clarity (it's the only variant that wraps actual Redis errors)
- Implemented `From<redis::RedisError>` to automatically convert Redis errors via `Arc`
- Added `from_redis_kind()` helper method for test code that needs to create specific error kinds
- Delegated `is_unrecoverable_error()` and `retry_method()` to the inner `redis::RedisError` for Redis errors

## How did you test this code?

- Unit Tests
- Manual Smoke test of the /flags service

## Changelog: (features only) Is this feature complete?

No - internal refactoring only.
