### PR TITLE
fix: improve UX for count warnings, empty states, data refresh

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -145,6 +145,8 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
             },
         },
         showOpenEditorButton: false,
+        emptyStateHeading: 'There are no persons matching your search',
+        emptyStateDetail: 'Try adjusting your search to see more results.',
     }
 
     if (cohortMissing) {
@@ -554,6 +556,9 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
                                                               },
                                                           }
                                                         : undefined,
+                                                    emptyStateHeading: 'There are no matching persons for this cohort',
+                                                    emptyStateDetail:
+                                                        'Try adjusting your matching criteria or search to see more results.',
                                                 }}
                                             />
                                         )}

--- a/frontend/src/scenes/cohorts/cohortCountWarningLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortCountWarningLogic.ts
@@ -1,7 +1,7 @@
 import { connect, kea, key, path, props, selectors } from 'kea'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
-import { ActorsQuery, DataTableNode } from '~/queries/schema/schema-general'
+import { ActorsQuery, ActorsQueryResponse, DataTableNode } from '~/queries/schema/schema-general'
 import { CohortType } from '~/types'
 
 import type { cohortCountWarningLogicType } from './cohortCountWarningLogicType'
@@ -24,7 +24,7 @@ export const cohortCountWarningLogic = kea<cohortCountWarningLogicType>([
     selectors(({ props }) => ({
         shouldShowCountWarning: [
             (s, p) => [s.response, p.query],
-            (response: any, query: DataTableNode): boolean => {
+            (response: ActorsQueryResponse, query: DataTableNode): boolean => {
                 const { cohort } = props
 
                 if (!cohort.count || cohort.is_calculating || cohort.id === 'new' || cohort.is_static) {
@@ -35,7 +35,7 @@ export const cohortCountWarningLogic = kea<cohortCountWarningLogicType>([
                     return false
                 }
 
-                if ((response as any)?.hasMore) {
+                if (response.hasMore) {
                     return false
                 }
 

--- a/frontend/src/scenes/cohorts/cohortCountWarningLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortCountWarningLogic.ts
@@ -1,7 +1,7 @@
 import { connect, kea, key, path, props, selectors } from 'kea'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
-import { DataTableNode } from '~/queries/schema/schema-general'
+import { ActorsQuery, DataTableNode } from '~/queries/schema/schema-general'
 import { CohortType } from '~/types'
 
 import type { cohortCountWarningLogicType } from './cohortCountWarningLogicType'
@@ -23,8 +23,8 @@ export const cohortCountWarningLogic = kea<cohortCountWarningLogicType>([
 
     selectors(({ props }) => ({
         shouldShowCountWarning: [
-            (s) => [s.response],
-            (response): boolean => {
+            (s, p) => [s.response, p.query],
+            (response: any, query: DataTableNode): boolean => {
                 const { cohort } = props
 
                 if (!cohort.count || cohort.is_calculating || cohort.id === 'new' || cohort.is_static) {
@@ -37,6 +37,21 @@ export const cohortCountWarningLogic = kea<cohortCountWarningLogicType>([
 
                 if ((response as any)?.hasMore) {
                     return false
+                }
+
+                const source = query.source as ActorsQuery
+                if (source.search) {
+                    return false
+                }
+
+                if (source.properties) {
+                    if (Array.isArray(source.properties) && source.properties.length > 0) {
+                        return false
+                    }
+
+                    if (!Array.isArray(source.properties) && source.properties.values?.length > 0) {
+                        return false
+                    }
                 }
 
                 const displayedCount = (response as any)?.results?.length || 0


### PR DESCRIPTION
## Problem

Users editing cohorts were experiencing several UX issues that made the interface confusing and less responsive:

1. **Misleading count warnings**: The "deleted persons" warning tooltip appeared when searching or filtering the persons list
2. After saving the cohort, the count is updated, but the table is empty.
3. The message references events, not persons or cohorts.

<img width="4552" height="830" alt="image" src="https://github.com/user-attachments/assets/e1a5e2e6-9aca-46fc-812c-f0e107f3c283" />

## Changes

- Fixed alert of cohort count showing up when searching for persons (it should only display when there is a difference between the cohort count and the total of records found).
- Improved empty state messages for dynamic and static cohorts
- Reload persons table after loading count

<img width="459" height="160" alt="image" src="https://github.com/user-attachments/assets/f635be12-f025-4eb4-bfa5-7108cb762f71" />

<img width="1715" height="212" alt="image" src="https://github.com/user-attachments/assets/c6d5d6a5-79b6-4a96-b1a9-6b365916fb4a" />

<img width="1721" height="209" alt="image" src="https://github.com/user-attachments/assets/5f893520-e353-4a84-9d52-98561fda1af2" />

## How did you test this code?

- Unit tests
- Manually tested:
  - Count warning no longer shows when searching/filtering persons
  - Empty states show appropriate messages for both static and dynamic cohorts
  - Persons table refreshes automatically after cohort save and calculation completion
  - Person removal from cohort triggers data refresh