### PR TITLE
feat: add PostHog duckdb extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "duckdb"]
+	path = products/duckdb/duckdb
+	url = https://github.com/duckdb/duckdb
+	branch = main
+[submodule "extension-ci-tools"]
+	path = products/duckdb/extension-ci-tools
+	url = https://github.com/duckdb/extension-ci-tools
+	branch = main

--- a/products/duckdb/.clang-format
+++ b/products/duckdb/.clang-format
@@ -1,0 +1,1 @@
+duckdb/.clang-format

--- a/products/duckdb/.clang-tidy
+++ b/products/duckdb/.clang-tidy
@@ -1,0 +1,1 @@
+duckdb/.clang-tidy

--- a/products/duckdb/.editorconfig
+++ b/products/duckdb/.editorconfig
@@ -1,0 +1,1 @@
+duckdb/.editorconfig

--- a/products/duckdb/.gitignore
+++ b/products/duckdb/.gitignore
@@ -1,0 +1,8 @@
+build
+.idea
+cmake-build-debug
+duckdb_unittest_tempdir/
+.DS_Store
+testext
+test/python/__pycache__/
+.Rhistory

--- a/products/duckdb/CMakeLists.txt
+++ b/products/duckdb/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.5)
+
+# Set extension name here
+set(TARGET_NAME posthog)
+
+# DuckDB's extension distribution supports vcpkg. As such, dependencies can be added in ./vcpkg.json and then
+# used in cmake with find_package. Feel free to remove or replace with other dependencies.
+# Note that it should also be removed from vcpkg.json to prevent needlessly installing it..
+find_package(OpenSSL REQUIRED)
+find_path(CPP_HTTPLIB_INCLUDE_DIRS "httplib.h")
+
+# Enable OpenSSL support for HTTPS in cpp-httplib
+add_definitions(-DCPPHTTPLIB_OPENSSL_SUPPORT)
+
+set(EXTENSION_NAME ${TARGET_NAME}_extension)
+set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
+
+project(${TARGET_NAME})
+include_directories(src/include)
+include_directories(${CPP_HTTPLIB_INCLUDE_DIRS})
+
+set(EXTENSION_SOURCES src/posthog_extension.cpp)
+
+build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
+build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
+
+# Link OpenSSL in both the static library as the loadable extension
+target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto)
+
+install(
+  TARGETS ${EXTENSION_NAME}
+  EXPORT "${DUCKDB_EXPORT_SET}"
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")

--- a/products/duckdb/Makefile
+++ b/products/duckdb/Makefile
@@ -1,0 +1,8 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Configuration of extension
+EXT_NAME=posthog
+EXT_CONFIG=${PROJ_DIR}extension_config.cmake
+
+# Include the Makefile from extension-ci-tools
+include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/products/duckdb/README.md
+++ b/products/duckdb/README.md
@@ -1,0 +1,171 @@
+# PostHog DuckDB Extension
+
+Query your PostHog data directly from DuckDB using HogQL!
+
+## Features
+
+- 🔍 Query PostHog data using HogQL directly from DuckDB
+- 🔄 Automatic type mapping from PostHog/ClickHouse types to DuckDB types
+- 🔗 Join PostHog data with local data
+- 📊 Export PostHog data to Parquet, CSV, or any DuckDB-supported format
+- ⚡ Full support for HogQL features (events, persons, properties, etc.)
+- 🔐 Environment variable configuration for easy setup
+
+## Quick Start
+
+### 1. Build the Extension
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules https://github.com/PostHog/posthog-duckdb.git
+cd posthog-duckdb
+
+# Set up vcpkg (for dependencies)
+cd /tmp
+git clone https://github.com/Microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+# Build the extension
+cd -
+export VCPKG_TOOLCHAIN_PATH=/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake
+GEN=ninja make
+```
+
+The extension will be built to: `build/release/extension/posthog/posthog.duckdb_extension`
+
+### 2. Configure PostHog Credentials
+
+```bash
+export POSTHOG_HOST="https://us.posthog.com"  # or https://eu.posthog.com
+export POSTHOG_PROJECT_ID="YOUR_PROJECT_ID"
+export POSTHOG_API_KEY="YOUR_PERSONAL_API_KEY"
+```
+
+### 3. Use in DuckDB
+
+```sql
+-- Load the extension
+LOAD 'build/release/extension/posthog/posthog.duckdb_extension';
+
+-- Query your PostHog data
+SELECT * FROM posthog_query('
+    SELECT event, COUNT() as count
+    FROM events
+    GROUP BY event
+    ORDER BY count DESC
+    LIMIT 10
+');
+```
+
+## Usage Examples
+
+### Get Events from Last 7 Days
+
+```sql
+SELECT
+    event,
+    timestamp,
+    distinct_id
+FROM posthog_query('
+    SELECT event, timestamp, distinct_id
+    FROM events
+    WHERE timestamp > now() - interval 7 day
+')
+ORDER BY timestamp DESC;
+```
+
+### Join with Local Data
+
+```sql
+CREATE TABLE user_segments (distinct_id VARCHAR, segment VARCHAR);
+INSERT INTO user_segments VALUES ('user123', 'premium'), ('user456', 'free');
+
+SELECT
+    e.event,
+    s.segment,
+    COUNT(*) as event_count
+FROM posthog_query('SELECT event, distinct_id FROM events') e
+JOIN user_segments s ON e.distinct_id = s.distinct_id
+GROUP BY e.event, s.segment;
+```
+
+### Export to Parquet
+
+```sql
+COPY (
+    SELECT * FROM posthog_query('
+        SELECT * FROM events
+        WHERE timestamp > today() - interval 30 day
+    ')
+) TO 'last_30_days_events.parquet';
+```
+
+### Work with JSON Properties
+
+```sql
+SELECT
+    event,
+    json_extract_string(properties, '$.url') as url,
+    json_extract_string(properties, '$.browser') as browser
+FROM posthog_query('SELECT event, properties FROM events LIMIT 100');
+```
+
+## Documentation
+
+For detailed documentation, see [USAGE.md](USAGE.md) including:
+
+- Complete API reference
+- Type mapping details
+- HogQL examples
+- Configuration options
+
+## Type Mapping
+
+The extension automatically maps PostHog/ClickHouse types to DuckDB types:
+
+| PostHog Type | DuckDB Type | Notes |
+|--------------|-------------|-------|
+| DateTime64   | TIMESTAMP   | Automatically parsed from ISO strings |
+| String       | VARCHAR     | |
+| UUID         | VARCHAR     | |
+| Int64        | BIGINT      | |
+| Array(T)     | VARCHAR     | As JSON - use `json_extract()` |
+| Properties   | VARCHAR     | As JSON - use `json_extract_string()` |
+
+See [USAGE.md](USAGE.md) for the complete type mapping table.
+
+## Requirements
+
+- CMake >= 3.5
+- C++ compiler with C++11 support
+- DuckDB v1.4.2+
+- PostHog account with Personal API Key
+
+## Finding Your Credentials
+
+**PostHog Instance URL:**
+
+- US Cloud: `https://us.posthog.com`
+- EU Cloud: `https://eu.posthog.com`
+- Self-hosted: Your custom domain
+
+**Project ID:**
+
+- Found in PostHog project settings
+- Visible in the URL when viewing your project
+
+**Personal API Key:**
+
+1. Go to Settings
+2. Navigate to "Personal API Keys"
+3. Click "+ Create a Personal API Key"
+
+## Limitations
+
+- Rate limits: 120 HogQL queries/hour (PostHog limit)
+- Max result size: 50,000 rows per query (PostHog limit)
+- Results are cached in memory during query execution
+
+## License
+
+MIT License - see LICENSE file for details

--- a/products/duckdb/USAGE.md
+++ b/products/duckdb/USAGE.md
@@ -1,0 +1,202 @@
+# PostHog DuckDB Extension
+
+A DuckDB extension that enables querying PostHog data directly from DuckDB using HogQL.
+
+## Features
+
+- Query PostHog data using HogQL directly from DuckDB
+- Automatic type mapping from PostHog/ClickHouse types to DuckDB types
+- Combine PostHog data with local data using SQL joins
+- Export PostHog data to Parquet, CSV, or other formats
+- Full support for HogQL features (events, persons, properties, etc.)
+
+## Installation
+
+### Prerequisites
+
+- CMake >= 3.5
+- C++ compiler with C++11 support
+- vcpkg (automatically set up during build)
+
+### Building from Source
+
+```bash
+git clone --recurse-submodules https://github.com/PostHog/posthog-duckdb.git
+cd posthog-duckdb
+
+# Set up vcpkg
+cd /tmp
+git clone https://github.com/Microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+# Build the extension
+cd -
+export VCPKG_TOOLCHAIN_PATH=/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake
+GEN=ninja make
+
+# The extension will be built to: build/release/extension/posthog/posthog.duckdb_extension
+```
+
+## Usage
+
+### Loading the Extension
+
+```sql
+LOAD 'build/release/extension/posthog/posthog.duckdb_extension';
+-- Note: you might need to use the absolute path here
+```
+
+### Configuration
+
+The extension supports two methods of configuration:
+
+**Method 1: Environment Variables (Recommended)**
+
+```bash
+export POSTHOG_HOST="https://us.posthog.com"
+export POSTHOG_PROJECT_ID="YOUR_PROJECT_ID"
+export POSTHOG_API_KEY="YOUR_PERSONAL_API_KEY"
+```
+
+Then in DuckDB:
+
+```sql
+SELECT * FROM posthog_query('SELECT event, COUNT() FROM events GROUP BY event LIMIT 10');
+```
+
+**Method 2: Explicit Parameters**
+
+```sql
+SELECT * FROM posthog_query(
+    'https://us.posthog.com',          -- PostHog instance URL
+    'YOUR_PROJECT_ID',                  -- Your PostHog project ID
+    'YOUR_PERSONAL_API_KEY',            -- Your personal API key
+    'SELECT event, COUNT() FROM events GROUP BY event LIMIT 10'  -- HogQL query
+);
+```
+
+### Finding Your Credentials
+
+**PostHog Instance URL:**
+
+- US Cloud: `https://us.posthog.com`
+- EU Cloud: `https://eu.posthog.com`
+- Self-hosted: Your custom domain
+
+**Project ID:**
+
+- Found in PostHog project settings
+- Visible in the URL when viewing your project
+
+**Personal API Key:**
+
+1. Go to Settings
+2. Navigate to "Personal API Keys"
+3. Click "+ Create a Personal API Key"
+
+## Examples
+
+> **Note:** The following examples assume you've set the environment variables (`POSTHOG_HOST`, `POSTHOG_PROJECT_ID`, `POSTHOG_API_KEY`). You can also use the explicit 4-parameter syntax if you prefer.
+
+### Get Most Common Events
+
+```sql
+SELECT * FROM posthog_query(
+    'SELECT event, COUNT() as count FROM events GROUP BY event ORDER BY count DESC LIMIT 10'
+);
+```
+
+### Query Events with Timestamp Filtering
+
+```sql
+-- Types are automatically mapped: timestamp becomes TIMESTAMP in DuckDB
+SELECT
+    event,
+    timestamp,
+    distinct_id
+FROM posthog_query(
+    'SELECT event, timestamp, distinct_id FROM events WHERE timestamp > now() - interval 7 day'
+)
+ORDER BY timestamp DESC;
+```
+
+### Save Results to a Table
+
+```sql
+CREATE TABLE my_posthog_events AS
+SELECT * FROM posthog_query(
+    'SELECT * FROM events LIMIT 10000'
+);
+```
+
+### Join with Local Data
+
+```sql
+CREATE TABLE user_segments (distinct_id VARCHAR, segment VARCHAR);
+INSERT INTO user_segments VALUES ('user123', 'premium'), ('user456', 'free');
+
+SELECT
+    e.event,
+    s.segment,
+    COUNT(*) as event_count
+FROM posthog_query(
+    'SELECT event, distinct_id FROM events'
+) e
+JOIN user_segments s ON e.distinct_id = s.distinct_id
+GROUP BY e.event, s.segment;
+```
+
+### Export to Parquet
+
+```sql
+COPY (
+    SELECT * FROM posthog_query(
+        'SELECT * FROM events WHERE timestamp > today() - interval 30 day'
+    )
+) TO 'last_30_days_events.parquet';
+```
+
+## Type Mapping
+
+The extension automatically maps PostHog/ClickHouse types to DuckDB types:
+
+| PostHog/ClickHouse Type | DuckDB Type | Notes |
+|------------------------|-------------|-------|
+| String                 | VARCHAR     | |
+| LowCardinality(String) | VARCHAR     | PostHog's optimized string type |
+| UUID                   | VARCHAR     | |
+| UInt64                 | UBIGINT     | |
+| UInt32                 | UINTEGER    | |
+| UInt16                 | USMALLINT   | |
+| UInt8                  | UTINYINT    | |
+| Int64                  | BIGINT      | |
+| Int32                  | INTEGER     | |
+| Int16                  | SMALLINT    | |
+| Int8                   | TINYINT     | |
+| Float64                | DOUBLE      | |
+| Float32                | FLOAT       | |
+| DateTime               | TIMESTAMP   | Parsed from ISO strings |
+| DateTime64(N)          | TIMESTAMP   | N = precision (0-9) |
+| Date                   | DATE        | |
+| Date32                 | DATE        | |
+| Bool, Boolean          | BOOLEAN     | |
+| Nullable(T)            | Same as T   | Automatically unwrapped |
+
+**Note:** All `Nullable()` wrapper types are automatically handled - the extension strips the wrapper and maps the inner type, with full NULL value support.
+
+## HogQL Reference
+
+HogQL is PostHog's SQL dialect based on ClickHouse SQL. See [PostHog HogQL documentation](https://posthog.com/docs/hogql) for more details.
+
+## Limitations
+
+- Rate limits: 120 HogQL queries/hour (PostHog limit)
+- Max result size: 50,000 rows per query (PostHog limit)
+- The extension fetches all results during the bind phase (results are cached in memory)
+- For large result sets, consider using pagination in your HogQL query
+
+## Dependencies
+
+- **cpp-httplib**: HTTP client for API requests
+- **OpenSSL**: HTTPS support
+- **yyjson**: JSON parsing (DuckDB's built-in library)

--- a/products/duckdb/docs/UPDATING.md
+++ b/products/duckdb/docs/UPDATING.md
@@ -1,0 +1,26 @@
+# Extension updating
+
+When cloning this template, the target version of DuckDB should be the latest stable release of DuckDB. However, there
+will inevitably come a time when a new DuckDB is released and the extension repository needs updating. This process goes
+as follows:
+
+- Bump submodules
+  - `./duckdb` should be set to latest tagged release
+  - `./extension-ci-tools` should be set to updated branch corresponding to latest DuckDB release. So if you're building for DuckDB `v1.1.0` there will be a branch in `extension-ci-tools` named `v1.1.0` to which you should check out.
+- Bump versions in `./github/workflows`
+  - `duckdb_version` input in `duckdb-stable-build` job in `MainDistributionPipeline.yml` should be set to latest tagged release
+  - `duckdb_version` input in `duckdb-stable-deploy` job in `MainDistributionPipeline.yml` should be set to latest tagged release
+  - the reusable workflow `duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml` for the `duckdb-stable-build` job should be set to latest tagged release
+
+# API changes
+
+DuckDB extensions built with this extension template are built against the internal C++ API of DuckDB. This API is not guaranteed to be stable.
+What this means for extension development is that when updating your extensions DuckDB target version using the above steps, you may run into the fact that your extension no longer builds properly.
+
+Currently, DuckDB does not (yet) provide a specific change log for these API changes, but it is generally not too hard to figure out what has changed.
+
+For figuring out how and why the C++ API changed, we recommend using the following resources:
+
+- DuckDB's [Release Notes](https://github.com/duckdb/duckdb/releases)
+- DuckDB's history of [Core extension patches](https://github.com/duckdb/duckdb/commits/main/.github/patches/extensions)
+- The git history of the relevant C++ Header file of the API that has changed

--- a/products/duckdb/extension_config.cmake
+++ b/products/duckdb/extension_config.cmake
@@ -1,0 +1,10 @@
+# This file is included by DuckDB's build system. It specifies which extension to load
+
+# Extension from this repo
+duckdb_extension_load(posthog
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
+    LOAD_TESTS
+)
+
+# Any extra extensions that should be built
+# e.g.: duckdb_extension_load(json)

--- a/products/duckdb/scripts/extension-upload.sh
+++ b/products/duckdb/scripts/extension-upload.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Extension upload script
+
+# Usage: ./extension-upload.sh <name> <extension_version> <duckdb_version> <architecture> <s3_bucket> <copy_to_latest> <copy_to_versioned>
+# <name>                : Name of the extension
+# <extension_version>   : Version (commit / version tag) of the extension
+# <duckdb_version>      : Version (commit / version tag) of DuckDB
+# <architecture>        : Architecture target of the extension binary
+# <s3_bucket>           : S3 bucket to upload to
+# <copy_to_latest>      : Set this as the latest version ("true" / "false", default: "false")
+# <copy_to_versioned>   : Set this as a versioned version that will prevent its deletion
+
+set -e
+
+if [[ $4 == wasm* ]]; then
+  ext="/tmp/extension/$1.duckdb_extension.wasm"
+else
+  ext="/tmp/extension/$1.duckdb_extension"
+fi
+
+echo $ext
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+
+# calculate SHA256 hash of extension binary
+cat $ext > $ext.append
+
+if [[ $4 == wasm* ]]; then
+  # 0 for custom section
+  # 113 in hex = 275 in decimal, total lenght of what follows (1 + 16 + 2 + 256)
+  # [1(continuation) + 0010011(payload) = \x93, 0(continuation) + 10(payload) = \x02]
+  echo -n -e '\x00' >> $ext.append
+  echo -n -e '\x93\x02' >> $ext.append
+  # 10 in hex = 16 in decimal, lenght of name, 1 byte
+  echo -n -e '\x10' >> $ext.append
+  echo -n -e 'duckdb_signature' >> $ext.append
+  # the name of the WebAssembly custom section, 16 bytes
+  # 100 in hex, 256 in decimal
+  # [1(continuation) + 0000000(payload) = ff, 0(continuation) + 10(payload)],
+  # for a grand total of 2 bytes
+  echo -n -e '\x80\x02' >> $ext.append
+fi
+
+# (Optionally) Sign binary
+if [ "$DUCKDB_EXTENSION_SIGNING_PK" != "" ]; then
+  echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+  $script_dir/../duckdb/scripts/compute-extension-hash.sh $ext.append > $ext.hash
+  openssl pkeyutl -sign -in $ext.hash -inkey private.pem -pkeyopt digest:sha256 -out $ext.sign
+  rm -f private.pem
+fi
+
+# Signature is always there, potentially defaulting to 256 zeros
+truncate -s 256 $ext.sign
+
+# append signature to extension binary
+cat $ext.sign >> $ext.append
+
+# compress extension binary
+if [[ $4 == wasm_* ]]; then
+  brotli < $ext.append > "$ext.compressed"
+else
+  gzip < $ext.append > "$ext.compressed"
+fi
+
+set -e
+
+# Abort if AWS key is not set
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "No AWS key found, skipping.."
+    exit 0
+fi
+
+# upload versioned version
+if [[ $7 = 'true' ]]; then
+  if [[ $4 == wasm* ]]; then
+    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+  else
+    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.gz --acl public-read
+  fi
+fi
+
+# upload to latest version
+if [[ $6 = 'true' ]]; then
+  if [[ $4 == wasm* ]]; then
+    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+  else
+    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.gz --acl public-read
+  fi
+fi

--- a/products/duckdb/src/include/posthog_extension.hpp
+++ b/products/duckdb/src/include/posthog_extension.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+class PosthogExtension : public Extension {
+public:
+	void Load(ExtensionLoader &db) override;
+	std::string Name() override;
+	std::string Version() const override;
+};
+
+} // namespace duckdb

--- a/products/duckdb/src/posthog_extension.cpp
+++ b/products/duckdb/src/posthog_extension.cpp
@@ -1,0 +1,502 @@
+#define DUCKDB_EXTENSION_MAIN
+
+#include "posthog_extension.hpp"
+#include "duckdb.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "yyjson.hpp"
+
+// OpenSSL linked through vcpkg
+#include <openssl/opensslv.h>
+
+// cpp-httplib for HTTP requests
+#include <httplib.h>
+
+namespace duckdb {
+using namespace duckdb_yyjson;
+
+// Bind data to store PostHog query results
+struct PosthogQueryBindData : public TableFunctionData {
+	string url;
+	string project_id;
+	string api_key;
+	string hogql_query;
+
+	// Store the query results
+	vector<vector<Value>> results;
+	vector<string> column_names;
+	vector<LogicalType> column_types;
+
+	idx_t row_count;
+};
+
+// Convert PostHog type string to DuckDB LogicalType
+static LogicalType PosthogTypeToDuckDBType(const string &posthog_type) {
+	// Remove Nullable() wrapper if present
+	string base_type = posthog_type;
+	if (base_type.find("Nullable(") == 0 && base_type.back() == ')') {
+		base_type = base_type.substr(9, base_type.length() - 10);
+	}
+
+	// String types
+	if (base_type == "String" || base_type == "LowCardinality(String)") {
+		return LogicalType::VARCHAR;
+	}
+
+	// Unsigned integer types
+	if (base_type == "UInt64") {
+		return LogicalType::UBIGINT;
+	} else if (base_type == "UInt32") {
+		return LogicalType::UINTEGER;
+	} else if (base_type == "UInt16") {
+		return LogicalType::USMALLINT;
+	} else if (base_type == "UInt8") {
+		return LogicalType::UTINYINT;
+	}
+
+	// Signed integer types
+	if (base_type == "Int64") {
+		return LogicalType::BIGINT;
+	} else if (base_type == "Int32") {
+		return LogicalType::INTEGER;
+	} else if (base_type == "Int16") {
+		return LogicalType::SMALLINT;
+	} else if (base_type == "Int8") {
+		return LogicalType::TINYINT;
+	}
+
+	// Floating point types
+	if (base_type == "Float64") {
+		return LogicalType::DOUBLE;
+	} else if (base_type == "Float32") {
+		return LogicalType::FLOAT;
+	}
+
+	// Date/Time types - handle DateTime64 with any precision and timezone
+	// Examples: DateTime, DateTime64(6), DateTime64(6, 'UTC')
+	if (base_type == "DateTime" || base_type.find("DateTime64(") == 0) {
+		return LogicalType::TIMESTAMP;
+	} else if (base_type == "Date" || base_type == "Date32") {
+		return LogicalType::DATE;
+	}
+
+	// Boolean
+	if (base_type == "Bool" || base_type == "Boolean") {
+		return LogicalType::BOOLEAN;
+	}
+
+	// UUID
+	if (base_type == "UUID") {
+		return LogicalType::VARCHAR;  // Treat UUID as VARCHAR
+	}
+
+	// Enum types - treat as VARCHAR
+	// Examples: Enum8('value1' = 1, 'value2' = 2), Enum16(...)
+	if (base_type.find("Enum8(") == 0 || base_type.find("Enum16(") == 0) {
+		return LogicalType::VARCHAR;
+	}
+
+	// Array types - treat as VARCHAR (JSON representation)
+	// Examples: Array(String), Array(Int32), Array(Enum8(...))
+	if (base_type.find("Array(") == 0) {
+		return LogicalType::VARCHAR;
+	}
+
+	// Tuple types - treat as VARCHAR (JSON representation)
+	if (base_type.find("Tuple(") == 0) {
+		return LogicalType::VARCHAR;
+	}
+
+	// Default to VARCHAR for unknown types
+	return LogicalType::VARCHAR;
+}
+
+// Parse JSON value and convert to DuckDB Value
+static Value ParseJsonValue(yyjson_val *json_val, const LogicalType &type) {
+	if (!json_val || yyjson_is_null(json_val)) {
+		return Value(type);  // NULL value
+	}
+
+	switch (type.id()) {
+	case LogicalTypeId::VARCHAR:
+		if (yyjson_is_str(json_val)) {
+			return Value(yyjson_get_str(json_val));
+		} else if (yyjson_is_num(json_val)) {
+			return Value(to_string(yyjson_get_num(json_val)));
+		}
+		return Value(yyjson_val_write(json_val, 0, nullptr));
+
+	case LogicalTypeId::BIGINT:
+		if (yyjson_is_int(json_val)) {
+			return Value::BIGINT(yyjson_get_sint(json_val));
+		}
+		return Value::BIGINT(0);
+
+	case LogicalTypeId::UBIGINT:
+		if (yyjson_is_uint(json_val)) {
+			return Value::UBIGINT(yyjson_get_uint(json_val));
+		}
+		return Value::UBIGINT(0);
+
+	case LogicalTypeId::INTEGER:
+		if (yyjson_is_int(json_val)) {
+			return Value::INTEGER((int32_t)yyjson_get_sint(json_val));
+		}
+		return Value::INTEGER(0);
+
+	case LogicalTypeId::UINTEGER:
+		if (yyjson_is_uint(json_val)) {
+			return Value::UINTEGER((uint32_t)yyjson_get_uint(json_val));
+		}
+		return Value::UINTEGER(0);
+
+	case LogicalTypeId::DOUBLE:
+		if (yyjson_is_num(json_val)) {
+			return Value::DOUBLE(yyjson_get_num(json_val));
+		}
+		return Value::DOUBLE(0.0);
+
+	case LogicalTypeId::FLOAT:
+		if (yyjson_is_num(json_val)) {
+			return Value::FLOAT((float)yyjson_get_num(json_val));
+		}
+		return Value::FLOAT(0.0f);
+
+	case LogicalTypeId::BOOLEAN:
+		if (yyjson_is_bool(json_val)) {
+			return Value::BOOLEAN(yyjson_get_bool(json_val));
+		}
+		return Value::BOOLEAN(false);
+
+	case LogicalTypeId::SMALLINT:
+		if (yyjson_is_int(json_val)) {
+			return Value::SMALLINT((int16_t)yyjson_get_sint(json_val));
+		}
+		return Value::SMALLINT(0);
+
+	case LogicalTypeId::USMALLINT:
+		if (yyjson_is_uint(json_val)) {
+			return Value::USMALLINT((uint16_t)yyjson_get_uint(json_val));
+		}
+		return Value::USMALLINT(0);
+
+	case LogicalTypeId::TINYINT:
+		if (yyjson_is_int(json_val)) {
+			return Value::TINYINT((int8_t)yyjson_get_sint(json_val));
+		}
+		return Value::TINYINT(0);
+
+	case LogicalTypeId::UTINYINT:
+		if (yyjson_is_uint(json_val)) {
+			return Value::UTINYINT((uint8_t)yyjson_get_uint(json_val));
+		}
+		return Value::UTINYINT(0);
+
+	case LogicalTypeId::TIMESTAMP:
+		// PostHog returns timestamps as ISO strings - use Value constructor with string
+		if (yyjson_is_str(json_val)) {
+			return Value(yyjson_get_str(json_val)).DefaultCastAs(LogicalType::TIMESTAMP);
+		}
+		return Value(type);  // NULL
+
+	case LogicalTypeId::DATE:
+		// PostHog returns dates as strings - use Value constructor with string
+		if (yyjson_is_str(json_val)) {
+			return Value(yyjson_get_str(json_val)).DefaultCastAs(LogicalType::DATE);
+		}
+		return Value(type);  // NULL
+
+	default:
+		// For complex types, convert to string
+		if (yyjson_is_str(json_val)) {
+			return Value(yyjson_get_str(json_val));
+		}
+		return Value(yyjson_val_write(json_val, 0, nullptr));
+	}
+}
+
+// Bind function - validates inputs and fetches data from PostHog
+static unique_ptr<FunctionData> PosthogQueryBind(ClientContext &context, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<PosthogQueryBindData>();
+
+	// Validate input parameters - accept either 1 parameter (query only) or 4 parameters (explicit config)
+	if (input.inputs.size() == 1) {
+		// Read from environment variables
+		const char* env_host = std::getenv("POSTHOG_HOST");
+		const char* env_project_id = std::getenv("POSTHOG_PROJECT_ID");
+		const char* env_api_key = std::getenv("POSTHOG_API_KEY");
+
+		if (!env_host || !env_project_id || !env_api_key) {
+			throw BinderException("posthog_query requires either:\n"
+			                      "  - 1 parameter (hogql_query) with POSTHOG_HOST, POSTHOG_PROJECT_ID, and POSTHOG_API_KEY env vars set, or\n"
+			                      "  - 4 parameters: (url, project_id, api_key, hogql_query)");
+		}
+
+		result->url = string(env_host);
+		result->project_id = string(env_project_id);
+		result->api_key = string(env_api_key);
+		result->hogql_query = input.inputs[0].GetValue<string>();
+	} else if (input.inputs.size() == 4) {
+		// Explicit parameters
+		result->url = input.inputs[0].GetValue<string>();
+		result->project_id = input.inputs[1].GetValue<string>();
+		result->api_key = input.inputs[2].GetValue<string>();
+		result->hogql_query = input.inputs[3].GetValue<string>();
+	} else {
+		throw BinderException("posthog_query requires either:\n"
+		                      "  - 1 parameter (hogql_query) with POSTHOG_HOST, POSTHOG_PROJECT_ID, and POSTHOG_API_KEY env vars set, or\n"
+		                      "  - 4 parameters: (url, project_id, api_key, hogql_query)");
+	}
+
+	// Parse URL to extract host and scheme
+	string host = result->url;
+	bool use_ssl = true;
+
+	// Remove protocol if present
+	if (host.find("https://") == 0) {
+		host = host.substr(8);
+		use_ssl = true;
+	} else if (host.find("http://") == 0) {
+		host = host.substr(7);
+		use_ssl = false;
+	}
+
+	// Remove trailing slash
+	if (!host.empty() && host.back() == '/') {
+		host = host.substr(0, host.size() - 1);
+	}
+
+	// Make HTTP request to PostHog
+	try {
+		httplib::Client client(use_ssl ? ("https://" + host) : ("http://" + host));
+		client.set_follow_location(true);
+
+		// Escape quotes in the query
+		size_t pos = 0;
+		string escaped_query = result->hogql_query;
+		while ((pos = escaped_query.find("\"", pos)) != string::npos) {
+			escaped_query.replace(pos, 1, "\\\"");
+			pos += 2;
+		}
+		request_body = "{\"query\":{\"kind\":\"HogQLQuery\",\"query\":\"" + escaped_query + "\"}}";
+
+		string path = "/api/projects/" + result->project_id + "/query/";
+
+		httplib::Headers headers = {
+			{"Authorization", "Bearer " + result->api_key},
+		};
+
+		auto res = client.Post(path, headers, request_body, "application/json");
+
+		if (!res) {
+			throw IOException("HTTP request to PostHog failed: connection error");
+		}
+
+		if (res->status != 200) {
+			throw IOException("HTTP request to PostHog failed with status " + to_string(res->status) +
+			                  ": " + res->body);
+		}
+
+		// Parse JSON response
+		yyjson_doc *doc = yyjson_read(res->body.c_str(), res->body.length(), 0);
+		if (!doc) {
+			throw IOException("Failed to parse PostHog JSON response");
+		}
+
+		yyjson_val *root = yyjson_doc_get_root(doc);
+
+		// Extract columns
+		yyjson_val *columns = yyjson_obj_get(root, "columns");
+		if (!columns || !yyjson_is_arr(columns)) {
+			yyjson_doc_free(doc);
+			throw IOException("PostHog response missing 'columns' array");
+		}
+
+		// Extract types
+		yyjson_val *types = yyjson_obj_get(root, "types");
+		if (!types || !yyjson_is_arr(types)) {
+			yyjson_doc_free(doc);
+			throw IOException("PostHog response missing 'types' array");
+		}
+
+		// Extract results
+		yyjson_val *results_arr = yyjson_obj_get(root, "results");
+		if (!results_arr || !yyjson_is_arr(results_arr)) {
+			yyjson_doc_free(doc);
+			throw IOException("PostHog response missing 'results' array");
+		}
+
+		// Process columns and types
+		size_t col_count = yyjson_arr_size(columns);
+		size_t type_count = yyjson_arr_size(types);
+
+		if (col_count != type_count) {
+			yyjson_doc_free(doc);
+			throw IOException("PostHog response: columns and types arrays have different sizes");
+		}
+
+		// Build schema using simple index-based access
+		for (size_t i = 0; i < col_count; i++) {
+			yyjson_val *col_val = yyjson_arr_get(columns, i);
+			yyjson_val *type_val = yyjson_arr_get(types, i);
+
+			// Convert to string (handle both string and other types)
+			string col_name;
+			string type_name;
+
+			if (yyjson_is_str(col_val)) {
+				col_name = yyjson_get_str(col_val);
+			} else {
+				// Fallback: convert to JSON string
+				size_t len;
+				char *json_str = yyjson_val_write(col_val, 0, &len);
+				col_name = string(json_str ? json_str : "unknown");
+				if (json_str) free(json_str);
+			}
+
+			// PostHog returns types as arrays: ["column_name", "type_string"]
+			// We need to extract the second element
+			if (yyjson_is_arr(type_val) && yyjson_arr_size(type_val) >= 2) {
+				// Get the second element (index 1) which contains the actual type
+				yyjson_val *actual_type = yyjson_arr_get(type_val, 1);
+				if (yyjson_is_str(actual_type)) {
+					type_name = yyjson_get_str(actual_type);
+				} else {
+					type_name = "String";
+				}
+			} else if (yyjson_is_str(type_val)) {
+				type_name = yyjson_get_str(type_val);
+			} else {
+				// Fallback: convert to JSON string
+				size_t len;
+				char *json_str = yyjson_val_write(type_val, 0, &len);
+				type_name = string(json_str ? json_str : "String");
+				if (json_str) free(json_str);
+			}
+
+			result->column_names.push_back(col_name);
+			LogicalType duck_type = PosthogTypeToDuckDBType(type_name);
+			result->column_types.push_back(duck_type);
+
+			names.push_back(col_name);
+			return_types.push_back(duck_type);
+		}
+
+		// Process results using simple index-based access
+		result->row_count = yyjson_arr_size(results_arr);
+
+		for (size_t row_idx = 0; row_idx < result->row_count; row_idx++) {
+			yyjson_val *row = yyjson_arr_get(results_arr, row_idx);
+
+			if (!yyjson_is_arr(row)) {
+				yyjson_doc_free(doc);
+				throw IOException("PostHog response: result row is not an array");
+			}
+
+			vector<Value> row_values;
+			size_t row_size = yyjson_arr_size(row);
+
+			for (size_t col_idx = 0; col_idx < col_count && col_idx < row_size; col_idx++) {
+				yyjson_val *val = yyjson_arr_get(row, col_idx);
+				row_values.push_back(ParseJsonValue(val, result->column_types[col_idx]));
+			}
+
+			result->results.push_back(std::move(row_values));
+		}
+
+		yyjson_doc_free(doc);
+
+	} catch (const std::exception &e) {
+		throw IOException("PostHog query failed: " + string(e.what()));
+	}
+
+	return std::move(result);
+}
+
+// Local state for tracking which row we're on
+struct PosthogQueryLocalState : public LocalTableFunctionState {
+	idx_t current_row;
+
+	PosthogQueryLocalState() : current_row(0) {
+	}
+};
+
+static unique_ptr<LocalTableFunctionState> PosthogQueryInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                                   GlobalTableFunctionState *global_state) {
+	return make_uniq<PosthogQueryLocalState>();
+}
+
+// Execute function - outputs the cached results
+static void PosthogQueryExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+	auto &bind_data = data.bind_data->Cast<PosthogQueryBindData>();
+	auto &local_state = data.local_state->Cast<PosthogQueryLocalState>();
+
+	// Check if we're done
+	if (local_state.current_row >= bind_data.row_count) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	// Calculate how many rows to output
+	idx_t remaining = bind_data.row_count - local_state.current_row;
+	idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
+
+	// Fill the output chunk
+	for (idx_t col_idx = 0; col_idx < bind_data.column_types.size(); col_idx++) {
+		auto &vec = output.data[col_idx];
+
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row_idx = local_state.current_row + i;
+			const auto &value = bind_data.results[row_idx][col_idx];
+			vec.SetValue(i, value);
+		}
+	}
+
+	output.SetCardinality(count);
+	local_state.current_row += count;
+}
+
+static void LoadInternal(ExtensionLoader &loader) {
+	// Register the posthog_query table function
+	// Accepts either 1 argument (query with env vars) or 4 arguments (explicit config)
+	TableFunction posthog_query_func(
+		"posthog_query",
+		{LogicalType::VARCHAR},
+		PosthogQueryExecute,
+		PosthogQueryBind
+	);
+	posthog_query_func.init_local = PosthogQueryInitLocal;
+	posthog_query_func.varargs = LogicalType::VARCHAR;
+
+	loader.RegisterFunction(posthog_query_func);
+}
+
+void PosthogExtension::Load(ExtensionLoader &loader) {
+	LoadInternal(loader);
+}
+
+std::string PosthogExtension::Name() {
+	return "posthog";
+}
+
+std::string PosthogExtension::Version() const {
+#ifdef EXT_VERSION_POSTHOG
+	return EXT_VERSION_POSTHOG;
+#else
+	return "0.1.0";
+#endif
+}
+
+} // namespace duckdb
+
+extern "C" {
+
+DUCKDB_CPP_EXTENSION_ENTRY(posthog, loader) {
+	duckdb::LoadInternal(loader);
+}
+}

--- a/products/duckdb/test/README.md
+++ b/products/duckdb/test/README.md
@@ -1,0 +1,15 @@
+# Testing this extension
+
+This directory contains all the tests for this extension. The `sql` directory holds tests that are written as [SQLLogicTests](https://duckdb.org/dev/sqllogictest/intro.html). DuckDB aims to have most its tests in this format as SQL statements, so for the quack extension, this should probably be the goal too.
+
+The root makefile contains targets to build and run all of these tests. To run the SQLLogicTests:
+
+```bash
+make test
+```
+
+or
+
+```bash
+make test_debug
+```

--- a/products/duckdb/test/sql/posthog.test
+++ b/products/duckdb/test/sql/posthog.test
@@ -1,0 +1,26 @@
+# name: test/sql/posthog.test
+# description: test posthog extension
+# group: [sql]
+
+# Before we load the extension, this will fail
+statement error
+SELECT * FROM posthog_query('SELECT 1');
+----
+Catalog Error: Table Function with name posthog_query does not exist!
+
+# Require statement will ensure this test is run with this extension loaded
+require posthog
+
+# Test that the function exists and requires parameters
+statement error
+SELECT * FROM posthog_query();
+----
+Binder Error: No function matches the given name and argument types
+
+# Test that with 4 parameters it fails with invalid credentials (no network call in test)
+# Note: This test validates parameter parsing, not actual PostHog connectivity
+# Real integration tests would require valid PostHog credentials and network access
+statement error
+SELECT * FROM posthog_query('http://invalid-host', 'test_project', 'test_key', 'SELECT 1');
+----
+IO Error: HTTP request to PostHog failed

--- a/products/duckdb/vcpkg.json
+++ b/products/duckdb/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": ["openssl", "cpp-httplib"],
+    "vcpkg-configuration": {
+        "overlay-ports": ["./extension-ci-tools/vcpkg_ports"],
+        "overlay-triplets": ["./extension-ci-tools/toolchains"]
+    }
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

No real problem, just fun

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Add a DuckDB extension that queries the PostHog /query API.

Goes like this:

```
LOAD 'ABSOLUTE_PATH/TO/BUILD';

select * from posthog_query('select count() from events');
```

(assuming you've set the env variables for auth)

Can be useful if you want to work with a dataset locally without hitting ClickHouse repeatedly. Get the data you need once, store it in a parquet file locally, and then have fun with it there without putting more load on CH. 🎉

You may also want to join it to some other data like the backend Postgres DB, or a local CSV file?

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

- ran things locally, but the unit tests are no bueno ⛔

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->

prolly not