### PR TITLE
style(ai): Distinguish tool context from added context

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -28,9 +28,9 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { compareInsightTopLevelSections } from 'scenes/insights/utils'
 import MaxTool from 'scenes/max/MaxTool'
 import { castAssistantQuery } from 'scenes/max/utils'
+import { QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { userLogic } from 'scenes/userLogic'
 
-import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { StickinessCriteria } from '~/queries/nodes/InsightViz/StickinessCriteria'
 import {
     AssistantFunnelsQuery,
@@ -397,6 +397,8 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         },
     ]
 
+    const QueryTypeIcon = QUERY_TYPES_METADATA[query.kind].icon
+
     return (
         <CSSTransition in={showing} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
             <div className="EditorFiltersWrapper">
@@ -416,7 +418,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                         }}
                         contextDescription={{
                             text: 'Current query',
-                            icon: iconForType('insight/hog'),
+                            icon: <QueryTypeIcon />,
                         }}
                         callback={(
                             toolOutput:

--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -258,10 +258,10 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
 
     const tooltipContent =
         toolContextItems.length === 1 ? (
-            'PostHog AI can use this context to answer your question'
+            'This context is auto-included from the current view'
         ) : (
             <div className="flex flex-col gap-1">
-                <div className="text-xs font-semibold mb-1">PostHog AI can use this context:</div>
+                <div className="text-xs font-semibold mb-1">This context is auto-included from the current view:</div>
                 {toolContextItems.map((item, index) => (
                     <div key={index} className="flex items-center gap-1.5">
                         {item.icon}
@@ -275,7 +275,10 @@ export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'de
         <Tooltip title={tooltipContent}>
             <LemonTag
                 icon={toolContextItems[0].icon}
-                className={clsx('flex items-center', size === 'small' ? 'max-w-20' : 'max-w-48')}
+                className={clsx(
+                    'flex items-center cursor-default border-dashed',
+                    size === 'small' ? 'max-w-20' : 'max-w-48'
+                )}
             >
                 <span className="truncate min-w-0 flex-1">
                     {toolContextItems[0].text}


### PR DESCRIPTION
## Problem

This is basically my review of #41499 – all useful, just 1. wasn't clear the tool context isn't removable, 2. we were using the HogQL icon for classic insight types.

![2025-11-14 17.34.54.gif](https://app.graphite.com/user-attachments/assets/ae548b88-20df-4c06-aa1a-c838ce2304f7.gif)

## Changes

Using a dashed border + default cursor for distinguishing the two types of context:

![distinguish.gif](https://app.graphite.com/user-attachments/assets/18ef5820-cf12-4d9f-a84a-616c83f2a532.gif)

## How did you test this code?

Manual. UI snapshots.