### PR TITLE
fix: Change all alog signal receivers to mutable ones  …

### DIFF
--- a/ee/clickhouse/views/experiment_holdouts.py
+++ b/ee/clickhouse/views/experiment_holdouts.py
@@ -14,7 +14,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.experiment import ExperimentHoldout
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 
 
 class ExperimentHoldoutSerializer(serializers.ModelSerializer):
@@ -125,7 +125,7 @@ class ExperimentHoldoutViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
 
-@receiver(model_activity_signal, sender=ExperimentHoldout)
+@mutable_receiver(model_activity_signal, sender=ExperimentHoldout)
 def handle_experiment_holdout_change(
     sender, scope, before_update, after_update, activity, user=None, was_impersonated=False, **kwargs
 ):

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -20,7 +20,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 
 
 class ExperimentToSavedMetricSerializer(serializers.ModelSerializer):
@@ -112,7 +112,7 @@ class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
     serializer_class = ExperimentSavedMetricSerializer
 
 
-@receiver(model_activity_signal, sender=ExperimentSavedMetric)
+@mutable_receiver(model_activity_signal, sender=ExperimentSavedMetric)
 def handle_experiment_saved_metric_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -6,7 +6,6 @@ from zoneinfo import ZoneInfo
 
 from django.db.models import Case, F, Prefetch, Q, QuerySet, Value, When
 from django.db.models.functions import Now
-from django.dispatch import receiver
 
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -35,7 +34,7 @@ from posthog.models.experiment import (
 )
 from posthog.models.feature_flag.feature_flag import FeatureFlag, FeatureFlagEvaluationTag
 from posthog.models.filters.filter import Filter
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
@@ -1099,7 +1098,7 @@ class EnterpriseExperimentsViewSet(
         )
 
 
-@receiver(model_activity_signal, sender=Experiment)
+@mutable_receiver(model_activity_signal, sender=Experiment)
 def handle_experiment_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 from django.db.models import Count
-from django.dispatch import receiver
 
 from rest_framework import request, serializers, viewsets
 from rest_framework.response import Response
@@ -17,7 +16,7 @@ from posthog.event_usage import report_user_action
 from posthog.models import Action
 from posthog.models.action.action import ACTION_STEP_MATCHING_OPTIONS
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
@@ -174,7 +173,7 @@ class ActionViewSet(
         return Response({"results": actions_list})
 
 
-@receiver(model_activity_signal, sender=Action)
+@mutable_receiver(model_activity_signal, sender=Action)
 def handle_action_change(sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs):
     # Detect soft delete/restore by checking the deleted field
     if before_update and after_update:

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -25,7 +25,7 @@ from posthog.models.alert import (
     Threshold,
     are_alerts_supported_for_insight,
 )
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.utils import relative_date_parse
 
 
@@ -346,7 +346,7 @@ class AlertSubscriptionContext(AlertConfigurationContext):
     subscriber_email: Optional[str] = None
 
 
-@receiver(model_activity_signal, sender=AlertConfiguration)
+@mutable_receiver(model_activity_signal, sender=AlertConfiguration)
 def handle_alert_configuration_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
@@ -370,7 +370,7 @@ def handle_alert_configuration_change(
     )
 
 
-@receiver(model_activity_signal, sender=Threshold)
+@mutable_receiver(model_activity_signal, sender=Threshold)
 def handle_threshold_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
@@ -400,7 +400,7 @@ def handle_threshold_change(
         )
 
 
-@receiver(model_activity_signal, sender=AlertSubscription)
+@mutable_receiver(model_activity_signal, sender=AlertSubscription)
 def handle_alert_subscription_change(before_update, after_update, activity, user, was_impersonated=False, **kwargs):
     alert_config = after_update.alert_configuration
 

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -14,7 +14,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
 from posthog.models import Annotation
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 
 
 @dataclasses.dataclass(frozen=True)
@@ -166,7 +166,7 @@ def annotation_created(sender, instance, created, raw, using, **kwargs):
         report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())
 
 
-@receiver(model_activity_signal, sender=Annotation)
+@mutable_receiver(model_activity_signal, sender=Annotation)
 def handle_annotation_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -23,7 +23,7 @@ from posthog.models.activity_logging.batch_import_utils import (
 )
 from posthog.models.activity_logging.model_activity import get_current_user, get_was_impersonated
 from posthog.models.batch_imports import BatchImport, ContentType, DateRangeExportSource
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.user import User
 
 
@@ -469,7 +469,7 @@ class BatchImportContext(ActivityContextBase):
     created_by_user_name: str | None
 
 
