### PR TITLE
fix(llma): infinite loop customizable dashboard

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -935,7 +935,7 @@ class DashboardsViewSet(
                 creation_mode="unlisted",
             )
 
-            create_from_template(dashboard, template, cast(User, request.user))
+            create_from_template(dashboard, template, cast(User, request.user), force_system_tags=True)
 
             return Response(
                 DashboardSerializer(dashboard, context=self.get_serializer_context()).data,

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -466,12 +466,14 @@ DASHBOARD_TEMPLATES: dict[str, Callable] = {
 # end of area to be removed
 
 
-def create_from_template(dashboard: Dashboard, template: DashboardTemplate, user=None) -> None:
+def create_from_template(
+    dashboard: Dashboard, template: DashboardTemplate, user=None, force_system_tags: bool = False
+) -> None:
     if not dashboard.name or dashboard.name == "":
         dashboard.name = template.template_name
     dashboard.filters = template.dashboard_filters
     dashboard.description = template.dashboard_description
-    if dashboard.team.organization.is_feature_available(AvailableFeature.TAGGING):
+    if force_system_tags or dashboard.team.organization.is_feature_available(AvailableFeature.TAGGING):
         for template_tag in template.tags or []:
             tag, _ = Tag.objects.get_or_create(
                 name=template_tag,


### PR DESCRIPTION
#40965 introduced a bug that happens when users don't have tags available to them (`AvailableFeature.TAGGING`). I was unaware this was a scale plan exclusive feature when implementing that PR.

The cause of the issue is that we don't raise a validation error when users try to create a dashboard with tags but the feature is not available to them. Instead we silently swallow it, and create the dashboard without the tags. This seems to [be on purpose](https://github.com/PostHog/posthog/blob/5ec665c1bd463d6dc01fab9f985171d32acdcc38/posthog/api/tagged_item.py#L35), so I didn't change it in this PR to not break any existing code.

This created an infinite loop for this users where they would create the dashboard, try to query it after, wouldn't find it since it didn't have the tags, request creation again, and creation would go through because it also checks for duplication using tags.

This PR is a temporary fix, but highlights what we discussed in the previous PR that this is a brittle setup, and we should probably implement this unlisted dashboards as a proper Django model.

I have temporarily rolled back the feature flag for this while we sort it out, and soft deleted the affected dashboards created on a loop. Will do a full clean up next week after fixing and validating there were no issues.