### PR TITLE
feat(dagster): make persons new table duplicator job generic for future reuse

### DIFF
--- a/dags/duplicate_pg_table.py
+++ b/dags/duplicate_pg_table.py
@@ -197,8 +197,7 @@ WHERE s.id >= %s AND s.id <= %s
   AND NOT EXISTS (
     SELECT 1
     FROM {destination_table} d
-    WHERE d.team_id = s.team_id
-      AND d.id = s.id
+    WHERE d.id = s.id
   )
 ORDER BY s.id DESC
 """

--- a/dags/duplicate_pg_table.py
+++ b/dags/duplicate_pg_table.py
@@ -18,7 +18,7 @@ from posthog.clickhouse.custom_metrics import MetricsClient
 
 from dags.common import JobOwners
 
-MIGRATION_PREFIX = "duplicate_pg_table"
+METRICS_PREFIX = "duplicate_pg_table"
 
 
 class DuplicatePgTableConfig(dagster.Config):
@@ -210,7 +210,7 @@ ORDER BY s.id DESC
 
                     try:
                         metrics_client.increment(
-                            "{METRICS_PREFIX}_records_attempted_total",
+                            f"{METRICS_PREFIX}_records_attempted_total",
                             labels={"job_name": job_name, "chunk_id": chunk_id},
                             value=float(records_attempted),
                         ).result()
@@ -221,7 +221,7 @@ ORDER BY s.id DESC
 
                     try:
                         metrics_client.increment(
-                            "{METRICS_PREFIX}_records_inserted_total",
+                            f"{METRICS_PREFIX}_records_inserted_total",
                             labels={"job_name": job_name, "chunk_id": chunk_id},
                             value=float(records_inserted),
                         ).result()
@@ -230,7 +230,7 @@ ORDER BY s.id DESC
 
                     try:
                         metrics_client.increment(
-                            "{METRICS_PREFIX}_batches_copied_total",
+                            f"{METRICS_PREFIX}_batches_copied_total",
                             labels={"job_name": job_name, "chunk_id": chunk_id},
                             value=1.0,
                         ).result()
@@ -239,7 +239,7 @@ ORDER BY s.id DESC
                     # Track batch duration metric (IV)
                     try:
                         metrics_client.increment(
-                            "{METRICS_PREFIX}_batch_duration_seconds_total",
+                            f"{METRICS_PREFIX}_batch_duration_seconds_total",
                             labels={"job_name": job_name, "chunk_id": chunk_id},
                             value=batch_duration_seconds,
                         ).result()
@@ -294,7 +294,7 @@ ORDER BY s.id DESC
                     # Report fatal error metric before raising
                     try:
                         metrics_client.increment(
-                            "{METRICS_PREFIX}_error",
+                            f"{METRICS_PREFIX}_error",
                             labels={"job_name": job_name, "chunk_id": chunk_id, "reason": "batch_copy_failed"},
                             value=1.0,
                         ).result()
@@ -324,7 +324,7 @@ ORDER BY s.id DESC
         # Report fatal error metric before raising
         try:
             metrics_client.increment(
-                "{METRICS_PREFIX}_error",
+                f"{METRICS_PREFIX}_error",
                 labels={"job_name": job_name, "chunk_id": chunk_id, "reason": "unexpected_copy_error"},
                 value=1.0,
             ).result()
@@ -349,7 +349,7 @@ ORDER BY s.id DESC
     run_id = context.run.run_id
     try:
         metrics_client.increment(
-            "{METRICS_PREFIX}_chunks_completed_total",
+            f"{METRICS_PREFIX}_chunks_completed_total",
             labels={"job_name": job_name, "run_id": run_id, "chunk_id": chunk_id},
             value=1.0,
         ).result()

--- a/dags/duplicate_pg_table.py
+++ b/dags/duplicate_pg_table.py
@@ -3,7 +3,7 @@
     2. The schema includes an integer ID PK we can use to divide the ID space to parallelize data migration
 
 WARNING: the original inner subselect (NOT EXISTS clause) in the insertion SQL for persons duplication job employed
-         multiple WHERE filter to take advantage of (team_id, id) index. Depending on the table you're duplicating,
+         multiple WHERE filter to take advantage of (id, team_id) index. Depending on the table you're duplicating,
          you may require similar customization for efficiency. See comments on the SQL in copy_chunk for details.
 
 Note: duplicate keys are not rewritten (we assume *new* row writes/creates are handled elsewhere and that process is already active.)"""
