### PR TITLE
fix: update onboarding-use-case-selection feature flag to variant

### DIFF
--- a/frontend/src/layout/navigation/ProjectNotice.tsx
+++ b/frontend/src/layout/navigation/ProjectNotice.tsx
@@ -73,7 +73,7 @@ export function ProjectNotice({ className }: { className?: string }): JSX.Elemen
     }
 
     const altTeamForIngestion = currentOrganization?.teams?.find((team) => !team.is_demo && !team.ingested_event)
-    const useUseCaseSelection = featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === true
+    const useUseCaseSelection = featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
 
     const NOTICES: Record<ProjectNoticeVariant, ProjectNoticeBlueprint> = {
         demo_project: {

--- a/frontend/src/layout/navigation/ProjectNotice.tsx
+++ b/frontend/src/layout/navigation/ProjectNotice.tsx
@@ -73,7 +73,7 @@ export function ProjectNotice({ className }: { className?: string }): JSX.Elemen
     }
 
     const altTeamForIngestion = currentOrganization?.teams?.find((team) => !team.is_demo && !team.ingested_event)
-    const useUseCaseSelection = featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
+    const useUseCaseSelection = featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'test'
 
     const NOTICES: Record<ProjectNoticeVariant, ProjectNoticeBlueprint> = {
         demo_project: {

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -141,7 +141,7 @@ export const organizationLogic = kea<organizationLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions }) => ({
         loadCurrentOrganizationSuccess: ({ currentOrganization }) => {
             if (currentOrganization) {
                 ApiConfig.setCurrentOrganizationId(currentOrganization.id)
@@ -149,7 +149,8 @@ export const organizationLogic = kea<organizationLogicType>([
         },
         createOrganizationSuccess: () => {
             sidePanelStateLogic.findMounted()?.actions.closeSidePanel()
-            const useUseCaseSelection = values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === true
+            const useUseCaseSelection =
+                featureFlagLogic.values.featureFlags?.[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
             window.location.href = useUseCaseSelection ? urls.useCaseSelection() : urls.products()
         },
         updateOrganizationSuccess: () => {

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -141,7 +141,7 @@ export const organizationLogic = kea<organizationLogicType>([
             },
         ],
     }),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         loadCurrentOrganizationSuccess: ({ currentOrganization }) => {
             if (currentOrganization) {
                 ApiConfig.setCurrentOrganizationId(currentOrganization.id)
@@ -149,8 +149,8 @@ export const organizationLogic = kea<organizationLogicType>([
         },
         createOrganizationSuccess: () => {
             sidePanelStateLogic.findMounted()?.actions.closeSidePanel()
-            const useUseCaseSelection =
-                featureFlagLogic.values.featureFlags?.[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'test'
+
+            const useUseCaseSelection = values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'test'
             window.location.href = useUseCaseSelection ? urls.useCaseSelection() : urls.products()
         },
         updateOrganizationSuccess: () => {

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -150,7 +150,7 @@ export const organizationLogic = kea<organizationLogicType>([
         createOrganizationSuccess: () => {
             sidePanelStateLogic.findMounted()?.actions.closeSidePanel()
             const useUseCaseSelection =
-                featureFlagLogic.values.featureFlags?.[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
+                featureFlagLogic.values.featureFlags?.[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'test'
             window.location.href = useUseCaseSelection ? urls.useCaseSelection() : urls.products()
         },
         updateOrganizationSuccess: () => {

--- a/frontend/src/scenes/projectLogic.ts
+++ b/frontend/src/scenes/projectLogic.ts
@@ -137,7 +137,7 @@ export const projectLogic = kea<projectLogicType>([
         },
         createProjectSuccess: ({ currentProject }) => {
             if (currentProject) {
-                const useUseCaseSelection = values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
+                const useUseCaseSelection = values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'test'
                 const redirectUrl = useUseCaseSelection ? urls.useCaseSelection() : urls.products()
                 actions.switchTeam(currentProject.id, redirectUrl)
             }

--- a/frontend/src/scenes/projectLogic.ts
+++ b/frontend/src/scenes/projectLogic.ts
@@ -137,7 +137,7 @@ export const projectLogic = kea<projectLogicType>([
         },
         createProjectSuccess: ({ currentProject }) => {
             if (currentProject) {
-                const useUseCaseSelection = values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === true
+                const useUseCaseSelection = values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
                 const redirectUrl = useUseCaseSelection ? urls.useCaseSelection() : urls.products()
                 actions.switchTeam(currentProject.id, redirectUrl)
             }

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1129,7 +1129,7 @@ export const sceneLogic = kea<sceneLogicType>([
 
                                 // Default to false (products page) if feature flags haven't loaded yet
                                 const useUseCaseSelection =
-                                    values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
+                                    values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'test'
 
                                 if (useUseCaseSelection) {
                                     router.actions.replace(

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1129,7 +1129,7 @@ export const sceneLogic = kea<sceneLogicType>([
 
                                 // Default to false (products page) if feature flags haven't loaded yet
                                 const useUseCaseSelection =
-                                    values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === true
+                                    values.featureFlags[FEATURE_FLAGS.ONBOARDING_USE_CASE_SELECTION] === 'true'
 
                                 if (useUseCaseSelection) {
                                     router.actions.replace(


### PR DESCRIPTION
## Problem

the use case onboarding feature flag 
 https://github.com/PostHog/posthog/pull/41147/files was written as a boolean. But, we need to use a variant for it to work with experiments.

## Changes


## How did you test this code?

updated my feature flag to be a variant and toggled it on and made sure it works when I create a new org or project.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

no
