### PR TITLE
fix(django): add team_id to only clause in actor_base_query.py

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -661,6 +661,99 @@
                                                                                                             join_algorithm = 'auto'
   '''
 # ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.16
+  '''
+  (
+     (SELECT persons.id AS id
+      FROM
+        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+                person.id AS id
+         FROM person
+         WHERE and(equals(person.team_id, 99999), in(id,
+                                                       (SELECT where_optimization.id AS id
+                                                        FROM person AS where_optimization
+                                                        WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
+         GROUP BY person.id
+         HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+      WHERE ifNull(equals(persons.properties___name, 'test'), 0)
+      ORDER BY persons.id ASC
+      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                join_algorithm='auto'))
+  UNION DISTINCT (
+                    (SELECT source.id AS id
+                     FROM
+                       (SELECT actor_id AS actor_id,
+                               count() AS event_count,
+                               groupUniqArray(distinct_id) AS event_distinct_ids,
+                               actor_id AS id
+                        FROM
+                          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                  e.uuid AS uuid,
+                                  e.distinct_id AS distinct_id
+                           FROM events AS e
+                           LEFT OUTER JOIN
+                             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                     person_distinct_id_overrides.distinct_id AS distinct_id
+                              FROM person_distinct_id_overrides
+                              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                              GROUP BY person_distinct_id_overrides.distinct_id
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                        GROUP BY actor_id) AS source
+                     ORDER BY source.id ASC
+                     LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                               join_algorithm='auto')) SETTINGS readonly=2,
+                                                                                max_execution_time=600,
+                                                                                allow_experimental_object_type=1,
+                                                                                format_csv_allow_double_quotes=0,
+                                                                                max_ast_elements=4000000,
+                                                                                max_expanded_ast_elements=4000000,
+                                                                                max_bytes_before_external_group_by=0,
+                                                                                transform_null_in=1,
+                                                                                optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                                allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.17
+  '''
+  
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview'
+                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
+     FROM events e
+     LEFT OUTER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 99999
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 99999
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 1 week
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 99999
+        GROUP BY id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          OR ((coalesce(performed_event_condition_None_level_level_0_level_1_level_0_0, false))))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                            join_algorithm = 'auto'
+  '''
+# ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.2
   '''
   

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -283,7 +283,7 @@ def get_people(
             )
         )
         .order_by("-created_at", "uuid")
-        .only("id", "is_identified", "created_at", "properties", "uuid")
+        .only("id", "is_identified", "created_at", "properties", "uuid", "team_id")
     )
     return persons, serialize_people(team, persons, value_per_actor_id)
 

--- a/posthog/queries/test/__snapshots__/test_actors_base_query.ambr
+++ b/posthog/queries/test/__snapshots__/test_actors_base_query.ambr
@@ -21,6 +21,7 @@
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
+         "posthog_person"."team_id",
          "posthog_person"."properties",
          "posthog_person"."is_identified",
          "posthog_person"."uuid"
@@ -55,6 +56,7 @@
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
+         "posthog_person"."team_id",
          "posthog_person"."properties",
          "posthog_person"."is_identified",
          "posthog_person"."uuid"
@@ -90,6 +92,7 @@
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
+         "posthog_person"."team_id",
          "posthog_person"."properties",
          "posthog_person"."is_identified",
          "posthog_person"."uuid"

--- a/posthog/queries/test/__snapshots__/test_actors_base_query.ambr
+++ b/posthog/queries/test/__snapshots__/test_actors_base_query.ambr
@@ -1,0 +1,196 @@
+# serializer version: 1
+# name: TestActorsBaseQuery.test_get_groups
+  '''
+  SELECT "posthog_group"."id",
+         "posthog_group"."team_id",
+         "posthog_group"."group_key",
+         "posthog_group"."group_type_index",
+         "posthog_group"."group_properties",
+         "posthog_group"."created_at",
+         "posthog_group"."properties_last_updated_at",
+         "posthog_group"."properties_last_operation",
+         "posthog_group"."version"
+  FROM "posthog_group"
+  WHERE ("posthog_group"."group_key" IN ('org_1',
+                                         'org_2')
+         AND "posthog_group"."group_type_index" = 99999
+         AND "posthog_group"."team_id" = 99999)
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_people_with_distinct_id_limit
+  '''
+  SELECT "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND "posthog_person"."uuid" IN ('00000000000000000000000000000000'::uuid))
+  ORDER BY "posthog_person"."created_at" DESC,
+           "posthog_person"."uuid" ASC
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_people_with_distinct_id_limit.1
+  '''
+  SELECT "posthog_persondistinctid"."id",
+         "posthog_persondistinctid"."team_id",
+         "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id",
+         "posthog_persondistinctid"."version"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."id" IN
+           (SELECT U0."id"
+            FROM "posthog_persondistinctid" U0
+            WHERE U0."person_id" = ("posthog_persondistinctid"."person_id")
+            LIMIT 3)
+         AND "posthog_persondistinctid"."person_id" IN (1,
+                                                        2,
+                                                        3,
+                                                        4,
+                                                        5 /* ... */))
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_people_with_prefetch
+  '''
+  SELECT "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND "posthog_person"."uuid" IN ('00000000000000000000000000000000'::uuid,
+                                         '00000000000000000000000000000000'::uuid))
+  ORDER BY "posthog_person"."created_at" DESC,
+           "posthog_person"."uuid" ASC
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_people_with_prefetch.1
+  '''
+  SELECT "posthog_persondistinctid"."id",
+         "posthog_persondistinctid"."team_id",
+         "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id",
+         "posthog_persondistinctid"."version"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."id" IN
+           (SELECT U0."id"
+            FROM "posthog_persondistinctid" U0
+            WHERE U0."person_id" = ("posthog_persondistinctid"."person_id")
+            LIMIT 1000)
+         AND "posthog_persondistinctid"."person_id" IN (1,
+                                                        2,
+                                                        3,
+                                                        4,
+                                                        5 /* ... */))
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_people_with_value_per_actor
+  '''
+  SELECT "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND "posthog_person"."uuid" IN ('00000000000000000000000000000000'::uuid,
+                                         '00000000000000000000000000000000'::uuid))
+  ORDER BY "posthog_person"."created_at" DESC,
+           "posthog_person"."uuid" ASC
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_people_with_value_per_actor.1
+  '''
+  SELECT "posthog_persondistinctid"."id",
+         "posthog_persondistinctid"."team_id",
+         "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id",
+         "posthog_persondistinctid"."version"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."id" IN
+           (SELECT U0."id"
+            FROM "posthog_persondistinctid" U0
+            WHERE U0."person_id" = ("posthog_persondistinctid"."person_id")
+            LIMIT 1000)
+         AND "posthog_persondistinctid"."person_id" IN (1,
+                                                        2,
+                                                        3,
+                                                        4,
+                                                        5 /* ... */))
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_serialized_people_empty
+  '''
+  SELECT posthog_person.id,
+         posthog_person.uuid,
+         posthog_person.properties,
+         posthog_person.is_identified,
+         posthog_person.created_at
+  FROM posthog_person
+  WHERE posthog_person.uuid = ANY('{}')
+    AND posthog_person.team_id = 99999
+  ORDER BY created_at DESC,
+           uuid
+  '''
+# ---
+# name: TestActorsBaseQuery.test_get_serialized_people_empty.1
+  '''
+  SELECT posthog_persondistinctid.person_id,
+         posthog_persondistinctid.distinct_id
+  FROM posthog_persondistinctid
+  WHERE posthog_persondistinctid.person_id = ANY('{}')
+    AND posthog_persondistinctid.team_id = 99999
+  '''
+# ---
+# name: TestActorsBaseQuery.test_serialize_groups_with_values
+  '''
+  SELECT "posthog_group"."id",
+         "posthog_group"."team_id",
+         "posthog_group"."group_key",
+         "posthog_group"."group_type_index",
+         "posthog_group"."group_properties",
+         "posthog_group"."created_at",
+         "posthog_group"."properties_last_updated_at",
+         "posthog_group"."properties_last_operation",
+         "posthog_group"."version"
+  FROM "posthog_group"
+  WHERE "posthog_group"."group_key" IN ('company_a',
+                                        'company_b')
+  '''
+# ---
+# name: TestActorsBaseQuery.test_serialize_people_basic
+  '''
+  SELECT "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties_last_updated_at",
+         "posthog_person"."properties_last_operation",
+         "posthog_person"."team_id",
+         "posthog_person"."properties",
+         "posthog_person"."is_user_id",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid",
+         "posthog_person"."version"
+  FROM "posthog_person"
+  WHERE "posthog_person"."uuid" = '00000000000000000000000000000000'::uuid
+  '''
+# ---
+# name: TestActorsBaseQuery.test_serialize_people_basic.1
+  '''
+  SELECT "posthog_persondistinctid"."distinct_id"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."person_id" = 99999
+         AND "posthog_persondistinctid"."team_id" = 99999)
+  ORDER BY "posthog_persondistinctid"."id" ASC
+  '''
+# ---
+# name: TestActorsBaseQuery.test_serialize_people_basic.2
+  '''
+  SELECT "posthog_persondistinctid"."distinct_id"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."person_id" = 99999
+         AND "posthog_persondistinctid"."team_id" = 99999)
+  ORDER BY "posthog_persondistinctid"."id" ASC
+  '''
+# ---

