### PR TITLE
feat(flags): handle partioned person tables in the foreign key lookup

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -152,7 +152,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     // That's fine though, we shouldn't error out just because we can't find a person ID.
     let person_query_start = Instant::now();
     let person_query_timer = common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &query_labels);
-    let person = Person::from_distinct_id(&mut *conn, team_id, &distinct_id).await?;
+    let person = Person::from_distinct_id(&mut conn, team_id, &distinct_id).await?;
     let (person_id, person_props) = person
         .map(|p| (Some(p.id), Some(p.properties)))
         .unwrap_or((None, None));


### PR DESCRIPTION
## Problem

We're doing some emergency persons table surgery and flags need some work done. This PR does the following:

1. supports removing the foreign key constraint from the `posthog_featureflaghashkeyoverride` table

Context: we now might see foreign key constraint violations in this case

```
Time T1: Query with EXISTS runs → finds person_id=123 (valid)
Time T2: Person 123 gets deleted
Time T3: Bulk insert runs → inserts person_id=123 (NOW INVALID)
```

This is an edge case for sure, and the consequences basically are that we might accidentally insert overrides into the table for people that no longer exist. The good news is that it doesn't really affect the flag targeting at all, it just means that we would insert invalid data into the override table (the garbage data wouldn't get used ever, but it would just set there being incorrect). However, we can always clean it up later. As I said on the call, it's an acceptable risk IMO. Going to whip up a PR that removes the foreign key constraint and the code that works around it.

2. Handles the partition table lookup for the FK existence check that I talked about in (1)