### PR TITLE
refactor: Standardize materialization even further

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1068,7 +1068,6 @@ products/data_warehouse/backend/data_load/create_table.py:0: error: Item "None" 
 products/data_warehouse/backend/data_load/create_table.py:0: error: Item "None" of "DataWarehouseSavedQuery | None" has no attribute "pk"  [union-attr]
 products/data_warehouse/backend/data_load/create_table.py:0: error: Item "None" of "DataWarehouseSavedQuery | None" has no attribute "pk"  [union-attr]
 products/data_warehouse/backend/data_load/create_table.py:0: error: Item "None" of "DataWarehouseSavedQuery | None" has no attribute "url_pattern"  [union-attr]
-products/data_warehouse/backend/data_load/saved_query_service.py:0: error: Incompatible type for lookup 'path__contains': (got "list[Any]", expected "str")  [misc]
 products/data_warehouse/backend/data_load/source_templates.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "ExternalDataSourceType")  [assignment]
 products/data_warehouse/backend/external_data_source/jobs.py:0: error: Incompatible type for lookup 'id': (got "UUID | None", expected "UUID | str")  [misc]
 products/data_warehouse/backend/max_tools.py:0: error: Argument "toolkit_class" to "__init__" of "TaxonomyAgentNode" has incompatible type "HogQLGeneratorToolkit"; expected "type[TaxonomyAgentToolkit]"  [arg-type]

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -42,7 +42,6 @@ from posthog.temporal.common.client import sync_connect
 
 from products.data_warehouse.backend.data_load.saved_query_service import (
     pause_saved_query_schedule,
-    recreate_model_paths,
     trigger_saved_query_schedule,
 )
 from products.data_warehouse.backend.models import (
@@ -332,10 +331,10 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
                 self.context["activity_log"] = latest_activity_log
 
             if sync_frequency and sync_frequency != "never":
-                recreate_model_paths(view)
+                view.setup_model_paths()
 
         if was_sync_frequency_updated:
-            view.enable_materialization(
+            view.schedule_materialization(
                 unpause=before_update is not None and before_update.sync_frequency_interval is None
             )
 

--- a/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
@@ -106,7 +106,7 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
                 saved_query.sync_frequency_interval = timedelta(hours=12)
 
                 saved_query.save()
-                saved_query.enable_materialization()
+                saved_query.schedule_materialization()
 
                 if created:
                     views_created += 1

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -129,7 +129,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
         else:
             DataWarehouseModelPath.objects.update_from_saved_query(self)
 
-    def enable_materialization(self, unpause: bool = False):
+    def schedule_materialization(self, unpause: bool = False):
         """
         It will schedule the saved query workflow to run at the configured frequency.
         If unpause is True, it will unpause the saved query workflow if it already exists.

--- a/products/data_warehouse/backend/models/modeling.py
+++ b/products/data_warehouse/backend/models/modeling.py
@@ -288,11 +288,11 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
 
             parent_paths = self.get_or_create_query_parent_paths(query, team=team)
 
-            # One path just for us, and then one including us on the parent paths for each parent
-            paths = [
-                [label],
-                *[[*model_path.path, label] for model_path in parent_paths],
-            ]
+            # If we don't have any parent paths then we can treat ourselves as a root node
+            # This can happen when creating a query that returns a static set of rows, like a SELECT 1.e
+            paths = [[*model_path.path, label] for model_path in parent_paths]
+            if not paths:
+                paths = [[label]]
 
             results: list[DataWarehouseModelPath] = []
             for path in paths:

--- a/products/data_warehouse/backend/models/modeling.py
+++ b/products/data_warehouse/backend/models/modeling.py
@@ -1,7 +1,6 @@
 import enum
 import uuid
 import dataclasses
-import collections.abc
 
 from django.contrib.postgres import indexes as pg_indexes
 from django.core.exceptions import ObjectDoesNotExist
@@ -478,18 +477,6 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
 
                 cursor.execute(DELETE_DUPLICATE_PATHS_QUERY, params={"team_id": team.pk})
                 cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
-
-    def get_longest_common_ancestor_path(
-        self, leaf_models: collections.abc.Iterable[DataWarehouseSavedQuery | DataWarehouseTable]
-    ) -> str | None:
-        """Return the longest common ancestor path among paths from all leaf models, if any."""
-        query = "select lca(array_agg(path)) from posthog_datawarehousemodelpath where path ? %(lqueries)s"
-
-        with connection.cursor() as cursor:
-            cursor.execute(query, params={"lqueries": [f"*.{leaf_model.id.hex}" for leaf_model in leaf_models]})
-            row = cursor.fetchone()
-
-        return row[0] or None
 
     def get_dag(self, team: Team):
         """Return a DAG of all the models for the given team.

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -227,37 +227,6 @@ class TestModelPath(BaseTest):
         self.assertEqual(len(grand_child_paths), 1)
         self.assertIn(["events", child_saved_query.id.hex, grand_child_saved_query.id.hex], grand_child_paths)
 
-    def test_get_longest_common_ancestor_path(self):
-        """Test resolving the longest common ancestor of two simple queries."""
-        query_1 = """\
-          select
-            events.event
-          from events
-          where events.event = 'login'
-        """
-        query_2 = """\
-          select
-            events.person_id as person_id
-          from events
-          where events.event = 'logout'
-        """
-
-        saved_query_1 = DataWarehouseSavedQuery.objects.create(
-            team=self.team,
-            name="my_model1",
-            query={"query": query_1},
-        )
-        saved_query_2 = DataWarehouseSavedQuery.objects.create(
-            team=self.team,
-            name="my_model2",
-            query={"query": query_2},
-        )
-        DataWarehouseModelPath.objects.create_from_saved_query(saved_query_1)
-        DataWarehouseModelPath.objects.create_from_saved_query(saved_query_2)
-
-        lca = DataWarehouseModelPath.objects.get_longest_common_ancestor_path([saved_query_1, saved_query_2])
-        self.assertEqual(lca, "events")
-
     def test_get_dag(self):
         """Test the generation of a DAG with a couple simple models."""
         parent_query = """\

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -61,6 +61,21 @@ def test_get_parents_from_model_query(query: str, parents: set[str]):
 
 
 class TestModelPath(BaseTest):
+    def test_create_from_static_query(self):
+        """Test creation of a model path from a query that returns a static set of rows."""
+        query = "SELECT 1 AS a, 2 AS b, NOW() AS c"
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="my_model",
+            query={"query": query},
+        )
+
+        model_paths = DataWarehouseModelPath.objects.create_from_saved_query(saved_query)
+
+        paths = [model_path.path for model_path in model_paths]
+        self.assertEqual(len(paths), 1)
+        self.assertIn([saved_query.id.hex], paths)
+
     def test_create_from_posthog_root_nodes_query(self):
         """Test creation of a model path from a query that reads from PostHog root tables."""
         query = """\


### PR DESCRIPTION
We'd created this `enable_materialization` method to centralize our logic but we didn't use it for endpoints, so let's use that now! I've also changed it to `schedule_materialization` since this is a more accurate name (you still need to configure materialization settings before calling it).

There's also a fix in `create_leaf_paths_from_query` to guarantee we follow the same logic we had in `recreate_model_paths` which was only called when updating a saved query (which was called when turning materialization on and, therefore, a step that was needed and we missed on the previous attempt to standardize this). This meant that revenue analytics and endpoints materialized queries would fail in case they were simple constant queries (i.e. no `FROM` field)
