### PR TITLE
feat(ph-ai): back to chat arrow

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconExternal } from '@posthog/icons'
+import { IconArrowLeft, IconExternal } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { capitalizeFirstLetter } from 'lib/utils'
@@ -10,12 +10,16 @@ import { settingsLogic } from 'scenes/settings/settingsLogic'
 import { SettingsLogicProps } from 'scenes/settings/types'
 import { urls } from 'scenes/urls'
 
+import { SidePanelTab } from '~/types'
+
 import { SidePanelPaneHeader } from '../components/SidePanelPaneHeader'
+import { sidePanelStateLogic } from '../sidePanelStateLogic'
 import { sidePanelSettingsLogic } from './sidePanelSettingsLogic'
 
 export const SidePanelSettings = (): JSX.Element => {
-    const { settings } = useValues(sidePanelSettingsLogic)
-    const { closeSidePanel, setSettings } = useActions(sidePanelSettingsLogic)
+    const { settings, previousTab } = useValues(sidePanelSettingsLogic)
+    const { setSettings, setPreviousTab } = useActions(sidePanelSettingsLogic)
+    const { openSidePanel, closeSidePanel } = useActions(sidePanelStateLogic)
 
     const settingsLogicProps: SettingsLogicProps = {
         ...settings,
@@ -30,9 +34,29 @@ export const SidePanelSettings = (): JSX.Element => {
         })
     }, [selectedSectionId, selectedLevel, setSettings])
 
+    const cameFromMax = previousTab === SidePanelTab.Max && selectedSectionId === 'environment-max'
+
     return (
         <div className="flex flex-col overflow-hidden">
-            <SidePanelPaneHeader title={`${capitalizeFirstLetter(selectedLevel)} settings`}>
+            <SidePanelPaneHeader
+                title={
+                    <>
+                        {cameFromMax && (
+                            <LemonButton
+                                size="small"
+                                icon={<IconArrowLeft />}
+                                onClick={() => {
+                                    setPreviousTab(null)
+                                    openSidePanel(SidePanelTab.Max)
+                                }}
+                                tooltip="Back to PostHog AI"
+                                tooltipPlacement="bottom-end"
+                            />
+                        )}
+                        {`${capitalizeFirstLetter(selectedLevel)} settings`}
+                    </>
+                }
+            >
                 <LemonButton
                     size="small"
                     to={urls.settings(settings.sectionId ?? settings.settingLevelId, settings.settingId)}

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSettingsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSettingsLogic.tsx
@@ -1,6 +1,5 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SettingsLogicProps } from 'scenes/settings/types'
 
 import { SidePanelTab } from '~/types'
@@ -9,9 +8,9 @@ import { sidePanelStateLogic } from '../sidePanelStateLogic'
 import type { sidePanelSettingsLogicType } from './sidePanelSettingsLogicType'
 
 export const sidePanelSettingsLogic = kea<sidePanelSettingsLogicType>([
-    path(['scenes', 'navigation', 'sidepanel', 'sidePanelSettingsLogic']),
+    path(['layout', 'navigation-3000', 'sidepanel', 'panels', 'sidePanelSettingsLogic']),
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags'], sidePanelStateLogic, ['selectedTab', 'sidePanelOpen']],
+        values: [sidePanelStateLogic, ['selectedTab', 'sidePanelOpen']],
         actions: [sidePanelStateLogic, ['openSidePanel', 'closeSidePanel']],
     })),
 
@@ -20,9 +19,10 @@ export const sidePanelSettingsLogic = kea<sidePanelSettingsLogicType>([
         openSettingsPanel: (settingsLogicProps: SettingsLogicProps) => ({
             settingsLogicProps,
         }),
-        setSettings: (settingsLogicProps: SettingsLogicProps) => ({
+        setSettings: (settingsLogicProps: Partial<SettingsLogicProps>) => ({
             settingsLogicProps,
         }),
+        setPreviousTab: (tab: SidePanelTab | null) => ({ tab }),
     }),
 
     reducers(() => ({
@@ -33,10 +33,17 @@ export const sidePanelSettingsLogic = kea<sidePanelSettingsLogicType>([
                 openSettingsPanel: (_, { settingsLogicProps }) => {
                     return settingsLogicProps
                 },
-                setSettings: (_, { settingsLogicProps }) => {
-                    return settingsLogicProps
+                setSettings: (state, { settingsLogicProps }) => {
+                    return { ...state, ...settingsLogicProps }
                 },
                 closeSettingsPanel: () => ({}),
+            },
+        ],
+        previousTab: [
+            null as SidePanelTab | null,
+            {
+                setPreviousTab: (_, { tab }) => tab,
+                closeSettingsPanel: () => null,
             },
         ],
     })),
@@ -48,8 +55,10 @@ export const sidePanelSettingsLogic = kea<sidePanelSettingsLogicType>([
         ],
     }),
 
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         openSettingsPanel: () => {
+            // Capture the current tab before switching to settings
+            actions.setPreviousTab(values.selectedTab)
             actions.openSidePanel(SidePanelTab.Settings)
         },
         closeSettingsPanel: () => {


### PR DESCRIPTION
## Problem

<p align="center">
  <img width="512" height="512" alt="Back to the Chat" src="https://github.com/user-attachments/assets/0379d4f5-2850-4399-b81e-a1bd905ee9cf" />
</p>

Once entering PostHog AI memory settings, getting back to chat directly was not possible. The only option was to close the sidebar entirely and re-open it, not ideal.

## Changes

* allow going back to chat

## How did you test this code?

- [x] manual tests

https://github.com/user-attachments/assets/8f28f466-d16c-4f74-b364-570d94393070

