### PR TITLE
fix(sql-editor): data grid keyed rendering

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -358,7 +358,7 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
                 const finalWidth = isLongContent ? 600 : undefined
 
                 const baseColumn: DataGridProps<Record<string, any>>['columns'][0] = {
-                    key: column,
+                    key: `${column}_${index}`,
                     name: (
                         <>
                             {column}{' '}
@@ -399,10 +399,11 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
                     return {
                         ...baseColumn,
                         renderCell: (props: any) => {
-                            if (props.row[column] === null) {
+                            const columnKey = `${column}_${index}`
+                            if (props.row[columnKey] === null) {
                                 return null
                             }
-                            return props.row[column].toString()
+                            return props.row[columnKey].toString()
                         },
                     }
                 }
@@ -410,7 +411,8 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
                 return {
                     ...baseColumn,
                     renderCell: (props: any) => {
-                        const value = props.row[column]
+                        const columnKey = `${column}_${index}`
+                        const value = props.row[columnKey]
                         if (typeof value === 'string' && value.startsWith('["__hx_tag",') && value.endsWith(']')) {
                             try {
                                 const parsedHogQLX = JSON.parse(value)
@@ -437,11 +439,12 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
         let processedRows = response.results.map((row: any[], index: number) => {
             const rowObject: Record<string, any> = { __index: index }
             response.columns?.forEach((column: string, i: number) => {
+                const columnKey = `${column}_${i}`
                 // Handling objects here as other viz methods can accept objects. Data grid does not for now
                 if (typeof row[i] === 'object' && row[i] !== null) {
-                    rowObject[column] = JSON.stringify(row[i])
+                    rowObject[columnKey] = JSON.stringify(row[i])
                 } else {
-                    rowObject[column] = row[i]
+                    rowObject[columnKey] = row[i]
                 }
             })
             return rowObject


### PR DESCRIPTION
## Problem

- renders the wrong columns if there are repeat column names (example: you self join a table and want columns from both tables)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- make sure to key the columns

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
