### PR TITLE
refactor(ph-ai): conversation stream manager to agent executor

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -21,11 +21,16 @@ from posthog.exceptions import Conflict
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
 from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle
-from posthog.temporal.ai.conversation import AssistantConversationRunnerWorkflowInputs
+from posthog.temporal.ai.chat_agent import (
+    CHAT_AGENT_STREAM_MAX_LENGTH,
+    CHAT_AGENT_WORKFLOW_TIMEOUT,
+    AssistantConversationRunnerWorkflow,
+    AssistantConversationRunnerWorkflowInputs,
+)
 from posthog.utils import get_instance_region
 
+from ee.hogai.agent.executor import AgentExecutor
 from ee.hogai.api.serializers import ConversationSerializer
-from ee.hogai.stream.conversation_stream import ConversationStreamManager
 from ee.hogai.utils.aio import async_to_sync
 from ee.hogai.utils.sse import AssistantSSESerializer
 from ee.hogai.utils.types.base import AssistantMode
@@ -131,7 +136,8 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
 
         has_message = serializer.validated_data.get("content") is not None
         is_deep_research = serializer.validated_data.get("deep_research_mode", False)
-        mode = AssistantMode.DEEP_RESEARCH if is_deep_research else AssistantMode.ASSISTANT
+        if is_deep_research:
+            raise NotImplementedError("Deep research is not supported yet")
 
         is_new_conversation = False
         # Safely set the lookup kwarg for potential error handling
@@ -175,15 +181,18 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
             trace_id=serializer.validated_data["trace_id"],
             session_id=request.headers.get("X-POSTHOG-SESSION-ID"),  # Relies on posthog-js __add_tracing_headers
             billing_context=serializer.validated_data.get("billing_context"),
-            mode=mode,
+            mode=AssistantMode.ASSISTANT,
         )
+        workflow_class = AssistantConversationRunnerWorkflow
 
         async def async_stream(
             workflow_inputs: AssistantConversationRunnerWorkflowInputs,
         ) -> AsyncGenerator[bytes, None]:
             serializer = AssistantSSESerializer()
-            stream_manager = ConversationStreamManager(conversation)
-            async for chunk in stream_manager.astream(workflow_inputs):
+            stream_manager = AgentExecutor(
+                conversation, timeout=CHAT_AGENT_WORKFLOW_TIMEOUT, max_length=CHAT_AGENT_STREAM_MAX_LENGTH
+            )
+            async for chunk in stream_manager.astream(workflow_class, workflow_inputs):
                 yield serializer.dumps(chunk).encode("utf-8")
 
         return StreamingHttpResponse(
@@ -201,8 +210,8 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         async def cancel_workflow():
-            conversation_manager = ConversationStreamManager(conversation)
-            await conversation_manager.cancel_conversation()
+            agent_executor = AgentExecutor(conversation)
+            await agent_executor.cancel_workflow()
 
         try:
             asgi_async_to_sync(cancel_workflow)()

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -102,7 +102,7 @@ class TestConversation(APIBaseTest):
         conversation_id = str(uuid.uuid4())
 
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ) as mock_start_workflow_and_stream:
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -120,7 +120,7 @@ class TestConversation(APIBaseTest):
                 # Check that the method was called with workflow_inputs
                 mock_start_workflow_and_stream.assert_called_once()
                 call_args = mock_start_workflow_and_stream.call_args
-                workflow_inputs = call_args[0][0]
+                workflow_inputs = call_args[0][1]
                 self.assertEqual(workflow_inputs.user_id, self.user.id)
                 self.assertEqual(workflow_inputs.is_new_conversation, True)
                 self.assertEqual(workflow_inputs.conversation_id, conversation.id)
@@ -129,7 +129,7 @@ class TestConversation(APIBaseTest):
 
     def test_add_message_to_existing_conversation(self):
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ) as mock_start_workflow_and_stream:
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -149,7 +149,7 @@ class TestConversation(APIBaseTest):
                 # Check that the method was called with workflow_inputs
                 mock_start_workflow_and_stream.assert_called_once()
                 call_args = mock_start_workflow_and_stream.call_args
-                workflow_inputs = call_args[0][0]
+                workflow_inputs = call_args[0][1]
                 self.assertEqual(workflow_inputs.user_id, self.user.id)
                 self.assertEqual(workflow_inputs.is_new_conversation, False)
                 self.assertEqual(workflow_inputs.conversation_id, conversation.id)
