### PR TITLE
feat: change expiring recordings output to just include the count

### DIFF
--- a/posthog/temporal/tests/weekly_digest/test_activities.py
+++ b/posthog/temporal/tests/weekly_digest/test_activities.py
@@ -467,7 +467,7 @@ async def test_generate_recording_lookup(mock_redis, common_input, digest):
 
     mock_ch_response = AsyncMock()
     mock_ch_response.content.read = AsyncMock(
-        return_value=b'{"meta": [], "data": [{"session_id": "session123", "recording_ttl": 10}], "statistics": {}, "rows": 1}'
+        return_value=b'{"meta": [], "data": [{"recording_count": 10}], "statistics": {}, "rows": 1}'
     )
     mock_ch_response.__aenter__ = AsyncMock(return_value=mock_ch_response)
     mock_ch_response.__aexit__ = AsyncMock(return_value=None)
@@ -559,7 +559,7 @@ async def test_generate_organization_digest_batch(mock_redis, common_input, dige
     await mock_redis.setex(f"{digest.key}-external-data-sources-1", 3600, "[]")
     await mock_redis.setex(f"{digest.key}-feature-flags-1", 3600, "[]")
     await mock_redis.setex(f"{digest.key}-saved-filters-1", 3600, "[]")
-    await mock_redis.setex(f"{digest.key}-expiring-recordings-1", 3600, "[]")
+    await mock_redis.setex(f"{digest.key}-expiring-recordings-1", 3600, '{"recording_count": 0}')
     await mock_redis.setex(f"{digest.key}-surveys-launched-1", 3600, "[]")
 
     mock_org_queryset = MockAsyncQuerySet([mock_org])
@@ -612,7 +612,7 @@ async def test_send_weekly_digest_batch(mock_redis, common_input, digest):
                 ],
                 "feature_flags": [],
                 "filters": [],
-                "recordings": [],
+                "expiring_recordings": {"recording_count": 0},
                 "surveys_launched": []
             }
         ]
@@ -637,7 +637,7 @@ async def test_send_weekly_digest_batch(mock_redis, common_input, digest):
 
     with patch("posthog.temporal.weekly_digest.activities.query_orgs_for_digest", return_value=mock_org_queryset):
         with patch("posthog.temporal.weekly_digest.activities.query_org_members", return_value=mock_member_queryset):
-            with patch("posthog.temporal.weekly_digest.activities.get_regional_ph_client", return_value=mock_ph_client):
+            with patch("posthog.temporal.weekly_digest.activities.get_ph_client", return_value=mock_ph_client):
                 with patch("posthog.temporal.weekly_digest.activities.MessagingRecord.objects", mock_messaging_objects):
                     with patch("posthog.temporal.weekly_digest.activities.redis.from_url", return_value=mock_redis):
                         await send_weekly_digest_batch(input_data)
@@ -687,7 +687,7 @@ async def test_send_weekly_digest_batch_dry_run(mock_redis, common_input, digest
                 ],
                 "feature_flags": [],
                 "filters": [],
-                "recordings": [],
+                "expiring_recordings": {"recording_count": 0},
                 "surveys_launched": []
             }
         ]
