### PR TITLE
Add code to llm.py

### DIFF
--- a/ee/hogai/llm.py
+++ b/ee/hogai/llm.py
@@ -113,14 +113,22 @@ class MaxChatMixin(BaseModel):
         self,
         kwargs: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Return a shallow copy of kwargs with PostHog properties, billable flag, and team_id injected into metadata."""
+        """Return a shallow copy of kwargs with PostHog properties, billable flag, team_id, and region injected into metadata."""
         new_kwargs = dict(kwargs or {})
         metadata = dict(new_kwargs.get("metadata") or {})
 
-        # Build posthog_properties with billable flag and team_id
+        # Determine region
+        region = CLOUD_DEPLOYMENT or "US"
+        if region in ["US", "EU"]:
+            region = region.lower()
+        else:
+            region = "us"
+
+        # Build posthog_properties with billable flag, team_id, and region
         posthog_props = dict(self.posthog_properties or {})
         posthog_props["$ai_billable"] = self.billable
         posthog_props["team_id"] = self.team.id
+        posthog_props["region"] = region
 
         metadata["posthog_properties"] = posthog_props
         new_kwargs["metadata"] = metadata


### PR DESCRIPTION
## Problem

LLM tracing events (`$ai_generation`, `$ai_trace`) currently lack a `region` property. This prevents accurate usage reporting, making it difficult to differentiate between US and EU customers and potentially leading to `team_id` collisions in reporting.

## Changes

- In `ee/hogai/llm.py`, the `_with_posthog_properties` method now determines the deployment region based on `CLOUD_DEPLOYMENT`.
- The `region` (normalized to "us" or "eu", defaulting to "us") is added to the `posthog_properties` dictionary for all LLM tracing events.

## How did you test this code?

Manually verified by triggering LLM events and confirming the `region` property is correctly included in `$ai_generation` and `$ai_trace` events in PostHog.

## Changelog: (features only) Is this feature complete?

No

---
[Slack Thread](https://posthog.slack.com/archives/C08PXTGQQA2/p1763393945585269?thread_ts=1763393945.585269&cid=C08PXTGQQA2)

<a href="https://cursor.com/background-agent?bcId=bc-a3fca71a-bfde-45de-800d-69787749b8fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3fca71a-bfde-45de-800d-69787749b8fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

