### PR TITLE
feat(logs): log the token when we can't find team

### DIFF
--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -114,7 +114,7 @@ export class LogsIngestionConsumer {
 
                     if (!team) {
                         // Write to DLQ topic maybe?
-                        logger.error('team_not_found', { token_with_no_team: token });
+                        logger.error('team_not_found', { token_with_no_team: token })
                         logMessageDroppedCounter.inc({ reason: 'team_not_found' })
                         return
                     }

--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -114,7 +114,7 @@ export class LogsIngestionConsumer {
 
                     if (!team) {
                         // Write to DLQ topic maybe?
-                        logger.error('team_not_found', { missing_team_for_token: token });
+                        logger.error('team_not_found', { token_with_no_team: token });
                         logMessageDroppedCounter.inc({ reason: 'team_not_found' })
                         return
                     }

--- a/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/plugin-server/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -114,7 +114,7 @@ export class LogsIngestionConsumer {
 
                     if (!team) {
                         // Write to DLQ topic maybe?
-                        logger.error('team_not_found')
+                        logger.error('team_not_found', { missing_team_for_token: token });
                         logMessageDroppedCounter.inc({ reason: 'team_not_found' })
                         return
                     }


### PR DESCRIPTION

## Problem
we got a spike of team_not_found log messages but have no idea what token was sent with that, log this info

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
