### PR TITLE
fix(exports): Apply dashboard variables and cache warm dashboard insights

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -20,9 +20,11 @@ from webdriver_manager.core.os_manager import ChromeType
 
 from posthog.hogql.constants import LimitContext
 
+from posthog.api.insight_variable import map_stale_to_latest
 from posthog.api.services.query import process_query_dict
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models import InsightVariable
 from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 from posthog.tasks.exporter import EXPORT_FAILED_COUNTER, EXPORT_SUCCEEDED_COUNTER, EXPORT_TIMER
@@ -330,18 +332,55 @@ def export_image(exported_asset: ExportedAsset, max_height_pixels: Optional[int]
 
         try:
             if exported_asset.insight:
-                # NOTE: Dashboards are regularly updated but insights are not
-                # so, we need to trigger a manual update to ensure the results are good
+                logger.info(
+                    "export_image.calculate_insight",
+                    insight_id=exported_asset.insight.id,
+                    dashboard_id=exported_asset.dashboard.id if exported_asset.dashboard else None,
+                )
+                dashboard_variables = None
+                if exported_asset.dashboard and exported_asset.dashboard.variables:
+                    variables = list(InsightVariable.objects.filter(team=exported_asset.team).all())
+                    dashboard_variables = map_stale_to_latest(exported_asset.dashboard.variables, variables)
+
                 with upgrade_query(exported_asset.insight):
                     process_query_dict(
                         exported_asset.team,
                         exported_asset.insight.query,
                         dashboard_filters_json=exported_asset.dashboard.filters if exported_asset.dashboard else None,
+                        variables_override_json=dashboard_variables,
                         limit_context=LimitContext.QUERY_ASYNC,
                         execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
                         insight_id=exported_asset.insight.id,
                         dashboard_id=exported_asset.dashboard.id if exported_asset.dashboard else None,
                     )
+            elif exported_asset.dashboard:
+                logger.info(
+                    "export_image.calculate_dashboard_insights",
+                    dashboard_id=exported_asset.dashboard.id,
+                )
+                dashboard_variables = None
+                if exported_asset.dashboard.variables:
+                    variables = list(InsightVariable.objects.filter(team=exported_asset.team).all())
+                    dashboard_variables = map_stale_to_latest(exported_asset.dashboard.variables, variables)
+
+                tiles = (
+                    exported_asset.dashboard.tiles.select_related("insight")
+                    .filter(insight__isnull=False, insight__deleted=False)
+                    .all()
+                )
+                insights_to_update = [tile.insight for tile in tiles if tile.insight]
+                for insight in insights_to_update:
+                    with upgrade_query(insight):
+                        process_query_dict(
+                            exported_asset.team,
+                            insight.query,
+                            dashboard_filters_json=exported_asset.dashboard.filters,
+                            variables_override_json=dashboard_variables,
+                            limit_context=LimitContext.QUERY_ASYNC,
+                            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+                            insight_id=insight.id,
+                            dashboard_id=exported_asset.dashboard.id,
+                        )
 
             if exported_asset.export_format == "image/png":
                 with EXPORT_TIMER.labels(type="image").time():

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -370,6 +370,8 @@ def export_image(exported_asset: ExportedAsset, max_height_pixels: Optional[int]
                 )
                 insights_to_update = [tile.insight for tile in tiles if tile.insight]
                 for insight in insights_to_update:
+                    if not insight.query:
+                        continue
                     with upgrade_query(insight):
                         process_query_dict(
                             exported_asset.team,

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -4,7 +4,10 @@ from unittest.mock import mock_open, patch
 from boto3 import resource
 from botocore.client import Config
 
-from posthog.models import ExportedAsset, Insight
+from posthog.api.insight_variable import map_stale_to_latest
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models import Dashboard, ExportedAsset, Insight, InsightVariable
+from posthog.models.dashboard_tile import DashboardTile
 from posthog.settings import (
     OBJECT_STORAGE_ACCESS_KEY_ID,
     OBJECT_STORAGE_BUCKET,
@@ -86,3 +89,94 @@ class TestImageExporter(APIBaseTest):
             assert self.exported_asset.content_location is None
 
             assert self.exported_asset.content == b"image_data"
+
+    @patch("posthog.tasks.exports.image_exporter.process_query_dict")
+    def test_dashboard_export_calculates_all_insights(self, mock_process_query, *args) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        insight_count = 3
+
+        insights = []
+        for i in range(insight_count):
+            insight = Insight.objects.create(
+                team=self.team,
+                name=f"SQL Insight {i}",
+                query={
+                    "kind": "DataVisualizationNode",
+                    "source": {"kind": "HogQLQuery", "query": f"SELECT {i} as value"},
+                },
+            )
+            insights.append(insight)
+            DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        dashboard_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            dashboard=dashboard,
+            insight=None,
+        )
+
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(dashboard_asset)
+
+        assert (
+            mock_process_query.call_count == insight_count
+        ), f"Expected cache warming for {insight_count} insights, got {mock_process_query.call_count} calls"
+
+        for i, call in enumerate(mock_process_query.call_args_list):
+            call_kwargs = call[1]
+
+            assert call_kwargs["dashboard_id"] == dashboard.id, f"Call {i+1} missing dashboard_id"
+
+            assert (
+                call_kwargs["execution_mode"] == ExecutionMode.CALCULATE_BLOCKING_ALWAYS
+            ), f"Call {i+1} should use CALCULATE_BLOCKING_ALWAYS, got {call_kwargs['execution_mode']}"
+
+            assert call_kwargs["insight_id"] in [
+                ins.id for ins in insights
+            ], f"Call {i+1} has unexpected insight_id {call_kwargs['insight_id']}"
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    def test_export_includes_dashboard_variables(self, *args) -> None:
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Test Dashboard with Variables",
+            variables={"test_var": {"id": "var_123", "name": "test_var", "type": "String", "default": "value1"}},
+        )
+
+        InsightVariable.objects.create(team=self.team, name="test_var", type="String", default_value="value1")
+
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Test Insight",
+            query={"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT 1 as value"}},
+        )
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            dashboard=dashboard,
+            insight=insight,
+        )
+
+        with patch("posthog.tasks.exports.image_exporter.process_query_dict") as mock_process_query:
+            mock_process_query.return_value = {"cache_key": "test_key", "results": []}
+
+            with self.settings(OBJECT_STORAGE_ENABLED=False):
+                image_exporter.export_image(exported_asset)
+
+            assert mock_process_query.call_count == 1
+            call_kwargs = mock_process_query.call_args[1]
+
+            assert "variables_override_json" in call_kwargs, "variables_override_json parameter missing"
+            assert (
+                call_kwargs["variables_override_json"] is not None
+            ), "variables_override_json should not be None when dashboard has variables"
+
+            variables = list(InsightVariable.objects.filter(team=self.team).all())
+            expected_variables = map_stale_to_latest(dashboard.variables, variables)
+            assert (
+                call_kwargs["variables_override_json"] == expected_variables
+            ), "variables_override_json should match the transformed dashboard variables"

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from posthog.test.base import APIBaseTest
 from unittest.mock import mock_open, patch
 
