### PR TITLE
chore(persons): table swap approach for person schema cutover

### DIFF
--- a/posthog/models/test/test_person_schema.py
+++ b/posthog/models/test/test_person_schema.py
@@ -91,11 +91,3 @@ class TestPersonSchemaConsistency(TestCase):
             f"Expected composite primary key (team_id, id) but got {pk_columns}. "
             "This indicates the table wasn't properly swapped to the partitioned schema.",
         )
-
-    def test_posthog_person_new_placeholder_exists(self):
-        """Verify posthog_person_new placeholder table exists for compatibility."""
-        self.assertTrue(
-            table_exists("posthog_person_new"),
-            "posthog_person_new placeholder table does not exist. "
-            "The swap migration should have created this for backward compatibility.",
-        )

--- a/posthog/models/test/test_person_schema.py
+++ b/posthog/models/test/test_person_schema.py
@@ -1,4 +1,4 @@
-"""Smoke test that Rust sqlx migrations ran and created posthog_person_new table."""
+"""Smoke test that Rust sqlx migrations ran and created the partitioned person table."""
 
 from django.db import connection
 from django.test import TestCase
@@ -19,13 +19,83 @@ def table_exists(table_name: str) -> bool:
         return cursor.fetchone()[0]
 
 
+def is_table_partitioned(table_name: str) -> bool:
+    """Check if a table is partitioned."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT EXISTS (
+                SELECT FROM pg_tables
+                WHERE schemaname = 'public' AND tablename = %s AND tableowner = 'postgres'
+            )
+        """,
+            [table_name],
+        )
+        result = cursor.fetchone()
+        if result[0]:
+            # Check if it has partitions
+            cursor.execute(
+                """
+                SELECT COUNT(*) FROM pg_partitioned_table
+                WHERE relid = %s::regclass
+            """,
+                [f"public.{table_name}"],
+            )
+            return cursor.fetchone()[0] > 0
+        return False
+
+
+def get_table_primary_key(table_name: str) -> list[str]:
+    """Get primary key columns of a table."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT a.attname
+            FROM pg_index i
+            JOIN pg_attribute a ON a.attrelid = i.indrelid
+                AND a.attnum = ANY(i.indkey)
+            WHERE i.indrelid = %s::regclass
+                AND i.indisprimary
+            ORDER BY a.attnum
+        """,
+            [f"public.{table_name}"],
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+
 class TestPersonSchemaConsistency(TestCase):
     """Smoke test that Rust sqlx migrations ran successfully."""
 
-    def test_posthog_person_new_exists(self):
-        """Verify posthog_person_new table was created by sqlx migrations."""
+    def test_posthog_person_table_exists(self):
+        """Verify posthog_person table exists (created by sqlx migrations)."""
+        self.assertTrue(
+            table_exists("posthog_person"),
+            "posthog_person table does not exist. "
+            "Rust sqlx migrations from rust/persons_migrations/ should have created it.",
+        )
+
+    def test_posthog_person_is_partitioned(self):
+        """Verify posthog_person table is partitioned."""
+        self.assertTrue(
+            is_table_partitioned("posthog_person"),
+            "posthog_person table is not partitioned. "
+            "The swap migration (20251116000001) should have renamed posthog_person_new to posthog_person.",
+        )
+
+    def test_posthog_person_has_composite_primary_key(self):
+        """Verify posthog_person has composite PK (team_id, id) from partitioned schema."""
+        pk_columns = get_table_primary_key("posthog_person")
+        self.assertEqual(
+            pk_columns,
+            ["team_id", "id"],
+            f"Expected composite primary key (team_id, id) but got {pk_columns}. "
+            "This indicates the table wasn't properly swapped to the partitioned schema.",
+        )
+
+    def test_posthog_person_new_placeholder_exists(self):
+        """Verify posthog_person_new placeholder table exists for compatibility."""
         self.assertTrue(
             table_exists("posthog_person_new"),
-            "posthog_person_new table does not exist. "
-            "Rust sqlx migrations from rust/persons_migrations/ should have created it.",
+            "posthog_person_new placeholder table does not exist. "
+            "The swap migration should have created this for backward compatibility.",
         )

