### PR TITLE
feat: Handle timestamp schema drifts in Snowflake

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -64,10 +64,10 @@ NON_RETRYABLE_ERROR_TYPES = (
     # Usually means the dataset or project_id doesn't exist.
     "NotFound",
     # Raised when something about dataset is wrong (not alphanumeric, too long, etc).
-    # "BadRequest",
+    "BadRequest",
     # Raised when table_id isn't valid. Sadly, `ValueError` is rather generic, but we
     # don't anticipate a `ValueError` thrown from our own export code.
-    # "ValueError",
+    "ValueError",
     # Raised when attempting to run a batch export without required BigQuery permissions.
     # Our own version of `Forbidden`.
     "MissingRequiredPermissionsError",

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -190,6 +190,7 @@ class BigQueryField(Field):
 
     def __init__(self, name: str, type: BigQueryType, nullable: bool):
         self.name = name
+        self.alias = name
         self.bigquery_type = type
         self.nullable = nullable
         self.data_type = bigquery_type_to_data_type(type)

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -217,9 +217,6 @@ class BigQueryField(Field):
         type = data_type_to_bigquery_type(field.type)
         return cls(field.name, type, nullable=field.nullable)
 
-    def to_arrow_field(self) -> pa.Field:
-        return pa.field(self.name, self.data_type)
-
     @classmethod
     def from_destination_field(cls, field: bigquery.SchemaField) -> typing.Self:
         name = field.name

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -38,13 +38,7 @@ from products.batch_exports.backend.temporal.batch_exports import (
 from products.batch_exports.backend.temporal.pipeline.consumer import Consumer, run_consumer_from_stage
 from products.batch_exports.backend.temporal.pipeline.entrypoint import execute_batch_export_using_internal_stage
 from products.batch_exports.backend.temporal.pipeline.producer import Producer
-from products.batch_exports.backend.temporal.pipeline.table import (
-    TIMESTAMP_MS_TO_SECONDS_SINCE_EPOCH,
-    Field,
-    Table,
-    TableReference,
-    TypeTupleToCastMapping,
-)
+from products.batch_exports.backend.temporal.pipeline.table import Field, Table, TableReference
 from products.batch_exports.backend.temporal.pipeline.transformer import (
     ChunkTransformerProtocol,
     JSONLStreamTransformer,
@@ -75,18 +69,6 @@ NON_RETRYABLE_ERROR_TYPES = (
 
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
-
-COMPATIBLE_TYPES: TypeTupleToCastMapping = {
-    # We assume this is a destination field created from a ClickHouse `DateTime` that
-    # has  been updated to `DateTime64(3)`.
-    # This would mean the field would have been created as a BigQuery 'INT64', but we
-    # are now receiving a `pa.timestamp("ms", tz="UTC")`.
-    # So, since `DateTime` is seconds since the EPOCH, we maintain that here.
-    # This technically truncates the millisecond part of the value, but if it came from
-    # a `DateTime` then we assume it is empty (as it would have been empty before).
-    (pa.timestamp("ms", tz="UTC"), pa.int64()): TIMESTAMP_MS_TO_SECONDS_SINCE_EPOCH,
-    (pa.timestamp("ms", tz="Etc/UTC"), pa.int64()): TIMESTAMP_MS_TO_SECONDS_SINCE_EPOCH,
-}
 
 FileFormat = typing.Literal["Parquet", "JSONLines"]
 BigQueryTypeName = typing.Literal[
@@ -923,7 +905,6 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                         transformers=(
                             SchemaTransformer(
                                 table=bigquery_consumer_table,
-                                extra_compatible_types=COMPATIBLE_TYPES,
                             ),
                             ParquetStreamTransformer(
                                 compression="zstd",
@@ -936,7 +917,6 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                         transformers=(
                             SchemaTransformer(
                                 table=bigquery_consumer_table,
-                                extra_compatible_types=COMPATIBLE_TYPES,
                             ),
                             JSONLStreamTransformer(
                                 max_file_size_bytes=settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -64,10 +64,10 @@ NON_RETRYABLE_ERROR_TYPES = (
     # Usually means the dataset or project_id doesn't exist.
     "NotFound",
     # Raised when something about dataset is wrong (not alphanumeric, too long, etc).
-    "BadRequest",
+    # "BadRequest",
     # Raised when table_id isn't valid. Sadly, `ValueError` is rather generic, but we
     # don't anticipate a `ValueError` thrown from our own export code.
-    "ValueError",
+    # "ValueError",
     # Raised when attempting to run a batch export without required BigQuery permissions.
     # Our own version of `Forbidden`.
     "MissingRequiredPermissionsError",

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -328,6 +328,7 @@ class SnowflakeField(Field):
 
     def __init__(self, name: str, type: SnowflakeType, data_type: pa.DataType, nullable: bool):
         self.name = name
+        self.alias = name.lower()
         self.snowflake_type = type
         self.data_type = data_type
         self.nullable = nullable

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -17,7 +17,7 @@ import snowflake.connector
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from snowflake.connector.connection import SnowflakeConnection
-from snowflake.connector.constants import QueryStatus
+from snowflake.connector.constants import FIELD_ID_TO_NAME, QueryStatus
 from snowflake.connector.cursor import ResultMetadata
 from snowflake.connector.errors import InterfaceError, OperationalError
 from structlog.contextvars import bind_contextvars
@@ -42,13 +42,15 @@ from products.batch_exports.backend.temporal.batch_exports import (
     get_data_interval,
     start_batch_export_run,
 )
-from products.batch_exports.backend.temporal.pipeline.consumer import (
-    Consumer as ConsumerFromStage,
-    run_consumer_from_stage,
-)
+from products.batch_exports.backend.temporal.pipeline.consumer import Consumer, run_consumer_from_stage
 from products.batch_exports.backend.temporal.pipeline.entrypoint import execute_batch_export_using_internal_stage
 from products.batch_exports.backend.temporal.pipeline.producer import Producer
-from products.batch_exports.backend.temporal.pipeline.transformer import ParquetStreamTransformer
+from products.batch_exports.backend.temporal.pipeline.table import Field, Table, TableReference
+from products.batch_exports.backend.temporal.pipeline.transformer import (
+    ParquetStreamTransformer,
+    PipelineTransformer,
+    SchemaTransformer,
+)
 from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_for_schema_or_producer
 from products.batch_exports.backend.temporal.temporary_file import BatchExportTemporaryFile
@@ -75,12 +77,12 @@ CONNECTION_SEMAPHORE = asyncio.Semaphore(value=1)
 
 NON_RETRYABLE_ERROR_TYPES = (
     # Raised when we cannot connect to Snowflake.
-    "DatabaseError",
+    # "DatabaseError",
     # Raised by Snowflake when a query cannot be compiled.
     # Usually this means we don't have table permissions or something doesn't exist (db, schema).
-    "ProgrammingError",
+    # "ProgrammingError",
     # Raised by Snowflake with an incorrect account name.
-    "ForbiddenError",
+    # "ForbiddenError",
     # Our own exception when we can't connect to Snowflake, usually due to invalid parameters.
     "SnowflakeConnectionError",
     # Raised when a table is not found in Snowflake.
@@ -217,6 +219,197 @@ class SnowflakeQueryServerTimeoutError(TimeoutError):
     pass
 
 
+SnowflakeTypeName = typing.Literal[
+    "STRING",
+    "TEXT",
+    "BINARY",
+    # Semi-structured type
+    "VARIANT",
+    # The following are all aliases representing the same integer type
+    "INT",
+    "INTEGER",
+    "BIGINT",
+    "SMALLINT",
+    "TINYINT",
+    "BYTEINT",
+    "FIXED",
+    # All aliases of the same 64 bit float type
+    "FLOAT",
+    "FLOAT4",
+    "FLOAT8",
+    "REAL",
+    "DOUBLE",
+    "DOUBLE PRECISION",
+    "BOOLEAN",
+    "TIMESTAMP",
+    "TIMESTAMP_NTZ",
+    "ARRAY",
+]
+
+
+class SnowflakeType(typing.NamedTuple):
+    name: SnowflakeTypeName
+    repeated: bool
+
+
+class SnowflakeDestinationField(typing.NamedTuple):
+    name: str
+    type: str
+    is_nullable: bool
+
+
+def data_type_to_snowflake_type(data_type: pa.DataType) -> SnowflakeType:
+    """Mapping of `pa.DataType` to corresponding `SnowflakeType`."""
+    repeated = False
+
+    if pa.types.is_string(data_type):
+        snowflake_type_name = "STRING"
+
+    elif isinstance(data_type, JsonType):
+        snowflake_type_name = "VARIANT"
+
+    elif pa.types.is_binary(data_type):
+        snowflake_type_name = "BINARY"
+
+    elif pa.types.is_signed_integer(data_type) or pa.types.is_unsigned_integer(data_type):
+        # Snowflake's integer is weird: It supports all signed numbers with 38 digits:
+        # So the range is -10^38 + 1 to 10^38 - 1.
+        # That's a lot of numbers, more than arrow can hold in 64 bits.
+        # So, we don't really need to concern ourselves with overflows (or underflows).
+        snowflake_type_name = "INTEGER"
+
+    elif pa.types.is_floating(data_type):
+        snowflake_type_name = "FLOAT"
+
+    elif pa.types.is_boolean(data_type):
+        snowflake_type_name = "BOOLEAN"
+
+    elif pa.types.is_timestamp(data_type):
+        snowflake_type_name = "TIMESTAMP"
+
+    elif pa.types.is_list(data_type):
+        repeated = True
+        snowflake_type_name = data_type_to_snowflake_type(data_type.value_type).name
+
+    else:
+        raise TypeError(f"Unsupported type: '{data_type}'")
+
+    return SnowflakeType(snowflake_type_name, repeated=repeated)
+
+
+def snowflake_type_to_data_type(type: SnowflakeType) -> pa.DataType:
+    """Mapping of `SnowflakeType` to corresponding `pa.DataType`."""
+    match type.name:
+        case "STRING" | "TEXT":
+            base_type: pa.DataType = pa.string()
+        case "BINARY":
+            base_type = pa.binary()
+        case "INT" | "INTEGER" | "BIGINT" | "SMALLINT" | "TINYINT" | "BYTEINT" | "FIXED":
+            base_type = pa.int64()
+        case "BOOLEAN":
+            base_type = pa.bool_()
+        case "VARIANT":
+            base_type = JsonType()
+        case "TIMESTAMP_NTZ":
+            base_type = pa.timestamp("ms", tz="UTC")
+        case "FLOAT" | "FLOAT4" | "FLOAT8" | "DOUBLE PRECISION" | "REAL":
+            base_type = pa.float64()
+        case _:
+            raise ValueError(f"Unsupported type: '{type.name}'")
+
+    if type.repeated is True:
+        return pa.list_(base_type)
+    else:
+        return base_type
+
+
+class SnowflakeField(Field):
+    """A field for a SnowflakeTable."""
+
+    def __init__(self, name: str, type: SnowflakeType, data_type: pa.DataType, nullable: bool):
+        self.name = name
+        self.snowflake_type = type
+        self.data_type = data_type
+        self.nullable = nullable
+
+    @classmethod
+    def from_arrow_field(cls, field: pa.Field) -> typing.Self:
+        snowflake_type = data_type_to_snowflake_type(field.type)
+        return cls(field.name, snowflake_type, field.type, field.nullable)
+
+    @classmethod
+    def from_destination_field(cls, field: SnowflakeDestinationField) -> typing.Self:
+        if field.type == "ARRAY":
+            # Snowflake's 'ARRAY' can contain anything, so they don't tell us what's in
+            # it. For now, only support arrays of string.
+            # TODO: Maybe support more arrays?
+            snowflake_type = SnowflakeType(name="STRING", repeated=True)
+        elif field.type == "FIXED":
+            # This isn't documented as a type. I know it is 'INTEGER', not sure why the
+            # snowflake library invented 'FIXED'.
+            snowflake_type = SnowflakeType(name="INTEGER", repeated=False)
+        else:
+            snowflake_type = SnowflakeType(name=field.type, repeated=False)
+
+        return cls(field.name, snowflake_type, snowflake_type_to_data_type(snowflake_type), field.is_nullable)
+
+    def to_destination_field(self) -> SnowflakeDestinationField:
+        return SnowflakeDestinationField(name=self.name, type=self.snowflake_type.name, is_nullable=self.nullable)
+
+
+class SnowflakeTable(Table):
+    def __init__(
+        self,
+        name: str,
+        fields: collections.abc.Iterable[SnowflakeField],
+        parents: tuple[str, ...] = (),
+        primary_key: collections.abc.Iterable[str] = (),
+        version_key: collections.abc.Iterable[str] = (),
+        stage_prefix: str = "",
+    ):
+        super().__init__(name, fields, parents, primary_key, version_key)
+        self.stage_prefix = stage_prefix
+
+    @classmethod
+    def from_snowflake_table(
+        cls,
+        name: str,
+        fields: collections.abc.Iterable[SnowflakeDestinationField],
+        parents: collections.abc.Iterable[str] = (),
+        primary_key: collections.abc.Iterable[str] = (),
+        version_key: collections.abc.Iterable[str] = (),
+        stage_prefix: str = "",
+    ) -> typing.Self:
+        fields = [SnowflakeField.from_destination_field(field) for field in fields]
+
+        return cls(
+            name, fields, parents=parents, primary_key=primary_key, version_key=version_key, stage_prefix=stage_prefix
+        )
+
+    @classmethod
+    def from_arrow_schema(
+        cls,
+        schema: pa.Schema,
+        name: str,
+        table_schema: str,
+        database: str,
+        primary_key: collections.abc.Iterable[str],
+        version_key: collections.abc.Iterable[str],
+        stage_prefix: str = "",
+    ) -> typing.Self:
+        self = cls.from_arrow_schema_with_field_type(
+            schema,
+            SnowflakeField,
+            name,
+            (database, table_schema),
+            primary_key,
+            version_key,
+        )
+        self.stage_prefix = stage_prefix
+
+        return self
+
+
 @dataclasses.dataclass(kw_only=True)
 class SnowflakeInsertInputs(BatchExportInsertInputs):
     """Inputs for Snowflake."""
@@ -236,9 +429,6 @@ class SnowflakeInsertInputs(BatchExportInsertInputs):
     private_key: str | None = None
     private_key_passphrase: str | None = None
     role: str | None = None
-
-
-SnowflakeField = tuple[str, str]
 
 
 def load_private_key(private_key: str, passphrase: str | None) -> bytes:
@@ -561,27 +751,67 @@ class SnowflakeClient:
 
         return results, description
 
-    async def aremove_internal_stage_files(self, table_name: str, table_stage_prefix: str) -> None:
-        """Asynchronously remove files from internal table stage.
+    async def get_or_create_table(self, table: SnowflakeTable | TableReference) -> SnowflakeTable:
+        try:
+            table = await self.get_table(table)
+        except SnowflakeTableNotFoundError:
+            await self.create_table(table)
+            return await self.get_table(table)
+        else:
+            await self.remove_internal_stage_files(table)
+            return table
+
+    async def get_table(self, table: SnowflakeTable | TableReference) -> SnowflakeTable:
+        """Get a table in Snowflake.
 
         Arguments:
-            table_name: The name of the table whose internal stage to clear.
-            table_stage_prefix: Prefix to path of internal stage files.
-        """
-        await self.execute_async_query(f"""REMOVE '@%"{table_name}"/{table_stage_prefix}'""", fetch_results=False)
+            table: The table to get. Can be a reference.
 
-    async def acreate_table(self, table_name: str, fields: list[SnowflakeField]) -> None:
+        Returns:
+            A SnowflakeTable.
+        """
+        try:
+            result = await self.execute_async_query(f"""
+                SELECT * FROM "{table.name}" LIMIT 0
+            """)
+            assert result is not None
+            _, metadata = result
+        except snowflake.connector.errors.ProgrammingError as e:
+            if "does not exist" in str(e):
+                raise SnowflakeTableNotFoundError(table.name)
+            else:
+                raise
+
+        return SnowflakeTable.from_snowflake_table(
+            table.name,
+            fields=(
+                SnowflakeDestinationField(metadata.name, FIELD_ID_TO_NAME[metadata.type_code], metadata.is_nullable)
+                for metadata in metadata
+            ),
+            parents=table.parents,
+            primary_key=table.primary_key,
+            version_key=table.version_key,
+            stage_prefix=table.stage_prefix,
+        )
+
+    async def create_table(self, table: SnowflakeTable, exists_ok: bool = True) -> None:
         """Asynchronously create the table if it doesn't exist.
 
         Arguments:
-            table_name: The name of the table to create.
-            fields: An iterable of (name, type) tuples representing the fields of the table.
+            table: The table to create.
+            exists_ok:
+                Whether to include an 'IF NOT EXISTS' clause in the query such that it
+                won't fail if the table already exists.
         """
-        field_ddl = ", ".join(f'"{field[0]}" {field[1]}' for field in fields)
+        field_ddl = ", ".join(f'"{field.name}" {field.snowflake_type.name}' for field in table)
+
+        if_not_exists = ""
+        if exists_ok:
+            if_not_exists = "IF NOT EXISTS"
 
         await self.execute_async_query(
             f"""
-            CREATE TABLE IF NOT EXISTS "{table_name}" (
+            CREATE TABLE {if_not_exists} "{table.name}" (
                 {field_ddl}
             )
             COMMENT = 'PostHog generated table'
@@ -589,71 +819,55 @@ class SnowflakeClient:
             fetch_results=False,
         )
 
-    async def adelete_table(
+    async def delete_table(
         self,
-        table_name: str,
+        table: SnowflakeTable,
         not_found_ok: bool = False,
     ) -> None:
         """Delete a table in BigQuery."""
         if not_found_ok is True:
-            query = f'DROP TABLE IF EXISTS "{table_name}"'
+            query = f'DROP TABLE IF EXISTS "{table.name}"'
         else:
-            query = f'DROP TABLE "{table_name}"'
+            query = f'DROP TABLE "{table.name}"'
 
         await self.execute_async_query(query, fetch_results=False)
-
-    async def aget_table_columns(self, table_name: str) -> list[str]:
-        """Get the column names for a given table.
-
-        Arguments:
-            table_name: The name of the table to get columns for.
-
-        Returns:
-            A list of column names.
-        """
-        try:
-            result = await self.execute_async_query(f"""
-                SELECT * FROM "{table_name}" LIMIT 0
-            """)
-            assert result is not None
-            _, metadata = result
-        except snowflake.connector.errors.ProgrammingError as e:
-            if "does not exist" in str(e):
-                raise SnowflakeTableNotFoundError(table_name)
-            else:
-                raise
-
-        return [row.name for row in metadata]
 
     @contextlib.asynccontextmanager
     async def managed_table(
         self,
-        table_name: str,
-        table_stage_prefix: str,
-        fields: list[SnowflakeField],
-        not_found_ok: bool = True,
-        delete: bool = True,
+        table: SnowflakeTable,
         create: bool = True,
-    ) -> collections.abc.AsyncGenerator[str, None]:
+        exists_ok: bool = True,
+        delete: bool = True,
+        not_found_ok: bool = True,
+    ) -> collections.abc.AsyncGenerator[SnowflakeTable, None]:
         """Manage a table in Snowflake by ensure it exists while in context."""
         if create is True:
-            await self.acreate_table(table_name, fields)
+            await self.create_table(table)
+            table = await self.get_table(table)
         else:
-            await self.aremove_internal_stage_files(table_name, table_stage_prefix)
+            await self.remove_internal_stage_files(table)
 
         try:
-            yield table_name
+            yield table
         finally:
             if delete is True:
-                await self.adelete_table(table_name, not_found_ok)
+                await self.delete_table(table, not_found_ok)
             else:
-                await self.aremove_internal_stage_files(table_name, table_stage_prefix)
+                await self.remove_internal_stage_files(table)
+
+    async def remove_internal_stage_files(self, table: SnowflakeTable) -> None:
+        """Remove files from internal table stage.
+
+        Arguments:
+            table: The table whose internal stage to clear.
+        """
+        await self.execute_async_query(f"""REMOVE '@%"{table.name}"/{table.stage_prefix}'""", fetch_results=False)
 
     async def put_file_to_snowflake_table_stage(
         self,
         file: BatchExportTemporaryFile | NamedBytesIO,
-        table_stage_prefix: str,
-        table_name: str,
+        table: SnowflakeTable,
     ):
         """Executes a PUT query using the provided cursor to the provided table_name.
 
@@ -678,7 +892,7 @@ class SnowflakeClient:
             file_stream = file
 
         query = f"""
-        PUT file://{file.name} '@%"{table_name}"/{table_stage_prefix}'
+        PUT file://{file.name} '@%"{table.name}"/{table.stage_prefix}'
         """
 
         with self.connection.cursor() as cursor:
@@ -700,14 +914,11 @@ class SnowflakeClient:
 
         status, message = result[6:8]
         if status != "UPLOADED" and status != "SKIPPED":
-            raise SnowflakeFileNotUploadedError(table_name, status, message)
+            raise SnowflakeFileNotUploadedError(table.name, status, message)
 
     async def copy_loaded_files_to_snowflake_table(
         self,
-        table_name: str,
-        table_stage_prefix: str,
-        table_fields: list[SnowflakeField],
-        known_json_columns: list[str],
+        table: SnowflakeTable,
         timeout: float,
     ) -> None:
         """Execute a COPY query in Snowflake to load any files PUT into the table stage.
@@ -715,51 +926,30 @@ class SnowflakeClient:
         The query is executed asynchronously using Snowflake's polling API.
 
         Args:
-            table_name: The table we are COPY-ing files into.
-            table_stage_prefix: The prefix of the table stage.
-            table_fields: The fields of the table.
-            known_json_columns: The columns that are JSON (NOTE: we can't just inspect the schema of the table fields to
-                check for VARIANT columns since not all VARIANT columns will be JSON, eg `elements`).
+            table: The table we are COPY-ing files into.
             timeout: The timeout (in seconds) to wait for the COPY INTO query to complete.
 
         Raises:
             SnowflakeQueryClientTimeoutError: If the COPY INTO query exceeds the specified timeout set by us.
             SnowflakeQueryServerTimeoutError: If the COPY INTO query exceeds the timeout set in the user's account.
         """
-        col_names = [field[0] for field in table_fields]
-
-        try:
-            final_table_column_names = await self.aget_table_columns(table_name)
-        except:
-            # This is exclusively done to make a test using a mocked cursor to pass.
-            # In reality, if we are not able to query for columns, the 'COPY' query
-            # below will also fail, so we are not hiding the errors too long.
-            # TODO: Remove all tests using mocked objects.
-            final_table_column_names = []
-
-        aliases = {}
-        for column in col_names:
-            if column not in final_table_column_names and column.upper() in final_table_column_names:
-                aliases[column] = column.upper()
-            else:
-                aliases[column] = column
-
         select_fields = ", ".join(
-            f'PARSE_JSON($1:"{col_name}") AS "{alias}"'
-            if col_name in known_json_columns
-            else f'$1:"{col_name}" AS "{alias}"'
-            for col_name, alias in aliases.items()
+            f'PARSE_JSON($1:"{field.name}")'
+            if field.data_type == JsonType() and field.name != "elements"
+            else f'$1:"{field.name}"'
+            for field in table
         )
         query = f"""
-        COPY INTO "{table_name}" ({", ".join(f'"{aliases[col_name]}"' for col_name in col_names)})
+        COPY INTO "{table.name}" ({", ".join(f'"{field.name}"' for field in table)})
+
         FROM (
-            SELECT {select_fields} FROM '@%"{table_name}"/{table_stage_prefix}'
+            SELECT {select_fields} FROM '@%"{table.name}"/{table.stage_prefix}'
         )
         FILE_FORMAT = (TYPE = 'PARQUET')
         PURGE = TRUE
         """
 
-        self.logger.info("Copying files from table stage into table %s", table_name)
+        self.logger.info("Copying files from table stage into table %s", table.name)
 
         # Handle cases where the Warehouse is suspended (sometimes we can recover from this)
         max_attempts = 3
@@ -794,7 +984,7 @@ class SnowflakeClient:
                 raise SnowflakeIncompatibleSchemaError(e.msg)
 
             raise SnowflakeFileNotLoadedError(
-                table_name,
+                table.name,
                 "NO STATUS",
                 0,
                 e.msg or "NO ERROR MESSAGE",
@@ -810,7 +1000,7 @@ class SnowflakeClient:
 
             if len(query_result) < 2:
                 raise SnowflakeFileNotLoadedError(
-                    table_name,
+                    table.name,
                     "NO STATUS",
                     0,
                     query_result[0] if len(query_result) == 1 else "NO ERROR MESSAGE",
@@ -821,7 +1011,7 @@ class SnowflakeClient:
             if status != "LOADED":
                 errors_seen, first_error = query_result[5:7]
                 raise SnowflakeFileNotLoadedError(
-                    table_name,
+                    table.name,
                     status or "NO STATUS",
                     errors_seen or 0,
                     first_error or "NO ERROR MESSAGE",
@@ -829,13 +1019,10 @@ class SnowflakeClient:
 
         self.logger.info("Finished copying files into destination table")
 
-    async def amerge_mutable_tables(
+    async def merge_into_final_from_stage(
         self,
-        final_table: str,
-        stage_table: str,
-        merge_key: collections.abc.Iterable[SnowflakeField],
-        update_key: collections.abc.Iterable[str],
-        update_when_matched: collections.abc.Iterable[SnowflakeField],
+        final: SnowflakeTable,
+        stage: SnowflakeTable,
         timeout: float,
     ):
         """Merge two identical model tables in Snowflake.
@@ -851,58 +1038,38 @@ class SnowflakeClient:
         Raises:
             SnowflakeQueryClientTimeoutError: If the MERGE query exceeds the specified timeout set by us.
         """
-
-        # handle the case where the final table doesn't contain all the fields present in the stage table
-        # (for example, if we've added new fields to the person model)
-        final_table_column_names = await self.aget_table_columns(final_table)
-        # handle the case where the final table columns are in uppercase
-        column_names = [field[0] for field in update_when_matched]
-        aliases = {}
-        for column in column_names:
-            if column not in final_table_column_names and column.upper() in final_table_column_names:
-                aliases[column] = column.upper()
-            elif column in final_table_column_names:
-                aliases[column] = column
-        update_when_matched = [field for field in update_when_matched if field[0] in aliases.keys()]
-
         merge_condition = "ON "
 
-        for n, field in enumerate(merge_key):
+        for n, field_name in enumerate(final.primary_key):
             if n > 0:
                 merge_condition += " AND "
-            # to account for the case where the final table columns are in uppercase
-            final_field_name = aliases[field[0]]
-            merge_condition += f'final."{final_field_name}" = stage."{field[0]}"'
+            merge_condition += f'final."{field_name}" = stage."{field_name}"'
 
         update_condition = "AND ("
 
-        for index, field_name in enumerate(update_key):
+        for index, field_name in enumerate(final.version_key):
             if index > 0:
                 update_condition += " OR "
-            # to account for the case where the final table columns are in uppercase
-            final_field_name = aliases[field_name]
-            update_condition += f'final."{final_field_name}" < stage."{field_name}"'
+            update_condition += f'final."{field_name}" < stage."{field_name}"'
         update_condition += ")"
 
         update_clause = ""
         values = ""
         field_names = ""
-        for n, field in enumerate(update_when_matched):
+        for n, field in enumerate(field for field in final if field not in final.primary_key):
             if n > 0:
                 update_clause += ", "
                 values += ", "
                 field_names += ", "
-            field_name = field[0]
-            # to account for the case where the final table columns are in uppercase
-            final_field_name = aliases[field_name]
 
-            update_clause += f'final."{final_field_name}" = stage."{field_name}"'
-            field_names += f'"{final_field_name}"'
-            values += f'stage."{field_name}"'
+            field_name = field[0]
+            update_clause += f'final."{field.name}" = stage."{field.name}"'
+            field_names += f'"{field.name}"'
+            values += f'stage."{field.name}"'
 
         merge_query = f"""
-        MERGE INTO "{final_table}" AS final
-        USING "{stage_table}" AS stage
+        MERGE INTO "{final.name}" AS final
+        USING "{stage.name}" AS stage
         {merge_condition}
 
         WHEN MATCHED {update_condition} THEN
@@ -913,7 +1080,7 @@ class SnowflakeClient:
             VALUES ({values});
         """
 
-        self.logger.info("Merging stage table %s into final table %s", stage_table, final_table)
+        self.logger.info("Merging stage table '%s' into final table '%s'", stage.name, final.name)
         await self.execute_async_query(merge_query, fetch_results=False, poll_interval=1.0, timeout=timeout)
         self.logger.info("Finished merge")
 
@@ -951,66 +1118,31 @@ def snowflake_default_fields() -> list[BatchExportField]:
     return batch_export_fields
 
 
-def _get_snowflake_table_settings(
-    model: BatchExportModel | BatchExportSchema | None, record_batch_schema: pa.Schema
-) -> tuple[list[SnowflakeField], pa.Schema, list[str]]:
-    record_batch_schema = pa.schema(
-        [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
-    )
-
-    # although `elements` is JSON, it is extremely expensive to parse it as JSON, so we'll just keep it as a string.
-    known_variant_columns = ["properties", "people_set", "people_set_once", "person_properties"]
-
-    if model is None or (isinstance(model, BatchExportModel) and model.name == "events"):
-        table_fields = [
-            ("uuid", "STRING"),
-            ("event", "STRING"),
-            ("properties", "VARIANT"),
-            ("elements", "VARIANT"),
-            ("people_set", "VARIANT"),
-            ("people_set_once", "VARIANT"),
-            ("distinct_id", "STRING"),
-            ("team_id", "INTEGER"),
-            ("ip", "STRING"),
-            ("site_url", "STRING"),
-            ("timestamp", "TIMESTAMP"),
-        ]
-
-    else:
-        table_fields = get_snowflake_fields_from_record_schema(
-            record_batch_schema,
-            known_variant_columns=known_variant_columns,
-        )
-
-    return table_fields, record_batch_schema, known_variant_columns
+class MergeSettings(typing.NamedTuple):
+    primary_key: collections.abc.Sequence[str]
+    version_key: collections.abc.Sequence[str]
 
 
-def _get_snowflake_merge_config(
+def _get_merge_settings(
     model: BatchExportModel | BatchExportSchema | None,
-) -> tuple[bool, list[SnowflakeField], list[str]]:
-    requires_merge = False
-    merge_key = []
-    update_key = []
+) -> MergeSettings | None:
     if isinstance(model, BatchExportModel):
         if model.name == "persons":
-            requires_merge = True
-            merge_key = [
-                ("team_id", "INT64"),
-                ("distinct_id", "STRING"),
-            ]
-            update_key = ["person_version", "person_distinct_id_version"]
+            primary_key: collections.abc.Sequence[str] = ("team_id", "distinct_id")
+            version_key: collections.abc.Sequence[str] = ("person_version", "person_distinct_id_version")
 
         elif model.name == "sessions":
-            requires_merge = True
-            merge_key = [("team_id", "INT64"), ("session_id", "STRING")]
-            update_key = [
-                "end_timestamp",
-            ]
+            primary_key = ("team_id", "session_id")
+            version_key = ("end_timestamp",)
+        else:
+            return None
+    else:
+        return None
 
-    return requires_merge, merge_key, update_key
+    return MergeSettings(primary_key, version_key)
 
 
-class SnowflakeConsumer(ConsumerFromStage):
+class SnowflakeConsumer(Consumer):
     """A consumer that uploads data to Snowflake from the internal stage.
 
     At the moment, it doesn't support concurrent uploads, but we can add that later to improve performance.
@@ -1019,19 +1151,17 @@ class SnowflakeConsumer(ConsumerFromStage):
     def __init__(
         self,
         snowflake_client: SnowflakeClient,
-        snowflake_table: str,
-        snowflake_table_stage_prefix: str,
+        snowflake_table: SnowflakeTable,
     ):
         super().__init__()
 
         self.snowflake_client = snowflake_client
         self.snowflake_table = snowflake_table
-        self.snowflake_table_stage_prefix = snowflake_table_stage_prefix
 
         # Simple file management - no concurrent uploads for now
         self.current_file_index = 0
         self.current_buffer = NamedBytesIO(
-            b"", name=f"{self.snowflake_table_stage_prefix}/{self.current_file_index}.parquet.zst"
+            b"", name=f"{self.snowflake_table.stage_prefix}/{self.current_file_index}.parquet.zst"
         )
 
     async def consume_chunk(self, data: bytes):
@@ -1046,7 +1176,7 @@ class SnowflakeConsumer(ConsumerFromStage):
         """Start a new file (reset state for file splitting)."""
         self.current_file_index += 1
         self.current_buffer = NamedBytesIO(
-            b"", name=f"{self.snowflake_table_stage_prefix}/{self.current_file_index}.parquet.zst"
+            b"", name=f"{self.snowflake_table.stage_prefix}/{self.current_file_index}.parquet.zst"
         )
 
     async def _upload_current_buffer(self):
@@ -1066,8 +1196,7 @@ class SnowflakeConsumer(ConsumerFromStage):
 
         await self.snowflake_client.put_file_to_snowflake_table_stage(
             file=self.current_buffer,
-            table_stage_prefix=self.snowflake_table_stage_prefix,
-            table_name=self.snowflake_table,
+            table=self.snowflake_table,
         )
 
         self.external_logger.info(
@@ -1191,19 +1320,36 @@ async def insert_into_snowflake_activity_from_stage(inputs: SnowflakeInsertInput
 
             return BatchExportResult(records_completed=0, bytes_exported=0)
 
-        table_fields, record_batch_schema, known_variant_columns = _get_snowflake_table_settings(
-            model=model, record_batch_schema=record_batch_schema
+        record_batch_schema = pa.schema(
+            [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
         )
 
-        requires_merge, merge_key, update_key = _get_snowflake_merge_config(model=model)
+        # TODO: Figure out which fields are JSON without hard-coding them here.
+        json_fields = {"properties", "people_set", "people_set_once", "person_properties"}
+        record_batch_schema = pa.schema(
+            field.with_type(JsonType()) if field.name in json_fields else field for field in record_batch_schema
+        )
 
         data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
         attempt = activity.info().attempt
-        stage_table_name = (
-            f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}_{attempt}"
-            if requires_merge
-            else inputs.table_name
+        stage_table_name = f"stage_{inputs.table_name}_{data_interval_end_str}_{inputs.team_id}_{attempt}"
+
+        merge_settings = _get_merge_settings(model)
+        target_table = SnowflakeTable.from_arrow_schema(
+            record_batch_schema,
+            name=inputs.table_name,
+            table_schema=inputs.schema,
+            database=inputs.database,
+            primary_key=merge_settings.primary_key if merge_settings else (),
+            version_key=merge_settings.version_key if merge_settings else (),
+            stage_prefix=data_interval_end_str,
         )
+        if "elements" in target_table:
+            # `elements` is exported into a 'VARIANT' column, despite it being a
+            # pa.string.
+            # TODO: Export the JSON representation of elements, or drop it completely.
+            field = target_table["elements"]
+            field.snowflake_type = SnowflakeType("VARIANT", repeated=False)
 
         # Calculate timeout for long-running queries (COPY INTO and MERGE)
         long_running_query_timeout = _get_snowflake_query_timeout(
@@ -1212,53 +1358,65 @@ async def insert_into_snowflake_activity_from_stage(inputs: SnowflakeInsertInput
         )
 
         async with SnowflakeClient.from_inputs(inputs).connect() as snow_client:
+            consumer_table = snow_target_table = await snow_client.get_or_create_table(target_table)
+            # Exporting directly to target table
+            should_delete = False
+            should_exist = True
+
+            if snow_target_table.is_mutable():
+                consumer_table = SnowflakeTable(
+                    stage_table_name,
+                    snow_target_table.fields,
+                    snow_target_table.parents,
+                    primary_key=snow_target_table.primary_key,
+                    version_key=snow_target_table.version_key,
+                )
+                # Using a stage table to later merge
+                should_delete = True
+                should_exist = False
+
             async with (
                 snow_client.managed_table(
-                    inputs.table_name, data_interval_end_str, table_fields, delete=False
-                ) as snow_table,
-                snow_client.managed_table(
-                    stage_table_name,
-                    data_interval_end_str,
-                    table_fields,
-                    create=requires_merge,
-                    delete=requires_merge,
-                ) as snow_stage_table,
+                    consumer_table,
+                    create=True,
+                    exists_ok=should_exist,
+                    delete=should_delete,
+                ) as snow_consumer_table,
             ):
                 consumer = SnowflakeConsumer(
                     snowflake_client=snow_client,
-                    snowflake_table=snow_stage_table if requires_merge else snow_table,
-                    snowflake_table_stage_prefix=data_interval_end_str,
+                    snowflake_table=snow_consumer_table,
                 )
 
-                transformer = ParquetStreamTransformer(
-                    compression="zstd",
-                    max_file_size_bytes=settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES,
+                transformer = PipelineTransformer(
+                    transformers=(
+                        SchemaTransformer(table=snow_consumer_table),
+                        ParquetStreamTransformer(
+                            compression="zstd",
+                            max_file_size_bytes=settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES,
+                        ),
+                    )
                 )
                 result = await run_consumer_from_stage(
                     queue=queue,
                     consumer=consumer,
                     producer_task=producer_task,
                     transformer=transformer,
-                    json_columns=known_variant_columns,
+                    # TODO: Deprecate this argument once all other destinations are also migrated.
+                    json_columns=(),
                 )
 
                 # TODO - maybe move this into the consumer finalize method?
                 # Copy all staged files to the table
                 await snow_client.copy_loaded_files_to_snowflake_table(
-                    snow_stage_table if requires_merge else snow_table,
-                    data_interval_end_str,
-                    table_fields,
-                    known_json_columns=known_variant_columns,
+                    snow_consumer_table,
                     timeout=long_running_query_timeout,
                 )
 
-                if requires_merge:
-                    await snow_client.amerge_mutable_tables(
-                        final_table=snow_table,
-                        stage_table=snow_stage_table,
-                        update_when_matched=table_fields,
-                        merge_key=merge_key,
-                        update_key=update_key,
+                if snow_target_table.is_mutable():
+                    await snow_client.merge_into_final_from_stage(
+                        final=snow_target_table,
+                        stage=snow_consumer_table,
                         timeout=long_running_query_timeout,
                     )
 

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -1078,7 +1078,6 @@ class SnowflakeClient:
                 values += ", "
                 field_names += ", "
 
-            field_name = field[0]
             update_clause += f'final."{field.name}" = stage."{field.name}"'
             field_names += f'"{field.name}"'
             values += f'stage."{field.name}"'

--- a/products/batch_exports/backend/temporal/pipeline/table.py
+++ b/products/batch_exports/backend/temporal/pipeline/table.py
@@ -66,6 +66,15 @@ COMPATIBLE_TYPES: TypeTupleToCastMapping = {
         functools.partial(pa.compute.seconds_between, EPOCH_SECONDS)
     ),
     (pa.string(), JsonType()): _make_ensure_array(functools.partial(pa.compute.cast, target_type=JsonType())),
+    # We assume this is a destination field created from a ClickHouse `DateTime` that
+    # has  been updated to `DateTime64(3)`.
+    # This would mean the field would have been created as a BigQuery 'INT64', but we
+    # are now receiving a `pa.timestamp("ms", tz="UTC")`.
+    # So, since `DateTime` is seconds since the EPOCH, we maintain that here.
+    # This technically truncates the millisecond part of the value, but if it came from
+    # a `DateTime` then we assume it is empty (as it would have been empty before).
+    (pa.timestamp("ms", tz="UTC"), pa.int64()): TIMESTAMP_MS_TO_SECONDS_SINCE_EPOCH,
+    (pa.timestamp("ms", tz="Etc/UTC"), pa.int64()): TIMESTAMP_MS_TO_SECONDS_SINCE_EPOCH,
 }
 
 

--- a/products/batch_exports/backend/temporal/pipeline/table.py
+++ b/products/batch_exports/backend/temporal/pipeline/table.py
@@ -121,7 +121,8 @@ class Field[T](typing.Protocol):
     @classmethod
     def from_arrow_field(cls, field: pa.Field) -> typing.Self: ...
 
-    def to_arrow_field(cls) -> pa.Field: ...
+    def to_arrow_field(self) -> pa.Field:
+        return pa.field(self.name, self.data_type)
 
     @classmethod
     def from_destination_field(cls, field: T) -> typing.Self: ...

--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -752,12 +752,29 @@ class SchemaTransformer:
         exception is raised when `self.raise_on_incompatible` is `True`, otherwise we
         optimistically assume the destination can handle the inconsistency.
         """
-        schema_names = {field.name for field in record_batch.schema}
-        field_names = [field.name for field in self.table.fields if field.name in schema_names]
+        field_names = record_batch.schema.names
 
         arrays = []
+        new_field_names = []
         for field_name, array in zip(field_names, record_batch.select(field_names).itercolumns()):
-            field = self.table[field_name]
+            try:
+                field = self.table[field_name]
+            except KeyError:
+                logger.warning(
+                    "Field missing in target",
+                    name=field_name,
+                    table=self.table.fully_qualified_name,
+                )
+                continue
+
+            if field.name != field_name:
+                logger.warning(
+                    "Field aliased",
+                    field=field.name,
+                    alias=field.alias,
+                    table=self.table.fully_qualified_name,
+                )
+            new_field_names.append(field.name)
 
             if array.type == field.data_type:
                 arrays.append(array)
@@ -783,7 +800,7 @@ class SchemaTransformer:
 
         return pa.RecordBatch.from_arrays(
             arrays,
-            names=field_names,
+            names=new_field_names,
         )
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -62,6 +62,7 @@ async def _run_activity(
     primary_key=None,
     assert_clickhouse_records: bool = True,
     timestamp_columns: collections.abc.Sequence[str] = (),
+    uppercase_columns: list[str] | None = None,
 ):
     """Helper function to run insert_into_snowflake_activity_from_stage and assert records in Snowflake"""
     insert_inputs = SnowflakeInsertInputs(
@@ -111,6 +112,7 @@ async def _run_activity(
             expect_duplicates=expect_duplicates,
             primary_key=primary_key,
             timestamp_columns=timestamp_columns,
+            uppercase_columns=uppercase_columns,
         )
     return result
 
@@ -633,4 +635,69 @@ async def test_insert_into_snowflake_activity_from_stage_handles_datetime_to_int
 
     assert isinstance(result, BatchExportResult)
     assert result.error is None
-    assert result.error.type == "SnowflakeIncompatibleSchemaError"
+
+
+@pytest.mark.parametrize(
+    "model", [BatchExportModel(name="events", schema=None), BatchExportModel(name="persons", schema=None)]
+)
+async def test_insert_into_snowflake_activity_handles_uppercased_columns(
+    clickhouse_client,
+    activity_environment,
+    snowflake_cursor,
+    snowflake_config,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+    model,
+):
+    """Test that the `insert_into_snowflake_activity_from_stage` can handle target
+    table columns being in UPPERCASE.
+
+    Due to the relatively simple way to resolve that a column name is UPPERCASED, this
+    should not cause a schema error.
+
+    This test first runs the batch export normally to create a target table, then
+    updates some columns to be UPPERCASE, and finally re-runs the batch export.
+    """
+    table_name = f"test_insert_activity_{model.name}_table_handle_uppercased_{ateam.pk}"
+
+    sort_key = "uuid" if model.name == "events" else "person_id"
+    await _run_activity(
+        activity_environment=activity_environment,
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        snowflake_config=snowflake_config,
+        team=ateam,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        table_name=table_name,
+        batch_export_model=model,
+        sort_key=sort_key,
+    )
+
+    uppercase_columns = ["team_id"]
+    if model.name == "events":
+        uppercase_columns.append("event")
+    elif model.name == "persons":
+        uppercase_columns.append("person_version")
+        uppercase_columns.append("person_id")
+    snowflake_cursor.execute(f'TRUNCATE TABLE "{table_name}"')
+    for column in uppercase_columns:
+        snowflake_cursor.execute(f'ALTER TABLE "{table_name}" RENAME COLUMN "{column}" TO "{column.upper()}"')
+    # person_id is now in uppercase
+    sort_key = "uuid" if model.name == "events" else "PERSON_ID"
+
+    await _run_activity(
+        activity_environment=activity_environment,
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        snowflake_config=snowflake_config,
+        team=ateam,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        table_name=table_name,
+        batch_export_model=model,
+        sort_key=sort_key,
+        uppercase_columns=uppercase_columns,
+    )

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -7,6 +7,7 @@ Note: This module uses a real Snowflake connection.
 import os
 import uuid
 import datetime as dt
+import collections.abc
 
 import pytest
 
@@ -60,7 +61,7 @@ async def _run_activity(
     expect_duplicates: bool = False,
     primary_key=None,
     assert_clickhouse_records: bool = True,
-    uppercase_columns: list[str] | None = None,
+    timestamp_columns: collections.abc.Sequence[str] = (),
 ):
     """Helper function to run insert_into_snowflake_activity_from_stage and assert records in Snowflake"""
     insert_inputs = SnowflakeInsertInputs(
@@ -109,7 +110,7 @@ async def _run_activity(
             expected_fields=expected_fields,
             expect_duplicates=expect_duplicates,
             primary_key=primary_key,
-            uppercase_columns=uppercase_columns,
+            timestamp_columns=timestamp_columns,
         )
     return result
 
@@ -570,7 +571,7 @@ async def test_insert_into_snowflake_activity_handles_person_schema_changes(
     )
 
 
-async def test_insert_into_snowflake_activity_raises_error_when_schema_is_incompatible(
+async def test_insert_into_snowflake_activity_from_stage_handles_datetime_to_int(
     clickhouse_client,
     activity_environment,
     snowflake_cursor,
@@ -580,15 +581,24 @@ async def test_insert_into_snowflake_activity_raises_error_when_schema_is_incomp
     data_interval_end,
     ateam,
 ):
-    """Test that the `insert_into_snowflake_activity_from_stage` raises an error when the schema of the destination table is
-    incompatible with the schema of the data we are trying to load. This typically applies to the events table, which
-    has a fixed schema (for now).
+    """Test that the `insert_into_snowflake_activity_from_stage` handles columns in the
+    destination having INT64 type for DateTime64 columns.
 
-    To replicate this situation we first export the data with the original
-    schema, then delete a column in the destination and then rerun the export.
+    ClickHouse exports DateTime columns as uint32. Not to be confused with DateTime64
+    columns which are exported as Arrow's native timestamp type.
+
+    This can lead to fields in destination tables corresponding to DateTime types being
+    created as Snowflake's INTEGER, as that's how we resolve Arrow's uint32.
+
+    If the ClickHouse type ever changes from DateTime to DateTime64, for example, if the
+    query is updated, we want to ensure we can continue exporting to an INTEGER field,
+    even if the field is now DateTime64.
+
+    To replicate this situation we first export the data to create the table, then alter
+    'created_at' to be of type INTEGER, and then rerun the export.
     """
-    model = BatchExportModel(name="events", schema=None)
-    table_name = f"test_insert_activity_events_table_{ateam.pk}"
+    model = BatchExportModel(name="persons", schema=None)
+    table_name = f"test_insert_activity_persons_table_{ateam.pk}"
 
     await _run_activity(
         activity_environment=activity_environment,
@@ -600,11 +610,12 @@ async def test_insert_into_snowflake_activity_raises_error_when_schema_is_incomp
         data_interval_end=data_interval_end,
         table_name=table_name,
         batch_export_model=model,
-        sort_key="uuid",
+        sort_key="person_id",
     )
 
-    # Drop the timestamp column from the Snowflake table
-    snowflake_cursor.execute(f'ALTER TABLE "{table_name}" DROP COLUMN "timestamp"')
+    snowflake_cursor.execute(f'TRUNCATE TABLE "{table_name}"')
+    snowflake_cursor.execute(f'ALTER TABLE "{table_name}" DROP COLUMN "created_at"')
+    snowflake_cursor.execute(f'ALTER TABLE "{table_name}" ADD COLUMN "created_at" INTEGER')
 
     result = await _run_activity(
         activity_environment=activity_environment,
@@ -616,76 +627,10 @@ async def test_insert_into_snowflake_activity_raises_error_when_schema_is_incomp
         data_interval_end=data_interval_end,
         table_name=table_name,
         batch_export_model=model,
-        sort_key="uuid",
-        assert_clickhouse_records=False,
+        sort_key="person_id",
+        timestamp_columns=("created_at",),
     )
 
     assert isinstance(result, BatchExportResult)
-    assert result.error is not None
+    assert result.error is None
     assert result.error.type == "SnowflakeIncompatibleSchemaError"
-
-
-@pytest.mark.parametrize(
-    "model", [BatchExportModel(name="events", schema=None), BatchExportModel(name="persons", schema=None)]
-)
-async def test_insert_into_snowflake_activity_handles_uppercased_columns(
-    clickhouse_client,
-    activity_environment,
-    snowflake_cursor,
-    snowflake_config,
-    generate_test_data,
-    data_interval_start,
-    data_interval_end,
-    ateam,
-    model,
-):
-    """Test that the `insert_into_snowflake_activity_from_stage` can handle target
-    table columns being in UPPERCASE.
-
-    Due to the relatively simple way to resolve that a column name is UPPERCASED, this
-    should not cause a schema error.
-
-    This test first runs the batch export normally to create a target table, then
-    updates some columns to be UPPERCASE, and finally re-runs the batch export.
-    """
-    table_name = f"test_insert_activity_{model.name}_table_handle_uppercased_{ateam.pk}"
-
-    sort_key = "uuid" if model.name == "events" else "person_id"
-    await _run_activity(
-        activity_environment=activity_environment,
-        snowflake_cursor=snowflake_cursor,
-        clickhouse_client=clickhouse_client,
-        snowflake_config=snowflake_config,
-        team=ateam,
-        data_interval_start=data_interval_start,
-        data_interval_end=data_interval_end,
-        table_name=table_name,
-        batch_export_model=model,
-        sort_key=sort_key,
-    )
-
-    uppercase_columns = ["team_id"]
-    if model.name == "events":
-        uppercase_columns.append("event")
-    elif model.name == "persons":
-        uppercase_columns.append("person_version")
-        uppercase_columns.append("person_id")
-    snowflake_cursor.execute(f'TRUNCATE TABLE "{table_name}"')
-    for column in uppercase_columns:
-        snowflake_cursor.execute(f'ALTER TABLE "{table_name}" RENAME COLUMN "{column}" TO "{column.upper()}"')
-    # person_id is now in uppercase
-    sort_key = "uuid" if model.name == "events" else "PERSON_ID"
-
-    await _run_activity(
-        activity_environment=activity_environment,
-        snowflake_cursor=snowflake_cursor,
-        clickhouse_client=clickhouse_client,
-        snowflake_config=snowflake_config,
-        team=ateam,
-        data_interval_start=data_interval_start,
-        data_interval_end=data_interval_end,
-        table_name=table_name,
-        batch_export_model=model,
-        sort_key=sort_key,
-        uppercase_columns=uppercase_columns,
-    )

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -174,10 +174,12 @@ async def test_snowflake_export_workflow_exports_events(
 
     assert all(query.startswith("PUT") for query in execute_calls[0:9])
 
-    assert execute_async_calls[5].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
-    assert execute_async_calls[6].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[4].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
+    assert execute_async_calls[5].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[6].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
     assert execute_async_calls[7].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
     assert execute_async_calls[8].startswith(f'COPY INTO "{table_name}"')
+    assert execute_async_calls[9].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
 
 
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -174,12 +174,12 @@ async def test_snowflake_export_workflow_exports_events(
 
     assert all(query.startswith("PUT") for query in execute_calls[0:9])
 
-    assert execute_async_calls[4].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
-    assert execute_async_calls[5].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
-    assert execute_async_calls[6].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
-    assert execute_async_calls[7].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
-    assert execute_async_calls[8].startswith(f'COPY INTO "{table_name}"')
-    assert execute_async_calls[9].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[5].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
+    assert execute_async_calls[6].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[7].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
+    assert execute_async_calls[8].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
+    assert execute_async_calls[9].startswith(f'COPY INTO "{table_name}"')
+    assert execute_async_calls[10].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
 
 
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -5,6 +5,7 @@ import json
 import typing as t
 import datetime as dt
 import operator
+import collections.abc
 from collections import deque
 from uuid import uuid4
 
@@ -370,7 +371,7 @@ async def assert_clickhouse_records_in_snowflake(
     expected_fields: list[str] | None = None,
     expect_duplicates: bool = False,
     primary_key: list[str] | None = None,
-    uppercase_columns: list[str] | None = None,
+    timestamp_columns: collections.abc.Sequence[str] = (),
 ):
     """Assert ClickHouse records are written to Snowflake table.
 
@@ -397,15 +398,18 @@ async def assert_clickhouse_records_in_snowflake(
     # Rows are tuples, so we construct a dictionary using the metadata from cursor.description.
     # We rely on the order of the columns in each row matching the order set in cursor.description.
     # This seems to be the case, at least for now.
-    inserted_records = [
-        {
-            columns[index]: json.loads(row[index])
-            if columns[index] in json_columns and row[index] is not None
-            else row[index]
-            for index in columns.keys()
-        }
-        for row in rows
-    ]
+    inserted_records = []
+    for row in rows:
+        record = {}
+
+        for index in columns.keys():
+            if columns[index] in json_columns and row[index] is not None:
+                record[columns[index]] = json.loads(row[index])
+            elif isinstance(row[index], int) and columns[index] in timestamp_columns:
+                record[columns[index]] = dt.datetime.fromtimestamp(row[index])
+            else:
+                record[columns[index]] = row[index]
+        inserted_records.append(record)
 
     if batch_export_model is not None:
         if isinstance(batch_export_model, BatchExportModel):

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -2,6 +2,7 @@ import os
 import re
 import gzip
 import json
+import typing
 import typing as t
 import datetime as dt
 import operator
@@ -90,6 +91,12 @@ TEST_MODELS: list[BatchExportModel | BatchExportSchema | None] = [
 ]
 
 
+class FakeMetadata(typing.NamedTuple):
+    name: str
+    type_code: int
+    is_nullable: bool
+
+
 class FakeSnowflakeCursor:
     """A fake Snowflake cursor that can fail on PUT and COPY queries."""
 
@@ -150,8 +157,9 @@ class FakeSnowflakeCursor:
         else:
             return [("test", "LOADED", 100, 99, 1, 1, "Some error on copy", 3)]
 
+    @property
     def description(self):
-        return []
+        return [FakeMetadata("uuid", 2, False)]
 
 
 class FakeSnowflakeConnection:

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -380,6 +380,7 @@ async def assert_clickhouse_records_in_snowflake(
     expect_duplicates: bool = False,
     primary_key: list[str] | None = None,
     timestamp_columns: collections.abc.Sequence[str] = (),
+    uppercase_columns: list[str] | None = None,
 ):
     """Assert ClickHouse records are written to Snowflake table.
 

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_table.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_table.py
@@ -100,6 +100,7 @@ def test_table_is_a_sequence_of_fields():
     class TestField(Field):
         def __init__(self, name: str, data_type: pa.DataType):
             self.name = name
+            self.alias = name
             self.data_type = data_type
 
         @classmethod

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
@@ -152,6 +152,7 @@ async def test_csv_stream_transformer_writes_record_batches():
 class TestField(Field):
     def __init__(self, name: str, data_type: pa.DataType):
         self.name = name
+        self.alias = name
         self.data_type = data_type
 
     @classmethod

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
@@ -176,7 +176,12 @@ async def test_transformer_pipeline_pipes_multiple_transformers():
     """Test piping a `SchemaTransformer` into a `JSONLStreamTransformer`."""
     fibo = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
     numbers = pa.array(fibo)
-    record_batch = pa.RecordBatch.from_arrays([numbers], names=("number",))
+    record_batch = pa.RecordBatch.from_arrays(
+        [numbers],
+        names=[
+            "number",
+        ],
+    )
 
     async def record_batch_iter():
         yield record_batch

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
@@ -176,12 +176,7 @@ async def test_transformer_pipeline_pipes_multiple_transformers():
     """Test piping a `SchemaTransformer` into a `JSONLStreamTransformer`."""
     fibo = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
     numbers = pa.array(fibo)
-    record_batch = pa.RecordBatch.from_arrays(
-        [numbers],
-        names=[
-            "number",
-        ],
-    )
+    record_batch = pa.RecordBatch.from_arrays([numbers], names=("number",))
 
     async def record_batch_iter():
         yield record_batch


### PR DESCRIPTION
## Problem

In a similar fashion to https://github.com/PostHog/posthog/pull/41032, this adds support for handling some forms of schema drift in Snowflake by introducing abstractions from #40872.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* New `SnowflakeTable` and `SnowflakeField` implementations.
* Made `SnowflakeClient` take and return `SnowflakeTable` everywhere.
* Got rid of one `managed_table` to better differentiate between target table and stage table.
* Using `PipelineTransformer` and `SchemaTransformer` in Snowflake batch export.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran snowflake test suite, added a unit test similar to #41032. Everything passing.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
