### PR TITLE
chore(ingestion): add team id to where clause in person update

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -788,7 +788,7 @@ export class PostgresPersonRepository
             return [person, [], false]
         }
 
-        const values = [...updateValues, person.id].map(sanitizeJsonbValue)
+        const values = [...updateValues, person.id, person.team_id].map(sanitizeJsonbValue)
 
         // Measure JSON field sizes after sanitization (using already sanitized values)
         const updateKeys = Object.keys(unparsedUpdate)
@@ -816,14 +816,14 @@ export class PostgresPersonRepository
             update
         ).map((field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`)} WHERE id = $${
             Object.values(update).length + 1
-        }
+        } AND team_id = $${Object.values(update).length + 2}
         RETURNING *, COALESCE(pg_column_size(properties)::bigint, 0::bigint) as properties_size_bytes
         /* operation='updatePersonWithPropertiesSize',purpose='${tag || 'update'}' */`
 
         // Potentially overriding values badly if there was an update to the person after computing updateValues above
         const queryString = `UPDATE posthog_person SET version = ${versionString}, ${Object.keys(update).map(
             (field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`
-        )} WHERE id = $${Object.values(update).length + 1}
+        )} WHERE id = $${Object.values(update).length + 1} AND team_id = $${Object.values(update).length + 2}
         RETURNING *
         /* operation='updatePerson',purpose='${tag || 'update'}' */`
 


### PR DESCRIPTION
## Problem

If we partition posthog_person table by team_id we'll want to include the team_id in the WHERE clause of our UPDATE queries.

## Changes

Adds the team_id to the person update query. It is already available on the incoming person, so its a small change.

## How did you test this code?

Unit tests validate this update query
