### PR TITLE
fix: remove cmd b + cmd shift b shortcuts

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1556,7 +1556,6 @@ export const sceneLogic = kea<sceneLogicType>([
                 const isTKey = keyCode === 'keyt' || key === 't'
                 const isWKey = keyCode === 'keyw' || key === 'w'
                 const isKKey = keyCode === 'keyk' || key === 'k'
-                const isBKey = keyCode === 'keyb' || key === 'b'
 
                 // New shortcuts: Command+Option+T for new tab, Command+Option+W for close tab
                 if (commandKey && optionKey) {
@@ -1601,25 +1600,6 @@ export const sceneLogic = kea<sceneLogicType>([
                     router.actions.push(urls.newTab())
 
                     return
-                }
-
-                // Existing shortcuts (to be deprecated)
-                if (commandKey && isBKey) {
-                    const element = event.target as HTMLElement
-                    if (element?.closest('.NotebookEditor')) {
-                        return
-                    }
-
-                    event.preventDefault()
-                    event.stopPropagation()
-                    if (event.shiftKey) {
-                        if (activeTab) {
-                            actions.removeTab(activeTab)
-                        }
-                    } else {
-                        // else open a new tab as normal
-                        actions.newTab()
-                    }
                 }
             }
             window.addEventListener('keydown', onKeyDown)


### PR DESCRIPTION
## Problem
`cmd+shift+b` toggles browser bookmark bar, and we prevent default those things for close active tab 

https://github.com/PostHog/posthog/issues/40462

## Changes
Remove these deprecated shortcuts (we previously added  `cmd+option+w` to close active tab, and `cmd+option+t` for new tab instead)

## How did you test this code?
Locally