### PR TITLE
fix(search): cmd+left

### DIFF
--- a/frontend/src/scenes/new-tab/components/SearchInput.tsx
+++ b/frontend/src/scenes/new-tab/components/SearchInput.tsx
@@ -144,10 +144,14 @@ export const SearchInput = forwardRef<SearchInputHandle, SearchInputProps>(funct
     }
 
     const handleKeyDown = (e: React.KeyboardEvent): void => {
-        if (e.metaKey && e.key === 'ArrowLeft' && inputValue === '') {
-            e.preventDefault()
-            e.stopPropagation()
-            window.history.back()
+        const currentInputValue = inputRef.current?.value ?? inputValue
+
+        if (e.metaKey && e.key === 'ArrowLeft') {
+            if (currentInputValue === '') {
+                e.preventDefault()
+                e.stopPropagation()
+                window.history.back()
+            }
             return
         }
 

--- a/frontend/src/scenes/new-tab/components/SearchInput.tsx
+++ b/frontend/src/scenes/new-tab/components/SearchInput.tsx
@@ -144,6 +144,13 @@ export const SearchInput = forwardRef<SearchInputHandle, SearchInputProps>(funct
     }
 
     const handleKeyDown = (e: React.KeyboardEvent): void => {
+        if (e.metaKey && e.key === 'ArrowLeft' && inputValue === '') {
+            e.preventDefault()
+            e.stopPropagation()
+            window.history.back()
+            return
+        }
+
         const isModKeyPressed = e.metaKey || e.ctrlKey
 
         // Allow browser navigation keys with modifier

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1598,7 +1598,7 @@ export const sceneLogic = kea<sceneLogicType>([
                         }
                         return
                     }
-                    router.actions.replace(urls.newTab())
+                    router.actions.push(urls.newTab())
 
                     return
                 }


### PR DESCRIPTION
## Problem

You could not go back from the searchfield on the new tab page:
- The history was overridden by CMD+K so there was nothing to go back to
- The CMD+LEFT key was hijacked so you couldn't go back

## Changes

Fixes that. CMD+K and CMD+Left now work.

## How did you test this code?

Clicked
