### PR TITLE
feat(ph-ai): eu callback for billing

### DIFF
--- a/ee/hogai/assistant/base.py
+++ b/ee/hogai/assistant/base.py
@@ -26,9 +26,12 @@ from posthog.schema import (
 )
 
 from posthog import event_usage
+from posthog.cloud_utils import is_cloud
 from posthog.event_usage import report_user_action
 from posthog.models import Team, User
+from posthog.ph_client import get_client
 from posthog.sync import database_sync_to_async
+from posthog.utils import get_instance_region
 
 from ee.hogai.utils.exceptions import GenerationCanceled
 from ee.hogai.utils.helpers import extract_stream_update
@@ -60,7 +63,7 @@ class BaseAssistant(ABC):
     _session_id: Optional[str]
     _latest_message: Optional[HumanMessage]
     _state: Optional[AssistantMaxGraphState]
-    _callback_handler: Optional[BaseCallbackHandler]
+    _callback_handlers: Optional[list[BaseCallbackHandler]]
     _trace_id: Optional[str | UUID]
     _billing_context: Optional[MaxBillingContext]
     _initial_state: Optional[AssistantMaxGraphState | AssistantMaxPartialGraphState]
@@ -98,23 +101,38 @@ class BaseAssistant(ABC):
         self._graph = graph
         self._state_type = state_type
         self._partial_state_type = partial_state_type
-        self._callback_handler = callback_handler or (
-            CallbackHandler(
-                posthoganalytics.default_client,
-                distinct_id=user.distinct_id if user else None,
-                properties={
+
+        self._callback_handlers = []
+        if callback_handler:
+            self._callback_handlers.append(callback_handler)
+        else:
+
+            def init_handler(client: posthoganalytics.Client):
+                callback_properties = {
                     "conversation_id": str(self._conversation.id),
                     "$ai_session_id": str(self._conversation.id),
                     "is_first_conversation": is_new_conversation,
                     "$session_id": self._session_id,
                     "assistant_mode": mode.value,
                     "$groups": event_usage.groups(team=team),
-                },
-                trace_id=trace_id,
-            )
-            if posthoganalytics.default_client
-            else None
-        )
+                }
+                return CallbackHandler(
+                    client,
+                    distinct_id=user.distinct_id if user else None,
+                    properties=callback_properties,
+                    trace_id=trace_id,
+                )
+
+            # Local deployment or hobby
+            if not is_cloud() and (local_client := posthoganalytics.default_client):
+                self._callback_handlers.append(init_handler(local_client))
+            elif region := get_instance_region():
+                # Add regional client first
+                self._callback_handlers.append(init_handler(get_client(region)))
+                # If we're in EU, add the US client as well, so we can see US and EU traces
+                if region == "EU":
+                    self._callback_handlers.append(init_handler(get_client("US")))
+
         self._trace_id = trace_id
         self._billing_context = billing_context
         self._mode = mode
@@ -238,10 +256,9 @@ class BaseAssistant(ABC):
                         yield AssistantEventType.MESSAGE, FailureMessage()
 
     def _get_config(self) -> RunnableConfig:
