### PR TITLE
fix: Fix cohort metrics dropping to zero on worker restart

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -32,21 +32,27 @@ from posthog.tasks.utils import CeleryQueue
 COHORT_RECALCULATIONS_BACKLOG_GAUGE = Gauge(
     "cohort_recalculations_backlog",
     "Number of cohorts that are waiting to be calculated",
+    multiprocess_mode="livesum",
 )
 
 COHORT_STALENESS_HOURS_GAUGE = Gauge(
     "cohort_staleness_hours",
     "Cohort's count of hours since last calculation",
+    multiprocess_mode="livesum",
 )
 
 COHORTS_STALE_COUNT_GAUGE = Gauge(
-    "cohorts_stale", "Number of cohorts that haven't been calculated in more than X hours", ["hours"]
+    "cohorts_stale",
+    "Number of cohorts that haven't been calculated in more than X hours",
+    ["hours"],
+    multiprocess_mode="livesum",
 )
 
 COHORT_STUCK_COUNT_GAUGE = Gauge(
     # TODO: rename to cohorts_stuck because this is a gauge not a counter
     "cohort_stuck_count",
     "Number of cohorts that are stuck calculating for more than 1 hour",
+    multiprocess_mode="livesum",
 )
 
 COHORT_DEPENDENCY_CALCULATION_FAILURES_COUNTER = Counter(
@@ -56,7 +62,9 @@ COHORT_DEPENDENCY_CALCULATION_FAILURES_COUNTER = Counter(
 COHORT_STUCK_RESETS_COUNTER = Counter("cohort_stuck_resets_total", "Number of stuck cohorts that have been reset")
 
 COHORT_MAXED_ERRORS_GAUGE = Gauge(
-    "cohort_maxed_errors", "Number of cohorts that have reached the maximum number of errors"
+    "cohort_maxed_errors",
+    "Number of cohorts that have reached the maximum number of errors",
+    multiprocess_mode="livesum",
 )
 
 COHORT_CALCULATION_STARTED_COUNTER = Counter(

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -38,21 +38,18 @@ COHORT_RECALCULATIONS_BACKLOG_GAUGE = Gauge(
 COHORT_STALENESS_HOURS_GAUGE = Gauge(
     "cohort_staleness_hours",
     "Cohort's count of hours since last calculation",
-    multiprocess_mode="livesum",
 )
 
 COHORTS_STALE_COUNT_GAUGE = Gauge(
     "cohorts_stale",
     "Number of cohorts that haven't been calculated in more than X hours",
     ["hours"],
-    multiprocess_mode="livesum",
 )
 
 COHORT_STUCK_COUNT_GAUGE = Gauge(
     # TODO: rename to cohorts_stuck because this is a gauge not a counter
     "cohort_stuck_count",
     "Number of cohorts that are stuck calculating for more than 1 hour",
-    multiprocess_mode="livesum",
 )
 
 COHORT_DEPENDENCY_CALCULATION_FAILURES_COUNTER = Counter(
@@ -64,7 +61,6 @@ COHORT_STUCK_RESETS_COUNTER = Counter("cohort_stuck_resets_total", "Number of st
 COHORT_MAXED_ERRORS_GAUGE = Gauge(
     "cohort_maxed_errors",
     "Number of cohorts that have reached the maximum number of errors",
-    multiprocess_mode="livesum",
 )
 
 COHORT_CALCULATION_STARTED_COUNTER = Counter(


### PR DESCRIPTION
Follow up to https://github.com/PostHog/posthog/pull/41465 to fix zero-value metrics on worker restart.

Without deployments, this is what the chart looks like.

<img width="1108" height="305" alt="image" src="https://github.com/user-attachments/assets/19f121ce-3538-4247-80ec-4c9910e4da9f" />
<img width="1112" height="299" alt="image" src="https://github.com/user-attachments/assets/8c71673e-1cb1-4934-ba2c-dab896c7fd35" />

