### PR TITLE
feat(data-import-source): build Mailchimp data warehouse import source

### DIFF
--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -135,7 +135,7 @@ class MSSQLSourceConfig(config.Config):
 
 @config.config
 class MailchimpSourceConfig(config.Config):
-    pass
+    api_key: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/mailchimp/mailchimp.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/mailchimp.py
@@ -1,0 +1,224 @@
+from typing import Any
+
+import dlt
+import requests
+from dlt.sources.helpers.rest_client.paginators import BasePaginator
+
+from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resources
+from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+
+
+class MailchimpPaginator(BasePaginator):
+    """Custom paginator for Mailchimp API using offset-based pagination."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.offset = 0
+        self.count = 0
+
+    def update_state(self, response: requests.Response) -> None:
+        """Update paginator state from response."""
+        data = response.json()
+        total_items = data.get("total_items", 0)
+        self.count = len(data.get(self._get_data_key(response.url), []))
+        self.offset += self.count
+
+        if self.offset >= total_items or self.count == 0:
+            self._has_next_page = False
+        else:
+            self._has_next_page = True
+
+    def update_request(self, request: dict[str, Any]) -> None:
+        """Update request with pagination parameters."""
+        if request.get("params") is None:
+            request["params"] = {}
+        request["params"]["offset"] = self.offset
+        request["params"]["count"] = 1000  # Mailchimp max is 1000
+
+    def _get_data_key(self, url: str) -> str:
+        """Get the data key from the URL path."""
+        if "lists" in url and "members" not in url:
+            return "lists"
+        elif "campaigns" in url:
+            return "campaigns"
+        elif "automations" in url:
+            return "automations"
+        elif "reports" in url:
+            return "reports"
+        return "data"
+
+
+def get_resource(name: str, api_key: str, server_prefix: str, should_use_incremental_field: bool) -> EndpointResource:
+    """Get endpoint resource configuration for Mailchimp API."""
+    resources: dict[str, EndpointResource] = {
+        "lists": {
+            "name": "lists",
+            "table_name": "lists",
+            "primary_key": "id",
+            "write_disposition": "replace",
+            "endpoint": {
+                "data_selector": "lists",
+                "path": "/lists",
+                "params": {
+                    "count": 1000,
+                },
+            },
+        },
+        "campaigns": {
+            "name": "campaigns",
+            "table_name": "campaigns",
+            "primary_key": "id",
+            "write_disposition": {
+                "disposition": "merge",
+                "strategy": "upsert",
+            }
+            if should_use_incremental_field
+            else "replace",
+            "endpoint": {
+                "data_selector": "campaigns",
+                "path": "/campaigns",
+                "params": {
+                    "count": 1000,
+                    "since_send_time": {
+                        "type": "incremental",
+                        "cursor_path": "send_time",
+                        "initial_value": "1970-01-01T00:00:00+00:00",
+                    }
+                    if should_use_incremental_field
+                    else None,
+                    "sort_field": "send_time",
+                    "sort_dir": "ASC",
+                },
+            },
+            "table_format": "delta",
+        },
+        "automations": {
+            "name": "automations",
+            "table_name": "automations",
+            "primary_key": "id",
+            "write_disposition": "replace",
+            "endpoint": {
+                "data_selector": "automations",
+                "path": "/automations",
+                "params": {
+                    "count": 1000,
+                },
+            },
+        },
+        "reports": {
+            "name": "reports",
+            "table_name": "reports",
+            "primary_key": "id",
+            "write_disposition": {
+                "disposition": "merge",
+                "strategy": "upsert",
+            }
+            if should_use_incremental_field
+            else "replace",
+            "endpoint": {
+                "data_selector": "reports",
+                "path": "/reports",
+                "params": {
+                    "count": 1000,
+                    "since_send_time": {
+                        "type": "incremental",
+                        "cursor_path": "send_time",
+                        "initial_value": "1970-01-01T00:00:00+00:00",
+                    }
+                    if should_use_incremental_field
+                    else None,
+                },
+            },
+            "table_format": "delta",
+        },
+    }
+
+    return resources[name]
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str]:
+    """Validate Mailchimp API credentials and extract server prefix.
+
+    Returns:
+        A tuple of (is_valid, server_prefix).
+        If invalid, server_prefix will contain an error message.
+    """
+    # Extract server prefix from API key (last part after the dash)
+    # API keys are in format: {key}-{server_prefix}
+    if "-" not in api_key:
+        return False, "Invalid API key format. API key should contain a server prefix (e.g., key-us1)"
+
+    parts = api_key.split("-")
+    if len(parts) < 2:
+        return False, "Invalid API key format. API key should contain a server prefix (e.g., key-us1)"
+
+    server_prefix = parts[-1]
+    base_url = f"https://{server_prefix}.api.mailchimp.com/3.0"
+
+    # Test the API key by making a simple request to the ping endpoint
+    try:
+        response = requests.get(
+            f"{base_url}/ping",
+            auth=("anystring", api_key),
+            timeout=10,
+        )
+
+        if response.status_code == 200:
+            return True, server_prefix
+        elif response.status_code == 401:
+            return False, "Invalid API key"
+        else:
+            return False, f"API error: {response.status_code}"
+    except requests.exceptions.RequestException as e:
+        return False, f"Connection error: {str(e)}"
+
+
+@dlt.source(max_table_nesting=0)
+def mailchimp_source(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any | None = None,
+):
+    """Create a DLT source for Mailchimp data.
+
+    Args:
+        api_key: Mailchimp API key
+        endpoint: The endpoint to sync (lists, campaigns, automations, reports)
+        team_id: PostHog team ID
+        job_id: PostHog job ID
+        should_use_incremental_field: Whether to use incremental syncing
+        db_incremental_field_last_value: Last value for incremental field
+    """
+    # Extract server prefix from API key
+    is_valid, result = validate_credentials(api_key)
+    if not is_valid:
+        raise ValueError(f"Invalid Mailchimp credentials: {result}")
+
+    server_prefix = result
+    base_url = f"https://{server_prefix}.api.mailchimp.com/3.0"
+
+    # Get resource configuration
+    resource = get_resource(endpoint, api_key, server_prefix, should_use_incremental_field)
+
+    # Configure REST API
+    config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            "auth": {
+                "type": "http_basic",
+                "username": "anystring",  # Mailchimp accepts any string as username
+                "password": api_key,
+            },
+            "paginator": MailchimpPaginator(),
+        },
+        "resource_defaults": {
+            "primary_key": "id",
+            "write_disposition": "replace",
+        },
+        "resources": [resource],
+    }
+
+    yield from rest_api_resources(config)

--- a/posthog/temporal/data_imports/sources/mailchimp/settings.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/settings.py
@@ -1,0 +1,31 @@
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+# Endpoints to sync from Mailchimp Marketing API v3
+# Based on Airbyte and Fivetran implementations
+ENDPOINTS = (
+    "lists",
+    "campaigns",
+    "automations",
+    "reports",
+)
+
+# Incremental fields for each endpoint
+# Most Mailchimp endpoints support date-based filtering
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    "campaigns": [
+        {
+            "label": "send_time",
+            "type": IncrementalFieldType.DateTime,
+            "field": "send_time",
+            "field_type": IncrementalFieldType.DateTime,
+        },
+    ],
+    "reports": [
+        {
+            "label": "send_time",
+            "type": IncrementalFieldType.DateTime,
+            "field": "send_time",
+            "field_type": IncrementalFieldType.DateTime,
+        },
+    ],
+}

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -3,11 +3,21 @@ from typing import cast
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.common.utils import dlt_source_to_source_response
 from posthog.temporal.data_imports.sources.generated_configs import MailchimpSourceConfig
+from posthog.temporal.data_imports.sources.mailchimp.mailchimp import (
+    mailchimp_source,
+    validate_credentials as validate_mailchimp_credentials,
+)
+from posthog.temporal.data_imports.sources.mailchimp.settings import ENDPOINTS, INCREMENTAL_FIELDS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -25,6 +35,54 @@ class MailchimpSource(SimpleSource[MailchimpSourceConfig]):
             label="Mailchimp",
             iconPath="/static/services/mailchimp.png",
             docsUrl="https://posthog.com/docs/cdp/sources/mailchimp",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            caption="""Enter your Mailchimp API key to automatically pull your Mailchimp data into the PostHog Data warehouse.