-        callbacks = [self._callback_handler] if self._callback_handler else None
         config: RunnableConfig = {
             "recursion_limit": 48,
-            "callbacks": callbacks,
+            "callbacks": self._callback_handlers,
             "configurable": {
                 "thread_id": self._conversation.id,
                 "trace_id": self._trace_id,

--- a/ee/hogai/assistant/base.py
+++ b/ee/hogai/assistant/base.py
@@ -63,7 +63,7 @@ class BaseAssistant(ABC):
     _session_id: Optional[str]
     _latest_message: Optional[HumanMessage]
     _state: Optional[AssistantMaxGraphState]
-    _callback_handlers: Optional[list[BaseCallbackHandler]]
+    _callback_handlers: list[BaseCallbackHandler]
     _trace_id: Optional[str | UUID]
     _billing_context: Optional[MaxBillingContext]
     _initial_state: Optional[AssistantMaxGraphState | AssistantMaxPartialGraphState]

--- a/ee/hogai/assistant/test/test_base_callback_handlers.py
+++ b/ee/hogai/assistant/test/test_base_callback_handlers.py
@@ -1,0 +1,171 @@
+from uuid import uuid4
+
+from posthog.test.base import BaseTest
+from unittest.mock import Mock, patch
+
+import posthoganalytics
+from posthoganalytics.ai.langchain.callbacks import CallbackHandler
+
+from ee.hogai.assistant import Assistant
+from ee.models import Conversation
+
+
+class TestBaseAssistantCallbackHandlers(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.conversation = Conversation.objects.create(team=self.team, user=self.user)
+
+    @patch("ee.hogai.assistant.base.is_cloud")
+    @patch("ee.hogai.assistant.base.get_instance_region")
+    def test_callback_handler_local_deployment_no_client(self, mock_get_region, mock_is_cloud):
+        mock_is_cloud.return_value = False
+        mock_get_region.return_value = None
+
+        with patch.object(posthoganalytics, "default_client", None):
+            assistant = Assistant.create(
+                team=self.team,
+                conversation=self.conversation,
+                user=self.user,
+            )
+
+            self.assertEqual(assistant._callback_handlers, [])
+
+    @patch("ee.hogai.assistant.base.is_cloud")
+    @patch("ee.hogai.assistant.base.get_instance_region")
+    def test_callback_handler_local_deployment_with_client(self, mock_get_region, mock_is_cloud):
+        mock_is_cloud.return_value = False
+        mock_get_region.return_value = None
+
+        mock_client = Mock()
+        with patch.object(posthoganalytics, "default_client", mock_client):
+            assistant = Assistant.create(
+                team=self.team,
+                conversation=self.conversation,
+                user=self.user,
+            )
+
+            self.assertEqual(len(assistant._callback_handlers), 1)
+            self.assertIsInstance(assistant._callback_handlers[0], CallbackHandler)
+
+    @patch("ee.hogai.assistant.base.is_cloud")
+    @patch("ee.hogai.assistant.base.get_instance_region")
+    @patch("ee.hogai.assistant.base.get_client")
+    def test_callback_handler_cloud_us_region(self, mock_get_client, mock_get_region, mock_is_cloud):
+        mock_is_cloud.return_value = True
+        mock_get_region.return_value = "US"
+
+        mock_us_client = Mock()
+        mock_get_client.return_value = mock_us_client
+
+        assistant = Assistant.create(
+            team=self.team,
+            conversation=self.conversation,
+            user=self.user,
+        )
+
+        self.assertEqual(len(assistant._callback_handlers), 1)
+        mock_get_client.assert_called_once_with("US")
+
+    @patch("ee.hogai.assistant.base.is_cloud")
+    @patch("ee.hogai.assistant.base.get_instance_region")
+    @patch("ee.hogai.assistant.base.get_client")
+    def test_callback_handler_cloud_eu_region(self, mock_get_client, mock_get_region, mock_is_cloud):
+        mock_is_cloud.return_value = True
+        mock_get_region.return_value = "EU"
+
+        mock_eu_client = Mock()
+        mock_us_client = Mock()
+
+        def get_client_side_effect(region):
+            if region == "EU":
+                return mock_eu_client
+            elif region == "US":
+                return mock_us_client
+            return None
+
+        mock_get_client.side_effect = get_client_side_effect
+
+        assistant = Assistant.create(
+            team=self.team,
+            conversation=self.conversation,
+            user=self.user,
+        )
+
+        self.assertEqual(len(assistant._callback_handlers), 2)
+        self.assertEqual(mock_get_client.call_count, 2)
+        mock_get_client.assert_any_call("EU")
+        mock_get_client.assert_any_call("US")
+
+    @patch("ee.hogai.assistant.base.is_cloud")
+    @patch("ee.hogai.assistant.base.get_instance_region")
+    def test_callback_handler_cloud_no_region(self, mock_get_region, mock_is_cloud):
+        mock_is_cloud.return_value = True
+        mock_get_region.return_value = None
+
+        assistant = Assistant.create(
+            team=self.team,
+            conversation=self.conversation,
+            user=self.user,
+        )
+
+        self.assertEqual(assistant._callback_handlers, [])
+
+    @patch("ee.hogai.assistant.base.is_cloud")
+    @patch("ee.hogai.assistant.base.get_instance_region")
+    @patch("ee.hogai.assistant.base.get_client")
+    def test_callback_handler_properties(self, mock_get_client, mock_get_region, mock_is_cloud):
+        mock_is_cloud.return_value = True
+        mock_get_region.return_value = "US"
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        trace_id = uuid4()
+        session_id = "test-session"
+
+        with patch("ee.hogai.assistant.base.CallbackHandler") as mock_callback_handler_class:
+            mock_handler_instance = Mock()
+            mock_callback_handler_class.return_value = mock_handler_instance
+
+            assistant = Assistant.create(
+                team=self.team,
+                conversation=self.conversation,
+                user=self.user,
+                session_id=session_id,
+                trace_id=trace_id,
+                is_new_conversation=True,
+            )
+
+            self.assertEqual(len(assistant._callback_handlers), 1)
+
+            call_args = mock_callback_handler_class.call_args
+            self.assertEqual(call_args[0][0], mock_client)
+            self.assertEqual(call_args[1]["distinct_id"], self.user.distinct_id)
+            self.assertEqual(call_args[1]["trace_id"], trace_id)
+
+            properties = call_args[1]["properties"]
+            self.assertEqual(properties["conversation_id"], str(self.conversation.id))
+            self.assertEqual(properties["$ai_session_id"], str(self.conversation.id))
+            self.assertEqual(properties["is_first_conversation"], True)
+            self.assertEqual(properties["$session_id"], session_id)
+
+    @patch("ee.hogai.assistant.base.is_cloud")
+    @patch("ee.hogai.assistant.base.get_instance_region")
+    @patch("ee.hogai.assistant.base.get_client")
+    def test_get_config_uses_callback_handlers(self, mock_get_client, mock_get_region, mock_is_cloud):
+        mock_is_cloud.return_value = True
+        mock_get_region.return_value = "US"
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        assistant = Assistant.create(
+            team=self.team,
+            conversation=self.conversation,
+            user=self.user,
+        )
+
+        config = assistant._get_config()
+        assert isinstance(config["callbacks"], list)
+        self.assertEqual(config["callbacks"], assistant._callback_handlers)
+        self.assertEqual(len(config["callbacks"]), 1)


### PR DESCRIPTION
## Problem

Usage reports are isolated, so we need to change the logic of trace capturing.

## Changes

If we are not in the cloud: Use a default posthoganalytics client (mostly for dev).
If we are in the US: Only use the US client.
If we are in the EU: Use both the US and EU clients to duplicate data, so we see all traces in the US and have usage reports in the EU.

## How did you test this code?

N/A