### PR TITLE
chore(flags): Add `HyperCache` for Rust feature-flags service

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -85,6 +85,9 @@ class PostHogConfig(AppConfig):
 
         file_system_registrations.register_core_file_system_types()
 
+        # Import signal handlers to register them
+        from posthog.models.feature_flag import flags_cache  # noqa: F401
+
     def _setup_lazy_admin(self):
         """Set up lazy loading of admin classes to avoid importing all at startup."""
         import sys

--- a/posthog/models/feature_flag/__init__.py
+++ b/posthog/models/feature_flag/__init__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401
+# ruff: noqa: F401, I001
 
 from .feature_flag import (
     FeatureFlag,

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -1,10 +1,11 @@
 import json
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.cache import cache
 from django.db import DatabaseError, models, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.http import HttpRequest
 from django.utils import timezone
@@ -525,49 +526,91 @@ class FeatureFlagOverride(models.Model):
         ]
 
 
-def set_feature_flags_for_team_in_cache(
-    project_id: int,
-    feature_flags: Optional[list[FeatureFlag]] = None,
-    using_database: str = "default",
+def get_feature_flags(
+    team: Optional["Team"] = None,
+    project_id: Optional[int] = None,
 ) -> list[FeatureFlag]:
-    from django.contrib.postgres.aggregates import ArrayAgg
-    from django.db.models import Q
+    """
+    Fetch FeatureFlag objects for a team or project.
 
+    Evaluation tags are always aggregated using ArrayAgg for performance.
+    This avoids N+1 queries when serializing flags with evaluation tags.
+
+    Args:
+        team: Team to get flags for (mutually exclusive with project_id)
+        project_id: Project ID to get flags for (mutually exclusive with team)
+
+    Returns:
+        List of FeatureFlag model instances with evaluation tags pre-loaded
+    """
+    # Build query filter
+    filter_kwargs: dict[str, Any]
+    if team is not None:
+        filter_kwargs = {"team": team}
+    elif project_id is not None:
+        filter_kwargs = {"team__project_id": project_id}
+    else:
+        raise ValueError("Either team or project_id must be provided")
+
+    filter_kwargs.update({"active": True, "deleted": False})
+
+    # Build queryset with evaluation tags aggregated
+    # Single-shot query: flags plus evaluation tag names aggregated to a string array.
+    # We use ArrayAgg to fetch all evaluation tag names in one query instead of
+    # doing a separate query per flag. This is crucial for performance when we have
+    # many flags. The evaluation tags are stored as a many-to-many relationship
+    # through FeatureFlagEvaluationTag, but we aggregate them here for efficiency.
+    qs = FeatureFlag.objects.filter(**filter_kwargs)
+    qs = qs.annotate(
+        evaluation_tag_names_agg=ArrayAgg(
+            "evaluation_tags__tag__name",
+            filter=Q(evaluation_tags__isnull=False),
+            distinct=True,
+        )
+    )
+
+    all_feature_flags = list(qs)
+
+    # Transfer the aggregated tag names to the _evaluation_tag_names attribute
+    # so the serializer can access them without additional queries. This is a
+    # cache projection pattern - we're storing derived data on the model instance
+    # that will be serialized to cache.
+    for _flag in all_feature_flags:
+        try:
+            _flag._evaluation_tag_names = getattr(_flag, "evaluation_tag_names_agg", None)
+        except AttributeError:
+            # evaluation_tag_names_agg field missing from aggregation query
+            _flag._evaluation_tag_names = None
+
+    return all_feature_flags
+
+
+def serialize_feature_flags(flags: list[FeatureFlag]) -> list[dict[str, Any]]:
+    """
+    Serialize FeatureFlag objects to dictionary format.
+
+    Args:
+        flags: List of FeatureFlag instances to serialize
+
+    Returns:
+        List of serialized flag dictionaries
+    """
     from posthog.api.feature_flag import MinimalFeatureFlagSerializer
 
-    if feature_flags is not None:
-        all_feature_flags = feature_flags
-    else:
-        # Single-shot query: flags plus evaluation tag names aggregated to a string array.
-        # We use ArrayAgg to fetch all evaluation tag names in one query instead of
-        # doing a separate query per flag. This is crucial for performance when we have
-        # many flags. The evaluation tags are stored as a many-to-many relationship
-        # through FeatureFlagEvaluationTag, but we aggregate them here for efficiency.
-        qs = (
-            FeatureFlag.objects.db_manager(using_database)
-            .filter(team__project_id=project_id, active=True, deleted=False)
-            .annotate(
-                evaluation_tag_names_agg=ArrayAgg(
-                    "evaluation_tags__tag__name",
-                    filter=Q(evaluation_tags__isnull=False),
-                    distinct=True,
-                )
-            )
-        )
-        all_feature_flags = list(qs)
-        # Transfer the aggregated tag names to the _evaluation_tag_names attribute
-        # so the serializer can access them without additional queries. This is a
-        # cache projection pattern - we're storing derived data on the model instance
-        # that will be serialized to Redis.
-        for _flag in all_feature_flags:
-            try:
-                _flag._evaluation_tag_names = getattr(_flag, "evaluation_tag_names_agg", None)
-            except AttributeError:
-                # evaluation_tag_names_agg field missing from aggregation query
-                _flag._evaluation_tag_names = None
+    serialized_data = MinimalFeatureFlagSerializer(flags, many=True).data
+    return list(serialized_data)
 
-    serialized_flags = MinimalFeatureFlagSerializer(all_feature_flags, many=True).data
 
+def set_feature_flags_for_team_in_cache(
+    project_id: int,
+) -> list[FeatureFlag]:
+    # Fetch flags once (with evaluation tags pre-loaded)
+    all_feature_flags = get_feature_flags(project_id=project_id)
+
+    # Serialize for cache storage
+    serialized_flags = serialize_feature_flags(all_feature_flags)
+
+    # Write to Redis cache
     write_flags_to_cache(f"team_feature_flags_{project_id}", json.dumps(serialized_flags), FIVE_DAYS)
 
     return all_feature_flags

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -1,0 +1,171 @@
+"""
+Flags HyperCache for feature-flags service.
+
+This module provides a HyperCache that stores feature flags for the feature-flags service.
+Unlike the local_evaluation.py cache which provides rich data for SDKs (including cohorts
+and group type mappings), this cache provides just the raw flag data.
+
+The cache is automatically invalidated when:
+- FeatureFlag models are created, updated, or deleted
+- Team models are created or deleted (to ensure flag caches are cleaned up)
+
+Cache Key Pattern:
+- Uses team_id as the key
+- Stored in both Redis and S3 via HyperCache
+
+Configuration:
+- Redis TTL: 7 days (configurable via FLAGS_CACHE_TTL env var)
+- Miss TTL: 1 day (configurable via FLAGS_CACHE_MISS_TTL env var)
+"""
+
+from typing import Any
+
+from django.conf import settings
+from django.core.cache import cache, caches
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+import structlog
+
+from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
+from posthog.models.feature_flag import FeatureFlag
+from posthog.models.feature_flag.feature_flag import get_feature_flags, serialize_feature_flags
+from posthog.models.team import Team
+from posthog.storage.hypercache import HyperCache
+
+logger = structlog.get_logger(__name__)
+
+
+def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
+    """
+    Get feature flags for the feature-flags service.
+
+    Fetches all active, non-deleted feature flags for the team and returns them
+    wrapped in a dict that HyperCache can serialize. The actual flag data is in the
+    "flags" key as a list of flag dictionaries.
+
+    Returns:
+        dict: {"flags": [...]} where flags is a list of flag dictionaries
+    """
+    flags = get_feature_flags(team=team)
+    flags_data = serialize_feature_flags(flags)
+
+    logger.info(
+        "Loaded feature flags for service cache",
+        team_id=team.id,
+        project_id=team.project_id,
+        flag_count=len(flags_data),
+    )
+
+    # Wrap in dict for HyperCache compatibility
+    return {"flags": flags_data}
+
+
+# Use dedicated flags cache if available, otherwise fall back to default cache
+if FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES:
+    _flags_cache_client = caches[FLAGS_DEDICATED_CACHE_ALIAS]
+else:
+    _flags_cache_client = cache
+
+# HyperCache instance for feature-flags service
+flags_hypercache = HyperCache(
+    namespace="feature_flags",
+    value="flags.json",
+    load_fn=lambda key: _get_feature_flags_for_service(HyperCache.team_from_key(key)),
+    cache_ttl=settings.FLAGS_CACHE_TTL,
+    cache_miss_ttl=settings.FLAGS_CACHE_MISS_TTL,
+    cache_client=_flags_cache_client,
+)
+
+
+def get_flags_from_cache(team: Team) -> list[dict[str, Any]]:
+    """
+    Get feature flags from the cache for a team.
+
+    Args:
+        team: The team to get flags for
+
+    Returns:
+        List of flag dictionaries (empty list if not found)
+    """
+    result = flags_hypercache.get_from_cache(team)
+    if result is None:
+        return []
+    return result.get("flags", [])
+
+
+def update_flags_cache(team: Team) -> None:
+    """
+    Update the flags cache for a team.
+
+    This explicitly updates both Redis and S3 with the latest flag data.
+
+    Args:
+        team: The team to update cache for
+    """
+    flags_hypercache.update_cache(team)
+
+
+def clear_flags_cache(team: Team, kinds: list[str] | None = None) -> None:
+    """
+    Clear the flags cache for a team.
+
+    Args:
+        team: The team to clear cache for
+        kinds: Optional list of cache kinds to clear ("redis", "s3")
+    """
+    flags_hypercache.clear_cache(team, kinds=kinds)
+
+
+# Signal handlers for automatic cache invalidation
+
+
+@receiver(post_save, sender=FeatureFlag)
+@receiver(post_delete, sender=FeatureFlag)
+def feature_flag_changed_flags_cache(sender, instance: "FeatureFlag", **kwargs):
+    """
+    Invalidate flags cache when a feature flag is created, updated, or deleted.
+
+    This ensures the feature-flags service always has fresh flag data after any flag changes.
+    Only operates when FLAGS_REDIS_URL is configured.
+    """
+    if not settings.FLAGS_REDIS_URL:
+        return
+
+    from posthog.tasks.feature_flags import update_team_service_flags_cache
+
+    # Defer task execution until after the transaction commits to avoid race conditions
+    transaction.on_commit(lambda: update_team_service_flags_cache.delay(instance.team_id))
+
+
+@receiver(post_save, sender=Team)
+def team_created_flags_cache(sender, instance: "Team", created: bool, **kwargs):
+    """
+    Warm flags cache when a team is created.
+
+    This ensures the cache is immediately available for new teams.
+    Only operates when FLAGS_REDIS_URL is configured.
+    """
+    if not created or not settings.FLAGS_REDIS_URL:
+        return
+
+    from posthog.tasks.feature_flags import update_team_service_flags_cache
+
+    transaction.on_commit(lambda: update_team_service_flags_cache.delay(instance.id))
+
+
+@receiver(post_delete, sender=Team)
+def team_deleted_flags_cache(sender, instance: "Team", **kwargs):
+    """
+    Clear flags cache when a team is deleted.
+
+    This ensures we don't have stale cache entries for deleted teams.
+    Only operates when FLAGS_REDIS_URL is configured.
+    """
+    if not settings.FLAGS_REDIS_URL:
+        return
+
+    # For unit tests, only clear Redis to avoid S3 timestamp issues with frozen time
+    kinds = ["redis"] if settings.TEST else None
+    clear_flags_cache(instance, kinds=kinds)

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -83,12 +83,17 @@ def get_flags_from_cache(team: Team) -> list[dict[str, Any]]:
     """
     Get feature flags from the cache for a team.
 
+    Only operates when FLAGS_REDIS_URL is configured to avoid reading from/writing to shared cache.
+
     Args:
         team: The team to get flags for
 
     Returns:
-        List of flag dictionaries (empty list if not found)
+        List of flag dictionaries (empty list if not found or FLAGS_REDIS_URL not configured)
     """
+    if not settings.FLAGS_REDIS_URL:
+        return []
+
     result = flags_hypercache.get_from_cache(team)
     if result is None:
         return []
@@ -100,10 +105,14 @@ def update_flags_cache(team: Team) -> None:
     Update the flags cache for a team.
 
     This explicitly updates both Redis and S3 with the latest flag data.
+    Only operates when FLAGS_REDIS_URL is configured to avoid writing to shared cache.
 
     Args:
         team: The team to update cache for
     """
+    if not settings.FLAGS_REDIS_URL:
+        return
+
     flags_hypercache.update_cache(team)
 
 
@@ -111,10 +120,15 @@ def clear_flags_cache(team: Team, kinds: list[str] | None = None) -> None:
     """
     Clear the flags cache for a team.
 
+    Only operates when FLAGS_REDIS_URL is configured to avoid writing to shared cache.
+
     Args:
         team: The team to clear cache for
         kinds: Optional list of cache kinds to clear ("redis", "s3")
     """
+    if not settings.FLAGS_REDIS_URL:
+        return
+
     flags_hypercache.clear_cache(team, kinds=kinds)
 
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1,0 +1,391 @@
+"""
+Tests for the flags HyperCache for feature-flags service.
+
+Tests cover:
+- Basic cache operations (get, update, clear)
+- Signal handlers for automatic cache invalidation
+- Celery task integration
+- Data format compatibility with service
+"""
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from posthog.models import FeatureFlag, Team
+from posthog.models.feature_flag.flags_cache import (
+    _get_feature_flags_for_service,
+    clear_flags_cache,
+    flags_hypercache,
+    get_flags_from_cache,
+    update_flags_cache,
+)
+
+
+class TestServiceFlagsCache(BaseTest):
+    """Test basic cache operations for service flags HyperCache."""
+
+    def setUp(self):
+        super().setUp()
+        # Clear cache before each test
+        clear_flags_cache(self.team, kinds=["redis", "s3"])
+
+    def test_cache_key_format(self):
+        """Test that cache key is formatted correctly for service flags."""
+        key = flags_hypercache.get_cache_key(self.team.id)
+        assert key == f"cache/teams/{self.team.id}/feature_flags/flags.json"
+
+    def test_get_feature_flags_for_service_empty(self):
+        """Test fetching flags when team has no flags."""
+        result = _get_feature_flags_for_service(self.team)
+
+        assert result == {"flags": []}
+
+    def test_get_feature_flags_for_service_with_flags(self):
+        """Test fetching flags returns correct format for service."""
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            name="Test Flag",
+            created_by=self.user,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+            },
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+        flags = result["flags"]
+
+        assert len(flags) == 1
+        flag_data = flags[0]
+
+        # Verify service-compatible fields are present
+        assert flag_data["id"] == flag.id
+        assert flag_data["team_id"] == self.team.id
+        assert flag_data["key"] == "test-flag"
+        assert flag_data["name"] == "Test Flag"
+        assert flag_data["deleted"] is False
+        assert flag_data["active"] is True
+        assert "filters" in flag_data
+        assert "version" in flag_data
+
+    def test_get_feature_flags_for_service_excludes_deleted(self):
+        """Test that deleted flags are excluded from cache."""
+        # Create active flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="active-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Create deleted flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="deleted-flag",
+            created_by=self.user,
+            deleted=True,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+        flags = result["flags"]
+
+        assert len(flags) == 1
+        assert flags[0]["key"] == "active-flag"
+
+    def test_get_feature_flags_for_service_excludes_inactive(self):
+        """Test that inactive flags are excluded from cache."""
+        # Create active flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="active-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Create inactive flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="inactive-flag",
+            created_by=self.user,
+            active=False,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+        flags = result["flags"]
+
+        assert len(flags) == 1
+        assert flags[0]["key"] == "active-flag"
+
+    def test_get_flags_from_cache_redis_hit(self):
+        """Test getting flags from Redis cache."""
+        # Create a flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="cached-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Warm the cache
+        update_flags_cache(self.team)
+
+        # Get from cache (should hit Redis)
+        flags = get_flags_from_cache(self.team)
+
+        assert len(flags) == 1
+        assert flags[0]["key"] == "cached-flag"
+
+    def test_update_flags_cache(self):
+        """Test explicitly updating the service flags cache."""
+        # Create a flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Update cache
+        update_flags_cache(self.team)
+
+        # Verify cache was updated
+        flags = get_flags_from_cache(self.team)
+        assert len(flags) == 1
+        assert flags[0]["key"] == "test-flag"
+
+    def test_clear_flags_cache(self):
+        """Test clearing the service flags cache."""
+        # Create and cache a flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flags_cache(self.team)
+
+        # Clear the cache
+        clear_flags_cache(self.team)
+
+        # Cache should now load from DB (source will be "db")
+        flags, source = flags_hypercache.get_from_cache_with_source(self.team)
+        assert source == "db"
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestServiceFlagsSignals(BaseTest):
+    """Test Django signal handlers for automatic cache invalidation."""
+
+    def setUp(self):
+        super().setUp()
+        clear_flags_cache(self.team, kinds=["redis", "s3"])
+
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    def test_signal_fired_on_flag_create(self, mock_task):
+        """Test that signal fires when a flag is created."""
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="new-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Signal should trigger the Celery task
+        mock_task.delay.assert_called_once_with(self.team.id)
+
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    def test_signal_fired_on_flag_update(self, mock_task):
+        """Test that signal fires when a flag is updated."""
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+        )
+
+        # Reset mock to ignore the create signal
+        mock_task.reset_mock()
+
+        # Update the flag
+        flag.filters = {"groups": [{"properties": [], "rollout_percentage": 100}]}
+        flag.save()
+
+        # Signal should trigger the Celery task
+        mock_task.delay.assert_called_once_with(self.team.id)
+
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    def test_signal_fired_on_flag_delete(self, mock_task):
+        """Test that signal fires when a flag is deleted."""
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Reset mock to ignore the create signal
+        mock_task.reset_mock()
+
+        # Delete the flag
+        flag.delete()
+
+        # Signal should trigger the Celery task
+        mock_task.delay.assert_called_once_with(self.team.id)
+
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    def test_signal_fired_on_team_create(self, mock_task):
+        """Test that signal fires when a team is created."""
+        # Create a new team
+        new_team = Team.objects.create(
+            organization=self.organization,
+            name="New Test Team",
+        )
+
+        # Signal should trigger the Celery task to warm cache
+        mock_task.delay.assert_called_once_with(new_team.id)
+
+    def test_signal_clears_cache_on_team_delete(self):
+        """Test that cache is cleared when a team is deleted."""
+        # Create and cache a flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        update_flags_cache(self.team)
+
+        # Verify cache exists
+        flags = get_flags_from_cache(self.team)
+        assert len(flags) == 1
+
+        # Delete the team
+        self.team.delete()
+
+        # Cache should be cleared (this will load from DB and return empty)
+        # We can't test directly with the deleted team object, but the signal should have fired
+        # In production, this prevents stale cache entries
+
+
+class TestServiceFlagsCeleryTasks(BaseTest):
+    """Test Celery task integration for service flags cache updates."""
+
+    def setUp(self):
+        super().setUp()
+        clear_flags_cache(self.team, kinds=["redis", "s3"])
+
+    def test_update_team_service_flags_cache_task(self):
+        """Test the Celery task that updates service flags cache."""
+        from posthog.tasks.feature_flags import update_team_service_flags_cache
+
+        # Create a flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Run the task synchronously
+        update_team_service_flags_cache(self.team.id)
+
+        # Verify cache was updated
+        flags = get_flags_from_cache(self.team)
+        assert len(flags) == 1
+        assert flags[0]["key"] == "test-flag"
+
+    def test_update_team_service_flags_cache_task_team_not_found(self):
+        """Test the Celery task handles missing team gracefully."""
+        from posthog.tasks.feature_flags import update_team_service_flags_cache
+
+        # Run task with non-existent team ID
+        # Should not raise an exception
+        update_team_service_flags_cache(999999)
+
+
+class TestServiceFlagsDataFormat(BaseTest):
+    """Test that cached data format matches service expectations."""
+
+    def setUp(self):
+        super().setUp()
+        clear_flags_cache(self.team, kinds=["redis", "s3"])
+
+    def test_flag_data_contains_required_rust_fields(self):
+        """Test that flag data includes all fields expected by Rust."""
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="rust-compatible-flag",
+            name="Rust Compatible Flag",
+            created_by=self.user,
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"key": "email", "value": "test@example.com", "type": "person"}],
+                        "rollout_percentage": 50,
+                    }
+                ],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+            ensure_experience_continuity=True,
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+        flags = result["flags"]
+        flag_data = flags[0]
+
+        # Required fields for service FeatureFlag struct
+        required_fields = [
+            "id",
+            "team_id",
+            "name",
+            "key",
+            "filters",
+            "deleted",
+            "active",
+            "ensure_experience_continuity",
+            "version",
+        ]
+
+        for field in required_fields:
+            assert field in flag_data, f"Missing required field: {field}"
+
+        # Verify filters structure
+        assert "groups" in flag_data["filters"]
+        assert len(flag_data["filters"]["groups"]) == 1
+        assert "multivariate" in flag_data["filters"]
+
+    def test_flag_data_serializes_to_json(self):
+        """Test that flag data can be serialized to JSON (for Redis/S3 storage)."""
+        import json
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="json-test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+
+        # Should serialize without errors
+        json_str = json.dumps(result)
+        assert json_str is not None
+
+        # Should deserialize back to same structure
+        deserialized = json.loads(json_str)
+        assert "flags" in deserialized
+        assert len(deserialized["flags"]) == 1
+        assert deserialized["flags"][0]["key"] == "json-test-flag"

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -410,6 +410,8 @@ if not EMBEDDING_API_URL:
 # Dedicated Redis for feature flags
 # This allows feature-flags service to have dedicated Redis for better resource isolation
 FLAGS_REDIS_URL = os.getenv("FLAGS_REDIS_URL", None)
+FLAGS_CACHE_TTL = int(os.getenv("FLAGS_CACHE_TTL", str(60 * 60 * 24 * 7)))  # 7 days
+FLAGS_CACHE_MISS_TTL = int(os.getenv("FLAGS_CACHE_MISS_TTL", str(60 * 60 * 24)))  # 1 day
 
 
 CACHES = {

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -1,6 +1,7 @@
 import structlog
 from celery import shared_task
 
+from posthog.models.feature_flag.flags_cache import update_flags_cache
 from posthog.models.feature_flag.local_evaluation import update_flag_caches
 from posthog.models.team import Team
 from posthog.tasks.utils import CeleryQueue
@@ -17,6 +18,23 @@ def update_team_flags_cache(team_id: int) -> None:
         return
 
     update_flag_caches(team)
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+def update_team_service_flags_cache(team_id: int) -> None:
+    """
+    Update the service flags cache for a specific team.
+
+    This task is triggered when feature flags change or when teams are created,
+    ensuring the feature-flags service has fresh data in HyperCache.
+    """
+    try:
+        team = Team.objects.get(id=team_id)
+    except Team.DoesNotExist:
+        logger.exception("Team does not exist for service flags cache update", team_id=team_id)
+        return
+
+    update_flags_cache(team)
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -48,6 +48,7 @@
     'posthog.tasks.exporter.export_asset',
     'posthog.tasks.feature_flags.sync_all_flags_cache',
     'posthog.tasks.feature_flags.update_team_flags_cache',
+    'posthog.tasks.feature_flags.update_team_service_flags_cache',
     'posthog.tasks.heatmap_screenshot.generate_heatmap_screenshot',
     'posthog.tasks.hog_flows.refresh_affected_hog_flows',
     'posthog.tasks.hog_functions.refresh_affected_hog_functions',


### PR DESCRIPTION
Implements a Django `HyperCache` that stores feature flags in a format compatible with the Rust feature-flags service. This is the first step in transitioning from `ReadThroughCache` to `HyperCache`.

Related PR: #41123

## Problem

Per the dedicated [flags redis rfc](https://github.com/PostHog/requests-for-comments-internal/pull/909), the rust flags service needs a cache of flags data in its own dedicated Redis cluster:

## Changes

This adds a new `HyperCache` instance pointing to the flags dedicated cache. If the dedicated cache is not configured, the cache points to the shared cache, but we avoid writing to it.

We then update the cache in response to signals:
- Flag created, updated, deleted
- Team created, deleted.

TTLs for cache entries are configurable:

- `FLAGS_CACHE_TTL` - default 7 days
- `FLAGS_CACHE_MISS_TTL` - default 1 day

## How did you test this code?

Unit Tests
Manually

## Notes

- This PR only implements the cache and signal handling:
  - Management commands to prime the cache and verify the cache (like we do in #41123) will come later.
  - The code to refresh the cache for entries about to expire will also come later.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
