### PR TITLE
fix: empty text nodes are not allowed

### DIFF
--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -235,12 +235,14 @@ export function getText(comment: CommentType): string {
               content: [
                   {
                       type: 'paragraph',
-                      content: [
-                          {
-                              type: 'text',
-                              text: comment.content || '',
-                          },
-                      ],
+                      content: comment.content
+                          ? [
+                                {
+                                    type: 'text',
+                                    text: comment.content,
+                                },
+                            ]
+                          : [],
                   },
               ],
           }


### PR DESCRIPTION
## Problem

<img width="511" height="510" alt="Screenshot 2025-11-14 at 16 10 47" src="https://github.com/user-attachments/assets/253dcea0-44c6-47d6-8e0d-3fee7a37732f" />


## Changes

TipTap foes not allow empty text nodes

