### PR TITLE
fix: pull goal line listing into a component

### DIFF
--- a/frontend/src/lib/components/GoalLinesList.tsx
+++ b/frontend/src/lib/components/GoalLinesList.tsx
@@ -1,0 +1,74 @@
+import { IconEye, IconTrash } from '@posthog/icons'
+
+import { SeriesLetter } from 'lib/components/SeriesGlyph'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
+import { IconEyeHidden } from 'lib/lemon-ui/icons'
+
+import { GoalLine } from '~/queries/schema/schema-general'
+
+interface GoalLinesListProps {
+    goalLines: GoalLine[]
+    updateGoalLine: (
+        goalLineIndex: number,
+        key: keyof GoalLine,
+        value: NonNullable<string | number | boolean | undefined>
+    ) => void
+    removeGoalLine: (goalLineIndex: number) => void
+}
+
+export function GoalLinesList({ goalLines, updateGoalLine, removeGoalLine }: GoalLinesListProps): JSX.Element {
+    return (
+        <>
+            {goalLines.map(({ label, value = 0, displayLabel = true, position }, goalLineIndex) => (
+                <div className="flex flex-1 gap-1 mb-1 items-center" key={`${goalLineIndex}`}>
+                    <SeriesLetter className="self-center" hasBreakdown={false} seriesIndex={goalLineIndex} />
+                    <LemonInput
+                        placeholder="Label"
+                        className="grow-2"
+                        value={label}
+                        suffix={
+                            <LemonButton
+                                size="small"
+                                noPadding
+                                icon={displayLabel ? <IconEye /> : <IconEyeHidden />}
+                                tooltip={displayLabel ? 'Display label' : 'Hide label'}
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    updateGoalLine(goalLineIndex, 'displayLabel', !displayLabel)
+                                }}
+                            />
+                        }
+                        onChange={(value) => updateGoalLine(goalLineIndex, 'label', value)}
+                    />
+                    <LemonInput
+                        placeholder="Value"
+                        className="grow"
+                        value={value.toString()}
+                        inputMode="numeric"
+                        onChange={(value) => updateGoalLine(goalLineIndex, 'value', parseInt(value))}
+                    />
+                    <LemonSegmentedButton
+                        value={position ?? 'end'}
+                        onChange={(value) => updateGoalLine(goalLineIndex, 'position', value as 'start' | 'end')}
+                        options={[
+                            { value: 'start', label: 'Start' },
+                            { value: 'end', label: 'End' },
+                        ]}
+                        size="xsmall"
+                        data-attr="goal-line-position-selector"
+                    />
+                    <LemonButton
+                        key="delete"
+                        icon={<IconTrash />}
+                        status="danger"
+                        title="Delete goal line"
+                        noPadding
+                        onClick={() => removeGoalLine(goalLineIndex)}
+                    />
+                </div>
+            ))}
+        </>
+    )
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -1,10 +1,9 @@
 import { useActions, useValues } from 'kea'
 
