### PR TITLE
fix: show warning when event was buffering

### DIFF
--- a/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
@@ -124,11 +124,15 @@ const recordingDisabledReason = (
 
 const recordingWarningReason = (
     recordingDuration: number | undefined,
-    minimumDuration: number | undefined
+    minimumDuration: number | undefined,
+    recordingStatus: string | undefined
 ): string | undefined => {
     if (recordingDuration && minimumDuration && recordingDuration < minimumDuration) {
         const minimumDurationInSeconds = minimumDuration / 1000
         return `There is a chance this recording was not captured because the event happened earlier than the ${minimumDurationInSeconds}s minimum session duration.`
+    }
+    if (recordingStatus === 'buffering') {
+        return 'The recorder was buffering at this time. There may not be a recording to watch.'
     }
     return undefined
 }
@@ -162,7 +166,7 @@ export function useRecordingButton({
     }
 
     const disabledReason = recordingDisabledReason(sessionId, recordingStatus)
-    const warningReason = recordingWarningReason(recordingDuration, minimumDuration)
+    const warningReason = recordingWarningReason(recordingDuration, minimumDuration, recordingStatus)
     const to = inModal ? undefined : urls.replaySingle(sessionId ?? '')
 
     return { onClick, disabledReason, warningReason, to }


### PR DESCRIPTION
when putting a view recording button in the page we pass a status from the event that we're linking from

if the status is buffering we show the button as enabled

this makes sense since we don't know there will be no recording

but

it may be that session is buffering waiting for a trigger that it never sees, and so you click through and get not found

confusion!
despair!
bad UX!

the button already has the concept of a warning

so, let's add a warning that the recording was buffering and _might_ be watchable

![2025-11-13 11.02.50.gif](https://app.graphite.com/user-attachments/assets/e34d28cd-c028-43e6-a750-decc407bfec7.gif)