@@ -195,7 +195,7 @@ class TestConversation(APIBaseTest):
     def test_rate_limit_burst(self):
         # Create multiple requests to trigger burst rate limit
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ):
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -227,7 +227,7 @@ class TestConversation(APIBaseTest):
             user=self.user, team=self.team, status=Conversation.Status.IN_PROGRESS
         )
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ) as mock_stream_conversation:
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -263,7 +263,7 @@ class TestConversation(APIBaseTest):
 
     def test_nonexistent_conversation(self):
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ):
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -296,7 +296,7 @@ class TestConversation(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    @patch("ee.hogai.stream.conversation_stream.ConversationStreamManager.cancel_conversation")
+    @patch("ee.hogai.agent.executor.AgentExecutor.cancel_workflow")
     def test_cancel_conversation(self, mock_cancel):
         conversation = Conversation.objects.create(
             user=self.user,
@@ -340,7 +340,7 @@ class TestConversation(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    @patch("ee.hogai.stream.conversation_stream.ConversationStreamManager.cancel_conversation")
+    @patch("ee.hogai.agent.executor.AgentExecutor.cancel_workflow")
     def test_cancel_conversation_with_async_cleanup(self, mock_cancel):
         """Test that cancel endpoint properly handles async cleanup."""
         conversation = Conversation.objects.create(
@@ -360,7 +360,7 @@ class TestConversation(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    @patch("ee.hogai.stream.conversation_stream.ConversationStreamManager.cancel_conversation")
+    @patch("ee.hogai.agent.executor.AgentExecutor.cancel_workflow")
     def test_cancel_conversation_async_cleanup_failure(self, mock_cancel):
         """Test cancel endpoint behavior when async cleanup fails."""
         conversation = Conversation.objects.create(
@@ -428,7 +428,7 @@ class TestConversation(APIBaseTest):
             user=self.user, team=self.team, status=Conversation.Status.IN_PROGRESS
         )
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ) as mock_stream_conversation:
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -606,7 +606,7 @@ class TestConversation(APIBaseTest):
         conversation = Conversation.objects.create(user=self.user, team=self.team)
 
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ) as mock_start_workflow_and_stream:
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -622,7 +622,7 @@ class TestConversation(APIBaseTest):
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 call_args = mock_start_workflow_and_stream.call_args
-                workflow_inputs = call_args[0][0]
+                workflow_inputs = call_args[0][1]
                 self.assertEqual(workflow_inputs.billing_context, self.billing_context)
 
     def test_billing_context_validation_invalid_data(self):
@@ -630,7 +630,7 @@ class TestConversation(APIBaseTest):
         conversation = Conversation.objects.create(user=self.user, team=self.team)
 
         with patch(
-            "ee.hogai.stream.conversation_stream.ConversationStreamManager.astream",
+            "ee.hogai.agent.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ) as mock_start_workflow_and_stream:
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
@@ -646,5 +646,5 @@ class TestConversation(APIBaseTest):
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 call_args = mock_start_workflow_and_stream.call_args
-                workflow_inputs = call_args[0][0]
+                workflow_inputs = call_args[0][1]
                 self.assertEqual(workflow_inputs.billing_context, None)

--- a/ee/hogai/agent/test/test_redis_stream.py
+++ b/ee/hogai/agent/test/test_redis_stream.py
@@ -15,9 +15,8 @@ from posthog.schema import (
     AssistantMessage,
 )
 
-from posthog.temporal.ai.conversation import CONVERSATION_STREAM_TIMEOUT
-
-from ee.hogai.stream.redis_stream import (
+from ee.hogai.agent.redis_stream import (
+    CONVERSATION_STREAM_TIMEOUT,
     ConversationRedisStream,
     ConversationStreamSerializer,
     MessageEvent,
@@ -35,7 +34,7 @@ class TestRedisStream(BaseTest):
         self.stream_key = f"test_stream:{uuid4()}"
         self.redis_stream = ConversationRedisStream(self.stream_key)
 
-    @patch("ee.hogai.stream.redis_stream.get_async_client")
+    @patch("ee.hogai.agent.redis_stream.get_async_client")
     def test_init(self, mock_get_client):
         mock_client = AsyncMock()
         mock_get_client.return_value = mock_client
@@ -61,7 +60,7 @@ class TestRedisStream(BaseTest):
             mock_client.exists = AsyncMock(return_value=False)
 
             with patch("asyncio.sleep", new_callable=AsyncMock):
-                with patch("ee.hogai.stream.redis_stream.asyncio.get_event_loop") as mock_get_loop:
+                with patch("ee.hogai.agent.redis_stream.asyncio.get_event_loop") as mock_get_loop:
                     from unittest.mock import MagicMock
 
                     mock_loop = MagicMock()

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -1,4 +1,4 @@
-from posthog.temporal.ai.conversation import AssistantConversationRunnerWorkflow, process_conversation_activity
+from posthog.temporal.ai.chat_agent import AssistantConversationRunnerWorkflow, process_conversation_activity
 from posthog.temporal.ai.session_summary.activities.patterns import (
     assign_events_to_patterns_activity,
     combine_patterns_from_chunks_activity,

--- a/posthog/temporal/ai/base.py
+++ b/posthog/temporal/ai/base.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+
+class AgentBaseWorkflow(PostHogWorkflow):
+    """Base temporal workflow for processing agents asynchronously."""
+
+    async def run(self, inputs: Any) -> None:
+        """Execute the agent workflow."""
+        raise NotImplementedError

--- a/posthog/temporal/tests/ai/test_chat_agent_activity.py
+++ b/posthog/temporal/tests/ai/test_chat_agent_activity.py
@@ -5,18 +5,18 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from posthog.models import Team, User
-from posthog.temporal.ai.conversation import (
+from posthog.temporal.ai.chat_agent import (
     AssistantConversationRunnerWorkflowInputs,
     get_conversation_stream_key,
     process_conversation_activity,
 )
 
-from ee.hogai.stream.redis_stream import CONVERSATION_STREAM_PREFIX
+from ee.hogai.agent.redis_stream import CONVERSATION_STREAM_PREFIX
 from ee.hogai.utils.types import AssistantMode
 from ee.models import Conversation
 
 
-class TestProcessConversationActivity:
+class TestProcessChatAgentActivity:
     """Test the process_conversation_activity function."""
 
     @pytest.fixture
@@ -94,16 +94,16 @@ class TestProcessConversationActivity:
     ):
         """Test successful conversation processing."""
         with (
-            patch("posthog.temporal.ai.conversation.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.conversation.User.objects.aget", new=AsyncMock(return_value=mock_user)),
+            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
+            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
             patch(
-                "posthog.temporal.ai.conversation.Conversation.objects.aget",
+                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
                 new=AsyncMock(return_value=mock_conversation),
             ),
             patch(
-                "posthog.temporal.ai.conversation.ConversationRedisStream", return_value=mock_redis_stream
+                "posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream
             ) as mock_redis_stream_class,
-            patch("posthog.temporal.ai.conversation.Assistant.create", return_value=mock_assistant),
+            patch("posthog.temporal.ai.chat_agent.Assistant.create", return_value=mock_assistant),
         ):
             # Execute the activity
             await process_conversation_activity(conversation_inputs)
@@ -142,14 +142,14 @@ class TestProcessConversationActivity:
         mock_redis_stream.write_to_stream = AsyncMock(side_effect=Exception("Streaming error"))
 
         with (
-            patch("posthog.temporal.ai.conversation.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.conversation.User.objects.aget", new=AsyncMock(return_value=mock_user)),
+            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
+            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
             patch(
-                "posthog.temporal.ai.conversation.Conversation.objects.aget",
+                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
                 new=AsyncMock(return_value=mock_conversation),
             ),
-            patch("posthog.temporal.ai.conversation.ConversationRedisStream", return_value=mock_redis_stream),
-            patch("posthog.temporal.ai.conversation.Assistant.create", return_value=mock_assistant),
+            patch("posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream),
+            patch("posthog.temporal.ai.chat_agent.Assistant.create", return_value=mock_assistant),
         ):
             # Should raise the streaming error
             with pytest.raises(Exception, match="Streaming error"):
@@ -176,15 +176,15 @@ class TestProcessConversationActivity:
         )
 
         with (
-            patch("posthog.temporal.ai.conversation.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.conversation.User.objects.aget", new=AsyncMock(return_value=mock_user)),
+            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
+            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
             patch(
-                "posthog.temporal.ai.conversation.Conversation.objects.aget",
+                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
                 new=AsyncMock(return_value=mock_conversation),
             ),
-            patch("posthog.temporal.ai.conversation.ConversationRedisStream", return_value=mock_redis_stream),
+            patch("posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream),
             patch(
-                "posthog.temporal.ai.conversation.Assistant.create", return_value=mock_assistant
+                "posthog.temporal.ai.chat_agent.Assistant.create", return_value=mock_assistant
             ) as mock_assistant_create,
         ):
             # Execute the activity
@@ -207,15 +207,15 @@ class TestProcessConversationActivity:
         mock_activity = Mock()
         mock_activity.heartbeat = Mock()
         with (
-            patch("posthog.temporal.ai.conversation.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.conversation.User.objects.aget", new=AsyncMock(return_value=mock_user)),
+            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
+            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
             patch(
-                "posthog.temporal.ai.conversation.Conversation.objects.aget",
+                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
                 new=AsyncMock(return_value=mock_conversation),
             ),
-            patch("posthog.temporal.ai.conversation.ConversationRedisStream", return_value=mock_redis_stream),
-            patch("posthog.temporal.ai.conversation.Assistant.create", return_value=mock_assistant),
-            patch("posthog.temporal.ai.conversation.activity", mock_activity),
+            patch("posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream),
+            patch("posthog.temporal.ai.chat_agent.Assistant.create", return_value=mock_assistant),
+            patch("posthog.temporal.ai.chat_agent.activity", mock_activity),
         ):
             # Track callback invocations
             callback_invocations = []


### PR DESCRIPTION
## Problem
`ConversationStreamManager` is now `AgentExecutor`, a class to run an agent workflow and stream its content, taking as input the workflow type and workflow inputs. This will allow us to run deep research using a different workflow than the base chat agent one.

## Changes
- Renamed `ConversationStreamManager` to `AgentExecutor` and moved it from `ee/hogai/stream/` to `ee/hogai/agent/`
- Renamed `AssistantConversationRunnerWorkflow` to `ChatAgentWorkflow` for better clarity
- Created a new base class `AgentBaseWorkflow` to support different types of agent workflows
- Moved Redis stream implementation to the agent package
- Made timeout and max length parameters configurable in the executor

## How did you test this code?
- Migrated all existing tests to the new structure

## Changelog: Yes