### PR TITLE
fix: Allow extra columns in schema

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -752,7 +752,8 @@ class SchemaTransformer:
         exception is raised when `self.raise_on_incompatible` is `True`, otherwise we
         optimistically assume the destination can handle the inconsistency.
         """
-        field_names = [field.name for field in self.table.fields]
+        schema_names = {field.name for field in record_batch.schema}
+        field_names = [field.name for field in self.table.fields if field.name in schema_names]
 
         arrays = []
         for field_name, array in zip(field_names, record_batch.select(field_names).itercolumns()):

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_transformer.py
@@ -315,7 +315,7 @@ async def test_schema_transformer(
     class TestTable(Table):
         pass
 
-    t = TestTable(name="test", fields=[TestField(record_batch[0]._name, target_type)])  # type: ignore[attr-defined]
+    t = TestTable(name="test", fields=[TestField(record_batch[0]._name, target_type), TestField("extra", pa.string())])  # type: ignore[attr-defined]
     transformer = SchemaTransformer(t, compatible_types)
 
     transformed_record_batches = [record_batch async for record_batch in transformer.iter(record_batch_iter())]


### PR DESCRIPTION
## Problem

In line with being more flexible, we should not fail if the target schema contains extra columns.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Only check for casting those columns that we know about.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Extended unit test to add an extra field. Test fails without the patch.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