@@ -193,8 +193,10 @@ def copy_chunk(
                     cursor.execute("BEGIN")
 
                     # Execute INSERT INTO ... SELECT with NOT EXISTS check
+                    #
                     # IMPORTANT: original NOT EXISTS subselect included additional
-                    # WHERE filter clauses: ```WHERE d.team_id = s.team_id AND d.id = s.id```
+                    # WHERE filter clauses to use an index: ```WHERE d.id = s.id AND d.team_id = s.team_id```
+                    # depending on the table you're duplicating, you may want to do something similar
                     insert_query = f"""
 INSERT INTO {destination_table}
 SELECT s.*

--- a/dags/locations/ingestion.py
+++ b/dags/locations/ingestion.py
@@ -1,15 +1,15 @@
 import dagster
 
-from dags import persons_new_backfill
+from dags import duplicate_pg_table
 
 from . import resources
 
 defs = dagster.Definitions(
     assets=[
-        persons_new_backfill.postgres_env_check,
+        duplicate_pg_table.postgres_env_check,
     ],
     jobs=[
-        persons_new_backfill.persons_new_backfill_job,
+        duplicate_pg_table.duplicate_pg_table_job,
     ],
     resources=resources,
 )

--- a/dags/locations/ingestion.py
+++ b/dags/locations/ingestion.py
@@ -9,7 +9,7 @@ defs = dagster.Definitions(
         duplicate_pg_table.postgres_env_check,
     ],
     jobs=[
-        duplicate_pg_table.duplicate_pg_table_job,
+        duplicate_pg_table.duplicate_postgres_table_job,
     ],
     resources=resources,
 )

--- a/dags/tests/test_duplicate_pg_table.py
+++ b/dags/tests/test_duplicate_pg_table.py
@@ -434,7 +434,6 @@ class TestCopyChunk:
         assert "WHERE s.id >=" in insert_query
         assert "AND s.id <=" in insert_query
         assert "NOT EXISTS" in insert_query
-        assert "d.team_id = s.team_id" in insert_query
         assert "d.id = s.id" in insert_query
         assert "ORDER BY s.id DESC" in insert_query
 

--- a/dags/tests/test_duplicate_pg_table.py
+++ b/dags/tests/test_duplicate_pg_table.py
@@ -252,7 +252,7 @@ class TestCopyChunk:
         assert "INSERT INTO posthog_person_new" in insert_query
         assert "SELECT s.*" in insert_query
         assert "FROM posthog_person s" in insert_query
-        assert "WHERE s.id >" in insert_query
+        assert "WHERE s.id >=" in insert_query
         assert "AND s.id <=" in insert_query
         assert "NOT EXISTS" in insert_query
         assert "ORDER BY s.id DESC" in insert_query
@@ -431,7 +431,7 @@ class TestCopyChunk:
         assert "INSERT INTO test_dest" in insert_query
         assert "SELECT s.*" in insert_query
         assert "FROM test_source s" in insert_query
-        assert "WHERE s.id >" in insert_query
+        assert "WHERE s.id >=" in insert_query
         assert "AND s.id <=" in insert_query
         assert "NOT EXISTS" in insert_query
         assert "d.team_id = s.team_id" in insert_query

--- a/dags/tests/test_duplicate_pg_table.py
+++ b/dags/tests/test_duplicate_pg_table.py
@@ -1,4 +1,4 @@
-"""Tests for the persons new backfill job."""
+"""Tests for the duplicate Postgres table job."""
 
 from unittest.mock import MagicMock, patch
 
@@ -251,7 +251,7 @@ class TestCopyChunk:
         insert_query = insert_calls[0]
         assert "INSERT INTO posthog_person_new" in insert_query
         assert "SELECT s.*" in insert_query
-        assert "FROM posthog_persons s" in insert_query
+        assert "FROM posthog_person s" in insert_query
         assert "WHERE s.id >" in insert_query
         assert "AND s.id <=" in insert_query
         assert "NOT EXISTS" in insert_query
@@ -362,7 +362,7 @@ class TestCopyChunk:
     def test_copy_chunk_error_handling_and_rollback(self):
         """Test error handling and rollback on non-duplicate errors."""
         config = DuplicatePgTableConfig(
-            chunk_size=1000, batch_size=100, source_table="posthog_persons", destination_table="posthog_persons_new"
+            chunk_size=1000, batch_size=100, source_table="posthog_person", destination_table="posthog_person_new"
         )
         chunk = (1, 100)
 


### PR DESCRIPTION
## Problem
The `persons_new_backfill` Dagster job worked well for parallelizing the `posthog_person` -> `posthog_person_new` full table duplication while maintaining resilience and observability.

The job will work fine for any such table duplication in the future as long as both tables include a sortable PK ID field, and exist on the same database instance. We should make sure it's more obviously reusable in the future.

**Note: In case we have to rerun the current persons table duplication job as part of the remediation work with current defaults etc. DO NOT merge this until the remediations are complete!**

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Rename things, update test cases
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (all tests pass)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
