### PR TITLE
fix(experiments): Fix new form width

### DIFF
--- a/frontend/src/scenes/experiments/create/CreateExperiment.tsx
+++ b/frontend/src/scenes/experiments/create/CreateExperiment.tsx
@@ -58,222 +58,220 @@ export const CreateExperiment = ({ draftExperiment, tabId }: CreateExperimentPro
     const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
 
     return (
-        <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
-            <div className="max-w-none flex-1">
-                <SceneContent>
-                    <SceneTitleSection
-                        name={experiment.name}
-                        description={null}
-                        resourceType={{
-                            type: 'experiment',
-                        }}
-                        canEdit={userHasAccess(
-                            AccessControlResourceType.Experiment,
-                            AccessControlLevel.Editor,
-                            experiment.user_access_level
-                        )}
-                        forceEdit
-                        saveOnBlur
-                        onNameChange={(name) => {
-                            setExperimentValue('name', name)
-                            validateField('name')
-                        }}
-                        actions={
-                            <>
-                                <LemonButton
-                                    data-attr="cancel-experiment"
-                                    type="secondary"
-                                    size="small"
-                                    onClick={() => {
-                                        router.actions.push(urls.experiments())
-                                    }}
-                                >
-                                    Cancel
-                                </LemonButton>
-
-                                <AccessControlAction
-                                    resourceType={AccessControlResourceType.Experiment}
-                                    minAccessLevel={AccessControlLevel.Editor}
-                                    userAccessLevel={experiment.user_access_level}
-                                >
-                                    <LemonButton
-                                        loading={isExperimentSubmitting}
-                                        disabledReason={!canSubmitExperiment ? 'Experiment is not valid' : undefined}
-                                        data-attr="save-experiment"
-                                        type="primary"
-                                        size="small"
-                                        onClick={saveExperiment}
-                                    >
-                                        Save as draft
-                                    </LemonButton>
-                                </AccessControlAction>
-                            </>
-                        }
-                    />
-                    {experimentErrors.name && typeof experimentErrors.name === 'string' && (
-                        <LemonFieldError error={experimentErrors.name} />
+        <div>
+            <SceneContent>
+                <SceneTitleSection
+                    name={experiment.name}
+                    description={null}
+                    resourceType={{
+                        type: 'experiment',
+                    }}
+                    canEdit={userHasAccess(
+                        AccessControlResourceType.Experiment,
+                        AccessControlLevel.Editor,
+                        experiment.user_access_level
                     )}
-                    <SceneSection title="Hypothesis" description="Describe your experiment in a few sentences.">
-                        <LemonTextArea
-                            placeholder="The goal of this experiment is ..."
-                            data-attr="experiment-hypothesis"
-                            value={experiment.description}
-                            onChange={(value) => {
-                                setExperimentValue('description', value)
-                            }}
-                        />
-                    </SceneSection>
-                    <SceneDivider />
-                    <LemonCollapse
-                        activeKey={selectedPanel ?? undefined}
-                        defaultActiveKey="experiment-exposure"
-                        onChange={setSelectedPanel}
-                        className="bg-surface-primary"
-                        panels={[
-                            {
-                                key: 'experiment-exposure',
-                                header: <ExposureCriteriaPanelHeader experiment={experiment} />,
-                                content: (
-                                    <ExposureCriteriaPanel
-                                        experiment={experiment}
-                                        onChange={setExposureCriteria}
-                                        onNext={() => setSelectedPanel('experiment-variants')}
-                                    />
-                                ),
-                            },
-                            {
-                                key: 'experiment-variants',
-                                header: <VariantsPanelHeader experiment={experiment} disabled={isEditMode} />,
-                                content: (
-                                    <VariantsPanel
-                                        experiment={experiment}
-                                        updateFeatureFlag={setFeatureFlagConfig}
-                                        onPrevious={() => setSelectedPanel('experiment-exposure')}
-                                        onNext={() => setSelectedPanel('experiment-metrics')}
-                                        disabled={isEditMode}
-                                    />
-                                ),
-                            },
-                            {
-                                key: 'experiment-metrics',
-                                header: <MetricsPanelHeader experiment={experiment} sharedMetrics={sharedMetrics} />,
-                                content: (
-                                    <MetricsPanel
-                                        experiment={experiment}
-                                        sharedMetrics={sharedMetrics}
-                                        onSaveMetric={(metric, context) => {
-                                            const isNew = !experiment[context.field].some((m) => m.uuid === metric.uuid)
+                    forceEdit
+                    saveOnBlur
+                    onNameChange={(name) => {
+                        setExperimentValue('name', name)
+                        validateField('name')
+                    }}
+                    actions={
+                        <>
+                            <LemonButton
+                                data-attr="cancel-experiment"
+                                type="secondary"
+                                size="small"
+                                onClick={() => {
+                                    router.actions.push(urls.experiments())
+                                }}
+                            >
+                                Cancel
+                            </LemonButton>
 
-                                            setExperiment({
-                                                ...experiment,
-                                                [context.field]: isNew
-                                                    ? [...experiment[context.field], metric]
-                                                    : experiment[context.field].map((m) =>
-                                                          m.uuid === metric.uuid ? metric : m
-                                                      ),
-                                                ...(isNew && {
-                                                    [context.orderingField]: [
-                                                        ...(experiment[context.orderingField] ?? []),
-                                                        metric.uuid,
-                                                    ],
-                                                }),
-                                            })
-                                        }}
-                                        onDeleteMetric={(metric, context) => {
-                                            if (metric.isSharedMetric) {
-                                                setExperiment({
-                                                    ...experiment,
-                                                    [context.orderingField]: (
-                                                        experiment[context.orderingField] ?? []
-                                                    ).filter((uuid) => uuid !== metric.uuid),
-                                                    // Remove from saved_metrics so modal shows it as available again
-                                                    saved_metrics: (experiment.saved_metrics ?? []).filter(
-                                                        (sm) => sm.saved_metric !== metric.sharedMetricId
-                                                    ),
-                                                })
-                                                setSharedMetrics({
-                                                    ...sharedMetrics,
-                                                    [context.type]: sharedMetrics[context.type].filter(
-                                                        (m) => m.uuid !== metric.uuid
-                                                    ),
-                                                })
-                                                return
-                                            }
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.Experiment}
+                                minAccessLevel={AccessControlLevel.Editor}
+                                userAccessLevel={experiment.user_access_level}
+                            >
+                                <LemonButton
+                                    loading={isExperimentSubmitting}
+                                    disabledReason={!canSubmitExperiment ? 'Experiment is not valid' : undefined}
+                                    data-attr="save-experiment"
+                                    type="primary"
+                                    size="small"
+                                    onClick={saveExperiment}
+                                >
+                                    Save as draft
+                                </LemonButton>
+                            </AccessControlAction>
+                        </>
+                    }
+                />
+                {experimentErrors.name && typeof experimentErrors.name === 'string' && (
+                    <LemonFieldError error={experimentErrors.name} />
+                )}
+                <SceneSection title="Hypothesis" description="Describe your experiment in a few sentences.">
+                    <LemonTextArea
+                        placeholder="The goal of this experiment is ..."
+                        data-attr="experiment-hypothesis"
+                        value={experiment.description}
+                        onChange={(value) => {
+                            setExperimentValue('description', value)
+                        }}
+                    />
+                </SceneSection>
+                <SceneDivider />
+                <LemonCollapse
+                    activeKey={selectedPanel ?? undefined}
+                    defaultActiveKey="experiment-exposure"
+                    onChange={setSelectedPanel}
+                    className="bg-surface-primary"
+                    panels={[
+                        {
+                            key: 'experiment-exposure',
+                            header: <ExposureCriteriaPanelHeader experiment={experiment} />,
+                            content: (
+                                <ExposureCriteriaPanel
+                                    experiment={experiment}
+                                    onChange={setExposureCriteria}
+                                    onNext={() => setSelectedPanel('experiment-variants')}
+                                />
+                            ),
+                        },
+                        {
+                            key: 'experiment-variants',
+                            header: <VariantsPanelHeader experiment={experiment} disabled={isEditMode} />,
+                            content: (
+                                <VariantsPanel
+                                    experiment={experiment}
+                                    updateFeatureFlag={setFeatureFlagConfig}
+                                    onPrevious={() => setSelectedPanel('experiment-exposure')}
+                                    onNext={() => setSelectedPanel('experiment-metrics')}
+                                    disabled={isEditMode}
+                                />
+                            ),
+                        },
+                        {
+                            key: 'experiment-metrics',
+                            header: <MetricsPanelHeader experiment={experiment} sharedMetrics={sharedMetrics} />,
+                            content: (
+                                <MetricsPanel
+                                    experiment={experiment}
+                                    sharedMetrics={sharedMetrics}
+                                    onSaveMetric={(metric, context) => {
+                                        const isNew = !experiment[context.field].some((m) => m.uuid === metric.uuid)
 
-                                            const metricIndex = experiment[context.field].findIndex(
-                                                ({ uuid }) => uuid === metric.uuid
-                                            )
-
-                                            if (metricIndex !== -1) {
-                                                setExperiment({
-                                                    ...experiment,
-                                                    [context.field]: experiment[context.field].filter(
-                                                        ({ uuid }) => uuid !== metric.uuid
-                                                    ),
-                                                    [context.orderingField]: (
-                                                        experiment[context.orderingField] ?? []
-                                                    ).filter((uuid) => uuid !== metric.uuid),
-                                                })
-                                            }
-                                        }}
-                                        onSaveSharedMetrics={(metrics, context) => {
-                                            setExperiment({
-                                                ...experiment,
+                                        setExperiment({
+                                            ...experiment,
+                                            [context.field]: isNew
+                                                ? [...experiment[context.field], metric]
+                                                : experiment[context.field].map((m) =>
+                                                      m.uuid === metric.uuid ? metric : m
+                                                  ),
+                                            ...(isNew && {
                                                 [context.orderingField]: [
                                                     ...(experiment[context.orderingField] ?? []),
-                                                    ...metrics.map((metric) => metric.uuid),
+                                                    metric.uuid,
                                                 ],
-                                                saved_metrics: [
-                                                    ...(experiment.saved_metrics ?? []),
-                                                    ...metrics.map((metric) => ({
-                                                        saved_metric: metric.sharedMetricId,
-                                                    })),
-                                                ],
+                                            }),
+                                        })
+                                    }}
+                                    onDeleteMetric={(metric, context) => {
+                                        if (metric.isSharedMetric) {
+                                            setExperiment({
+                                                ...experiment,
+                                                [context.orderingField]: (
+                                                    experiment[context.orderingField] ?? []
+                                                ).filter((uuid) => uuid !== metric.uuid),
+                                                // Remove from saved_metrics so modal shows it as available again
+                                                saved_metrics: (experiment.saved_metrics ?? []).filter(
+                                                    (sm) => sm.saved_metric !== metric.sharedMetricId
+                                                ),
                                             })
                                             setSharedMetrics({
                                                 ...sharedMetrics,
-                                                [context.type]: [...sharedMetrics[context.type], ...metrics],
+                                                [context.type]: sharedMetrics[context.type].filter(
+                                                    (m) => m.uuid !== metric.uuid
+                                                ),
                                             })
-                                        }}
-                                        onPrevious={() => setSelectedPanel('experiment-variants')}
-                                    />
-                                ),
-                            },
-                        ]}
-                    />
+                                            return
+                                        }
 
-                    <SceneDivider />
-                    <div className="flex justify-end gap-2">
+                                        const metricIndex = experiment[context.field].findIndex(
+                                            ({ uuid }) => uuid === metric.uuid
+                                        )
+
+                                        if (metricIndex !== -1) {
+                                            setExperiment({
+                                                ...experiment,
+                                                [context.field]: experiment[context.field].filter(
+                                                    ({ uuid }) => uuid !== metric.uuid
+                                                ),
+                                                [context.orderingField]: (
+                                                    experiment[context.orderingField] ?? []
+                                                ).filter((uuid) => uuid !== metric.uuid),
+                                            })
+                                        }
+                                    }}
+                                    onSaveSharedMetrics={(metrics, context) => {
+                                        setExperiment({
+                                            ...experiment,
+                                            [context.orderingField]: [
+                                                ...(experiment[context.orderingField] ?? []),
+                                                ...metrics.map((metric) => metric.uuid),
+                                            ],
+                                            saved_metrics: [
+                                                ...(experiment.saved_metrics ?? []),
+                                                ...metrics.map((metric) => ({
+                                                    saved_metric: metric.sharedMetricId,
+                                                })),
+                                            ],
+                                        })
+                                        setSharedMetrics({
+                                            ...sharedMetrics,
+                                            [context.type]: [...sharedMetrics[context.type], ...metrics],
+                                        })
+                                    }}
+                                    onPrevious={() => setSelectedPanel('experiment-variants')}
+                                />
+                            ),
+                        },
+                    ]}
+                />
+
+                <SceneDivider />
+                <div className="flex justify-end gap-2">
+                    <LemonButton
+                        data-attr="cancel-experiment"
+                        type="secondary"
+                        size="small"
+                        onClick={() => {
+                            router.actions.push(urls.experiments())
+                        }}
+                    >
+                        Cancel
+                    </LemonButton>
+
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.Experiment}
+                        minAccessLevel={AccessControlLevel.Editor}
+                        userAccessLevel={experiment.user_access_level}
+                    >
                         <LemonButton
-                            data-attr="cancel-experiment"
-                            type="secondary"
+                            loading={isExperimentSubmitting}
+                            disabledReason={!canSubmitExperiment ? 'Experiment is not valid' : undefined}
+                            data-attr="save-experiment"
+                            type="primary"
                             size="small"
-                            onClick={() => {
-                                router.actions.push(urls.experiments())
-                            }}
+                            onClick={saveExperiment}
                         >
-                            Cancel
+                            Save as draft
                         </LemonButton>
-
-                        <AccessControlAction
-                            resourceType={AccessControlResourceType.Experiment}
-                            minAccessLevel={AccessControlLevel.Editor}
-                            userAccessLevel={experiment.user_access_level}
-                        >
-                            <LemonButton
-                                loading={isExperimentSubmitting}
-                                disabledReason={!canSubmitExperiment ? 'Experiment is not valid' : undefined}
-                                data-attr="save-experiment"
-                                type="primary"
-                                size="small"
-                                onClick={saveExperiment}
-                            >
-                                Save as draft
-                            </LemonButton>
-                        </AccessControlAction>
-                    </div>
-                </SceneContent>
-            </div>
+                    </AccessControlAction>
+                </div>
+            </SceneContent>
         </div>
     )
 }


### PR DESCRIPTION
## Problem
The form has a fixed width and UX breaks when the sidebar is popped.

## Changes
**The only actual change here is the removal of the outer divs.**

Make the new form full width. This looks alright as there's plenty of content to fill it up + looks good when the sidebar is popped.

## How did you test this code?
|Before|After|
|----|----|
|<img width="1510" height="781" alt="image" src="https://github.com/user-attachments/assets/1b143803-363f-43a8-b7ef-7ec83288cbe6" />|<img width="1509" height="780" alt="image" src="https://github.com/user-attachments/assets/c1fcfa61-bcfa-4b72-a6ec-110055f119d9" />|

|Before|After|
|----|----|
|<img width="1511" height="781" alt="image" src="https://github.com/user-attachments/assets/e0655f48-7c54-43ce-bd3c-6b5d631136ff" />|<img width="1509" height="780" alt="image" src="https://github.com/user-attachments/assets/e1c011af-8e5c-4470-bef6-7c390f0ee3a3" />|