@@ -711,7 +711,7 @@ async def test_send_weekly_digest_batch_dry_run(mock_redis, common_input, digest
 
     with patch("posthog.temporal.weekly_digest.activities.query_orgs_for_digest", return_value=mock_org_queryset):
         with patch("posthog.temporal.weekly_digest.activities.query_org_members", return_value=mock_member_queryset):
-            with patch("posthog.temporal.weekly_digest.activities.get_regional_ph_client", return_value=mock_ph_client):
+            with patch("posthog.temporal.weekly_digest.activities.get_ph_client", return_value=mock_ph_client):
                 with patch("posthog.temporal.weekly_digest.activities.MessagingRecord.objects", mock_messaging_objects):
                     with patch("posthog.temporal.weekly_digest.activities.redis.from_url", return_value=mock_redis):
                         await send_weekly_digest_batch(input_data)

--- a/posthog/temporal/tests/weekly_digest/test_types.py
+++ b/posthog/temporal/tests/weekly_digest/test_types.py
@@ -10,7 +10,6 @@ from posthog.temporal.weekly_digest.types import (
     DigestExternalDataSource,
     DigestFeatureFlag,
     DigestFilter,
-    DigestRecording,
     DigestSurvey,
     EventDefinitionList,
     ExperimentList,
@@ -18,7 +17,7 @@ from posthog.temporal.weekly_digest.types import (
     FeatureFlagList,
     FilterList,
     OrganizationDigest,
-    RecordingList,
+    RecordingCount,
     SurveyList,
     TeamDigest,
 )
@@ -90,7 +89,7 @@ def test_team_digest_is_empty():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -106,7 +105,7 @@ def test_team_digest_is_empty():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -125,7 +124,7 @@ def test_team_digest_count_items():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[DigestFeatureFlag(name="Feature", id=1, key="feature")]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=5),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -138,7 +137,6 @@ def test_team_digest_render_payload():
     event = DigestEventDefinition(name="pageview", id=uuid4())
     flag = DigestFeatureFlag(name="Feature", id=1, key="feature")
     filter = DigestFilter(name="Filter", short_id="abc", view_count=5, recording_count=10)
-    recording = DigestRecording(session_id="session123", recording_ttl=7)
 
     digest = TeamDigest(
         id=1,
@@ -150,7 +148,7 @@ def test_team_digest_render_payload():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[flag]),
         filters=FilterList(root=[filter]),
-        recordings=RecordingList(root=[recording]),
+        expiring_recordings=RecordingCount(recording_count=7),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -165,9 +163,10 @@ def test_team_digest_render_payload():
     assert len(report["new_event_definitions"]) == 1
     assert len(report["new_feature_flags"]) == 1
     assert len(report["interesting_saved_filters"]) == 1
-    assert len(report["expiring_recordings"]) == 1
-    assert report["expiring_recordings"][0]["session_id"] == "session123"
-    assert report["expiring_recordings"][0]["recording_ttl"] == 7
+    assert "expiring_recordings" in report
+    expiring_recordings = report["expiring_recordings"]
+    assert isinstance(expiring_recordings, dict)
+    assert expiring_recordings["recording_count"] == 7
 
 
 def test_team_digest_render_payload_empty_recordings():
@@ -184,7 +183,7 @@ def test_team_digest_render_payload_empty_recordings():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -193,7 +192,9 @@ def test_team_digest_render_payload_empty_recordings():
     report = payload["report"]
     assert isinstance(report, dict)
     assert "expiring_recordings" in report
-    assert len(report["expiring_recordings"]) == 0
+    expiring_recordings = report["expiring_recordings"]
+    assert isinstance(expiring_recordings, dict)
+    assert expiring_recordings["recording_count"] == 0
 
 
 def test_organization_digest_filter_for_user():
@@ -208,7 +209,7 @@ def test_organization_digest_filter_for_user():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -222,7 +223,7 @@ def test_organization_digest_filter_for_user():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -236,7 +237,7 @@ def test_organization_digest_filter_for_user():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -265,7 +266,7 @@ def test_organization_digest_is_empty():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -283,7 +284,7 @@ def test_organization_digest_is_empty():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -304,7 +305,7 @@ def test_organization_digest_count_items():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -318,7 +319,7 @@ def test_organization_digest_count_items():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[DigestFeatureFlag(name="Flag", id=1, key="flag")]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -340,7 +341,7 @@ def test_organization_digest_render_payload():
         external_data_sources=ExternalDataSourceList(root=[]),
         feature_flags=FeatureFlagList(root=[]),
         filters=FilterList(root=[]),
-        recordings=RecordingList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
         surveys_launched=SurveyList(root=[]),
     )
 
@@ -388,12 +389,11 @@ def test_digest_experiment_without_end_date():
     assert experiment.end_date is None
 
 
