### PR TITLE
fix: add dashboard context to edit button

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -1,5 +1,6 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
+import { combineUrl } from 'kea-router'
 import { useState } from 'react'
 
 import { IconCode2, IconInfo, IconPencil, IconPeople, IconShare, IconTrash } from '@posthog/icons'
@@ -85,7 +86,8 @@ const RESOURCE_TYPE = 'insight'
 
 export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
     // insightSceneLogic
-    const { insightMode, itemId, alertId, filtersOverride, variablesOverride } = useValues(insightSceneLogic)
+    const { insightMode, itemId, alertId, filtersOverride, variablesOverride, dashboardId } =
+        useValues(insightSceneLogic)
 
     const { setInsightMode } = useActions(insightSceneLogic)
 
@@ -541,7 +543,12 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                     urls.sqlEditor(undefined, undefined, insight.short_id)
                                                 )
                                             } else if (insight.short_id) {
-                                                push(urls.insightEdit(insight.short_id))
+                                                const editUrl = dashboardId
+                                                    ? combineUrl(urls.insightEdit(insight.short_id), {
+                                                          dashboard: dashboardId,
+                                                      }).url
+                                                    : urls.insightEdit(insight.short_id)
+                                                push(editUrl)
                                             } else {
                                                 setInsightMode(ItemMode.Edit, null)
                                             }


### PR DESCRIPTION
## Problem
on Dashboard, click an insight, back button (to dashboard) works ✅ 
on Dashboard, click an insight, click "Edit", back button (to dashboard) works ❌ 

## Changes
* Pass dashboard context to edit button, this persists the back button across edit/cancel
    * Note: on refresh, the context is lost (intentional perhaps?)

![2025-11-14 11 44 05](https://github.com/user-attachments/assets/078aef20-9892-4794-b8b1-3bb323921377)


## How did you test this code?
Locally

on Dashboard, click an insight, back button (to dashboard) works ✅ 
on Dashboard, click an insight, click "Edit", back button (to dashboard) works ✅  
on Dashboard, click an insight, click "Edit", Click "Cancel", back button (to dashboard) works ✅  
on Dashboard, click an insight, click "Edit", make changes, click "Save", back button (to dashboard) works ✅  