### PR TITLE
feat: realtime cohort calculation with precalculated events

### DIFF
--- a/posthog/admin/admins/realtime_cohort_calculation_admin.py
+++ b/posthog/admin/admins/realtime_cohort_calculation_admin.py
@@ -29,6 +29,12 @@ class RealtimeCohortCalculationForm(forms.Form):
         help_text="Delay between batches in minutes",
         label="Batch delay (minutes)",
     )
+    team_id = forms.IntegerField(
+        required=False,
+        min_value=1,
+        help_text="Filter cohorts by team_id (optional)",
+        label="Team ID",
+    )
 
 
 def analyze_realtime_cohort_calculation_view(request):
@@ -46,6 +52,8 @@ def analyze_realtime_cohort_calculation_view(request):
             command_args.extend(["--parallelism", str(form.cleaned_data["parallelism"])])
             command_args.extend(["--workflows-per-batch", str(form.cleaned_data["workflows_per_batch"])])
             command_args.extend(["--batch-delay-minutes", str(form.cleaned_data["batch_delay_minutes"])])
+            if form.cleaned_data.get("team_id"):
+                command_args.extend(["--team-id", str(form.cleaned_data["team_id"])])
 
             try:
                 call_command("analyze_realtime_cohort_calculation", *command_args)

--- a/posthog/admin/admins/realtime_cohort_calculation_admin.py
+++ b/posthog/admin/admins/realtime_cohort_calculation_admin.py
@@ -8,10 +8,6 @@ from django.shortcuts import redirect, render
 
 
 class RealtimeCohortCalculationForm(forms.Form):
