### PR TITLE
chore(flags): Implement configurable Redis timeouts

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "redis",
  "serde-pickle",
  "thiserror 2.0.16",
+ "tokio",
  "tracing",
  "zstd",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1969,7 +1969,6 @@ dependencies = [
  "redis",
  "serde-pickle",
  "thiserror 2.0.16",
- "tokio",
  "tracing",
  "zstd",
 ]

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -40,6 +40,13 @@ pub struct Config {
     pub address: SocketAddr,
 
     pub redis_url: String,
+
+    #[envconfig(default = "100")]
+    pub redis_response_timeout_ms: u64,
+
+    #[envconfig(default = "5000")]
+    pub redis_connection_timeout_ms: u64,
+
     pub otel_url: Option<String>,
 
     #[envconfig(default = "false")]

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -133,9 +133,23 @@ where
         HealthRegistry::new_with_strategy("liveness", config.healthcheck_strategy.clone());
 
     let redis_client = Arc::new(
-        RedisClient::new(config.redis_url.clone())
-            .await
-            .expect("failed to create redis client"),
+        RedisClient::with_config(
+            config.redis_url.clone(),
+            common_redis::CompressionConfig::disabled(),
+            common_redis::RedisValueFormat::default(),
+            if config.redis_response_timeout_ms == 0 {
+                None
+            } else {
+                Some(Duration::from_millis(config.redis_response_timeout_ms))
+            },
+            if config.redis_connection_timeout_ms == 0 {
+                None
+            } else {
+                Some(Duration::from_millis(config.redis_connection_timeout_ms))
+            },
+        )
+        .await
+        .expect("failed to create redis client"),
     );
 
     // add new "scoped" quota limiters here as new quota tracking buckets are added

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -35,6 +35,8 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     print_sink: false,
     address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
     redis_url: "redis://localhost:6379/".to_string(),
+    redis_response_timeout_ms: 100,
+    redis_connection_timeout_ms: 5000,
     overflow_enabled: false,
     overflow_preserve_partition_locality: false,
     overflow_burst_limit: NonZeroU32::new(5).unwrap(),

--- a/rust/common/cache/src/read_through.rs
+++ b/rust/common/cache/src/read_through.rs
@@ -193,7 +193,9 @@ impl ReadThroughCache {
                 );
                 self.handle_corrupted_cache(key, cache_key, loader).await
             }
