### PR TITLE
feat(dagster): implement overrides for max_id and min_id in persons_new_backfill 

### DIFF
--- a/dags/persons_new_backfill.py
+++ b/dags/persons_new_backfill.py
@@ -84,6 +84,7 @@ def get_id_range(
         context.add_output_metadata(
             {
                 "min_id": dagster.MetadataValue.int(min_id),
+                "min_id_source": dagster.MetadataValue.text("config" if config.min_id is not None else "database"),
                 "max_id": dagster.MetadataValue.int(max_id),
                 "max_id_source": dagster.MetadataValue.text("config" if config.max_id is not None else "database"),
                 "total_ids": dagster.MetadataValue.int(max_id - min_id + 1),

--- a/dags/persons_new_backfill.py
+++ b/dags/persons_new_backfill.py
@@ -22,6 +22,7 @@ class PersonsNewBackfillConfig(dagster.Config):
     batch_size: int = 100_000  # Records per batch insert
     source_table: str = "posthog_persons"
     destination_table: str = "posthog_persons_new"
+    min_id: int | None = None  # Optional override for min ID to resume from partial state
     max_id: int | None = None  # Optional override for max ID to resume from partial state
 
 
@@ -37,18 +38,23 @@ def get_id_range(
     Returns tuple (min_id, max_id).
     """
     with database.cursor() as cursor:
-        # Always query for min_id
-        min_query = f"SELECT MIN(id) as min_id FROM {config.source_table}"
-        context.log.info(f"Querying min ID: {min_query}")
-        cursor.execute(min_query)
-        min_result = cursor.fetchone()
+        # Use config min_id if provided, otherwise query database
+        if config.min_id is not None:
+            min_id = config.min_id
+            context.log.info(f"Using configured min_id override: {config.min_id}")
+        else:
+            # Always query for min_id
+            min_query = f"SELECT MIN(id) as min_id FROM {config.source_table}"
+            context.log.info(f"Querying min ID: {min_query}")
+            cursor.execute(min_query)
+            min_result = cursor.fetchone()
 
-        if min_result is None or min_result["min_id"] is None:
-            context.log.exception("Source table is empty or has no valid IDs")
-            # Note: No metrics client here as this is get_id_range op, not copy_chunk
-            raise dagster.Failure("Source table is empty or has no valid IDs")
+            if min_result is None or min_result["min_id"] is None:
+                context.log.exception("Source table has no valid min ID")
+                # Note: No metrics client here as this is get_id_range op, not copy_chunk
+                raise dagster.Failure("Source table has no valid min ID")
 
-        min_id = int(min_result["min_id"])
+            min_id = int(min_result["min_id"])
 
         # Use config max_id if provided, otherwise query database
         if config.max_id is not None:

--- a/dags/tests/test_persons_new_backfill.py
+++ b/dags/tests/test_persons_new_backfill.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import psycopg2.errors
 from dagster import build_op_context
 
-from dags.persons_new_backfill import PersonsNewBackfillConfig, copy_chunk, create_chunks
+from dags.persons_new_backfill import PersonsNewBackfillConfig, copy_chunk, create_chunks, get_id_range
 
 
 class TestCreateChunks:
@@ -483,3 +483,117 @@ class TestCopyChunk:
 
         if set_indices and begin_indices:
             assert max(set_indices) < min(begin_indices), "SET statements should come before BEGIN statements"
+
+
+class TestGetIdRange:
+    """Test the get_id_range function."""
+
+    def test_get_id_range_uses_min_id_override(self):
+        """Test that min_id override is honored when provided."""
+        config = PersonsNewBackfillConfig(min_id=100, max_id=None, source_table="posthog_persons")
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = {"max_id": 5000}
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (100, 5000)
+        assert result[0] == 100  # min_id override used
+
+        # Verify min_id query was NOT executed (override used)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        min_queries = [call for call in execute_calls if "MIN(id)" in call]
+        assert len(min_queries) == 0, "Should not query for min_id when override is provided"
+
+        # Verify max_id query WAS executed
+        max_queries = [call for call in execute_calls if "MAX(id)" in call]
+        assert len(max_queries) == 1, "Should query for max_id when override is not provided"
+
+    def test_get_id_range_uses_max_id_override(self):
+        """Test that max_id override is honored when provided."""
+        config = PersonsNewBackfillConfig(min_id=None, max_id=5000, source_table="posthog_persons")
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = {"min_id": 1}
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (1, 5000)
+        assert result[1] == 5000  # max_id override used
+
+        # Verify max_id query was NOT executed (override used)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        max_queries = [call for call in execute_calls if "MAX(id)" in call]
+        assert len(max_queries) == 0, "Should not query for max_id when override is provided"
+
+        # Verify min_id query WAS executed
+        min_queries = [call for call in execute_calls if "MIN(id)" in call]
+        assert len(min_queries) == 1, "Should query for min_id when override is not provided"
+
+    def test_get_id_range_uses_both_overrides(self):
+        """Test that both min_id and max_id overrides are honored when provided."""
+        config = PersonsNewBackfillConfig(min_id=100, max_id=5000, source_table="posthog_persons")
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (100, 5000)
+        assert result[0] == 100  # min_id override used
+        assert result[1] == 5000  # max_id override used
+
+        # Verify NO queries were executed (both overrides used)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        min_queries = [call for call in execute_calls if "MIN(id)" in call]
+        max_queries = [call for call in execute_calls if "MAX(id)" in call]
+        assert len(min_queries) == 0, "Should not query for min_id when override is provided"
+        assert len(max_queries) == 0, "Should not query for max_id when override is provided"
+
+    def test_get_id_range_queries_database_when_no_overrides(self):
+        """Test that database is queried when no overrides are provided."""
+        config = PersonsNewBackfillConfig(min_id=None, max_id=None, source_table="posthog_persons")
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        # First call returns min_id, second call returns max_id
+        cursor.fetchone.side_effect = [{"min_id": 1}, {"max_id": 5000}]
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (1, 5000)
+
+        # Verify both queries were executed
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        min_queries = [call for call in execute_calls if "MIN(id)" in call]
+        max_queries = [call for call in execute_calls if "MAX(id)" in call]
+        assert len(min_queries) == 1, "Should query for min_id when override is not provided"
+        assert len(max_queries) == 1, "Should query for max_id when override is not provided"
+
+    def test_get_id_range_validates_max_id_greater_than_min_id(self):
+        """Test that validation fails when max_id < min_id."""
+        config = PersonsNewBackfillConfig(min_id=5000, max_id=100, source_table="posthog_persons")
+        mock_db = create_mock_database_resource()
+
+        context = build_op_context(resources={"database": mock_db})
+
+        from dagster import Failure
+
+        try:
+            get_id_range(context, config)
+            raise AssertionError("Expected Dagster.Failure to be raised")
+        except Failure as e:
+            assert e.description is not None
+            description = e.description
+            assert "max_id" in description.lower() or "invalid" in description.lower()
+            assert "5000" in description or "100" in description


### PR DESCRIPTION
## Problem
We need to do a 2nd pass of the Dagster backfill job over the high ID ranges that the bash script covered, to fix some gaps. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement override for Dagster `persons_new_backfill` job on `min_id` as we already have for `max_id`, to ensure we only run over the range we care about
* Related unit tests
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No updates required ✅ 
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
