### PR TITLE
fix: use sync-mode for event capture

### DIFF
--- a/posthog/ph_client.py
+++ b/posthog/ph_client.py
@@ -15,7 +15,7 @@ PH_EU_HOST = "https://eu.i.posthog.com"
 logger = structlog.get_logger(__name__)
 
 
-def get_regional_ph_client():
+def get_regional_ph_client(**kwargs: Any):
     if not is_cloud():
         return
 
@@ -25,7 +25,7 @@ def get_regional_ph_client():
     if not region:
         return
 
-    return get_client(region)
+    return get_client(region, **kwargs)
 
 
 @contextmanager
@@ -41,7 +41,7 @@ def ph_scoped_capture():
     ph_client.shutdown()
 
 
-def get_client(region: str = "US"):
+def get_client(region: str = "US", **kwargs: Any):
     from posthoganalytics import Posthog
 
     api_key = None
@@ -55,4 +55,4 @@ def get_client(region: str = "US"):
     else:
         return
 
-    return Posthog(api_key, host=host, super_properties={"region": region})
+    return Posthog(api_key, host=host, super_properties={"region": region}, **kwargs)

--- a/posthog/temporal/tests/weekly_digest/test_activities.py
+++ b/posthog/temporal/tests/weekly_digest/test_activities.py
@@ -622,7 +622,6 @@ async def test_send_weekly_digest_batch(mock_redis, common_input, digest):
 
     mock_ph_client = MagicMock()
     mock_ph_client.capture = MagicMock()
-    mock_ph_client.shutdown = MagicMock()
 
     mock_messaging_record = MagicMock()
     mock_messaging_record.sent_at = None
@@ -640,7 +639,6 @@ async def test_send_weekly_digest_batch(mock_redis, common_input, digest):
 
     # Verify PostHog client was called
     mock_ph_client.capture.assert_called_once()
-    mock_ph_client.shutdown.assert_called_once()
 
     # Verify messaging record was updated
     mock_messaging_objects.abulk_update.assert_called_once()
@@ -694,7 +692,6 @@ async def test_send_weekly_digest_batch_dry_run(mock_redis, common_input, digest
 
     mock_ph_client = MagicMock()
     mock_ph_client.capture = MagicMock()
-    mock_ph_client.shutdown = MagicMock()
 
     mock_messaging_record = MagicMock()
     mock_messaging_record.sent_at = None
@@ -711,4 +708,3 @@ async def test_send_weekly_digest_batch_dry_run(mock_redis, common_input, digest
 
     # In dry run mode, PostHog client should not be called
     mock_ph_client.capture.assert_not_called()
-    mock_ph_client.shutdown.assert_called_once()

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -465,7 +465,7 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
         empty_org_digest_count = 0
         empty_user_digest_count = 0
 
-        ph_client: Posthog = get_regional_ph_client()
+        ph_client: Posthog = get_regional_ph_client(sync_mode=True)
 
         if not ph_client and not input.dry_run:
             logger.error("Failed to set up Posthog client")
@@ -560,9 +560,6 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
 
         if len(messaging_record_batch) > 0:
             await MessagingRecord.objects.abulk_update(messaging_record_batch, ["sent_at"])
-
-        if ph_client:
-            ph_client.shutdown()
 
         logger.info(
             "Finished sending weekly digest batch",


### PR DESCRIPTION
The threaded event consumer is not playing nicely with Temporal - let's try to run the Python client in synchronous mode instead.