-            CustomRedisError::Timeout | CustomRedisError::Redis(_) => {
+            CustomRedisError::Timeout
+            | CustomRedisError::Redis(_)
+            | CustomRedisError::InvalidConfiguration(_) => {
                 // Redis infrastructure issues - use loader without caching
                 tracing::warn!(
                     "Redis infrastructure issue for key {}: {:?}. Operating without cache.",

--- a/rust/common/hypercache/tests/integration_tests.rs
+++ b/rust/common/hypercache/tests/integration_tests.rs
@@ -57,7 +57,14 @@ async fn setup_integration_clients() -> anyhow::Result<TestClients> {
 
     let s3_client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
 
-    let redis_client_for_cache = RedisClient::new("redis://localhost:6379".to_string()).await?;
+    let redis_client_for_cache = RedisClient::with_config(
+        "redis://localhost:6379".to_string(),
+        common_redis::CompressionConfig::disabled(),
+        common_redis::RedisValueFormat::default(),
+        Some(Duration::from_millis(1000)),
+        Some(Duration::from_millis(5000)),
+    )
+    .await?;
     let hypercache =
         HyperCacheReader::new(std::sync::Arc::new(redis_client_for_cache), config.clone()).await?;
 
@@ -268,7 +275,14 @@ async fn test_hypercache_token_based_cache_key() -> anyhow::Result<()> {
     config.token_based = true;
     config.s3_endpoint = Some("http://localhost:19000".to_string());
 
-    let redis_client_for_cache = RedisClient::new("redis://localhost:6379".to_string()).await?;
+    let redis_client_for_cache = RedisClient::with_config(
+        "redis://localhost:6379".to_string(),
+        common_redis::CompressionConfig::disabled(),
+        common_redis::RedisValueFormat::default(),
+        Some(Duration::from_millis(1000)),
+        Some(Duration::from_millis(5000)),
+    )
+    .await?;
     let token_based_hypercache =
         HyperCacheReader::new(std::sync::Arc::new(redis_client_for_cache), config).await?;
 
@@ -342,7 +356,14 @@ async fn test_hypercache_keytype_variants() -> anyhow::Result<()> {
     config_token.token_based = true;
     config_token.s3_endpoint = Some("http://localhost:19000".to_string());
 
-    let redis_client_token = RedisClient::new("redis://localhost:6379".to_string()).await?;
+    let redis_client_token = RedisClient::with_config(
+        "redis://localhost:6379".to_string(),
+        common_redis::CompressionConfig::disabled(),
+        common_redis::RedisValueFormat::default(),
+        Some(Duration::from_millis(1000)),
+        Some(Duration::from_millis(5000)),
+    )
+    .await?;
     let hypercache_token = HyperCacheReader::new(
         std::sync::Arc::new(redis_client_token),
         config_token.clone(),

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -11,7 +11,6 @@ async-trait = { workspace = true }
 redis = { workspace = true }
 serde-pickle = { version = "1.1.1" }
 thiserror = { workspace = true }
-tokio = { workspace = true }
 tracing = { workspace = true }
 zstd = "0.13"
 

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -14,3 +14,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 zstd = "0.13"
 
+[dev-dependencies]
+tokio = { workspace = true }
+

--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -2,19 +2,9 @@ use async_trait::async_trait;
 use redis::aio::MultiplexedConnection;
 use redis::{AsyncCommands, RedisError};
 use std::time::Duration;
-use tokio::time::timeout;
 use tracing::warn;
 
-use crate::{
-    Client, CompressionConfig, CustomRedisError, RedisValueFormat, DEFAULT_REDIS_TIMEOUT_MILLISECS,
-};
-
-fn get_redis_timeout_ms() -> u64 {
-    std::env::var("REDIS_TIMEOUT_MS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_REDIS_TIMEOUT_MILLISECS)
-}
+use crate::{Client, CompressionConfig, CustomRedisError, RedisValueFormat};
 
 // Error messages for consistent handling of RawBytes format
 const ERR_RAWBYTES_GET: &str = "Use get_raw_bytes() for RawBytes format";
@@ -33,13 +23,16 @@ impl RedisClient {
     /// Defaults:
     /// - Format: Pickle (Django-compatible)
     /// - Compression: Disabled
+    /// - Timeouts: None (blocks indefinitely)
     ///
-    /// For Django-compatible compression, use `with_config()` with `CompressionConfig::default()`
+    /// For timeout configuration, use `with_config()` and specify `response_timeout` and `connection_timeout`.
     pub async fn new(addr: String) -> Result<RedisClient, CustomRedisError> {
         Self::with_config(
             addr,
             CompressionConfig::disabled(),
             RedisValueFormat::default(),
+            None, // No response timeout
+            None, // No connection timeout
         )
         .await
     }
@@ -50,34 +43,61 @@ impl RedisClient {
     /// * `addr` - Redis connection string
     /// * `compression` - Compression configuration (see CompressionConfig)
     /// * `format` - Serialization format for values (see RedisValueFormat)
+    /// * `response_timeout` - Optional timeout for Redis command responses. `None` means no timeout (blocks indefinitely).
+    /// * `connection_timeout` - Optional timeout for establishing connections. `None` means no timeout (blocks indefinitely).
+    ///
+    /// # Panics
+    /// Panics if `Some(Duration::ZERO)` is passed - use `None` for no timeout instead.
     ///
     /// # Examples
     /// ```no_run
     /// use common_redis::{RedisClient, CompressionConfig, RedisValueFormat};
+    /// use std::time::Duration;
     ///
     /// # async fn example() {
-    /// // Default settings
-    /// let client = RedisClient::new("redis://localhost:6379".to_string()).await.unwrap();
+    /// // With timeouts (100ms response, 5000ms connection)
+    /// let client = RedisClient::with_config(
+    ///     "redis://localhost:6379".to_string(),
+    ///     CompressionConfig::disabled(),
+    ///     RedisValueFormat::default(),
+    ///     Some(Duration::from_millis(100)),
+    ///     Some(Duration::from_millis(5000)),
+    /// ).await.unwrap();
     ///
-    /// // Custom compression only
+    /// // No timeouts (blocks indefinitely)
+    /// let client = RedisClient::with_config(
+    ///     "redis://localhost:6379".to_string(),
+    ///     CompressionConfig::disabled(),
+    ///     RedisValueFormat::default(),
+    ///     None,
+    ///     None,
+    /// ).await.unwrap();
+    ///
+    /// // Custom compression with timeouts
     /// let client = RedisClient::with_config(
     ///     "redis://localhost:6379".to_string(),
     ///     CompressionConfig::new(true, 1024, 3),
     ///     RedisValueFormat::default(),
+    ///     Some(Duration::from_millis(100)),
+    ///     Some(Duration::from_millis(5000)),
     /// ).await.unwrap();
     ///
-    /// // Custom format only
+    /// // Custom format with no timeouts
     /// let client = RedisClient::with_config(
     ///     "redis://localhost:6379".to_string(),
     ///     CompressionConfig::default(),
     ///     RedisValueFormat::Utf8,
+    ///     None,
+    ///     None,
     /// ).await.unwrap();
     ///
-    /// // Full custom configuration
+    /// // Full custom configuration with timeouts
     /// let client = RedisClient::with_config(
     ///     "redis://localhost:6379".to_string(),
     ///     CompressionConfig::new(true, 1024, 3),
     ///     RedisValueFormat::Utf8,
+    ///     Some(Duration::from_millis(100)),
+    ///     Some(Duration::from_millis(5000)),
     /// ).await.unwrap();
     /// # }
     /// ```
@@ -85,9 +105,41 @@ impl RedisClient {
         addr: String,
         compression: CompressionConfig,
         format: RedisValueFormat,
+        response_timeout: Option<Duration>,
+        connection_timeout: Option<Duration>,
     ) -> Result<RedisClient, CustomRedisError> {
         let client = redis::Client::open(addr)?;
-        let connection = client.get_multiplexed_async_connection().await?;
+
+        // Validate that Duration::ZERO is not passed - use None instead
+        if let Some(timeout) = response_timeout {
+            if timeout.is_zero() {
+                panic!("Redis response timeout cannot be Duration::ZERO - use None for no timeout");
+            }
+        }
+        if let Some(timeout) = connection_timeout {
+            if timeout.is_zero() {
+                panic!(
+                    "Redis connection timeout cannot be Duration::ZERO - use None for no timeout"
+                );
+            }
+        }
+
+        // Use Redis native timeout configuration
+        // None means no timeout (blocks indefinitely)
+        let mut config = redis::AsyncConnectionConfig::new();
+
+        if let Some(timeout) = response_timeout {
+            config = config.set_response_timeout(timeout);
+        }
+
+        if let Some(timeout) = connection_timeout {
+            config = config.set_connection_timeout(timeout);
+        }
+
+        let connection = client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await?;
+
         Ok(RedisClient {
             connection,
             compression,
@@ -172,9 +224,8 @@ impl Client for RedisClient {
         max: String,
     ) -> Result<Vec<String>, CustomRedisError> {
         let mut conn = self.connection.clone();
-        let results = conn.zrangebyscore(k, min, max);
-        let fut = timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
-        Ok(fut?)
+        let results = conn.zrangebyscore(k, min, max).await?;
+        Ok(results)
     }
 
     async fn hincrby(
@@ -185,9 +236,8 @@ impl Client for RedisClient {
     ) -> Result<(), CustomRedisError> {
         let mut conn = self.connection.clone();
         let count = count.unwrap_or(1);
-        let results = conn.hincr(k, v, count);
-        let fut = timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
-        fut.map_err(|e| e.into())
+        conn.hincr::<_, _, _, ()>(k, v, count).await?;
+        Ok(())
     }
 
     async fn get(&self, k: String) -> Result<String, CustomRedisError> {
@@ -200,17 +250,15 @@ impl Client for RedisClient {
         format: RedisValueFormat,
     ) -> Result<String, CustomRedisError> {
         let mut conn = self.connection.clone();
-        let results = conn.get(k);
-        let fut: Result<Vec<u8>, RedisError> =
-            timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
+        let raw_bytes: Vec<u8> = conn.get(k).await?;
 
-        if matches!(&fut, Ok(v) if v.is_empty()) {
+        // return NotFound error when empty
+        if raw_bytes.is_empty() {
             return Err(CustomRedisError::NotFound);
         }
 
-        let raw_bytes = fut?;
-
-        // Decompress if needed - gracefully handles both compressed and uncompressed data
+        // Always attempt decompression - handles both compressed and uncompressed data gracefully
+        // This ensures clients can read data regardless of compression settings used when writing
         let decompressed = Self::try_decompress(raw_bytes);
 
         match format {
@@ -231,16 +279,15 @@ impl Client for RedisClient {
 
     async fn get_raw_bytes(&self, k: String) -> Result<Vec<u8>, CustomRedisError> {
         let mut conn = self.connection.clone();
-        let results = conn.get(k);
-        let fut: Result<Vec<u8>, RedisError> =
-            timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
+        let raw_bytes: Vec<u8> = conn.get(k).await?;
 
-        if matches!(&fut, Ok(v) if v.is_empty()) {
+        // return NotFound error when empty
+        if raw_bytes.is_empty() {
             return Err(CustomRedisError::NotFound);
         }
 
-        let raw_bytes = fut?;
-
+        // Always attempt decompression - handles both compressed and uncompressed data gracefully
+        // This ensures clients can read data regardless of compression settings used when writing
         Ok(Self::try_decompress(raw_bytes))
     }
 
@@ -257,18 +304,16 @@ impl Client for RedisClient {
         let final_bytes = self.serialize_and_compress(v, format)?;
 
         let mut conn = self.connection.clone();
-        let results = conn.set(k, final_bytes);
-        let fut = timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
-        Ok(fut?)
+        conn.set::<_, _, ()>(k, final_bytes).await?;
+        Ok(())
     }
 
     async fn setex(&self, k: String, v: String, seconds: u64) -> Result<(), CustomRedisError> {
         let final_bytes = self.serialize_and_compress(v, self.format)?;
 
         let mut conn = self.connection.clone();
-        let results = conn.set_ex(k, final_bytes, seconds);
-        let fut = timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
-        Ok(fut?)
+        conn.set_ex::<_, _, ()>(k, final_bytes, seconds).await?;
+        Ok(())
     }
 
     async fn set_nx_ex(
@@ -292,39 +337,34 @@ impl Client for RedisClient {
         let mut conn = self.connection.clone();
         let seconds_usize = seconds as usize;
 
-        let result: Result<Option<String>, RedisError> = timeout(
-            Duration::from_millis(get_redis_timeout_ms()),
-            redis::cmd("SET")
-                .arg(&k)
-                .arg(&final_bytes)
-                .arg("EX")
-                .arg(seconds_usize)
-                .arg("NX")
-                .query_async(&mut conn),
-        )
-        .await?;
+        // Use SET with both NX and EX options
+        let result: Result<Option<String>, RedisError> = redis::cmd("SET")
+            .arg(&k)
+            .arg(&final_bytes)
+            .arg("EX")
+            .arg(seconds_usize)
+            .arg("NX")
+            .query_async(&mut conn)
+            .await;
 
         match result {
-            Ok(Some(_)) => Ok(true),
-            Ok(None) => Ok(false),
+            Ok(Some(_)) => Ok(true), // Key was set successfully
+            Ok(None) => Ok(false),   // Key already existed
             Err(e) => Err(e.into()),
         }
     }
 
     async fn del(&self, k: String) -> Result<(), CustomRedisError> {
         let mut conn = self.connection.clone();
-        let results = conn.del(k);
-        let fut = timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
-        fut.map_err(|e| e.into())
+        conn.del::<_, ()>(k).await?;
+        Ok(())
     }
 
     async fn hget(&self, k: String, field: String) -> Result<String, CustomRedisError> {
         let mut conn = self.connection.clone();
-        let results = conn.hget(k, field);
-        let fut: Result<Option<String>, RedisError> =
-            timeout(Duration::from_millis(get_redis_timeout_ms()), results).await?;
+        let result: Option<String> = conn.hget(k, field).await?;
 
-        match fut? {
+        match result {
             Some(value) => Ok(value),
             None => Err(CustomRedisError::NotFound),
         }
@@ -332,10 +372,8 @@ impl Client for RedisClient {
 
     async fn scard(&self, k: String) -> Result<u64, CustomRedisError> {
         let mut conn = self.connection.clone();
-        let results = conn.scard(k);
-        timeout(Duration::from_millis(get_redis_timeout_ms()), results)
-            .await?
-            .map_err(|e| e.into())
+        let result = conn.scard(k).await?;
+        Ok(result)
     }
 }
 

--- a/rust/common/redis/src/read_write.rs
+++ b/rust/common/redis/src/read_write.rs
@@ -22,6 +22,8 @@ use crate::{Client, CompressionConfig, CustomRedisError, RedisClient, RedisValue
 ///     "redis://replica:6379".to_string(),
 ///     CompressionConfig::default(),
 ///     RedisValueFormat::Pickle,
+///     None, // No response timeout
+///     None, // No connection timeout
 /// );
 ///
 /// let client = config.build().await.unwrap();
@@ -95,6 +97,8 @@ impl ReadWriteClientConfig {
 ///     "redis://replica:6379".to_string(),
 ///     CompressionConfig::default(),
 ///     RedisValueFormat::Pickle,
+///     None, // No response timeout
+///     None, // No connection timeout
 /// );
 ///
 /// let client = ReadWriteClient::with_config(config).await.unwrap();
@@ -105,6 +109,8 @@ impl ReadWriteClientConfig {
 ///     "redis://replica:6379".to_string(),
 ///     CompressionConfig::default(),
 ///     RedisValueFormat::Pickle,
+///     None, // No response timeout
+///     None, // No connection timeout
 /// )
 /// .build()
 /// .await
@@ -159,6 +165,8 @@ impl ReadWriteClient {
     ///         "redis://replica:6379".to_string(),
     ///         CompressionConfig::default(),
     ///         RedisValueFormat::Pickle,
+    ///         None, // No response timeout
+    ///         None, // No connection timeout
     ///     )
     ///     .await
     ///     .unwrap()
@@ -169,6 +177,8 @@ impl ReadWriteClient {
     ///         "redis://primary:6379".to_string(),
     ///         CompressionConfig::default(),
     ///         RedisValueFormat::Pickle,
+    ///         None, // No response timeout
+    ///         None, // No connection timeout
     ///     )
     ///     .await
     ///     .unwrap()
@@ -203,6 +213,8 @@ impl ReadWriteClient {
     ///     "redis://replica:6379".to_string(),
     ///     CompressionConfig::default(),
     ///     RedisValueFormat::Pickle,
+    ///     None, // No response timeout
+    ///     None, // No connection timeout
     /// );
     ///
     /// let client = ReadWriteClient::with_config(config).await.unwrap();

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -148,7 +148,22 @@ impl AppContext {
 
         let geoip_client = GeoIpClient::new(config.maxmind_db_path.clone())?;
 
-        let redis_client = RedisClient::new(config.redis_url.clone()).await?;
+        let redis_client = RedisClient::with_config(
+            config.redis_url.clone(),
+            common_redis::CompressionConfig::disabled(),
+            common_redis::RedisValueFormat::default(),
+            if config.redis_response_timeout_ms == 0 {
+                None
+            } else {
+                Some(Duration::from_millis(config.redis_response_timeout_ms))
+            },
+            if config.redis_connection_timeout_ms == 0 {
+                None
+            } else {
+                Some(Duration::from_millis(config.redis_connection_timeout_ms))
+            },
+        )
+        .await?;
         let redis_client = Arc::new(redis_client);
 
         // TODO - we expect here rather returning an UnhandledError because the limiter returns an Anyhow::Result,

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -139,6 +139,12 @@ pub struct Config {
     #[envconfig(default = "redis://localhost:6379/")]
     pub redis_url: String,
 
+    #[envconfig(default = "100")]
+    pub redis_response_timeout_ms: u64,
+
+    #[envconfig(default = "5000")]
+    pub redis_connection_timeout_ms: u64,
+
     #[envconfig(default = "")]
     pub filtered_teams: String, // Comma seperated list of teams to either filter in (process) or filter out (ignore)
 

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -345,7 +345,9 @@ impl From<CustomRedisError> for FlagError {
             CustomRedisError::NotFound => FlagError::TokenValidationError,
             CustomRedisError::ParseError(_) => FlagError::RedisDataParsingError,
             CustomRedisError::Timeout => FlagError::TimeoutError(Some("Redis timeout".to_string())),
-            CustomRedisError::Redis(_) => FlagError::RedisUnavailable,
+            CustomRedisError::InvalidConfiguration(_) | CustomRedisError::Redis(_) => {
+                FlagError::RedisUnavailable
+            }
         }
     }
 }

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -344,7 +344,7 @@ impl From<CustomRedisError> for FlagError {
         match e {
             CustomRedisError::NotFound => FlagError::TokenValidationError,
             CustomRedisError::ParseError(_) => FlagError::RedisDataParsingError,
-            CustomRedisError::Timeout => FlagError::TimeoutError(Some("redis_timeout".to_string())),
+            CustomRedisError::Timeout => FlagError::TimeoutError(Some("Redis timeout".to_string())),
             CustomRedisError::Redis(_) => FlagError::RedisUnavailable,
         }
     }
@@ -487,10 +487,10 @@ mod tests {
 
     #[test]
     fn test_redis_timeout_conversion() {
-        // Test that Redis timeout errors include timeout type
+        // Test that Redis timeout errors are converted to FlagError::TimeoutError
         let redis_timeout: FlagError = CustomRedisError::Timeout.into();
         assert!(
-            matches!(redis_timeout, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "redis_timeout")
+            matches!(redis_timeout, FlagError::TimeoutError(Some(ref timeout_type)) if timeout_type == "Redis timeout")
         );
     }
 }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -478,7 +478,7 @@ impl Config {
         let mut fixed = false;
 
         // Note: Zero values are now valid - they mean "no timeout" (blocks indefinitely)
-        // The RedisClient will convert Duration::ZERO to None internally
+        // The RedisClient will skip setting the timeout when Duration::ZERO is provided
 
         // Fix excessive values
         if self.redis_response_timeout_ms > Self::MAX_RESPONSE_TIMEOUT_MS {

--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -66,7 +66,8 @@ fn init_tracer(
 
 #[tokio::main]
 async fn main() {
-    let config = Config::init_from_env().expect("Invalid configuration:");
+    let mut config = Config::init_from_env().expect("Invalid configuration:");
+    config.validate_and_fix_timeouts();
 
     // Instantiate tracing outputs following Django's DEBUG-based approach:
     //   - stdout with a level configured by the RUST_LOG envvar


### PR DESCRIPTION
Replace problematic `tokio::timeout` wrappers with Redis native `AsyncConnectionConfig` timeout support to prevent server-side resource waste and improve error handling.

## Problem

For redis operations, we use `tokio:timeout` to wrap the operations with a timeout. The problem with this is this is a client timeout only. It has no effect on the underlying Redis operation. So it's possible the underlying operation continues even though the client code moves on.

It's exacerbated if we have retry logic, because we could end up retrying an operation that's already in-progress.

## Changes

- Remove manual `tokio::timeout` wrappers from all Redis operations (The idea is to let the Redis timeout raise the error).
- Add native timeout configuration using `AsyncConnectionConfig`
- Implement configurable per-client timeout settings:
  * feature-flags: reader (100ms), writer (200ms), cookieless (500ms)
  * capture/cymbal: configurable response (100ms) and connection (5000ms) timeouts
- Improve error handling to properly detect and map Redis timeout errors
- Updated `RedisClient::new()` to accept timeout parameters across all services

## How did you test this code?

Unit Tests
Some manual smoke testing of the /flags service.

> [!WARNING]  
> I did not test the other services affected by this change. I'm hoping folks who work on those library can review this and test it as well.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
