### PR TITLE
chore: clean up eval executions failures

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4420,7 +4420,13 @@ const api = {
     },
 
     evaluationRuns: {
-        async create(data: { evaluation_id: string; target_event_id: string; timestamp: string }): Promise<{
+        async create(data: {
+            evaluation_id: string
+            target_event_id: string
+            timestamp: string
+            event: string
+            distinct_id?: string
+        }): Promise<{
             workflow_id: string
             status: string
             evaluation: { id: string; name: string }

--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -3,7 +3,6 @@ from posthog.temporal.llm_analytics.run_evaluation import (
     emit_evaluation_event_activity,
     execute_llm_judge_activity,
     fetch_evaluation_activity,
-    fetch_legacy_event_activity,
 )
 
 WORKFLOWS = [
@@ -12,7 +11,6 @@ WORKFLOWS = [
 
 ACTIVITIES = [
     fetch_evaluation_activity,
-    fetch_legacy_event_activity,
     execute_llm_judge_activity,
     emit_evaluation_event_activity,
 ]

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
-from posthog.clickhouse.client import sync_execute
 from posthog.models.event.util import create_event
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
@@ -37,51 +36,7 @@ class BooleanEvalResult(BaseModel):
 @dataclass
 class RunEvaluationInputs:
     evaluation_id: str
-    event_data: dict[str, Any] | None = None
-    # Legacy fields for backward compatibility during deployment
-    target_event_id: str | None = None
-    timestamp: str | None = None
-
-
-@temporalio.activity.defn
-async def fetch_legacy_event_activity(target_event_id: str, team_id: int, timestamp: str) -> dict[str, Any]:
-    """Fetch target event from ClickHouse - kept for backward compatibility with pending workflows"""
-    query = """
-        SELECT
-            uuid,
-            event,
-            properties,
-            timestamp,
-            team_id,
-            distinct_id,
-            person_id
-        FROM events
-        WHERE team_id = %(team_id)s
-            AND toDate(timestamp) = toDate(parseDateTimeBestEffort(%(target_timestamp)s))
-            AND event = '$ai_generation'
-            AND uuid = %(event_id)s
-        LIMIT 1
-    """
-
-    result = await database_sync_to_async(sync_execute, thread_sensitive=False)(
-        query, {"event_id": target_event_id, "team_id": team_id, "target_timestamp": timestamp}
-    )
-
-    if not result:
-        logger.exception("Event not found", target_event_id=target_event_id, team_id=team_id)
-        raise ValueError(f"Event {target_event_id} not found for team {team_id}")
-
-    row = result[0]
-    event_data = {
-        "uuid": str(row[0]),
-        "event": row[1],
-        "properties": json.loads(row[2]) if isinstance(row[2], str) else row[2],
-        "timestamp": row[3],
-        "team_id": row[4],
-        "distinct_id": row[5],
-        "person_id": str(row[6]) if row[6] is not None else None,
-    }
-    return event_data
+    event_data: dict[str, Any]
 
 
 @temporalio.activity.defn
@@ -235,26 +190,10 @@ async def emit_evaluation_event_activity(
 class RunEvaluationWorkflow(PostHogWorkflow):
     @staticmethod
     def parse_inputs(inputs: list[str]) -> RunEvaluationInputs:
-        # Support both old and new input formats for backward compatibility
-        if len(inputs) == 3:
-            # Legacy format: [evaluation_id, target_event_id, timestamp]
-            logger.warning(
-                "Workflow started with legacy input format",
-                evaluation_id=inputs[0],
-                target_event_id=inputs[1],
-            )
-            return RunEvaluationInputs(
-                evaluation_id=inputs[0],
-                event_data=None,
-                target_event_id=inputs[1],
-                timestamp=inputs[2],
-            )
-        else:
-            # New format: [evaluation_id, event_data_json]
-            return RunEvaluationInputs(
-                evaluation_id=inputs[0],
-                event_data=json.loads(inputs[1]),
-            )
+        return RunEvaluationInputs(
+            evaluation_id=inputs[0],
+            event_data=json.loads(inputs[1]),
+        )
 
     @temporalio.workflow.run
     async def run(self, inputs: RunEvaluationInputs) -> dict[str, Any]:
@@ -266,31 +205,10 @@ class RunEvaluationWorkflow(PostHogWorkflow):
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
-        # Handle backward compatibility: fetch event if using legacy format
-        if inputs.event_data is None and inputs.target_event_id and inputs.timestamp:
-            logger.warning(
-                "Fetching event from ClickHouse for legacy workflow",
-                evaluation_id=inputs.evaluation_id,
-                target_event_id=inputs.target_event_id,
-            )
-            event_data = await temporalio.workflow.execute_activity(
-                fetch_legacy_event_activity,
-                args=[inputs.target_event_id, evaluation["team_id"], inputs.timestamp],
-                schedule_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=1),
-                    maximum_interval=timedelta(seconds=10),
-                    maximum_attempts=10,
-                    backoff_coefficient=2.0,
-                ),
-            )
-        else:
-            # New format: event_data provided directly
-            assert inputs.event_data is not None, "event_data must be provided when not using legacy format"
-            event_data = inputs.event_data.copy()
-            # Normalize: ensure properties is a dict, not a string
-            if isinstance(event_data.get("properties"), str):
-                event_data["properties"] = json.loads(event_data["properties"])
+        # Normalize event_data: ensure properties is a dict, not a string
+        event_data = inputs.event_data.copy()
+        if isinstance(event_data.get("properties"), str):
+            event_data["properties"] = json.loads(event_data["properties"])
 
         # Activity 2: Execute LLM judge
         result = await temporalio.workflow.execute_activity(

--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.clickhouse.client import query_with_columns
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.llm_analytics.run_evaluation import RunEvaluationInputs
 
@@ -23,6 +24,8 @@ class EvaluationRunRequestSerializer(serializers.Serializer):
     evaluation_id = serializers.UUIDField(required=True)
     target_event_id = serializers.UUIDField(required=True)
     timestamp = serializers.DateTimeField(required=True)
+    event = serializers.CharField(required=True)
+    distinct_id = serializers.CharField(required=False, allow_null=True)
 
 
 class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
@@ -42,7 +45,9 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
         evaluation_id = str(serializer.validated_data["evaluation_id"])
         target_event_id = str(serializer.validated_data["target_event_id"])
-        timestamp = serializer.validated_data["timestamp"].isoformat()
+        timestamp = serializer.validated_data["timestamp"]
+        event = serializer.validated_data["event"]
+        distinct_id = serializer.validated_data.get("distinct_id")
 
         # Verify evaluation exists and belongs to this team
         try:
@@ -50,11 +55,53 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         except Evaluation.DoesNotExist:
             return Response({"error": f"Evaluation {evaluation_id} not found"}, status=404)
 
+        # Fetch event data from ClickHouse efficiently using available index keys
+        # The compound index is (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
+        where_clauses = [
+            "team_id = %(team_id)s",
+            "toDate(timestamp) = toDate(%(timestamp)s)",
+            "event = %(event)s",
+            "uuid = %(event_id)s",
+        ]
+        params = {
+            "team_id": self.team_id,
+            "event_id": target_event_id.replace("-", ""),
+            "timestamp": timestamp,
+            "event": event,
+        }
+
+        if distinct_id:
+            where_clauses.append("distinct_id = %(distinct_id)s")
+            params["distinct_id"] = distinct_id
+
+        query_result = query_with_columns(
+            f"""
+            SELECT
+                uuid,
+                event,
+                properties,
+                timestamp,
+                team_id,
+                distinct_id,
+                elements_chain,
+                created_at,
+                person_id
+            FROM events
+            WHERE {" AND ".join(where_clauses)}
+            LIMIT 1
+            """,
+            params,
+            team_id=self.team_id,
+        )
+        if len(query_result) == 0:
+            return Response({"error": f"Event {target_event_id} not found"}, status=404)
+
+        event_data = query_result[0]
+
         # Build workflow inputs
         inputs = RunEvaluationInputs(
             evaluation_id=evaluation_id,
-            target_event_id=target_event_id,
-            timestamp=timestamp,
+            event_data=event_data,
         )
 
         # Generate unique workflow ID

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -898,6 +898,8 @@ const EventContent = React.memo(
                                                   <EvalsTabContent
                                                       generationEventId={event.id}
                                                       timestamp={event.createdAt}
+                                                      event={event.event}
+                                                      distinctId={event.distinct_id ?? undefined}
                                                   />
                                               ),
                                           },

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -899,7 +899,7 @@ const EventContent = React.memo(
                                                       generationEventId={event.id}
                                                       timestamp={event.createdAt}
                                                       event={event.event}
-                                                      distinctId={event.distinct_id ?? undefined}
+                                                      distinctId={trace.person.distinct_id}
                                                   />
                                               ),
                                           },

--- a/products/llm_analytics/frontend/components/EvalsTabContent.tsx
+++ b/products/llm_analytics/frontend/components/EvalsTabContent.tsx
@@ -11,13 +11,22 @@ import { GenerationEvalRunsTable } from './GenerationEvalRunsTable'
 export function EvalsTabContent({
     generationEventId,
     timestamp,
+    event,
+    distinctId,
 }: {
     generationEventId: string
     timestamp: string
+    event: string
+    distinctId?: string
 }): JSX.Element {
     return (
         <BindLogic logic={generationEvaluationRunsLogic} props={{ generationEventId }}>
-            <EvalsTabContentInner generationEventId={generationEventId} timestamp={timestamp} />
+            <EvalsTabContentInner
+                generationEventId={generationEventId}
+                timestamp={timestamp}
+                event={event}
+                distinctId={distinctId}
+            />
         </BindLogic>
     )
 }
@@ -25,9 +34,13 @@ export function EvalsTabContent({
 function EvalsTabContentInner({
     generationEventId,
     timestamp,
+    event,
+    distinctId,
 }: {
     generationEventId: string
     timestamp: string
+    event: string
+    distinctId?: string
 }): JSX.Element {
     const { evaluations, evaluationsLoading } = useValues(llmEvaluationsLogic)
     const { runEvaluation } = useActions(llmEvaluationExecutionLogic)
@@ -60,7 +73,7 @@ function EvalsTabContentInner({
                         icon={<IconCheckCircle />}
                         onClick={() => {
                             if (selectedEvaluationId) {
-                                runEvaluation(selectedEvaluationId, generationEventId, timestamp)
+                                runEvaluation(selectedEvaluationId, generationEventId, timestamp, event, distinctId)
                             }
                         }}
                         loading={evaluationRunLoading}

--- a/products/llm_analytics/frontend/components/EvaluationRunModal.tsx
+++ b/products/llm_analytics/frontend/components/EvaluationRunModal.tsx
@@ -10,6 +10,8 @@ interface EvaluationRunModalProps {
     visible: boolean
     targetEventId: string
     timestamp: string
+    event: string
+    distinctId?: string
     onClose: () => void
 }
 
@@ -17,6 +19,8 @@ export function EvaluationRunModal({
     visible,
     targetEventId,
     timestamp,
+    event,
+    distinctId,
     onClose,
 }: EvaluationRunModalProps): JSX.Element {
     const { evaluations, evaluationsLoading } = useValues(llmEvaluationsLogic)
@@ -27,7 +31,7 @@ export function EvaluationRunModal({
 
     const handleRun = (): void => {
         if (selectedEvaluationId) {
-            runEvaluation(selectedEvaluationId, targetEventId, timestamp)
+            runEvaluation(selectedEvaluationId, targetEventId, timestamp, event, distinctId)
             onClose()
         }
     }

--- a/products/llm_analytics/frontend/llmEvaluationExecutionLogic.ts
+++ b/products/llm_analytics/frontend/llmEvaluationExecutionLogic.ts
@@ -13,27 +13,48 @@ export const llmEvaluationExecutionLogic = kea<llmEvaluationExecutionLogicType>(
         values: [teamLogic, ['currentTeamId']],
     })),
     actions({
-        runEvaluation: (evaluationId: string, targetEventId: string, timestamp: string) => ({
+        runEvaluation: (
+            evaluationId: string,
+            targetEventId: string,
+            timestamp: string,
+            event: string,
+            distinctId?: string
+        ) => ({
             evaluationId,
             targetEventId,
             timestamp,
+            event,
+            distinctId,
         }),
     }),
     loaders(({ values }) => ({
         evaluationRun: [
             null as { workflow_id: string } | null,
             {
-                runEvaluation: async ({ evaluationId, targetEventId, timestamp }) => {
+                runEvaluation: async ({ evaluationId, targetEventId, timestamp, event, distinctId }) => {
                     if (!values.currentTeamId) {
                         throw new Error('No team selected')
                     }
 
                     try {
-                        const response = await api.evaluationRuns.create({
+                        const payload: {
+                            evaluation_id: string
+                            target_event_id: string
+                            timestamp: string
+                            event: string
+                            distinct_id?: string
+                        } = {
                             evaluation_id: evaluationId,
                             target_event_id: targetEventId,
                             timestamp: timestamp,
-                        })
+                            event: event,
+                        }
+
+                        if (distinctId) {
+                            payload.distinct_id = distinctId
+                        }
+
+                        const response = await api.evaluationRuns.create(payload)
 
                         lemonToast.success('Evaluation started successfully')
                         return response


### PR DESCRIPTION
To be merged after #41350 has been in production for a while and old jobs enqueued by ID have run out. Cleans up the code.