@@ -91,7 +93,7 @@ class TestImageExporter(APIBaseTest):
             assert self.exported_asset.content == b"image_data"
 
     @patch("posthog.tasks.exports.image_exporter.process_query_dict")
-    def test_dashboard_export_calculates_all_insights(self, mock_process_query, *args) -> None:
+    def test_dashboard_export_calculates_all_insights(self, mock_process_query: Any, *args: Any) -> None:
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
         insight_count = 3
 
@@ -138,7 +140,7 @@ class TestImageExporter(APIBaseTest):
     @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
     @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
     @patch("os.remove")
-    def test_export_includes_dashboard_variables(self, *args) -> None:
+    def test_export_includes_dashboard_variables(self, *args: Any) -> None:
         dashboard = Dashboard.objects.create(
             team=self.team,
             name="Test Dashboard with Variables",
@@ -176,7 +178,7 @@ class TestImageExporter(APIBaseTest):
             ), "variables_override_json should not be None when dashboard has variables"
 
             variables = list(InsightVariable.objects.filter(team=self.team).all())
-            expected_variables = map_stale_to_latest(dashboard.variables, variables)
+            expected_variables = map_stale_to_latest(dashboard.variables or {}, variables)
             assert (
                 call_kwargs["variables_override_json"] == expected_variables
             ), "variables_override_json should match the transformed dashboard variables"


### PR DESCRIPTION
## Problem

There are two problems with image exports:

1. When exporting an image of a dashboard, we don't calculate the insights on the dashboard (i.e. cache warm all the insights) resulting in a cache missing when chrome calls the /exporter endpoint to load the query results. 

2. When exporting a single insight that is part of a dashboard with variable overrides, we didn't pass the overrides to `process_query_dict` on the initial cache warming resulting in a cache key different from the one chrome will use to load the insight also resulting in a cache miss. 

Since both of these issues result in a cache miss, another query is run asynchronously and the frontend polls for results. However, the JWT token used for the /exporter endpoint does not have authorization to poll for query results, leading to a 403 and "error loading data" shown to the user. 

<details>
<summary>Image of error</summary>
<img width="1192" height="952" alt="image" src="https://github.com/user-attachments/assets/a14a90f8-e22f-478a-9f48-f59b31adae00" />
</details>


The issues can be reproduced locally with the following steps:
Problem 1: 
- create an insight 
- add the insight to a dashboard
- clear the query cache, key starts with cache_ (I used the vscode redis extension to do this)
- export the dashboard as png from the dashboard view 
- see the "Error loading data" in the image

Problem 2: 
- create an insight with a variable
- add the insight to a dashboard
- add a variable override
- clear the query cache, key starts with cache_ (I used the vscode redis extension to do this)
- export the insight as png **from the dashboard view**  (see image on how I do this from the frontend)

<img width="988" height="693" alt="Screenshot 2025-11-12 at 12 58 55 PM" src="https://github.com/user-attachments/assets/293242bc-244a-4985-8715-f589f394ca8f" />

- see the "Error loading data" in the image


https://github.com/PostHog/posthog/issues/39055

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

1. run `process_query_dict` for each insight on the dashboard to cache warm all the insights to ensure a cache hit
2. pass dashboard variable overrides if they are present to `process_query_dict` to ensure a cache hit

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I reproduced both issues locally and added a unit test for both issues.


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
