### PR TITLE
feat: source maps upload preset

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -99,6 +99,11 @@ export const API_KEY_SCOPE_PRESETS: {
 }[] = [
     { value: 'local_evaluation', label: 'Local feature flag evaluation', scopes: ['feature_flag:read'] },
     {
+        value: 'source_map_upload',
+        label: 'Source map upload',
+        scopes: ['organization:read', 'error_tracking:write'],
+    },
+    {
         value: 'zapier',
         label: 'Zapier integration',
         scopes: ['action:read', 'query:read', 'project:read', 'organization:read', 'user:read', 'webhook:write'],


### PR DESCRIPTION
## Problem

We've had a bunch of requests about what scopes are needed for the source map uploads e.g. https://posthog.com/questions/personal-api-key-scope

## Changes

Add a preset in case folks look for the answer there
<img width="681" height="590" alt="Screenshot 2025-11-14 at 11 45 57" src="https://github.com/user-attachments/assets/933d4212-06e8-4c9f-963a-0ae4ab5a1d8a" />