### PR TITLE
feat(cutover): Update persons in new table if they exist there

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1012,6 +1012,8 @@ export interface RawPerson extends BasePerson {
 export interface InternalPerson extends BasePerson {
     created_at: DateTime
     version: number
+    /** Internal flag to track which table this person exists in during cutover migration */
+    __useNewTable?: boolean
 }
 
 /** Mutable fields that can be updated on a Person via updatePerson. */

--- a/plugin-server/src/worker/ingestion/persons/person-context.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-context.ts
@@ -14,6 +14,12 @@ import { PersonsStoreForBatch } from './persons-store-for-batch'
 export class PersonContext {
     public readonly eventProperties: Properties
     public updateIsIdentified: boolean = false
+    /**
+     * Flag indicating whether this person should be routed to the new table.
+     * Set during person fetch/lookup and used throughout the processing pipeline.
+     * When true, all operations (updates, merges, etc.) will target the new table.
+     */
+    public useNewTable: boolean = false
 
     constructor(
         public readonly event: PluginEvent,

--- a/plugin-server/src/worker/ingestion/persons/person-context.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-context.ts
@@ -14,12 +14,6 @@ import { PersonsStoreForBatch } from './persons-store-for-batch'
 export class PersonContext {
     public readonly eventProperties: Properties
     public updateIsIdentified: boolean = false
-    /**
-     * Flag indicating whether this person should be routed to the new table.
-     * Set during person fetch/lookup and used throughout the processing pipeline.
-     * When true, all operations (updates, merges, etc.) will target the new table.
-     */
-    public useNewTable: boolean = false
 
     constructor(
         public readonly event: PluginEvent,

--- a/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update-batch.ts
@@ -22,6 +22,8 @@ export interface PersonUpdate {
     properties_to_unset: string[] // Property keys to unset
     original_is_identified: boolean
     original_created_at: DateTime
+    /** Internal flag to track which table this person exists in during cutover migration */
+    __useNewTable?: boolean
 }
 
 export interface PersonPropertyUpdate {
@@ -49,6 +51,7 @@ export function fromInternalPerson(person: InternalPerson, distinctId: string): 
         properties_to_unset: [],
         original_is_identified: person.is_identified,
         original_created_at: person.created_at,
+        __useNewTable: person.__useNewTable,
     }
 }
 
@@ -77,5 +80,6 @@ export function toInternalPerson(personUpdate: PersonUpdate): InternalPerson {
         version: personUpdate.version,
         is_identified: personUpdate.is_identified,
         is_user_id: personUpdate.is_user_id,
+        __useNewTable: personUpdate.__useNewTable,
     }
 }

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -75,15 +75,17 @@ export class PostgresPersonRepository
         this.options = { ...DEFAULT_OPTIONS, ...options }
     }
 
-    private getTableName(personId?: string): string {
+    private getTableName(personId: string, person?: InternalPerson): string {
         if (!this.options.tableCutoverEnabled || !this.options.newTableName || !this.options.newTableIdOffset) {
             return 'posthog_person'
         }
 
-        if (!personId) {
-            return 'posthog_person'
+        // If person object provided with routing decision, use it
+        if (person?.__useNewTable !== undefined) {
+            return person.__useNewTable ? this.options.newTableName : 'posthog_person'
         }
 
+        // Fall back to ID-based routing
         const numericPersonId = parseInt(personId, 10)
         if (isNaN(numericPersonId)) {
             return 'posthog_person'
@@ -98,7 +100,7 @@ export class PostgresPersonRepository
         update: PersonUpdateFields,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[], boolean]> {
-        const currentSize = await this.personPropertiesSize(person.id, person.team_id)
+        const currentSize = await this.personPropertiesSize(person.id, person.team_id, person)
 
         if (currentSize >= this.options.personPropertiesDbConstraintLimitBytes) {
             try {
@@ -269,10 +271,11 @@ export class PostgresPersonRepository
             }
 
             const personId = distinctIdRows[0].person_id
-            const tableName = sanitizeSqlIdentifier(this.getTableName(personId))
             const forUpdateClause = options.forUpdate ? ' FOR UPDATE' : ''
 
-            const personQuery = `
+            // Check new table first (by existence, not by ID threshold)
+            const newTableName = sanitizeSqlIdentifier(this.options.newTableName)
+            const personQueryNew = `
                 SELECT
                     id,
                     uuid,
@@ -284,18 +287,51 @@ export class PostgresPersonRepository
                     is_user_id,
                     version,
                     is_identified
-                FROM ${tableName}
+                FROM ${newTableName}
                 WHERE team_id = $1 AND id = $2${forUpdateClause}`
 
-            const { rows } = await this.postgres.query<RawPerson>(
+            const { rows: newTableRows } = await this.postgres.query<RawPerson>(
                 options.useReadReplica ? PostgresUse.PERSONS_READ : PostgresUse.PERSONS_WRITE,
-                personQuery,
+                personQueryNew,
                 [teamId, personId],
-                'fetchPerson'
+                'fetchPersonFromNewTable'
             )
 
-            if (rows.length > 0) {
-                return this.toPerson(rows[0])
+            if (newTableRows.length > 0) {
+                const person = this.toPerson(newTableRows[0])
+                // Mark that this person exists in the new table
+                ;(person as any).__useNewTable = true
+                return person
+            }
+
+            // Fall back to old table
+            const personQueryOld = `
+                SELECT
+                    id,
+                    uuid,
+                    created_at,
+                    team_id,
+                    properties,
+                    properties_last_updated_at,
+                    properties_last_operation,
+                    is_user_id,
+                    version,
+                    is_identified
+                FROM posthog_person
+                WHERE team_id = $1 AND id = $2${forUpdateClause}`
+
+            const { rows: oldTableRows } = await this.postgres.query<RawPerson>(
+                options.useReadReplica ? PostgresUse.PERSONS_READ : PostgresUse.PERSONS_WRITE,
+                personQueryOld,
+                [teamId, personId],
+                'fetchPersonFromOldTable'
+            )
+
+            if (oldTableRows.length > 0) {
+                const person = this.toPerson(oldTableRows[0])
+                // Mark that this person exists in the old table
+                ;(person as any).__useNewTable = false
+                return person
             }
         } else {
             const forUpdateClause = options.forUpdate ? ' FOR UPDATE' : ''
@@ -709,7 +745,7 @@ export class PostgresPersonRepository
     async deletePerson(person: InternalPerson, tx?: TransactionClient): Promise<TopicMessage[]> {
         let rows: { version: string }[] = []
         try {
-            const tableName = sanitizeSqlIdentifier(this.getTableName(person.id))
+            const tableName = sanitizeSqlIdentifier(this.getTableName(person.id, person))
             const result = await this.postgres.query<{ version: string }>(
                 tx ?? PostgresUse.PERSONS_WRITE,
                 `DELETE FROM ${tableName} WHERE team_id = $1 AND id = $2 RETURNING version`,
@@ -963,8 +999,8 @@ export class PostgresPersonRepository
         return result.rows[0].inserted
     }
 
-    async personPropertiesSize(personId: string, teamId: number): Promise<number> {
-        const tableName = sanitizeSqlIdentifier(this.getTableName(personId))
+    async personPropertiesSize(personId: string, teamId: number, person?: InternalPerson): Promise<number> {
+        const tableName = sanitizeSqlIdentifier(this.getTableName(personId, person))
 
         // For partitioned tables, we need team_id for efficient querying
         const queryString = `
@@ -1024,7 +1060,7 @@ export class PostgresPersonRepository
         }
 
         const calculatePropertiesSize = this.options.calculatePropertiesSize
-        const tableName = sanitizeSqlIdentifier(this.getTableName(person.id))
+        const tableName = sanitizeSqlIdentifier(this.getTableName(person.id, person))
 
         // Add team_id and person_id to values for WHERE clause (for partitioning)
         const allValues = [...values, person.team_id, person.id]
@@ -1121,7 +1157,7 @@ export class PostgresPersonRepository
                 personUpdate.version,
             ]
 
-            const tableName = sanitizeSqlIdentifier(this.getTableName(personUpdate.id))
+            const tableName = sanitizeSqlIdentifier(this.getTableName(personUpdate.id, personUpdate))
             const queryString = `
                 UPDATE ${tableName} SET
                     properties = $1,

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -75,7 +75,7 @@ export class PostgresPersonRepository
         this.options = { ...DEFAULT_OPTIONS, ...options }
     }
 
-    private getTableName(personId: string, person?: InternalPerson): string {
+    private getTableName(personId?: string, person?: InternalPerson): string {
         if (!this.options.tableCutoverEnabled || !this.options.newTableName || !this.options.newTableIdOffset) {
             return 'posthog_person'
         }
@@ -86,6 +86,10 @@ export class PostgresPersonRepository
         }
 
         // Fall back to ID-based routing
+        if (!personId) {
+            return 'posthog_person'
+        }
+
         const numericPersonId = parseInt(personId, 10)
         if (isNaN(numericPersonId)) {
             return 'posthog_person'


### PR DESCRIPTION
## Problem

We are still doing lots of updates to the old persons table, once we have made a write to it, it is replicated onto the new table. Therefore, we added a check to see if a person exists in the new database to reduce the number of unnecessary updates to the old table.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
