### PR TITLE
feat: allow users to select for goal line label to be at the start or end of the goal line

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -216,7 +216,7 @@ export const LineGraph = ({
                     label: {
                         display: cur.displayLabel ?? true,
                         content: cur.label,
-                        position: 'end',
+                        position: cur.position ?? 'end',
                     },
                     scaleID: hasLeftYAxis ? 'yLeft' : 'yRight',
                     value: cur.value,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -14891,6 +14891,10 @@
                 "label": {
                     "type": "string"
                 },
+                "position": {
+                    "enum": ["start", "end"],
+                    "type": "string"
+                },
                 "value": {
                     "type": "number"
                 }

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -887,6 +887,7 @@ export interface GoalLine {
     borderColor?: string
     displayLabel?: boolean
     displayIfCrossed?: boolean
+    position?: 'start' | 'end'
 }
 
 export interface ChartAxis {

--- a/frontend/src/scenes/insights/EditorFilters/GoalLines.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/GoalLines.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconEye, IconPlusSmall, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { IconEyeHidden } from 'lib/lemon-ui/icons'
@@ -20,7 +20,7 @@ export function GoalLines({ insightProps }: GoalLinesProps): JSX.Element {
 
     return (
         <div className="mt-1 mb-2">
-            {goalLines.map(({ label, value = 0, displayLabel = true }, goalLineIndex) => (
+            {goalLines.map(({ label, value = 0, displayLabel = true, position }, goalLineIndex) => (
                 <div className="flex flex-1 gap-1 mb-1" key={`${goalLineIndex}`}>
                     <SeriesLetter className="self-center" hasBreakdown={false} seriesIndex={goalLineIndex} />
                     <LemonInput
@@ -48,11 +48,21 @@ export function GoalLines({ insightProps }: GoalLinesProps): JSX.Element {
                         inputMode="numeric"
                         onChange={(value) => updateGoalLine(goalLineIndex, 'value', parseInt(value))}
                     />
+                    <LemonSegmentedButton
+                        value={position ?? 'end'}
+                        onChange={(value) => updateGoalLine(goalLineIndex, 'position', value as 'start' | 'end')}
+                        options={[
+                            { value: 'start', label: 'Start' },
+                            { value: 'end', label: 'End' },
+                        ]}
+                        size="small"
+                        data-attr="goal-line-position-selector"
+                    />
                     <LemonButton
                         key="delete"
                         icon={<IconTrash />}
                         status="danger"
-                        title="Delete Goal Line"
+                        title="Delete goal line"
                         noPadding
                         onClick={() => removeGoalLine(goalLineIndex)}
                     />

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -666,7 +666,7 @@ export function LineGraph_({
                             label: {
                                 content: annotation.label,
                                 display: annotation.displayLabel ?? true,
-                                position: 'end',
+                                position: annotation.position ?? 'end',
                             },
                             borderWidth: 1,
                             borderDash: [5, 8],

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1686,6 +1686,11 @@ class FunnelVizType(StrEnum):
     TRENDS = "trends"
 
 
+class Position(StrEnum):
+    START = "start"
+    END = "end"
+
+
 class GoalLine(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1694,6 +1699,7 @@ class GoalLine(BaseModel):
     displayIfCrossed: Optional[bool] = None
     displayLabel: Optional[bool] = None
     label: str
+    position: Optional[Position] = None
     value: float
 
 


### PR DESCRIPTION
## Problem

every time we get close to a goal on a trend that goes up and to the right i can't see how close we are to the goal because the label covers the data

## Changes

allows a user to select start or end for goal line position

## How did you test this code?

ran it and saw it work

![2025-11-12 12.00.30.gif](https://app.graphite.com/user-attachments/assets/cadb4c45-7a8d-4edb-891a-43fd6a8a10cd.gif)

## Changelog: (features only) Is this feature complete?

yes, this very exciting and defining feature can go in the change log :p
