### PR TITLE
fix(data-warehouse): Dont overwrite delta table if resuming sync

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -122,7 +122,7 @@ class DeltaTableHelper:
         self,
         data: pa.Table,
         write_type: Literal["incremental", "full_refresh", "append"],
-        chunk_index: int,
+        should_overwrite_table: bool,
         primary_keys: Sequence[Any] | None,
     ) -> deltalake.DeltaTable:
         delta_table = self.get_delta_table()
@@ -130,7 +130,9 @@ class DeltaTableHelper:
         if delta_table:
             delta_table = self._evolve_delta_schema(data.schema)
 
-        self._logger.debug(f"write_to_deltalake: _is_first_sync = {self._is_first_sync}")
+        self._logger.debug(
+            f"write_to_deltalake: _is_first_sync = {self._is_first_sync}. should_overwrite_table = {should_overwrite_table}"
+        )
 
         use_partitioning = False
         if PARTITION_KEY in data.column_names:
@@ -202,7 +204,7 @@ class DeltaTableHelper:
         ):
             mode: Literal["error", "append", "overwrite", "ignore"] = "append"
             schema_mode: Literal["merge", "overwrite"] | None = "merge"
-            if chunk_index == 0 or delta_table is None:
+            if should_overwrite_table or delta_table is None:
                 mode = "overwrite"
                 schema_mode = "overwrite"
 


### PR DESCRIPTION
## Problem
- When a resumable sync resumes, we were overwriting the deltalake table in S3 instead of appending to it 

## Changes
Fix this - dont overwrite if we're resuming