### PR TITLE
feat(data-import-source): Build Mailchimp data warehouse import source

### DIFF
--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -135,7 +135,7 @@ class MSSQLSourceConfig(config.Config):
 
 @config.config
 class MailchimpSourceConfig(config.Config):
-    pass
+    api_key: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/mailchimp/mailchimp.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/mailchimp.py
@@ -1,0 +1,183 @@
+from typing import Any
+
+import requests
+from structlog.types import FilteringBoundLogger
+
+from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_source
+from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+
+
+def extract_data_center(api_key: str) -> str:
+    """Extract data center from Mailchimp API key.
+
+    Mailchimp API keys are in format: <key>-<dc> where dc is the data center (e.g., us1, us19).
+    """
+    parts = api_key.split("-")
+    if len(parts) != 2:
+        raise ValueError("Invalid Mailchimp API key format. Expected format: <key>-<datacenter>")
+    return parts[1]
+
+
+def get_base_url(api_key: str) -> str:
+    """Get the Mailchimp API base URL for the given API key."""
+    dc = extract_data_center(api_key)
+    return f"https://{dc}.api.mailchimp.com/3.0"
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Validate Mailchimp API credentials by making a test request."""
+    try:
+        base_url = get_base_url(api_key)
+        response = requests.get(
+            f"{base_url}/ping",
+            auth=("anystring", api_key),
+            timeout=10,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def get_resource(
+    name: str,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any | None = None,
+) -> EndpointResource:
+    """Get endpoint resource configuration for a given Mailchimp endpoint."""
+
+    resources: dict[str, EndpointResource] = {
+        "lists": {
+            "name": "lists",
+            "table_name": "lists",
+            **({"primary_key": "id"} if should_use_incremental_field else {}),
+            "write_disposition": {
+                "disposition": "merge",
+                "strategy": "upsert",
+            }
+            if should_use_incremental_field
+            else "replace",
+            "endpoint": {
+                "data_selector": "lists",
+                "path": "/lists",
+                "params": {
+                    "count": 1000,
+                    "offset": 0,
+                    "sort_field": "date_created",
+                    "sort_dir": "ASC",
+                },
+            },
+            "table_format": "delta",
+        },
+        "campaigns": {
+            "name": "campaigns",
+            "table_name": "campaigns",
+            **({"primary_key": "id"} if should_use_incremental_field else {}),
+            "write_disposition": {
+                "disposition": "merge",
+                "strategy": "upsert",
+            }
+            if should_use_incremental_field
+            else "replace",
+            "endpoint": {
+                "data_selector": "campaigns",
+                "path": "/campaigns",
+                "params": {
+                    "count": 1000,
+                    "offset": 0,
+                    "sort_field": "send_time",
+                    "sort_dir": "ASC",
+                    "status": "sent",
+                },
+            },
+            "table_format": "delta",
+        },
+        "automations": {
+            "name": "automations",
+            "table_name": "automations",
+            **({"primary_key": "id"} if should_use_incremental_field else {}),
+            "write_disposition": {
+                "disposition": "merge",
+                "strategy": "upsert",
+            }
+            if should_use_incremental_field
+            else "replace",
+            "endpoint": {
+                "data_selector": "automations",
+                "path": "/automations",
+                "params": {
+                    "count": 1000,
+                    "offset": 0,
+                },
+            },
+            "table_format": "delta",
+        },
+        "reports": {
+            "name": "reports",
+            "table_name": "reports",
+            **({"primary_key": "id"} if should_use_incremental_field else {}),
+            "write_disposition": {
+                "disposition": "merge",
+                "strategy": "upsert",
+            }
+            if should_use_incremental_field
+            else "replace",
+            "endpoint": {
+                "data_selector": "reports",
+                "path": "/reports",
+                "params": {
+                    "count": 1000,
+                    "offset": 0,
+                },
+            },
+            "table_format": "delta",
+        },
+    }
+
+    if name not in resources:
+        raise ValueError(f"Unknown Mailchimp endpoint: {name}")
+
+    return resources[name]
+
+
+def mailchimp_source(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any | None = None,
+    logger: FilteringBoundLogger | None = None,
+):
+    """Create a Mailchimp data source using the REST API pattern."""
+
+    base_url = get_base_url(api_key)
+
+    resource = get_resource(endpoint, should_use_incremental_field, db_incremental_field_last_value)
+
+    config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            "auth": {
+                "type": "http_basic",
+                "username": "anystring",
+                "password": api_key,
+            },
+            "paginator": {
+                "type": "offset",
+                "limit": 1000,
+                "offset": 0,
+                "offset_param": "offset",
+                "limit_param": "count",
+                "total_path": "total_items",
+            },
+        },
+        "resources": [resource],
+    }
+
+    yield from rest_api_source(
+        config=config,
+        team_id=team_id,
+        job_id=job_id,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+        name=f"mailchimp_{endpoint}",
+    )

--- a/posthog/temporal/data_imports/sources/mailchimp/settings.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/settings.py
@@ -1,0 +1,50 @@
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+ENDPOINTS = (
+    "lists",
+    "campaigns",
+    "automations",
+    "reports",
+)
+
+INCREMENTAL_ENDPOINTS = (
+    "lists",
+    "campaigns",
+    "automations",
+    "reports",
+)
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    "lists": [
+        {
+            "label": "date_created",
+            "type": IncrementalFieldType.DateTime,
+            "field": "date_created",
+            "field_type": IncrementalFieldType.DateTime,
+        }
+    ],
+    "campaigns": [
+        {
+            "label": "send_time",
+            "type": IncrementalFieldType.DateTime,
+            "field": "send_time",
+            "field_type": IncrementalFieldType.DateTime,
+        }
+    ],
+    "automations": [
+        {
+            "label": "create_time",
+            "type": IncrementalFieldType.DateTime,
+            "field": "create_time",
+            "field_type": IncrementalFieldType.DateTime,
+        }
+    ],
+    "reports": [
+        {
+            "label": "send_time",
+            "type": IncrementalFieldType.DateTime,
+            "field": "send_time",
+            "field_type": IncrementalFieldType.DateTime,
+        }
+    ],
+}

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -3,11 +3,24 @@ from typing import cast
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.common.utils import dlt_source_to_source_response
 from posthog.temporal.data_imports.sources.generated_configs import MailchimpSourceConfig
+from posthog.temporal.data_imports.sources.mailchimp.mailchimp import (
+    mailchimp_source,
+    validate_credentials as validate_mailchimp_credentials,
+)
+from posthog.temporal.data_imports.sources.mailchimp.settings import (
+    ENDPOINTS as MAILCHIMP_ENDPOINTS,
+    INCREMENTAL_FIELDS as MAILCHIMP_INCREMENTAL_FIELDS,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -23,8 +36,61 @@ class MailchimpSource(SimpleSource[MailchimpSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.MAILCHIMP,
             label="Mailchimp",
+            caption="""Connect your Mailchimp account to automatically import your email marketing data into PostHog.
+
+You'll need a Mailchimp API key which you can create [in your Mailchimp account](https://admin.mailchimp.com/account/api/).
+
+Your API key should be in the format: `<key>-<datacenter>` (e.g., `abc123-us19`). The data center is automatically extracted from your API key.""",
             iconPath="/static/services/mailchimp.png",
             docsUrl="https://posthog.com/docs/cdp/sources/mailchimp",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="abc123-us19",
+                    ),
+                ],
+            ),
+            feature_flag="dwh_mailchimp",
+        )
+
+    def validate_credentials(self, config: MailchimpSourceConfig, team_id: int) -> tuple[bool, str | None]:
+        try:
+            if validate_mailchimp_credentials(config.api_key):
+                return True, None
+            else:
+                return False, "Invalid Mailchimp API key"
+        except ValueError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, f"Error validating credentials: {str(e)}"
+
+    def get_schemas(self, config: MailchimpSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+        return [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=MAILCHIMP_INCREMENTAL_FIELDS.get(endpoint, None) is not None,
+                supports_append=MAILCHIMP_INCREMENTAL_FIELDS.get(endpoint, None) is not None,
+                incremental_fields=MAILCHIMP_INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in MAILCHIMP_ENDPOINTS
+        ]
+
+    def source_for_pipeline(self, config: MailchimpSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return dlt_source_to_source_response(
+            mailchimp_source(
+                api_key=config.api_key,
+                endpoint=inputs.schema_name,
+                team_id=inputs.team_id,
+                job_id=inputs.job_id,
+                should_use_incremental_field=inputs.should_use_incremental_field,
+                db_incremental_field_last_value=inputs.db_incremental_field_last_value
+                if inputs.should_use_incremental_field
+                else None,
+                logger=inputs.logger,
+            )
         )


### PR DESCRIPTION
This commit implements a complete data warehouse import source for Mailchimp, allowing users to sync their email marketing data into PostHog.

Changes:
- Add Mailchimp source implementation with API key authentication
- Support for 4 main endpoints: lists, campaigns, automations, and reports
- Implement incremental syncing with datetime-based fields
- Add data center extraction from API key (format: <key>-<datacenter>)
- Use REST API client pattern for efficient data fetching
- Add feature flag: dwh_mailchimp
- Update generated configs with MailchimpSourceConfig

The implementation follows the existing source patterns and includes:
- Credential validation via Mailchimp ping endpoint
- Schema discovery with incremental field support
- Pagination support using offset-based pagination
- Proper error handling and validation

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