--- a/rust/persons_migrations/20251116000001_swap_person_tables.sql
+++ b/rust/persons_migrations/20251116000001_swap_person_tables.sql
@@ -1,0 +1,13 @@
+-- Swap person tables: make partitioned table the primary one
+-- Production already has posthog_person_new (partitioned), this migration makes it the main table
+-- and renames the old unpartitioned table out of the way.
+
+-- Rename old unpartitioned table out of the way
+ALTER TABLE IF EXISTS posthog_person RENAME TO posthog_person_old;
+
+-- Rename new (partitioned) table to primary name
+ALTER TABLE IF EXISTS posthog_person_new RENAME TO posthog_person;
+
+-- Create empty posthog_person_new for compatibility (in case any code still references it)
+-- This won't be actively used, but allows for zero-downtime switchover
+CREATE TABLE IF NOT EXISTS posthog_person_new (LIKE posthog_person INCLUDING ALL);

--- a/rust/persons_migrations/20251116000001_swap_person_tables.sql
+++ b/rust/persons_migrations/20251116000001_swap_person_tables.sql
@@ -1,32 +1,9 @@
 -- Swap person tables: make partitioned table the primary one
--- Production already has posthog_person_new (partitioned), this migration makes it the main table
--- and renames the old unpartitioned table out of the way.
+-- This migration renames the unpartitioned posthog_person to posthog_person_old
+-- and renames the partitioned posthog_person_new to posthog_person
 
--- Rename old unpartitioned table out of the way (if it exists - it might not in fresh installs)
-DO $$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.tables
-        WHERE table_schema = 'public' AND table_name = 'posthog_person'
-        AND table_type = 'BASE TABLE'
-    ) THEN
-        -- Check if it's not partitioned (old table)
-        IF NOT EXISTS (
-            SELECT 1 FROM pg_partitioned_table
-            WHERE relid = 'public.posthog_person'::regclass
-        ) THEN
-            ALTER TABLE posthog_person RENAME TO posthog_person_old;
-        END IF;
-    END IF;
-END $$;
+-- Rename unpartitioned table out of the way
+ALTER TABLE IF EXISTS posthog_person RENAME TO posthog_person_old;
 
--- Rename new (partitioned) table to primary name
-DO $$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.tables
-        WHERE table_schema = 'public' AND table_name = 'posthog_person_new'
-    ) THEN
-        ALTER TABLE posthog_person_new RENAME TO posthog_person;
-    END IF;
-END $$;
+-- Rename partitioned table to primary name
+ALTER TABLE IF EXISTS posthog_person_new RENAME TO posthog_person;


### PR DESCRIPTION
## Summary

POC branch testing a simpler approach to person schema migration: instead of changing Django's db_table to point to a different table, we simply rename the tables at the database level.

**Key idea:** Production already has `posthog_person_new` (partitioned). We just swap the names so the partitioned table becomes `posthog_person`.

## Changes

- Add sqlx migration `20251116000001_swap_person_tables.sql`: renames unpartitioned `posthog_person` → `posthog_person_old`, then renames partitioned `posthog_person_new` → `posthog_person`
- Enhance smoke test to verify table is partitioned and has composite PK (team_id, id)
- No Django model changes needed - db_table stays as default "posthog_person"

## Advantages Over switch-person-to-new-table

- No environment variable configuration needed
- No conftest.py workarounds for constraint handling
- Simpler conceptually: "person is the table" not "person is in the_new_table"
- Should avoid the test infrastructure complexity we hit before

## Test Plan

- Runs smoke test to verify partitioning and schema correctness
- Check if CI validates the approach without test infrastructure issues