### PR TITLE
fix(logs): fixes wrong attribute operator appearing in the logs universal filter

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -289,10 +289,12 @@ export function isPropertyFilterWithOperator(
     | SessionPropertyFilter
     | RecordingPropertyFilter
     | LogEntryPropertyFilter
+    | LogPropertyFilter
     | FeaturePropertyFilter
     | GroupPropertyFilter
     | DataWarehousePropertyFilter
-    | DataWarehousePersonPropertyFilter {
+    | DataWarehousePersonPropertyFilter
+    | LogPropertyFilter {
     return (
         !isPropertyGroupFilterLike(filter) &&
         (isEventPropertyFilter(filter) ||
@@ -309,7 +311,8 @@ export function isPropertyFilterWithOperator(
             isCohortPropertyFilter(filter) ||
             isDataWarehousePropertyFilter(filter) ||
             isDataWarehousePersonPropertyFilter(filter) ||
-            isErrorTrackingIssuePropertyFilter(filter))
+            isErrorTrackingIssuePropertyFilter(filter) ||
+            isLogPropertyFilter(filter))
     )
 }
 

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -26,7 +26,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { LogMessage } from '~/queries/schema/schema-general'
-import { ProductKey, PropertyFilterType, PropertyOperator, UniversalFiltersGroup } from '~/types'
+import { ProductKey, PropertyOperator } from '~/types'
 
 import { LogsTableRowActions } from 'products/logs/frontend/components/LogsTable/LogsTableRowActions'
 import { LogsFilterGroup } from 'products/logs/frontend/components/filters/LogsFilters/FilterGroup'
@@ -166,24 +166,11 @@ export function LogsScene(): JSX.Element {
 }
 
 const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
-    const { filterGroup, expandedAttributeBreaksdowns } = useValues(logsLogic)
-    const { setFilterGroup, toggleAttributeBreakdown } = useActions(logsLogic)
+    const { expandedAttributeBreaksdowns } = useValues(logsLogic)
+    const { addFilter, toggleAttributeBreakdown } = useActions(logsLogic)
 
     const attributes = log.attributes
     const rows = Object.entries(attributes).map(([key, value]) => ({ key, value }))
-
-    const addFilter = (key: string, value: string, operator = PropertyOperator.Exact): void => {
-        const newGroup = { ...filterGroup.values[0] } as UniversalFiltersGroup
-
-        newGroup.values.push({
-            key,
-            value: [value],
-            operator: operator,
-            type: PropertyFilterType.Log,
-        })
-
-        setFilterGroup({ ...filterGroup, values: [newGroup] }, false)
-    }
 
     return (
         <LemonTable

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -14,7 +14,7 @@ import { Params } from 'scenes/sceneTypes'
 
 import { DateRange, LogMessage, LogsQuery } from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
-import { JsonType, PropertyGroupFilter, UniversalFiltersGroup } from '~/types'
+import { JsonType, PropertyFilterType, PropertyGroupFilter, PropertyOperator, UniversalFiltersGroup } from '~/types'
 
 import { zoomDateRange } from './filters/zoom-utils'
 import type { logsLogicType } from './logsLogicType'
@@ -103,6 +103,11 @@ export const logsLogic = kea<logsLogicType>([
         zoomDateRange: (multiplier: number) => ({ multiplier }),
         setDateRangeFromSparkline: (startIndex: number, endIndex: number) => ({ startIndex, endIndex }),
         setTimestampFormat: (timestampFormat: 'absolute' | 'relative') => ({ timestampFormat }),
+        addFilter: (key: string, value: string, operator: PropertyOperator = PropertyOperator.Exact) => ({
+            key,
+            value,
+            operator,
+        }),
     }),
 
     reducers({
@@ -391,6 +396,24 @@ export const logsLogic = kea<logsLogicType>([
                 date_to: dateTo,
             }
             actions.setDateRange(newDateRange)
+        },
+        addFilter: ({ key, value, operator }) => {
+            const currentGroup = values.filterGroup.values[0] as UniversalFiltersGroup
+
+            const newGroup: UniversalFiltersGroup = {
+                ...currentGroup,
+                values: [
+                    ...currentGroup.values,
+                    {
+                        key,
+                        value: [value],
+                        operator,
+                        type: PropertyFilterType.Log,
+                    },
+                ],
+            }
+
+            actions.setFilterGroup({ ...values.filterGroup, values: [newGroup] }, false)
         },
     })),
 ])


### PR DESCRIPTION
## Problem

The wrong operator was appearing in the logs universal filter, we were seeing "exact" when it should have been "is_not"

## Changes

<img width="975" height="105" alt="image" src="https://github.com/user-attachments/assets/971d4d56-2dab-4adc-88a8-424a281c49ed" />

- Adds log property filter to PropertyFilter utils
- Places "Add Filter" logic into logs logic instead of ExpandedLog component

## How did you test this code?

local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._