### PR TITLE
chore(flags): Prevent crash when dedicated flags Redis is unavailable

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -451,6 +451,12 @@ pub struct Config {
     // The `default_test_config()` sets this to true for test/development scenarios.
     #[envconfig(from = "REDIS_COMPRESSION_ENABLED", default = "false")]
     pub redis_compression_enabled: FlexBool,
+
+    // Number of times to retry creating a Redis client before giving up
+    // Helps handle transient network issues during startup
+    // Set to 0 to disable retries (fail immediately on first error)
+    #[envconfig(from = "REDIS_CLIENT_RETRY_COUNT", default = "3")]
+    pub redis_client_retry_count: u32,
 }
 
 impl Config {
@@ -524,6 +530,7 @@ impl Config {
             flags_rate_limit_log_only: FlexBool(true),
             flags_ip_rate_limit_log_only: FlexBool(true),
             redis_compression_enabled: FlexBool(true),
+            redis_client_retry_count: 3,
         }
     }
 

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -263,7 +263,7 @@ async fn create_dedicated_redis_clients(
         (None, None) => {
             if writer_url.is_some() || reader_url.is_some() {
                 tracing::warn!(
-                    "Dedicated flags Redis connection failed, falling back to shared Redis"
+                    "Both dedicated flags Redis connections failed falling back to shared Redis"
                 );
             } else {
                 tracing::info!(

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -330,6 +330,10 @@ async fn create_redis_client(
     })
     .await;
 
+    // Use nested Result to distinguish:
+    // - Ok(Ok(client)): successful connection
+    // - Ok(Err(e)): permanent error, don't retry
+    // - Err(e): retryable error that will trigger retry logic
     match result {
         Ok(Ok(client)) => Some(Arc::new(client)),
         Ok(Err(_)) => {

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -8,6 +8,8 @@ use common_redis::{CompressionConfig, RedisClient};
 use health::{HealthHandle, HealthRegistry};
 use limiters::redis::QUOTA_LIMITER_CACHE_KEY;
 use tokio::net::TcpListener;
+use tokio_retry::strategy::{jitter, ExponentialBackoff};
+use tokio_retry::Retry;
 
 use crate::billing_limiters::{FeatureFlagsLimiter, SessionReplayLimiter};
 use crate::cohorts::cohort_cache_manager::CohortCacheManager;
@@ -16,33 +18,6 @@ use crate::database_pools::DatabasePools;
 use crate::db_monitor::DatabasePoolMonitor;
 use crate::router;
 use common_cookieless::CookielessManager;
-
-/// Helper to create a Redis client with error logging
-/// Returns None and logs an error if client creation fails
-async fn create_redis_client(
-    url: &str,
-    client_type: &str,
-    compression_config: CompressionConfig,
-) -> Option<Arc<RedisClient>> {
-    match RedisClient::with_config(
-        url.to_string(),
-        compression_config,
-        common_redis::RedisValueFormat::default(),
-    )
-    .await
-    {
-        Ok(client) => Some(Arc::new(client)),
-        Err(e) => {
-            tracing::error!(
-                "Failed to create {} Redis client for URL {}: {}",
-                client_type,
-                url,
-                e
-            );
-            None
-        }
-    }
-}
 
 pub async fn serve<F>(config: Config, listener: TcpListener, shutdown: F)
 where
@@ -62,10 +37,12 @@ where
     };
 
     // Create separate Redis clients for shared Redis (non-critical path: analytics, billing, cookieless)
+    // "shared" means the Redis client shares the cache with the Dango PostHog web app.
     let Some(redis_reader_client) = create_redis_client(
         config.get_redis_reader_url(),
         "shared reader",
         compression_config.clone(),
+        config.redis_client_retry_count,
     )
     .await
     else {
@@ -76,6 +53,7 @@ where
         config.get_redis_writer_url(),
         "shared writer",
         compression_config.clone(),
+        config.redis_client_retry_count,
     )
     .await
     else {
@@ -83,49 +61,8 @@ where
     };
 
     // Create dedicated Redis clients for flags cache (critical path isolation)
-    // Only create separate clients if dedicated flags Redis URLs are configured
-    let (dedicated_redis_reader_client, dedicated_redis_writer_client) = match (
-        config.get_flags_redis_reader_url(),
-        config.get_flags_redis_writer_url(),
-    ) {
-        (Some(reader_url), Some(writer_url)) => {
-            // Dedicated flags Redis is configured
-            let Some(reader) = create_redis_client(
-                reader_url,
-                "dedicated flags reader",
-                compression_config.clone(),
-            )
-            .await
-            else {
-                return;
-            };
-
-            let Some(writer) = create_redis_client(
-                writer_url,
-                "dedicated flags writer",
-                compression_config.clone(),
-            )
-            .await
-            else {
-                return;
-            };
-
-            tracing::info!("Dedicated flags Redis configured");
-            (Some(reader), Some(writer))
-        }
-        (Some(_), None) | (None, Some(_)) => {
-            tracing::warn!(
-                "Incomplete flags Redis configuration: both reader and writer URLs must be set. Falling back to shared Redis (Mode 1)."
-            );
-            (None, None)
-        }
-        _ => {
-            tracing::info!(
-                "Using shared Redis for flags cache (no dedicated flags Redis configured)"
-            );
-            (None, None)
-        }
-    };
+    let (dedicated_redis_reader_client, dedicated_redis_writer_client) =
+        create_dedicated_redis_clients(&config, compression_config.clone()).await;
 
     // Log the cache migration mode based on configuration
     let cache_mode = match (
@@ -220,22 +157,15 @@ where
         }
     };
 
-    let redis_cookieless_client = match RedisClient::with_config(
-        config.get_redis_cookieless_url().to_string(),
+    let Some(redis_cookieless_client) = create_redis_client(
+        &config.get_redis_cookieless_url(),
+        "cookieless",
         compression_config.clone(),
-        common_redis::RedisValueFormat::default(),
+        config.redis_client_retry_count,
     )
     .await
-    {
-        Ok(client) => Arc::new(client),
-        Err(e) => {
-            tracing::error!(
-                "Failed to create Redis cookieless client for URL {}: {}",
-                config.get_redis_cookieless_url(),
-                e
-            );
-            return;
-        }
+    else {
+        return;
     };
 
     let cookieless_manager = Arc::new(CookielessManager::new(
@@ -268,9 +198,248 @@ where
     .unwrap()
 }
 
+/// Create dedicated Redis clients for flags cache with graceful fallback
+///
+/// Implements fallback strategy:
+/// 1. FLAGS_REDIS_READER_URL fails or is not set → use FLAGS_REDIS_URL for reads
+/// 2. FLAGS_REDIS_URL fails or is not set → return None (use shared Redis)
+///
+/// Returns: (reader_client, writer_client)
+async fn create_dedicated_redis_clients(
+    config: &Config,
+    compression_config: CompressionConfig,
+) -> (Option<Arc<RedisClient>>, Option<Arc<RedisClient>>) {
+    let writer_url = config.get_flags_redis_writer_url();
+    let reader_url = config.get_flags_redis_reader_url();
+
+    // Try to create writer client
+    let writer = if let Some(url) = writer_url {
+        create_redis_client(
+            url,
+            "dedicated flags writer",
+            compression_config.clone(),
+            config.redis_client_retry_count,
+        )
+        .await
+    } else {
+        None
+    };
+
+    // Try to create reader client independently (don't depend on writer success)
+    let reader = if let Some(url) = reader_url {
+        create_redis_client(
+            url,
+            "dedicated flags reader",
+            compression_config.clone(),
+            config.redis_client_retry_count,
+        )
+        .await
+    } else {
+        None
+    };
+
+    // Determine final configuration with fallback logic
+    match (reader, writer) {
+        (Some(r), Some(w)) => {
+            tracing::info!("Dedicated flags Redis configured with separate reader endpoint");
+            (Some(r), Some(w))
+        }
+        (None, Some(w)) => {
+            if reader_url.is_some() {
+                tracing::warn!(
+                    "FLAGS_REDIS_READER_URL connection failed, falling back to FLAGS_REDIS_URL for reads"
+                );
+            }
+            (Some(w.clone()), Some(w))
+        }
+        (Some(_), None) => {
+            // Reader succeeded but writer failed - can't use reader without writer
+            tracing::warn!(
+                "FLAGS_REDIS_URL connection failed but FLAGS_REDIS_READER_URL succeeded. \
+                 Cannot use reader without writer. Falling back to shared Redis."
+            );
+            (None, None)
+        }
+        (None, None) => {
+            if writer_url.is_some() || reader_url.is_some() {
+                tracing::warn!(
+                    "Dedicated flags Redis connection failed, falling back to shared Redis"
+                );
+            } else {
+                tracing::info!(
+                    "Using shared Redis for flags cache (no dedicated flags Redis configured)"
+                );
+            }
+            (None, None)
+        }
+    }
+}
+
+/// Helper to create a Redis client with error logging and retry logic
+/// Returns None and logs an error if client creation fails after all retries
+///
+/// Retry behavior:
+/// - Delegates to redis crate's `is_unrecoverable_error()` for error classification
+/// - Overrides: InvalidClientConfig and AuthenticationFailed always treated as permanent (no retry)
+/// - In practice, most connection errors (DNS, connection refused) are also permanent
+/// - Uses exponential backoff with jitter when retrying transient errors
+async fn create_redis_client(
+    url: &str,
+    client_type: &str,
+    compression_config: CompressionConfig,
+    retry_count: u32,
+) -> Option<Arc<RedisClient>> {
+    // Use exponential backoff with jitter: 100ms, 200ms, 400ms, etc.
+    // When retry_count=0, .take(0) means no retries (only initial attempt)
+    let retry_strategy = ExponentialBackoff::from_millis(100)
+        .map(jitter)
+        .take(retry_count as usize);
+
+    let url_owned = url.to_string();
+    let client_type_owned = client_type.to_string();
+
+    let result = Retry::spawn(retry_strategy, || async {
+        match RedisClient::with_config(
+            url_owned.clone(),
+            compression_config.clone(),
+            common_redis::RedisValueFormat::default(),
+        )
+        .await
+        {
+            Ok(client) => Ok(Ok(client)),
+            Err(e) => {
+                if e.is_unrecoverable_error() {
+                    tracing::error!(
+                        "Permanent error creating {} Redis client for URL {}: {}",
+                        client_type_owned,
+                        url_owned,
+                        e
+                    );
+                    // Return Ok(Err) to stop retrying but signal error
+                    Ok(Err(e))
+                } else {
+                    tracing::debug!(
+                        "Transient error creating {} Redis client, will retry: {}",
+                        client_type_owned,
+                        e
+                    );
+                    Err(e)
+                }
+            }
+        }
+    })
+    .await;
+
+    match result {
+        Ok(Ok(client)) => Some(Arc::new(client)),
+        Ok(Err(_)) => {
+            // Permanent error - already logged above
+            None
+        }
+        Err(e) => {
+            tracing::error!(
+                "Failed to create {} Redis client for URL {} after {} retries: {}",
+                client_type_owned,
+                url_owned,
+                retry_count,
+                e
+            );
+            None
+        }
+    }
+}
+
 async fn liveness_loop(handle: HealthHandle) {
     loop {
         handle.report_healthy().await;
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create_dedicated_redis_clients_no_config() {
+        // When FLAGS_REDIS_URL is not set, should return (None, None)
+        let config = Config {
+            flags_redis_url: "".to_string(),
+            flags_redis_reader_url: "".to_string(),
+            redis_client_retry_count: 0,
+            ..Config::default_test_config()
+        };
+
+        let compression_config = CompressionConfig::disabled();
+        let (reader, writer) = create_dedicated_redis_clients(&config, compression_config).await;
+
+        assert!(reader.is_none());
+        assert!(writer.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_dedicated_redis_clients_with_invalid_url() {
+        // When FLAGS_REDIS_URL is set but unreachable, should return (None, None)
+        let config = Config {
+            flags_redis_url: "redis://invalid-host:6379/".to_string(),
+            flags_redis_reader_url: "".to_string(),
+            redis_client_retry_count: 0, // No retries for fast test
+            ..Config::default_test_config()
+        };
+
+        let compression_config = CompressionConfig::disabled();
+        let (reader, writer) = create_dedicated_redis_clients(&config, compression_config).await;
+
+        assert!(reader.is_none());
+        assert!(writer.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_dedicated_redis_clients_reader_without_writer() {
+        // When only FLAGS_REDIS_READER_URL is set (misconfiguration), should return (None, None)
+        let config = Config {
+            flags_redis_url: "".to_string(),
+            flags_redis_reader_url: "redis://localhost:6379/".to_string(),
+            redis_client_retry_count: 0,
+            ..Config::default_test_config()
+        };
+
+        let compression_config = CompressionConfig::disabled();
+        let (reader, writer) = create_dedicated_redis_clients(&config, compression_config).await;
+
+        assert!(reader.is_none());
+        assert!(writer.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_redis_error_types() {
+        use common_redis::RedisClient;
+
+        let test_cases = vec![
+            ("absolutegarbage", "Garbage URL"),
+            ("wrong-protocol://localhost:6379", "Wrong protocol"),
+            ("redis://localhost:6378", "Wrong port (connection refused)"),
+        ];
+
+        for (url, description) in test_cases {
+            println!("\n--- Testing: {description} ---");
+            println!("URL: {url}");
+
+            let result = RedisClient::with_config(
+                url.to_string(),
+                CompressionConfig::disabled(),
+                common_redis::RedisValueFormat::default(),
+            )
+            .await;
+
+            match result {
+                Ok(_) => println!("✅ Success (unexpected!)"),
+                Err(e) => {
+                    println!("❌ Error type: {e:?}");
+                    println!("   Error message: {e}");
+                    println!("   Is recoverable: {}", !e.is_unrecoverable_error());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

If we mess up the configuration for `FLAGS_REDIS_URL`, then we could end up preventing the /flags service from starting up. That's no good.

## Changes

Implements graceful fallback for resilient startup instead of panicking when `FLAGS_REDIS_URL` or `FLAGS_REDIS_READER_URL` connections fail (I didn't make this change for the existing `REDIS_URL` because there is no fallback for that and that's already deployed. I'm willing to revisit that decision later).

Fallback chain:
- `FLAGS_REDIS_READER_URL` fails (or is not set) → use `FLAGS_REDIS_URL` for reads
- `FLAGS_REDIS_URL` fails (or is not set) → use shared Redis (no dedicated cache)

Retry strategy:
- Retries transient errors (connection refused, timeouts) using exponential backoff with jitter (100ms, 200ms, 400ms, etc.)
- Stops immediately for permanent errors (DNS failures, auth failures, invalid URLs)
- Retry count configurable via `REDIS_CLIENT_RETRY_COUNT` (default: 3)

Error classification fix (common-redis):
- Added explicit checks for `InvalidClientConfig` and `AuthenticationFailed` error kinds
- These are now correctly treated as permanent errors (the redis crate incorrectly classifies them as retryable)
- Added tests to verify configuration errors are not retried

This ensures deployments succeed even when new Redis instances are misconfigured.

## How did you test this code?

- Unit Tests
- Manual tests:
    - Start with garbage connection string
	- `DEBUG=true RUST_LOG=debug FLAGS_REDIS_ENABLED=true FLAGS_REDIS_URL=xxxx cargo run -p feature-flags`
	- Expected: "Connection Refused" and no retries
	```text
	2025-11-12T01:11:54.300988Z  INFO ThreadId(01) feature_flags::server: Redis compression disabled
	2025-11-12T01:11:54.305727Z ERROR ThreadId(01) feature_flags::server: Permanent error creating dedicated flags writer Redis client for URL xxxx: Redis URL did not parse- InvalidClientConfig
	2025-11-12T01:11:54.305767Z  WARN ThreadId(01) feature_flags::server: FLAGS_REDIS_URL connection failed, dedicated flags Redis disabled. Feature flags will use shared Redis.
	```

	- Start with wrong port
	`DEBUG=true RUST_LOG=debug FLAGS_REDIS_ENABLED=true FLAGS_REDIS_URL=redis://localhost:6378/1 cargo run -p feature-flags`
	- Expected: "Connection Refused" and no retries
	```text
	025-11-12T01:14:48.522136Z  INFO ThreadId(01) feature_flags::server: Redis compression disabled
	2025-11-12T01:14:48.525879Z ERROR ThreadId(01) feature_flags::server: Permanent error creating dedicated flags writer Redis client for URL redis://localhost:6378/1: Connection refused (os error 61)
	2025-11-12T01:14:48.525891Z  WARN ThreadId(01) feature_flags::server: FLAGS_REDIS_URL connection failed, dedicated flags Redis disabled. Feature flags will use shared Redis.
	```

## Open Questions:

1. Since this only applies to startup, does a retry count of 3 seem reasonable? Originally I was going to default to 0. It's controllable through a config setting.
2. Should we extend this to the shared redis client too (perhaps in a follow-up?).
	
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
