### PR TITLE
feat(flags): add the ability to search by experiment keys to the placeholder

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -255,7 +255,7 @@ export const scene: SceneExport = {
 
 export function OverViewTab({
     flagPrefix = '',
-    searchPlaceholder = 'Search for feature flags',
+    searchPlaceholder = 'Search for feature flags (or experiment keys)',
     nouns = ['feature flag', 'feature flags'],
 }: {
     flagPrefix?: string


### PR DESCRIPTION
## Problem

With https://github.com/PostHog/posthog/pull/41298, we gave users the ability to search for feature flags _and_ experiment keys on the feature flags list page (helps folks find flags associated with experiments)

So, let's say that in the placeholder.