### PR TITLE
fix: new processing mode of worker and yielding so we can test that

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.test.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.test.ts
@@ -338,7 +338,7 @@ describe('process all snapshots', () => {
 
             const result = await parseEncodedSnapshots(convertInput(mockCompressedData), sessionId)
 
-            expect(mockWorkerManager.decompress).toHaveBeenCalledWith(fakeCompressedBlock, { blockCount: 1 })
+            expect(mockWorkerManager.decompress).toHaveBeenCalledWith(fakeCompressedBlock, { isParallel: false })
             expect(result).toHaveLength(1)
             expect(result[0].windowId).toBe('1')
             expect(result[0].timestamp).toBe(1234567890)
@@ -422,7 +422,7 @@ describe('process all snapshots', () => {
 
             const result = await parseEncodedSnapshots(fakeRawSnappyData, sessionId)
 
-            expect(mockWorkerManager.decompress).toHaveBeenCalledWith(fakeRawSnappyData)
+            expect(mockWorkerManager.decompress).toHaveBeenCalledWith(fakeRawSnappyData, { isParallel: false })
             expect(result).toHaveLength(1)
             expect(result[0].windowId).toBe('1')
             expect(result[0].timestamp).toBe(1234567890)


### PR DESCRIPTION
we're testing decompression in a worker and yielding to the main thread periodically separately

but what if Egon Spengler was wrong

Let's have a mode where we put decompression in a worker _and_ yield to the main thread periodically