### PR TITLE
fix: Allow Etc/UTC and UTC to be treated the same

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -97,6 +97,7 @@ COMPATIBLE_TYPES: TypeTupleToCastMapping = {
     # This technically truncates the millisecond part of the value, but if it came from
     # a `DateTime` then we assume it is empty (as it would have been empty before).
     (pa.timestamp("ms", tz="UTC"), pa.int64()): TIMESTAMP_MS_TO_SECONDS_SINCE_EPOCH,
+    (pa.timestamp("ms", tz="Etc/UTC"), pa.int64()): TIMESTAMP_MS_TO_SECONDS_SINCE_EPOCH,
 }
 
 FileFormat = typing.Literal["Parquet", "JSONLines"]

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -88,6 +88,7 @@ COMPATIBLE_TYPES: TypeTupleToCastMapping = {
     # BigQuery deals with timestamps in microseconds, but it does interpret timestamps
     # in milliseconds correctly, so we don't need to cast.
     (pa.timestamp("ms", tz="UTC"), pa.timestamp("us", tz="UTC")): _noop_cast,
+    (pa.timestamp("ms", tz="Etc/UTC"), pa.timestamp("us", tz="UTC")): _noop_cast,
     # We assume this is a destination field created from a ClickHouse `DateTime` that
     # has  been updated to `DateTime64(3)`.
     # This would mean the field would have been created as a BigQuery 'INT64', but we


### PR DESCRIPTION
## Problem

For some reason, values returned from clickhouse with Etc/UTC timezone are not compatible with UTC timezone.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make them compatible.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
