### PR TITLE
fix: remove configured attributed from k8s job executor

### DIFF
--- a/dags/persons_new_backfill.py
+++ b/dags/persons_new_backfill.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import dagster
 import psycopg2
-import dagster_k8s
 import psycopg2.errors
+from dagster_k8s import k8s_job_executor
 
 from posthog.clickhouse.cluster import ClickhouseCluster
 from posthog.clickhouse.custom_metrics import MetricsClient
@@ -386,7 +386,7 @@ def postgres_env_check(context: dagster.AssetExecutionContext) -> None:
 
 @dagster.job(
     tags={"owner": JobOwners.TEAM_INGESTION.value},
-    executor_def=dagster_k8s.k8s_job_executor.configured({"max_concurrent": 48}),
+    executor_def=k8s_job_executor,
 )
 def persons_new_backfill_job():
     """


### PR DESCRIPTION
## Problem

Setting the configured parameter stops us from editing it on the fly

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
