### PR TITLE
refactor(logs): json prettify render optimisation

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -38,7 +38,7 @@ export const scene: SceneExport = {
 }
 
 export function LogsScene(): JSX.Element {
-    const { wrapBody, prettifyJson, processedLogs, sparklineData, logsLoading, sparklineLoading, timestampFormat } =
+    const { wrapBody, prettifyJson, parsedLogs, sparklineData, logsLoading, sparklineLoading, timestampFormat } =
         useValues(logsLogic)
     const { runQuery, setDateRangeFromSparkline } = useActions(logsLogic)
 
@@ -88,7 +88,7 @@ export function LogsScene(): JSX.Element {
             <div className="flex-1 overflow-y-auto border rounded bg-bg-light">
                 <LemonTable
                     hideScrollbar
-                    dataSource={processedLogs}
+                    dataSource={parsedLogs}
                     loading={logsLoading}
                     size="small"
                     embedded

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,4 +1,3 @@
-import colors from 'ansi-colors'
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
@@ -39,7 +38,7 @@ export const scene: SceneExport = {
 }
 
 export function LogsScene(): JSX.Element {
-    const { wrapBody, prettifyJson, logs, sparklineData, logsLoading, sparklineLoading, timestampFormat } =
+    const { wrapBody, prettifyJson, processedLogs, sparklineData, logsLoading, sparklineLoading, timestampFormat } =
         useValues(logsLogic)
     const { runQuery, setDateRangeFromSparkline } = useActions(logsLogic)
 
@@ -89,7 +88,7 @@ export function LogsScene(): JSX.Element {
             <div className="flex-1 overflow-y-auto border rounded bg-bg-light">
                 <LemonTable
                     hideScrollbar
-                    dataSource={logs}
+                    dataSource={processedLogs}
                     loading={logsLoading}
                     size="small"
                     embedded
@@ -112,19 +111,11 @@ export function LogsScene(): JSX.Element {
                             title: 'Message',
                             key: 'body',
                             dataIndex: 'body',
-                            render: (_, { body }) => {
-                                const cleanBody = colors.unstyle(body)
-                                let parsed: any = null
-                                try {
-                                    parsed = JSON.parse(cleanBody)
-                                } catch {
-                                    // Not JSON, that's fine
-                                }
-
-                                if (parsed && prettifyJson) {
+                            render: (_, { cleanBody, parsedBody }) => {
+                                if (parsedBody && prettifyJson) {
                                     return (
                                         <pre className={cn('text-xs', wrapBody ? '' : 'whitespace-nowrap')}>
-                                            {JSON.stringify(parsed, null, 2)}
+                                            {JSON.stringify(parsedBody, null, 2)}
                                         </pre>
                                     )
                                 }

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -1,3 +1,4 @@
+import colors from 'ansi-colors'
 import equal from 'fast-deep-equal'
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
@@ -286,6 +287,21 @@ export const logsLogic = kea<logsLogicType>([
                     : dateRange.date_to,
                 explicitDate: dateRange.explicitDate,
             }),
+        ],
+        processedLogs: [
+            (s) => [s.logs],
+            (logs: LogMessage[]): Array<LogMessage & { cleanBody: string; parsedBody: any }> => {
+                return logs.map((log: LogMessage) => {
+                    const cleanBody = colors.unstyle(log.body)
+                    let parsedBody: any = null
+                    try {
+                        parsedBody = JSON.parse(cleanBody)
+                    } catch {
+                        // Not JSON, that's fine
+                    }
+                    return { ...log, cleanBody, parsedBody }
+                })
+            },
         ],
         sparklineData: [
             (s) => [s.sparkline],

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -14,10 +14,11 @@ import { Params } from 'scenes/sceneTypes'
 
 import { DateRange, LogMessage, LogsQuery } from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
-import { PropertyGroupFilter, UniversalFiltersGroup } from '~/types'
+import { JsonType, PropertyGroupFilter, UniversalFiltersGroup } from '~/types'
 
 import { zoomDateRange } from './filters/zoom-utils'
 import type { logsLogicType } from './logsLogicType'
+import { ParsedLogMessage } from './types'
 
 const DEFAULT_DATE_RANGE = { date_from: '-1h', date_to: null }
 const DEFAULT_SEVERITY_LEVELS = [] as LogsQuery['severityLevels']
@@ -288,12 +289,12 @@ export const logsLogic = kea<logsLogicType>([
                 explicitDate: dateRange.explicitDate,
             }),
         ],
-        processedLogs: [
+        parsedLogs: [
             (s) => [s.logs],
-            (logs: LogMessage[]): Array<LogMessage & { cleanBody: string; parsedBody: any }> => {
+            (logs: LogMessage[]): ParsedLogMessage[] => {
                 return logs.map((log: LogMessage) => {
                     const cleanBody = colors.unstyle(log.body)
-                    let parsedBody: any = null
+                    let parsedBody: JsonType | null = null
                     try {
                         parsedBody = JSON.parse(cleanBody)
                     } catch {

--- a/products/logs/frontend/types.ts
+++ b/products/logs/frontend/types.ts
@@ -1,0 +1,4 @@
+import { LogMessage } from '~/queries/schema/schema-general'
+import { JsonType } from '~/types'
+
+export type ParsedLogMessage = LogMessage & { cleanBody: string; parsedBody: JsonType | null }


### PR DESCRIPTION
## Problem

Prettified JSON logs were running JSON.parse on every render, reducing FE performance.

## Changes

- Removed JSON.parse from the scene & added processedLogs to logsLogic for cleaning and parsing log bodies so that it only runs when the data / setting changes

## How did you test this code?

local dev
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._