### PR TITLE
fix: Avoid linking to SQL editor for managed views

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
@@ -20,6 +20,14 @@ const STATUS_TAG_SETTINGS: Record<string, LemonTagType> = {
     Modified: 'warning',
 }
 
+const getDisabledReason = (view: DataWarehouseSavedQuery): string | undefined => {
+    if (view.managed_viewset_kind !== null) {
+        return `Cannot delete a view that belongs to a managed viewset. You can turn the viewset off in the ${urls.dataWarehouseManagedViewsets()} page.`
+    }
+
+    return undefined
+}
+
 function RunHistoryDisplay({
     runHistory,
     loading,
@@ -214,18 +222,7 @@ export function ViewsTab(): JSX.Element {
                                                 <LemonButton
                                                     status="danger"
                                                     onClick={() => deleteView(view.id)}
-                                                    disabledReason={
-                                                        view.managed_viewset_kind !== null ? (
-                                                            <span>
-                                                                Cannot delete a view that belongs to a managed viewset.
-                                                                You can turn the viewset off in the{' '}
-                                                                <Link to={urls.dataWarehouseManagedViewsets()}>
-                                                                    Managed Viewsets
-                                                                </Link>{' '}
-                                                                page.
-                                                            </span>
-                                                        ) : undefined
-                                                    }
+                                                    disabledReason={getDisabledReason(view)}
                                                 >
                                                     Delete
                                                 </LemonButton>
@@ -332,7 +329,11 @@ export function ViewsTab(): JSX.Element {
                                     <More
                                         overlay={
                                             <>
-                                                <LemonButton status="danger" onClick={() => deleteView(view.id)}>
+                                                <LemonButton
+                                                    status="danger"
+                                                    onClick={() => deleteView(view.id)}
+                                                    disabledReason={getDisabledReason(view)}
+                                                >
                                                     Delete
                                                 </LemonButton>
                                             </>

--- a/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonButton, LemonInput, LemonTable, LemonTag, LemonTagType, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonTable, LemonTag, LemonTagType, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -107,13 +107,39 @@ export function ViewsTab(): JSX.Element {
                             {
                                 title: 'Name',
                                 key: 'name',
-                                render: (_, view: DataWarehouseSavedQuery) => (
-                                    <LemonTableLink
-                                        to={urls.sqlEditor(undefined, view.id)}
-                                        title={view.name}
-                                        description="Materialized view"
-                                    />
-                                ),
+                                render: (_, view: DataWarehouseSavedQuery) =>
+                                    view.managed_viewset_kind !== null ? (
+                                        <>
+                                            <Tooltip
+                                                title={
+                                                    <>
+                                                        You cannot edit the definition for a view that belongs to a
+                                                        managed viewset. You can enable/disable the viewset in the{' '}
+                                                        <Link to={urls.dataWarehouseManagedViewsets()}>
+                                                            Managed Viewsets
+                                                        </Link>{' '}
+                                                        page.
+                                                    </>
+                                                }
+                                            >
+                                                <span className="font-bold text-primary">{view.name}</span>
+                                            </Tooltip>
+                                            <br />
+                                            <span className="text-muted text-xs">
+                                                Created by the{' '}
+                                                <Link to={urls.dataWarehouseManagedViewsets()} className="text-muted">
+                                                    <code>{view.managed_viewset_kind}</code>
+                                                </Link>{' '}
+                                                managed viewset
+                                            </span>
+                                        </>
+                                    ) : (
+                                        <LemonTableLink
+                                            to={urls.sqlEditor(undefined, view.id)}
+                                            title={view.name}
+                                            description="Materialized view"
+                                        />
+                                    ),
                             },
                             {
                                 title: 'Last run',
@@ -185,7 +211,22 @@ export function ViewsTab(): JSX.Element {
                                                 <LemonButton onClick={() => runMaterialization(view.id)}>
                                                     Run now
                                                 </LemonButton>
-                                                <LemonButton status="danger" onClick={() => deleteView(view.id)}>
+                                                <LemonButton
+                                                    status="danger"
+                                                    onClick={() => deleteView(view.id)}
+                                                    disabledReason={
+                                                        view.managed_viewset_kind !== null ? (
+                                                            <span>
+                                                                Cannot delete a view that belongs to a managed viewset.
+                                                                You can turn the viewset off in the{' '}
+                                                                <Link to={urls.dataWarehouseManagedViewsets()}>
+                                                                    Managed Viewsets
+                                                                </Link>{' '}
+                                                                page.
+                                                            </span>
+                                                        ) : undefined
+                                                    }
+                                                >
                                                     Delete
                                                 </LemonButton>
                                             </>
@@ -222,13 +263,35 @@ export function ViewsTab(): JSX.Element {
                             {
                                 title: 'Name',
                                 key: 'name',
-                                render: (_, view: DataWarehouseSavedQuery) => (
-                                    <LemonTableLink
-                                        to={urls.sqlEditor(undefined, view.id)}
-                                        title={view.name}
-                                        description="View"
-                                    />
-                                ),
+                                render: (_, view: DataWarehouseSavedQuery) =>
+                                    view.managed_viewset_kind !== null ? (
+                                        <>
+                                            <Tooltip
+                                                title={
+                                                    <>
+                                                        You cannot edit the definition for a view that belongs to a
+                                                        managed viewset. You can enable/disable the viewset in the{' '}
+                                                        <Link to={urls.dataWarehouseManagedViewsets()}>
+                                                            Managed Viewsets
+                                                        </Link>{' '}
+                                                        page.
+                                                    </>
+                                                }
+                                            >
+                                                <span className="font-bold text-primary">{view.name}</span>
+                                            </Tooltip>
+                                            <br />
+                                            <span className="text-muted text-xs">
+                                                Created by the{' '}
+                                                <Link to={urls.dataWarehouseManagedViewsets()} className="text-muted">
+                                                    <code>{view.managed_viewset_kind}</code>
+                                                </Link>{' '}
+                                                managed viewset
+                                            </span>
+                                        </>
+                                    ) : (
+                                        <LemonTableLink to={urls.sqlEditor(undefined, view.id)} title={view.name} />
+                                    ),
                             },
                             {
                                 title: 'Created',


### PR DESCRIPTION
These shouldn't link to the SQL editor because they can't be edited - the UI would show, but it'd fail to save as expected.

Instead, let's link people to the managed viewset page

<img width="1205" height="492" alt="image" src="https://github.com/user-attachments/assets/b32dd43b-9db8-4057-9dd5-55561779a880" />
