### PR TITLE
feat: added new Temporal workflow for hard-deleting recordings

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -73,7 +73,11 @@ from posthog.session_recordings.models.session_recording_event import SessionRec
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.session_recordings.session_recording_v2_service import list_blocks
-from posthog.session_recordings.utils import clean_prompt_whitespace
+from posthog.session_recordings.utils import (
+    clean_prompt_whitespace,
+    filter_from_params_to_query,
+    query_as_params_to_dict,
+)
 from posthog.settings.session_replay import SESSION_REPLAY_AI_REGEX_MODEL
 from posthog.storage import object_storage, session_recording_v2_object_storage
 from posthog.storage.session_recording_v2_object_storage import BlockFetchError
@@ -172,19 +176,6 @@ def _get_session_ids_from_comment_search(
         raise ValidationError("Unsupported operator for comment search: " + str(operator))
 
     return list(base_query.values_list("item_id", flat=True).distinct())
-
-
-def filter_from_params_to_query(params: dict) -> RecordingsQuery:
-    data_dict = query_as_params_to_dict(params)
-    # we used to send `version` and it's not part of query, so we pop to make sure
-    data_dict.pop("version", None)
-    # we used to send `hogql_filtering` and it's not part of query, so we pop to make sure
-    data_dict.pop("hogql_filtering", None)
-
-    try:
-        return RecordingsQuery.model_validate(data_dict)
-    except ValidationError as pydantic_validation_error:
-        raise exceptions.ValidationError(json.dumps(pydantic_validation_error.errors()))
 
 
 class ChatMessage(BaseModel):
@@ -477,28 +468,6 @@ class SnapshotsBurstRateThrottle(PersonalApiKeyRateThrottle):
 class SnapshotsSustainedRateThrottle(PersonalApiKeyRateThrottle):
     scope = "snapshots_sustained"
     rate = "600/hour"
-
-
-def query_as_params_to_dict(params_dict: dict) -> dict:
-    """
-    before (if ever) we convert this to a query runner that takes a post
-    we need to convert to a valid dict from the data that arrived in query params
-    """
-    converted = {}
-    for key in params_dict:
-        try:
-            converted[key] = json.loads(params_dict[key]) if isinstance(params_dict[key], str) else params_dict[key]
-        except JSONDecodeError:
-            converted[key] = params_dict[key]
-
-    # we used to accept this value,
-    # but very unlikely to receive it now
-    # it's safe to pop
-    # to make sure any old URLs or filters don't error
-    # if they still include it
-    converted.pop("as_query", None)
-
-    return converted
 
 
 def clean_referer_url(current_url: str | None) -> str:

--- a/posthog/session_recordings/utils.py
+++ b/posthog/session_recordings/utils.py
@@ -1,3 +1,11 @@
+import json
+
+from rest_framework import exceptions
+from pydantic import ValidationError
+
+from posthog.schema import RecordingsQuery
+
+
 def clean_prompt_whitespace(prompt: str) -> str:
     """
     Cleans unnecessary whitespace from prompts while preserving single spaces between words.
@@ -8,3 +16,38 @@ def clean_prompt_whitespace(prompt: str) -> str:
     """
     # Replace multiple spaces with single space and strip leading/trailing whitespace
     return " ".join(prompt.split())
+
+
+def query_as_params_to_dict(params_dict: dict) -> dict:
+    """
+    before (if ever) we convert this to a query runner that takes a post
+    we need to convert to a valid dict from the data that arrived in query params
+    """
+    converted = {}
+    for key in params_dict:
+        try:
+            converted[key] = json.loads(params_dict[key]) if isinstance(params_dict[key], str) else params_dict[key]
+        except json.JSONDecodeError:
+            converted[key] = params_dict[key]
+
+    # we used to accept this value,
+    # but very unlikely to receive it now
+    # it's safe to pop
+    # to make sure any old URLs or filters don't error
+    # if they still include it
+    converted.pop("as_query", None)
+
+    return converted
+
+
+def filter_from_params_to_query(params: dict) -> RecordingsQuery:
+    data_dict = query_as_params_to_dict(params)
+    # we used to send `version` and it's not part of query, so we pop to make sure
+    data_dict.pop("version", None)
+    # we used to send `hogql_filtering` and it's not part of query, so we pop to make sure
+    data_dict.pop("hogql_filtering", None)
+
+    try:
+        return RecordingsQuery.model_validate(data_dict)
+    except ValidationError as pydantic_validation_error:
+        raise exceptions.ValidationError(json.dumps(pydantic_validation_error.errors()))

--- a/posthog/session_recordings/utils.py
+++ b/posthog/session_recordings/utils.py
@@ -1,7 +1,7 @@
 import json
 
-from rest_framework import exceptions
 from pydantic import ValidationError
+from rest_framework import exceptions
 
 from posthog.schema import RecordingsQuery
 

--- a/posthog/temporal/delete_recordings/__init__.py
+++ b/posthog/temporal/delete_recordings/__init__.py
@@ -7,8 +7,8 @@ from posthog.temporal.delete_recordings.activities import (
 )
 from posthog.temporal.delete_recordings.workflows import (
     DeleteRecordingsWithPersonWorkflow,
-    DeleteRecordingWorkflow,
     DeleteRecordingsWithQueryWorkflow,
+    DeleteRecordingWorkflow,
 )
 
 WORKFLOWS = [

--- a/posthog/temporal/delete_recordings/__init__.py
+++ b/posthog/temporal/delete_recordings/__init__.py
@@ -3,12 +3,18 @@ from posthog.temporal.delete_recordings.activities import (
     group_recording_blocks,
     load_recording_blocks,
     load_recordings_with_person,
+    load_recordings_with_query,
 )
-from posthog.temporal.delete_recordings.workflows import DeleteRecordingsWithPersonWorkflow, DeleteRecordingWorkflow
+from posthog.temporal.delete_recordings.workflows import (
+    DeleteRecordingsWithPersonWorkflow,
+    DeleteRecordingWorkflow,
+    DeleteRecordingsWithQueryWorkflow,
+)
 
 WORKFLOWS = [
     DeleteRecordingWorkflow,
     DeleteRecordingsWithPersonWorkflow,
+    DeleteRecordingsWithQueryWorkflow,
 ]
 
 ACTIVITIES = [
@@ -16,4 +22,5 @@ ACTIVITIES = [
     delete_recording_blocks,
     load_recordings_with_person,
     group_recording_blocks,
+    load_recordings_with_query,
 ]

--- a/posthog/temporal/delete_recordings/types.py
+++ b/posthog/temporal/delete_recordings/types.py
@@ -23,6 +23,14 @@ class RecordingsWithPersonInput:
 
 
 @dataclass(frozen=True)
+class RecordingsWithQueryInput:
+    query: str
+    team_id: int
+    dry_run: bool = False
+    batch_size: int = 100
+
+
+@dataclass(frozen=True)
 class RecordingBlockGroup:
     recording: Recording
     path: str

--- a/posthog/temporal/tests/delete_recordings/test_activities.py
+++ b/posthog/temporal/tests/delete_recordings/test_activities.py
@@ -1,0 +1,412 @@
+import json
+from datetime import datetime
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from posthog.session_recordings.session_recording_v2_service import RecordingBlock
+from posthog.temporal.delete_recordings.activities import (
+    _parse_block_listing_response,
+    _parse_session_recording_list_response,
+    delete_recording_blocks,
+    load_recording_blocks,
+    load_recordings_with_person,
+    load_recordings_with_query,
+)
+from posthog.temporal.delete_recordings.types import (
+    DeleteRecordingError,
+    LoadRecordingError,
+    Recording,
+    RecordingBlockGroup,
+    RecordingsWithPersonInput,
+    RecordingsWithQueryInput,
+)
+
+
+@pytest.mark.asyncio
+async def test_load_recordings_with_query_single_page():
+    TEST_QUERY = 'events=[{"id":"$pageview","type":"events"}]&date_from=-7d'
+    TEST_TEAM_ID = 12345
+    EXPECTED_SESSION_IDS = [
+        "session-1",
+        "session-2",
+        "session-3",
+    ]
+
+    mock_team = MagicMock()
+    mock_team.id = TEST_TEAM_ID
+    mock_team.organization = MagicMock()
+    mock_team.organization.available_product_features = []
+
+    mock_query_results = MagicMock()
+    mock_query_results.results = [{"session_id": sid} for sid in EXPECTED_SESSION_IDS]
+    mock_query_results.has_more_recording = False
+    mock_query_results.next_cursor = None
+
+    with (
+        patch("posthog.temporal.delete_recordings.activities.Team.objects") as mock_team_objects,
+        patch("posthog.temporal.delete_recordings.activities.database_sync_to_async") as mock_sync_to_async,
+        patch("posthog.temporal.delete_recordings.activities.SessionRecordingListFromQuery") as mock_query_class,
+    ):
+        mock_team_objects.select_related.return_value.only.return_value.aget = AsyncMock(return_value=mock_team)
+
+        mock_query_instance = MagicMock()
+        mock_query_instance.run = MagicMock(return_value=mock_query_results)
+        mock_query_class.return_value = mock_query_instance
+
+        mock_sync_to_async.return_value = AsyncMock(return_value=mock_query_results)
+
+        result = await load_recordings_with_query(RecordingsWithQueryInput(query=TEST_QUERY, team_id=TEST_TEAM_ID))
+
+        assert result == EXPECTED_SESSION_IDS
+        assert mock_sync_to_async.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_load_recordings_with_query_multiple_pages():
+    TEST_QUERY = 'events=[{"id":"$pageview","type":"events"}]&date_from=-30d'
+    TEST_TEAM_ID = 67890
+    PAGE_1_SESSION_IDS = ["session-1", "session-2"]
+    PAGE_2_SESSION_IDS = ["session-3", "session-4"]
+    PAGE_3_SESSION_IDS = ["session-5"]
+    ALL_SESSION_IDS = PAGE_1_SESSION_IDS + PAGE_2_SESSION_IDS + PAGE_3_SESSION_IDS
+
+    mock_team = MagicMock()
+    mock_team.id = TEST_TEAM_ID
+    mock_team.organization = MagicMock()
+    mock_team.organization.available_product_features = []
+
+    mock_results_page_1 = MagicMock()
+    mock_results_page_1.results = [{"session_id": sid} for sid in PAGE_1_SESSION_IDS]
+    mock_results_page_1.has_more_recording = True
+    mock_results_page_1.next_cursor = "cursor-1"
+
+    mock_results_page_2 = MagicMock()
+    mock_results_page_2.results = [{"session_id": sid} for sid in PAGE_2_SESSION_IDS]
+    mock_results_page_2.has_more_recording = True
+    mock_results_page_2.next_cursor = "cursor-2"
+
+    mock_results_page_3 = MagicMock()
+    mock_results_page_3.results = [{"session_id": sid} for sid in PAGE_3_SESSION_IDS]
+    mock_results_page_3.has_more_recording = False
+    mock_results_page_3.next_cursor = None
+
+    with (
+        patch("posthog.temporal.delete_recordings.activities.Team.objects") as mock_team_objects,
+        patch("posthog.temporal.delete_recordings.activities.database_sync_to_async") as mock_sync_to_async,
+        patch("posthog.temporal.delete_recordings.activities.SessionRecordingListFromQuery") as mock_query_class,
+    ):
+        mock_team_objects.select_related.return_value.only.return_value.aget = AsyncMock(return_value=mock_team)
+
+        mock_query_instance = MagicMock()
+        mock_query_class.return_value = mock_query_instance
+
+        async def mock_run_side_effect():
+            if mock_sync_to_async.call_count == 1:
+                return mock_results_page_1
+            elif mock_sync_to_async.call_count == 2:
+                return mock_results_page_2
+            else:
+                return mock_results_page_3
+
+        mock_sync_to_async.return_value = mock_run_side_effect
+
+        result = await load_recordings_with_query(RecordingsWithQueryInput(query=TEST_QUERY, team_id=TEST_TEAM_ID))
+
+        assert result == ALL_SESSION_IDS
+        assert mock_sync_to_async.call_count == 3
+
+
+def test_parse_session_recording_list_response_valid():
+    raw_response = b'{"data":[{"session_id":"session-1"},{"session_id":"session-2"},{"session_id":"session-3"}]}'
+    result = _parse_session_recording_list_response(raw_response)
+    assert result == ["session-1", "session-2", "session-3"]
+
+
+def test_parse_session_recording_list_response_empty_data():
+    raw_response = b'{"data":[]}'
+    result = _parse_session_recording_list_response(raw_response)
+    assert result == []
+
+
+def test_parse_session_recording_list_response_empty_bytes():
+    with pytest.raises(LoadRecordingError, match="Got empty response from ClickHouse."):
+        _parse_session_recording_list_response(b"")
+
+
+def test_parse_session_recording_list_response_invalid_json():
+    with pytest.raises(LoadRecordingError, match="Unable to parse JSON response from ClickHouse."):
+        _parse_session_recording_list_response(b"not valid json")
+
+
+def test_parse_session_recording_list_response_malformed_json():
+    with pytest.raises(LoadRecordingError, match="Got malformed JSON response from ClickHouse."):
+        _parse_session_recording_list_response(b'{"wrong_key":[]}')
+
+
+def test_parse_session_recording_list_response_missing_session_id():
+    with pytest.raises(LoadRecordingError, match="Got malformed JSON response from ClickHouse."):
+        _parse_session_recording_list_response(b'{"data":[{"wrong_key":"value"}]}')
+
+
+@pytest.mark.asyncio
+async def test_load_recordings_with_person():
+    TEST_DISTINCT_IDS = ["user-1", "user-2", "user-3"]
+    TEST_TEAM_ID = 99999
+    EXPECTED_SESSION_IDS = ["session-a", "session-b", "session-c", "session-d"]
+
+    mock_response = {"data": [{"session_id": sid} for sid in EXPECTED_SESSION_IDS]}
+    raw_response = json.dumps(mock_response).encode()
+
+    mock_client = MagicMock()
+    mock_ch_response = MagicMock()
+    mock_ch_response.content.read = AsyncMock(return_value=raw_response)
+    mock_client.aget_query = MagicMock()
+    mock_client.aget_query.return_value.__aenter__ = AsyncMock(return_value=mock_ch_response)
+    mock_client.aget_query.return_value.__aexit__ = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("posthog.temporal.delete_recordings.activities.get_client") as mock_get_client:
+        mock_get_client.return_value = mock_client
+
+        result = await load_recordings_with_person(
+            RecordingsWithPersonInput(distinct_ids=TEST_DISTINCT_IDS, team_id=TEST_TEAM_ID)
+        )
+
+        assert result == EXPECTED_SESSION_IDS
+
+
+@pytest.mark.asyncio
+async def test_load_recording_blocks():
+    import json
+
+    TEST_SESSION_ID = "test-session-123"
+    TEST_TEAM_ID = 54321
+
+    mock_block_listing_response = {
+        "data": [
+            {
+                "start_time": "2025-11-17T10:00:00Z",
+                "block_first_timestamps": [1700217600000, 1700218600000],
+                "block_last_timestamps": [1700218500000, 1700219500000],
+                "block_urls": [
+                    "s3://bucket/path1?range=bytes=0-1000",
+                    "s3://bucket/path2?range=bytes=0-2000",
+                ],
+            }
+        ]
+    }
+    raw_response = json.dumps(mock_block_listing_response).encode()
+
+    mock_client = MagicMock()
+    mock_ch_response = MagicMock()
+    mock_ch_response.content.read = AsyncMock(return_value=raw_response)
+    mock_client.aget_query = MagicMock()
+    mock_client.aget_query.return_value.__aenter__ = AsyncMock(return_value=mock_ch_response)
+    mock_client.aget_query.return_value.__aexit__ = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    mock_counter = MagicMock()
+    mock_counter.add = MagicMock()
+
+    with (
+        patch("posthog.temporal.delete_recordings.activities.get_client") as mock_get_client,
+        patch("posthog.temporal.delete_recordings.activities.build_block_list") as mock_build_block_list,
+        patch("posthog.temporal.delete_recordings.activities.get_block_loaded_counter") as mock_get_counter,
+    ):
+        mock_get_client.return_value = mock_client
+        mock_get_counter.return_value = mock_counter
+
+        expected_blocks = [
+            RecordingBlock(
+                start_time=datetime(2025, 11, 17, 10, 0, 0),
+                end_time=datetime(2025, 11, 17, 10, 15, 0),
+                url="s3://bucket/path1?range=bytes=0-1000",
+            ),
+            RecordingBlock(
+                start_time=datetime(2025, 11, 17, 10, 16, 0),
+                end_time=datetime(2025, 11, 17, 10, 31, 0),
+                url="s3://bucket/path2?range=bytes=0-2000",
+            ),
+        ]
+        mock_build_block_list.return_value = expected_blocks
+
+        result = await load_recording_blocks(Recording(session_id=TEST_SESSION_ID, team_id=TEST_TEAM_ID))
+
+        assert result == expected_blocks
+        assert len(result) == 2
+        mock_counter.add.assert_called_once_with(2)
+
+
+@pytest.mark.asyncio
+async def test_delete_recording_blocks():
+    import os
+    from tempfile import mkstemp
+
+    TEST_SESSION_ID = "session-to-delete"
+    TEST_TEAM_ID = 77777
+    TEST_PATH = "session_recordings/90d/test-file"
+    TEST_RANGES = [(100, 199), (500, 599)]
+
+    # Create a temporary file to simulate the downloaded object storage file
+    _, tmpfile = mkstemp()
+    try:
+        # Write some test data to the file
+        test_data = b"\x01" * 100 + b"\x02" * 100 + b"\x03" * 300 + b"\x04" * 100 + b"\x05" * 400
+        with open(tmpfile, "wb") as f:
+            f.write(test_data)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock()
+        mock_storage.upload_file = AsyncMock()
+        mock_storage.__aenter__ = AsyncMock(return_value=mock_storage)
+        mock_storage.__aexit__ = AsyncMock(return_value=None)
+
+        mock_deleted_counter = MagicMock()
+        mock_error_counter = MagicMock()
+
+        with (
+            patch(
+                "posthog.temporal.delete_recordings.activities.session_recording_v2_object_storage.async_client"
+            ) as mock_client,
+            patch("posthog.temporal.delete_recordings.activities.mkstemp") as mock_mkstemp,
+            patch("posthog.temporal.delete_recordings.activities.os.remove") as mock_remove,
+            patch("posthog.temporal.delete_recordings.activities.get_block_deleted_counter") as mock_get_deleted,
+            patch("posthog.temporal.delete_recordings.activities.get_block_deleted_error_counter") as mock_get_error,
+        ):
+            mock_client.return_value = mock_storage
+            mock_mkstemp.return_value = (0, tmpfile)
+            mock_get_deleted.return_value = mock_deleted_counter
+            mock_get_error.return_value = mock_error_counter
+
+            input = RecordingBlockGroup(
+                recording=Recording(session_id=TEST_SESSION_ID, team_id=TEST_TEAM_ID),
+                path=TEST_PATH,
+                ranges=TEST_RANGES,
+            )
+
+            await delete_recording_blocks(input)
+
+            # Verify download was called
+            mock_storage.download_file.assert_called_once_with(TEST_PATH, tmpfile)
+
+            # Verify upload was called
+            mock_storage.upload_file.assert_called_once_with(TEST_PATH, tmpfile)
+
+            # Verify file was cleaned up
+            mock_remove.assert_called_once_with(tmpfile)
+
+            # Verify metrics were updated
+            mock_deleted_counter.add.assert_called_once_with(2)
+            mock_error_counter.add.assert_called_once_with(0)
+
+            # Verify the blocks were overwritten with zeros in the temp file
+            with open(tmpfile, "rb") as f:
+                content = f.read()
+                # Bytes 100-199 should be zeros
+                assert content[100:200] == b"\x00" * 100
+                # Bytes 500-599 should be zeros
+                assert content[500:600] == b"\x00" * 100
+                # Other bytes should be unchanged
+                assert content[0:100] == b"\x01" * 100
+                assert content[200:500] == b"\x03" * 300
+                assert content[600:1000] == b"\x05" * 400
+    finally:
+        if os.path.exists(tmpfile):
+            os.remove(tmpfile)
+
+
+@pytest.mark.asyncio
+async def test_delete_recording_blocks_download_error():
+    from posthog.storage import session_recording_v2_object_storage
+
+    TEST_SESSION_ID = "session-error"
+    TEST_TEAM_ID = 88888
+    TEST_PATH = "session_recordings/error/test-file"
+    TEST_RANGES = [(0, 99)]
+
+    mock_storage = MagicMock()
+    mock_storage.download_file = AsyncMock(side_effect=session_recording_v2_object_storage.FileDownloadError("Failed"))
+    mock_storage.__aenter__ = AsyncMock(return_value=mock_storage)
+    mock_storage.__aexit__ = AsyncMock(return_value=None)
+
+    mock_deleted_counter = MagicMock()
+    mock_error_counter = MagicMock()
+
+    with (
+        patch(
+            "posthog.temporal.delete_recordings.activities.session_recording_v2_object_storage.async_client"
+        ) as mock_client,
+        patch("posthog.temporal.delete_recordings.activities.mkstemp") as mock_mkstemp,
+        patch("posthog.temporal.delete_recordings.activities.os.remove") as mock_remove,
+        patch("posthog.temporal.delete_recordings.activities.get_block_deleted_counter") as mock_get_deleted,
+        patch("posthog.temporal.delete_recordings.activities.get_block_deleted_error_counter") as mock_get_error,
+    ):
+        mock_client.return_value = mock_storage
+        tmpfile = "/tmp/test-temp-file"
+        mock_mkstemp.return_value = (0, tmpfile)
+        mock_get_deleted.return_value = mock_deleted_counter
+        mock_get_error.return_value = mock_error_counter
+
+        input = RecordingBlockGroup(
+            recording=Recording(session_id=TEST_SESSION_ID, team_id=TEST_TEAM_ID),
+            path=TEST_PATH,
+            ranges=TEST_RANGES,
+        )
+
+        # Should not raise an exception, just log a warning
+        await delete_recording_blocks(input)
+
+        # Verify download was attempted
+        mock_storage.download_file.assert_called_once()
+
+        # Verify upload was NOT called due to download failure
+        mock_storage.upload_file.assert_not_called()
+
+        # Verify cleanup happened
+        mock_remove.assert_called_once_with(tmpfile)
+
+        # Verify metrics were updated (0 deleted, 0 errors since we skipped the file)
+        mock_deleted_counter.add.assert_called_once_with(0)
+        mock_error_counter.add.assert_called_once_with(0)
+
+
+def test_parse_block_listing_response_valid():
+    raw_response = b"""{
+        "data": [{
+            "start_time": "2025-11-17T10:00:00Z",
+            "block_first_timestamps": [1700217600000, 1700218600000],
+            "block_last_timestamps": [1700218500000, 1700219500000],
+            "block_urls": ["url1", "url2"]
+        }]
+    }"""
+
+    result = _parse_block_listing_response(raw_response)
+
+    assert len(result) == 1
+    assert result[0][0] == "2025-11-17T10:00:00Z"
+    assert result[0][1] == [1700217600000, 1700218600000]
+    assert result[0][2] == [1700218500000, 1700219500000]
+    assert result[0][3] == ["url1", "url2"]
+
+
+def test_parse_block_listing_response_empty_bytes():
+    with pytest.raises(DeleteRecordingError, match="Got empty response from ClickHouse."):
+        _parse_block_listing_response(b"")
+
+
+def test_parse_block_listing_response_invalid_json():
+    with pytest.raises(DeleteRecordingError, match="Unable to parse JSON response from ClickHouse."):
+        _parse_block_listing_response(b"not valid json")
+
+
+def test_parse_block_listing_response_malformed_json():
+    with pytest.raises(DeleteRecordingError, match="Got malformed JSON response from ClickHouse."):
+        _parse_block_listing_response(b'{"wrong_key":[]}')
+
+
+def test_parse_block_listing_response_no_rows():
+    with pytest.raises(DeleteRecordingError, match="No rows in response from ClickHouse."):
+        _parse_block_listing_response(b'{"data":[]}')

--- a/posthog/temporal/tests/delete_recordings/test_types.py
+++ b/posthog/temporal/tests/delete_recordings/test_types.py
@@ -1,0 +1,69 @@
+from posthog.temporal.delete_recordings.types import Recording, RecordingsWithPersonInput, RecordingsWithQueryInput
+
+
+def test_recording_creation():
+    recording = Recording(session_id="test-session-id", team_id=12345)
+    assert recording.session_id == "test-session-id"
+    assert recording.team_id == 12345
+
+
+def test_recordings_with_person_input_creation():
+    input = RecordingsWithPersonInput(distinct_ids=["user-1", "user-2"], team_id=67890, batch_size=50)
+    assert input.distinct_ids == ["user-1", "user-2"]
+    assert input.team_id == 67890
+    assert input.batch_size == 50
+
+
+def test_recordings_with_person_input_default_batch_size():
+    input = RecordingsWithPersonInput(distinct_ids=["user-1"], team_id=111)
+    assert input.distinct_ids == ["user-1"]
+    assert input.team_id == 111
+    assert input.batch_size == 100
+
+
+def test_recordings_with_query_input_creation():
+    query_string = 'events=[{"id":"$pageview","type":"events"}]&date_from=-7d'
+    input = RecordingsWithQueryInput(query=query_string, team_id=22222, dry_run=True, batch_size=25)
+    assert input.query == query_string
+    assert input.team_id == 22222
+    assert input.dry_run is True
+    assert input.batch_size == 25
+
+
+def test_recordings_with_query_input_defaults():
+    query_string = 'events=[{"id":"$pageview","type":"events"}]'
+    input = RecordingsWithQueryInput(query=query_string, team_id=33333)
+    assert input.query == query_string
+    assert input.team_id == 33333
+    assert input.dry_run is False
+    assert input.batch_size == 100
+
+
+def test_recordings_with_query_input_dry_run_false():
+    input = RecordingsWithQueryInput(query="test_query", team_id=44444, dry_run=False)
+    assert input.dry_run is False
+
+
+def test_recordings_with_query_input_dry_run_true():
+    input = RecordingsWithQueryInput(query="test_query", team_id=55555, dry_run=True)
+    assert input.dry_run is True
+
+
+def test_recording_immutability():
+    """Test that Recording is frozen (immutable)."""
+    recording = Recording(session_id="test-id", team_id=123)
+    try:
+        recording.session_id = "new-id"  # type: ignore[misc]
+        raise AssertionError()
+    except AttributeError:
+        pass
+
+
+def test_recordings_with_query_input_immutability():
+    """Test that RecordingsWithQueryInput is frozen (immutable)."""
+    input = RecordingsWithQueryInput(query="test", team_id=123)
+    try:
+        input.dry_run = True  # type: ignore[misc]
+        raise AssertionError()
+    except AttributeError:
+        pass

--- a/posthog/temporal/tests/delete_recordings/test_workflows.py
+++ b/posthog/temporal/tests/delete_recordings/test_workflows.py
@@ -11,8 +11,17 @@ from temporalio.worker import Worker
 
 from posthog.session_recordings.session_recording_v2_service import RecordingBlock
 from posthog.temporal.delete_recordings.activities import group_recording_blocks
-from posthog.temporal.delete_recordings.types import Recording, RecordingBlockGroup, RecordingsWithPersonInput
-from posthog.temporal.delete_recordings.workflows import DeleteRecordingsWithPersonWorkflow, DeleteRecordingWorkflow
+from posthog.temporal.delete_recordings.types import (
+    Recording,
+    RecordingBlockGroup,
+    RecordingsWithPersonInput,
+    RecordingsWithQueryInput,
+)
+from posthog.temporal.delete_recordings.workflows import (
+    DeleteRecordingsWithPersonWorkflow,
+    DeleteRecordingsWithQueryWorkflow,
+    DeleteRecordingWorkflow,
+)
 
 
 @pytest.mark.asyncio
@@ -208,3 +217,193 @@ async def test_delete_recording_with_person_workflow():
         "791244f2-2569-4ed9-a448-d5a6e35471cd": [],
         "3d2b505b-3a0e-48fd-89ab-6eb65a08e915": [],
     }
+
+
+@pytest.mark.asyncio
+async def test_delete_recordings_with_query_workflow():
+    TEST_QUERY = 'events=[{"id":"$pageview","type":"events"}]&date_from=-7d'
+    TEST_TEAM_ID: int = 78901
+    TEST_SESSIONS = {
+        "4a1b2c3d-5e6f-7g8h-9i0j-1k2l3m4n5o6p": [
+            RecordingBlock(
+                start_time=datetime.now(),
+                end_time=datetime.now() + timedelta(hours=1),
+                url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6?range=bytes=12269307-12294780",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() + timedelta(hours=2),
+                end_time=datetime.now() + timedelta(hours=3),
+                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=81788204-81793010",
+            ),
+        ],
+        "5b2c3d4e-6f7g-8h9i-0j1k-2l3m4n5o6p7q": [
+            RecordingBlock(
+                start_time=datetime.now(),
+                end_time=datetime.now() + timedelta(hours=5),
+                url="s3://test_bucket/session_recordings/5y/1756117699905-b688321ffa0fa994?range=bytes=12269307-12294780",
+            ),
+        ],
+        "6c3d4e5f-7g8h-9i0j-1k2l-3m4n5o6p7q8r": [
+            RecordingBlock(
+                start_time=datetime.now(),
+                end_time=datetime.now() + timedelta(hours=10),
+                url="s3://test_bucket/session_recordings/30d/1756117708699-28b991ee5019274d?range=bytes=81788204-81793010",
+            ),
+            RecordingBlock(
+                start_time=datetime.now() + timedelta(hours=11),
+                end_time=datetime.now() + timedelta(hours=12),
+                url="s3://test_bucket/session_recordings/30d/1756117711878-61ed9e32ebf3e27a?range=bytes=2790658-2800843",
+            ),
+        ],
+    }
+
+    EXPECTED_GROUPED_RANGES = {
+        "4a1b2c3d-5e6f-7g8h-9i0j-1k2l3m4n5o6p": [
+            [(12269307, 12294780)],
+            [(81788204, 81793010)],
+        ],
+        "5b2c3d4e-6f7g-8h9i-0j1k-2l3m4n5o6p7q": [
+            [(12269307, 12294780)],
+        ],
+        "6c3d4e5f-7g8h-9i0j-1k2l-3m4n5o6p7q8r": [
+            [(81788204, 81793010)],
+            [(2790658, 2800843)],
+        ],
+    }
+
+    EXPECTED_PATHS = [
+        "session_recordings/1y/1756117652764-84b1bccb847e7ea6",
+        "session_recordings/90d/1756117747546-97a0b1e81d492d3a",
+        "session_recordings/5y/1756117699905-b688321ffa0fa994",
+        "session_recordings/30d/1756117708699-28b991ee5019274d",
+        "session_recordings/30d/1756117711878-61ed9e32ebf3e27a",
+    ]
+
+    @activity.defn(name="load-recordings-with-query")
+    async def load_recordings_with_query_mocked(input: RecordingsWithQueryInput) -> list[str]:
+        assert input.query == TEST_QUERY
+        assert input.team_id == TEST_TEAM_ID
+        assert input.dry_run is False
+        return list(TEST_SESSIONS.keys())
+
+    @activity.defn(name="load-recording-blocks")
+    async def load_recording_blocks_mocked(input: Recording) -> list[RecordingBlock]:
+        assert input.session_id in TEST_SESSIONS
+        assert input.team_id == TEST_TEAM_ID
+        return TEST_SESSIONS[input.session_id]
+
+    @activity.defn(name="delete-recording-blocks")
+    async def delete_recording_blocks_mocked(input: RecordingBlockGroup) -> None:
+        assert input.recording.session_id in TEST_SESSIONS
+        assert input.recording.team_id == TEST_TEAM_ID
+        assert input.ranges in EXPECTED_GROUPED_RANGES[input.recording.session_id]
+        assert input.path in EXPECTED_PATHS
+        TEST_SESSIONS[input.recording.session_id] = []  # Delete recording blocks
+
+    task_queue_name = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue_name,
+            workflows=[DeleteRecordingsWithQueryWorkflow, DeleteRecordingWorkflow],
+            activities=[
+                load_recording_blocks_mocked,
+                delete_recording_blocks_mocked,
+                load_recordings_with_query_mocked,
+                group_recording_blocks,
+            ],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            parent_id = str(uuid.uuid4())
+
+            await env.client.execute_workflow(
+                DeleteRecordingsWithQueryWorkflow.run,
+                RecordingsWithQueryInput(query=TEST_QUERY, team_id=TEST_TEAM_ID, dry_run=False),
+                id=parent_id,
+                task_queue=task_queue_name,
+            )
+
+            # Wait a short while to let child workflows complete
+            await asyncio.sleep(3)
+
+    # Check that all recording blocks were deleted
+    assert TEST_SESSIONS == {
+        "4a1b2c3d-5e6f-7g8h-9i0j-1k2l3m4n5o6p": [],
+        "5b2c3d4e-6f7g-8h9i-0j1k-2l3m4n5o6p7q": [],
+        "6c3d4e5f-7g8h-9i0j-1k2l-3m4n5o6p7q8r": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_recordings_with_query_workflow_dry_run():
+    TEST_QUERY = 'events=[{"id":"$pageview","type":"events"}]&date_from=-30d'
+    TEST_TEAM_ID: int = 11111
+    TEST_SESSIONS = {
+        "7d4e5f6g-8h9i-0j1k-2l3m-4n5o6p7q8r9s": [
+            RecordingBlock(
+                start_time=datetime.now(),
+                end_time=datetime.now() + timedelta(hours=1),
+                url="s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6?range=bytes=12269307-12294780",
+            ),
+        ],
+        "8e5f6g7h-9i0j-1k2l-3m4n-5o6p7q8r9s0t": [
+            RecordingBlock(
+                start_time=datetime.now(),
+                end_time=datetime.now() + timedelta(hours=2),
+                url="s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=81788204-81793010",
+            ),
+        ],
+    }
+
+    @activity.defn(name="load-recordings-with-query")
+    async def load_recordings_with_query_mocked(input: RecordingsWithQueryInput) -> list[str]:
+        assert input.query == TEST_QUERY
+        assert input.team_id == TEST_TEAM_ID
+        assert input.dry_run is True
+        return list(TEST_SESSIONS.keys())
+
+    @activity.defn(name="load-recording-blocks")
+    async def load_recording_blocks_mocked(input: Recording) -> list[RecordingBlock]:
+        raise AssertionError("Should not be called in dry run mode")
+
+    @activity.defn(name="delete-recording-blocks")
+    async def delete_recording_blocks_mocked(input: RecordingBlockGroup) -> None:
+        raise AssertionError("Should not be called in dry run mode")
+
+    task_queue_name = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue_name,
+            workflows=[DeleteRecordingsWithQueryWorkflow, DeleteRecordingWorkflow],
+            activities=[
+                load_recording_blocks_mocked,
+                delete_recording_blocks_mocked,
+                load_recordings_with_query_mocked,
+                group_recording_blocks,
+            ],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            parent_id = str(uuid.uuid4())
+
+            await env.client.execute_workflow(
+                DeleteRecordingsWithQueryWorkflow.run,
+                RecordingsWithQueryInput(query=TEST_QUERY, team_id=TEST_TEAM_ID, dry_run=True),
+                id=parent_id,
+                task_queue=task_queue_name,
+            )
+
+            # Wait a short while to ensure no child workflows were started
+            await asyncio.sleep(1)
+
+    # Check that no recording blocks were deleted in dry run mode
+    assert len(TEST_SESSIONS["7d4e5f6g-8h9i-0j1k-2l3m-4n5o6p7q8r9s"]) == 1
+    assert len(TEST_SESSIONS["8e5f6g7h-9i0j-1k2l-3m4n-5o6p7q8r9s0t"]) == 1
+    assert (
+        TEST_SESSIONS["7d4e5f6g-8h9i-0j1k-2l3m-4n5o6p7q8r9s"][0].url
+        == "s3://test_bucket/session_recordings/1y/1756117652764-84b1bccb847e7ea6?range=bytes=12269307-12294780"
+    )
+    assert (
+        TEST_SESSIONS["8e5f6g7h-9i0j-1k2l-3m4n-5o6p7q8r9s0t"][0].url
+        == "s3://test_bucket/session_recordings/90d/1756117747546-97a0b1e81d492d3a?range=bytes=81788204-81793010"
+    )


### PR DESCRIPTION
This PR adds a new Temporal workflow for hard-deleting recordings based on arbitrary recording-queries from the Session Replay frontend.