-def test_digest_recording():
-    """Test that DigestRecording correctly stores recording data."""
-    recording = DigestRecording(session_id="session123", recording_ttl=7)
+def test_recording_count():
+    """Test that RecordingCount correctly stores recording count data."""
+    recording_count = RecordingCount(recording_count=7)
 
-    assert recording.session_id == "session123"
-    assert recording.recording_ttl == 7
+    assert recording_count.recording_count == 7
 
 
 def test_digest_survey():

--- a/posthog/temporal/weekly_digest/types.py
+++ b/posthog/temporal/weekly_digest/types.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, RootModel
 
+from posthog.utils import get_instance_region
+
 
 class CommonInput(BaseModel):
     redis_ttl: int = 3600 * 24 * 3  # 3 days
@@ -107,11 +109,6 @@ class DigestFilter(BaseModel):
         }
 
 
-class DigestRecording(BaseModel):
-    session_id: str
-    recording_ttl: int
-
-
 class DigestSurvey(BaseModel):
     name: str
     id: UUID
@@ -146,8 +143,8 @@ class FilterList(RootModel):
         return FilterList(root=sorted(self.root, key=lambda f: f.recording_count, reverse=True))
 
 
-class RecordingList(RootModel):
-    root: list[DigestRecording]
+class RecordingCount(BaseModel):
+    recording_count: int
 
 
 class SurveyList(RootModel):
@@ -164,7 +161,6 @@ DigestResourceType: TypeAlias = (
     | type[ExternalDataSourceList]
     | type[FeatureFlagList]
     | type[FilterList]
-    | type[RecordingList]
     | type[SurveyList]
 )
 
@@ -179,7 +175,7 @@ class TeamDigest(BaseModel):
     external_data_sources: ExternalDataSourceList
     feature_flags: FeatureFlagList
     filters: FilterList
-    recordings: RecordingList
+    expiring_recordings: RecordingCount
     surveys_launched: SurveyList
 
     def _fields(self) -> list[RootModel]:
@@ -191,7 +187,6 @@ class TeamDigest(BaseModel):
             self.external_data_sources,
             self.feature_flags,
             self.filters,
-            self.recordings,
             self.surveys_launched,
         ]
 
@@ -201,7 +196,7 @@ class TeamDigest(BaseModel):
     def count_items(self) -> int:
         return sum(len(f.root) for f in self._fields())
 
-    def render_payload(self) -> dict[str, str | int | dict[str, list]]:
+    def render_payload(self) -> dict[str, str | int | dict[str, list | dict]]:
         return {
             "team_name": self.name,
             "team_id": self.id,
@@ -213,7 +208,7 @@ class TeamDigest(BaseModel):
                 "new_external_data_sources": self.external_data_sources.model_dump(),
                 "new_feature_flags": self.feature_flags.model_dump(),
                 "interesting_saved_filters": [f.render_payload() for f in self.filters.root],
-                "expiring_recordings": self.recordings.model_dump(),
+                "expiring_recordings": self.expiring_recordings.model_dump(),
                 "new_surveys_launched": self.surveys_launched.model_dump(),
             },
         }
@@ -242,7 +237,7 @@ class OrganizationDigest(BaseModel):
     def count_items(self) -> int:
         return sum(td.count_items() for td in self.team_digests)
 
-    def render_payload(self, digest: Digest) -> dict[str, str | list | dict[str, str] | int]:
+    def render_payload(self, digest: Digest) -> dict[str, str | list | dict[str, str] | int | None]:
         return {
             "organization_name": self.name,
             "organization_id": str(self.id),
@@ -250,6 +245,7 @@ class OrganizationDigest(BaseModel):
             "scope": "user",
             "template_name": "weekly_digest_report",
             "period": digest.render_payload(),
+            "region": get_instance_region(),
         }
 
 


### PR DESCRIPTION
Also include region in payload in order to parameterize URLs in EU/US digests.