### PR TITLE
fix(experiments): Refresh results on metrics change

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -193,8 +193,8 @@ export const MetricHeader = ({
                                                 <div className="text-sm text-secondary max-w-lg">
                                                     <p>
                                                         We'll take you to the form to customize and save this metric.
-                                                        Your new version will appear in your shared metrics, ready to
-                                                        add to your experiment.
+                                                        Your new version will appear in your shared metrics, ready to be
+                                                        added to your experiment.
                                                     </p>
                                                 </div>
                                             ),

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1068,7 +1068,12 @@ export const experimentLogic = kea<experimentLogicType>([
         updateExperimentSuccess: async ({ experiment, payload }) => {
             actions.updateExperiments(experiment)
             if (experiment.start_date) {
-                const forceRefresh = payload?.start_date !== undefined || payload?.end_date !== undefined
+                // For running experiments, refresh results if any of these fields are updated
+                const forceRefresh =
+                    payload?.start_date !== undefined ||
+                    payload?.end_date !== undefined ||
+                    payload?.metrics !== undefined ||
+                    payload?.metrics_secondary !== undefined
                 actions.refreshExperimentResults(forceRefresh)
             }
         },


### PR DESCRIPTION
## Problem
Prompted by: https://posthog.slack.com/archives/C07PXH2GTGV/p1762939163366799

When a metric is duplicated, it’s immediately recalculated and a fresh result is shown. This result might differ from the original metric, which could still be showing an older (cached) value.

## Changes
Whenever metric fields are modified, refresh all metrics to keep all results in sync.

## How did you test this code?
👀 