### PR TITLE
fix(django): ensure person DELETE is scoped by team_id in _raw_delete_batch

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -661,6 +661,99 @@
                                                                                                             join_algorithm = 'auto'
   '''
 # ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.16
+  '''
+  (
+     (SELECT persons.id AS id
+      FROM
+        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+                person.id AS id
+         FROM person
+         WHERE and(equals(person.team_id, 99999), in(id,
+                                                       (SELECT where_optimization.id AS id
+                                                        FROM person AS where_optimization
+                                                        WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
+         GROUP BY person.id
+         HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+      WHERE ifNull(equals(persons.properties___name, 'test'), 0)
+      ORDER BY persons.id ASC
+      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                join_algorithm='auto'))
+  UNION DISTINCT (
+                    (SELECT source.id AS id
+                     FROM
+                       (SELECT actor_id AS actor_id,
+                               count() AS event_count,
+                               groupUniqArray(distinct_id) AS event_distinct_ids,
+                               actor_id AS id
+                        FROM
+                          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                  e.uuid AS uuid,
+                                  e.distinct_id AS distinct_id
+                           FROM events AS e
+                           LEFT OUTER JOIN
+                             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                     person_distinct_id_overrides.distinct_id AS distinct_id
+                              FROM person_distinct_id_overrides
+                              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                              GROUP BY person_distinct_id_overrides.distinct_id
+                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                        GROUP BY actor_id) AS source
+                     ORDER BY source.id ASC
+                     LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                               join_algorithm='auto')) SETTINGS readonly=2,
+                                                                                max_execution_time=600,
+                                                                                allow_experimental_object_type=1,
+                                                                                format_csv_allow_double_quotes=0,
+                                                                                max_ast_elements=4000000,
+                                                                                max_expanded_ast_elements=4000000,
+                                                                                max_bytes_before_external_group_by=0,
+                                                                                transform_null_in=1,
+                                                                                optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                                allow_experimental_join_condition=1
+  '''
+# ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.17
+  '''
+  
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview'
+                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
+     FROM events e
+     LEFT OUTER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 99999
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 99999
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 1 week
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 99999
+        GROUP BY id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          OR ((coalesce(performed_event_condition_None_level_level_0_level_1_level_0_0, false))))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                            join_algorithm = 'auto'
+  '''
+# ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.2
   '''
   

--- a/posthog/api/test/__snapshots__/test_project.ambr
+++ b/posthog/api/test/__snapshots__/test_project.ambr
@@ -1,0 +1,41 @@
+# serializer version: 1
+# name: TestProjectAPI.test_delete_bulky_postgres_data
+  '''
+  DELETE
+  FROM "posthog_persondistinctid"
+  WHERE ("id",
+         "team_id") IN ((1,
+                         2)/* ... */)
+  '''
+# ---
+# name: TestProjectAPI.test_delete_bulky_postgres_data.1
+  '''
+  DELETE
+  FROM "posthog_person"
+  WHERE ("id",
+         "team_id") IN ((1,
+                         2)/* ... */)
+  '''
+# ---
+# name: TestProjectAPI.test_delete_bulky_postgres_data.2
+  '''
+  DELETE
+  FROM "posthog_personlessdistinctid"
+  WHERE "posthog_personlessdistinctid"."team_id" IN (1,
+                                                     2,
+                                                     3,
+                                                     4,
+                                                     5 /* ... */)
+  '''
+# ---
+# name: TestProjectAPI.test_delete_bulky_postgres_data.3
+  '''
+  DELETE
+  FROM "posthog_personoverride"
+  WHERE "posthog_personoverride"."team_id" IN (1,
+                                               2,
+                                               3,
+                                               4,
+                                               5 /* ... */)
+  '''
+# ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((174,
-                         120),(175,
+         "team_id") IN ((10,
+                         120),(11,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((172,
+         "team_id") IN ((8,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((16,
-                         120),(17,
+         "team_id") IN ((12,
+                         120),(13,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((15,
+         "team_id") IN ((9,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((102,
-                         120),(103,
+         "team_id") IN ((11,
+                         120),(12,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((101,
+         "team_id") IN ((9,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -3,32 +3,19 @@
   '''
   DELETE
   FROM "posthog_persondistinctid"
-  WHERE ("posthog_persondistinctid"."team_id" IN (1,
-                                                  2,
-                                                  3,
-                                                  4,
-                                                  5 /* ... */)
-         AND "posthog_persondistinctid"."id" IN (1,
-                                                 2,
-                                                 3,
-                                                 4,
-                                                 5 /* ... */))
+  WHERE ("id",
+         "team_id") IN ((5,
+                         53),(6,
+                              53))
   '''
 # ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.1
   '''
   DELETE
   FROM "posthog_person"
-  WHERE ("posthog_person"."team_id" IN (1,
-                                        2,
-                                        3,
-                                        4,
-                                        5 /* ... */)
-         AND "posthog_person"."id" IN (1,
-                                       2,
-                                       3,
-                                       4,
-                                       5 /* ... */))
+  WHERE ("id",
+         "team_id") IN ((3,
+                         53))
   '''
 # ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.2

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((54,
-                         120),(55,
+         "team_id") IN ((23,
+                         120),(24,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((51,
+         "team_id") IN ((21,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((10,
-                         120),(11,
+         "team_id") IN ((32,
+                         120),(33,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((8,
+         "team_id") IN ((32,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((23,
-                         120),(24,
+         "team_id") IN ((10,
+                         120),(11,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((21,
+         "team_id") IN ((8,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((11,
-                         120),(12,
+         "team_id") IN ((9,
+                         120),(10,
                                120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((58,
-                         120),(59,
+         "team_id") IN ((12,
+                         120),(13,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((56,
+         "team_id") IN ((9,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((6,
-                         120),(7,
+         "team_id") IN ((12,
+                         120),(13,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((6,
+         "team_id") IN ((9,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,9 +4,9 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((5,
-                         53),(6,
-                              53))
+         "team_id") IN ((174,
+                         120),(175,
+                               120))
   '''
 # ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.1
@@ -14,8 +14,8 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((3,
-                         53))
+         "team_id") IN ((172,
+                         120))
   '''
 # ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.2

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((11,
-                         120),(12,
+         "team_id") IN ((58,
+                         120),(59,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((9,
+         "team_id") IN ((56,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((8,
-                         120),(9,
+         "team_id") IN ((102,
+                         120),(103,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((7,
+         "team_id") IN ((101,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((165,
-                         120),(166,
+         "team_id") IN ((64,
+                         120),(65,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((165,
+         "team_id") IN ((62,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -1,0 +1,55 @@
+# serializer version: 1
+# name: TestTeamAPI.test_delete_bulky_postgres_data
+  '''
+  DELETE
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."team_id" IN (1,
+                                                  2,
+                                                  3,
+                                                  4,
+                                                  5 /* ... */)
+         AND "posthog_persondistinctid"."id" IN (1,
+                                                 2,
+                                                 3,
+                                                 4,
+                                                 5 /* ... */))
+  '''
+# ---
+# name: TestTeamAPI.test_delete_bulky_postgres_data.1
+  '''
+  DELETE
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" IN (1,
+                                        2,
+                                        3,
+                                        4,
+                                        5 /* ... */)
+         AND "posthog_person"."id" IN (1,
+                                       2,
+                                       3,
+                                       4,
+                                       5 /* ... */))
+  '''
+# ---
+# name: TestTeamAPI.test_delete_bulky_postgres_data.2
+  '''
+  DELETE
+  FROM "posthog_personlessdistinctid"
+  WHERE "posthog_personlessdistinctid"."team_id" IN (1,
+                                                     2,
+                                                     3,
+                                                     4,
+                                                     5 /* ... */)
+  '''
+# ---
+# name: TestTeamAPI.test_delete_bulky_postgres_data.3
+  '''
+  DELETE
+  FROM "posthog_personoverride"
+  WHERE "posthog_personoverride"."team_id" IN (1,
+                                               2,
+                                               3,
+                                               4,
+                                               5 /* ... */)
+  '''
+# ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((64,
-                         120),(65,
+         "team_id") IN ((33,
+                         120),(34,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((62,
+         "team_id") IN ((31,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((24,
-                         120),(25,
+         "team_id") IN ((54,
+                         120),(55,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((24,
+         "team_id") IN ((51,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((24,
-                         120),(25,
+         "team_id") IN ((11,
+                         120),(12,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((24,
+         "team_id") IN ((9,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,9 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((12,
-                         120),(13,
-                               120))
+         "team_id") IN ((1,
+                         2)/* ... */)
   '''
 # ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.1
@@ -14,8 +13,8 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((9,
-                         120))
+         "team_id") IN ((1,
+                         2)/* ... */)
   '''
 # ---
 # name: TestTeamAPI.test_delete_bulky_postgres_data.2

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((8,
-                         120),(9,
+         "team_id") IN ((165,
+                         120),(166,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((7,
+         "team_id") IN ((165,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((32,
-                         120),(33,
+         "team_id") IN ((24,
+                         120),(25,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((32,
+         "team_id") IN ((24,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((9,
-                         120),(10,
+         "team_id") IN ((8,
+                         120),(9,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((9,
+         "team_id") IN ((7,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((10,
-                         120),(11,
+         "team_id") IN ((6,
+                         120),(7,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((8,
+         "team_id") IN ((6,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((10,
-                         120),(11,
+         "team_id") IN ((16,
+                         120),(17,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((8,
+         "team_id") IN ((15,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((12,
-                         120),(13,
+         "team_id") IN ((24,
+                         120),(25,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((9,
+         "team_id") IN ((23,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((12,
-                         120),(13,
+         "team_id") IN ((10,
+                         120),(11,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((9,
+         "team_id") IN ((8,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((24,
-                         120),(25,
+         "team_id") IN ((8,
+                         120),(9,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((23,
+         "team_id") IN ((7,
                          120))
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_team.ambr
+++ b/posthog/api/test/__snapshots__/test_team.ambr
@@ -4,8 +4,8 @@
   DELETE
   FROM "posthog_persondistinctid"
   WHERE ("id",
-         "team_id") IN ((33,
-                         120),(34,
+         "team_id") IN ((24,
+                         120),(25,
                                120))
   '''
 # ---
@@ -14,7 +14,7 @@
   DELETE
   FROM "posthog_person"
   WHERE ("id",
-         "team_id") IN ((31,
+         "team_id") IN ((24,
                          120))
   '''
 # ---

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from freezegun import freeze_time
-from posthog.test.base import APIBaseTest, snapshot_postgres_queries
+from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries_context
 from unittest import mock
 from unittest.mock import ANY, MagicMock, call, patch
 
@@ -43,7 +43,7 @@ from ee.models.rbac.access_control import AccessControl
 
 
 def team_api_test_factory():
-    class TestTeamAPI(APIBaseTest):
+    class TestTeamAPI(APIBaseTest, QueryMatchingTest):
         """Tests for /api/environments/."""
 
         def _assert_activity_log(self, expected: list[dict], team_id: int | None = None) -> None:
@@ -550,7 +550,6 @@ def team_api_test_factory():
             assert mock_capture.call_args_list == expected_capture_calls
             mock_delete_bulky_postgres_data.assert_called_once_with(team_ids=[team.pk])
 
-        @snapshot_postgres_queries
         def test_delete_bulky_postgres_data(self):
             self.organization_membership.level = OrganizationMembership.Level.ADMIN
             self.organization_membership.save()
@@ -595,7 +594,10 @@ def team_api_test_factory():
             )
 
             # if something is missing then teardown fails
-            response = self.client.delete(f"/api/environments/{team.id}")
+            with snapshot_postgres_queries_context(
+                self, custom_query_matcher=lambda query: "DELETE" in query and "posthog_person" in query
+            ):
+                response = self.client.delete(f"/api/environments/{team.id}")
             self.assertEqual(response.status_code, 204)
 
         def test_delete_batch_exports(self):

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from freezegun import freeze_time
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, snapshot_postgres_queries
 from unittest import mock
 from unittest.mock import ANY, MagicMock, call, patch
 
@@ -550,6 +550,7 @@ def team_api_test_factory():
             assert mock_capture.call_args_list == expected_capture_calls
             mock_delete_bulky_postgres_data.assert_called_once_with(team_ids=[team.pk])
 
+        @snapshot_postgres_queries
         def test_delete_bulky_postgres_data(self):
             self.organization_membership.level = OrganizationMembership.Level.ADMIN
             self.organization_membership.save()

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -51,19 +51,34 @@ def _raw_delete_batch(queryset: Any, batch_size: int = 10000):
     Note: For partitioned tables (like posthog_person_new), preserving filters
     like team_id ensures efficient single-partition deletes instead of scanning
     all partitions.
-    """
-    while True:
-        batch_ids = list(queryset.values_list("id", flat=True)[:batch_size])
 
-        if not batch_ids:
+    Uses tuple IN clause (id, team_id) IN ((...), (...)) to ensure accurate
+    deletion of specific record combinations rather than a Cartesian product.
+    """
+    from django.db import connections
+
+    while True:
+        # Get tuples of (id, team_id) to ensure accurate deletion
+        batch_tuples = list(queryset.values_list("id", "team_id")[:batch_size])
+
+        if not batch_tuples:
             break
 
-        # Preserve original queryset filters (e.g., team_id__in) by filtering the original queryset
-        # This ensures the DELETE query includes both team_id and id filters
-        queryset.filter(id__in=batch_ids)._raw_delete(queryset.db)
+        # Use raw SQL with tuple IN clause for accurate deletion
+        # Format: DELETE FROM table WHERE (id, team_id) IN ((1, 1), (2, 1), ...)
+        db_connection = connections[queryset.db]
+        with db_connection.cursor() as cursor:
+            table_name = queryset.model._meta.db_table
+            # Build tuple placeholders: (%s, %s), (%s, %s), ...
+            tuple_placeholders = ",".join(["(%s, %s)"] * len(batch_tuples))
+            # Flatten tuples for parameters: [id1, team_id1, id2, team_id2, ...]
+            params = [item for tuple_pair in batch_tuples for item in tuple_pair]
+
+            query = f'DELETE FROM "{table_name}" WHERE ("id", "team_id") IN ({tuple_placeholders})'
+            cursor.execute(query, params)
 
         # If we got fewer records than batch_size, we're done
-        if len(batch_ids) < batch_size:
+        if len(batch_tuples) < batch_size:
             break
 
         time.sleep(0.1)

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -58,10 +58,9 @@ def _raw_delete_batch(queryset: Any, batch_size: int = 10000):
         if not batch_ids:
             break
 
-        # Create a new queryset from the original to preserve filters (e.g., team_id)
-        # then add the id__in filter for the batch
-        batch_queryset = queryset.filter(id__in=batch_ids)
-        batch_queryset._raw_delete(queryset.db)
+        # Preserve original queryset filters (e.g., team_id__in) by filtering the original queryset
+        # This ensures the DELETE query includes both team_id and id filters
+        queryset.filter(id__in=batch_ids)._raw_delete(queryset.db)
 
         # If we got fewer records than batch_size, we're done
         if len(batch_ids) < batch_size:

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -213,6 +213,12 @@ def clean_varying_query_parts(query, replace_all_numbers):
         query = re.sub(r"(\"?) = \d+", r"\1 = 99999", query)
         query = re.sub(r"(\"?) (in|IN) \(\d+(, ?\d+)*\)", r"\1 \2 (1, 2, 3, 4, 5 /* ... */)", query)
         query = re.sub(r"(\"?) (in|IN) \[\d+(, ?\d+)*\]", r"\1 \2 [1, 2, 3, 4, 5 /* ... */]", query)
+        # Handle nested tuples: IN ((1, 2), (3, 4)) -> IN ((1, 2) /* ... */)
+        query = re.sub(
+            r"(in|IN) \(\(\d+(, ?\d+)*\)(, ?\(\d+(, ?\d+)*\))*\)",
+            r"\1 ((1, 2) /* ... */)",
+            query,
+        )
         # replace "uuid" IN ('00000000-0000-4000-8000-000000000001'::uuid) effectively:
         query = re.sub(
             r"\"uuid\" (in|IN) \('[0-9a-f-]{36}'(::uuid)?(, '[0-9a-f-]{36}'(::uuid)?)*\)",


### PR DESCRIPTION
## Problem

Now that `posthog_persons` is partitioned by `team_id` we need to ensure team ID is included in filtering clauses in relevant queries against the table, to ensure the database doesn't fan out to every partition.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fixes `DELETE` stmt generated in Team model `util.py`'s `_raw_delete_batch`
* Add query snapshot to test case to verify the change has the desired effect
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
