### PR TITLE
fix(ph-ai): do not capture max tool retryable exception

### DIFF
--- a/ee/hogai/graph/agent_modes/nodes.py
+++ b/ee/hogai/graph/agent_modes/nodes.py
@@ -26,7 +26,7 @@ from ee.hogai.graph.conversation_summarizer.nodes import AnthropicConversationSu
 from ee.hogai.graph.shared_prompts import CORE_MEMORY_PROMPT
 from ee.hogai.llm import MaxChatAnthropic
 from ee.hogai.tool import ToolMessagesArtifact
-from ee.hogai.tool_errors import MaxToolError
+from ee.hogai.tool_errors import MaxToolError, MaxToolRetryableError
 from ee.hogai.tools import ReadDataTool, ReadTaxonomyTool, SearchTool, TodoWriteTool
 from ee.hogai.utils.anthropic import add_cache_control, convert_to_anthropic_messages
 from ee.hogai.utils.helpers import convert_tool_messages_to_dict, normalize_ai_message
@@ -475,15 +475,16 @@ class AgentToolsExecutable(BaseAgentExecutable):
             logger.exception(
                 "maxtool_error", extra={"tool": tool_call.name, "error": str(e), "retry_strategy": e.retry_strategy}
             )
-            capture_exception(
-                e,
-                distinct_id=self._get_user_distinct_id(config),
-                properties={
-                    **self._get_debug_props(config),
-                    "tool": tool_call.name,
-                    "retry_strategy": e.retry_strategy,
-                },
-            )
+            if not isinstance(e, MaxToolRetryableError):
+                capture_exception(
+                    e,
+                    distinct_id=self._get_user_distinct_id(config),
+                    properties={
+                        **self._get_debug_props(config),
+                        "tool": tool_call.name,
+                        "retry_strategy": e.retry_strategy,
+                    },
+                )
 
             content = f"Tool failed: {e.to_summary()}.{e.retry_hint}"
             return PartialAssistantState(


### PR DESCRIPTION
## Problem
Currently, we're capturing all MaxToolError exceptions in Sentry, including retryable errors. This creates unnecessary noise in our error tracking system.

## Changes
- Added a condition to check if the error is not a `MaxToolRetryableError` before capturing it

## How did you test this code?
Locally