### PR TITLE
fix: add missing deps

### DIFF
--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -91,7 +91,7 @@ export function Login(): JSX.Element {
             passwordInputRef.current?.focus()
         } else {
             // clear form when password field becomes hidden
-            resetLogin()
+            resetLogin() // oxlint-disable-line react-hooks/exhaustive-deps
         }
     }, [isPasswordHidden])
 

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -91,9 +91,9 @@ export function Login(): JSX.Element {
             passwordInputRef.current?.focus()
         } else {
             // clear form when password field becomes hidden
-            resetLogin() // oxlint-disable-line react-hooks/exhaustive-deps
+            resetLogin()
         }
-    }, [isPasswordHidden])
+    }, [isPasswordHidden, resetLogin])
 
     return (
         <BridgePage

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -61,7 +61,7 @@ export function TextViewDisplay({
             if (popoutSegment !== null) {
                 const target = event.target as HTMLElement
                 if (!target.closest('[data-popout-content]') && !target.closest('[data-popout-button]')) {
-                    setPopoutSegment(null)
+                    setPopoutSegment(null) // oxlint-disable-line react-hooks/exhaustive-deps
                 }
             }
         }

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -61,7 +61,7 @@ export function TextViewDisplay({
             if (popoutSegment !== null) {
                 const target = event.target as HTMLElement
                 if (!target.closest('[data-popout-content]') && !target.closest('[data-popout-button]')) {
-                    setPopoutSegment(null) // oxlint-disable-line react-hooks/exhaustive-deps
+                    setPopoutSegment(null)
                 }
             }
         }
@@ -72,7 +72,7 @@ export function TextViewDisplay({
                 document.removeEventListener('mousedown', handleClickOutside)
             }
         }
-    }, [popoutSegment])
+    }, [popoutSegment, setPopoutSegment])
 
     const segments = useMemo(() => parseTextSegments(textRepr || ''), [textRepr])
     const lineNumberPadding = useMemo(() => calculateLineNumberPadding(textRepr || ''), [textRepr])


### PR DESCRIPTION
## Problem
running `pnpm format` on a fresh pull adds useEffect deps in unrelated files - this is a little annoying :P

## Changes
~adding `// oxlint-disable-line react-hooks/exhaustive-deps` to two `useEffect` hooks to prevent the formatter from automatically adding them every time~

just adding the missing deps

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