-@receiver(model_activity_signal, sender=BatchImport)
+@mutable_receiver(model_activity_signal, sender=BatchImport)
 def handle_batch_import_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -6,7 +6,6 @@ from typing import Any, Optional, cast
 from django.conf import settings
 from django.db.models import CharField, DateTimeField, F, FilteredRelation, Prefetch, Q, QuerySet, Value
 from django.db.models.functions import Cast
-from django.dispatch import receiver
 from django.http import StreamingHttpResponse
 from django.utils.timezone import now
 
@@ -41,7 +40,7 @@ from posthog.models.alert import AlertConfiguration
 from posthog.models.dashboard_templates import DashboardTemplate
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.insight_variable import InsightVariable
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.user import User
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
@@ -956,7 +955,7 @@ class LegacyInsightViewSet(InsightViewSet):
     param_derived_from_user_current_team = "project_id"
 
 
-@receiver(model_activity_signal, sender=Dashboard)
+@mutable_receiver(model_activity_signal, sender=Dashboard)
 def handle_dashboard_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -10,7 +10,6 @@ from typing import Any, Optional, cast
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Prefetch, Q, QuerySet, deletion
-from django.dispatch import receiver
 
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
@@ -66,7 +65,7 @@ from posthog.models.feature_flag.local_evaluation import (
 )
 from posthog.models.feature_flag.types import PropertyFilterType
 from posthog.models.property import Property
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.surveys.survey import Survey
 from posthog.permissions import ProjectSecretAPITokenPermission
 from posthog.queries.base import determine_parsed_date_for_property_matching