-    days = forms.IntegerField(initial=30, min_value=1, help_text="Number of days to look back", label="Days Lookback")
-    min_matches = forms.IntegerField(
-        initial=3, min_value=1, help_text="Minimum number of matches required", label="Minimum Matches"
-    )
     parallelism = forms.IntegerField(
         initial=10,
         min_value=1,
@@ -47,8 +43,6 @@ def analyze_realtime_cohort_calculation_view(request):
         form = RealtimeCohortCalculationForm(request.POST)
         if form.is_valid():
             command_args = []
-            command_args.extend(["--days", str(form.cleaned_data["days"])])
-            command_args.extend(["--min-matches", str(form.cleaned_data["min_matches"])])
             command_args.extend(["--parallelism", str(form.cleaned_data["parallelism"])])
             command_args.extend(["--workflows-per-batch", str(form.cleaned_data["workflows_per_batch"])])
             command_args.extend(["--batch-delay-minutes", str(form.cleaned_data["batch_delay_minutes"])])

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -53,6 +53,7 @@ from posthog.hogql.database.models import (
 )
 from posthog.hogql.database.schema.app_metrics2 import AppMetrics2Table
 from posthog.hogql.database.schema.channel_type import create_initial_channel_type, create_initial_domain_type
+from posthog.hogql.database.schema.cohort_membership import CohortMembershipTable
 from posthog.hogql.database.schema.cohort_people import CohortPeople, RawCohortPeople
 from posthog.hogql.database.schema.document_embeddings import DocumentEmbeddingsTable, RawDocumentEmbeddingsTable
 from posthog.hogql.database.schema.error_tracking_issue_fingerprint_overrides import (
@@ -81,6 +82,7 @@ from posthog.hogql.database.schema.person_distinct_ids import PersonDistinctIdsT
 from posthog.hogql.database.schema.persons import PersonsTable, RawPersonsTable, join_with_persons_table
 from posthog.hogql.database.schema.persons_revenue_analytics import PersonsRevenueAnalyticsTable
 from posthog.hogql.database.schema.pg_embeddings import PgEmbeddingsTable
+from posthog.hogql.database.schema.precalculated_events import PrecalculatedEventsTable
 from posthog.hogql.database.schema.query_log_archive import QueryLogArchiveTable, RawQueryLogArchiveTable
 from posthog.hogql.database.schema.session_replay_events import (
     RawSessionReplayEventsTable,
@@ -173,6 +175,8 @@ class Database(BaseModel):
             "session_replay_events": TableNode(name="session_replay_events", table=SessionReplayEventsTable()),
             "cohort_people": TableNode(name="cohort_people", table=CohortPeople()),
             "static_cohort_people": TableNode(name="static_cohort_people", table=StaticCohortPeople()),
+            "cohort_membership": TableNode(name="cohort_membership", table=CohortMembershipTable()),
+            "precalculated_events": TableNode(name="precalculated_events", table=PrecalculatedEventsTable()),
             "log_entries": TableNode(name="log_entries", table=LogEntriesTable()),
             "query_log": TableNode(name="query_log", table=QueryLogArchiveTable()),
             "app_metrics": TableNode(name="app_metrics", table=AppMetrics2Table()),

--- a/posthog/hogql/database/schema/cohort_membership.py
+++ b/posthog/hogql/database/schema/cohort_membership.py
@@ -4,6 +4,7 @@ from posthog.hogql.database.models import (
     IntegerDatabaseField,
     StringDatabaseField,
     Table,
+    UUIDDatabaseField,
 )
 
 
@@ -13,7 +14,7 @@ class CohortMembershipTable(Table):
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id", nullable=False),
         "cohort_id": IntegerDatabaseField(name="cohort_id", nullable=False),
-        "person_id": StringDatabaseField(name="person_id", nullable=False),
+        "person_id": UUIDDatabaseField(name="person_id", nullable=False),
         "status": StringDatabaseField(name="status", nullable=False),
         "last_updated": DateTimeDatabaseField(name="last_updated", nullable=False),
     }

--- a/posthog/hogql/database/schema/cohort_membership.py
+++ b/posthog/hogql/database/schema/cohort_membership.py
@@ -1,0 +1,25 @@
+from posthog.hogql.database.models import (
+    DateTimeDatabaseField,
+    FieldOrTable,
+    IntegerDatabaseField,
+    StringDatabaseField,
+    Table,
+)
+
+
+class CohortMembershipTable(Table):
+    """Table tracking realtime cohort membership changes."""
+
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "cohort_id": IntegerDatabaseField(name="cohort_id", nullable=False),
+        "person_id": StringDatabaseField(name="person_id", nullable=False),
+        "status": StringDatabaseField(name="status", nullable=False),
+        "last_updated": DateTimeDatabaseField(name="last_updated", nullable=False),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "cohort_membership"
+
+    def to_printed_hogql(self):
+        return "cohort_membership"

--- a/posthog/hogql/database/schema/precalculated_events.py
+++ b/posthog/hogql/database/schema/precalculated_events.py
@@ -1,0 +1,24 @@
+from posthog.hogql.database.models import (
+    DateDatabaseField,
+    FieldOrTable,
+    IntegerDatabaseField,
+    StringDatabaseField,
+    Table,
+)
+
+
+class PrecalculatedEventsTable(Table):
+    """Table for precalculated behavioral events populated by CdpBehaviouralEventsConsumer."""
+
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "distinct_id": StringDatabaseField(name="distinct_id", nullable=False),
+        "condition": StringDatabaseField(name="condition", nullable=False),
+        "date": DateDatabaseField(name="date", nullable=False),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "precalculated_events"
+
+    def to_printed_hogql(self):
+        return "precalculated_events"

--- a/posthog/hogql/database/schema/precalculated_events.py
+++ b/posthog/hogql/database/schema/precalculated_events.py
@@ -1,9 +1,11 @@
 from posthog.hogql.database.models import (
     DateDatabaseField,
+    DateTimeDatabaseField,
     FieldOrTable,
     IntegerDatabaseField,
     StringDatabaseField,
     Table,
+    UUIDDatabaseField,
 )
 
 
@@ -13,8 +15,14 @@ class PrecalculatedEventsTable(Table):
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id", nullable=False),
         "distinct_id": StringDatabaseField(name="distinct_id", nullable=False),
+        "person_id": UUIDDatabaseField(name="person_id", nullable=False),
         "condition": StringDatabaseField(name="condition", nullable=False),
         "date": DateDatabaseField(name="date", nullable=False),
+        "uuid": UUIDDatabaseField(name="uuid", nullable=False),
+        "source": StringDatabaseField(name="source", nullable=False),
+        "_timestamp": DateTimeDatabaseField(name="_timestamp", nullable=False),
+        "_partition": IntegerDatabaseField(name="_partition", nullable=False),
+        "_offset": IntegerDatabaseField(name="_offset", nullable=False),
     }
 
     def to_printed_clickhouse(self, context):

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from datetime import datetime
 from numbers import Number
 from typing import Literal, Optional, Union, cast
 
@@ -44,6 +45,7 @@ from posthog.hogql.query import HogQLQueryExecutor
 from posthog.constants import PropertyOperatorType
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.hogql_queries.events_query_runner import EventsQueryRunner
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Cohort, Filter, Property, Team
 from posthog.models.property import PropertyGroup
 from posthog.queries.cohort_query import CohortQuery
@@ -573,3 +575,251 @@ class HogQLCohortQuery:
         if condition.negation:
             raise ValidationError("Top level condition cannot be negated", str(self.property_groups))
         return condition.query
+
+
+class HogQLRealtimeCohortQuery(HogQLCohortQuery):
+    """
+    Realtime cohort query that uses prefiltered_events for behavioral conditions
+    and cohort_membership for child cohort filters.
+
+    This extends HogQLCohortQuery and overrides the methods that need to query
+    different tables for realtime cohort calculation.
+    """
+
+    def __init__(
+        self,
+        cohort_query: Optional[CohortQuery] = None,
+        cohort: Optional[Cohort] = None,
+        team: Optional[Team] = None,
+    ):
+        super().__init__(cohort_query=cohort_query, cohort=cohort, team=team)
+        self.cohort = cohort
+
+    def get_performed_event_condition(self, prop: Property, first_time: bool = False) -> ast.SelectQuery:
+        """
+        Query precalculated_events using conditionHash for realtime behavioral matching.
+        Uses the precalculated_events table populated by CdpBehaviouralEventsConsumer.
+        """
+        condition_hash = getattr(prop, "conditionHash", None)
+        if not condition_hash:
+            cohort_id = self.cohort.id if self.cohort else "unknown"
+            raise ValueError(
+                f"BUG: Realtime cohort (cohort_id={cohort_id}) has behavioral property without conditionHash. "
+                f"All realtime cohorts MUST have conditionHash for behavioral filters. Property: {prop}"
+            )
+
+        # Extract date_from using same logic as parent class
+        if prop.explicit_datetime:
+            # Explicit datetime filter, can be a relative or absolute date
+            date_from_str = prop.explicit_datetime
+        else:
+            date_value = parse_and_validate_positive_integer(prop.time_value, "time_value")
+            date_interval = validate_interval(prop.time_interval)
+            date_from_str = f"-{date_value}{date_interval[:1]}"
+
+        # Parse the date string using QueryDateRange to get actual datetime
+        date_range = DateRange(date_from=date_from_str)
+        query_date_range = QueryDateRange(
+            date_range=date_range,
+            team=self.team,
+            interval=None,
+            now=datetime.now(),
+        )
+        date_from_datetime = query_date_range.date_from()
+
+        # Build query using precalculated_events
+        query_str = """
+            SELECT
+                pdi2.person_id as id
+            FROM
+            (
+                SELECT DISTINCT distinct_id
+                FROM precalculated_events
+                WHERE
+                    team_id = {team_id}
+                    AND condition = {condition_hash}
+                    AND date >= toDate({date_from})
+            ) AS pfe
+            INNER JOIN
+            (
+                SELECT
+                    distinct_id,
+                    argMax(person_id, version) as person_id
+                FROM raw_person_distinct_ids
+                WHERE team_id = {team_id}
+                GROUP BY distinct_id
+                HAVING argMax(is_deleted, version) = 0
+            ) AS pdi2 ON pdi2.distinct_id = pfe.distinct_id
+        """
+
+        return cast(
+            ast.SelectQuery,
+            parse_select(
+                query_str,
+                {
+                    "team_id": ast.Constant(value=self.team.pk),
+                    "condition_hash": ast.Constant(value=condition_hash),
+                    "date_from": ast.Constant(value=date_from_datetime),
+                },
+            ),
+        )
+
+    def get_performed_event_multiple(self, prop: Property) -> ast.SelectQuery:
+        """
+        Query precalculated_events with count aggregation for multiple event occurrences.
+        Supports operators: gte, lte, gt, lt, eq.
+        """
+        condition_hash = getattr(prop, "conditionHash", None)
+        if not condition_hash:
+            cohort_id = self.cohort.id if self.cohort else "unknown"
+            raise ValueError(
+                f"BUG: Realtime cohort (cohort_id={cohort_id}) has behavioral property without conditionHash. "
+                f"All realtime cohorts MUST have conditionHash for behavioral filters. Property: {prop}"
+            )
+
+        min_matches = parse_and_validate_positive_integer(prop.operator_value, "operator_value")
+
+        # Extract date_from using same logic as parent class
+        if prop.explicit_datetime:
+            # Explicit datetime filter, can be a relative or absolute date
+            date_from_str = prop.explicit_datetime
+        else:
+            date_value = parse_and_validate_positive_integer(prop.time_value, "time_value")
+            date_interval = validate_interval(prop.time_interval)
+            date_from_str = f"-{date_value}{date_interval[:1]}"
+
+        # Parse the date string using QueryDateRange to get actual datetime
+        date_range = DateRange(date_from=date_from_str)
+        query_date_range = QueryDateRange(
+            date_range=date_range,
+            team=self.team,
+            interval=None,
+            now=datetime.now(),
+        )
+        date_from_datetime = query_date_range.date_from()
+
+        # Map operator to SQL comparison
+        operator_sql_map = {
+            "gte": ">=",
+            "lte": "<=",
+            "gt": ">",
+            "lt": "<",
+            "eq": "=",
+            "exact": "=",
+        }
+        sql_operator = operator_sql_map.get(prop.operator, "=")
+
+        query_str = f"""
+            SELECT
+                pdi2.person_id as id
+            FROM
+            (
+                SELECT distinct_id, count() as event_count
+                FROM precalculated_events
+                WHERE
+                    team_id = {{team_id}}
+                    AND condition = {{condition_hash}}
+                    AND date >= toDate({{date_from}})
+                GROUP BY distinct_id
+                HAVING event_count {sql_operator} {min_matches}
+            ) AS pfe
+            INNER JOIN
+            (
+                SELECT
+                    distinct_id,
+                    argMax(person_id, version) as person_id
+                FROM raw_person_distinct_ids
+                WHERE team_id = {{team_id}}
+                GROUP BY distinct_id
+                HAVING argMax(is_deleted, version) = 0
+            ) AS pdi2 ON pdi2.distinct_id = pfe.distinct_id
+        """
+
+        return cast(
+            ast.SelectQuery,
+            parse_select(
+                query_str,
+                {
+                    "team_id": ast.Constant(value=self.team.pk),
+                    "condition_hash": ast.Constant(value=condition_hash),
+                    "date_from": ast.Constant(value=date_from_datetime),
+                },
+            ),
+        )
+
+    def get_dynamic_cohort_condition(self, prop: Property) -> ast.SelectQuery:
+        """
+        Query cohort_membership table for realtime cohort membership.
+        Filters most recent status='entered' to find current members.
+        """
+        cohort_id = cast(int, prop.value)
+
+        return cast(
+            ast.SelectQuery,
+            parse_select(
+                """
+                SELECT person_id as id FROM (
+                    SELECT person_id, argMax(status, last_updated) as status
+                    FROM cohort_membership
+                    WHERE cohort_id = {cohort_id}
+                    AND team_id = {team_id}
+                    GROUP BY person_id
+                    HAVING status = 'entered'
+                )
+                """,
+                {
+                    "cohort_id": ast.Constant(value=cohort_id),
+                    "team_id": ast.Constant(value=self.team.pk),
+                },
+            ),
+        )
+
+    def get_static_cohort_condition(self, prop: Property) -> ast.SelectQuery:
+        """
+        Realtime cohorts do not support static cohorts.
+        Static cohorts use manually uploaded CSV data and are not compatible with realtime calculation.
+        """
+        raise ValueError(
+            "Realtime cohorts do not support static cohort filters. "
+            "Only dynamic cohorts and behavioral filters are supported for realtime calculation."
+        )
+
+    def get_performed_event_sequence(self, prop: Property) -> ast.SelectQuery:
+        """
+        Realtime cohorts do not support performed_event_sequence.
+        Only performed_event and performed_event_multiple are supported by build_behavioral_event_expr.
+        """
+        raise ValueError(
+            "Realtime cohorts do not support 'performed_event_sequence'. "
+            "Only 'performed_event' and 'performed_event_multiple' are supported."
+        )
+
+    def get_stopped_performing_event(self, prop: Property) -> ast.SelectSetQuery:
+        """
+        Realtime cohorts do not support stopped_performing_event.
+        Only performed_event and performed_event_multiple are supported by build_behavioral_event_expr.
+        """
+        raise ValueError(
+            "Realtime cohorts do not support 'stopped_performing_event'. "
+            "Only 'performed_event' and 'performed_event_multiple' are supported."
+        )
+
+    def get_restarted_performing_event(self, prop: Property) -> ast.SelectSetQuery:
+        """
+        Realtime cohorts do not support restarted_performing_event.
+        Only performed_event and performed_event_multiple are supported by build_behavioral_event_expr.
+        """
+        raise ValueError(
+            "Realtime cohorts do not support 'restarted_performing_event'. "
+            "Only 'performed_event' and 'performed_event_multiple' are supported."
+        )
+
+    def get_performed_event_regularly(self, prop: Property) -> ast.SelectQuery:
+        """
+        Realtime cohorts do not support performed_event_regularly.
+        Only performed_event and performed_event_multiple are supported by build_behavioral_event_expr.
+        """
+        raise ValueError(
+            "Realtime cohorts do not support 'performed_event_regularly'. "
+            "Only 'performed_event' and 'performed_event_multiple' are supported."
+        )

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -1,7 +1,7 @@
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import MagicMock, patch
 
-from posthog.hogql_queries.hogql_cohort_query import HogQLCohortQuery
+from posthog.hogql_queries.hogql_cohort_query import HogQLCohortQuery, HogQLRealtimeCohortQuery
 from posthog.models import Cohort
 
 
@@ -192,3 +192,239 @@ class TestHogQLCohortQuery(ClickhouseTestMixin, APIBaseTest):
 
         # Should use EXCEPT because one property is negated
         self.assertIn("EXCEPT", query_str)
+
+
+class TestHogQLRealtimeCohortQuery(ClickhouseTestMixin, APIBaseTest):
+    """Tests for HogQLRealtimeCohortQuery which uses precalculated_events for behavioral filters."""
+
+    def test_person_property_query(self) -> None:
+        """
+        Test that person property filters work correctly in realtime cohorts.
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@posthog.com",
+                            "negation": False,
+                            "operator": "icontains",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Realtime Person Property", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # Should query persons table for person properties
+        self.assertIn("persons", query_str)
+        # Should have the email filter
+        self.assertIn("email", query_str.lower())
+
+    def test_behavioral_performed_event_pageview(self) -> None:
+        """
+        Test that a simple behavioral performed_event filter works with conditionHash.
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "type": "behavioral",
+                            "value": "performed_event",
+                            "negation": False,
+                            "event_type": "events",
+                            "time_value": 7,
+                            "time_interval": "day",
+                            "conditionHash": "abc123def456",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Behavioral Pageview", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+
+        query_str = hogql_query.query_str("clickhouse")
+
+        # Should query precalculated_events table
+        self.assertIn("precalculated_events", query_str)
+        # Should have condition field (conditionHash is parameterized)
+        self.assertIn("precalculated_events.condition", query_str)
+        # Should join with person_distinct_id table for person mapping
+        self.assertIn("person_distinct_id", query_str)
+        # Should use argMax for getting latest person_id
+        self.assertIn("argMax", query_str)
+        # Should have date filtering with toDate
+        self.assertIn("toDate", query_str)
+
+    def test_cohort_membership_in_cohort_direct(self) -> None:
+        """
+        Test that get_dynamic_cohort_condition generates correct query for cohort membership.
+        """
+        from posthog.models.property import Property
+
+        # Create a target cohort
+        target_cohort = Cohort.objects.create(
+            team=self.team, name="Target Cohort", filters={"properties": {"type": "AND", "values": []}}
+        )
+
+        # Create a simple cohort for the query object
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Cohort", filters={"properties": {"type": "AND", "values": []}}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+
+        # Create a dynamic-cohort property (this is what unwrap_cohort would create)
+        prop = Property(type="dynamic-cohort", key="id", value=target_cohort.id, negation=False)
+
+        # Call get_dynamic_cohort_condition directly
+        query_ast = hogql_query.get_dynamic_cohort_condition(prop)
+
+        # Print the AST to string
+        from posthog.hogql.printer import prepare_and_print_ast
+
+        query_str = prepare_and_print_ast(query_ast, hogql_query.hogql_context, "clickhouse", pretty=True)[0]
+
+        # Should query cohort_membership table
+        self.assertIn("cohort_membership", query_str)
+        # Should have cohort_id filter
+        self.assertIn("cohort_membership.cohort_id", query_str)
+        # Should check status field and use argMax for latest status
+        self.assertIn("cohort_membership.status", query_str)
+        self.assertIn("argmax", query_str.lower())
+        # Should filter by person_id and use HAVING clause for status check
+        self.assertIn("person_id", query_str.lower())
+        self.assertIn("having", query_str.lower())
+
+    def test_cohort_membership_not_in_cohort_direct(self) -> None:
+        """
+        Test that negated cohort membership uses EXCEPT to exclude cohort members.
+        """
+        from posthog.hogql.printer import prepare_and_print_ast
+
+        from posthog.models.property import Property
+
+        # Create a target cohort
+        target_cohort = Cohort.objects.create(
+            team=self.team, name="Target Cohort", filters={"properties": {"type": "AND", "values": []}}
+        )
+
+        # Create a simple cohort for the query object
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Cohort", filters={"properties": {"type": "AND", "values": []}}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+
+        # Create a negated dynamic-cohort property
+        prop = Property(type="dynamic-cohort", key="id", value=target_cohort.id, negation=True)
+
+        # When negation=True, the property is handled through build_conditions with EXCEPT
+        # We need to test through _get_condition_for_property
+        query_ast = hogql_query._get_condition_for_property(prop)
+
+        # Print the AST to string
+        query_str = prepare_and_print_ast(query_ast, hogql_query.hogql_context, "clickhouse", pretty=True)[0]
+
+        # Should still query cohort_membership table
+        self.assertIn("cohort_membership", query_str)
+        # Should have cohort_id filter
+        self.assertIn("cohort_membership.cohort_id", query_str)
+
+    def test_behavioral_performed_event_multiple(self) -> None:
+        """
+        Test that performed_event_multiple queries precalculated_events with count aggregation.
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "type": "behavioral",
+                            "value": "performed_event_multiple",
+                            "negation": False,
+                            "operator": "gte",
+                            "event_type": "events",
+                            "operator_value": 5,
+                            "time_value": 30,
+                            "time_interval": "day",
+                            "conditionHash": "xyz789abc123",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Behavioral Multiple", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # Should query precalculated_events
+        self.assertIn("precalculated_events", query_str)
+        # Should have count aggregation
+        self.assertIn("count()", query_str)
+        # Should have event_count field
+        self.assertIn("event_count", query_str)
+        # Should have greaterOrEquals comparison with 5
+        self.assertIn("greaterOrEquals(event_count, 5)", query_str)
+        # Should have HAVING clause for count filtering
+        self.assertIn("HAVING", query_str)
+        # Should join with person_distinct_id table
+        self.assertIn("person_distinct_id", query_str)
+
+    def test_static_cohort_raises_error(self) -> None:
+        """
+        Test that static cohort filters raise an error for realtime cohorts.
+        Static cohorts are not supported in realtime calculation.
+        """
+        # First create a static cohort
+        static_cohort = Cohort.objects.create(
+            team=self.team, name="Static Cohort", is_static=True, is_calculating=False
+        )
+
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [{"key": "id", "type": "static-cohort", "value": static_cohort.id, "negation": False}],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Static Cohort Error", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+
+        # Should raise ValueError when trying to generate query
+        with self.assertRaises(ValueError) as context:
+            hogql_query.query_str("clickhouse")
+
+        self.assertIn("static cohort", str(context.exception).lower())

--- a/posthog/management/commands/analyze_realtime_cohort_calculation.py
+++ b/posthog/management/commands/analyze_realtime_cohort_calculation.py
@@ -39,23 +39,32 @@ class Command(BaseCommand):
             default=5,
             help="Delay between batches in minutes (default: 5)",
         )
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            default=None,
+            help="Filter cohorts by team_id (optional)",
+        )
 
     def handle(self, *args, **options):
         parallelism = options.get("parallelism", 10)
         workflows_per_batch = options.get("workflows_per_batch", 5)
         batch_delay_minutes = options.get("batch_delay_minutes", 5)
+        team_id = options.get("team_id")
 
         logger.info(
             "Starting realtime cohort calculation coordinator",
             parallelism=parallelism,
             workflows_per_batch=workflows_per_batch,
             batch_delay_minutes=batch_delay_minutes,
+            team_id=team_id,
         )
 
         self.run_temporal_workflow(
             parallelism=parallelism,
             workflows_per_batch=workflows_per_batch,
             batch_delay_minutes=batch_delay_minutes,
+            team_id=team_id,
         )
 
         logger.info(
@@ -71,6 +80,7 @@ class Command(BaseCommand):
         parallelism: int,
         workflows_per_batch: int,
         batch_delay_minutes: int,
+        team_id: int | None,
     ) -> None:
         """Run the Temporal workflow for parallel processing."""
 
@@ -83,6 +93,7 @@ class Command(BaseCommand):
                 parallelism=parallelism,
                 workflows_per_batch=workflows_per_batch,
                 batch_delay_minutes=batch_delay_minutes,
+                team_id=team_id,
             )
 
             # Generate unique workflow ID

--- a/posthog/management/commands/analyze_realtime_cohort_calculation.py
+++ b/posthog/management/commands/analyze_realtime_cohort_calculation.py
@@ -22,18 +22,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--days",
-            type=int,
-            default=30,
-            help="Number of days to look back (default: 30)",
-        )
-        parser.add_argument(
-            "--min-matches",
-            type=int,
-            default=3,
-            help="Minimum number of matches required (default: 3)",
-        )
-        parser.add_argument(
             "--parallelism",
             type=int,
             default=10,
@@ -53,24 +41,18 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        days = options.get("days", 30)
-        min_matches = options.get("min_matches", 3)
         parallelism = options.get("parallelism", 10)
         workflows_per_batch = options.get("workflows_per_batch", 5)
         batch_delay_minutes = options.get("batch_delay_minutes", 5)
 
         logger.info(
             "Starting realtime cohort calculation coordinator",
-            days=days,
-            min_matches=min_matches,
             parallelism=parallelism,
             workflows_per_batch=workflows_per_batch,
             batch_delay_minutes=batch_delay_minutes,
         )
 
         self.run_temporal_workflow(
-            days=days,
-            min_matches=min_matches,
             parallelism=parallelism,
             workflows_per_batch=workflows_per_batch,
             batch_delay_minutes=batch_delay_minutes,
@@ -86,8 +68,6 @@ class Command(BaseCommand):
 
     def run_temporal_workflow(
         self,
-        days: int,
-        min_matches: int,
         parallelism: int,
         workflows_per_batch: int,
         batch_delay_minutes: int,
@@ -100,8 +80,6 @@ class Command(BaseCommand):
 
             # Create coordinator workflow inputs
             inputs = RealtimeCohortCalculationCoordinatorWorkflowInputs(
-                days=days,
-                min_matches=min_matches,
                 parallelism=parallelism,
                 workflows_per_batch=workflows_per_batch,
                 batch_delay_minutes=batch_delay_minutes,

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -220,6 +220,9 @@ class Property:
     total_periods: Optional[int]
     min_periods: Optional[int]
     negation: Optional[bool] = False
+    # Fields for realtime cohorts
+    conditionHash: Optional[str]
+    bytecode: Optional[list[Any]]
     _data: dict
 
     def __init__(
@@ -244,6 +247,9 @@ class Property:
         seq_time_interval: Optional[OperatorInterval] = None,
         negation: Optional[bool] = None,
         event_filters: Optional[list["Property"]] = None,
+        # Only set for realtime cohorts
+        conditionHash: Optional[str] = None,
+        bytecode: Optional[list[Any]] = None,
         **kwargs,
     ) -> None:
         self.key = key
@@ -263,6 +269,8 @@ class Property:
         self.seq_time_interval = seq_time_interval
         self.negation = None if negation is None else str_to_bool(negation)
         self.event_filters = event_filters
+        self.conditionHash = conditionHash
+        self.bytecode = bytecode
 
         if value is None and self.operator in ["is_set", "is_not_set"]:
             self.value = self.operator

--- a/posthog/templates/admin/realtime_cohort_calculation.html
+++ b/posthog/templates/admin/realtime_cohort_calculation.html
@@ -49,28 +49,6 @@
         <h2>Configuration</h2>
         
         <div class="form-row">
-            <label for="{{ form.days.id_for_label }}" class="required">
-                {{ form.days.label }}:
-            </label>
-            {{ form.days }}
-            {% if form.days.help_text %}
-                <p class="help">{{ form.days.help_text }}</p>
-            {% endif %}
-            {{ form.days.errors }}
-        </div>
-        
-        <div class="form-row">
-            <label for="{{ form.min_matches.id_for_label }}" class="required">
-                {{ form.min_matches.label }}:
-            </label>
-            {{ form.min_matches }}
-            {% if form.min_matches.help_text %}
-                <p class="help">{{ form.min_matches.help_text }}</p>
-            {% endif %}
-            {{ form.min_matches.errors }}
-        </div>
-        
-        <div class="form-row">
             <label for="{{ form.parallelism.id_for_label }}" class="required">
                 {{ form.parallelism.label }}:
             </label>

--- a/posthog/templates/admin/realtime_cohort_calculation.html
+++ b/posthog/templates/admin/realtime_cohort_calculation.html
@@ -47,6 +47,13 @@
     
     <fieldset class="module aligned">
         <h2>Configuration</h2>
+
+        <div class="form-row">
+            <label for="{{ form.team_id.id_for_label }}">{{ form.team_id.label }}:</label>
+            {{ form.team_id }}
+            {% if form.team_id.help_text %}<p class="help">{{ form.team_id.help_text }}</p>{% endif %}
+            {{ form.team_id.errors }}
+        </div>
         
         <div class="form-row">
             <label for="{{ form.parallelism.id_for_label }}" class="required">

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -524,32 +524,32 @@ def configure_logger(
 
     is_test_or_tty = sys.stderr.isatty() or settings.TEST
 
-    if is_test_or_tty:
+    # if is_test_or_tty:
+    #     logger_factory = LoggerFactory(file=file, is_test_or_tty=is_test_or_tty)
+    #     base_processors += [
+    #         EventRenamer("msg"),
+    #         structlog.dev.ConsoleRenderer(event_key="msg"),
+    #     ]
+    # else:
+    try:
+        log_producer = KafkaLogProducerFromQueueAsync(
+            queue=log_queue, topic=KAFKA_LOG_ENTRIES, producer=producer, loop=loop
+        )
+    except Exception as e:
+        # Skip putting logs in queue if we don't have a producer that can consume the queue.
+        # We save the error to log it later as the logger hasn't yet been configured at this time.
+        log_producer_error = e
         logger_factory = LoggerFactory(file=file, is_test_or_tty=is_test_or_tty)
-        base_processors += [
-            EventRenamer("msg"),
-            structlog.dev.ConsoleRenderer(event_key="msg"),
-        ]
     else:
-        try:
-            log_producer = KafkaLogProducerFromQueueAsync(
-                queue=log_queue, topic=KAFKA_LOG_ENTRIES, producer=producer, loop=loop
-            )
-        except Exception as e:
-            # Skip putting logs in queue if we don't have a producer that can consume the queue.
-            # We save the error to log it later as the logger hasn't yet been configured at this time.
-            log_producer_error = e
-            logger_factory = LoggerFactory(file=file, is_test_or_tty=is_test_or_tty)
-        else:
-            logger_factory = LoggerFactory(
-                loop=loop or asyncio.get_running_loop(), queue=log_queue, file=file, is_test_or_tty=is_test_or_tty
-            )
+        logger_factory = LoggerFactory(
+            loop=loop or asyncio.get_running_loop(), queue=log_queue, file=file, is_test_or_tty=is_test_or_tty
+        )
 
-        base_processors += [
-            structlog.processors.dict_tracebacks,
-            EventRenamer("msg"),
-            LogMessagesRenderer(event_key="msg"),
-        ]
+    base_processors += [
+        structlog.processors.dict_tracebacks,
+        EventRenamer("msg"),
+        LogMessagesRenderer(event_key="msg"),
+    ]
 
     extra_processors_to_add = extra_processors if extra_processors is not None else []
 

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -8,10 +8,14 @@ import temporalio.activity
 import temporalio.workflow
 from structlog.contextvars import bind_contextvars
 
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.printer import prepare_and_print_ast
+
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.hogql_queries.hogql_cohort_query import HogQLRealtimeCohortQuery
 from posthog.kafka_client.client import KafkaProducer
 from posthog.kafka_client.topics import KAFKA_COHORT_MEMBERSHIP_CHANGED
-from posthog.models.action import Action
+from posthog.models.cohort.cohort import Cohort, CohortType
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
@@ -25,16 +29,12 @@ LOGGER = get_logger(__name__)
 class RealtimeCohortCalculationWorkflowInputs:
     """Inputs for the realtime cohort calculation workflow."""
 
-    days: int = 30
-    min_matches: int = 3
     limit: Optional[int] = None
     offset: int = 0
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
         return {
-            "days": self.days,
-            "min_matches": self.min_matches,
             "limit": self.limit,
             "offset": self.offset,
         }
@@ -42,26 +42,19 @@ class RealtimeCohortCalculationWorkflowInputs:
 
 @temporalio.activity.defn
 async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCalculationWorkflowInputs) -> None:
-    """Process a batch of actions with bytecode."""
+    """Process a batch of realtime cohorts using HogQLRealtimeCohortQuery."""
     bind_contextvars()
     logger = LOGGER.bind()
 
     logger.info(f"Starting realtime cohort calculation workflow for range offset={inputs.offset}, limit={inputs.limit}")
 
-    async with Heartbeater(details=(f"Starting to process actions (offset={inputs.offset})",)) as heartbeater:
+    async with Heartbeater(details=(f"Starting to process cohorts (offset={inputs.offset})",)) as heartbeater:
         start_time = time.time()
 
-        # Basic validation
-        if not isinstance(inputs.days, int) or inputs.days < 0 or inputs.days > 365:
-            raise ValueError(f"Invalid days value: {inputs.days}")
-        if not isinstance(inputs.min_matches, int) or inputs.min_matches < 0:
-            raise ValueError(f"Invalid min_matches value: {inputs.min_matches}")
-
         @database_sync_to_async
-        def get_actions():
-            # Only get actions that are not deleted and have bytecode
-            # Only fetch the fields we need for efficiency
-            queryset = Action.objects.filter(deleted=False, bytecode__isnull=False).only("id", "team_id")
+        def get_cohorts():
+            # Only get cohorts that are not deleted and have cohort_type='realtime'
+            queryset = Cohort.objects.filter(deleted=False, cohort_type=CohortType.REALTIME).select_related("team")
 
             # Apply pagination
             queryset = (
@@ -72,101 +65,74 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
 
             return list(queryset)
 
-        actions: list[Action] = await get_actions()
+        cohorts: list[Cohort] = await get_cohorts()
 
-        actions_count = 0
+        cohorts_count = 0
 
         # Initialize Kafka producer once before the loop
         kafka_producer = KafkaProducer()
 
-        # Process each action
-        for idx, action in enumerate(actions, 1):
-            # Update heartbeat progress every 100 actions to minimize overhead
-            if idx % 100 == 0 or idx == len(actions):
-                heartbeater.details = (f"Processing action {idx}/{len(actions)}",)
+        # Process each cohort
+        for idx, cohort in enumerate(cohorts, 1):
+            # Update heartbeat progress every 100 cohorts to minimize overhead
+            if idx % 100 == 0 or idx == len(cohorts):
+                heartbeater.details = (f"Processing cohort {idx}/{len(cohorts)}",)
 
             # Log progress periodically
-            if idx % 100 == 0 or idx == len(actions):
-                logger.info(f"Processed {idx}/{len(actions)} actions so far")
-
-            # Query ClickHouse for persons who performed event X at least N times over the last X days
-            query = """
-               SELECT
-                    COALESCE(bcm.team_id, cmc.team_id) as team_id,
-                    %(action_id)s as cohort_id,
-                    COALESCE(bcm.person_id, cmc.person_id) as person_id,
-                    now64() as last_updated,
-                    CASE
-                        WHEN
-                            cmc.person_id IS NULL -- Does not exist in cohort_membership_changed
-                            THEN 'entered' -- so, new member (or re-entered, as we filter members who left)
-                        WHEN
-                            bcm.person_id IS NULL -- There is no match in behavioral_cohorts_matches
-                            THEN 'left' -- so, it left the cohort
-                        ELSE
-                            'unchanged' -- for all other cases, the membership did not change
-                    END as status
-                FROM
-                (
-                    SELECT
-                        team_id,
-                        person_id
-                    FROM
-                    (
-                        SELECT team_id, distinct_id
-                        FROM prefiltered_events
-                        WHERE
-                            team_id = %(team_id)s
-                            AND condition = toString(%(action_id)s)
-                            AND date >= now() - toIntervalDay(%(days)s)
-                    ) AS pfe
-                    INNER JOIN
-                    (
-                        SELECT
-                            distinct_id,
-                            argMax(person_id, version) as person_id
-                        FROM person_distinct_id2
-                        WHERE team_id = %(team_id)s
-                        GROUP BY distinct_id
-                        HAVING argMax(is_deleted, version) = 0
-                    ) AS pdi2 ON pdi2.distinct_id = pfe.distinct_id
-                    GROUP BY
-                        team_id,
-                        person_id
-                    HAVING count() >= %(min_matches)s
-                ) bcm
-                FULL OUTER JOIN
-                (
-                    SELECT team_id, person_id, argMax(status, last_updated) as status
-                    FROM cohort_membership
-                    WHERE
-                        team_id = %(team_id)s
-                        AND cohort_id = %(action_id)s
-                    GROUP BY team_id, person_id
-                    HAVING status = 'entered'
-                ) cmc ON bcm.team_id = cmc.team_id AND bcm.person_id = cmc.person_id
-                WHERE status != 'unchanged'
-                SETTINGS join_use_nulls = 1
-                FORMAT JSONEachRow
-            """
+            if idx % 100 == 0 or idx == len(cohorts):
+                logger.info(f"Processed {idx}/{len(cohorts)} cohorts so far")
 
             try:
+                # Build query in sync context (HogQLRealtimeCohortQuery accesses team properties)
+                @database_sync_to_async
+                def build_query(cohort_obj):
+                    realtime_query = HogQLRealtimeCohortQuery(cohort=cohort_obj, team=cohort_obj.team)
+                    current_members_query = realtime_query.get_query()
+                    hogql_context = HogQLContext(team_id=cohort_obj.team_id, enable_select_queries=True)
+                    current_members_sql, _ = prepare_and_print_ast(current_members_query, hogql_context, "clickhouse")
+                    return current_members_sql, hogql_context.values
+
+                current_members_sql, query_params = await build_query(cohort)
+
+                # Wrap with comparison to previous membership to detect changes
+                final_query = f"""
+                    SELECT
+                        {cohort.team_id} as team_id,
+                        {cohort.id} as cohort_id,
+                        COALESCE(current_matches.id, previous_members.person_id) as person_id,
+                        now64() as last_updated,
+                        CASE
+                            WHEN previous_members.person_id IS NULL THEN 'entered'
+                            WHEN current_matches.id IS NULL THEN 'left'
+                            ELSE 'unchanged'
+                        END as status
+                    FROM
+                    (
+                        {current_members_sql}
+                    ) AS current_matches
+                    FULL OUTER JOIN
+                    (
+                        SELECT team_id, person_id, argMax(status, last_updated) as status
+                        FROM cohort_membership
+                        WHERE
+                            team_id = {cohort.team_id}
+                            AND cohort_id = {cohort.id}
+                        GROUP BY team_id, person_id
+                        HAVING status = 'entered'
+                    ) previous_members ON current_matches.id = previous_members.person_id
+                    WHERE status != 'unchanged'
+                    SETTINGS join_use_nulls = 1
+                    FORMAT JSONEachRow
+                """
+
                 with tags_context(
-                    team_id=action.team_id,
+                    team_id=cohort.team_id,
                     feature=Feature.BEHAVIORAL_COHORTS,
                     product=Product.MESSAGING,
-                    query_type="action_event_counts_per_person_per_day",
+                    query_type="realtime_cohort_calculation",
                 ):
-                    async with get_client(team_id=action.team_id) as client:
-                        async for row in client.stream_query_as_jsonl(
-                            query,
-                            query_parameters={
-                                "team_id": action.team_id,
-                                "action_id": action.id,
-                                "days": inputs.days,
-                                "min_matches": inputs.min_matches,
-                            },
-                        ):
+                    async with get_client(team_id=cohort.team_id) as client:
+                        async for row in client.stream_query_as_jsonl(final_query, query_parameters=query_params):
                             payload = {
                                 "team_id": row["team_id"],
                                 "cohort_id": row["cohort_id"],
@@ -183,23 +149,24 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
 
             except Exception as e:
                 logger.exception(
-                    f"Error querying events for action {action.id}",
-                    action_id=action.id,
-                    error=str(e),
+                    f"Error calculating cohort {cohort.id}: {type(e).__name__}: {str(e)}",
+                    cohort_id=cohort.id,
+                    error_type=type(e).__name__,
+                    error_message=str(e),
                 )
                 continue
 
-            actions_count += 1
+            cohorts_count += 1
 
         end_time = time.time()
         duration_seconds = end_time - start_time
         duration_minutes = duration_seconds / 60
 
-        heartbeater.details = (f"Completed: processed {actions_count} actions in {duration_minutes:.1f} minutes",)
+        heartbeater.details = (f"Completed: processed {cohorts_count} cohorts in {duration_minutes:.1f} minutes",)
 
         logger.info(
-            f"Completed processing: processed {actions_count} actions in {duration_minutes:.1f} minutes ({duration_seconds:.1f} seconds)",
-            actions_processed=actions_count,
+            f"Completed processing: processed {cohorts_count} cohorts in {duration_minutes:.1f} minutes ({duration_seconds:.1f} seconds)",
+            cohorts_processed=cohorts_count,
             duration_seconds=duration_seconds,
             duration_minutes=duration_minutes,
             offset=inputs.offset,

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -57,12 +57,14 @@ class RealtimeCohortCalculationWorkflowInputs:
 
     limit: Optional[int] = None
     offset: int = 0
+    team_id: Optional[int] = None
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
         return {
             "limit": self.limit,
             "offset": self.offset,
+            "team_id": self.team_id,
         }
 
 
@@ -81,6 +83,10 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
         def get_cohorts():
             # Only get cohorts that are not deleted and have cohort_type='realtime'
             queryset = Cohort.objects.filter(deleted=False, cohort_type=CohortType.REALTIME).select_related("team")
+
+            # Apply team_id filter if provided
+            if inputs.team_id is not None:
+                queryset = queryset.filter(team_id=inputs.team_id)
 
             # Apply pagination
             queryset = (

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow_coordinator.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow_coordinator.py
@@ -9,7 +9,7 @@ import temporalio.common
 import temporalio.activity
 import temporalio.workflow
 
-from posthog.models.action import Action
+from posthog.models.cohort.cohort import Cohort, CohortType
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.logger import get_logger
@@ -35,8 +35,6 @@ class WorkflowConfig(TypedDict):
 class RealtimeCohortCalculationCoordinatorWorkflowInputs:
     """Inputs for the coordinator workflow that spawns child workflows."""
 
-    days: int = 30  # Number of days to look back
-    min_matches: int = 3  # Minimum number of matches required
     parallelism: int = 10  # Number of child workflows to spawn
     workflows_per_batch: int = 5  # Number of workflows to start per batch
     batch_delay_minutes: int = 5  # Delay between batches in minutes
@@ -44,8 +42,6 @@ class RealtimeCohortCalculationCoordinatorWorkflowInputs:
     @property
     def properties_to_log(self) -> dict[str, Any]:
         return {
-            "days": self.days,
-            "min_matches": self.min_matches,
             "parallelism": self.parallelism,
             "workflows_per_batch": self.workflows_per_batch,
             "batch_delay_minutes": self.batch_delay_minutes,
@@ -54,7 +50,7 @@ class RealtimeCohortCalculationCoordinatorWorkflowInputs:
 
 @dataclasses.dataclass
 class RealtimeCohortCalculationCountResult:
-    """Result from counting total actions."""
+    """Result from counting total cohorts."""
 
     count: int
 
@@ -63,14 +59,14 @@ class RealtimeCohortCalculationCountResult:
 async def get_realtime_cohort_calculation_count_activity(
     inputs: RealtimeCohortCalculationCoordinatorWorkflowInputs,
 ) -> RealtimeCohortCalculationCountResult:
-    """Get the total count of actions with bytecode."""
+    """Get the total count of realtime cohorts."""
 
     @database_sync_to_async
-    def get_action_count():
-        # Only get actions that are not deleted and have bytecode
-        return Action.objects.filter(deleted=False, bytecode__isnull=False).count()
+    def get_cohort_count():
+        # Only get cohorts that are not deleted and have cohort_type='realtime'
+        return Cohort.objects.filter(deleted=False, cohort_type=CohortType.REALTIME).count()
 
-    count = await get_action_count()
+    count = await get_cohort_count()
     return RealtimeCohortCalculationCountResult(count=count)
 
 
@@ -89,7 +85,7 @@ class RealtimeCohortCalculationCoordinatorWorkflow(PostHogWorkflow):
         workflow_logger = temporalio.workflow.logger
         workflow_logger.info(f"Starting realtime cohort calculation coordinator with parallelism={inputs.parallelism}")
 
-        # Step 1: Get total count of actions
+        # Step 1: Get total count of cohorts
         count_result = await temporalio.workflow.execute_activity(
             get_realtime_cohort_calculation_count_activity,
             inputs,
@@ -97,24 +93,24 @@ class RealtimeCohortCalculationCoordinatorWorkflow(PostHogWorkflow):
             retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
         )
 
-        total_actions = count_result.count
-        if total_actions == 0:
-            workflow_logger.warning("No actions found")
+        total_cohorts = count_result.count
+        if total_cohorts == 0:
+            workflow_logger.warning("No realtime cohorts found")
             return
 
         workflow_logger.info(
-            f"Scheduling {total_actions} actions across {inputs.parallelism} child workflows "
+            f"Scheduling {total_cohorts} cohorts across {inputs.parallelism} child workflows "
             f"in batches of {inputs.workflows_per_batch} every {inputs.batch_delay_minutes} minutes"
         )
 
         # Step 2: Calculate ranges for each child workflow
-        actions_per_workflow = math.ceil(total_actions / inputs.parallelism)
+        cohorts_per_workflow = math.ceil(total_cohorts / inputs.parallelism)
 
         # Step 3: Prepare all workflow configs first
         workflow_configs: list[WorkflowConfig] = []
         for i in range(inputs.parallelism):
-            offset = i * actions_per_workflow
-            limit = min(actions_per_workflow, total_actions - offset)
+            offset = i * cohorts_per_workflow
+            limit = min(cohorts_per_workflow, total_cohorts - offset)
 
             if limit <= 0:
                 break
@@ -123,8 +119,6 @@ class RealtimeCohortCalculationCoordinatorWorkflow(PostHogWorkflow):
                 WorkflowConfig(
                     id=f"{temporalio.workflow.info().workflow_id}-child-{i}",
                     inputs=RealtimeCohortCalculationWorkflowInputs(
-                        days=inputs.days,
-                        min_matches=inputs.min_matches,
                         limit=limit,
                         offset=offset,
                     ),
@@ -161,7 +155,7 @@ class RealtimeCohortCalculationCoordinatorWorkflow(PostHogWorkflow):
                 workflows_scheduled += 1
 
                 workflow_logger.info(
-                    f"Scheduled workflow {config['index']} for actions {config['offset']}-{config['offset'] + config['limit'] - 1}"
+                    f"Scheduled workflow {config['index']} for cohorts {config['offset']}-{config['offset'] + config['limit'] - 1}"
                 )
 
             workflow_logger.info(


### PR DESCRIPTION
## Problem

The cohort membership calculation is still using actions as a proxy

## Changes

 - Implemented HogQLRealtimeCohortQuery that queries precalculated_events (indexed by conditionHash) instead of raw events table
  - Queries cohort_membership table for dynamic cohort-in-cohort filters
  - Switched from querying events directly to using HogQLRealtimeCohortQuery
  - Added HogQL schema definitions for both new tables (`cohort_membership` and `precalculated_events`)
  - Removed filters (`days` and `min_matches`) from the command
  - Added optional `team_id` filter to the command

## How did you test this code?

### Unit tests
- New tests covering behavioral filters, person properties, cohort membership queries, and error cases

### Manual tests
- Cohort with criteria "Completed event"
- Cohort with criteria "Completed an event multiple times"
- Cohort with criteria "Have the property"
- Cohort with criteria "do not have the property"
- Cohort with criteria "in Cohort"
- Cohort with criteria "not in Cohort"
- Cohort with multiple criteria and criterion using "AND"
- Cohort with multiple criteria and criterion using "OR"
