### PR TITLE
chore(experiments): Dagster alerts to separate channel

### DIFF
--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -13,7 +13,7 @@ notification_channel_per_team = {
     JobOwners.TEAM_CLICKHOUSE.value: "#alerts-clickhouse",
     JobOwners.TEAM_DATA_WAREHOUSE.value: "#alerts-data-warehouse",
     JobOwners.TEAM_ERROR_TRACKING.value: "#alerts-error-tracking",
-    JobOwners.TEAM_EXPERIMENTS.value: "#alerts-experiments",
+    JobOwners.TEAM_EXPERIMENTS.value: "#alerts-experiments-dagster",
     JobOwners.TEAM_GROWTH.value: "#alerts-growth",
     JobOwners.TEAM_MAX_AI.value: "#alerts-max-ai",
     JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-revenue-analytics",


### PR DESCRIPTION
## Changes
Use a separate Slack channel for Dagster errors for now.