### PR TITLE
fix: url to state filters

### DIFF
--- a/products/error_tracking/frontend/components/IssueFilteringTool.tsx
+++ b/products/error_tracking/frontend/components/IssueFilteringTool.tsx
@@ -7,7 +7,7 @@ import { ErrorTrackingIssueFilteringToolOutput } from '~/queries/schema/schema-g
 import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
 import { errorTrackingSceneLogic } from '../scenes/ErrorTrackingScene/errorTrackingSceneLogic'
-import { taxonomicFilterLogicKey, taxonomicGroupTypes } from './IssueFilters/FilterGroup'
+import { TAXONOMIC_FILTER_LOGIC_KEY, TAXONOMIC_GROUP_TYPES } from './IssueFilters/consts'
 import { issueFiltersLogic } from './IssueFilters/issueFiltersLogic'
 import { issueQueryOptionsLogic } from './IssueQueryOptions/issueQueryOptionsLogic'
 
@@ -68,8 +68,8 @@ export function ErrorTrackingIssueFilteringTool(): JSX.Element {
     const { filterGroup } = useValues(issueFiltersLogic)
     const { setSearchQuery } = useActions(
         taxonomicFilterLogic({
-            taxonomicFilterLogicKey: taxonomicFilterLogicKey,
-            taxonomicGroupTypes: taxonomicGroupTypes,
+            taxonomicFilterLogicKey: TAXONOMIC_FILTER_LOGIC_KEY,
+            taxonomicGroupTypes: TAXONOMIC_GROUP_TYPES,
         })
     )
 

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { LemonDropdown } from '@posthog/lemon-ui'
@@ -15,17 +15,8 @@ import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 
 import { FilterLogicalOperator, PropertyFilterType, UniversalFiltersGroup } from '~/types'
 
+import { TAXONOMIC_FILTER_LOGIC_KEY, TAXONOMIC_GROUP_TYPES } from './consts'
 import { issueFiltersLogic } from './issueFiltersLogic'
-
-export const taxonomicFilterLogicKey = 'error-tracking'
-export const taxonomicGroupTypes = [
-    TaxonomicFilterGroupType.ErrorTrackingProperties,
-    TaxonomicFilterGroupType.ErrorTrackingIssues,
-    TaxonomicFilterGroupType.EventProperties,
-    TaxonomicFilterGroupType.PersonProperties,
-    TaxonomicFilterGroupType.Cohorts,
-    TaxonomicFilterGroupType.HogQLExpression,
-]
 
 export const FilterGroup = (): JSX.Element => {
     const { filterGroup } = useValues(issueFiltersLogic)
@@ -33,10 +24,10 @@ export const FilterGroup = (): JSX.Element => {
 
     return (
         <UniversalFilters
-            rootKey={taxonomicFilterLogicKey}
+            rootKey={TAXONOMIC_FILTER_LOGIC_KEY}
             group={filterGroup.values[0] as UniversalFiltersGroup}
             // TODO: Probably makes sense to create a new taxonomic group for exception-specific event property filters only, keep it clean.
-            taxonomicGroupTypes={taxonomicGroupTypes}
+            taxonomicGroupTypes={TAXONOMIC_GROUP_TYPES}
             onChange={(group) => setFilterGroup({ type: FilterLogicalOperator.And, values: [group] })}
         >
             <UniversalSearch />
@@ -59,8 +50,8 @@ const UniversalSearch = (): JSX.Element => {
     }
 
     const taxonomicFilterLogicProps: TaxonomicFilterLogicProps = {
-        taxonomicFilterLogicKey,
-        taxonomicGroupTypes,
+        taxonomicFilterLogicKey: TAXONOMIC_FILTER_LOGIC_KEY,
+        taxonomicGroupTypes: TAXONOMIC_GROUP_TYPES,
         onChange: (taxonomicGroup, value, item, originalQuery) => {
             searchInputRef.current?.blur()
             setVisible(false)
@@ -74,12 +65,6 @@ const UniversalSearch = (): JSX.Element => {
     }
 
     const onChange = useDebouncedCallback((value: string) => setSearchQuery(value), 250)
-
-    const { setSearchQuery: setTaxonomicSearchQuery } = useActions(taxonomicFilterLogic(taxonomicFilterLogicProps))
-
-    useEffect(() => {
-        setTaxonomicSearchQuery(searchQuery)
-    }, [searchQuery, setTaxonomicSearchQuery])
 
     return (
         <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { LemonDropdown } from '@posthog/lemon-ui'
@@ -74,6 +74,12 @@ const UniversalSearch = (): JSX.Element => {
     }
 
     const onChange = useDebouncedCallback((value: string) => setSearchQuery(value), 250)
+
+    const { setSearchQuery: setTaxonomicSearchQuery } = useActions(taxonomicFilterLogic(taxonomicFilterLogicProps))
+
+    useEffect(() => {
+        setTaxonomicSearchQuery(searchQuery)
+    }, [searchQuery, setTaxonomicSearchQuery])
 
     return (
         <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>

--- a/products/error_tracking/frontend/components/IssueFilters/consts.ts
+++ b/products/error_tracking/frontend/components/IssueFilters/consts.ts
@@ -1,0 +1,11 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+export const TAXONOMIC_FILTER_LOGIC_KEY = 'error-tracking'
+export const TAXONOMIC_GROUP_TYPES = [
+    TaxonomicFilterGroupType.ErrorTrackingProperties,
+    TaxonomicFilterGroupType.ErrorTrackingIssues,
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.PersonProperties,
+    TaxonomicFilterGroupType.Cohorts,
+    TaxonomicFilterGroupType.HogQLExpression,
+]

--- a/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
+++ b/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
@@ -3,13 +3,13 @@ import { actions, connect, kea, key, path, props, reducers } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Params } from 'scenes/sceneTypes'
 
 import { DateRange } from '~/queries/schema/schema-general'
 import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
 import { syncSearchParams, updateSearchParams } from '../../utils'
+import { TAXONOMIC_FILTER_LOGIC_KEY, TAXONOMIC_GROUP_TYPES } from './consts'
 import type { issueFiltersLogicType } from './issueFiltersLogicType'
 
 const DEFAULT_DATE_RANGE = { date_from: '-7d', date_to: null }
@@ -32,15 +32,8 @@ export const issueFiltersLogic = kea<issueFiltersLogicType>([
     connect(() => ({
         actions: [
             taxonomicFilterLogic({
-                taxonomicFilterLogicKey: 'error-tracking',
-                taxonomicGroupTypes: [
-                    TaxonomicFilterGroupType.ErrorTrackingProperties,
-                    TaxonomicFilterGroupType.ErrorTrackingIssues,
-                    TaxonomicFilterGroupType.EventProperties,
-                    TaxonomicFilterGroupType.PersonProperties,
-                    TaxonomicFilterGroupType.Cohorts,
-                    TaxonomicFilterGroupType.HogQLExpression,
-                ],
+                taxonomicFilterLogicKey: TAXONOMIC_FILTER_LOGIC_KEY,
+                taxonomicGroupTypes: TAXONOMIC_GROUP_TYPES,
             }),
             ['setSearchQuery as setTaxonomicSearchQuery'],
         ],

--- a/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
+++ b/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
@@ -1,7 +1,9 @@
 import equal from 'fast-deep-equal'
-import { actions, kea, key, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, path, props, reducers } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
+import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Params } from 'scenes/sceneTypes'
 
 import { DateRange } from '~/queries/schema/schema-general'
@@ -26,6 +28,23 @@ export const issueFiltersLogic = kea<issueFiltersLogicType>([
     path(['products', 'error_tracking', 'components', 'IssueFilters', 'issueFiltersLogic']),
     props({} as IssueFiltersLogicProps),
     key(({ logicKey }) => logicKey),
+
+    connect(() => ({
+        actions: [
+            taxonomicFilterLogic({
+                taxonomicFilterLogicKey: 'error-tracking',
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.ErrorTrackingProperties,
+                    TaxonomicFilterGroupType.ErrorTrackingIssues,
+                    TaxonomicFilterGroupType.EventProperties,
+                    TaxonomicFilterGroupType.PersonProperties,
+                    TaxonomicFilterGroupType.Cohorts,
+                    TaxonomicFilterGroupType.HogQLExpression,
+                ],
+            }),
+            ['setSearchQuery as setTaxonomicSearchQuery'],
+        ],
+    })),
 
     actions({
         setDateRange: (dateRange: DateRange) => ({ dateRange }),
@@ -76,6 +95,7 @@ export const issueFiltersLogic = kea<issueFiltersLogicType>([
             }
             if (params.searchQuery && !equal(params.searchQuery, values.searchQuery)) {
                 actions.setSearchQuery(params.searchQuery)
+                actions.setTaxonomicSearchQuery(params.searchQuery)
             }
         }
         return {


### PR DESCRIPTION
## Problem

When we have a plain search query without any filters in the omni search, refreshing the page wipes it from the UI (but the search query is still used as a filter)

## Changes

Fixed it
