### PR TITLE
fix(ds): update snowflake config so that password isn't "required"

### DIFF
--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -45,9 +45,9 @@ class GoogleAdsIsMccAccountConfig(config.Config):
 @config.config
 class SnowflakeAuthTypeConfig(config.Config):
     user: str
-    password: str
-    private_key: str
     selection: Literal["password", "keypair"] = "password"
+    password: str | None = None
+    private_key: str | None = None
     passphrase: str | None = None
 
 

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -71,6 +71,7 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
                         required=True,
                         placeholder="COMPUTE_WAREHOUSE",
                     ),
+                    # the validation for these options happens in validate_credentials
                     SourceFieldSelectConfig(
                         name="auth_type",
                         label="Authentication type",
@@ -94,7 +95,7 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
                                             name="password",
                                             label="Password",
                                             type=SourceFieldInputConfigType.PASSWORD,
-                                            required=True,
+                                            required=False,
                                             placeholder="",
                                         ),
                                     ],
@@ -117,7 +118,7 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
                                             name="private_key",
                                             label="Private key",
                                             type=SourceFieldInputConfigType.TEXTAREA,
-                                            required=True,
+                                            required=False,
                                             placeholder="",
                                         ),
                                         SourceFieldInputConfig(
@@ -184,10 +185,9 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
         if config.auth_type.selection == "password" and (not config.auth_type.user or not config.auth_type.password):
             return False, "Missing required parameters: username, password"
 
-        if config.auth_type.selection == "keypair" and (
-            not config.auth_type.passphrase or not config.auth_type.private_key or not config.auth_type.user
-        ):
-            return False, "Missing required parameters: passphrase, private key"
+        # passphrase is optional if the key they use to auth is not encrypted
+        if config.auth_type.selection == "keypair" and (not config.auth_type.user or not config.auth_type.private_key):
+            return False, "Missing required parameters: username, private key"
 
         try:
             self.get_schemas(config, team_id)


### PR DESCRIPTION
## Problem

Customers using keypair validation are met with an error which says "password" (not passphrase) is required. The config validation is incorrect;y failing because no password is required with keypair auth.

## Changes

This removes the required status for passphrase, private key, and password from the source config. These are checked in the validate_credentials method anyway and will surface an error when not provided by the user. This also removes a requirement for passphrase as customer's can use unencrypted private keys (which don't require a passphrase) for keypair if they want to in snowflake.

## How did you test this code?

Ran a small snowflake sync locally. Validated that missing password or private key is still caught by validate_credentials and doesn't advance the connection.