+
+You can find your API key by logging into your Mailchimp account and navigating to **Account** > **Extras** > **API keys**. If you don't have an API key yet, you can create one by clicking **Create A Key**.
+
+Your API key will include a server prefix (e.g., `abc123-us19`) which identifies your Mailchimp data center. This is automatically detected from your API key.
+            """,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="abc123-us19",
+                    ),
+                ],
+            ),
+            featureFlag="dwh_mailchimp",
+        )
+
+    def get_schemas(self, config: MailchimpSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+        return [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
+                supports_append=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+    def validate_credentials(self, config: MailchimpSourceConfig, team_id: int) -> tuple[bool, str | None]:
+        is_valid, result = validate_mailchimp_credentials(config.api_key)
+        if is_valid:
+            return True, None
+        return False, result
+
+    def source_for_pipeline(self, config: MailchimpSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return dlt_source_to_source_response(
+            mailchimp_source(
+                api_key=config.api_key,
+                endpoint=inputs.schema_name,
+                team_id=inputs.team_id,
+                job_id=inputs.job_id,
+                should_use_incremental_field=inputs.should_use_incremental_field,
+                db_incremental_field_last_value=inputs.db_incremental_field_last_value
+                if inputs.should_use_incremental_field
+                else None,
+            )
         )


### PR DESCRIPTION
Add support for importing Mailchimp data into PostHog Data Warehouse.

Changes:
- Implement MailchimpSource with API key authentication
- Add support for lists, campaigns, automations, and reports endpoints
- Implement custom pagination for Mailchimp's offset-based API
- Add incremental syncing support for campaigns and reports using send_time field
- Configure feature flag: dwh_mailchimp
- Add API key validation with server prefix auto-detection

The implementation follows the REST API source pattern and includes:
- mailchimp.py: Core API logic with custom paginator
- settings.py: Endpoint and incremental field definitions
- source.py: Source configuration and field definitions
- generated_configs.py: Added api_key field to MailchimpSourceConfig

Mailchimp logo already exists at frontend/public/services/mailchimp.png No non-confidential fields to add to ExternalDataSourceSerializers

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