--- a/posthog/queries/test/test_actors_base_query.py
+++ b/posthog/queries/test/test_actors_base_query.py
@@ -1,0 +1,156 @@
+from typing import Any
+
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_person,
+    flush_persons_and_events,
+    snapshot_postgres_queries,
+)
+
+from posthog.models import Group, Person
+from posthog.queries.actor_base_query import (
+    get_groups,
+    get_people,
+    get_serialized_people,
+    serialize_groups,
+    serialize_people,
+)
+
+
+class TestActorsBaseQuery(ClickhouseTestMixin, APIBaseTest):
+    @snapshot_postgres_queries
+    def test_serialize_people_basic(self):
+        person = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p1"],
+            properties={
+                "name": "p1",
+                "email": "test@posthog.com",
+            },
+        )
+        flush_persons_and_events()
+
+        persons = Person.objects.filter(uuid=person.uuid)
+        result = serialize_people(self.team, persons)
+
+        assert len(result) == 1
+        assert result[0]["uuid"] == person.uuid
+        assert result[0]["properties"]["email"] == "test@posthog.com"
+
+    @snapshot_postgres_queries
+    def test_get_people_with_prefetch(self):
+        person1 = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p1", "p1_alias"],
+            properties={"name": "Person 1", "email": "p1@test.com"},
+        )
+        person2 = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p2", "p2_alias", "p2_another"],
+            properties={"name": "Person 2", "email": "p2@test.com"},
+        )
+        flush_persons_and_events()
+
+        people_ids = [person1.uuid, person2.uuid]
+        persons_queryset, serialized = get_people(self.team, people_ids)
+
+        assert len(serialized) == 2
+        assert persons_queryset.count() == 2
+
+    @snapshot_postgres_queries
+    def test_get_people_with_value_per_actor(self):
+        person1 = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p1"],
+            properties={"name": "High Value"},
+        )
+        person2 = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p2"],
+            properties={"name": "Low Value"},
+        )
+        flush_persons_and_events()
+
+        people_ids = [person1.uuid, person2.uuid]
+        value_per_actor_id = {
+            str(person1.uuid): 100.5,
+            str(person2.uuid): 25.3,
+        }
+
+        _, serialized = get_people(self.team, people_ids, value_per_actor_id)
+
+        assert len(serialized) == 2
+        values = [s["value_at_data_point"] for s in serialized]
+        assert set(values) == {100.5, 25.3}
+
+    @snapshot_postgres_queries
+    def test_get_people_with_distinct_id_limit(self):
+        person = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["id1", "id2", "id3", "id4", "id5"],
+            properties={"name": "Many IDs"},
+        )
+        flush_persons_and_events()
+
+        _, serialized = get_people(self.team, [person.uuid], distinct_id_limit=3)
+
+        assert len(serialized) == 1
+        assert len(serialized[0]["distinct_ids"]) <= 3
+
+    @snapshot_postgres_queries
+    def test_get_serialized_people_empty(self):
+        people_ids: list[Any] = []
+        get_serialized_people(self.team, people_ids)
+
+    @snapshot_postgres_queries
+    def test_get_groups(self):
+        Group.objects.create(
+            team=self.team,
+            group_type_index=0,
+            group_key="org_1",
+            group_properties={"name": "Organization 1", "industry": "Tech"},
+            version=1,
+        )
+        Group.objects.create(
+            team=self.team,
+            group_type_index=0,
+            group_key="org_2",
+            group_properties={"name": "Organization 2", "industry": "Finance"},
+            version=1,
+        )
+
+        group_ids = ["org_1", "org_2"]
+        groups_queryset, serialized = get_groups(self.team.pk, 0, group_ids)
+
+        assert len(serialized) == 2
+        assert serialized[0]["group_key"] in group_ids
+        assert serialized[1]["group_key"] in group_ids
+
+    @snapshot_postgres_queries
+    def test_serialize_groups_with_values(self):
+        Group.objects.create(
+            team=self.team,
+            group_type_index=1,
+            group_key="company_a",
+            group_properties={"name": "Company A"},
+            version=1,
+        )
+        Group.objects.create(
+            team=self.team,
+            group_type_index=1,
+            group_key="company_b",
+            group_properties={"name": "Company B"},
+            version=1,
+        )
+
+        groups = Group.objects.filter(group_key__in=["company_a", "company_b"])
+        value_per_actor_id = {
+            "company_a": 500.0,
+            "company_b": 300.0,
+        }
+
+        serialized = serialize_groups(groups, value_per_actor_id)
+
+        assert len(serialized) == 2
+        assert serialized[0]["value_at_data_point"] in [500.0, 300.0]


### PR DESCRIPTION
## Problem
We need to ensure all `posthog_person` queries include a filtering clause on `team_id` for the new partitioned tables to avoid a fanout. (`team_id` is our new partition key.)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Attempt to address the improperly scoped SELECT linked above by adding `team_id` to  `only()` clause in `actor_base_query.py''s `get_people` to avoid the unscoped fetch we're trying to eliminate
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
