### PR TITLE
feat(llma): manual eval processing banner

### DIFF
--- a/products/llm_analytics/frontend/components/EvalsTabContent.tsx
+++ b/products/llm_analytics/frontend/components/EvalsTabContent.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconCheckCircle, IconRefresh } from '@posthog/icons'
-import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonSelect } from '@posthog/lemon-ui'
 
 import { llmEvaluationsLogic } from '../evaluations/llmEvaluationsLogic'
 import { generationEvaluationRunsLogic } from '../generationEvaluationRunsLogic'
@@ -37,6 +37,10 @@ function EvalsTabContentInner({
 
     return (
         <div className="py-4">
+            <LemonBanner type="info" className="mb-4">
+                Manually triggered evaluations typically appear within seconds, but may take a few minutes to process.
+                Click Refresh to see new results.
+            </LemonBanner>
             <div className="flex justify-between items-center mb-4">
                 <div className="flex gap-2">
                     <LemonSelect


### PR DESCRIPTION
Adds a banner explaining that evals might take a bit to show up when manually triggered. We discussed implementing a better UX for this but decided it's not worth it since the use cases for manual triggering are very few, mostly related to debugging.
<img width="878" height="198" alt="image" src="https://github.com/user-attachments/assets/90594bcc-d5d3-4959-adc0-8ef9dbbb1cd3" />
