### PR TITLE
chore(experiments): Add description to flag condition when ship

### DIFF
--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -96,7 +96,12 @@ describe('utils', () => {
                 ],
             },
             groups: [
-                { properties: [], rollout_percentage: 100 },
+                {
+                    properties: [],
+                    rollout_percentage: 100,
+                    description:
+                        'Added by shipping experiment variant - enables 100% rollout of selected variant to all users',
+                },
                 { properties: [], rollout_percentage: 100 },
             ],
         }
@@ -176,7 +181,12 @@ describe('utils', () => {
                 ],
             },
             groups: [
-                { properties: [], rollout_percentage: 100 },
+                {
+                    properties: [],
+                    rollout_percentage: 100,
+                    description:
+                        'Added by shipping experiment variant - enables 100% rollout of selected variant to all users',
+                },
                 { properties: [], rollout_percentage: 100 },
             ],
         }

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -99,8 +99,7 @@ describe('utils', () => {
                 {
                     properties: [],
                     rollout_percentage: 100,
-                    description:
-                        'Added automatically when the experiment variant was shipped',
+                    description: 'Added automatically when the experiment variant was shipped',
                 },
                 { properties: [], rollout_percentage: 100 },
             ],
@@ -184,8 +183,7 @@ describe('utils', () => {
                 {
                     properties: [],
                     rollout_percentage: 100,
-                    description:
-                        'Added automatically when the experiment variant was shipped',
+                    description: 'Added automatically when the experiment variant was shipped',
                 },
                 { properties: [], rollout_percentage: 100 },
             ],

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -185,7 +185,7 @@ describe('utils', () => {
                     properties: [],
                     rollout_percentage: 100,
                     description:
-                        'Added by shipping experiment variant - enables 100% rollout of selected variant to all users',
+                        'Added automatically when the experiment variant was shipped',
                 },
                 { properties: [], rollout_percentage: 100 },
             ],

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -100,7 +100,7 @@ describe('utils', () => {
                     properties: [],
                     rollout_percentage: 100,
                     description:
-                        'Added by shipping experiment variant - enables 100% rollout of selected variant to all users',
+                        'Added automatically when the experiment variant was shipped',
                 },
                 { properties: [], rollout_percentage: 100 },
             ],

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -87,8 +87,7 @@ export function transformFiltersForWinningVariant(
             {
                 properties: [],
                 rollout_percentage: 100,
-                description:
-                    'Added automatically when the experiment variant was shipped',
+                description: 'Added automatically when the experiment variant was shipped',
             },
             // Preserve existing groups so that users can roll back this action
             // by deleting the newly added release condition

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -88,7 +88,7 @@ export function transformFiltersForWinningVariant(
                 properties: [],
                 rollout_percentage: 100,
                 description:
-                    'Added by shipping experiment variant - enables 100% rollout of selected variant to all users',
+                    'Added automatically when the experiment variant was shipped',
             },
             // Preserve existing groups so that users can roll back this action
             // by deleting the newly added release condition

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -84,7 +84,12 @@ export function transformFiltersForWinningVariant(
             })),
         },
         groups: [
-            { properties: [], rollout_percentage: 100 },
+            {
+                properties: [],
+                rollout_percentage: 100,
+                description:
+                    'Added by shipping experiment variant - enables 100% rollout of selected variant to all users',
+            },
             // Preserve existing groups so that users can roll back this action
             // by deleting the newly added release condition
             ...(currentFlagFilters?.groups || []),


### PR DESCRIPTION
## Problem
When users use the `Ship variant` feature, we roll out the variant by adding a release condition to the feature flag. We do this to ensure existing conditions remain untouched, in case users want to restore the previous state.

In the past, some users have asked “Why is this condition here? It seems extra.”

## Changes
Now that release conditions have a `description` field (added recently), we can include a message explaining what this newly added condition means.

## How did you test this code?
|Before|After|
|----|----|
|<img width="1334" height="558" alt="image" src="https://github.com/user-attachments/assets/2bcd017c-89f5-4bef-bc55-9ec0ebc69e90" />|<img width="1335" height="610" alt="image" src="https://github.com/user-attachments/assets/8cf1121f-0a38-4bbe-bf3f-d2592551ec90" />|