### PR TITLE
chore: remove ngrok from flox manifest

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -45,7 +45,6 @@ cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql
 ffmpeg.pkg-path = "ffmpeg"
-ngrok = { pkg-path = "ngrok" }
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first


### PR DESCRIPTION
## Problem

ngrok is causing slow flox activation times for developers as it needs to be built from source due to its unfree/proprietary license in nixpkgs. Since ngrok is rarely used in PostHog development, it shouldn't be a required dependency in the flox environment.

Addresses feedback from https://github.com/PostHog/posthog/pull/41463#issuecomment-2588396326

## Changes

- Removed `ngrok = { pkg-path = "ngrok" }` from `.flox/env/manifest.toml`

Developers who need ngrok can install it separately via:
- Homebrew: `brew install ngrok`
- Direct download: https://ngrok.com/download
- Or add it back to their local flox manifest if preferred

## How did you test this code?

- Verified the manifest syntax is still valid after removal
- Confirmed ngrok is not referenced elsewhere in the flox configuration

## Changelog

No - internal developer tooling improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)