### PR TITLE
docs: Update `posthog-cli schema` documentation to adhere to recent code updates 

### DIFF
--- a/cli/src/experimental/schema.rs
+++ b/cli/src/experimental/schema.rs
@@ -194,10 +194,10 @@ pub fn pull(_host: Option<String>, output_override: Option<String>) -> Result<()
     println!("\nNext steps:");
     println!("  1. Import PostHog from your generated module:");
     println!("     import posthog from './{output_path}'");
-    println!("  2. Use typed events with autocomplete and type safety:");
-    println!("     posthog.captureTyped('event_name', {{ property: 'value' }})");
-    println!("  3. Or use regular capture() for flexibility:");
-    println!("     posthog.capture('dynamic_event', {{ any: 'data' }})");
+    println!("  2. Use typed events with autocomplete and type safety on known events:");
+    println!("     posthog.capture('event_name', {{ property: 'value' }})");
+    println!("  3. Use captureRaw() when you need to bypass type checking:");
+    println!("     posthog.captureRaw('dynamic_event_name', {{ whatever: 'data' }})");
     println!();
 
     Ok(())


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

This PR realigns documentation with code after review changes in https://github.com/PostHog/posthog/pull/39850.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Updated `schema sync` next step docs to match CLI behavior.

## How did you test this code?

1. Build the binary locally (`cargo install --path .`)
2. Authenticate (`posthog-cli login`, choosing the `Manual` option)
3. Execute the schema pull functionality (`posthog-cli exp schema pull`)

<img width="683" height="240" alt="Screenshot 2025-11-17 at 10 40 45" src="https://github.com/user-attachments/assets/ca0f380c-8933-40f1-9115-d3bc12111306" />

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

No (docs-only), this feature is still behind the experiments flag.

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