-import { IconEye, IconPlusSmall, IconTrash } from '@posthog/icons'
-import { LemonBadge, LemonButton, LemonCollapse, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { IconPlusSmall } from '@posthog/icons'
+import { LemonBadge, LemonButton, LemonCollapse, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
-import { SeriesLetter } from 'lib/components/SeriesGlyph'
-import { IconEyeHidden } from 'lib/lemon-ui/icons'
+import { GoalLinesList } from 'lib/components/GoalLinesList'
 
 import { ChartDisplayType } from '~/types'
 
@@ -164,50 +163,11 @@ export const DisplayTab = (): JSX.Element => {
                         className: 'p-2',
                         content: (
                             <>
-                                {goalLines.map(({ label, value = 0, displayLabel = true }, goalLineIndex) => (
-                                    <div className="flex flex-1 gap-1 mb-1" key={`${goalLineIndex}`}>
-                                        <SeriesLetter
-                                            className="self-center"
-                                            hasBreakdown={false}
-                                            seriesIndex={goalLineIndex}
-                                        />
-                                        <LemonInput
-                                            placeholder="Label"
-                                            className="grow-2"
-                                            value={label}
-                                            suffix={
-                                                <LemonButton
-                                                    size="small"
-                                                    noPadding
-                                                    icon={displayLabel ? <IconEye /> : <IconEyeHidden />}
-                                                    tooltip={displayLabel ? 'Display label' : 'Hide label'}
-                                                    onClick={(e) => {
-                                                        e.stopPropagation()
-                                                        updateGoalLine(goalLineIndex, 'displayLabel', !displayLabel)
-                                                    }}
-                                                />
-                                            }
-                                            onChange={(value) => updateGoalLine(goalLineIndex, 'label', value)}
-                                        />
-                                        <LemonInput
-                                            placeholder="Value"
-                                            className="grow"
-                                            value={value.toString()}
-                                            inputMode="numeric"
-                                            onChange={(value) =>
-                                                updateGoalLine(goalLineIndex, 'value', parseInt(value))
-                                            }
-                                        />
-                                        <LemonButton
-                                            key="delete"
-                                            icon={<IconTrash />}
-                                            status="danger"
-                                            title="Delete Goal Line"
-                                            noPadding
-                                            onClick={() => removeGoalLine(goalLineIndex)}
-                                        />
-                                    </div>
-                                ))}
+                                <GoalLinesList
+                                    goalLines={goalLines}
+                                    removeGoalLine={removeGoalLine}
+                                    updateGoalLine={updateGoalLine}
+                                />
                                 <LemonButton className="mt-1" onClick={addGoalLine} icon={<IconPlusSmall />} fullWidth>
                                     Add goal line
                                 </LemonButton>

--- a/frontend/src/scenes/insights/EditorFilters/GoalLines.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/GoalLines.tsx
@@ -1,10 +1,9 @@
 import { useActions, useValues } from 'kea'
 
-import { IconEye, IconPlusSmall, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { IconPlusSmall } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
 
-import { SeriesLetter } from 'lib/components/SeriesGlyph'
-import { IconEyeHidden } from 'lib/lemon-ui/icons'
+import { GoalLinesList } from 'lib/components/GoalLinesList'
 
 import { InsightLogicProps } from '~/types'
 
@@ -20,54 +19,7 @@ export function GoalLines({ insightProps }: GoalLinesProps): JSX.Element {
 
     return (
         <div className="mt-1 mb-2">
-            {goalLines.map(({ label, value = 0, displayLabel = true, position }, goalLineIndex) => (
-                <div className="flex flex-1 gap-1 mb-1" key={`${goalLineIndex}`}>
-                    <SeriesLetter className="self-center" hasBreakdown={false} seriesIndex={goalLineIndex} />
-                    <LemonInput
-                        placeholder="Label"
-                        className="grow-2"
-                        value={label}
-                        suffix={
-                            <LemonButton
-                                size="small"
-                                noPadding
-                                icon={displayLabel ? <IconEye /> : <IconEyeHidden />}
-                                tooltip={displayLabel ? 'Display label' : 'Hide label'}
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    updateGoalLine(goalLineIndex, 'displayLabel', !displayLabel)
-                                }}
-                            />
-                        }
-                        onChange={(value) => updateGoalLine(goalLineIndex, 'label', value)}
-                    />
-                    <LemonInput
-                        placeholder="Value"
-                        className="grow"
-                        value={value.toString()}
-                        inputMode="numeric"
-                        onChange={(value) => updateGoalLine(goalLineIndex, 'value', parseInt(value))}
-                    />
-                    <LemonSegmentedButton
-                        value={position ?? 'end'}
-                        onChange={(value) => updateGoalLine(goalLineIndex, 'position', value as 'start' | 'end')}
-                        options={[
-                            { value: 'start', label: 'Start' },
-                            { value: 'end', label: 'End' },
-                        ]}
-                        size="small"
-                        data-attr="goal-line-position-selector"
-                    />
-                    <LemonButton
-                        key="delete"
-                        icon={<IconTrash />}
-                        status="danger"
-                        title="Delete goal line"
-                        noPadding
-                        onClick={() => removeGoalLine(goalLineIndex)}
-                    />
-                </div>
-            ))}
+            <GoalLinesList goalLines={goalLines} removeGoalLine={removeGoalLine} updateGoalLine={updateGoalLine} />
 
             <LemonButton type="secondary" onClick={addGoalLine} icon={<IconPlusSmall />} sideIcon={null}>
                 Add goal line


### PR DESCRIPTION
we have the goal line form in two places 
but the code is duplicated
(and i didn't know)

so i missed it when i added goal line position

this

 * pulls the lines list into one place
 * so i can use it on sql editor visualisation config editing too  

the sql editor config pane isn't re-sizable and the line was pretty squashed so i made the segmented button xsmall 

![2025-11-12 19 35 31](https://github.com/user-attachments/assets/8f5547f9-d6fd-4fd3-9fad-02e7c2696881)

