### PR TITLE
test: remove unused minio/objectstorage service

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -133,12 +133,46 @@ jobs:
                   [ -d "data" ] && docker run --rm -v "$(pwd)/data:/data" alpine sh -c "rm -rf /data/seaweedfs /data/minio" || true
               continue-on-error: true
 
+            - name: Check disk BEFORE Docker Compose
+              run: |
+                  echo "=== BEFORE DOCKER COMPOSE ==="
+                  df -h
+                  echo ""
+                  echo "=== Docker System ==="
+                  docker system df
+                  echo ""
+                  echo "=== Workspace Size ==="
+                  du -sh ./ 2>/dev/null || true
+                  echo ""
+                  echo "=== Docker Images ==="
+                  docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" | head -20
+
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker compose -f docker-compose.dev.yml down --volumes --remove-orphans
                   docker system prune -af || true
                   docker volume prune -f || true
                   docker compose -f docker-compose.dev.yml up -d &
+
+            - name: Check disk AFTER Docker Compose
+              run: |
+                  echo "=== AFTER DOCKER COMPOSE UP ==="
+                  df -h
+                  echo ""
+                  echo "=== Docker System ==="
+                  docker system df
+                  echo ""
+                  echo "=== Docker Containers ==="
+                  docker ps -a
+                  echo ""
+                  echo "=== Docker Volumes ==="
+                  docker volume ls
+                  echo ""
+                  echo "=== Inspect SeaweedFS storage ==="
+                  docker exec seaweedfs du -sh /data 2>/dev/null || echo "SeaweedFS not ready or not running"
+                  echo ""
+                  echo "=== Data Directory ==="
+                  [ -d "data" ] && du -sh data/* 2>/dev/null || echo "No data directory"
 
             - name: Set up Python
               uses: actions/setup-python@v5
@@ -781,6 +815,27 @@ jobs:
                   else
                       exit $exit_code
                   fi
+
+            - name: Check disk AFTER tests (Core segment)
+              if: always()
+              run: |
+                  echo "=== AFTER TESTS (Shard ${{ matrix.group }}/${{ matrix.concurrency }}) ==="
+                  df -h
+                  echo ""
+                  echo "=== Docker System ==="
+                  docker system df
+                  echo ""
+                  echo "=== Docker System Detailed ==="
+                  docker system df -v | head -n 50
+                  echo ""
+                  echo "=== Inspect SeaweedFS storage ==="
+                  docker exec seaweedfs du -sh /data 2>/dev/null || echo "SeaweedFS not available"
+                  echo ""
+                  echo "=== Data Directory ==="
+                  [ -d "data" ] && du -sh data/* 2>/dev/null || echo "No data directory"
+                  echo ""
+                  echo "=== Workspace Top Dirs ==="
+                  du -sh ./* 2>/dev/null | sort -h | tail -n 10
 
             # Uncomment this code to create an ssh-able console so you can debug issues with github actions
             # (Consider changing the timeout in ci-backend.yml to have more time)

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -458,7 +458,7 @@ jobs:
         timeout-minutes: 30
 
         name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-        runs-on: ubuntu-latest
+        runs-on: depot-ubuntu-latest
 
         strategy:
             fail-fast: false
@@ -1018,7 +1018,7 @@ jobs:
             matrix:
                 clickhouse-server-image: ['clickhouse/clickhouse-server:25.6.9.98']
         if: needs.changes.outputs.backend == 'true'
-        runs-on: depot-ubuntu-24.04-8
+        runs-on: ubuntu-latest
         steps:
             - name: 'Checkout repo'
               uses: actions/checkout@v4

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -134,18 +134,37 @@ jobs:
               continue-on-error: true
 
             - name: Check disk BEFORE Docker Compose
+              shell: bash
               run: |
                   echo "=== BEFORE DOCKER COMPOSE ==="
-                  df -h
+                  df -hT
                   echo ""
-                  echo "=== Docker System ==="
-                  docker system df
+                  echo "=== Root Filesystem Breakdown ==="
+                  sudo du -sh /* 2>/dev/null | sort -h || echo "du command failed"
                   echo ""
-                  echo "=== Workspace Size ==="
-                  du -sh ./ 2>/dev/null || true
+                  echo "=== Detailed Tooling Directories (top 20) ==="
+                  sudo du -sh /opt/* /usr/* /var/* 2>/dev/null | sort -h | tail -20 || echo "du command failed"
+                  echo ""
+                  echo "=== Hostedtoolcache ==="
+                  sudo du -sh /opt/hostedtoolcache/* 2>/dev/null | sort -h || echo "No hostedtoolcache"
+                  echo ""
+                  echo "=== Android SDK ==="
+                  sudo du -sh /usr/local/lib/android 2>/dev/null || echo "No Android SDK"
+                  echo ""
+                  echo "=== Docker Pre-pull Storage ==="
+                  sudo du -sh /var/lib/docker 2>/dev/null || echo "No /var/lib/docker"
+                  echo ""
+                  echo "=== Journal Logs ==="
+                  journalctl --disk-usage 2>/dev/null || echo "journalctl not available"
                   echo ""
                   echo "=== Docker Images ==="
-                  docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" | head -20
+                  docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" | head -20 || true
+                  echo ""
+                  echo "=== DELETING ANDROID SDK ==="
+                  sudo rm -rf /usr/local/lib/android || echo "Failed to delete Android SDK"
+                  echo ""
+                  echo "=== Disk After Android SDK Deletion ==="
+                  df -hT
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -155,24 +174,37 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d &
 
             - name: Check disk AFTER Docker Compose
+              shell: bash
               run: |
                   echo "=== AFTER DOCKER COMPOSE UP ==="
-                  df -h
+                  df -hT
                   echo ""
                   echo "=== Docker System ==="
-                  docker system df
+                  docker system df || true
+                  echo ""
+                  echo "=== Docker System Detailed ==="
+                  docker system df -v | head -n 80 || true
+                  echo ""
+                  echo "=== Root Filesystem Breakdown ==="
+                  sudo du -sh /* 2>/dev/null | sort -h || echo "du command failed"
+                  echo ""
+                  echo "=== Docker Root Dir ==="
+                  docker info | grep "Docker Root Dir" || true
+                  echo ""
+                  echo "=== /mnt Contents ==="
+                  ls -lah /mnt/ 2>/dev/null && du -sh /mnt/* 2>/dev/null || echo "No /mnt"
                   echo ""
                   echo "=== Docker Containers ==="
-                  docker ps -a
+                  docker ps -a || true
                   echo ""
                   echo "=== Docker Volumes ==="
-                  docker volume ls
-                  echo ""
-                  echo "=== Inspect SeaweedFS storage ==="
-                  docker exec seaweedfs du -sh /data 2>/dev/null || echo "SeaweedFS not ready or not running"
+                  docker volume ls || true
                   echo ""
                   echo "=== Data Directory ==="
                   [ -d "data" ] && du -sh data/* 2>/dev/null || echo "No data directory"
+                  echo ""
+                  echo "=== Workspace Size ==="
+                  du -sh ./ 2>/dev/null || true
 
             - name: Set up Python
               uses: actions/setup-python@v5
@@ -818,24 +850,34 @@ jobs:
 
             - name: Check disk AFTER tests (Core segment)
               if: always()
+              shell: bash
               run: |
                   echo "=== AFTER TESTS (Shard ${{ matrix.group }}/${{ matrix.concurrency }}) ==="
-                  df -h
+                  df -hT
                   echo ""
                   echo "=== Docker System ==="
-                  docker system df
+                  docker system df || true
                   echo ""
                   echo "=== Docker System Detailed ==="
-                  docker system df -v | head -n 50
+                  docker system df -v | head -n 80 || true
                   echo ""
-                  echo "=== Inspect SeaweedFS storage ==="
+                  echo "=== Root Filesystem Breakdown ==="
+                  sudo du -sh /* 2>/dev/null | sort -h || echo "du command failed"
+                  echo ""
+                  echo "=== Workspace Top Dirs ==="
+                  du -sh ./* 2>/dev/null | sort -h | tail -n 10 || true
+                  echo ""
+                  echo "=== Python Packages Size ==="
+                  du -sh $pythonLocation/lib/python*/site-packages 2>/dev/null || echo "No Python packages found"
+                  echo ""
+                  echo "=== Rust Artifacts ==="
+                  du -sh rust/target 2>/dev/null || echo "No Rust target directory"
+                  echo ""
+                  echo "=== SeaweedFS Storage ==="
                   docker exec seaweedfs du -sh /data 2>/dev/null || echo "SeaweedFS not available"
                   echo ""
                   echo "=== Data Directory ==="
                   [ -d "data" ] && du -sh data/* 2>/dev/null || echo "No data directory"
-                  echo ""
-                  echo "=== Workspace Top Dirs ==="
-                  du -sh ./* 2>/dev/null | sort -h | tail -n 10
 
             # Uncomment this code to create an ssh-able console so you can debug issues with github actions
             # (Consider changing the timeout in ci-backend.yml to have more time)

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -90,6 +90,17 @@ jobs:
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
+            - name: Check disk usage after Docker Compose
+              run: |
+                  echo "=== Disk Usage After Compose Up ==="
+                  df -h
+                  echo ""
+                  echo "=== Docker Images (top 15) ==="
+                  docker image ls --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" | head -16
+                  echo ""
+                  echo "=== Data Directory Sizes ==="
+                  [ -d "data" ] && du -sh data/* 2>/dev/null || echo "No data directory yet"
+
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
@@ -152,3 +163,12 @@ jobs:
             - name: Run Dagster tests
               run: |
                   pytest dags
+
+            - name: Check disk usage after tests
+              if: always()
+              run: |
+                  echo "=== Disk Usage After Tests ==="
+                  df -h
+                  echo ""
+                  echo "=== Data Directory Sizes ==="
+                  [ -d "data" ] && du -sh data/* 2>/dev/null || echo "No data directory"


### PR DESCRIPTION
## Problem

After migrating all services from MinIO to SeaweedFS, the MinIO (`objectstorage`) service is still defined in docker-compose files and started in CI, consuming disk space unnecessarily.

This caused CI to run out of disk space, requiring:
- Runner bump from `depot-ubuntu-latest` to `depot-ubuntu-24.04-8`
- Temporary disk cleanup workarounds

## Solution

Remove the unused `objectstorage` service entirely and revert the workarounds.

## Changes

- Remove `objectstorage` service from all docker-compose files
- Revert ci-dagster runner back to `depot-ubuntu-latest`
- Remove temporary "Free disk space" cleanup step
- Update data cleanup to only remove `/data/seaweedfs` (not `/data/minio`)

## Testing

This PR is stacked on #41241. If CI passes with the standard runner, it confirms:
1. MinIO was the cause of disk space issues
2. We can avoid the larger runner type
3. The migration is complete

If this test succeeds, these changes should be squashed into the base PR.