### PR TITLE
fix: web analytics to heatmaps redirect

### DIFF
--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -442,6 +442,14 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 actions.setCommonFilters(searchParams.commonFilters as CommonFilters)
             }
         },
+        '/heatmaps/new': (_, searchParams) => {
+            if (searchParams.pageURL && searchParams.pageURL !== values.displayUrl) {
+                actions.setDisplayUrl(searchParams.pageURL)
+            }
+            if (searchParams.dataUrl && searchParams.dataUrl !== values.dataUrl) {
+                actions.setDataUrl(searchParams.dataUrl)
+            }
+        },
         '/heatmaps/recording': (_, searchParams) => {
             if (searchParams.iframeStorage) {
                 const replayFrameData = JSON.parse(

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -152,7 +152,8 @@ export const urls = {
     moveToPostHogCloud: (): string => '/move-to-cloud',
     heatmaps: (params?: string): string =>
         `/heatmaps${params ? `?${params.startsWith('?') ? params.slice(1) : params}` : ''}`,
-    heatmapNew: (): string => `/heatmaps/new`,
+    heatmapNew: (params?: string): string =>
+        `/heatmaps/new${params ? `?${params.startsWith('?') ? params.slice(1) : params}` : ''}`,
     heatmapRecording: (params?: string): string =>
         `/heatmaps/recording${params ? `?${params.startsWith('?') ? params.slice(1) : params}` : ''}`,
     heatmap: (id: string | number): string => `/heatmaps/${id}`,

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/HeatmapButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/HeatmapButton.tsx
@@ -62,7 +62,7 @@ export const HeatmapButton = ({ breakdownBy, value }: HeatmapButtonProps): JSX.E
 
     return (
         <LemonButton
-            to={urls.heatmaps(`pageURL=${url}`)}
+            to={urls.heatmapNew(`pageURL=${url}&dataURL=${url}`)}
             icon={<IconHeatmap />}
             type="tertiary"
             size="xsmall"


### PR DESCRIPTION
## Problem

Heatmaps button from WA was pointing to the previous version of heatmaps.


## Changes

Let's fix it and redirect to `/heatmaps/new` with params to preset the display and data urls

