### PR TITLE
fix: handle none created_by in email subscription delivery

### DIFF
--- a/ee/tasks/subscriptions/email_subscriptions.py
+++ b/ee/tasks/subscriptions/email_subscriptions.py
@@ -40,7 +40,7 @@ def send_email_subscription_report(
 
     inviter = subscription.created_by
     is_invite = invite_message is not None
-    self_invite = inviter.email == email
+    self_invite = inviter and inviter.email == email
 
     subject = "PostHog Report"
     invite_summary = None
@@ -59,7 +59,8 @@ def send_email_subscription_report(
         if self_invite:
             subject = f"You have been subscribed to a PostHog {resource_info.kind}"
         else:
-            subject = f"{inviter.first_name or 'Someone'} subscribed you to a PostHog {resource_info.kind}"
+            inviter_name = (inviter.first_name if inviter else None) or "Someone"
+            subject = f"{inviter_name} subscribed you to a PostHog {resource_info.kind}"
         campaign_key = f"{resource_info.kind.lower()}_subscription_new_{uuid.uuid4()}"
 
     message = EmailMessage(

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -401,8 +401,6 @@ ee/models/license.py:0: error: Cannot use a covariant type variable as a paramet
 ee/models/license.py:0: error: Incompatible return value type (got "Literal[''] | bool", expected "bool")  [return-value]
 ee/models/license.py:0: error: Incompatible return value type (got "_T", expected "License | None")  [return-value]
 ee/tasks/auto_rollback_feature_flag.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
-ee/tasks/subscriptions/email_subscriptions.py:0: error: Item "None" of "User | None" has no attribute "email"  [union-attr]
-ee/tasks/subscriptions/email_subscriptions.py:0: error: Item "None" of "User | None" has no attribute "first_name"  [union-attr]
 ee/tasks/subscriptions/email_subscriptions.py:0: error: Item "None" of "datetime | None" has no attribute "isoformat"  [union-attr]
 ee/tasks/subscriptions/email_subscriptions.py:0: error: Item "None" of "datetime | None" has no attribute "strftime"  [union-attr]
 ee/tasks/subscriptions/slack_subscriptions.py:0: error: Item "None" of "datetime | None" has no attribute "strftime"  [union-attr]


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Sometimes the created_by for a subscription can be none so we need to handle it. This results in the subscription email not being sent. 
Discovered in this error log: https://grafana.prod-us.posthog.dev/goto/2H7f1MmvR?orgId=1

```
...
"exc_type": "AttributeError",
"exc_value": "'NoneType' object has no attribute 'email'",
...
"filename": "/code/ee/tasks/subscriptions/email_subscriptions.py",
"lineno": 43,
"locals": {
    "email": "'...'",
    "subscription": "<Subscription: Subscription object (14049)>",
    ...
    "inviter": "None", 
    "is_invite": "False"
}
...
```


## Changes

check if created_by is none

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
