### PR TITLE
fix: move system status button to 2nd from top during incidents

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -83,6 +83,9 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                     // Show Max if user is already enrolled into beta OR they got a link to Max (even if they haven't enrolled)
                     tabs.push(SidePanelTab.Max)
                 }
+                if (isCloudOrDev) {
+                    tabs.push(SidePanelTab.Status)
+                }
                 tabs.push(SidePanelTab.Notebooks)
                 tabs.push(SidePanelTab.Docs)
                 if (isCloudOrDev) {
@@ -108,10 +111,6 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
 
                 if (featureFlags[FEATURE_FLAGS.SDK_DOCTOR_BETA]) {
                     tabs.push(SidePanelTab.SdkDoctor)
-                }
-
-                if (isCloudOrDev) {
-                    tabs.push(SidePanelTab.Status)
                 }
 
                 if (!currentTeam) {


### PR DESCRIPTION
## Problem

`System status` button on righthand sidebar was out of sight "below the fold" on laptops, smaller browser windows, and mobile during incidents.

## Changes

Moves the `System status` button to the 2nd position (just below `PostHog AI`) when `status !== 'operational'`

## How did you test this code?
Temporarily hard-code status `major_outage` on my local.

<img width="642" height="2110" alt="CleanShot 2025-11-17 at 10 43 26@2x" src="https://github.com/user-attachments/assets/017f98b0-742b-4231-8f6d-7ff93da232da" />

Fixes #41481