### PR TITLE
feat(sessions): Log metabase debug query url in dag

### DIFF
--- a/dags/common/common.py
+++ b/dags/common/common.py
@@ -2,6 +2,8 @@ from contextlib import suppress
 from enum import Enum
 from typing import Optional
 
+from django.conf import settings
+
 import dagster
 from clickhouse_driver.errors import Error, ErrorCodes
 
@@ -171,4 +173,13 @@ def check_for_concurrent_runs(
         context.log.info(f"Skipping {job_name} due to {len(run_records)} active run(s)")
         return dagster.SkipReason(f"Skipping {job_name} run because another run of the same job is already active")
 
+    return None
+
+
+def metabase_debug_query_url(run_id: str) -> Optional[str]:
+    cloud_deployment = getattr(settings, "CLOUD_DEPLOYMENT", None)
+    if cloud_deployment == "US":
+        return f"https://metabase.prod-us.posthog.dev/question/1671-get-clickhouse-query-log-for-given-dagster-run-id?dagster_run_id={run_id}"
+    if cloud_deployment == "EU":
+        return f"https://metabase.prod-eu.posthog.dev/question/544-get-clickhouse-query-log-for-given-dagster-run-id?dagster_run_id={run_id}"
     return None

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -109,7 +109,8 @@ def sessions_v3_backfill_replay(context: AssetExecutionContext) -> None:
         f"Running backfill for {partition_range_str} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
     context.log.info(backfill_sql)
-    context.log.info(metabase_debug_query_url(context.run_id))
+    if debug_url := metabase_debug_query_url(context.run_id):
+        context.log.info(f"Debug query: {debug_url}")
 
     cluster = get_cluster()
     tags = dagster_tags(context)

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -20,7 +20,7 @@ from posthog.models.raw_sessions.sessions_v3 import (
 )
 
 from dags.common import dagster_tags
-from dags.common.common import JobOwners
+from dags.common.common import JobOwners, metabase_debug_query_url
 
 # This is the number of days to backfill in one SQL operation
 MAX_PARTITIONS_PER_RUN = 10
@@ -74,6 +74,7 @@ def sessions_v3_backfill(context: AssetExecutionContext) -> None:
         f"Running backfill for {partition_range_str} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
     context.log.info(backfill_sql)
+    context.log.info(metabase_debug_query_url(context.run_id))
 
     cluster = get_cluster()
     tags = dagster_tags(context)
@@ -107,6 +108,7 @@ def sessions_v3_backfill_replay(context: AssetExecutionContext) -> None:
         f"Running backfill for {partition_range_str} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
     context.log.info(backfill_sql)
+    context.log.info(metabase_debug_query_url(context.run_id))
 
     cluster = get_cluster()
     tags = dagster_tags(context)

--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -74,7 +74,8 @@ def sessions_v3_backfill(context: AssetExecutionContext) -> None:
         f"Running backfill for {partition_range_str} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "
     )
     context.log.info(backfill_sql)
-    context.log.info(metabase_debug_query_url(context.run_id))
+    if debug_url := metabase_debug_query_url(context.run_id):
+        context.log.info(f"Debug query: {debug_url}")
 
     cluster = get_cluster()
     tags = dagster_tags(context)


### PR DESCRIPTION
## Problem

I wanted to make it super easy to debug a failure, so I linked out to a Metabase query

## Changes

It should work for any Dagster run where we hook up the Dagster query tags properly, so I put it in common.py

It'll log None on local dev, but 🤷 

## How did you test this code?

You can see a US one here https://metabase.prod-us.posthog.dev/question/1671-get-clickhouse-query-log-for-given-dagster-run-id?dagster_run_id=0ba8afaa-f3cc-4845-97c5-96731ec8231d

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
