### PR TITLE
feat(logs): add live tailing functionality for logs

### DIFF
--- a/bin/clickhouse-logs.sql
+++ b/bin/clickhouse-logs.sql
@@ -38,6 +38,7 @@ CREATE OR REPLACE TABLE logs31
     INDEX idx_attributes_str_values mapValues(attributes_map_str) TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_mat_body_ipv4_matches mat_body_ipv4_matches TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_body_ngram3 body TYPE ngrambf_v1(3, 25000, 2, 0) GRANULARITY 1,
+    INDEX idx_observed_minmax observed_timestamp TYPE minmax GRANULARITY 1,
     PROJECTION projection_aggregate_counts
     (
         SELECT
@@ -181,5 +182,32 @@ mapSort(mapFilter((k, v) -> isNotNull(v), mapApply((k,v) -> (concat(k, '__dateti
 mapSort(resource_attributes) as resource_attributes,
 toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id
 FROM kafka_logs_avro;
+
+create or replace table logs_kafka_metrics
+(
+    `_partition` UInt32,
+    `_topic` String,
+    `max_offset` SimpleAggregateFunction(max, UInt64),
+    `max_observed_timestamp` SimpleAggregateFunction(max, DateTime64(9)),
+    `max_timestamp` SimpleAggregateFunction(max, DateTime64(9)),
+    `max_created_at` SimpleAggregateFunction(max, DateTime64(9)),
+    `max_lag` SimpleAggregateFunction(max, UInt64)
+)
+ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/logs_kafka_metrics', '{replica}')
+ORDER BY (_topic, _partition);
+
+drop view if exists kafka_logs_avro_kafka_metrics_mv;
+CREATE MATERIALIZED VIEW kafka_logs_avro_kafka_metrics_mv TO logs_kafka_metrics
+AS
+    SELECT
+        _partition,
+        _topic,
+        maxSimpleState(_offset) as max_offset,
+        maxSimpleState(observed_timestamp) as max_observed_timestamp,
+        maxSimpleState(timestamp) as max_timestamp,
+        maxSimpleState(now()) as max_created_at,
+        maxSimpleState(now() - observed_timestamp) as max_lag
+    FROM kafka_logs_avro
+    group by _partition, _topic;
 
 select 'clickhouse logs tables initialised successfully!';

--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -32,6 +32,8 @@ export type TZLabelProps = Omit<LemonDropdownProps, 'overlay' | 'trigger' | 'chi
     className?: string
     title?: string
     children?: JSX.Element
+    showNow?: boolean
+    showToday?: boolean
 }
 
 const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
@@ -139,6 +141,8 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
     {
         time,
         showSeconds,
+        showNow = true,
+        showToday = true,
         formatDate,
         formatTime,
         showPopover = true,
@@ -154,7 +158,7 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
 
     const format = useCallback(() => {
         return formatDate || formatTime
-            ? humanFriendlyDetailedTime(parsedTime, formatDate, formatTime)
+            ? humanFriendlyDetailedTime(parsedTime, formatDate, formatTime, { showNow, showToday })
             : parsedTime.fromNow()
     }, [formatDate, formatTime, parsedTime])
 

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -1,3 +1,12 @@
+@keyframes flashHighlight {
+    0% {
+        background-color: var(--color-accent-highlight-secondary);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
 .LemonTable {
     --row-base-height: auto;
     --row-horizontal-padding: 0.5rem;
@@ -161,6 +170,10 @@
                 > td:not(.LemonTable__cell--sticky) {
                     background: var(--color-accent-highlight-secondary);
                 }
+            }
+
+            &.LemonTable__row--status-highlight-new {
+                animation: flashHighlight 1.5s ease-out;
             }
 
             &:not(.LemonTable__expansion) {

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -32,7 +32,7 @@ export interface LemonTableProps<T extends Record<string, any>> {
     /** Color to mark each row with. */
     rowRibbonColor?: string | ((record: T, rowIndex: number) => string | null | undefined)
     /** Status of each row. Defaults no status. */
-    rowStatus?: 'highlighted' | ((record: T, rowIndex: number) => 'highlighted' | null)
+    rowStatus?: 'highlighted' | 'highlight-new' | ((record: T, rowIndex: number) => 'highlighted' | 'highlight-new' | null)
     /** Function that for each row determines what props should its `tr` element have based on the row's record. */
     onRow?: (record: T, index: number) => Omit<HTMLProps<HTMLTableRowElement>, 'key'>
     /** How tall should rows be. The default value is `"middle"`. */

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -1150,6 +1150,19 @@ export function IconPlayCircle(props: LemonIconProps): JSX.Element {
     )
 }
 
+export function IconPauseCircle(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <path
+                d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20Z"
+                fill="currentColor"
+            />
+            <rect x="9.5" y="8" width="2" height="8" rx="0.75" fill="currentColor" />
+            <rect x="12.5" y="8" width="2" height="8" rx="0.75" fill="currentColor" />
+        </LemonIconBase>
+    )
+}
+
 export function IconSkipBackward(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -701,20 +701,29 @@ export function humanFriendlyDiff(from: dayjs.Dayjs | string, to: dayjs.Dayjs | 
 export function humanFriendlyDetailedTime(
     date: dayjs.Dayjs | string | null | undefined,
     formatDate = 'MMMM DD, YYYY',
-    formatTime = 'h:mm:ss A'
+    formatTime = 'h:mm:ss A',
+    options = {
+        showNow: true,
+        showToday: true,
+    }
 ): string {
+    const { showNow, showToday } = options
     if (!date) {
         return 'Never'
     }
     const parsedDate = dayjs(date)
     const today = dayjs().startOf('day')
     const yesterday = today.clone().subtract(1, 'days').startOf('day')
-    if (parsedDate.isSame(dayjs(), 'm')) {
+    if (showNow && parsedDate.isSame(dayjs(), 'm')) {
         return 'Just now'
     }
     let formatString: string
     if (parsedDate.isSame(today, 'd')) {
-        formatString = `[Today] ${formatTime}`
+        if (showToday) {
+            formatString = `[Today] ${formatTime}`
+        } else {
+            formatString = formatTime
+        }
     } else if (parsedDate.isSame(yesterday, 'd')) {
         formatString = `[Yesterday] ${formatTime}`
     } else {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2567,6 +2567,9 @@ export interface LogMessage {
     resource_attributes: any
     instrumentation_scope: string
     event_name: string
+    /**  @format date-time */
+    live_logs_checkpoint: string
+    new: boolean
 }
 
 export interface LogsQuery extends DataNode<LogsQueryResponse> {
@@ -2579,6 +2582,7 @@ export interface LogsQuery extends DataNode<LogsQueryResponse> {
     severityLevels: LogSeverityLevel[]
     filterGroup: PropertyGroupFilter
     serviceNames: string[]
+    liveLogsCheckpoint?: string
 }
 
 export interface LogsQueryResponse extends AnalyticsQueryResponseBase {

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -71,7 +71,7 @@ from posthog.hogql.database.schema.log_entries import (
     LogEntriesTable,
     ReplayConsoleLogsLogEntriesTable,
 )
-from posthog.hogql.database.schema.logs import LogsTable
+from posthog.hogql.database.schema.logs import LogsKafkaMetricsTable, LogsTable
 from posthog.hogql.database.schema.numbers import NumbersTable
 from posthog.hogql.database.schema.person_distinct_id_overrides import (
     PersonDistinctIdOverridesTable,
@@ -190,6 +190,7 @@ class Database(BaseModel):
             "document_embeddings": TableNode(name="document_embeddings", table=DocumentEmbeddingsTable()),
             "pg_embeddings": TableNode(name="pg_embeddings", table=PgEmbeddingsTable()),
             "logs": TableNode(name="logs", table=LogsTable()),
+            "logs_kafka_metrics": TableNode(name="logs_kafka_metrics", table=LogsKafkaMetricsTable()),
             "numbers": TableNode(name="numbers", table=NumbersTable()),
             "system": SystemTables(),  # This is a `TableNode` already, refer to implementation
             # Web analytics pre-aggregated tables (internal use only)

--- a/posthog/hogql/database/schema/logs.py
+++ b/posthog/hogql/database/schema/logs.py
@@ -1,4 +1,5 @@
 from posthog.hogql.database.models import (
+    DANGEROUS_NoTeamIdCheckTable,
     DateTimeDatabaseField,
     FieldOrTable,
     IntegerDatabaseField,
@@ -38,3 +39,17 @@ class LogsTable(Table):
 
     def to_printed_hogql(self):
         return "logs"
+
+
+class LogsKafkaMetricsTable(DANGEROUS_NoTeamIdCheckTable):
+    fields: dict[str, FieldOrTable] = {
+        "_partition": IntegerDatabaseField(name="_partition", nullable=False),
+        "_topic": StringDatabaseField(name="_topic", nullable=False),
+        "max_observed_timestamp": DateTimeDatabaseField(name="max_observed_timestamp", nullable=False),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "logs_kafka_metrics"
+
+    def to_printed_hogql(self):
+        return "logs_kafka_metrics"

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -14670,6 +14670,7 @@ class LogsQuery(BaseModel):
     severityLevels: list[LogSeverityLevel]
     tags: Optional[QueryLogTags] = None
     version: Optional[float] = Field(default=None, description="version of the node, used for schema migrations")
+    liveLogsCheckpoint: Optional[str] = None
 
 
 class QueryResponseAlternative18(BaseModel):

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -27,6 +27,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         if query_data is None:
             return Response({"error": "No query provided"}, status=status.HTTP_400_BAD_REQUEST)
 
+        live_logs_checkpoint = query_data.get("liveLogsCheckpoint", None)
         date_range = self.get_model(query_data.get("dateRange"), DateRange)
         logs_query_params = {
             "dateRange": date_range,
@@ -37,6 +38,8 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             "filterGroup": query_data.get("filterGroup", None),
             "limit": min(query_data.get("limit", 1000), 2000),
         }
+        if live_logs_checkpoint:
+            logs_query_params["liveLogsCheckpoint"] = live_logs_checkpoint
         query = LogsQuery(**logs_query_params)
 
         def results_generator(query: LogsQuery, logs_query_params: dict):
@@ -106,6 +109,13 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
 
                 return LogsQueryRunner(slice_query, self.team), LogsQueryRunner(remainder_query, self.team)
 
+            # if we're live tailing don't do the runner slicing optimisations
+            # we're always only looking at the most recent 1 or 2 minutes of observed data
+            # which should cut things down more than the slicing anyway
+            if live_logs_checkpoint:
+                response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+                yield from response.results
+                return
             # if we're searching more than 20 minutes, first fetch the first 3 minutes of logs and see if that hits the limit
             if date_range_length > dt.timedelta(minutes=20):
                 recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=3), query.orderBy)

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -100,7 +100,6 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
             filters=HogQLFilters(dateRange=self.query.dateRange),
             settings=self.settings,
         )
-
         results = []
         for result in response.results:
             results.append(
@@ -118,6 +117,7 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
                     "resource_attributes": result[10],
                     "instrumentation_scope": result[11],
                     "event_name": result[12],
+                    "live_logs_checkpoint": result[13],
                 }
             )
 
@@ -161,7 +161,8 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
                 severity_text as level,
                 resource_attributes,
                 instrumentation_scope,
-                event_name
+                event_name,
+                (select min(max_observed_timestamp) from logs_kafka_metrics) as live_logs_checkpoint
             FROM logs where (_part_starting_offset+_part_offset) in ({query})
         """,
             placeholders={"query": query},
@@ -224,6 +225,14 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
 
         if self.query.filterGroup:
             exprs.append(property_to_expr(self.query.filterGroup, team=self.team))
+
+        if self.query.liveLogsCheckpoint:
+            exprs.append(
+                parse_expr(
+                    "observed_timestamp >= {liveLogsCheckpoint}",
+                    placeholders={"liveLogsCheckpoint": ast.Constant(value=self.query.liveLogsCheckpoint)},
+                )
+            )
 
         return ast.And(exprs=exprs)
 

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -80,7 +80,7 @@ export function LogsScene(): JSX.Element {
         timestampFormat === 'absolute'
             ? {
                   formatDate: 'YYYY-MM-DD',
-                  formatTime: 'HH:mm:ss',
+                  formatTime: 'HH:mm:ss.SSS',
               }
             : {}
 
@@ -212,7 +212,7 @@ function LogsTable({
                 size="small"
                 embedded
                 rowKey="uuid"
-                rowStatus={(record) => (record.uuid === highlightedLogId ? 'highlighted' : null)}
+                rowStatus={(record) => (record.uuid === highlightedLogId ? 'highlighted' : (record.new ? 'highlight-new' : null))}
                 rowClassName={(record) =>
                     isPinned(record.uuid) ? cn('bg-primary-highlight', showPinnedWithOpacity && 'opacity-50') : 'group'
                 }
@@ -375,8 +375,8 @@ const LogTag = ({ level }: { level: LogMessage['severity_text'] }): JSX.Element 
 }
 
 const Filters = (): JSX.Element => {
-    const { logsLoading, liveTailEnabled, liveTailDisabledReason } = useValues(logsLogic)
-    const { runQuery, zoomDateRange, setLiveTailEnabled } = useActions(logsLogic)
+    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsLogic)
+    const { runQuery, zoomDateRange, setLiveTailRunning } = useActions(logsLogic)
 
     return (
         <div className="flex flex-col gap-y-1.5">
@@ -404,19 +404,19 @@ const Filters = (): JSX.Element => {
                         icon={<IconRefresh />}
                         type="secondary"
                         onClick={() => runQuery()}
-                        loading={logsLoading}
-                        disabledReason={liveTailEnabled ? 'Disable live tail to manually refresh' : undefined}
+                        loading={logsLoading || liveTailRunning}
+                        disabledReason={liveTailRunning ? 'Disable live tail to manually refresh' : undefined}
                     >
-                        {logsLoading ? 'Loading...' : 'Search'}
+                        {liveTailRunning ? 'Tailing...' : logsLoading ? 'Loading...' : 'Search'}
                     </LemonButton>
                     <LemonButton
                         size="small"
-                        type={liveTailEnabled ? 'primary' : 'secondary'}
-                        icon={liveTailEnabled ? <IconPauseCircle /> : <IconPlayCircle />}
-                        onClick={() => setLiveTailEnabled(!liveTailEnabled)}
-                        disabledReason={liveTailEnabled ? undefined : liveTailDisabledReason}
+                        type={liveTailRunning ? 'primary' : 'secondary'}
+                        icon={liveTailRunning ? <IconPauseCircle /> : <IconPlayCircle />}
+                        onClick={() => setLiveTailRunning(!liveTailRunning)}
+                        disabledReason={liveTailRunning ? undefined : liveTailDisabledReason}
                     >
-                        {liveTailEnabled ? 'Live tail' : 'Live tail'}
+                        Live tail
                     </LemonButton>
                 </div>
             </div>

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -27,6 +27,7 @@ import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductI
 import { Sparkline } from 'lib/components/Sparkline'
 import { TZLabel, TZLabelProps } from 'lib/components/TZLabel'
 import { ListHog } from 'lib/components/hedgehogs'
+import { IconPauseCircle, IconPlayCircle } from 'lib/lemon-ui/icons'
 import { cn } from 'lib/utils/css-classes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -374,8 +375,8 @@ const LogTag = ({ level }: { level: LogMessage['severity_text'] }): JSX.Element 
 }
 
 const Filters = (): JSX.Element => {
-    const { logsLoading } = useValues(logsLogic)
-    const { runQuery, zoomDateRange } = useActions(logsLogic)
+    const { logsLoading, liveTailEnabled, liveTailDisabledReason } = useValues(logsLogic)
+    const { runQuery, zoomDateRange, setLiveTailEnabled } = useActions(logsLogic)
 
     return (
         <div className="flex flex-col gap-y-1.5">
@@ -404,8 +405,18 @@ const Filters = (): JSX.Element => {
                         type="secondary"
                         onClick={() => runQuery()}
                         loading={logsLoading}
+                        disabledReason={liveTailEnabled ? 'Disable live tail to manually refresh' : undefined}
                     >
                         {logsLoading ? 'Loading...' : 'Search'}
+                    </LemonButton>
+                    <LemonButton
+                        size="small"
+                        type={liveTailEnabled ? 'primary' : 'secondary'}
+                        icon={liveTailEnabled ? <IconPauseCircle /> : <IconPlayCircle />}
+                        onClick={() => setLiveTailEnabled(!liveTailEnabled)}
+                        disabledReason={liveTailEnabled ? undefined : liveTailDisabledReason}
+                    >
+                        {liveTailEnabled ? 'Live tail' : 'Live tail'}
                     </LemonButton>
                 </div>
             </div>

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -33,7 +33,7 @@ const DEFAULT_PRETTIFY_JSON = true
 const DEFAULT_TIMESTAMP_FORMAT = 'absolute' as 'absolute' | 'relative'
 const DEFAULT_LOG_LIMIT = 100
 const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
-const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 3000
+const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 5000
 
 export const logsLogic = kea<logsLogicType>([
     path(['products', 'logs', 'frontend', 'logsLogic']),

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -319,20 +319,15 @@ export const logsLogic = kea<logsLogicType>([
             [] as LogMessage[],
             { persist: true },
             {
-              pinLog: (state, { log }) => [...state, log],
-              unpinLog: (state, { logId }) => state.filter((log) => log.uuid !== logId),
+                pinLog: (state, { log }) => [...state, log],
+                unpinLog: (state, { logId }) => state.filter((log) => log.uuid !== logId),
             },
         ],
         liveTailRunning: [
             false as boolean,
             {
                 setLiveTailRunning: (_, { enabled }) => enabled,
-                setDateRange: () => false,
-                setFilterGroup: () => false,
-                setSearchTerm: () => false,
-                setSeverityLevels: () => false,
-                setServiceNames: () => false,
-                setOrderBy: () => false,
+                runQuery: () => false,
             },
         ],
         liveTailPollInterval: [

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -8,7 +8,7 @@ import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tr
 
 import api from 'lib/api'
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
-import { dayjs } from 'lib/dayjs'
+import { Dayjs, dayjs } from 'lib/dayjs'
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
@@ -32,8 +32,8 @@ const DEFAULT_WRAP_BODY = true
 const DEFAULT_PRETTIFY_JSON = true
 const DEFAULT_TIMESTAMP_FORMAT = 'absolute' as 'absolute' | 'relative'
 const DEFAULT_LOG_LIMIT = 100
-const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 3000
-const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 10000
+const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
+const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 3000
 
 export const logsLogic = kea<logsLogicType>([
     path(['products', 'logs', 'frontend', 'logsLogic']),
@@ -161,6 +161,8 @@ export const logsLogic = kea<logsLogicType>([
         setServiceNames: (serviceNames: LogsQuery['serviceNames']) => ({ serviceNames }),
         setWrapBody: (wrapBody: boolean) => ({ wrapBody }),
         setPrettifyJson: (prettifyJson: boolean) => ({ prettifyJson }),
+        setLiveLogsCheckpoint: (liveLogsCheckpoint: string) => ({ liveLogsCheckpoint }),
+        setLastSparklineUpdate: (lastSparklineUpdate: Dayjs) => ({ lastSparklineUpdate }),
         setFilterGroup: (filterGroup: UniversalFiltersGroup, openFilterOnInsert: boolean = true) => ({
             filterGroup,
             openFilterOnInsert,
@@ -180,9 +182,14 @@ export const logsLogic = kea<logsLogicType>([
         unpinLog: (logId: string) => ({ logId }),
         setHighlightedLogId: (highlightedLogId: string | null) => ({ highlightedLogId }),
         setLiveTailEnabled: (enabled: boolean) => ({ enabled }),
+        setLiveTailRunning: (enabled: boolean) => ({ enabled }),
         setLiveTailInterval: (interval: number) => ({ interval }),
         pollForNewLogs: true,
         setLogs: (logs: LogMessage[]) => ({ logs }),
+        setSparkline: (sparkline: any[]) => ({ sparkline }),
+        expireLiveTail: () => true,
+        setLiveTailExpired: (liveTailExpired: boolean) => ({ liveTailExpired }),
+        addLogsToSparkline: (logs: LogMessage[]) => logs,
     }),
 
     reducers({
@@ -226,6 +233,21 @@ export const logsLogic = kea<logsLogicType>([
             DEFAULT_WRAP_BODY as boolean,
             {
                 setWrapBody: (_, { wrapBody }) => wrapBody,
+            },
+        ],
+        liveLogsCheckpoint: [
+            null as string | null,
+            { persist: false },
+            {
+                setLiveLogsCheckpoint: (_, { liveLogsCheckpoint }) => liveLogsCheckpoint,
+            },
+        ],
+        liveTailExpired: [
+            true as boolean,
+            { persist: false },
+            {
+                setLiveTailExpired: (_, { liveTailExpired }) => liveTailExpired,
+                fetchLogsSuccess: () => false,
             },
         ],
         prettifyJson: [
@@ -301,17 +323,16 @@ export const logsLogic = kea<logsLogicType>([
               unpinLog: (state, { logId }) => state.filter((log) => log.uuid !== logId),
             },
         ],
-        liveTailEnabled: [
+        liveTailRunning: [
             false as boolean,
             {
-                setLiveTailEnabled: (_, { enabled }) => enabled,
+                setLiveTailRunning: (_, { enabled }) => enabled,
                 setDateRange: () => false,
                 setFilterGroup: () => false,
                 setSearchTerm: () => false,
                 setSeverityLevels: () => false,
                 setServiceNames: () => false,
                 setOrderBy: () => false,
-                runQuery: () => false,
             },
         ],
         liveTailPollInterval: [
@@ -324,6 +345,12 @@ export const logsLogic = kea<logsLogicType>([
             DEFAULT_HIGHLIGHTED_LOG_ID,
             {
                 setHighlightedLogId: (_, { highlightedLogId }) => highlightedLogId,
+            },
+        ],
+        sparkline: [
+            [] as any[],
+            {
+                setSparkline: (_, { sparkline }) => sparkline,
             },
         ],
     }),
@@ -350,6 +377,13 @@ export const logsLogic = kea<logsLogicType>([
                     signal,
                 })
                 actions.setLogsAbortController(null)
+                // expire live tail has a 30 second delay
+                actions.expireLiveTail()
+                if (response.results.length > 0) {
+                    // the live_logs_checkpoint is the latest known timestamp for which we know we have all logs up to that point
+                    // it's returned from clickhouse as a value on every log row - but the value is fixed per query
+                    actions.setLiveLogsCheckpoint(response.results[0].live_logs_checkpoint)
+                }
                 response.results.forEach((row) => {
                     Object.keys(row.attributes).forEach((key) => {
                         const value = row.attributes[key]
@@ -382,20 +416,34 @@ export const logsLogic = kea<logsLogicType>([
                     actions.setSparklineAbortController(null)
                     return response
                 },
+                setSparkline: ({ sparkline }) => sparkline,
             },
         ],
     })),
 
     selectors(() => ({
         liveTailDisabledReason: [
-            (s) => [s.orderBy, s.dateRange],
-            (orderBy: LogsQuery['orderBy'], dateRange: DateRange): string | undefined => {
+            (s) => [s.orderBy, s.dateRange, s.logsLoading, s.liveTailExpired],
+            (
+                orderBy: LogsQuery['orderBy'],
+                dateRange: DateRange,
+                logsLoading: boolean,
+                liveTailExpired: boolean
+            ): string | undefined => {
                 if (orderBy !== 'latest') {
                     return 'Live tail only works with "Latest" ordering'
                 }
 
                 if (dateRange.date_to) {
                     return 'Live tail requires an open-ended time range'
+                }
+
+                if (logsLoading) {
+                    return 'Wait for query to finish'
+                }
+
+                if (liveTailExpired) {
+                    return 'Live tail has expired, run search again to live tail'
                 }
 
                 return undefined
@@ -475,7 +523,7 @@ export const logsLogic = kea<logsLogicType>([
         ],
         sparklineData: [
             (s) => [s.sparkline],
-            (sparkline) => {
+            (sparkline: any[]) => {
                 let lastTime = ''
                 let i = -1
                 const labels: string[] = []
@@ -483,16 +531,20 @@ export const logsLogic = kea<logsLogicType>([
                 const data = Object.entries(
                     sparkline.reduce((accumulator, currentItem) => {
                         if (currentItem.time !== lastTime) {
-                            labels.push(humanFriendlyDetailedTime(currentItem.time))
+                            labels.push(
+                                humanFriendlyDetailedTime(currentItem.time, 'YYYY-MM-DD', 'HH:mm:ss', {
+                                    showNow: false,
+                                })
+                            )
                             dates.push(currentItem.time)
                             lastTime = currentItem.time
                             i++
                         }
                         const key = currentItem.level
                         if (!accumulator[key]) {
-                            accumulator[key] = Array(sparkline.length)
+                            accumulator[key] = [...Array(sparkline.length)].map(() => 0)
                         }
-                        accumulator[key][i] = currentItem.count
+                        accumulator[key][i] += currentItem.count
                         return accumulator
                     }, {})
                 )
@@ -569,6 +621,13 @@ export const logsLogic = kea<logsLogicType>([
             }
             actions.setDateRange(newDateRange)
         },
+        expireLiveTail: async ({}, breakpoint) => {
+            await breakpoint(30000)
+            if (values.liveTailRunning) {
+                return
+            }
+            actions.setLiveTailExpired(true)
+        },
         addFilter: ({ key, value, operator }) => {
             const currentGroup = values.filterGroup.values[0] as UniversalFiltersGroup
 
@@ -598,41 +657,46 @@ export const logsLogic = kea<logsLogicType>([
                 }
             }
         },
-        setLiveTailEnabled: ({ enabled }) => {
+        setLiveTailRunning: async ({ enabled }) => {
             if (enabled) {
                 actions.pollForNewLogs()
             } else {
                 actions.cancelInProgressLiveTail(null)
+                actions.expireLiveTail()
             }
         },
         pollForNewLogs: async () => {
-            if (!values.liveTailEnabled || values.orderBy !== 'latest') {
+            if (!values.liveTailRunning || values.orderBy !== 'latest' || document.hidden) {
                 return
             }
 
             const liveTailController = new AbortController()
             const signal = liveTailController.signal
             actions.cancelInProgressLiveTail(liveTailController)
-
-            const mostRecentLog = values.logs[0]
-            const dateFrom = mostRecentLog?.timestamp ?? values.utcDateRange.date_from
+            let duration = 0
 
             try {
+                const start = Date.now()
                 const response = await api.logs.query({
                     query: {
                         limit: DEFAULT_LOG_LIMIT,
                         orderBy: values.orderBy,
-                        dateRange: {
-                            date_from: dateFrom,
-                            date_to: null,
-                        },
+                        dateRange: values.utcDateRange,
                         searchTerm: values.searchTerm,
                         filterGroup: values.filterGroup as PropertyGroupFilter,
                         severityLevels: values.severityLevels,
                         serviceNames: values.serviceNames,
+                        liveLogsCheckpoint: values.liveLogsCheckpoint,
                     },
                     signal,
                 })
+                duration = Date.now() - start
+
+                if (response.results.length > 0) {
+                    // the live_logs_checkpoint is the latest known timestamp for which we know we have all logs up to that point
+                    // it's returned from clickhouse as a value on every log row - but the value is fixed per query
+                    actions.setLiveLogsCheckpoint(response.results[0].live_logs_checkpoint)
+                }
 
                 response.results.forEach((row) => {
                     Object.keys(row.attributes).forEach((key) => {
@@ -646,7 +710,15 @@ export const logsLogic = kea<logsLogicType>([
 
                 if (newLogs.length > 0) {
                     actions.setLiveTailInterval(DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS)
-                    actions.setLogs([...newLogs, ...values.logs].slice(0, DEFAULT_LOG_LIMIT))
+                    actions.setLogs(
+                        [
+                            ...newLogs.map((log) => ({ ...log, new: true })),
+                            ...values.logs.map((log) => ({ ...log, new: false })),
+                        ]
+                            .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+                            .slice(0, DEFAULT_LOG_LIMIT)
+                    )
+                    actions.addLogsToSparkline(newLogs)
                 } else {
                     const newInterval = Math.min(
                         values.liveTailPollInterval * 1.5,
@@ -659,24 +731,71 @@ export const logsLogic = kea<logsLogicType>([
                     return
                 }
                 console.error('Live tail polling error:', error)
-                actions.setLiveTailEnabled(false)
+                actions.setLiveTailRunning(false)
             } finally {
                 actions.setLiveTailAbortController(null)
-                if (values.liveTailEnabled) {
+                if (values.liveTailRunning) {
                     cache.disposables.add(() => {
-                        const timerId = setTimeout(() => {
-                            actions.pollForNewLogs()
-                        }, values.liveTailPollInterval)
+                        const timerId = setTimeout(
+                            () => {
+                                actions.pollForNewLogs()
+                            },
+                            Math.min(duration, values.liveTailPollInterval)
+                        )
                         return () => clearTimeout(timerId)
                     }, 'liveTailTimer')
                 }
             }
         },
+        // insert logs into the sparkline data
+        addLogsToSparkline: (logs: LogMessage[]) => {
+            // if the sparkline hasn't loaded do nothing.
+            if (!values.sparkline || values.sparkline.length < 2) {
+                return
+            }
+
+            const first_bucket = values.sparklineData.dates[0]
+            const last_bucket = values.sparklineData.dates[values.sparklineData.dates.length - 1]
+            const duration = dayjs(last_bucket).diff(first_bucket, 'seconds')
+            const interval = dayjs(values.sparklineData.dates[1]).diff(first_bucket, 'seconds')
+            let latest_time_bucket = dayjs(last_bucket)
+            for (const log of logs) {
+                const time_bucket = dayjs.unix(Math.floor(dayjs(log.timestamp).unix() / interval) * interval)
+                if (time_bucket.isAfter(latest_time_bucket)) {
+                    latest_time_bucket = time_bucket
+                }
+                // insert all new logs into the sparkline data as their own bucket - we'll later aggregate them
+                values.sparkline.push({ time: time_bucket.toISOString(), level: log.level, count: 1 })
+            }
+            actions.setSparkline(
+                values.sparkline
+                    .sort(
+                        // sort buckets by time, then level
+                        (a, b) => dayjs(a.time).diff(dayjs(b.time)) || a.level.localeCompare(b.level)
+                    )
+                    .reduce((acc, curr) => {
+                        // aggregate buckets by time and level
+                        const index = acc.findIndex(
+                            (item) => dayjs(item.time).isSame(dayjs(curr.time)) && item.level === curr.level
+                        )
+                        if (index === -1) {
+                            // haven't seen this time/level combo before, add it to the accumulator
+                            acc.push(curr)
+                        } else {
+                            // increase existing bucket
+                            acc[index].count += curr.count
+                        }
+                        return acc
+                        // Keep the overall sparkline time range the same by dropping older buckets
+                    }, [])
+                    .filter((item) => latest_time_bucket.diff(dayjs(item.time), 'seconds') <= duration)
+            )
+        },
     })),
 
     events(({ values, actions }) => ({
         beforeUnmount: () => {
-            actions.setLiveTailEnabled(false)
+            actions.setLiveTailRunning(false)
             actions.cancelInProgressLiveTail(null)
             if (values.logsAbortController) {
                 values.logsAbortController.abort('unmounting component')


### PR DESCRIPTION
## Problem

When searching logs, sometimes users need to monitor live activity in their remote environments. Currently, this requires spamming the search button to refresh results. This PR adds live log tailing so users can see a live stream of the latest logs for their selected query filters.

---

**P.S.:** This is a side quest of mine to better understand the PostHog arch and codebase! I'm curious how the first <100 alpha customers are using logs. I'm currently integrating PostHog logs into a project of mine and I was missing this functionality from CloudWatch, happy to hear any feedback on the idea or make any requested changes!

## Changes

* Added a "Live Tail" toggle button next to the search button (requires an open-ended time range and latest ordering)
* Implements polling that continuously fetches new log entries matching the current query filters and appends them to the logs list (while making sure the list is sliced to stay within log entries limits)
* Implemented exponential backoff, polling interval starts at 1s/req and increases x1.5 each time we query and receive no new logs to append, until reaching a max delay of 5s/req
* add "live logs checkpoint" subquery to the logs query which gets the latest observed timestamp at which we know we've received all logs from capture and filter new logs by this
* "live tail" can only be pressed for 30 seconds after a query, after that you need to search again before live tailing

https://github.com/user-attachments/assets/8a30d723-79db-44b9-9cf4-409471232b1b


## How did you test this code?

- Manual testing: Verified live tail correctly streams new logs matching the selected query filters. It should be noted that any changes to the filters will turn off live tailing automatically
