### PR TITLE
fix: Remove people from cohort create activity log

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1198,13 +1198,6 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         serializer.save()
         instance = cast(Cohort, serializer.instance)
 
-        # Although there are no changes when creating a Cohort, we synthesize one here because
-        # it is helpful to show the list of people in the cohort when looking at the activity log.
-        people = instance.to_dict()["people"]
-        changes = dict_changes_between(
-            "Cohort", previous={"people": []}, new={"people": people}, use_field_exclusions=True
-        )
-
         log_activity(
             organization_id=self.organization.id,
             team_id=self.team_id,
@@ -1213,7 +1206,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             item_id=instance.id,
             scope="Cohort",
             activity="created",
-            detail=Detail(changes=changes, name=instance.name),
+            detail=Detail(name=instance.name),
         )
 
     def perform_update(self, serializer):


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/41290 which was reverted. I've gotten rid of the person `count()` which seemed to be problematic in production.

> With large static cohorts, this would exceed the maximum size of a message that Kafka allows, causing the cohort creation to fail.
> See [us.posthog.com/project/2/error_tracking/0199ea23-18f0-70c0-b371-aec526a4d832?dcb7217cc6896112706b0b7913984ddbc1dc4cc470aaebb1397ddb25546d411887129478541e250a00cf4db0ca206f5c2db3a1bb7843046e95c6ffc944c4f3e6&timestamp=2025-11-11%2007%3A48%3A19.065000-08%3A00](https://us.posthog.com/project/2/error_tracking/0199ea23-18f0-70c0-b371-aec526a4d832?dcb7217cc6896112706b0b7913984ddbc1dc4cc470aaebb1397ddb25546d411887129478541e250a00cf4db0ca206f5c2db3a1bb7843046e95c6ffc944c4f3e6&timestamp=2025-11-11%2007%3A48%3A19.065000-08%3A00)


The revert occurred because two additional exceptions were raised in production:
1. [TypeError](https://us.posthog.com/project/2/error_tracking/0199e7f6-b0d3-7830-97d2-3cb370b3481b?timestamp=2025-11-11%2011%3A43%3A49-08%3A00)
2. [ReadOnlySqlTransaction](https://us.posthog.com/project/2/error_tracking/019a7444-2402-7113-ac3d-c7e836f130ab?timestamp=2025-11-11T13%3A05%3A06.482000-08%3A00)

Given the `ReadOnlySqlTransaction`, my theory is it has something to do with Cohort.count being set in this exception handler:
https://github.com/PostHog/posthog/blob/0396ad2046d83435b688cd728891fac367045845/posthog/models/cohort/cohort.py#L564-L565

Then later, during serialization, `instance.count` ends up being a `CombinedExpression` instead of an integer and we get the `TypeError` (???).

I'm still trying to work this out, but this is a very real fix that is affecting users, so it's worth going out without an additional query.

## How did you test this code?
Unit testing, manual testing