### PR TITLE
fix: show applied balance in the upgrade modal

### DIFF
--- a/frontend/src/scenes/billing/ConfirmUpgradeModal.tsx
+++ b/frontend/src/scenes/billing/ConfirmUpgradeModal.tsx
@@ -18,7 +18,10 @@ export function ConfirmUpgradeModal({ product }: { product: BillingProductV2Addo
     const isLoading = switchPlanLoading === product.type
 
     const targetPlan = currentAndUpgradePlans?.upgradePlan
-    const amountDue = Math.max(0, proratedAmount - unusedPlatformAddonAmount)
+    const amountDueBeforeCredits = Math.max(0, proratedAmount - unusedPlatformAddonAmount)
+    const availableCreditBalance = billing?.discount_amount_usd ? parseFloat(billing.discount_amount_usd) : 0
+    const appliedBalance = Math.min(amountDueBeforeCredits, availableCreditBalance)
+    const amountDue = Math.max(0, amountDueBeforeCredits - appliedBalance)
 
     const periodEnd = billing?.billing_period?.current_period_end
     const remainingPeriodFormatted = periodEnd
@@ -40,12 +43,20 @@ export function ConfirmUpgradeModal({ product }: { product: BillingProductV2Addo
             dateRange: remainingPeriodFormatted,
             amount: `-$${unusedPlatformAddonAmount.toFixed(2)}`,
         },
-        {
-            description: 'Amount due today',
-            amount: `$${amountDue.toFixed(2)}`,
-            isBold: true,
-        },
     ]
+
+    if (appliedBalance > 0) {
+        rows.push({
+            description: 'Applied balance',
+            amount: `-$${appliedBalance.toFixed(2)}`,
+        })
+    }
+
+    rows.push({
+        description: 'Amount due today',
+        amount: `$${amountDue.toFixed(2)}`,
+        isBold: true,
+    })
 
     const columns: LemonTableColumns<BillingInvoiceItemRow> = [
         {


### PR DESCRIPTION
## Problem
When upgrading a subscription, if the customer has a credit balance, it’s applied automatically. As a result, the actual charged amount can be lower than what the confirmation modal currently shows.

## Changes
Added a new line in the confirmation modal to display the applied balance.  

<img width="752" height="562" alt="Screenshot 2025-11-12 at 09 47 46" src="https://github.com/user-attachments/assets/f1633c98-67e2-4792-9926-a189c972c139" />

If the customer has more credit than needed, only the amount required to bring the invoice total to zero is applied.

<img width="793" height="571" alt="Screenshot 2025-11-12 at 09 52 54" src="https://github.com/user-attachments/assets/9b71d6e4-43cc-4d8d-a5d4-17ab352e08f3" />

## How did you test this code?
Manually added credits to my account through Billing Admin.  
Then went to the Billing page and upgraded from the Scale plan to the Enterprise add-on. 