### PR TITLE
feat: Add clear indication that viewset is being enabled

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -17,6 +17,7 @@ export interface LemonSwitchProps {
     fullWidth?: boolean
     size?: 'xxsmall' | 'xsmall' | 'small' | 'medium'
     bordered?: boolean
+    /** @deprecated Checkboxes should never be quietly disabled. Use `disabledReason` to provide an explanation instead. */
     disabled?: boolean
     /** Like plain `disabled`, except we enforce a reason to be shown in the tooltip. */
     disabledReason?: string | null | false

--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetCard.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetCard.tsx
@@ -76,13 +76,27 @@ export function DataWarehouseManagedViewsetCard({
                 </div>
 
                 <AccessControlAction resourceType={resourceType} minAccessLevel={AccessControlLevel.Editor}>
-                    <LemonSwitch
-                        checked={isEnabled}
-                        onChange={(enabled) => toggleViewset(kind, enabled)}
-                        disabled={isToggling}
-                        label={isEnabled ? 'Enabled' : 'Disabled'}
-                        bordered
-                    />
+                    {({ disabledReason }) => (
+                        <div className="flex flex-col gap-2 flex-start items-start">
+                            <LemonSwitch
+                                checked={isEnabled}
+                                onChange={(enabled) => toggleViewset(kind, enabled)}
+                                disabledReason={
+                                    isToggling ? 'Saving, this might take a few seconds...' : disabledReason
+                                }
+                                label={
+                                    isToggling
+                                        ? isEnabled
+                                            ? 'Disabling, please wait a moment...'
+                                            : 'Enabling, please wait a moment...'
+                                        : isEnabled
+                                          ? 'Enabled'
+                                          : 'Disabled'
+                                }
+                                bordered
+                            />
+                        </div>
+                    )}
                 </AccessControlAction>
             </div>
         </div>


### PR DESCRIPTION
This takes a while because we gotta create a lot of views and setup materialization for them, so let's add a more clear indicator that something's happening