@@ -1755,7 +1754,7 @@ class FeatureFlagViewSet(
         return activity_page_response(activity_page, limit, page, request)
 
 
-@receiver(model_activity_signal, sender=FeatureFlag)
+@mutable_receiver(model_activity_signal, sender=FeatureFlag)
 def handle_feature_flag_change(sender, scope, before_update, after_update, activity, was_impersonated=False, **kwargs):
     # Extract scheduled change context if present
     scheduled_change_context = getattr(after_update, "_scheduled_change_context", {})

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -4,7 +4,6 @@ from functools import cached_property
 from typing import Any, Optional, Union, cast
 
 from django.db.models import Model, QuerySet
-from django.dispatch import receiver
 from django.shortcuts import get_object_or_404
 
 import posthoganalytics
@@ -28,7 +27,7 @@ from posthog.models.activity_logging.model_activity import ImpersonatedContext
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.organization import OrganizationMembership
 from posthog.models.organization_invite import OrganizationInvite
-from posthog.models.signals import model_activity_signal, mute_selected_signals
+from posthog.models.signals import model_activity_signal, mutable_receiver, mute_selected_signals
 from posthog.models.team.util import delete_bulky_postgres_data
 from posthog.models.uploaded_media import UploadedMedia
 from posthog.permissions import (
@@ -448,7 +447,7 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response({"success": True, "message": "Migration started"}, status=202)
 
 
-@receiver(model_activity_signal, sender=Organization)
+@mutable_receiver(model_activity_signal, sender=Organization)
 def handle_organization_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
@@ -488,7 +487,7 @@ class OrganizationInviteContext(ActivityContextBase):
     level: str
 
 
-@receiver(model_activity_signal, sender=OrganizationMembership)
+@mutable_receiver(model_activity_signal, sender=OrganizationMembership)
 def handle_organization_membership_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):
@@ -533,7 +532,7 @@ def handle_organization_membership_change(
     )
 
 
-@receiver(model_activity_signal, sender=OrganizationInvite)
+@mutable_receiver(model_activity_signal, sender=OrganizationInvite)
 def handle_organization_invite_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/posthog/api/personal_api_key.py
+++ b/posthog/api/personal_api_key.py
@@ -17,7 +17,7 @@ from posthog.models.activity_logging.personal_api_key_utils import (
     log_personal_api_key_scope_change,
 )
 from posthog.models.personal_api_key import hash_key_value
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal, mask_key_value
 from posthog.permissions import TimeSensitiveActionPermission
@@ -207,7 +207,7 @@ class PersonalAPIKeyViewSet(viewsets.ModelViewSet):
         return response.Response(serializer.data, status=status.HTTP_200_OK)
 
 
-@receiver(model_activity_signal, sender=PersonalAPIKey)
+@mutable_receiver(model_activity_signal, sender=PersonalAPIKey)
 def handle_personal_api_key_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -2,7 +2,6 @@ import dataclasses
 from typing import Optional
 
 from django.db.models import Prefetch, Q, QuerySet
-from django.dispatch import receiver
 
 from rest_framework import response, serializers, status, viewsets
 from rest_framework.viewsets import GenericViewSet
@@ -12,7 +11,7 @@ from posthog.constants import AvailableFeature
 from posthog.models import Tag, TaggedItem, User
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.activity_logging.tag_utils import get_tagged_item_related_object_info
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.tag import tagify
 
 
@@ -148,7 +147,7 @@ class TaggedItemContext(ActivityContextBase):
     related_object_name: Optional[str] = None
 
 
-@receiver(model_activity_signal, sender=Tag)
+@mutable_receiver(model_activity_signal, sender=Tag)
 def handle_tag_change(sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs):
     context = TagContext(
         team_id=after_update.team_id,
@@ -171,7 +170,7 @@ def handle_tag_change(sender, scope, before_update, after_update, activity, user
     )
 
 
-@receiver(model_activity_signal, sender=TaggedItem)
+@mutable_receiver(model_activity_signal, sender=TaggedItem)
 def handle_tagged_item_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Any, TypedDict, cast
 
 from django.db import transaction
-from django.dispatch import receiver
 from django.utils.timezone import now
 
 import structlog
@@ -47,7 +46,7 @@ from posthog.batch_exports.service import (
 from posthog.models import BatchExport, BatchExportBackfill, BatchExportDestination, BatchExportRun, Team, User
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.integration import DatabricksIntegration, DatabricksIntegrationError, Integration
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.temporal.common.client import sync_connect
 from posthog.utils import relative_date_parse, str_to_bool
 
@@ -1022,7 +1021,7 @@ class BatchExportContext(ActivityContextBase):
     created_by_user_name: str | None
 
 
-@receiver(model_activity_signal, sender=BatchExport)
+@mutable_receiver(model_activity_signal, sender=BatchExport)
 def handle_batch_export_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -2,8 +2,6 @@ import datetime as dt
 import dataclasses
 from typing import Any, Optional
 
-from django.dispatch import receiver
-
 import structlog
 import temporalio
 from rest_framework import filters, serializers, status, viewsets
@@ -17,7 +15,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.temporal.data_imports.sources import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 
@@ -373,7 +371,7 @@ class ExternalDataSchemaContext(ActivityContextBase):
     source_type: str
 
 
-@receiver(model_activity_signal, sender=ExternalDataSchema)
+@mutable_receiver(model_activity_signal, sender=ExternalDataSchema)
 def handle_external_data_schema_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -3,7 +3,6 @@ import dataclasses
 from typing import Any
 
 from django.db.models import Prefetch, Q
-from django.dispatch import receiver
 
 import structlog
 import temporalio
@@ -23,7 +22,7 @@ from posthog.models.activity_logging.external_data_utils import (
     get_external_data_source_created_by_info,
     get_external_data_source_detail_name,
 )
-from posthog.models.signals import model_activity_signal
+from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.user import User
 from posthog.temporal.data_imports.sources import SourceRegistry
 from posthog.temporal.data_imports.sources.common.config import Config
@@ -710,7 +709,7 @@ class ExternalDataSourceContext(ActivityContextBase):
     created_by_user_name: str | None
 
 
-@receiver(model_activity_signal, sender=ExternalDataSource)
+@mutable_receiver(model_activity_signal, sender=ExternalDataSource)
 def handle_external_data_source_change(
     sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
 ):


### PR DESCRIPTION
## Problem

- Some ops, such as mass-delete, require signal receivers to be muted via `with mute_selected_signals()`. So we need to change all `@receiver` decorators to `@mutable_receiver` for the alogs to avoid creating a bunch of alogs during org deletes.

## Changes

- Change all alog signal receivers to mutable ones to allow them to be muted during eg mass-delete ops.
