### PR TITLE
fix(retention): cumulative breakdown

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -12,7 +12,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
-import { OVERALL_MEAN_KEY } from './retentionLogic'
+import { OVERALL_MEAN_KEY, retentionLogic } from './retentionLogic'
 import { retentionModalLogic } from './retentionModalLogic'
 import { retentionTableLogic } from './retentionTableLogic'
 import { NO_BREAKDOWN_VALUE } from './types'
@@ -36,8 +36,9 @@ export function RetentionTable({
         tableHeaders,
         retentionFilter,
     } = useValues(retentionTableLogic(insightProps))
-    const { toggleBreakdown } = useActions(retentionTableLogic(insightProps))
+    const { toggleBreakdown, setHoveredColumn } = useActions(retentionTableLogic(insightProps))
     const { hoveredColumn } = useValues(retentionTableLogic(insightProps))
+    const { updateInsightFilter } = useActions(retentionLogic(insightProps))
     const { openModal } = useActions(retentionModalLogic(insightProps))
 
     const selectedInterval = retentionFilter?.selectedInterval ?? null
@@ -68,8 +69,40 @@ export function RetentionTable({
                 <tr>
                     <th className="bg whitespace-nowrap">Cohort</th>
                     {!hideSizeColumn && <th className="bg">Size</th>}
-                    {tableHeaders.map((header) => (
-                        <th key={header}>{header}</th>
+                    {tableHeaders.map((header, columnIndex) => (
+                        <th
+                            key={header}
+                            className={clsx({
+                                'RetentionTable__SelectedColumn--header':
+                                    allowSelectingColumns && columnIndex === selectedInterval,
+                                'RetentionTable__HoveredColumn--header':
+                                    allowSelectingColumns &&
+                                    columnIndex === hoveredColumn &&
+                                    columnIndex !== selectedInterval,
+                            })}
+                            onClick={() => {
+                                if (allowSelectingColumns) {
+                                    updateInsightFilter({
+                                        selectedInterval: columnIndex === selectedInterval ? null : columnIndex,
+                                    })
+                                }
+                            }}
+                            onMouseEnter={() => {
+                                if (allowSelectingColumns) {
+                                    setHoveredColumn(columnIndex)
+                                }
+                            }}
+                            onMouseLeave={() => {
+                                if (allowSelectingColumns) {
+                                    setHoveredColumn(null)
+                                }
+                            }}
+                            style={{
+                                cursor: allowSelectingColumns ? 'pointer' : 'default',
+                            }}
+                        >
+                            {header}
+                        </th>
                     ))}
                 </tr>
 

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -149,7 +149,14 @@ export function RetentionTable({
                                 )}
 
                                 {tableHeaders.map((_, interval) => (
-                                    <td key={interval}>
+                                    <td
+                                        key={interval}
+                                        className={clsx({
+                                            'RetentionTable__SelectedColumn--cell': interval === selectedInterval,
+                                            'RetentionTable__HoveredColumn--cell':
+                                                interval === hoveredColumn && interval !== selectedInterval,
+                                        })}
+                                    >
                                         <CohortDay
                                             percentage={meanData?.meanPercentages?.[interval] ?? 0}
                                             clickable={false}

--- a/frontend/src/scenes/retention/retentionGraphLogic.ts
+++ b/frontend/src/scenes/retention/retentionGraphLogic.ts
@@ -259,12 +259,24 @@ export const retentionGraphLogic = kea<retentionGraphLogicType>([
         ],
 
         xAxisLabels: [
-            (s) => [s.retentionFilter, s.results],
-            (retentionFilter, results) => {
+            (s) => [s.retentionFilter, s.results, s.filteredResults],
+            (retentionFilter, results, filteredResults) => {
                 if (!retentionFilter || !results) {
                     return []
                 }
-                const { period, retentionCustomBrackets } = retentionFilter
+                const { period, retentionCustomBrackets, selectedInterval } = retentionFilter
+
+                // When an interval is selected, show cohort dates on x-axis
+                if (selectedInterval !== null && selectedInterval !== undefined) {
+                    const formatCohortLabel = (cohort: ProcessedRetentionPayload): string => {
+                        if (cohort.date) {
+                            return period === 'Hour' ? cohort.date.format('MMM D, h A') : cohort.date.format('MMM D')
+                        }
+                        return cohort.label
+                    }
+                    return filteredResults.map(formatCohortLabel)
+                }
+
                 const unit = dateOptionPlurals[period || 'Day']
 
                 if (retentionCustomBrackets) {

--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -61,6 +61,12 @@ export const retentionLogic = kea<retentionLogicType>([
             // Reset selected breakdown value when breakdown filter changes
             // This prevents the dropdown from showing invalid cohort IDs
             actions.setSelectedBreakdownValue(null)
+            // Reset selected interval when breakdown filter changes
+            actions.updateInsightFilter({ selectedInterval: null })
+        },
+        updateDateRange: () => {
+            // Reset selected interval when date range changes
+            actions.updateInsightFilter({ selectedInterval: null })
         },
         updateLocalCustomBracket: async (_, breakpoint) => {
             await breakpoint(1000)

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -894,7 +894,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                     actor_id,
                     max(intervals_from_base) as max_interval,
                     start_interval_index,
-                    any(breakdown_value) as breakdown_value
+                    breakdown_value
                 FROM {actor_query}
                 GROUP BY actor_id, start_interval_index, breakdown_value
                 """,


### PR DESCRIPTION
## Problem
Fixes #41496 

## Changes
- Breakdown when using cumulative mode works
<img width="1021" height="577" alt="image" src="https://github.com/user-attachments/assets/836d588e-d283-41fe-9dc5-ddf49ca028f6" />

- [Adds back changes for column selection](https://posthog.slack.com/archives/C0368RPHLQH/p1763390878119629)

<img width="1103" height="717" alt="image" src="https://github.com/user-attachments/assets/cf0c387f-3d6a-4c23-97ac-38f939b28a89" />


## How did you test this code?
Added tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
