### PR TITLE
fix: improve behaviour of web worker decompression

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -12,9 +12,11 @@ import './buffer-polyfill'
 import { initKea } from './initKea'
 import { ErrorBoundary } from './layout/ErrorBoundary'
 import { loadPostHogJS } from './loadPostHogJS'
+import { preWarmDecompression } from './scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager'
 
 loadPostHogJS()
 initKea()
+preWarmDecompression()
 
 // On Chrome + Windows, the country flag emojis don't render correctly. This is a polyfill for that.
 // It won't be applied on other platforms.

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -179,6 +179,7 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
                     viewportForTimestamp,
                     sessionRecordingId
                 )
+
                 return snapshots || []
             },
         ],

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.test.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.test.ts
@@ -338,7 +338,7 @@ describe('process all snapshots', () => {
 
             const result = await parseEncodedSnapshots(convertInput(mockCompressedData), sessionId)
 
-            expect(mockWorkerManager.decompress).toHaveBeenCalledWith(fakeCompressedBlock)
+            expect(mockWorkerManager.decompress).toHaveBeenCalledWith(fakeCompressedBlock, { blockCount: 1 })
             expect(result).toHaveLength(1)
             expect(result[0].windowId).toBe('1')
             expect(result[0].timestamp).toBe(1234567890)

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
@@ -339,7 +339,8 @@ async function processAllSnapshotsAsync(
         const sourceKey = keyForSource(source)
 
         if (sourceKey in processingCache) {
-            for (const snapshot of processingCache[sourceKey]) {
+            const cachedSnapshots = processingCache[sourceKey]
+            for (const snapshot of cachedSnapshots) {
                 context.result.push(snapshot)
             }
             continue
@@ -388,6 +389,7 @@ async function processAllSnapshotsAsync(
     }
 
     context.result.sort((a, b) => a.timestamp - b.timestamp)
+
     return context.result
 }
 
@@ -417,7 +419,8 @@ function processAllSnapshotsSync(
         const sourceKey = keyForSource(source)
 
         if (sourceKey in processingCache) {
-            for (const snapshot of processingCache[sourceKey]) {
+            const cachedSnapshots = processingCache[sourceKey]
+            for (const snapshot of cachedSnapshots) {
                 context.result.push(snapshot)
             }
             continue
@@ -458,6 +461,7 @@ function processAllSnapshotsSync(
     }
 
     context.result.sort((a, b) => a.timestamp - b.timestamp)
+
     return context.result
 }
 
@@ -528,10 +532,11 @@ const lengthPrefixedSnappyDecompress = async (
     posthogInstance?: PostHog
 ): Promise<string> => {
     const workerManager = getDecompressionWorkerManager(mode, posthogInstance)
-    const decompressedParts: string[] = []
+
+    // Phase 1: Parse and collect all compressed blocks
+    const compressedBlocks: Uint8Array[] = []
     let offset = 0
 
-    // Parse length-prefixed blocks: [4 bytes length][compressed block][4 bytes length][compressed block]...
     while (offset < uint8Data.byteLength) {
         // Read 4-byte length prefix (big-endian unsigned int)
         if (offset + 4 > uint8Data.byteLength) {
@@ -555,16 +560,22 @@ const lengthPrefixedSnappyDecompress = async (
             break
         }
 
-        const compressedBlock = uint8Data.subarray(offset, offset + length)
+        // Create a copy of the block to avoid ArrayBuffer detachment issues
+        // when transferring to workers in parallel
+        const compressedBlock = uint8Data.slice(offset, offset + length)
+        compressedBlocks.push(compressedBlock)
         offset += length
-
-        const decompressedData = await workerManager.decompress(compressedBlock)
-
-        // Convert bytes to string
-        const textDecoder = new TextDecoder('utf-8')
-        const decompressedText = textDecoder.decode(decompressedData)
-        decompressedParts.push(decompressedText)
     }
+
+    // Phase 2: Decompress all blocks in parallel
+    const blockCount = compressedBlocks.length
+    const decompressedBlocks = await Promise.all(
+        compressedBlocks.map((block) => workerManager.decompress(block, { blockCount }))
+    )
+
+    // Phase 3: Decode all blocks to strings
+    const textDecoder = new TextDecoder('utf-8')
+    const decompressedParts = decompressedBlocks.map((data) => textDecoder.decode(data))
 
     return decompressedParts.join('\n')
 }
@@ -582,13 +593,34 @@ const rawSnappyDecompress = async (
     return textDecoder.decode(decompressedData)
 }
 
+function reportParseStats(
+    posthogInstance: PostHog | undefined,
+    snapshotCount: number,
+    parseDuration: number,
+    lineCount: number,
+    compressionType: 'length_prefixed_snappy' | 'raw_snappy'
+): void {
+    if (!posthogInstance) {
+        return
+    }
+
+    posthogInstance.capture('replay_parse_timing', {
+        snapshot_count: snapshotCount,
+        parse_duration_ms: parseDuration,
+        line_count: lineCount,
+        compression_type: compressionType,
+    })
+}
+
 export const parseEncodedSnapshots = async (
     items: (RecordingSnapshot | EncodedRecordingSnapshot | string)[] | ArrayBuffer | Uint8Array,
     sessionId: string,
     decompressionMode?: DecompressionMode,
-    posthogInstance?: PostHog,
-    enableYielding: boolean = false
+    posthogInstance?: PostHog
 ): Promise<RecordingSnapshot[]> => {
+    const startTime = performance.now()
+    const enableYielding = decompressionMode === 'yielding'
+
     if (!postHogEEModule) {
         postHogEEModule = await posthogEE()
     }
@@ -600,9 +632,17 @@ export const parseEncodedSnapshots = async (
         if (isLengthPrefixedSnappy(uint8Data)) {
             try {
                 const combinedText = await lengthPrefixedSnappyDecompress(uint8Data, decompressionMode, posthogInstance)
-
                 const lines = combinedText.split('\n').filter((line) => line.trim().length > 0)
-                return parseEncodedSnapshots(lines, sessionId, decompressionMode, posthogInstance, enableYielding)
+                const snapshots = await parseEncodedSnapshots(lines, sessionId, decompressionMode, posthogInstance)
+                const parseDuration = performance.now() - startTime
+                reportParseStats(
+                    posthogInstance,
+                    snapshots.length,
+                    parseDuration,
+                    lines.length,
+                    'length_prefixed_snappy'
+                )
+                return snapshots
             } catch (error) {
                 console.error('Length-prefixed Snappy decompression failed:', error)
                 posthog.captureException(new Error('Failed to decompress length-prefixed snapshot data'), {
@@ -616,16 +656,18 @@ export const parseEncodedSnapshots = async (
 
         try {
             const combinedText = await rawSnappyDecompress(uint8Data, decompressionMode, posthogInstance)
-
             const lines = combinedText.split('\n').filter((line) => line.trim().length > 0)
-            return parseEncodedSnapshots(lines, sessionId, decompressionMode, posthogInstance, enableYielding)
+            const snapshots = await parseEncodedSnapshots(lines, sessionId, decompressionMode, posthogInstance)
+            const parseDuration = performance.now() - startTime
+            reportParseStats(posthogInstance, snapshots.length, parseDuration, lines.length, 'raw_snappy')
+            return snapshots
         } catch (error) {
             try {
                 const textDecoder = new TextDecoder('utf-8')
                 const combinedText = textDecoder.decode(uint8Data)
 
                 const lines = combinedText.split('\n').filter((line) => line.trim().length > 0)
-                return parseEncodedSnapshots(lines, sessionId, decompressionMode, posthogInstance, enableYielding)
+                return parseEncodedSnapshots(lines, sessionId, decompressionMode, posthogInstance)
             } catch (decodeError) {
                 console.error('Failed to decompress or decode binary data:', error, decodeError)
                 posthog.captureException(new Error('Failed to process snapshot data'), {
@@ -656,6 +698,7 @@ export const parseEncodedSnapshots = async (
             if (typeof l === 'string') {
                 // is loaded from blob v1 storage
                 snapshotLine = JSON.parse(l) as EncodedRecordingSnapshot
+
                 if (Array.isArray(snapshotLine)) {
                     snapshotLine = {
                         windowId: snapshotLine[0],
@@ -666,6 +709,7 @@ export const parseEncodedSnapshots = async (
                 // is loaded from file export
                 snapshotLine = l
             }
+
             let snapshotData: ({ windowId: string } | EncodedRecordingSnapshot)[]
             if (isRecordingSnapshot(snapshotLine)) {
                 // is loaded from file export
@@ -685,6 +729,7 @@ export const parseEncodedSnapshots = async (
 
                 // Apply chunking to the snapshot if needed
                 const chunkedSnapshots = chunkMutationSnapshot(baseSnapshot)
+
                 parsedLines.push(...chunkedSnapshots)
             }
         } catch {

--- a/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
@@ -250,7 +250,8 @@ export const snapshotDataLogic = kea<snapshotDataLogicType>([
             const sourceKey = snapshotsForSource.sources
                 ? keyForSource(snapshotsForSource.sources[0])
                 : keyForSource(snapshotsForSource.source)
-            const snapshots = (cache.snapshotsBySource || {})[sourceKey] || []
+            const snapshotsData = (cache.snapshotsBySource || {})[sourceKey]
+            const snapshots = snapshotsData?.snapshots || []
 
             if (!snapshots.length && sources?.length === 1 && sources[0].source !== SnapshotSourceType.file) {
                 // We got only a single source to load, loaded it successfully, but it had no snapshots.


### PR DESCRIPTION
processing replay decompression in a web worker is unexpectedly slow

claude and i did some loops locally loading recordings and timing the steps and figuring out how to improve things

locally my reference recording was 81% faster after improvements (obvs local references might not play out in production)

1. Changed to parallel block decompression
2. WASM pre-warming - Eliminating a cold start penalty
3. tracks potential error cases and falls back to main thread decompression - since some folk reported getting stuck buffering