### PR TITLE
fix(ph-ai): conversation compaction edge cases

### DIFF
--- a/ee/hogai/graph/agent_modes/nodes.py
+++ b/ee/hogai/graph/agent_modes/nodes.py
@@ -186,12 +186,18 @@ class AgentExecutable(BaseAgentExecutable):
         start_id = state.start_id
 
         # Summarize the conversation if it's too long.
-        if await self._window_manager.should_compact_conversation(
+        current_token_count = await self._window_manager.calculate_token_count(
             model, langchain_messages, tools=tools, thinking_config=self.THINKING_CONFIG
-        ):
+        )
+        if current_token_count > self._window_manager.CONVERSATION_WINDOW_SIZE:
             # Exclude the last message if it's the first turn.
             messages_to_summarize = langchain_messages[:-1] if self._is_first_turn(state) else langchain_messages
-            summary = await AnthropicConversationSummarizer(self._team, self._user).summarize(messages_to_summarize)
+            summary = await AnthropicConversationSummarizer(
+                self._team,
+                self._user,
+                extend_context_window=current_token_count > 195_000,
+            ).summarize(messages_to_summarize)
+
             summary_message = ContextMessage(
                 content=ROOT_CONVERSATION_SUMMARY_PROMPT.format(summary=summary),
                 id=str(uuid4()),

--- a/ee/hogai/graph/conversation_summarizer/nodes.py
+++ b/ee/hogai/graph/conversation_summarizer/nodes.py
@@ -55,9 +55,14 @@ class ConversationSummarizer:
 
 
 class AnthropicConversationSummarizer(ConversationSummarizer):
+    def __init__(self, team: Team, user: User, extend_context_window: bool | None = False):
+        super().__init__(team, user)
+        self._extend_context_window = extend_context_window
+
     def _get_model(self):
+        # Haiku has 200k token limit. Sonnet has 1M token limit.
         return MaxChatAnthropic(
-            model="claude-haiku-4-5",
+            model="claude-sonnet-4-5" if self._extend_context_window else "claude-haiku-4-5",
             streaming=False,
             stream_usage=False,
             max_tokens=8192,
@@ -65,6 +70,7 @@ class AnthropicConversationSummarizer(ConversationSummarizer):
             user=self._user,
             team=self._team,
             billable=True,
+            betas=["context-1m-2025-08-07"] if self._extend_context_window else None,
         )
 
     def _construct_messages(self, messages: Sequence[BaseMessage]):


### PR DESCRIPTION
## Problem

- Compaction only happens after the third message.
- Compaction breaks on >200K tokens.

## Changes

Fixed both issues and added additional tests.

## How did you test this code?

Added tests
