### PR TITLE
feat(logs): remove last 30 day filter, add last 5mins filter

### DIFF
--- a/products/logs/frontend/filters/DateRangeFilter.tsx
+++ b/products/logs/frontend/filters/DateRangeFilter.tsx
@@ -12,6 +12,14 @@ import { logsLogic } from '../logsLogic'
 const dateMapping: DateMappingOption[] = [
     { key: CUSTOM_OPTION_KEY, values: [] },
     {
+        key: 'Last 5 minutes',
+        values: ['-5M'],
+        getFormattedDate: (date: dayjs.Dayjs): string => {
+            return date.subtract(5, 'minute').format(DATE_TIME_FORMAT)
+        },
+        defaultInterval: 'minute',
+    },
+    {
         key: 'Last 30 minutes',
         values: ['-30M'],
         getFormattedDate: (date: dayjs.Dayjs): string => {
@@ -41,12 +49,6 @@ const dateMapping: DateMappingOption[] = [
         key: 'Last 7 days',
         values: ['-7d'],
         getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(7, 'd'), date.endOf('d')),
-        defaultInterval: 'day',
-    },
-    {
-        key: 'Last 30 days',
-        values: ['-30d'],
-        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(30, 'd'), date.endOf('d')),
         defaultInterval: 'day',
     },
 ]


### PR DESCRIPTION

## Problem
we only have 7 day retention right now so 30 days search makes no sense

most recent 5 mins is a useful one

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
