### PR TITLE
feat(sessions): Tune raw_sessions_table to use insert delays to avoid too many parts

### DIFF
--- a/posthog/clickhouse/migrations/0178_sessions_v3_insert_delay_settings_and_drop_mvs.py
+++ b/posthog/clickhouse/migrations/0178_sessions_v3_insert_delay_settings_and_drop_mvs.py
@@ -1,0 +1,18 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sessions_v3 import (
+    ALTER_SHARDED_RAW_SESSIONS_TABLE_SETTINGS_V3,
+    DROP_RAW_SESSION_MATERIALIZED_VIEW_RECORDINGS_SQL_V3,
+    DROP_RAW_SESSION_MATERIALIZED_VIEW_SQL_V3,
+)
+
+operations = [
+    run_sql_with_exceptions(
+        ALTER_SHARDED_RAW_SESSIONS_TABLE_SETTINGS_V3(),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(DROP_RAW_SESSION_MATERIALIZED_VIEW_SQL_V3(), node_roles=[NodeRole.DATA]),
+    run_sql_with_exceptions(DROP_RAW_SESSION_MATERIALIZED_VIEW_RECORDINGS_SQL_V3(), node_roles=[NodeRole.DATA]),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0177_llma_metrics_daily
+0178_sessions_v3_insert_delay_settings_and_drop_mvs

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -4094,6 +4094,7 @@
       session_timestamp,
       session_id_v7
   )
+  SETTINGS parts_to_delay_insert = 250, max_delay_to_insert = 10, parts_to_throw_insert = 1000
   
   '''
 # ---
@@ -6633,6 +6634,7 @@
       session_timestamp,
       session_id_v7
   )
+  SETTINGS parts_to_delay_insert = 250, max_delay_to_insert = 10, parts_to_throw_insert = 1000
   
   '''
 # ---

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -172,6 +172,11 @@ def SHARDED_RAW_SESSIONS_DATA_TABLE_ENGINE_V3():
     return AggregatingMergeTree(TABLE_BASE_NAME_V3, replication_scheme=ReplicationScheme.SHARDED)
 
 
+def SHARDED_RAW_SESSIONS_DATA_TABLE_SETTINGS_V3():
+    # try to make the backfill self-regulating by leaning on insert delays
+    return "parts_to_delay_insert = 250, max_delay_to_insert = 10, parts_to_throw_insert = 1000"
+
+
 def SHARDED_RAW_SESSIONS_TABLE_SQL_V3():
     return (
         RAW_SESSIONS_TABLE_BASE_SQL_V3
@@ -182,10 +187,18 @@ ORDER BY (
     session_timestamp,
     session_id_v7
 )
+SETTINGS {settings}
 """
     ).format(
         table_name=SHARDED_RAW_SESSIONS_TABLE_V3(),
         engine=SHARDED_RAW_SESSIONS_DATA_TABLE_ENGINE_V3(),
+        settings=SHARDED_RAW_SESSIONS_DATA_TABLE_SETTINGS_V3(),
+    )
+
+
+def ALTER_SHARDED_RAW_SESSIONS_TABLE_SETTINGS_V3():
+    return (
+        f"ALTER TABLE {SHARDED_RAW_SESSIONS_TABLE_V3()} MODIFY SETTING {SHARDED_RAW_SESSIONS_DATA_TABLE_SETTINGS_V3()}"
     )
 
 


### PR DESCRIPTION
## Problem

The backfill job is still running into Too Many Parts

## Changes
* Drop the MVs from ingestion; this way, we're not getting many smaller parts from ingestion
* Tune some settings on the table, so that we are more likely to be delayed when there are many parts, rather than an error being thrown

## How did you test this code?

Tests still pass, migration runs locally.

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
