### PR TITLE
fix(ph-ai): don't throw error when tool is hallucinated

### DIFF
--- a/ee/hogai/registry.py
+++ b/ee/hogai/registry.py
@@ -31,5 +31,5 @@ def get_contextual_tool_class(tool_name: str) -> type["MaxTool"] | None:
 
     try:
         return CONTEXTUAL_TOOL_NAME_TO_TOOL[AssistantTool(tool_name)]
-    except KeyError:
+    except (KeyError, ValueError):
         return None

--- a/ee/hogai/test/test_registry.py
+++ b/ee/hogai/test/test_registry.py
@@ -8,3 +8,8 @@ class TestToolRegistry(BaseTest):
         from ee.hogai.registry import get_contextual_tool_class
 
         self.assertIsNotNone(get_contextual_tool_class(AssistantTool.GENERATE_HOGQL_QUERY))
+
+    def test_can_get_registered_contextual_tool_class_with_invalid_tool_name(self):
+        from ee.hogai.registry import get_contextual_tool_class
+
+        self.assertIsNone(get_contextual_tool_class("invalid_tool_name"))


### PR DESCRIPTION
## Problem
The current implementation of `get_contextual_tool_class` only catches `KeyError` exceptions when looking up a tool by name, but it doesn't handle `ValueError` exceptions that can occur when an invalid tool name is passed to the `AssistantTool` constructor.

## Changes
Updated the exception handling in `get_contextual_tool_class` to catch both `KeyError` and `ValueError` exceptions, ensuring the function properly returns `None` for any invalid tool name.

## How did you test this code?
Didn't, sue me