### PR TITLE
feat(sessions): Fix session backfill concurrency and add sync distributed insert

### DIFF
--- a/dags/locations/analytics_platform.py
+++ b/dags/locations/analytics_platform.py
@@ -1,7 +1,8 @@
 import dagster
 
 from dags import sessions
+from dags.sessions import sessions_backfill_job
 
 defs = dagster.Definitions(
-    assets=[sessions.sessions_v3_backfill, sessions.sessions_v3_backfill_replay],
+    assets=[sessions.sessions_v3_backfill, sessions.sessions_v3_backfill_replay], jobs=[sessions_backfill_job]
 )

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -509,6 +509,7 @@ def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where="TRUE", use_sharded_source=True):
     return """
 INSERT INTO {database}.{writable_table}
 {select_sql}
+SETTINGS insert_distributed_sync = 1
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
@@ -525,6 +526,7 @@ def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where="TRUE", use_sharded_sourc
     return """
 INSERT INTO {database}.{writable_table}
 {select_sql}
+SETTINGS insert_distributed_sync = 1
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),


### PR DESCRIPTION
## Problem

I'm still running into Too Many Parts

Additionally my concurrency limit on runs is not being applied correctly

## Changes
Add an asset job for the backfill assets, so that we can specify tags which will be correctly added to the runs.

Add `insert_distributed_sync = 1`

## How did you test this code?

On my local dagster, the run concurrency limit of 3 was successfully applied

<img width="2307" height="486" alt="Screenshot 2025-11-14 at 12 02 29" src="https://github.com/user-attachments/assets/20a7e7bb-cb27-487a-97c6-24b5689f9abf" />

The backfill SQL tests still pass

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
