### PR TITLE
fix: force treating searchQuery as a string

### DIFF
--- a/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
+++ b/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
@@ -86,9 +86,10 @@ export const issueFiltersLogic = kea<issueFiltersLogicType>([
             if (params.filterTestAccounts && !equal(params.filterTestAccounts, values.filterTestAccounts)) {
                 actions.setFilterTestAccounts(params.filterTestAccounts)
             }
-            if (params.searchQuery && !equal(params.searchQuery, values.searchQuery)) {
-                actions.setSearchQuery(params.searchQuery)
-                actions.setTaxonomicSearchQuery(params.searchQuery)
+            const newQuery = params.searchQuery.toString()
+            if (newQuery && !equal(newQuery, values.searchQuery)) {
+                actions.setSearchQuery(newQuery)
+                actions.setTaxonomicSearchQuery(newQuery)
             }
         }
         return {

--- a/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
+++ b/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
@@ -86,7 +86,7 @@ export const issueFiltersLogic = kea<issueFiltersLogicType>([
             if (params.filterTestAccounts && !equal(params.filterTestAccounts, values.filterTestAccounts)) {
                 actions.setFilterTestAccounts(params.filterTestAccounts)
             }
-            const newQuery = params.searchQuery.toString()
+            const newQuery = params.searchQuery ? params.searchQuery.toString() : null
             if (newQuery && !equal(newQuery, values.searchQuery)) {
                 actions.setSearchQuery(newQuery)
                 actions.setTaxonomicSearchQuery(newQuery)


### PR DESCRIPTION
kea-router [will assume a query param is a number if it's possible to parse it as a number](https://github.com/keajs/kea-router/blob/master/src/utils.ts#L5). There's no great system-level fix for this really (the opposite behaviour there would be strictly worse, and there's no way to feed expected type information up the chain to the parser in kea-router because, well, javascript), so this'll do.