### PR TITLE
feat(capture-logs): try to parse request as JSON if protobuf doesn't work

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -122,7 +122,7 @@ posthog-rs = { version = "0.3.5", features = ["async-client"] }
 redis = { version = "0.32.7", features = ["tokio-comp", "cluster", "cluster-async"] }
 regex = "1.11.1"
 lz-str = "0.2.1"
-opentelemetry-proto = "0.29.0"
+opentelemetry-proto = { version = "0.29.0", features = ["with-serde"] }
 tonic = "0.12.3"
 clickhouse = { version = "0.13.2", features = [
     "uuid",

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -105,7 +105,12 @@ impl KafkaLogRow {
         // Trace flags
         let trace_flags = record.flags;
 
-        let timestamp = DateTime::<Utc>::from_timestamp_nanos(record.time_unix_nano.try_into()?);
+
+        let timestamp = match record.time_unix_nano {
+            0 => Utc::now(),
+            _ => DateTime::<Utc>::from_timestamp_nanos(record.time_unix_nano.try_into()?),
+        };
+
         let observed_timestamp = Utc::now();
 
         let log_row = Self {

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -105,7 +105,6 @@ impl KafkaLogRow {
         // Trace flags
         let trace_flags = record.flags;
 
-
         let timestamp = match record.time_unix_nano {
             0 => Utc::now(),
             _ => DateTime::<Utc>::from_timestamp_nanos(record.time_unix_nano.try_into()?),

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -91,18 +91,21 @@ pub async fn export_logs_http(
     }
     let export_request = match ExportLogsServiceRequest::decode(body.as_ref()) {
         Ok(request) => request,
-        Err(proto_err) => {
-            match serde_json::from_slice(&body) {
-                Ok(request) => request,
-                Err(json_err) => {
-                    error!("Failed to decode JSON: {} or Protobuf: {}", json_err, proto_err);
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        Json(json!({"error": format!("Failed to decode JSON: {} or Protobuf: {}", json_err, proto_err)})),
-                    ));
-                }
+        Err(proto_err) => match serde_json::from_slice(&body) {
+            Ok(request) => request,
+            Err(json_err) => {
+                error!(
+                    "Failed to decode JSON: {} or Protobuf: {}",
+                    json_err, proto_err
+                );
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(
+                        json!({"error": format!("Failed to decode JSON: {} or Protobuf: {}", json_err, proto_err)}),
+                    ),
+                ));
             }
-        }
+        },
     };
 
     let mut rows: Vec<KafkaLogRow> = Vec::new();

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -89,6 +89,9 @@ pub async fn export_logs_http(
             Json(json!({"error": format!("Invalid token")})),
         ));
     }
+
+    // Try to decode as Protobuf, if this fails, try JSON.
+    // We do this over relying on Content-Type headers to be as permissive as possible in what we accept.
     let export_request = match ExportLogsServiceRequest::decode(body.as_ref()) {
         Ok(request) => request,
         Err(proto_err) => match serde_json::from_slice(&body) {

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -128,6 +128,7 @@ pub async fn export_logs_http(
         }
     }
 
+    let row_count = rows.len();
     if let Err(e) = service.sink.write(token, rows, body.len() as u64).await {
         error!("Failed to send logs to Kafka: {}", e);
         return Err((
@@ -135,7 +136,7 @@ pub async fn export_logs_http(
             Json(json!({"error": format!("Internal server error")})),
         ));
     } else {
-        debug!("Successfully sent logs to Kafka");
+        debug!("Successfully sent {} logs to Kafka", row_count);
     }
 
     // Return empty JSON object per OTLP spec


### PR DESCRIPTION
## Problem

we only support protobuf atm, but should support JSON requests too

## Changes

try to parse protobuf, if it fails, try to parse JSON.

We could look at request headers and use that to decide how to decode but that feels more fragile (we want to accept as much as we can if possible)

## How did you test this code?

ran locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
