### PR TITLE
feat(repartitioner): Simple topic repartitioning service for `property-defs-rs`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6402,6 +6402,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6397,6 +6397,8 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "rdkafka",
+ "serde",
+ "serde_json",
  "serve-metrics",
  "tokio",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6397,7 +6397,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "rdkafka",
- "serde",
  "serde_json",
  "serve-metrics",
  "tokio",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6390,6 +6390,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
+ "chrono",
  "common-kafka",
  "envconfig",
  "futures",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6385,6 +6385,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "repartitioner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.7.5",
+ "common-kafka",
+ "envconfig",
+ "futures",
+ "health",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "rdkafka",
+ "serve-metrics",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "replace_with"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "common/geoip",
     "common/hogvm",
     "kafka-deduplicator",
+    "repartitioner",
 ]
 
 [workspace.lints.rust]

--- a/rust/repartitioner/Cargo.toml
+++ b/rust/repartitioner/Cargo.toml
@@ -16,6 +16,8 @@ health = { path = "../common/health" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 rdkafka = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/repartitioner/Cargo.toml
+++ b/rust/repartitioner/Cargo.toml
@@ -21,4 +21,5 @@ serve-metrics = { path = "../common/serve_metrics" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = { workspace = true }
 

--- a/rust/repartitioner/Cargo.toml
+++ b/rust/repartitioner/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "repartitioner"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+common-kafka = { path = "../common/kafka" }
+envconfig = { workspace = true }
+futures = { workspace = true }
+health = { path = "../common/health" }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+rdkafka = { workspace = true }
+serve-metrics = { path = "../common/serve_metrics" }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+

--- a/rust/repartitioner/Cargo.toml
+++ b/rust/repartitioner/Cargo.toml
@@ -16,7 +16,6 @@ health = { path = "../common/health" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 rdkafka = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }
 tokio = { workspace = true }

--- a/rust/repartitioner/Cargo.toml
+++ b/rust/repartitioner/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }
+chrono = { workspace = true }
 common-kafka = { path = "../common/kafka" }
 envconfig = { workspace = true }
 futures = { workspace = true }

--- a/rust/repartitioner/src/config.rs
+++ b/rust/repartitioner/src/config.rs
@@ -35,17 +35,17 @@ pub struct Config {
     pub kafka_tls: bool,
 
     // Service specific configuration
-    #[envconfig(default = "repartitioner")]
+    #[envconfig(default = "repartitioner_v1")]
     pub kafka_consumer_group: String,
 
-    #[envconfig(default = "events")]
+    #[envconfig(default = "clickhouse_events_json")]
     pub kafka_source_topic: String,
 
     // Destination topic configuration
-    #[envconfig(default = "events_repartitioned")]
+    #[envconfig(default = "propdefs_events_json")]
     pub kafka_destination_topic: String,
 
-    #[envconfig(default = "propdefs_v1")]
+    #[envconfig(default = "propdefs_v1_by_team_id")]
     pub partition_key_compute_fn: String,
 
     // HTTP server configuration

--- a/rust/repartitioner/src/config.rs
+++ b/rust/repartitioner/src/config.rs
@@ -19,6 +19,9 @@ pub struct Config {
     #[envconfig(default = "20")]
     pub kafka_producer_linger_ms: u32,
 
+    #[envconfig(default = "10")]
+    pub kafka_producer_graceful_shutdown_secs: u64,
+
     #[envconfig(default = "400")]
     pub kafka_producer_queue_mib: u32,
 

--- a/rust/repartitioner/src/config.rs
+++ b/rust/repartitioner/src/config.rs
@@ -1,0 +1,60 @@
+use envconfig::Envconfig;
+
+#[derive(Envconfig, Clone, Debug)]
+pub struct Config {
+    // Kafka configuration
+    #[envconfig(default = "localhost:9092")]
+    pub kafka_hosts: String,
+
+    #[envconfig(default = "repartitioner")]
+    pub kafka_consumer_group: String,
+
+    #[envconfig(default = "events")]
+    pub kafka_source_topic: String,
+
+    #[envconfig(default = "latest")]
+    pub kafka_consumer_offset_reset: String,
+
+    #[envconfig(default = "true")]
+    pub kafka_consumer_auto_commit: bool,
+
+    #[envconfig(default = "5000")]
+    pub kafka_consumer_auto_commit_interval_ms: u32,
+
+    // Destination topic configuration
+    #[envconfig(default = "events_repartitioned")]
+    pub kafka_destination_topic: String,
+
+    // Producer configuration
+    #[envconfig(default = "20")]
+    pub kafka_producer_linger_ms: u32,
+
+    #[envconfig(default = "400")]
+    pub kafka_producer_queue_mib: u32,
+
+    #[envconfig(default = "10000000")]
+    pub kafka_producer_queue_messages: u32,
+
+    #[envconfig(default = "20000")]
+    pub kafka_message_timeout_ms: u32,
+
+    #[envconfig(default = "snappy")]
+    pub kafka_compression_codec: String,
+
+    #[envconfig(default = "false")]
+    pub kafka_tls: bool,
+
+    // HTTP server configuration
+    #[envconfig(default = "0.0.0.0:8080")]
+    pub bind_address: String,
+
+    #[envconfig(default = "false")]
+    pub export_prometheus: bool,
+}
+
+impl Config {
+    /// Initialize from environment variables (for production and tests)
+    pub fn init_with_defaults() -> Result<Self, envconfig::Error> {
+        Config::init_from_env()
+    }
+}

--- a/rust/repartitioner/src/config.rs
+++ b/rust/repartitioner/src/config.rs
@@ -6,12 +6,6 @@ pub struct Config {
     #[envconfig(default = "localhost:9092")]
     pub kafka_hosts: String,
 
-    #[envconfig(default = "repartitioner")]
-    pub kafka_consumer_group: String,
-
-    #[envconfig(default = "events")]
-    pub kafka_source_topic: String,
-
     #[envconfig(default = "latest")]
     pub kafka_consumer_offset_reset: String,
 
@@ -20,10 +14,6 @@ pub struct Config {
 
     #[envconfig(default = "5000")]
     pub kafka_consumer_auto_commit_interval_ms: u32,
-
-    // Destination topic configuration
-    #[envconfig(default = "events_repartitioned")]
-    pub kafka_destination_topic: String,
 
     // Producer configuration
     #[envconfig(default = "20")]
@@ -43,6 +33,20 @@ pub struct Config {
 
     #[envconfig(default = "false")]
     pub kafka_tls: bool,
+
+    // Service specific configuration
+    #[envconfig(default = "repartitioner")]
+    pub kafka_consumer_group: String,
+
+    #[envconfig(default = "events")]
+    pub kafka_source_topic: String,
+
+    // Destination topic configuration
+    #[envconfig(default = "events_repartitioned")]
+    pub kafka_destination_topic: String,
+
+    #[envconfig(default = "propdefs_v1")]
+    pub partition_key_compute_fn: String,
 
     // HTTP server configuration
     #[envconfig(default = "0.0.0.0:8080")]

--- a/rust/repartitioner/src/lib.rs
+++ b/rust/repartitioner/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod service;

--- a/rust/repartitioner/src/lib.rs
+++ b/rust/repartitioner/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod repartitioners;
 pub mod service;

--- a/rust/repartitioner/src/main.rs
+++ b/rust/repartitioner/src/main.rs
@@ -1,0 +1,101 @@
+use anyhow::{Context, Result};
+use axum::{routing::get, Router};
+use futures::future::ready;
+use health::HealthRegistry;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use serve_metrics::serve;
+use tokio::task::JoinHandle;
+use tracing::{error, info};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{fmt, EnvFilter, Layer};
+
+use repartitioner::{config::Config, service::RepartitionerService};
+
+fn setup_metrics() -> PrometheusHandle {
+    PrometheusBuilder::new()
+        .install_recorder()
+        .expect("Failed to install metrics recorder")
+}
+
+fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
+    let router = Router::new()
+        .route("/", get(|| async { "repartitioner service" }))
+        .route("/_readiness", get(|| async { "ok" }))
+        .route(
+            "/_liveness",
+            get(move || {
+                let liveness = liveness.clone();
+                async move {
+                    let status = liveness.get_status();
+                    if !status.healthy {
+                        let unhealthy_components: Vec<String> = status
+                            .components
+                            .iter()
+                            .filter(|(_, component_status)| !component_status.is_healthy())
+                            .map(|(name, component_status)| format!("{name}: {component_status:?}"))
+                            .collect();
+                        error!(
+                            "Health check FAILED - unhealthy components: [{}]",
+                            unhealthy_components.join(", ")
+                        );
+                    }
+                    status
+                }
+            }),
+        );
+
+    let router = if config.export_prometheus {
+        let recorder_handle = setup_metrics();
+        router.route("/metrics", get(move || ready(recorder_handle.render())))
+    } else {
+        router
+    };
+
+    let bind = config.bind_address.clone();
+
+    tokio::task::spawn(async move {
+        serve(router, &bind)
+            .await
+            .expect("failed to start serving metrics");
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let config = Config::init_with_defaults()
+        .context("Failed to load configuration from environment variables")?;
+
+    // Initialize tracing
+    let log_layer = fmt::layer()
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true)
+        .with_filter(EnvFilter::from_default_env())
+        .boxed();
+
+    tracing_subscriber::registry().with(log_layer).init();
+
+    info!("Starting Repartitioner service");
+    info!("Configuration loaded: {:?}", config);
+
+    // Create health registry
+    let liveness = HealthRegistry::new("liveness");
+
+    // Start HTTP server with metrics endpoint
+    let server_handle = start_server(&config, liveness.clone());
+    info!("Started metrics server on {}", config.bind_address);
+
+    // Create and run the service
+    let service = RepartitionerService::new(config, liveness)
+        .await
+        .context("Failed to create Repartitioner service")?;
+
+    // Run the service (this blocks until shutdown)
+    service.run().await?;
+
+    // Clean up metrics server
+    server_handle.abort();
+
+    Ok(())
+}

--- a/rust/repartitioner/src/repartitioners.rs
+++ b/rust/repartitioner/src/repartitioners.rs
@@ -3,7 +3,7 @@ use rdkafka::message::BorrowedHeaders;
 
 /// "propdefs_v1" repartitioning function uses Team ID as the destination
 /// partition key, and tries to minimize deserialization overhead to obtain it
-pub fn compute_propdefs_v1_key(
+pub fn compute_propdefs_v1_key_by_team_id(
     _source_key: Option<&[u8]>,
     _headers: Option<&BorrowedHeaders>,
     payload: Option<&[u8]>,

--- a/rust/repartitioner/src/repartitioners.rs
+++ b/rust/repartitioner/src/repartitioners.rs
@@ -1,0 +1,27 @@
+use anyhow::{Context, Result};
+use rdkafka::message::BorrowedHeaders;
+
+/// "propdefs_v1" repartitioning function uses Team ID as the destination
+/// partition key, and tries to minimize deserialization overhead to obtain it
+pub fn compute_propdefs_v1_key(
+    _source_key: Option<&[u8]>,
+    _headers: Option<&BorrowedHeaders>,
+    payload: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    let payload = payload.context("propdefs_v1: message payload is required")?;
+
+    // Parse to generic Value instead of full struct - only parses JSON structure
+    let json_value = serde_json::from_slice::<serde_json::Value>(payload)
+        .context("propdefs_v1: failed to parse JSON")?;
+
+    // Extract only the team_id field we need
+    let team_id: i64 = json_value
+        .get("team_id")
+        .and_then(|v| v.as_i64())
+        .context("propdefs_v1: team_id field missing or invalid")?;
+
+    // Convert to bytes for partition key
+    let destination_key = team_id.to_string().into_bytes();
+
+    Ok(destination_key)
+}

--- a/rust/repartitioner/src/service.rs
+++ b/rust/repartitioner/src/service.rs
@@ -390,6 +390,7 @@ impl RepartitionerService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use common_kafka::test::create_mock_kafka;
     use rdkafka::{
         client::DefaultClientContext,
@@ -443,6 +444,15 @@ mod tests {
             "event": event_name,
             "distinct_id": distinct_id,
             "team_id": team_id,
+            "project_id": team_id,
+            "timestamp": Utc::now().to_rfc3339(),
+            "created_at": Utc::now().to_rfc3339(),
+            "properties": {},
+            "person_mode": "full",
+            "person_id": Uuid::new_v4().to_string(),
+            "person_properties": {},
+            "person_created_at": Utc::now().to_rfc3339(),
+            "elements_chain": "",
         });
         serde_json::to_vec(&payload).expect("Failed to serialize test message")
     }

--- a/rust/repartitioner/src/service.rs
+++ b/rust/repartitioner/src/service.rs
@@ -446,10 +446,10 @@ mod tests {
             .set("group.id", "test_group")
             .set("auto.offset.reset", "earliest")
             .set("enable.auto.commit", "false")
-            .set("metadata.max.age.ms", "1000")
-            .set("session.timeout.ms", "3000")
+            .set("metadata.max.age.ms", "60000")
+            .set("session.timeout.ms", "30000")
             .set("heartbeat.interval.ms", "500")
-            .set("max.poll.interval.ms", "5000")
+            .set("max.poll.interval.ms", "30000")
             .create()
             .expect("Failed to create consumer");
 

--- a/rust/repartitioner/src/service.rs
+++ b/rust/repartitioner/src/service.rs
@@ -1,0 +1,176 @@
+use anyhow::{Context, Result};
+use common_kafka::{
+    config::KafkaConfig,
+    kafka_producer::{create_kafka_producer, KafkaContext},
+};
+use health::HealthRegistry;
+use rdkafka::{
+    consumer::{Consumer, StreamConsumer},
+    message::{BorrowedMessage, Headers},
+    producer::FutureRecord,
+    ClientConfig, Message,
+};
+use std::time::Duration;
+use tracing::{error, info};
+
+use crate::config::Config;
+
+pub struct RepartitionerService {
+    consumer: StreamConsumer,
+    producer: rdkafka::producer::FutureProducer<KafkaContext>,
+    destination_topic: String,
+    health: HealthRegistry,
+}
+
+impl RepartitionerService {
+    pub async fn new(config: Config, health: HealthRegistry) -> Result<Self> {
+        let kafka_config = KafkaConfig {
+            kafka_hosts: config.kafka_hosts.clone(),
+            kafka_tls: config.kafka_tls,
+            kafka_producer_linger_ms: config.kafka_producer_linger_ms,
+            kafka_producer_queue_mib: config.kafka_producer_queue_mib,
+            kafka_producer_queue_messages: config.kafka_producer_queue_messages,
+            kafka_message_timeout_ms: config.kafka_message_timeout_ms,
+            kafka_compression_codec: config.kafka_compression_codec.clone(),
+        };
+
+        // Create consumer directly to get raw messages
+        let mut client_config = ClientConfig::new();
+        client_config
+            .set("bootstrap.servers", &config.kafka_hosts)
+            .set("statistics.interval.ms", "10000")
+            .set("group.id", &config.kafka_consumer_group)
+            .set("auto.offset.reset", &config.kafka_consumer_offset_reset)
+            .set("enable.auto.offset.store", "false");
+
+        if config.kafka_tls {
+            client_config
+                .set("security.protocol", "ssl")
+                .set("enable.ssl.certificate.verification", "false");
+        }
+
+        if config.kafka_consumer_auto_commit {
+            client_config.set("enable.auto.commit", "true").set(
+                "auto.commit.interval.ms",
+                config.kafka_consumer_auto_commit_interval_ms.to_string(),
+            );
+        }
+
+        let consumer: StreamConsumer = client_config
+            .create()
+            .context("Failed to create Kafka consumer")?;
+        consumer
+            .subscribe(&[&config.kafka_source_topic])
+            .context("Failed to subscribe to topic")?;
+
+        let health_handle = health
+            .register("kafka_producer".to_string(), Duration::from_secs(30))
+            .await;
+        let producer = create_kafka_producer(&kafka_config, health_handle)
+            .await
+            .context("Failed to create Kafka producer")?;
+
+        info!(
+            "Repartitioner service initialized: consuming from '{}', producing to '{}'",
+            config.kafka_source_topic, config.kafka_destination_topic
+        );
+
+        Ok(Self {
+            consumer,
+            producer,
+            destination_topic: config.kafka_destination_topic,
+            health,
+        })
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        info!("Starting repartitioner service");
+
+        let consumer_health = self
+            .health
+            .register("kafka_consumer".to_string(), Duration::from_secs(30))
+            .await;
+        consumer_health.report_healthy().await;
+
+        loop {
+            match self.consumer.recv().await {
+                Ok(message) => {
+                    if let Err(e) = self.process_message(&message).await {
+                        error!("Failed to process message: {}", e);
+                    } else {
+                        consumer_health.report_healthy().await;
+                    }
+                }
+                Err(e) => {
+                    error!("Error receiving message: {}", e);
+                    consumer_health
+                        .report_status(health::ComponentStatus::Unhealthy)
+                        .await;
+                }
+            }
+        }
+    }
+
+    async fn process_message(&self, message: &BorrowedMessage<'_>) -> Result<()> {
+        let payload = message.payload().context("Message has no payload")?;
+        let key = message.key();
+
+        // Compute new partition key (example: using a hash of the payload)
+        // You can customize this logic based on your requirements
+        let new_key = self.compute_partition_key(payload, key);
+
+        // Build record with new partition key, using borrowed payload
+        // Headers are converted from BorrowedHeaders to OwnedHeaders only when needed
+        // (FutureRecord requires OwnedHeaders due to async send semantics)
+        let headers = message.headers().map(|h| {
+            use rdkafka::message::OwnedHeaders;
+            let mut owned = OwnedHeaders::new();
+            for header in h.iter() {
+                owned = owned.insert(rdkafka::message::Header {
+                    key: header.key,
+                    value: header.value,
+                });
+            }
+            owned
+        });
+
+        let record = FutureRecord {
+            topic: &self.destination_topic,
+            partition: None,
+            key: Some(&new_key),
+            payload: Some(payload),
+            timestamp: None,
+            headers,
+        };
+
+        // Send to Kafka
+        let future = self
+            .producer
+            .send_result(record)
+            .map_err(|(e, _)| anyhow::anyhow!("Failed to queue message: {:?}", e))
+            .context("Failed to send message to output topic")?;
+
+        match future.await {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err((e, _))) => Err(anyhow::anyhow!("Failed to send: {:?}", e))
+                .context("Failed to send message to output topic"),
+            Err(_) => Err(anyhow::anyhow!("Send future was canceled"))
+                .context("Failed to send message to output topic"),
+        }
+    }
+
+    fn compute_partition_key(&self, payload: &[u8], original_key: Option<&[u8]>) -> Vec<u8> {
+        // Example implementation: hash the payload
+        // You can customize this to use any partition key strategy you need
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = DefaultHasher::new();
+        payload.hash(&mut hasher);
+        if let Some(key) = original_key {
+            key.hash(&mut hasher);
+        }
+        let hash = hasher.finish();
+        hash.to_le_bytes().to_vec()
+    }
+}


### PR DESCRIPTION
## Problem
Ingestion team wants to experiment with replacing ShuffleHog with something lighter weight and cheaper.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Implements simple Rust repartitioning service, and related test suite. Tests pass locally but I can add CI integrations and Depot project now or in a follow-on PR. Will land deploy PRs (including new output topic def) in follow-on.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (deploy smoke tests coming soon!)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required ✅ 
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
