### PR TITLE
feat(ph-ai): visually show tool context

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -31,6 +31,7 @@ import { castAssistantQuery } from 'scenes/max/utils'
 import { userLogic } from 'scenes/userLogic'
 
 import { useFeatureFlag } from '~/lib/hooks/useFeatureFlag'
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { StickinessCriteria } from '~/queries/nodes/InsightViz/StickinessCriteria'
 import {
     AssistantFunnelsQuery,
@@ -414,6 +415,10 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                         identifier={hasAgentModesFeatureFlag ? 'create_insight' : 'create_and_query_insight'}
                         context={{
                             current_query: querySource,
+                        }}
+                        contextDescription={{
+                            text: 'Current query',
+                            icon: iconForType('insight/hog'),
                         }}
                         callback={(
                             toolOutput:

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -28,10 +28,10 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { compareInsightTopLevelSections } from 'scenes/insights/utils'
 import MaxTool from 'scenes/max/MaxTool'
 import { castAssistantQuery } from 'scenes/max/utils'
+import { QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { userLogic } from 'scenes/userLogic'
 
 import { useFeatureFlag } from '~/lib/hooks/useFeatureFlag'
-import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { StickinessCriteria } from '~/queries/nodes/InsightViz/StickinessCriteria'
 import {
     AssistantFunnelsQuery,
@@ -399,6 +399,8 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         },
     ]
 
+    const QueryTypeIcon = QUERY_TYPES_METADATA[query.kind].icon
+
     return (
         <CSSTransition in={showing} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
             <div className="EditorFiltersWrapper">
@@ -418,7 +420,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                         }}
                         contextDescription={{
                             text: 'Current query',
-                            icon: iconForType('insight/hog'),
+                            icon: <QueryTypeIcon />,
                         }}
                         callback={(
                             toolOutput:

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -38,6 +38,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import {
     ScenePanel,
     ScenePanelActionsSection,
@@ -522,6 +523,14 @@ export function DashboardHeader(): JSX.Element | null {
                                                       }
                                                     : undefined,
                                             }}
+                                            contextDescription={
+                                                dashboard
+                                                    ? {
+                                                          text: dashboard.name,
+                                                          icon: iconForType('dashboard'),
+                                                      }
+                                                    : undefined
+                                            }
                                             active={!!dashboard && canEditDashboard}
                                             callback={() => loadDashboard({ action: DashboardLoadAction.Update })}
                                             position="top-right"
@@ -537,7 +546,7 @@ export function DashboardHeader(): JSX.Element | null {
                                                     data-attr="dashboard-add-graph-header"
                                                     size="small"
                                                 >
-                                                    Add insight
+                                                    <span className="pr-3">Add insight</span>
                                                 </LemonButton>
                                             </AccessControlAction>
                                         </MaxTool>

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -9,6 +9,7 @@ import { CodeEditor, CodeEditorProps } from 'lib/monaco/CodeEditor'
 import MaxTool from 'scenes/max/MaxTool'
 
 import { useFeatureFlag } from '~/lib/hooks/useFeatureFlag'
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { HogQLQuery } from '~/queries/schema/schema-general'
 
 import { editorSizingLogic } from './editorSizingLogic'
@@ -79,6 +80,10 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                             identifier={hasAgentModesFeatureFlag ? 'execute_sql' : 'generate_hogql_query'}
                             context={{
                                 current_query: props.queryInput,
+                            }}
+                            contextDescription={{
+                                text: 'Current query',
+                                icon: iconForType('sql_editor'),
                             }}
                             callback={(toolOutput: string) => {
                                 setSuggestedQueryInput(toolOutput, 'max_ai')

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -8,8 +8,8 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { CodeEditor, CodeEditorProps } from 'lib/monaco/CodeEditor'
 import MaxTool from 'scenes/max/MaxTool'
 
-import { useFeatureFlag } from '~/lib/hooks/useFeatureFlag'
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { useFeatureFlag } from '~/lib/hooks/useFeatureFlag'
 import { HogQLQuery } from '~/queries/schema/schema-general'
 
 import { editorSizingLogic } from './editorSizingLogic'

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -36,6 +36,7 @@ import { captureMaxAISurveyCreationException } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { ScenePanel, ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { groupsModel } from '~/models/groupsModel'
@@ -79,6 +80,10 @@ export function createMaxToolExperimentSurveyConfig(
     initialMaxPrompt: string
     suggestions: string[]
     context: Record<string, any>
+    contextDescription: {
+        text: string
+        icon: JSX.Element
+    }
     callback: (toolOutput: { survey_id?: string; survey_name?: string; error?: string }) => void
 } {
     const variants = experiment.parameters?.feature_flag_variants || []
@@ -111,7 +116,6 @@ export function createMaxToolExperimentSurveyConfig(
                     `Create a survey to understand user reactions to changes introduced by feature flag "${featureFlagKey}" in the "${experiment.name}" experiment`,
                 ],
         context: {
-            user_id: user?.uuid,
             experiment_name: experiment.name,
             experiment_description: experiment.description,
             feature_flag_key: experiment.feature_flag?.key,
@@ -126,6 +130,10 @@ export function createMaxToolExperimentSurveyConfig(
                 rollout_percentage: v.rollout_percentage,
             })),
             variant_count: variants?.length || 0,
+        },
+        contextDescription: {
+            text: experiment.name,
+            icon: iconForType('experiment'),
         },
         callback: (toolOutput: { survey_id?: string; survey_name?: string; error?: string }) => {
             addProductIntent({

--- a/frontend/src/scenes/experiments/components/SummarizeExperimentButton.tsx
+++ b/frontend/src/scenes/experiments/components/SummarizeExperimentButton.tsx
@@ -8,7 +8,8 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { ProductIntentContext, addProductIntent } from 'lib/utils/product-intents'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 
-import { MaxExperimentMetricResult, MaxExperimentSummaryContext } from '~/queries/schema/schema-general'
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { MaxExperimentSummaryContext } from '~/queries/schema/schema-general'
 import { ExperimentStatsMethod, ProductKey } from '~/types'
 
 import { getDefaultMetricTitle } from '../MetricsView/shared/utils'
@@ -77,6 +78,10 @@ function useExperimentSummaryMaxTool(): ReturnType<typeof useMaxTool> {
     const maxToolResult = useMaxTool({
         identifier: 'experiment_results_summary',
         context: maxToolContext,
+        contextDescription: {
+            text: maxToolContext.experiment_name,
+            icon: iconForType('experiment'),
+        },
         active: shouldShowMaxSummaryTool,
         initialMaxPrompt: `Summarize the experiment "${experiment.name}"`,
         callback(toolOutput) {

--- a/frontend/src/scenes/experiments/components/SummarizeExperimentButton.tsx
+++ b/frontend/src/scenes/experiments/components/SummarizeExperimentButton.tsx
@@ -9,7 +9,7 @@ import { ProductIntentContext, addProductIntent } from 'lib/utils/product-intent
 import { useMaxTool } from 'scenes/max/useMaxTool'
 
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
-import { MaxExperimentSummaryContext } from '~/queries/schema/schema-general'
+import { MaxExperimentMetricResult, MaxExperimentSummaryContext } from '~/queries/schema/schema-general'
 import { ExperimentStatsMethod, ProductKey } from '~/types'
 
 import { getDefaultMetricTitle } from '../MetricsView/shared/utils'

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -64,6 +64,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import {
     ScenePanel,
     ScenePanelActionsSection,
@@ -125,6 +126,10 @@ export function createMaxToolSurveyConfig(
     initialMaxPrompt: string
     suggestions: string[]
     context: Record<string, any>
+    contextDescription: {
+        text: string
+        icon: JSX.Element
+    }
     callback: (toolOutput: { survey_id?: string; survey_name?: string; error?: string }) => void
 } {
     return {
@@ -147,7 +152,6 @@ export function createMaxToolSurveyConfig(
                       `Create a survey to understand user reactions to the "${featureFlag.key}" feature flag`,
                   ],
         context: {
-            user_id: user?.uuid,
             feature_flag_key: featureFlag.key,
             feature_flag_id: featureFlag.id,
             feature_flag_name: featureFlag.name,
@@ -163,6 +167,10 @@ export function createMaxToolSurveyConfig(
                       }))
                     : [],
             variant_count: variants?.length || 0,
+        },
+        contextDescription: {
+            text: featureFlag.name,
+            icon: iconForType('feature_flag'),
         },
         callback: (toolOutput: { survey_id?: string; survey_name?: string; error?: string }) => {
             addProductIntent({

--- a/frontend/src/scenes/hog-functions/configuration/components/HogFunctionCode.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/components/HogFunctionCode.tsx
@@ -9,6 +9,8 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
 import MaxTool from 'scenes/max/MaxTool'
 
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+
 import { hogFunctionConfigurationLogic } from '../hogFunctionConfigurationLogic'
 import { HogFunctionTemplateOptions } from './HogFunctionTemplateOptions'
 
@@ -159,6 +161,10 @@ export function HogFunctionCode(): JSX.Element {
             identifier="create_hog_transformation_function"
             context={{
                 current_hog_code: configuration.hog ?? '',
+            }}
+            contextDescription={{
+                text: 'Current Hog code',
+                icon: iconForType('data_warehouse'),
             }}
             callback={(toolOutput: string) => {
                 // Store the old value before changing

--- a/frontend/src/scenes/hog-functions/configuration/components/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/components/HogFunctionInputs.tsx
@@ -8,6 +8,7 @@ import { CyclotronJobInputs } from 'lib/components/CyclotronJob/CyclotronJobInpu
 import { PayGateButton } from 'lib/components/PayGateMini/PayGateButton'
 import MaxTool from 'scenes/max/MaxTool'
 
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { AvailableFeature, CyclotronJobInputSchemaType } from '~/types'
 
 import { hogFunctionConfigurationLogic } from '../hogFunctionConfigurationLogic'
@@ -135,6 +136,10 @@ export function HogFunctionInputs(): JSX.Element {
             context={{
                 current_inputs_schema: configuration.inputs_schema ?? [],
                 hog_code: configuration.hog ?? '',
+            }}
+            contextDescription={{
+                text: 'Current inputs schema',
+                icon: iconForType('data_warehouse'),
             }}
             callback={(toolOutput: CyclotronJobInputSchemaType[]) => {
                 // Store the old inputs before changing

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { IconCheck, IconX } from '@posthog/icons'
+import { IconCheck, IconFilter, IconX } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonLabel, LemonSelect } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -426,6 +426,10 @@ export function HogFunctionFilters({
             context={{
                 current_filters: JSON.stringify(configuration?.filters ?? {}),
                 function_type: type,
+            }}
+            contextDescription={{
+                text: 'Current filters',
+                icon: <IconFilter />,
             }}
             callback={(toolOutput: string) => {
                 const parsedFilters = JSON.parse(toolOutput)

--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -155,12 +155,19 @@ export function ContextSummary({
 }
 
 export function ContextTags({ size = 'default' }: { size?: 'small' | 'default' }): JSX.Element | null {
-    const { contextInsights, contextDashboards, contextEvents, contextActions } = useValues(maxContextLogic)
+    const { contextInsights, contextDashboards, contextEvents, contextActions, toolContextItems } =
+        useValues(maxContextLogic)
     const { removeContextInsight, removeContextDashboard, removeContextEvent, removeContextAction } =
         useActions(maxContextLogic)
 
     const allTags = useMemo(() => {
         const tags: JSX.Element[] = []
+
+        // Collect tool context item names (these have precedence and shouldn't be duplicated)
+        const toolContextNames = new Set<string>()
+        toolContextItems.forEach((item) => {
+            toolContextNames.add(item.text.toLowerCase())
+        })
 
         // Context items configuration
         const contextConfigs = [
@@ -194,11 +201,15 @@ export function ContextTags({ size = 'default' }: { size?: 'small' | 'default' }
             },
         ]
 
-        // Generate tags for each context type
+        // Generate tags for each context type, skipping items already in tool context
         contextConfigs.forEach(({ items, type, icon: IconComponent, removeAction, getName }) => {
             if (items) {
                 items.forEach((item: any) => {
                     const name = getName(item)
+                    // Skip if this item is already shown in tool context
+                    if (!name || toolContextNames.has(name.toLowerCase())) {
+                        return
+                    }
                     tags.push(
                         <Tooltip key={`${type}-${item.id}`} title={name}>
                             <LemonTag
@@ -224,6 +235,7 @@ export function ContextTags({ size = 'default' }: { size?: 'small' | 'default' }
         contextInsights,
         contextEvents,
         contextActions,
+        toolContextItems,
         removeContextDashboard,
         removeContextInsight,
         removeContextEvent,
@@ -237,18 +249,58 @@ export function ContextTags({ size = 'default' }: { size?: 'small' | 'default' }
     return <div className="flex flex-wrap gap-1 flex-1 min-w-0 overflow-hidden">{allTags}</div>
 }
 
+export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'default' }): JSX.Element | null {
+    const { toolContextItems } = useValues(maxContextLogic)
+
+    if (toolContextItems.length === 0) {
+        return null
+    }
+
+    const tooltipContent =
+        toolContextItems.length === 1 ? (
+            'PostHog AI can use this context to answer your question'
+        ) : (
+            <div className="flex flex-col gap-1">
+                <div className="text-xs font-semibold mb-1">PostHog AI can use this context:</div>
+                {toolContextItems.map((item, index) => (
+                    <div key={index} className="flex items-center gap-1.5">
+                        {item.icon}
+                        <span>{item.text}</span>
+                    </div>
+                ))}
+            </div>
+        )
+
+    return (
+        <Tooltip title={tooltipContent}>
+            <LemonTag
+                icon={toolContextItems[0].icon}
+                className={clsx('flex items-center', size === 'small' ? 'max-w-20' : 'max-w-48')}
+            >
+                <span className="truncate min-w-0 flex-1">
+                    {toolContextItems[0].text}
+                    {toolContextItems.length > 1 && <span className="ml-1">+{toolContextItems.length - 1}</span>}
+                </span>
+            </LemonTag>
+        </Tooltip>
+    )
+}
+
 interface ContextDisplayProps {
     size?: 'small' | 'default'
 }
 
 export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.Element | null {
     const { deepResearchMode, showContextUI } = useValues(maxThreadLogic)
-    const { hasData, contextOptions, taxonomicGroupTypes, mainTaxonomicGroupType } = useValues(maxContextLogic)
+    const { hasData, contextOptions, taxonomicGroupTypes, mainTaxonomicGroupType, toolContextItems } =
+        useValues(maxContextLogic)
     const { handleTaxonomicFilterChange } = useActions(maxContextLogic)
 
     if (!showContextUI) {
         return null
     }
+
+    const hasToolContext = toolContextItems.length > 0
 
     return (
         <div className="px-1 w-full">
@@ -273,12 +325,13 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
                             groupTypes={taxonomicGroupTypes}
                             onChange={handleTaxonomicFilterChange}
                             icon={<IconAtSign />}
-                            placeholder={!hasData ? 'Add context' : null}
+                            placeholder={!hasData && !hasToolContext ? 'Add context' : null}
                             maxContextOptions={contextOptions}
                             width={450}
                         />
                     </Tooltip>
                 )}
+                <ContextToolInfoTags size={size} />
                 <ContextTags size={size} />
             </div>
         </div>

--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -258,10 +258,10 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
 
     const tooltipContent =
         toolContextItems.length === 1 ? (
-            'PostHog AI can use this context to answer your question'
+            'This context is auto-included from the current view'
         ) : (
             <div className="flex flex-col gap-1">
-                <div className="text-xs font-semibold mb-1">PostHog AI can use this context:</div>
+                <div className="text-xs font-semibold mb-1">This context is auto-included from the current view:</div>
                 {toolContextItems.map((item, index) => (
                     <div key={index} className="flex items-center gap-1.5">
                         {item.icon}
@@ -275,7 +275,10 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
         <Tooltip title={tooltipContent}>
             <LemonTag
                 icon={toolContextItems[0].icon}
-                className={clsx('flex items-center', size === 'small' ? 'max-w-20' : 'max-w-48')}
+                className={clsx(
+                    'flex items-center cursor-default border-dashed',
+                    size === 'small' ? 'max-w-20' : 'max-w-48'
+                )}
             >
                 <span className="truncate min-w-0 flex-1">
                     {toolContextItems[0].text}

--- a/frontend/src/scenes/max/MaxTool.tsx
+++ b/frontend/src/scenes/max/MaxTool.tsx
@@ -22,6 +22,7 @@ interface MaxToolProps extends Omit<ToolRegistration, 'name' | 'description'> {
 export function MaxTool({
     identifier,
     context,
+    contextDescription,
     introOverride,
     callback,
     suggestions,
@@ -35,6 +36,7 @@ export function MaxTool({
     const { definition, isMaxOpen, openMax } = useMaxTool({
         identifier,
         context,
+        contextDescription,
         introOverride,
         callback,
         suggestions,

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -51,6 +51,16 @@ export interface ToolRegistration extends Pick<ToolDefinition, 'name' | 'descrip
     /** Contextual data to be included for use by the LLM */
     context?: Record<string, any>
     /**
+     * Optional: Describes what kind of context information is being provided
+     * This metadata is shown to users in the context topbar to indicate what contextual values are available
+     */
+    contextDescription?: {
+        /** The type or category of context (e.g., "Current insight", "Active filters") */
+        text: string
+        /** Icon to display for the context type */
+        icon: JSX.Element
+    }
+    /**
      * Optional: If this tool is the main one of the page, you can override the default intro headline and description when it's mounted.
      *
      * Note that if more than one mounted tool has an intro override, only one will take effect.

--- a/frontend/src/scenes/max/maxContextLogic.test.ts
+++ b/frontend/src/scenes/max/maxContextLogic.test.ts
@@ -275,6 +275,163 @@ describe('maxContextLogic', () => {
                 }),
             })
         })
+
+        describe('toolContextItems', () => {
+            it('returns empty array when no tools have context', async () => {
+                await expectLogic(logic).toMatchValues({
+                    toolContextItems: [],
+                })
+            })
+
+            it('returns tool context items from registered tools', async () => {
+                const { maxGlobalLogic } = require('./maxGlobalLogic')
+                const globalLogic = maxGlobalLogic()
+                globalLogic.mount()
+
+                // Register a tool with context description
+                globalLogic.actions.registerTool({
+                    identifier: 'test_tool',
+                    name: 'Test Tool',
+                    description: 'Test tool description',
+                    contextDescription: {
+                        text: 'Test Dashboard',
+                        icon: '<IconDashboard />',
+                    },
+                })
+
+                await expectLogic(logic).toMatchValues({
+                    toolContextItems: [
+                        {
+                            text: 'Test Dashboard',
+                            icon: '<IconDashboard />',
+                        },
+                    ],
+                })
+
+                globalLogic.unmount()
+            })
+
+            it('deduplicates tool context items with same name', async () => {
+                const { maxGlobalLogic } = require('./maxGlobalLogic')
+                const globalLogic = maxGlobalLogic()
+                globalLogic.mount()
+
+                // Register two tools with same context name
+                globalLogic.actions.registerTool({
+                    identifier: 'tool_one',
+                    name: 'Tool One',
+                    description: 'First tool',
+                    contextDescription: {
+                        text: 'Test Dashboard',
+                        icon: '<IconDashboard />',
+                    },
+                })
+
+                globalLogic.actions.registerTool({
+                    identifier: 'tool_two',
+                    name: 'Tool Two',
+                    description: 'Second tool',
+                    contextDescription: {
+                        text: 'Test Dashboard',
+                        icon: '<IconDashboard />',
+                    },
+                })
+
+                // Should only have one item (deduplicated)
+                await expectLogic(logic).toMatchValues({
+                    toolContextItems: [
+                        {
+                            text: 'Test Dashboard',
+                            icon: '<IconDashboard />',
+                        },
+                    ],
+                })
+
+                globalLogic.unmount()
+            })
+
+            it('includes multiple different tool context items', async () => {
+                const { maxGlobalLogic } = require('./maxGlobalLogic')
+                const globalLogic = maxGlobalLogic()
+                globalLogic.mount()
+
+                // Register tools with different context
+                globalLogic.actions.registerTool({
+                    identifier: 'tool_one',
+                    name: 'Tool One',
+                    description: 'First tool',
+                    contextDescription: {
+                        text: 'Dashboard A',
+                        icon: '<IconDashboard />',
+                    },
+                })
+
+                globalLogic.actions.registerTool({
+                    identifier: 'tool_two',
+                    name: 'Tool Two',
+                    description: 'Second tool',
+                    contextDescription: {
+                        text: 'Dashboard B',
+                        icon: '<IconGraph />',
+                    },
+                })
+
+                // Should have both items
+                await expectLogic(logic).toMatchValues({
+                    toolContextItems: [
+                        {
+                            text: 'Dashboard A',
+                            icon: '<IconDashboard />',
+                        },
+                        {
+                            text: 'Dashboard B',
+                            icon: '<IconGraph />',
+                        },
+                    ],
+                })
+
+                globalLogic.unmount()
+            })
+
+            it('is case-insensitive for deduplication', async () => {
+                const { maxGlobalLogic } = require('./maxGlobalLogic')
+                const globalLogic = maxGlobalLogic()
+                globalLogic.mount()
+
+                // Register tools with different casing
+                globalLogic.actions.registerTool({
+                    identifier: 'tool_one',
+                    name: 'Tool One',
+                    description: 'First tool',
+                    contextDescription: {
+                        text: 'test dashboard',
+                        icon: '<IconDashboard />',
+                    },
+                })
+
+                globalLogic.actions.registerTool({
+                    identifier: 'tool_two',
+                    name: 'Tool Two',
+                    description: 'Second tool',
+                    contextDescription: {
+                        text: 'Test Dashboard',
+                        icon: '<IconDashboard />',
+                    },
+                })
+
+                // Should only have one (first registered)
+                await expectLogic(logic).toMatchValues({
+                    toolContextItems: [
+                        {
+                            text: 'test dashboard',
+                            icon: '<IconDashboard />',
+                        },
+                    ],
+                })
+
+                globalLogic.unmount()
+            })
+        })
     })
 
     describe('listeners', () => {

--- a/frontend/src/scenes/max/maxContextLogic.ts
+++ b/frontend/src/scenes/max/maxContextLogic.ts
@@ -21,6 +21,7 @@ import {
 } from 'products/revenue_analytics/frontend/revenueAnalyticsLogic'
 
 import type { maxContextLogicType } from './maxContextLogicType'
+import { maxGlobalLogic } from './maxGlobalLogic'
 import {
     InsightWithQuery,
     MaxActionContext,
@@ -64,7 +65,7 @@ export type LoadedEntitiesMap = { dashboard: number[]; insight: string[] }
 export const maxContextLogic = kea<maxContextLogicType>([
     path(['scenes', 'max', 'maxContextLogic']),
     connect(() => ({
-        values: [sceneLogic, ['activeSceneId', 'activeSceneLogic', 'activeLoadedScene']],
+        values: [sceneLogic, ['activeSceneId', 'activeSceneLogic', 'activeLoadedScene'], maxGlobalLogic, ['toolMap']],
         actions: [router, ['locationChanged']],
     })),
     actions({
@@ -584,6 +585,26 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 contextActions: MaxActionContext[]
             ): boolean => {
                 return [contextInsights, contextDashboards, contextEvents, contextActions].some((arr) => arr.length > 0)
+            },
+        ],
+        toolContextItems: [
+            (s: any) => [s.toolMap],
+            (toolMap: any): Array<{ text: string; icon: any }> => {
+                const items: Array<{ text: string; icon: any }> = []
+                const addedNames = new Set<string>()
+
+                // First, add all tool context items (they have precedence)
+                Object.values(toolMap).forEach((tool: any) => {
+                    if (tool.contextDescription) {
+                        const itemName = tool.contextDescription.text.toLowerCase()
+                        if (!addedNames.has(itemName)) {
+                            items.push(tool.contextDescription)
+                            addedNames.add(itemName)
+                        }
+                    }
+                })
+
+                return items
             },
         ],
     }),

--- a/frontend/src/scenes/max/useMaxTool.ts
+++ b/frontend/src/scenes/max/useMaxTool.ts
@@ -20,6 +20,8 @@ export interface UseMaxToolOptions extends Omit<ToolRegistration, 'name' | 'desc
     initialMaxPrompt?: string
     /** Callback when Max panel opens */
     onMaxOpen?: () => void
+    /** Optional: Describes what kind of context information is being provided */
+    contextDescription?: ToolRegistration['contextDescription']
 }
 
 export interface UseMaxToolReturn {
@@ -35,6 +37,7 @@ export interface UseMaxToolReturn {
 export function useMaxTool({
     identifier,
     context,
+    contextDescription,
     introOverride,
     callback,
     suggestions,
@@ -63,6 +66,7 @@ export function useMaxTool({
                 name: definition.name,
                 description: definition.description,
                 context,
+                contextDescription,
                 introOverride,
                 suggestions,
                 callback,
@@ -74,6 +78,7 @@ export function useMaxTool({
         identifier,
         definition,
         JSON.stringify(context), // oxlint-disable-line react-hooks/exhaustive-deps
+        contextDescription,
         introOverride,
         suggestions,
         callback,

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -195,6 +195,10 @@ export const RecordingsUniversalFiltersEmbedButton = ({
                 context={{
                     current_filters: filters,
                 }}
+                contextDescription={{
+                    text: 'Current filters',
+                    icon: <IconFilter />,
+                }}
                 callback={(toolOutput: Record<string, any>) => {
                     // Improve type
                     setFilters(toolOutput)

--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -48,9 +48,7 @@ function NewSurveyButton(): JSX.Element {
                 'Create a product-market fit survey for trial users',
                 'Create a quick satisfaction survey for support interactions',
             ]}
-            context={{
-                user_id: user?.uuid,
-            }}
+            context={{}}
             callback={(toolOutput: {
                 survey_id?: string
                 survey_name?: string

--- a/frontend/src/scenes/surveys/components/AnalyzeResponsesButton.tsx
+++ b/frontend/src/scenes/surveys/components/AnalyzeResponsesButton.tsx
@@ -9,6 +9,7 @@ import { ProductIntentContext, addProductIntent } from 'lib/utils/product-intent
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { ProductKey } from '~/types'
 
 const NUM_OF_RESPONSES_FOR_MAX_ANALYSIS_TOOL = 5
@@ -36,6 +37,10 @@ function useSurveyAnalysisMaxTool(): ReturnType<typeof useMaxTool> {
     return useMaxTool({
         identifier: 'analyze_survey_responses',
         context: maxToolContext,
+        contextDescription: {
+            text: survey.name,
+            icon: iconForType('survey'),
+        },
         active: shouldShowMaxAnalysisTool,
         initialMaxPrompt: `Analyze the survey responses for the survey "${survey.name}"`,
         callback(toolOutput) {

--- a/frontend/src/scenes/surveys/components/empty-state/SurveysEmptyState.tsx
+++ b/frontend/src/scenes/surveys/components/empty-state/SurveysEmptyState.tsx
@@ -104,7 +104,7 @@ export function SurveysEmptyState({ numOfSurveys }: Props): JSX.Element {
                                     'Create an NPS survey for customers who completed checkout',
                                     'Create a feedback survey asking about our new dashboard',
                                 ]}
-                                context={{ user_id: user.uuid }}
+                                context={{}}
                                 callback={(toolOutput: {
                                     survey_id?: string
                                     error?: string

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconGear, IconGlobe, IconPhone } from '@posthog/icons'
+import { IconFilter, IconGear, IconGlobe, IconPhone } from '@posthog/icons'
 import { LemonButton, LemonSelect, LemonSwitch, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
@@ -94,6 +94,10 @@ const WebAnalyticsAIFilters = (): JSX.Element => {
                     doPathCleaning: isPathCleaningEnabled,
                     compareFilter: compareFilter,
                 },
+            }}
+            contextDescription={{
+                text: 'Current filters',
+                icon: <IconFilter />,
             }}
             callback={(toolOutput: Record<string, any>) => {
                 if (toolOutput.properties !== undefined) {

--- a/products/error_tracking/frontend/components/IssueFilteringTool.tsx
+++ b/products/error_tracking/frontend/components/IssueFilteringTool.tsx
@@ -1,5 +1,7 @@
 import { useActions, useValues } from 'kea'
 
+import { IconFilter } from '@posthog/icons'
+
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import MaxTool from 'scenes/max/MaxTool'
 
@@ -105,6 +107,10 @@ export function ErrorTrackingIssueFilteringTool(): JSX.Element {
             identifier="filter_error_tracking_issues"
             context={{
                 current_query: query,
+            }}
+            contextDescription={{
+                text: 'Current filters',
+                icon: <IconFilter />,
             }}
             callback={(toolOutput: ErrorTrackingIssueFilteringToolOutput) => {
                 callback(toolOutput)

--- a/products/revenue_analytics/frontend/RevenueAnalyticsFilters.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsFilters.tsx
@@ -137,6 +137,10 @@ const RevenueAnalyticsPropertyFilters = (): JSX.Element => {
                     properties: revenueAnalyticsFilter,
                 },
             }}
+            contextDescription={{
+                text: 'Current filters',
+                icon: <IconFilter />,
+            }}
             callback={(toolOutput: Record<string, any>) => {
                 // Types suck here, but they *should* be correct if pydantic does its job correctly
                 setRevenueAnalyticsFilters(toolOutput.properties)


### PR DESCRIPTION
## Problem

Currently, when users interact with PostHog AI, they don't have clear visibility into what tool context is being used to generate responses.

## Changes

Added a `contextDescription` property to MaxTools throughout the application to provide users with clear information about what context is being used, which is rendered in the context bar in the chat input.  
  
![image.png](https://app.graphite.com/user-attachments/assets/8369fe7b-4dc9-4fe2-a363-dced8d3ce1f1.png)



## How did you test this code?

Tests + visually