### PR TITLE
fix(plugin-server): fix broken ch tests

### DIFF
--- a/plugin-server/src/ingestion/ingestion-e2e.test.ts
+++ b/plugin-server/src/ingestion/ingestion-e2e.test.ts
@@ -242,7 +242,7 @@ describe('Event Pipeline E2E tests', () => {
             expect(warnings).toEqual([
                 expect.objectContaining({
                     type: 'client_ingestion_warning',
-                    team_id: team.id.toString(),
+                    team_id: team.id,
                     details: expect.objectContaining({ message: 'test message' }),
                 }),
             ])
@@ -259,7 +259,7 @@ describe('Event Pipeline E2E tests', () => {
         await waitForExpect(async () => {
             const events = await fetchEvents(hub, team.id)
             expect(events.length).toBe(1)
-            expect(events[0].team_id).toBe(team.id.toString())
+            expect(events[0].team_id).toBe(team.id)
         })
     })
 

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -396,7 +396,7 @@ describe('PersonState.processEvent()', () => {
                     expect.objectContaining({
                         distinct_id: 'new2',
                         person_id: newUserUuid,
-                        version: '1',
+                        version: 1,
                     }),
                 ])
             )
@@ -1465,13 +1465,13 @@ describe('PersonState.processEvent()', () => {
                         id: expect.any(String),
                         properties: '{}',
                         created_at: timestampch,
-                        version: '1',
+                        version: 1,
                         is_identified: 1,
                     }),
                     expect.objectContaining({
                         id: expect.any(String),
                         is_deleted: 1,
-                        version: '100',
+                        version: 100,
                     }),
                 ])
             )
@@ -1665,13 +1665,13 @@ describe('PersonState.processEvent()', () => {
                         id: expect.any(String),
                         properties: JSON.stringify({ a: 1, b: 3, c: 4, d: 6, e: 7, f: 9 }),
                         created_at: timestampch,
-                        version: '1',
+                        version: 1,
                         is_identified: 1,
                     }),
                     expect.objectContaining({
                         id: expect.any(String),
                         is_deleted: 1,
-                        version: '100',
+                        version: 100,
                     }),
                 ])
             )
@@ -1890,13 +1890,13 @@ describe('PersonState.processEvent()', () => {
                         id: expect.any(String),
                         properties: '{}',
                         created_at: timestampch,
-                        version: '1',
+                        version: 1,
                         is_identified: 1,
                     }),
                     expect.objectContaining({
                         id: expect.any(String),
                         is_deleted: 1,
-                        version: '100',
+                        version: 100,
                     }),
                 ])
             )
@@ -2383,13 +2383,13 @@ describe('PersonState.processEvent()', () => {
                         id: firstUserUuid,
                         properties: '{}',
                         created_at: timestampch,
-                        version: '1',
+                        version: 1,
                         is_identified: 1,
                     }),
                     expect.objectContaining({
                         id: secondUserUuid,
                         is_deleted: 1,
-                        version: '100',
+                        version: 100,
                     }),
                 ])
             )

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -117,7 +117,7 @@ describe('postgres parity', () => {
             {
                 id: uuid,
                 created_at: expect.any(String), // '2021-02-04 00:18:26.472',
-                team_id: teamId.toString(),
+                team_id: teamId,
                 properties: { userPropOnce: 'propOnceValue', userProp: 'propValue' },
                 is_identified: 1,
                 is_deleted: 0,
@@ -160,15 +160,15 @@ describe('postgres parity', () => {
             {
                 distinct_id: 'distinct1',
                 person_id: person.uuid,
-                team_id: teamId.toString(),
-                version: '0',
+                team_id: teamId,
+                version: 0,
                 is_deleted: 0,
             },
             {
                 distinct_id: 'distinct2',
                 person_id: person.uuid,
-                team_id: teamId.toString(),
-                version: '0',
+                team_id: teamId,
+                version: 0,
                 is_deleted: 0,
             },
         ])
@@ -332,8 +332,8 @@ describe('postgres parity', () => {
             {
                 distinct_id: 'distinct1',
                 person_id: person.uuid,
-                team_id: teamId.toString(),
-                version: '0',
+                team_id: teamId,
+                version: 0,
                 is_deleted: 0,
             },
         ])
@@ -431,15 +431,15 @@ describe('postgres parity', () => {
             {
                 distinct_id: 'another_distinct_id',
                 person_id: anotherPerson.uuid,
-                team_id: teamId.toString(),
-                version: '0',
+                team_id: teamId,
+                version: 0,
                 is_deleted: 0,
             },
             {
                 distinct_id: 'distinct1',
                 person_id: anotherPerson.uuid,
-                team_id: teamId.toString(),
-                version: '1',
+                team_id: teamId,
+                version: 1,
                 is_deleted: 0,
             },
         ])

--- a/plugin-server/tests/worker/ingestion/utils.test.ts
+++ b/plugin-server/tests/worker/ingestion/utils.test.ts
@@ -29,7 +29,7 @@ describe('captureIngestionWarning()', () => {
 
         expect(warnings).toEqual([
             expect.objectContaining({
-                team_id: '2',
+                team_id: 2,
                 source: 'plugin-server',
                 type: 'some_type',
                 details: '{"foo":"bar"}',


### PR DESCRIPTION
## Problem

There were some broken plugin-server tests on master. The ch client was returning ints not strings for a few values and some other differences

## Changes

Changed the strings to integers where the tests on master were failing

## How did you test this code?

They are changes to unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
