### PR TITLE
chore: Person/Group session adjustments

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/Session.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/Session.tsx
@@ -19,8 +19,8 @@ export const Session = ({ session }: SessionProps): JSX.Element => {
     const { children, nodeId } = useValues(notebookNodeLogic)
     const { updateAttributes } = useActions(notebookNodeLogic)
 
-    const startTime = dayjs(session.events[0].timestamp)
-    const endTime = dayjs(session.events[session.events.length - 1].timestamp)
+    const startTime = dayjs(session.events[session.events.length - 1].timestamp)
+    const endTime = dayjs(session.events[0].timestamp)
     const durationSeconds = endTime.diff(startTime, 'second')
 
     const [isFolded, setIsFolded] = useState(true)

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/Session.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/Session.tsx
@@ -23,7 +23,7 @@ export const Session = ({ session }: SessionProps): JSX.Element => {
     const endTime = dayjs(session.events[session.events.length - 1].timestamp)
     const durationSeconds = endTime.diff(startTime, 'second')
 
-    const [isFolded, setIsFolded] = useState(false)
+    const [isFolded, setIsFolded] = useState(true)
 
     const onOpenReplay = (): void => {
         const newChildren = [...(children || [])]


### PR DESCRIPTION
## Problem
Session length was showing a negative number.
Session timeline was hard on the eyes, too much info. Let's show them initially collapsed
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/41263
## Changes
- Show sessions initially collapsed
- Fix session length calculation
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="887" height="376" alt="image" src="https://github.com/user-attachments/assets/fd5b9f65-1a63-47ea-8b72-80347c34ad02" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
